### PR TITLE
move: fix source service stderr format

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -140,11 +140,11 @@ impl CloneCommand {
             })?;
             if !result.status.success() {
                 bail!(
-                    "Nonzero exit status when cloning {} with command `git {:#?}`.\
-		     Stderr: {:?}",
+                    "Nonzero exit status when cloning {} with command `git {:#?}`. \
+		     Stderr: {}",
                     self.repo_url,
                     args,
-                    result.stderr
+                    String::from_utf8_lossy(&result.stderr)
                 )
             }
         }


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/12665

Simple fix, noticed `stderr` printed the byte array and not a string.

## Test Plan 

How did you test the new or updated feature?

Manually tested for this strictly debugging feature--we don't want to exercise the actual `git clone` commands in automated tests at this stage.