### PR TITLE
[ts sdk] Creating new endpoint for batch faucet

### DIFF
--- a/.changeset/fast-bobcats-sing.md
+++ b/.changeset/fast-bobcats-sing.md
@@ -1,0 +1,17 @@
+---
+'@mysten/wallet-adapter-wallet-standard': minor
+'@mysten/wallet-adapter-unsafe-burner': minor
+'@mysten/wallet-adapter-base': minor
+'@mysten/wallet-adapter-all-wallets': minor
+'@mysten/wallet-kit-core': minor
+'@mysten/wallet-standard': minor
+'@mysten/wallet-kit': minor
+'@mysten/ledgerjs-hw-app-sui': minor
+'@mysten/suins-toolkit': minor
+'@mysten/sui.js': minor
+'@mysten/deepbook': minor
+'@mysten/kiosk': minor
+'@mysten/bcs': minor
+---
+
+Addition of the new faucet batch API implementation

--- a/.changeset/fast-bobcats-sing.md
+++ b/.changeset/fast-bobcats-sing.md
@@ -14,4 +14,4 @@
 '@mysten/bcs': minor
 ---
 
-Addition of the new faucet batch API implementation
+Addition of the new faucet batch API implementation, and renaming of `requestSuiFromFaucet` to `requestSuiFromFaucetV0`

--- a/apps/wallet/configs/environment/.env.defaults
+++ b/apps/wallet/configs/environment/.env.defaults
@@ -4,9 +4,9 @@
 API_ENV=mainnet
 API_ENDPOINT_LOCAL=http://127.0.0.1:5001/
 API_ENDPOINT_LOCAL_FULLNODE=http://127.0.0.1:9000/
-API_ENDPOINT_LOCAL_FAUCET=http://127.0.0.1:9123/gas
+API_ENDPOINT_LOCAL_FAUCET=http://127.0.0.1:9123/
 API_ENDPOINT_DEV_NET_FULLNODE=https://wallet-rpc.devnet.sui.io/
-API_ENDPOINT_DEV_NET_FAUCET=https://faucet.devnet.sui.io/gas
+API_ENDPOINT_DEV_NET_FAUCET=https://faucet.devnet.sui.io/
 API_ENDPOINT_TEST_NET_FULLNODE=https://wallet-rpc.testnet.sui.io/
-API_ENDPOINT_TEST_NET_FAUCET=https://faucet.testnet.sui.io/gas
+API_ENDPOINT_TEST_NET_FAUCET=https://faucet.testnet.sui.io/
 API_ENDPOINT_MAINNET_FULLNODE=https://wallet-rpc.mainnet.sui.io/

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -18,7 +18,7 @@ export function useFaucetMutation(options?: UseFaucetMutationOptions) {
 			if (!address) {
 				throw new Error('Failed, wallet address not found.');
 			}
-			const { error, transferredGasObjects } = await api.requestSuiFromFaucet(address);
+			const { error, transferredGasObjects } = await api.requestSuiFromFaucetV0(address);
 			if (error) {
 				throw new Error(error);
 			}

--- a/apps/wallet/tests/utils/localnet.ts
+++ b/apps/wallet/tests/utils/localnet.ts
@@ -19,5 +19,5 @@ export async function generateKeypair() {
 
 export async function requestingSuiFromFaucet(address: string) {
 	const provider = new JsonRpcProvider(localnetConnection);
-	await provider.requestSuiFromFaucet(address);
+	await provider.requestSuiFromFaucetV0(address);
 }

--- a/doc/src/build/faucet.md
+++ b/doc/src/build/faucet.md
@@ -44,7 +44,7 @@ import { JsonRpcProvider, devnetConnection } from '@mysten/sui.js';
 // connect to Devnet
 const provider = new JsonRpcProvider(devnetConnection);
 // get tokens from the Devnet faucet server
-await provider.requestSuiFromFaucet(
+await provider.requestSuiFromFaucetV0(
   '<YOUR SUI ADDRESS>'
 );
 ```

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -87,7 +87,7 @@ import { JsonRpcProvider, devnetConnection } from '@mysten/sui.js';
 // connect to Devnet
 const provider = new JsonRpcProvider(devnetConnection);
 // get tokens from the DevNet faucet server
-await provider.requestSuiFromFaucet(
+await provider.requestSuiFromFaucetV0(
 	'0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 );
 ```
@@ -99,7 +99,7 @@ import { JsonRpcProvider, localnetConnection } from '@mysten/sui.js';
 // connect to local RPC server
 const provider = new JsonRpcProvider(localnetConnection);
 // get tokens from the local faucet server
-await provider.requestSuiFromFaucet(
+await provider.requestSuiFromFaucetV0(
 	'0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 );
 ```
@@ -116,7 +116,7 @@ const connection = new Connection({
 // connect to a custom RPC server
 const provider = new JsonRpcProvider(connection);
 // get tokens from a custom faucet server
-await provider.requestSuiFromFaucet(
+await provider.requestSuiFromFaucetV0(
 	'0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 );
 ```

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -50,14 +50,20 @@ import {
 	Unsubscribe,
 	ResolvedNameServiceNames,
 	ProtocolConfig,
-} from '../types/index.js';
-import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields.js';
+	BatchFaucetResponse,
+	BatchStatusFaucetResponse,
+} from '../types';
+import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
 import {
 	DEFAULT_CLIENT_OPTIONS,
 	WebsocketClient,
 	WebsocketClientOptions,
-} from '../rpc/websocket-client.js';
-import { requestSuiFromFaucet } from '../rpc/faucet-client.js';
+} from '../rpc/websocket-client';
+import {
+	requestSuiFromFaucetV0,
+	requestSuiFromFaucetV1,
+	getFaucetRequestStatus,
+} from '../rpc/faucet-client';
 import { any, array, string, nullable } from 'superstruct';
 import { fromB58, toB64, toHEX } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature.js';
@@ -151,14 +157,34 @@ export class JsonRpcProvider {
 		return undefined;
 	}
 
-	async requestSuiFromFaucet(
+	async requestSuiFromFaucetV0(
 		recipient: SuiAddress,
 		httpHeaders?: HttpHeaders,
 	): Promise<FaucetResponse> {
 		if (!this.connection.faucet) {
 			throw new Error('Faucet URL is not specified');
 		}
-		return requestSuiFromFaucet(this.connection.faucet, recipient, httpHeaders);
+		return requestSuiFromFaucetV0(this.connection.faucet, recipient, httpHeaders);
+	}
+
+	async requestSuiFromFaucetV1(
+		recipient: SuiAddress,
+		httpHeaders?: HttpHeaders,
+	): Promise<BatchFaucetResponse> {
+		if (!this.connection.faucet) {
+			throw new Error('Faucet URL is not specified');
+		}
+		return requestSuiFromFaucetV1(this.connection.faucet + 'gas', recipient, httpHeaders);
+	}
+
+	async getFaucetRequestStatus(
+		task_id: string,
+		httpHeaders?: HttpHeaders,
+	): Promise<BatchStatusFaucetResponse> {
+		if (!this.connection.faucet) {
+			throw new Error('Faucet URL is not specified');
+		}
+		return getFaucetRequestStatus(this.connection.faucet + 'status', task_id, httpHeaders);
 	}
 
 	/**

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -52,18 +52,18 @@ import {
 	ProtocolConfig,
 	BatchFaucetResponse,
 	BatchStatusFaucetResponse,
-} from '../types';
-import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
+} from '../types/index.js';
+import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields.js';
 import {
 	DEFAULT_CLIENT_OPTIONS,
 	WebsocketClient,
 	WebsocketClientOptions,
-} from '../rpc/websocket-client';
+} from '../rpc/websocket-client.js';
 import {
 	requestSuiFromFaucetV0,
 	requestSuiFromFaucetV1,
 	getFaucetRequestStatus,
-} from '../rpc/faucet-client';
+} from '../rpc/faucet-client.js';
 import { any, array, string, nullable } from 'superstruct';
 import { fromB58, toB64, toHEX } from '@mysten/bcs';
 import { SerializedSignature } from '../cryptography/signature.js';

--- a/sdk/typescript/src/rpc/connection.ts
+++ b/sdk/typescript/src/rpc/connection.ts
@@ -25,14 +25,13 @@ export class Connection {
 	get faucet() {
 		return this.#options.faucet;
 	}
-
 }
 
 // TODO: Maybe don't have pre-built connections, and instead just have pre-built objects that folks
 // can use with the connection?
 export const localnetConnection = new Connection({
 	fullnode: 'http://127.0.0.1:9000',
-	faucet: 'http://127.0.0.1:9123',
+	faucet: 'http://127.0.0.1:9123/',
 });
 
 export const devnetConnection = new Connection({

--- a/sdk/typescript/src/rpc/connection.ts
+++ b/sdk/typescript/src/rpc/connection.ts
@@ -25,23 +25,24 @@ export class Connection {
 	get faucet() {
 		return this.#options.faucet;
 	}
+
 }
 
 // TODO: Maybe don't have pre-built connections, and instead just have pre-built objects that folks
 // can use with the connection?
 export const localnetConnection = new Connection({
 	fullnode: 'http://127.0.0.1:9000',
-	faucet: 'http://127.0.0.1:9123/gas',
+	faucet: 'http://127.0.0.1:9123',
 });
 
 export const devnetConnection = new Connection({
 	fullnode: 'https://fullnode.devnet.sui.io:443/',
-	faucet: 'https://faucet.devnet.sui.io/gas',
+	faucet: 'https://faucet.devnet.sui.io/',
 });
 
 export const testnetConnection = new Connection({
 	fullnode: 'https://fullnode.testnet.sui.io:443/',
-	faucet: 'https://faucet.testnet.sui.io/gas',
+	faucet: 'https://faucet.testnet.sui.io/',
 });
 
 export const mainnetConnection = new Connection({

--- a/sdk/typescript/src/rpc/faucet-client.ts
+++ b/sdk/typescript/src/rpc/faucet-client.ts
@@ -6,9 +6,9 @@ import {
 	SuiAddress,
 	BatchFaucetResponse,
 	BatchStatusFaucetResponse,
-} from '../types';
-import { FaucetRateLimitError } from '../utils/errors';
-import { HttpHeaders } from './client';
+} from '../types/index.js';
+import { FaucetRateLimitError } from '../utils/errors.js';
+import { HttpHeaders } from './client.js';
 
 export async function requestSuiFromFaucetV0(
 	endpoint: string,

--- a/sdk/typescript/src/rpc/faucet-client.ts
+++ b/sdk/typescript/src/rpc/faucet-client.ts
@@ -1,20 +1,99 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { FaucetResponse, SuiAddress } from '../types/index.js';
-import { FaucetRateLimitError } from '../utils/errors.js';
-import { HttpHeaders } from './client.js';
+import {
+	FaucetResponse,
+	SuiAddress,
+	BatchFaucetResponse,
+	BatchStatusFaucetResponse,
+} from '../types';
+import { FaucetRateLimitError } from '../utils/errors';
+import { HttpHeaders } from './client';
 
-export async function requestSuiFromFaucet(
+export async function requestSuiFromFaucetV0(
 	endpoint: string,
 	recipient: SuiAddress,
 	httpHeaders?: HttpHeaders,
 ): Promise<FaucetResponse> {
-	const res = await fetch(endpoint, {
+	const res = await fetch(endpoint + 'gas', {
 		method: 'POST',
 		body: JSON.stringify({
 			FixedAmountRequest: {
 				recipient,
+			},
+		}),
+		headers: {
+			'Content-Type': 'application/json',
+			...(httpHeaders || {}),
+		},
+	});
+
+	if (res.status === 429) {
+		throw new FaucetRateLimitError(
+			`Too many requests from this client have been sent to the faucet. Please retry later`,
+		);
+	}
+	let parsed;
+	try {
+		parsed = await res.json();
+	} catch (e) {
+		throw new Error(
+			`Encountered error when parsing response from faucet, error: ${e}, status ${res.status}, response ${res}`,
+		);
+	}
+	if (parsed.error) {
+		throw new Error(`Faucet returns error: ${parsed.error}`);
+	}
+	return parsed;
+}
+
+export async function requestSuiFromFaucetV1(
+	endpoint: string,
+	recipient: SuiAddress,
+	httpHeaders?: HttpHeaders,
+): Promise<BatchFaucetResponse> {
+	const res = await fetch(endpoint + 'v1/gas', {
+		method: 'POST',
+		body: JSON.stringify({
+			FixedAmountRequest: {
+				recipient,
+			},
+		}),
+		headers: {
+			'Content-Type': 'application/json',
+			...(httpHeaders || {}),
+		},
+	});
+
+	if (res.status === 429) {
+		throw new FaucetRateLimitError(
+			`Too many requests from this client have been sent to the faucet. Please retry later`,
+		);
+	}
+	let parsed;
+	try {
+		parsed = await res.json();
+	} catch (e) {
+		throw new Error(
+			`Encountered error when parsing response from faucet, error: ${e}, status ${res.status}, response ${res}`,
+		);
+	}
+	if (parsed.error) {
+		throw new Error(`Faucet returns error: ${parsed.error}`);
+	}
+	return parsed;
+}
+
+export async function getFaucetRequestStatus(
+	endpoint: string,
+	task_id: string,
+	httpHeaders?: HttpHeaders,
+): Promise<BatchStatusFaucetResponse> {
+	const res = await fetch(endpoint + 'v1/status', {
+		method: 'POST',
+		body: JSON.stringify({
+			task_id: {
+				task_id,
 			},
 		}),
 		headers: {

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -18,10 +18,10 @@ import {
 	SuiTransactionBlockResponseOptions,
 	BatchFaucetResponse,
 	BatchStatusFaucetResponse,
-} from '../types';
-import { IntentScope, messageWithIntent } from '../utils/intent';
-import { Signer } from './signer';
-import { SignedTransaction, SignedMessage } from './types';
+} from '../types/index.js';
+import { IntentScope, messageWithIntent } from '../utils/intent.js';
+import { Signer } from './signer.js';
+import { SignedTransaction, SignedMessage } from './types.js';
 
 ///////////////////////////////
 // Exported Abstracts

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -16,10 +16,12 @@ import {
 	DryRunTransactionBlockResponse,
 	SuiTransactionBlockResponse,
 	SuiTransactionBlockResponseOptions,
-} from '../types/index.js';
-import { IntentScope, messageWithIntent } from '../utils/intent.js';
-import { Signer } from './signer.js';
-import { SignedTransaction, SignedMessage } from './types.js';
+	BatchFaucetResponse,
+	BatchStatusFaucetResponse,
+} from '../types';
+import { IntentScope, messageWithIntent } from '../utils/intent';
+import { Signer } from './signer';
+import { SignedTransaction, SignedMessage } from './types';
 
 ///////////////////////////////
 // Exported Abstracts
@@ -49,8 +51,24 @@ export abstract class SignerWithProvider implements Signer {
 	 * address
 	 * @param httpHeaders optional request headers
 	 */
-	async requestSuiFromFaucet(httpHeaders?: HttpHeaders): Promise<FaucetResponse> {
-		return this.provider.requestSuiFromFaucet(await this.getAddress(), httpHeaders);
+	async requestSuiFromFaucetV0(httpHeaders?: HttpHeaders): Promise<FaucetResponse> {
+		return this.provider.requestSuiFromFaucetV0(await this.getAddress(), httpHeaders);
+	}
+
+	/**
+	 * Request gas tokens from a faucet server and send to the signer
+	 * address. This newer function uses batched functionality and returns a 202 (ACCEPTED) status.
+	 * @param httpHeaders optional request headers
+	 */
+	async requestSuiFromFaucetV1(httpHeaders?: HttpHeaders): Promise<BatchFaucetResponse> {
+		return this.provider.requestSuiFromFaucetV1(await this.getAddress(), httpHeaders);
+	}
+
+	async getFaucetRequestStatus(
+		task_id: string,
+		httpHeaders?: HttpHeaders,
+	): Promise<BatchStatusFaucetResponse> {
+		return this.provider.getFaucetRequestStatus(task_id, httpHeaders);
 	}
 
 	constructor(provider: JsonRpcProvider) {

--- a/sdk/typescript/src/types/faucet.ts
+++ b/sdk/typescript/src/types/faucet.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { array, nullable, number, object, Infer, string, union, literal } from 'superstruct';
-import { TransactionDigest, ObjectId } from './common';
+import { TransactionDigest, ObjectId } from './common.js';
 
 export const FaucetCoinInfo = object({
 	amount: number(),

--- a/sdk/typescript/src/types/faucet.ts
+++ b/sdk/typescript/src/types/faucet.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, nullable, number, object, Infer, string } from 'superstruct';
-import { TransactionDigest, ObjectId } from './common.js';
+import { array, nullable, number, object, Infer, string, union, literal } from 'superstruct';
+import { TransactionDigest, ObjectId } from './common';
 
 export const FaucetCoinInfo = object({
 	amount: number(),
@@ -18,3 +18,24 @@ export const FaucetResponse = object({
 });
 
 export type FaucetResponse = Infer<typeof FaucetResponse>;
+
+export const BatchFaucetResponse = object({
+	task: nullable(string()),
+	error: nullable(string()),
+});
+
+export type BatchFaucetResponse = Infer<typeof BatchFaucetResponse>;
+
+export const BatchSendStatusType = union([
+	literal('INPROGRESS'),
+	literal('SUCCEEDED'),
+	literal('DISCARDED'),
+]);
+export type BatchSendStatusType = Infer<typeof BatchSendStatusType>;
+
+export const BatchStatusFaucetResponse = object({
+	status: BatchSendStatusType,
+	error: nullable(string()),
+});
+
+export type BatchStatusFaucetResponse = Infer<typeof BatchStatusFaucetResponse>;

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -83,7 +83,7 @@ export async function setup() {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
 	const provider = getProvider();
-	const resp = await retry(() => provider.requestSuiFromFaucet(address), {
+	const resp = await retry(() => provider.requestSuiFromFaucetV0(address), {
 		backoff: 'EXPONENTIAL',
 		// overall timeout in 60 seconds
 		timeout: 1000 * 60,

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -69,7 +69,7 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
 	async connect() {
 		this.connecting = true;
 		try {
-			this.#signer.requestSuiFromFaucet();
+			this.#signer.requestSuiFromFaucetV0();
 		} catch (e) {
 			console.warn(
 				'Failed to request Sui from the faucet. This may prevent transactions from being submitted.',


### PR DESCRIPTION
## Description 

Addition of the faucet batch endpoint for the TS sdk as a part of https://github.com/MystenLabs/sui/pull/12257

we added the `v1/gas` and `v1/status` endpoints.

## Test Plan 

How did you test the new or updated feature?
locally

Local button still works: 
![image](https://github.com/MystenLabs/sui/assets/123408603/cfc5f8bd-2cc6-47cb-832a-3861173e0d1f)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
