### PR TITLE
move: source service verifies packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10492,6 +10492,7 @@ dependencies = [
  "axum",
  "clap 3.2.23",
  "expect-test",
+ "fs_extra",
  "hyper",
  "move-package",
  "reqwest",

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -38,6 +38,7 @@ workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]
 expect-test = "1.4.0"
+fs_extra = "1.3.0"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 
 test-utils = { path = "../test-utils" }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    ffi::OsString,
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{ffi::OsString, fs, path::Path, process::Command};
 
 use anyhow::{anyhow, bail};
 use axum::routing::{get, IntoMakeService};
@@ -14,6 +9,7 @@ use axum::{Router, Server};
 use hyper::server::conn::AddrIncoming;
 use serde::Deserialize;
 use std::net::TcpListener;
+use sui_sdk::SuiClient;
 use tracing::info;
 use url::Url;
 
@@ -35,15 +31,14 @@ pub struct Packages {
 }
 
 pub async fn verify_package(
-    context: &WalletContext,
+    client: &SuiClient,
     package_path: impl AsRef<Path>,
 ) -> anyhow::Result<()> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let config = resolve_lock_file_path(
         MoveBuildConfig::default(),
         Some(package_path.as_ref().to_path_buf()),
-    )
-    .unwrap();
+    )?;
     let build_config = BuildConfig {
         config,
         run_bytecode_verifier: false, /* no need to run verifier if code is on-chain */
@@ -53,7 +48,6 @@ pub async fn verify_package(
         .build(package_path.as_ref().to_path_buf())
         .unwrap();
 
-    let client = context.get_client().await?;
     BytecodeSourceVerifier::new(client.read_api())
         .verify_package(
             &compiled_package,
@@ -174,16 +168,36 @@ pub async fn initialize(
     dir: &Path,
 ) -> anyhow::Result<()> {
     clone_repositories(config, dir).await?;
-    verify_packages(context, vec![]).await?;
+    verify_packages(context, config, dir).await?;
     Ok(())
 }
 
 pub async fn verify_packages(
     context: &WalletContext,
-    package_paths: Vec<PathBuf>,
+    config: &Config,
+    dir: &Path,
 ) -> anyhow::Result<()> {
-    for p in package_paths {
-        verify_package(context, p).await?
+    let mut tasks = vec![];
+    for p in &config.packages {
+        let repo_url = Url::parse(&p.repository)?;
+        let Some(components) = repo_url.path_segments().map(|c| c.collect::<Vec<_>>()) else {
+	    bail!("Could not discover repository path in url {}", &p.repository)
+	};
+        let Some(repo_name) = components.last() else {
+	    bail!("Could not discover repository name in url {}", &p.repository)
+	};
+        let packages_dir = dir.join(repo_name);
+        for p in &p.paths {
+            let package_path = packages_dir.join(p).clone();
+            let client = context.get_client().await?;
+            info!("verifying {p}");
+            let t = tokio::spawn(async move { verify_package(&client, package_path).await });
+            tasks.push(t)
+        }
+    }
+
+    for t in tasks {
+        t.await.unwrap()?;
     }
     Ok(())
 }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -65,10 +65,10 @@ pub fn parse_config(config_path: impl AsRef<Path>) -> anyhow::Result<Config> {
 
 pub fn repo_name_from_url(url: &str) -> anyhow::Result<String> {
     let repo_url = Url::parse(url)?;
-    let Some(components) = repo_url.path_segments().map(|c| c.collect::<Vec<_>>()) else {
+    let Some(mut components) = repo_url.path_segments() else {
 	    bail!("Could not discover repository path in url {url}")
 	};
-    let Some(repo_name) = components.last() else {
+    let Some(repo_name) = components.next_back() else {
 	    bail!("Could not discover repository name in url {url}")
     };
 

--- a/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/Move.toml
+++ b/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "MoveStdlib"
+version = "1.5.0"
+published-at = "0x1"
+
+[addresses]
+std = "0x1"

--- a/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/sources/address.move
+++ b/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/sources/address.move
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Dummy module for testing
+module std::address {}

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -53,7 +53,7 @@ Multiple source verification errors found:
 
 - Local dependency did not match its on-chain version at 0000000000000000000000000000000000000000000000000000000000000001::MoveStdlib::address"#
     ];
-    expected.assert_eq(&truncated_error_message);
+    expected.assert_eq(truncated_error_message);
     Ok(())
 }
 

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -7,13 +7,54 @@ use expect_test::expect;
 use reqwest::Client;
 use serde::Deserialize;
 
-use sui_source_validation_service::{initialize, serve, CloneCommand, Config, Packages};
+use sui_source_validation_service::{
+    initialize, serve, verify_packages, CloneCommand, Config, Packages,
+};
 
 use test_utils::network::TestClusterBuilder;
+
+const TEST_FIXTURES_DIR: &str = "tests/fixture";
 
 #[derive(Deserialize)]
 struct Response {
     source: String,
+}
+
+#[tokio::test]
+async fn test_verify_packages() -> anyhow::Result<()> {
+    let mut cluster = TestClusterBuilder::new().build().await;
+    let context = &mut cluster.wallet;
+
+    let config = Config {
+        packages: vec![Packages {
+            repository: "https://github.com/mystenlabs/sui".into(),
+            paths: vec!["move-stdlib".into()],
+        }],
+    };
+
+    let fixtures = tempfile::tempdir()?;
+    fs_extra::dir::copy(
+        PathBuf::from(TEST_FIXTURES_DIR).join("sui"),
+        fixtures.path(),
+        &fs_extra::dir::CopyOptions::default(),
+    )?;
+    let result = verify_packages(context, &config, fixtures.path()).await;
+    let truncated_error_message = &result
+        .unwrap_err()
+        .to_string()
+        .lines()
+        .take(3)
+        .map(|s| s.into())
+        .collect::<Vec<String>>()
+        .join("\n");
+    let expected = expect![
+        r#"
+Multiple source verification errors found:
+
+- Local dependency did not match its on-chain version at 0000000000000000000000000000000000000000000000000000000000000001::MoveStdlib::address"#
+    ];
+    expected.assert_eq(&truncated_error_message);
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -579,7 +579,7 @@ fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
 }
 
 /// Compile and publish package at absolute path `package` to chain.
-async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
+pub async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
     let txn = context.make_publish_transaction(package).await;
     let response = context.execute_transaction_must_succeed(txn).await;
     let package = get_new_package_obj_from_response(&response).unwrap();
@@ -624,7 +624,7 @@ async fn publish_package_and_deps(context: &WalletContext, package: PathBuf) -> 
 
 /// Copy `package` from fixtures into `directory`, setting its named address in the copied package's
 /// `Move.toml` to `address`. (A fixture's self-address is assumed to match its package name).
-async fn copy_published_package<'s>(
+pub async fn copy_published_package<'s>(
     directory: impl AsRef<Path>,
     package: &str,
     address: SuiAddress,

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -579,7 +579,7 @@ fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
 }
 
 /// Compile and publish package at absolute path `package` to chain.
-pub async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
+async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
     let txn = context.make_publish_transaction(package).await;
     let response = context.execute_transaction_must_succeed(txn).await;
     let package = get_new_package_obj_from_response(&response).unwrap();
@@ -624,7 +624,7 @@ async fn publish_package_and_deps(context: &WalletContext, package: PathBuf) -> 
 
 /// Copy `package` from fixtures into `directory`, setting its named address in the copied package's
 /// `Move.toml` to `address`. (A fixture's self-address is assumed to match its package name).
-pub async fn copy_published_package<'s>(
+async fn copy_published_package<'s>(
     directory: impl AsRef<Path>,
     package: &str,
     address: SuiAddress,


### PR DESCRIPTION
## Description 

This hooks up package source verification on server start, for repos in `config`. Each package is processed async. Go by commit for an easier review, the second commit just factors out common code to a helper.

Note on test: we check whether a known-bad variety of `move-stdlib` fails. This is convenient because (a) `move-stdlib` is published in the test cluster setup without any dependencies (b) we can just use a small dummy package to verify against (i.e., not copy, build, and verify something large in the test) (c) it is resilient to changes to `movestdlib` or other `sui-framework` packages published on the test cluster chain.

If we also test against known-good packages, we have to do a lot of test setup similar to what `sui-source-validation` tests already do, which is why I feel comfortable only testing for the known-bad case in the server for now. For example, to replicate that effort would mean publishing packages and fixing up addresses (would want to factor out common functions in `sui-source-validation` for that).

## Test Plan 

See description