### PR TITLE
[wallet-ext] - suifrens / kiosk - add marketplace links for kiosk items

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -25,6 +25,7 @@
 		"@amplitude/analytics-core": "^0.13.3",
 		"@amplitude/analytics-types": "^0.20.0",
 		"@growthbook/growthbook-react": "^0.15.0",
+		"@mysten/kiosk": "workspace:*",
 		"@mysten/sui.js": "workspace:*",
 		"@sentry/react": "^7.47.0",
 		"@tanstack/react-query": "^4.29.3",

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -25,7 +25,6 @@
 		"@amplitude/analytics-core": "^0.13.3",
 		"@amplitude/analytics-types": "^0.20.0",
 		"@growthbook/growthbook-react": "^0.15.0",
-		"@mysten/kiosk": "workspace:*",
 		"@mysten/sui.js": "workspace:*",
 		"@sentry/react": "^7.47.0",
 		"@tanstack/react-query": "^4.29.3",

--- a/apps/core/src/hooks/useGetKioskContents.ts
+++ b/apps/core/src/hooks/useGetKioskContents.ts
@@ -1,71 +1,103 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SuiAddress, SuiObjectResponse } from '@mysten/sui.js';
+import { JsonRpcProvider, SuiAddress, SuiObjectResponse } from '@mysten/sui.js';
+import { fetchKiosk, getOwnedKiosks } from '@mysten/kiosk';
 import { useQuery } from '@tanstack/react-query';
 import { useRpcClient } from '../api/RpcClientContext';
-import { useGetOwnedObjects } from './useGetOwnedObjects';
-
-// OriginByte module for mainnet (we only support mainnet)
-export const ORIGINBYTE_KIOSK_MODULE =
-	'0x95a441d389b07437d00dd07e0b6f05f513d7659b13fd7c5d3923c7d9d847199b::ob_kiosk' as const;
-export const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
-
-const KIOSK_MODULE = '0x2::kiosk';
-const KIOSK_OWNER_CAP = `${KIOSK_MODULE}::KioskOwnerCap`;
 
 const getKioskId = (obj: SuiObjectResponse) =>
 	obj.data?.content &&
 	'fields' in obj.data.content &&
 	(obj.data.content.fields.for ?? obj.data.content.fields.kiosk);
 
-export function useGetKioskContents(address?: SuiAddress | null, disableOriginByteKiosk?: boolean) {
-	const rpc = useRpcClient();
-	const { data } = useGetOwnedObjects(address, {
-		MatchAny: [
-			{ StructType: KIOSK_OWNER_CAP },
-			...(!disableOriginByteKiosk ? [{ StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN }] : []),
-		],
+// OriginByte module for mainnet (we only support mainnet)
+export const ORIGINBYTE_KIOSK_MODULE =
+	'0x95a441d389b07437d00dd07e0b6f05f513d7659b13fd7c5d3923c7d9d847199b::ob_kiosk' as const;
+export const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
+
+async function getOriginByteKioskContents(address: SuiAddress, rpc: JsonRpcProvider) {
+	const data = await rpc.getOwnedObjects({
+		owner: address,
+		filter: {
+			StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN,
+		},
+		options: {
+			showContent: true,
+		},
+	});
+	const ids = data.data.map((object) => getKioskId(object) ?? []);
+
+	// fetch the user's kiosks
+	const ownedKiosks = await rpc.multiGetObjects({
+		ids: ids.flat(),
+		options: {
+			showContent: true,
+		},
 	});
 
-	// find list of kiosk IDs owned by address
-	const kioskIds = data?.pages.flatMap((page) => page.data).map((obj) => getKioskId(obj)) ?? [];
-
-	return useQuery({
-		queryKey: ['get-kiosk-contents', address, kioskIds],
-		queryFn: async () => {
-			if (!kioskIds.length) return [];
-
-			// fetch the user's kiosks
-			const ownedKiosks = await rpc.multiGetObjects({
-				ids: kioskIds,
-				options: {
-					showContent: true,
-				},
+	// find object IDs within a kiosk
+	const kioskObjectIds = await Promise.all(
+		ownedKiosks.map(async (kiosk) => {
+			if (!kiosk.data?.objectId) return [];
+			const objects = await rpc.getDynamicFields({
+				parentId: kiosk.data.objectId,
 			});
+			return objects.data.map((obj) => obj.objectId);
+		}),
+	);
 
-			// find object IDs within a kiosk
-			const kioskObjectIds = await Promise.all(
-				ownedKiosks.map(async (kiosk) => {
-					if (!kiosk.data?.objectId) return [];
-					const objects = await rpc.getDynamicFields({
-						parentId: kiosk.data.objectId,
-					});
-					return objects.data.map((obj) => obj.objectId);
-				}),
-			);
-
-			// fetch the contents of the objects within a kiosk
-			const kioskContent = await rpc.multiGetObjects({
-				ids: kioskObjectIds.flat(),
-				options: {
-					showDisplay: true,
-					showType: true,
-				},
-			});
-
-			return kioskContent;
+	// fetch the contents of the objects within a kiosk
+	const kioskContent = await rpc.multiGetObjects({
+		ids: kioskObjectIds.flat(),
+		options: {
+			showDisplay: true,
+			showType: true,
 		},
-		enabled: !!address,
+	});
+
+	return kioskContent;
+}
+
+async function getSuiKioskContents(address: SuiAddress, rpc: JsonRpcProvider) {
+	const ownedKiosks = await getOwnedKiosks(rpc, address!);
+	const kioskContents = await Promise.all(
+		ownedKiosks.kioskIds.map(async (id) => {
+			return fetchKiosk(rpc, id, { limit: 1000 }, {});
+		}),
+	);
+	const items = kioskContents.flatMap((k) => k.data.items);
+	const ids = items.map((item) => item.objectId);
+
+	// fetch the contents of the objects within a kiosk
+	const kioskContent = await rpc.multiGetObjects({
+		ids,
+		options: {
+			showContent: true,
+			showDisplay: true,
+			showType: true,
+		},
+	});
+
+	return kioskContent;
+}
+
+export function useGetKioskContents(address?: SuiAddress | null, disableOriginByteKiosk?: boolean) {
+	const rpc = useRpcClient();
+	return useQuery({
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: ['get-kiosk-contents', address, disableOriginByteKiosk],
+		queryFn: async () => {
+			const obKioskContents = await getOriginByteKioskContents(address!, rpc);
+			const suiKioskContents = await getSuiKioskContents(address!, rpc);
+
+			return {
+				list: [...suiKioskContents, ...obKioskContents],
+				kiosks: {
+					sui: suiKioskContents ?? [],
+					originByte: obKioskContents ?? [],
+				},
+			};
+		},
 	});
 }

--- a/apps/core/src/hooks/useGetKioskContents.ts
+++ b/apps/core/src/hooks/useGetKioskContents.ts
@@ -1,34 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { JsonRpcProvider, SuiAddress, getObjectFields } from '@mysten/sui.js';
+import { JsonRpcProvider, SuiAddress, SuiObjectResponse } from '@mysten/sui.js';
+import { fetchKiosk, getOwnedKiosks } from '@mysten/kiosk';
 import { useQuery } from '@tanstack/react-query';
 import { useRpcClient } from '../api/RpcClientContext';
+
+const getKioskId = (obj: SuiObjectResponse) =>
+	obj.data?.content &&
+	'fields' in obj.data.content &&
+	(obj.data.content.fields.for ?? obj.data.content.fields.kiosk);
 
 // OriginByte module for mainnet (we only support mainnet)
 export const ORIGINBYTE_KIOSK_MODULE =
 	'0x95a441d389b07437d00dd07e0b6f05f513d7659b13fd7c5d3923c7d9d847199b::ob_kiosk' as const;
 export const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
 
-const KIOSK_MODULE = '0x2::kiosk';
-const KIOSK_OWNER_CAP = `${KIOSK_MODULE}::KioskOwnerCap`;
-
-async function getKioskContents(address: SuiAddress, type: string, rpc: JsonRpcProvider) {
-	// fetch owner cap
+async function getOriginByteKioskContents(address: SuiAddress, rpc: JsonRpcProvider) {
 	const data = await rpc.getOwnedObjects({
 		owner: address,
 		filter: {
-			StructType: type,
+			StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN,
 		},
 		options: {
 			showContent: true,
 		},
 	});
-
-	// find kiosk ids
-	const ids = data.data.map(
-		(object) => getObjectFields(object)?.kiosk ?? getObjectFields(object)?.for,
-	);
+	const ids = data.data.map((object) => getKioskId(object) ?? []);
 
 	// fetch the user's kiosks
 	const ownedKiosks = await rpc.multiGetObjects({
@@ -57,6 +55,30 @@ async function getKioskContents(address: SuiAddress, type: string, rpc: JsonRpcP
 			showType: true,
 		},
 	});
+
+	return kioskContent;
+}
+
+async function getSuiKioskContents(address: SuiAddress, rpc: JsonRpcProvider) {
+	const ownedKiosks = await getOwnedKiosks(rpc, address!);
+	const kioskContents = await Promise.all(
+		ownedKiosks.kioskIds.map(async (id) => {
+			return fetchKiosk(rpc, id, { limit: 1000 }, {});
+		}),
+	);
+	const items = kioskContents.flatMap((k) => k.data.items);
+	const ids = items.map((item) => item.objectId);
+
+	// fetch the contents of the objects within a kiosk
+	const kioskContent = await rpc.multiGetObjects({
+		ids,
+		options: {
+			showContent: true,
+			showDisplay: true,
+			showType: true,
+		},
+	});
+
 	return kioskContent;
 }
 
@@ -66,8 +88,8 @@ export function useGetKioskContents(address?: SuiAddress | null, disableOriginBy
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: ['get-kiosk-contents', address, disableOriginByteKiosk],
 		queryFn: async () => {
-			const obKioskContents = await getKioskContents(address!, ORIGINBYTE_KIOSK_OWNER_TOKEN, rpc);
-			const suiKioskContents = await getKioskContents(address!, KIOSK_OWNER_CAP, rpc);
+			const obKioskContents = await getOriginByteKioskContents(address!, rpc);
+			const suiKioskContents = await getSuiKioskContents(address!, rpc);
 
 			return {
 				list: [...suiKioskContents, ...obKioskContents],

--- a/apps/core/tsconfig.json
+++ b/apps/core/tsconfig.json
@@ -17,5 +17,5 @@
 	},
 	"include": ["src"],
 	"exclude": ["node_modules"],
-	"references": [{ "path": "../../sdk/typescript/" }]
+	"references": [{ "path": "../../sdk/typescript/" }, { "path": "../../sdk/kiosk" }]
 }

--- a/apps/core/tsconfig.json
+++ b/apps/core/tsconfig.json
@@ -17,5 +17,5 @@
 	},
 	"include": ["src"],
 	"exclude": ["node_modules"],
-	"references": [{ "path": "../../sdk/typescript/" }, { "path": "../../sdk/kiosk" }]
+	"references": [{ "path": "../../sdk/typescript/" }]
 }

--- a/apps/explorer/src/components/OwnedObjects/index.tsx
+++ b/apps/explorer/src/components/OwnedObjects/index.tsx
@@ -20,13 +20,13 @@ export function OwnedObjects({ id }: { id: string }) {
 	const ownedObjects = useGetOwnedObjects(id, {
 		MatchNone: [{ StructType: '0x2::coin::Coin' }],
 	});
-	const { data: kioskContents } = useGetKioskContents(id);
+	const { data: kioskData } = useGetKioskContents(id);
 
 	const { data, isError, isFetching, pagination } = useCursorPagination(ownedObjects);
 
 	const filteredData = useMemo(
-		() => (filter === 'all' ? data?.data : kioskContents),
-		[filter, data, kioskContents],
+		() => (filter === 'all' ? data?.data : kioskData?.list),
+		[filter, data, kioskData],
 	);
 
 	if (isError) {
@@ -46,7 +46,7 @@ export function OwnedObjects({ id }: { id: string }) {
 						key={filter.value}
 						value={filter.value}
 						label={filter.label}
-						disabled={filter.value === 'kiosks' && !kioskContents?.length}
+						disabled={filter.value === 'kiosks' && !kioskData?.list?.length}
 					/>
 				))}
 			</RadioGroup>

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -23,6 +23,7 @@
 	"include": ["src", "tests"],
 	"references": [
 		{ "path": "../../sdk/typescript/" },
+		{ "path": "../../sdk/kiosk/" },
 		{ "path": "../../sdk/wallet-adapter/wallet-kit/" }
 	]
 }

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -23,7 +23,6 @@
 	"include": ["src", "tests"],
 	"references": [
 		{ "path": "../../sdk/typescript/" },
-		{ "path": "../../sdk/kiosk/" },
 		{ "path": "../../sdk/wallet-adapter/wallet-kit/" }
 	]
 }

--- a/apps/wallet/configs/ts/tsconfig.common.json
+++ b/apps/wallet/configs/ts/tsconfig.common.json
@@ -44,6 +44,7 @@
 			"_utils": ["./src/ui/styles/utils"],
 			"_utils/*": ["./src/ui/styles/utils/*"],
 			"@mysten/sui.js": ["../../sdk/typescript/src/"],
+			"@mysten/kiosk": ["../../sdk/kiosk/src/index.ts"],
 			"@mysten/bcs": ["../../sdk/bcs/src/"],
 			"@mysten/ledgerjs-hw-app-sui": ["../../sdk/ledgerjs-hw-app-sui/src/Sui.ts"],
 			"@mysten/wallet-standard": ["../../sdk/wallet-adapter/wallet-standard/src/"]

--- a/apps/wallet/configs/ts/tsconfig.common.json
+++ b/apps/wallet/configs/ts/tsconfig.common.json
@@ -44,7 +44,6 @@
 			"_utils": ["./src/ui/styles/utils"],
 			"_utils/*": ["./src/ui/styles/utils/*"],
 			"@mysten/sui.js": ["../../sdk/typescript/src/"],
-			"@mysten/kiosk": ["../../sdk/kiosk/src/index.ts"],
 			"@mysten/bcs": ["../../sdk/bcs/src/"],
 			"@mysten/ledgerjs-hw-app-sui": ["../../sdk/ledgerjs-hw-app-sui/src/Sui.ts"],
 			"@mysten/wallet-standard": ["../../sdk/wallet-adapter/wallet-standard/src/"]

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -123,6 +123,7 @@
 		"@metamask/browser-passworder": "^4.1.0",
 		"@mysten/core": "workspace:*",
 		"@mysten/icons": "workspace:*",
+		"@mysten/kiosk": "workspace:*",
 		"@mysten/ledgerjs-hw-app-sui": "workspace:*",
 		"@mysten/sui.js": "workspace:*",
 		"@mysten/wallet-standard": "workspace:*",

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -123,7 +123,6 @@
 		"@metamask/browser-passworder": "^4.1.0",
 		"@mysten/core": "workspace:*",
 		"@mysten/icons": "workspace:*",
-		"@mysten/kiosk": "workspace:*",
 		"@mysten/ledgerjs-hw-app-sui": "workspace:*",
 		"@mysten/sui.js": "workspace:*",
 		"@mysten/wallet-standard": "workspace:*",

--- a/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetOwnedObjects, useGetKioskContents, hasDisplayData } from '@mysten/core';
+import { useGetOwnedObjects, hasDisplayData, useGetKioskContents } from '@mysten/core';
 import { type SuiObjectData, type SuiAddress } from '@mysten/sui.js';
 
 import useAppSelector from './useAppSelector';
@@ -24,16 +24,16 @@ export function useGetNFTs(address?: SuiAddress | null) {
 		50,
 	);
 	const { apiEnv } = useAppSelector((state) => state.app);
-
 	const disableOriginByteKiosk = apiEnv !== 'mainnet';
-	const { data: kioskContents, isLoading: areKioskContentsLoading } = useGetKioskContents(
+
+	const { data: kioskData, isLoading: areKioskContentsLoading } = useGetKioskContents(
 		address,
 		disableOriginByteKiosk,
 	);
 
-	const filteredKioskContents = kioskContents
-		?.filter(hasDisplayData)
-		.map((data) => data.data as SuiObjectData);
+	const filteredKioskContents = (kioskData?.list ?? [])
+		.filter(hasDisplayData)
+		.map(({ data }) => (data as SuiObjectData) || []);
 
 	const nfts = [
 		...(filteredKioskContents ?? []),
@@ -42,6 +42,7 @@ export function useGetNFTs(address?: SuiAddress | null) {
 			.filter(hasDisplayData)
 			.map(({ data }) => data as SuiObjectData) || []),
 	];
+
 	return {
 		data: nfts,
 		isInitialLoading,

--- a/apps/wallet/src/ui/app/hooks/useOwnedNFT.ts
+++ b/apps/wallet/src/ui/app/hooks/useOwnedNFT.ts
@@ -7,13 +7,14 @@ import { useMemo } from 'react';
 
 export function useOwnedNFT(nftObjectId: string | null, address: SuiAddress | null) {
 	const data = useGetObject(nftObjectId);
-	const { data: kioskContents } = useGetKioskContents(address);
-	const { data: objectData } = data;
+	const { data: kioskData, isFetching: areKioskContentsLoading } = useGetKioskContents(address);
+	const { data: objectData, isLoading } = data;
+
 	const objectDetails = useMemo(() => {
 		if (!objectData || !is(objectData.data, SuiObjectData) || !address) return null;
-		const ownedKioskObjectIds = kioskContents?.map(({ data }) => data?.objectId) || [];
+		const ownedKioskObjectIds = kioskData?.list.map(({ data }) => data?.objectId) || [];
 		const objectOwner = getObjectOwner(objectData);
-		const isOwner =
+		const data =
 			ownedKioskObjectIds.includes(objectData.data.objectId) ||
 			(objectOwner &&
 				objectOwner !== 'Immutable' &&
@@ -21,7 +22,8 @@ export function useOwnedNFT(nftObjectId: string | null, address: SuiAddress | nu
 				objectOwner.AddressOwner === address)
 				? objectData.data
 				: null;
-		return isOwner;
-	}, [address, objectData, kioskContents]);
-	return { ...data, data: objectDetails };
+		return data;
+	}, [address, objectData, kioskData]);
+
+	return { ...data, isLoading: isLoading || areKioskContentsLoading, data: objectDetails };
 }

--- a/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useGetKioskContents } from '@mysten/core';
 import { ArrowUpRight12, ArrowRight16 } from '@mysten/icons';
 import { hasPublicTransfer, formatAddress } from '@mysten/sui.js';
 import cl from 'classnames';
@@ -26,6 +27,10 @@ function NFTDetailsPage() {
 	const { data: objectData, isLoading } = useOwnedNFT(nftId || '', accountAddress);
 	const isTransferable = !!objectData && hasPublicTransfer(objectData);
 	const { nftFields, fileExtensionType, filePath } = useNFTBasicData(objectData);
+	const address = useActiveAddress();
+	const { data } = useGetKioskContents(address);
+	const isContainedInSuiKiosk = data?.kiosks.sui.some((k) => k.data?.objectId === nftId);
+
 	// Extract either the attributes, or use the top-level NFT fields:
 	const metaFields =
 		nftFields?.metadata?.fields?.attributes?.fields ||
@@ -151,21 +156,39 @@ function NFTDetailsPage() {
 									</LabelValuesContainer>
 								</Collapse>
 							) : null}
-							<div className="mb-3 flex flex-1 items-end">
-								<Button
-									variant="primary"
-									size="tall"
-									disabled={!isTransferable}
-									to={`/nft-transfer/${nftId}`}
-									title={
-										isTransferable
-											? undefined
-											: "Unable to send. NFT doesn't have public transfer method"
-									}
-									text="Send NFT"
-									after={<ArrowRight16 />}
-								/>
-							</div>
+
+							{isContainedInSuiKiosk ? (
+								<div className="flex flex-col gap-2 mb-3">
+									<Button
+										after={<ArrowUpRight12 />}
+										variant="outline"
+										href="https://docs.sui.io/build/sui-kiosk"
+										text="Learn more about Kiosks"
+									/>
+									<Button
+										after={<ArrowUpRight12 />}
+										variant="outline"
+										href="https://sui.directory/?_project_type=marketplace"
+										text="Explore Sui Marketplaces"
+									/>
+								</div>
+							) : (
+								<div className="mb-3 flex flex-1 items-end">
+									<Button
+										variant="primary"
+										size="tall"
+										disabled={!isTransferable}
+										to={`/nft-transfer/${nftId}`}
+										title={
+											isTransferable
+												? undefined
+												: "Unable to send. NFT doesn't have public transfer method"
+										}
+										text="Send NFT"
+										after={<ArrowRight16 />}
+									/>
+								</div>
+							)}
 						</div>
 					</>
 				) : (

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -37,11 +37,9 @@ export function TransferNFTForm({
 	const navigate = useNavigate();
 	const { clientIdentifier, notificationModal } = useQredoTransaction();
 
-	const kioskContents = useGetKioskContents(activeAddress);
+	const { data: kiosk } = useGetKioskContents(activeAddress);
 	const transferKioskItem = useTransferKioskItem({ objectId, objectType });
-	const isContainedInKiosk = kioskContents?.data?.some(
-		(kioskItem) => kioskItem.data?.objectId === objectId,
-	);
+	const isContainedInKiosk = kiosk?.list.some((kioskItem) => kioskItem.data?.objectId === objectId);
 
 	const transferNFT = useMutation({
 		mutationFn: async (to: string) => {
@@ -80,7 +78,7 @@ export function TransferNFTForm({
 		},
 		onSuccess: (response) => {
 			queryClient.invalidateQueries(['object', objectId]);
-			queryClient.invalidateQueries(['get-kiosk-contents']);
+			queryClient.invalidateQueries(['get-kiosk-contents'], { refetchType: 'all' });
 			queryClient.invalidateQueries(['get-owned-objects']);
 			return navigate(
 				`/receipt?${new URLSearchParams({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: false
@@ -69,6 +69,9 @@ importers:
       '@growthbook/growthbook-react':
         specifier: ^0.15.0
         version: 0.15.0(react@18.2.0)
+      '@mysten/kiosk':
+        specifier: workspace:*
+        version: link:../../sdk/kiosk
       '@mysten/sui.js':
         specifier: workspace:*
         version: link:../../sdk/typescript
@@ -431,6 +434,9 @@ importers:
       '@mysten/icons':
         specifier: workspace:*
         version: link:../icons
+      '@mysten/kiosk':
+        specifier: workspace:*
+        version: link:../../sdk/kiosk
       '@mysten/ledgerjs-hw-app-sui':
         specifier: workspace:*
         version: link:../../sdk/ledgerjs-hw-app-sui
@@ -1252,10 +1258,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.0(next@13.3.0)(nextra@2.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1559,7 +1565,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2644,7 +2650,7 @@ packages:
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
       babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.21.4)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
-      semver: 7.5.3
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2915,13 +2921,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-
-  /@babel/runtime@7.22.5:
-    resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -4210,7 +4209,7 @@ packages:
       package-json: 6.5.0
       parse-github-url: 1.0.2
       sembear: 0.5.2
-      semver: 7.5.3
+      semver: 7.5.2
       spawndamnit: 2.0.0
       validate-npm-package-name: 3.0.0
     dev: true
@@ -4599,7 +4598,7 @@ packages:
       '@oclif/help': 1.0.7(supports-color@8.1.1)
       '@oclif/parser': 3.8.11
       debug: 4.3.4(supports-color@8.1.1)
-      semver: 7.5.3
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4694,7 +4693,7 @@ packages:
       chalk: 4.1.2
       cli-ux: 5.6.7
       debug: 4.3.4(supports-color@8.1.1)
-      fs-extra: 9.1.0
+      fs-extra: 9.0.1
       moment: 2.29.4
     transitivePeerDependencies:
       - supports-color
@@ -4732,11 +4731,11 @@ packages:
       cross-spawn: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       filesize: 6.4.0
-      fs-extra: 9.1.0
+      fs-extra: 9.0.1
       http-call: 5.3.0
       lodash: 4.17.21
       log-chopper: 1.0.2
-      semver: 7.5.3
+      semver: 7.5.2
       tar-fs: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4751,10 +4750,10 @@ packages:
       '@oclif/errors': 1.3.6
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
-      fs-extra: 9.1.0
+      fs-extra: 9.0.1
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.3
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5911,7 +5910,7 @@ packages:
     peerDependencies:
       size-limit: 8.2.4
     dependencies:
-      semver: 7.5.3
+      semver: 7.5.2
       size-limit: 8.2.4
     dev: true
 
@@ -6531,7 +6530,7 @@ packages:
       prompts: 2.4.2
       puppeteer-core: 2.1.1
       read-pkg-up: 7.0.1
-      semver: 7.5.3
+      semver: 7.5.2
       shelljs: 0.8.5
       simple-update-notifier: 1.1.0
       strip-json-comments: 3.1.1
@@ -6714,7 +6713,7 @@ packages:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.3
+      semver: 7.5.2
       serve-favicon: 2.5.0
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -6861,7 +6860,7 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      semver: 7.5.3
+      semver: 7.5.2
       store2: 2.14.2
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -8380,7 +8379,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.3
+      semver: 7.5.2
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -8400,7 +8399,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.3
+      semver: 7.5.2
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -8981,15 +8980,6 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.2
-    dev: true
-
-  /acorn-jsx@5.3.2(acorn@8.9.0):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.9.0
-    dev: false
 
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
@@ -9010,12 +9000,6 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  /acorn@8.9.0:
-    resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: false
 
   /addons-linter@5.32.0(node-fetch@3.3.1):
     resolution: {integrity: sha512-Lf6oOyw8X9z5BMd9xhQwSbPlN2PUlzDLnYLAVT5lkrgXEx0fO9hRk4JRxWZ8+rFGz+mCIA2TTClZF2f+MKgJQA==}
@@ -10325,7 +10309,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.3
+      semver: 7.5.2
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -10611,7 +10595,7 @@ packages:
       make-dir: 3.1.0
       onetime: 5.1.2
       pkg-up: 3.1.0
-      semver: 7.5.3
+      semver: 7.5.2
       write-file-atomic: 3.0.3
     dev: true
 
@@ -10805,7 +10789,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 7.5.3
+      semver: 7.5.2
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -11012,13 +10996,6 @@ packages:
       internmap: 2.0.3
     dev: false
 
-  /d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-    dependencies:
-      internmap: 2.0.3
-    dev: false
-
   /d3-axis@3.0.0:
     resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
     engines: {node: '>=12'}
@@ -11051,7 +11028,7 @@ packages:
     resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.4
+      d3-array: 3.2.3
     dev: false
 
   /d3-delaunay@6.0.4:
@@ -11120,7 +11097,7 @@ packages:
     resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.4
+      d3-array: 3.2.3
     dev: false
 
   /d3-hierarchy@3.1.2:
@@ -11250,7 +11227,7 @@ packages:
     resolution: {integrity: sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.4
+      d3-array: 3.2.3
       d3-axis: 3.0.0
       d3-brush: 3.0.0
       d3-chord: 3.0.1
@@ -13200,16 +13177,6 @@ packages:
       universalify: 1.0.0
     dev: true
 
-  /fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-    dev: true
-
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -14739,7 +14706,7 @@ packages:
       '@babel/parser': 7.22.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.5.3
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15187,7 +15154,7 @@ packages:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
     dependencies:
-      package-json: 8.1.1
+      package-json: 8.1.0
     dev: true
 
   /layout-base@1.0.2:
@@ -15431,8 +15398,8 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /lru-cache@9.1.2:
-    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
+  /lru-cache@9.0.2:
+    resolution: {integrity: sha512-7zYMKApzQ9qQE13xQUzbXVY3p2C5lh+9V+bs8M9fRf1TF59id+8jkljRWtIPfBfNP4yQAol5cqh/e8clxatdXw==}
     engines: {node: 14 || >=16.14}
     dev: true
 
@@ -15475,14 +15442,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 7.5.3
+      semver: 7.5.2
     dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 7.5.3
+      semver: 7.5.2
     dev: true
 
   /make-error-cause@2.3.0:
@@ -15555,7 +15522,7 @@ packages:
   /match-sorter@6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.22.3
       remove-accents: 0.4.2
     dev: false
 
@@ -16045,8 +16012,8 @@ packages:
   /micromark-extension-mdxjs@1.0.1:
     resolution: {integrity: sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==}
     dependencies:
-      acorn: 8.9.0
-      acorn-jsx: 5.3.2(acorn@8.9.0)
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2(acorn@8.8.2)
       micromark-extension-mdx-expression: 1.0.8
       micromark-extension-mdx-jsx: 1.0.5
       micromark-extension-mdx-md: 1.0.1
@@ -16560,8 +16527,8 @@ packages:
       - supports-color
     dev: false
 
-  /next-seo@6.1.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-iMBpFoJsR5zWhguHJvsoBDxDSmdYTHtnVPB1ij+CD0NReQCP78ZxxbdL9qkKIf4oEuZEqZkrjAQLB0bkII7RYA==}
+  /next-seo@6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
@@ -16628,11 +16595,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-C2DtoGH15q22t4r2JC89lvvajmnyiqsv3PaqHJpoHRlF2eR5giuLhZC5Oahb9AENRDcnUIUvqVi/8NlfiIM0yQ==}
+  /nextra-theme-docs@2.7.0(next@13.3.0)(nextra@2.7.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-984jZR13QO/YTIsLEYpFK2Pf4hQjD2Z2fHrBYJl/ZZQjylwxnnGcx1QAciy65mnPWr7/Kv9/dAKpjm9tYtyLrw==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.7.1
+      nextra: 2.7.0
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -16645,17 +16612,17 @@ packages:
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
-      next-seo: 6.1.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qchTb7XSm357XAHf9MV9UlUSGolPEPE8iFnC/9KMwvhIoE4seyPYWMrnH84XraZCcGERvy9TrkFD30VE7Qv1MA==}
+  /nextra@2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SXUsczIzb6+apg3ipRQQllBJk6W2FJfUrmJrQySu9DJpUfS36ylQYLX5ofkCI+Sq3ZHfefZbnut49KGozt/rGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -17192,11 +17159,11 @@ packages:
       got: 9.6.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 7.5.3
+      semver: 7.5.2
     dev: true
 
-  /package-json@8.1.1:
-    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+  /package-json@8.1.0:
+    resolution: {integrity: sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==}
     engines: {node: '>=14.16'}
     dependencies:
       got: 12.6.0
@@ -17361,7 +17328,7 @@ packages:
     resolution: {integrity: sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 9.1.2
+      lru-cache: 9.0.2
       minipass: 5.0.0
     dev: true
 
@@ -18455,6 +18422,7 @@ packages:
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
@@ -19463,7 +19431,7 @@ packages:
     resolution: {integrity: sha512-Ij1vCAdFgWABd7zTg50Xw1/p0JgESNxuLlneEAsmBrKishA06ulTTL/SHGmNy2Zud7+rKrHTKNI6moJsn1ppAQ==}
     dependencies:
       '@types/semver': 6.2.3
-      semver: 7.5.3
+      semver: 7.5.2
     dev: true
 
   /semver-diff@4.0.0:
@@ -19661,7 +19629,7 @@ packages:
     resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      semver: 7.5.3
+      semver: 7.5.2
     dev: true
 
   /sirv@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -69,9 +69,6 @@ importers:
       '@growthbook/growthbook-react':
         specifier: ^0.15.0
         version: 0.15.0(react@18.2.0)
-      '@mysten/kiosk':
-        specifier: workspace:*
-        version: link:../../sdk/kiosk
       '@mysten/sui.js':
         specifier: workspace:*
         version: link:../../sdk/typescript
@@ -434,9 +431,6 @@ importers:
       '@mysten/icons':
         specifier: workspace:*
         version: link:../icons
-      '@mysten/kiosk':
-        specifier: workspace:*
-        version: link:../../sdk/kiosk
       '@mysten/ledgerjs-hw-app-sui':
         specifier: workspace:*
         version: link:../../sdk/ledgerjs-hw-app-sui
@@ -1258,10 +1252,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.7.0(next@13.3.0)(nextra@2.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1565,7 +1559,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.5.3
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2650,7 +2644,7 @@ packages:
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
       babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.21.4)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2921,6 +2915,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+
+  /@babel/runtime@7.22.5:
+    resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+    dev: false
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -4209,7 +4210,7 @@ packages:
       package-json: 6.5.0
       parse-github-url: 1.0.2
       sembear: 0.5.2
-      semver: 7.5.2
+      semver: 7.5.3
       spawndamnit: 2.0.0
       validate-npm-package-name: 3.0.0
     dev: true
@@ -4598,7 +4599,7 @@ packages:
       '@oclif/help': 1.0.7(supports-color@8.1.1)
       '@oclif/parser': 3.8.11
       debug: 4.3.4(supports-color@8.1.1)
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4693,7 +4694,7 @@ packages:
       chalk: 4.1.2
       cli-ux: 5.6.7
       debug: 4.3.4(supports-color@8.1.1)
-      fs-extra: 9.0.1
+      fs-extra: 9.1.0
       moment: 2.29.4
     transitivePeerDependencies:
       - supports-color
@@ -4731,11 +4732,11 @@ packages:
       cross-spawn: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       filesize: 6.4.0
-      fs-extra: 9.0.1
+      fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
       log-chopper: 1.0.2
-      semver: 7.5.2
+      semver: 7.5.3
       tar-fs: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4750,10 +4751,10 @@ packages:
       '@oclif/errors': 1.3.6
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
-      fs-extra: 9.0.1
+      fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5910,7 +5911,7 @@ packages:
     peerDependencies:
       size-limit: 8.2.4
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
       size-limit: 8.2.4
     dev: true
 
@@ -6530,7 +6531,7 @@ packages:
       prompts: 2.4.2
       puppeteer-core: 2.1.1
       read-pkg-up: 7.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       shelljs: 0.8.5
       simple-update-notifier: 1.1.0
       strip-json-comments: 3.1.1
@@ -6713,7 +6714,7 @@ packages:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       serve-favicon: 2.5.0
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -6860,7 +6861,7 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      semver: 7.5.2
+      semver: 7.5.3
       store2: 2.14.2
       telejson: 7.1.0
       ts-dedent: 2.2.0
@@ -8379,7 +8380,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -8399,7 +8400,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -8980,6 +8981,15 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.2
+    dev: true
+
+  /acorn-jsx@5.3.2(acorn@8.9.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.9.0
+    dev: false
 
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
@@ -9000,6 +9010,12 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /acorn@8.9.0:
+    resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
 
   /addons-linter@5.32.0(node-fetch@3.3.1):
     resolution: {integrity: sha512-Lf6oOyw8X9z5BMd9xhQwSbPlN2PUlzDLnYLAVT5lkrgXEx0fO9hRk4JRxWZ8+rFGz+mCIA2TTClZF2f+MKgJQA==}
@@ -10309,7 +10325,7 @@ packages:
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.2
-      semver: 7.5.2
+      semver: 7.5.3
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
@@ -10595,7 +10611,7 @@ packages:
       make-dir: 3.1.0
       onetime: 5.1.2
       pkg-up: 3.1.0
-      semver: 7.5.2
+      semver: 7.5.3
       write-file-atomic: 3.0.3
     dev: true
 
@@ -10789,7 +10805,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 7.5.2
+      semver: 7.5.3
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -10996,6 +11012,13 @@ packages:
       internmap: 2.0.3
     dev: false
 
+  /d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+    dependencies:
+      internmap: 2.0.3
+    dev: false
+
   /d3-axis@3.0.0:
     resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
     engines: {node: '>=12'}
@@ -11028,7 +11051,7 @@ packages:
     resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.3
+      d3-array: 3.2.4
     dev: false
 
   /d3-delaunay@6.0.4:
@@ -11097,7 +11120,7 @@ packages:
     resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.3
+      d3-array: 3.2.4
     dev: false
 
   /d3-hierarchy@3.1.2:
@@ -11227,7 +11250,7 @@ packages:
     resolution: {integrity: sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.3
+      d3-array: 3.2.4
       d3-axis: 3.0.0
       d3-brush: 3.0.0
       d3-chord: 3.0.1
@@ -13177,6 +13200,16 @@ packages:
       universalify: 1.0.0
     dev: true
 
+  /fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -14706,7 +14739,7 @@ packages:
       '@babel/parser': 7.22.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.5.2
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15154,7 +15187,7 @@ packages:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
     dependencies:
-      package-json: 8.1.0
+      package-json: 8.1.1
     dev: true
 
   /layout-base@1.0.2:
@@ -15398,8 +15431,8 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /lru-cache@9.0.2:
-    resolution: {integrity: sha512-7zYMKApzQ9qQE13xQUzbXVY3p2C5lh+9V+bs8M9fRf1TF59id+8jkljRWtIPfBfNP4yQAol5cqh/e8clxatdXw==}
+  /lru-cache@9.1.2:
+    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
     dev: true
 
@@ -15442,14 +15475,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /make-error-cause@2.3.0:
@@ -15522,7 +15555,7 @@ packages:
   /match-sorter@6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.5
       remove-accents: 0.4.2
     dev: false
 
@@ -16012,8 +16045,8 @@ packages:
   /micromark-extension-mdxjs@1.0.1:
     resolution: {integrity: sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==}
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
       micromark-extension-mdx-expression: 1.0.8
       micromark-extension-mdx-jsx: 1.0.5
       micromark-extension-mdx-md: 1.0.1
@@ -16527,8 +16560,8 @@ packages:
       - supports-color
     dev: false
 
-  /next-seo@6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==}
+  /next-seo@6.1.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-iMBpFoJsR5zWhguHJvsoBDxDSmdYTHtnVPB1ij+CD0NReQCP78ZxxbdL9qkKIf4oEuZEqZkrjAQLB0bkII7RYA==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
@@ -16595,11 +16628,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.7.0(next@13.3.0)(nextra@2.7.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-984jZR13QO/YTIsLEYpFK2Pf4hQjD2Z2fHrBYJl/ZZQjylwxnnGcx1QAciy65mnPWr7/Kv9/dAKpjm9tYtyLrw==}
+  /nextra-theme-docs@2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-C2DtoGH15q22t4r2JC89lvvajmnyiqsv3PaqHJpoHRlF2eR5giuLhZC5Oahb9AENRDcnUIUvqVi/8NlfiIM0yQ==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.7.0
+      nextra: 2.7.1
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -16612,17 +16645,17 @@ packages:
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
-      next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      next-seo: 6.1.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.7.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-SXUsczIzb6+apg3ipRQQllBJk6W2FJfUrmJrQySu9DJpUfS36ylQYLX5ofkCI+Sq3ZHfefZbnut49KGozt/rGQ==}
+  /nextra@2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-qchTb7XSm357XAHf9MV9UlUSGolPEPE8iFnC/9KMwvhIoE4seyPYWMrnH84XraZCcGERvy9TrkFD30VE7Qv1MA==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -17159,11 +17192,11 @@ packages:
       got: 9.6.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
-  /package-json@8.1.0:
-    resolution: {integrity: sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==}
+  /package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
     engines: {node: '>=14.16'}
     dependencies:
       got: 12.6.0
@@ -17328,7 +17361,7 @@ packages:
     resolution: {integrity: sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 9.0.2
+      lru-cache: 9.1.2
       minipass: 5.0.0
     dev: true
 
@@ -18422,7 +18455,6 @@ packages:
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
@@ -19431,7 +19463,7 @@ packages:
     resolution: {integrity: sha512-Ij1vCAdFgWABd7zTg50Xw1/p0JgESNxuLlneEAsmBrKishA06ulTTL/SHGmNy2Zud7+rKrHTKNI6moJsn1ppAQ==}
     dependencies:
       '@types/semver': 6.2.3
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /semver-diff@4.0.0:
@@ -19629,7 +19661,7 @@ packages:
     resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      semver: 7.5.2
+      semver: 7.5.3
     dev: true
 
   /sirv@2.0.2:

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -12,7 +12,7 @@ import {
 	TransactionBlock,
 	getObjectFields,
 } from '@mysten/sui.js';
-import { DynamicFieldInfo } from '@mysten/sui.js/dist/types/dynamic_fields';
+import { type DynamicFieldInfo } from '@mysten/sui.js';
 import { bcs } from './bcs';
 import { KIOSK_TYPE, Kiosk, KioskData, KioskListing, RulesEnvironmentParam } from './types';
 import { MAINNET_RULES_PACKAGE_ADDRESS, TESTNET_RULES_PACKAGE_ADDRESS } from './constants';

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -15,4 +15,5 @@ export * from './epochs';
 export * from './transactions';
 export * from './subscriptions';
 export * from './name-service';
+export * from './dynamic_fields';
 export { GasCostSummary, CheckpointDigest, Checkpoint } from './checkpoints';


### PR DESCRIPTION
## Description 

As part of the work for supporting SuiFrens updates,  we are adding Kiosk / Marketplace links for items contained within a Sui Kiosk on the NFT Transfer page since Bullsharks will be locked in a Kiosk.

I started going down the route of adding support for transferring non-locked items, as well as re-working things to reduce some duplicate logic, but due to time constraints I will add that in a follow-up PR. 

<img width="405" alt="image" src="https://github.com/MystenLabs/sui/assets/122397493/e6df6696-eca5-42ef-b943-5346e9d42109">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
