### PR TITLE
move: source service requires repo branch

### DIFF
--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -1,5 +1,6 @@
 [[packages]]
 repository = "https://github.com/mystenlabs/sui"
+branch = "mainnet-v1.3.1"
 paths = [
     "crates/sui-framework/packages/deepbook",
     "crates/sui-framework/packages/move-stdlib",

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Config {
 #[derive(Clone, Deserialize, Debug)]
 pub struct Packages {
     pub repository: String,
+    pub branch: String,
     pub paths: Vec<String>,
 }
 
@@ -99,9 +100,10 @@ impl CloneCommand {
         // Args to clone empty repository
         let cmd_args: Vec<OsString> = vec![
             ostr!("clone"),
-            ostr!("-n"),
-            ostr!("--depth=1"),
+            ostr!("--no-checkout"),
+            ostr!("--depth=1"), // implies --single-branch
             ostr!("--filter=tree:0"),
+            ostr!(format!("--branch={}", p.branch)),
             ostr!(&p.repository),
             dest.clone(),
         ];

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -28,6 +28,7 @@ async fn test_verify_packages() -> anyhow::Result<()> {
     let config = Config {
         packages: vec![Packages {
             repository: "https://github.com/mystenlabs/sui".into(),
+            branch: "main".into(),
             paths: vec!["move-stdlib".into()],
         }],
     };
@@ -86,6 +87,7 @@ fn test_parse_package_config() -> anyhow::Result<()> {
     let config = r#"
     [[packages]]
     repository = "https://github.com/mystenlabs/sui"
+    branch = "main"
     paths = [
         "crates/sui-framework/packages/deepbook",
         "crates/sui-framework/packages/move-stdlib",
@@ -100,6 +102,7 @@ fn test_parse_package_config() -> anyhow::Result<()> {
     packages: [
         Packages {
             repository: "https://github.com/mystenlabs/sui",
+            branch: "main",
             paths: [
                 "crates/sui-framework/packages/deepbook",
                 "crates/sui-framework/packages/move-stdlib",
@@ -118,6 +121,7 @@ fn test_parse_package_config() -> anyhow::Result<()> {
 fn test_clone_command() -> anyhow::Result<()> {
     let packages = Packages {
         repository: "https://github.com/user/repo".into(),
+        branch: "main".into(),
         paths: vec!["a".into(), "b".into()],
     };
 
@@ -127,9 +131,10 @@ fn test_clone_command() -> anyhow::Result<()> {
     args: [
         [
             "clone",
-            "-n",
+            "--no-checkout",
             "--depth=1",
             "--filter=tree:0",
+            "--branch=main",
             "https://github.com/user/repo",
             "/tmp/repo",
         ],


### PR DESCRIPTION
## Description 

Introduce a `branch` field in `config` when cloning repositories. If we run the server on our code today, it won't verify source successfully (mismatch of `v1.5` framework packages `deepbook` and `sui-framework` due to changes). We'll need this in general for other repositories.

We could also consider supporting commit SHA additionally in future, though that will need a bit of a different translation to `git` commands, so punting for now.

## Test Plan 

Added test