### PR TITLE
move post processing before critical commits

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -231,6 +231,7 @@ pub struct AuthorityMetrics {
     post_processing_total_events_emitted: IntCounter,
     post_processing_total_tx_indexed: IntCounter,
     post_processing_total_tx_had_event_processed: IntCounter,
+    post_processing_total_failures: IntCounter,
 
     pending_notify_read: IntGauge,
 
@@ -504,6 +505,12 @@ impl AuthorityMetrics {
             post_processing_total_tx_had_event_processed: register_int_counter_with_registry!(
                 "post_processing_total_tx_had_event_processed",
                 "Total number of txes finished event processing in post processing",
+                registry,
+            )
+            .unwrap(),
+            post_processing_total_failures: register_int_counter_with_registry!(
+                "post_processing_total_failures",
+                "Total number of failure in post processing",
                 registry,
             )
             .unwrap(),
@@ -1101,17 +1108,7 @@ impl AuthorityState {
             .map(|(_, ((id, seq, _), obj, _))| InputKey(*id, (!obj.is_package()).then_some(*seq)))
             .collect();
 
-        let events = inner_temporary_store.events.clone();
-
-        let loaded_child_objects = if self.is_fullnode(epoch_store) {
-            // We only care about this for full nodes
-            inner_temporary_store.loaded_child_objects.clone()
-        } else {
-            BTreeMap::new()
-        };
-
-        let tx_coins = self
-            .commit_certificate(inner_temporary_store, certificate, effects, epoch_store)
+        self.commit_certificate(inner_temporary_store, certificate, effects, epoch_store)
             .await?;
 
         // commit_certificate finished, the tx is fully committed to the store.
@@ -1126,19 +1123,6 @@ impl AuthorityState {
         // before the output objects are actually available.
         self.transaction_manager
             .notify_commit(&digest, output_keys, epoch_store);
-
-        // index certificate
-        let _ = self
-            .post_process_one_tx(
-                certificate,
-                effects,
-                &events,
-                epoch_store,
-                tx_coins,
-                loaded_child_objects,
-            )
-            .await
-            .tap_err(|e| error!("tx post processing failed: {e}"));
 
         // Update metrics.
         self.metrics.total_effects.inc();
@@ -1527,10 +1511,11 @@ impl AuthorityState {
         timestamp_ms: u64,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         tx_coins: Option<TxCoins>,
+        written: &WrittenObjects,
         loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
     ) -> SuiResult<u64> {
         let changes = self
-            .process_object_index(effects, epoch_store)
+            .process_object_index(digest, effects, epoch_store, written)
             .tap_err(|e| warn!(tx_digest=?digest, "Failed to process object index, index_tx is skipped: {e}"))?;
 
         indexes
@@ -1566,8 +1551,10 @@ impl AuthorityState {
 
     fn process_object_index(
         &self,
+        tx_digest: &TransactionDigest,
         effects: &TransactionEffects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        written: &WrittenObjects,
     ) -> SuiResult<ObjectIndexChanges> {
         let modified_at_version = effects
             .modified_at_versions()
@@ -1579,8 +1566,11 @@ impl AuthorityState {
         let mut deleted_dynamic_fields = vec![];
         for (id, _, _) in effects.deleted().iter().chain(effects.wrapped()) {
             let old_version = modified_at_version.get(id).unwrap();
-
-            match self.get_owner_at_version(id, *old_version)? {
+            // When we process the index, the latest object hasn't been written yet so
+            // the old object must be present.
+            match self.get_owner_at_version(id, *old_version).unwrap_or_else(
+                |e| panic!("tx_digest={:?}, error processing object owner index, cannot find owner for object {:?} at version {:?}. Err: {:?}", tx_digest, id, old_version, e),
+            ) {
                 Owner::AddressOwner(addr) => deleted_owners.push((addr, *id)),
                 Owner::ObjectOwner(object_id) => {
                     deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
@@ -1596,14 +1586,14 @@ impl AuthorityState {
             let id = &oref.0;
             // For mutated objects, retrieve old owner and delete old index if there is a owner change.
             if let WriteKind::Mutate = kind {
-                let Some(old_version) = modified_at_version.get(id) else{
-                        error!("Error processing object owner index for tx [{:?}], cannot find modified at version for mutated object [{id}].", effects.transaction_digest());
-                        continue;
-                    };
+                let Some(old_version) = modified_at_version.get(id) else {
+                    panic!("tx_digest={:?}, error processing object owner index, cannot find modified at version for mutated object [{id}].", tx_digest);
+                };
+                // When we process the index, the latest object hasn't been written yet so
+                // the old object must be present.
                 let Some(old_object) = self.database.get_object_by_key(id, *old_version)? else {
-                        error!("Error processing object owner index for tx [{:?}], cannot find object [{id}] at version [{old_version}].", effects.transaction_digest());
-                        continue;
-                    };
+                    panic!("tx_digest={:?}, error processing object owner index, cannot find owner for object {:?} at version {:?}", tx_digest, id, old_version);
+                };
                 if &old_object.owner != owner {
                     match old_object.owner {
                         Owner::AddressOwner(addr) => {
@@ -1620,11 +1610,13 @@ impl AuthorityState {
             match owner {
                 Owner::AddressOwner(addr) => {
                     // TODO: We can remove the object fetching after we added ObjectType to TransactionEffects
-                    let Some(o) = self.database.get_object_by_key(id, oref.1)? else{
-                        continue;
-                    };
+                    let new_object = written.get(id).unwrap_or_else(
+                        || panic!("tx_digest={:?}, error processing object owner index, written does not contain object {:?}", tx_digest, id)
+                    );
+                    assert_eq!(new_object.0.1, oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched verison. Actual: {}, expected: {}", tx_digest, id, new_object.0.1, oref.1);
 
-                    let type_ = o
+                    let type_ = new_object
+                        .1
                         .type_()
                         .map(|type_| ObjectType::Struct(type_.clone()))
                         .unwrap_or(ObjectType::Package);
@@ -1642,10 +1634,12 @@ impl AuthorityState {
                     ));
                 }
                 Owner::ObjectOwner(owner) => {
-                    let Some(o) = self.database.get_object_by_key(&oref.0, oref.1)? else{
-                        continue;
-                    };
-                    let Some(df_info) = self.try_create_dynamic_field_info(&o, epoch_store)? else{
+                    let new_object = written.get(id).unwrap_or_else(
+                        || panic!("tx_digest={:?}, error processing object owner index, written does not contain object {:?}", tx_digest, id)
+                    );
+                    assert_eq!(new_object.0.1, oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched verison. Actual: {}, expected: {}", tx_digest, id, new_object.0.1, oref.1);
+
+                    let Some(df_info) = self.try_create_dynamic_field_info(&new_object.1, epoch_store)? else{
                         // Skip indexing for non dynamic field objects.
                         continue;
                     };
@@ -1740,6 +1734,7 @@ impl AuthorityState {
         events: &TransactionEvents,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         tx_coins: Option<TxCoins>,
+        written: &WrittenObjects,
         loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
     ) -> SuiResult {
         if self.indexes.is_none() {
@@ -1760,6 +1755,7 @@ impl AuthorityState {
                     timestamp_ms,
                     epoch_store,
                     tx_coins,
+                    written,
                     loaded_child_objects,
                 )
                 .await
@@ -3105,10 +3101,6 @@ impl AuthorityState {
         Ok(checkpoints)
     }
 
-    pub async fn get_timestamp_ms(&self, digest: &TransactionDigest) -> SuiResult<Option<u64>> {
-        self.get_indexes()?.get_timestamp_ms(digest)
-    }
-
     pub fn query_events(
         &self,
         query: EventFilter,
@@ -3455,7 +3447,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<Option<TxCoins>> {
+    ) -> SuiResult {
         let _metrics_guard = self.metrics.commit_certificate_latency.start_timer();
 
         let tx_digest = certificate.digest();
@@ -3472,9 +3464,33 @@ impl AuthorityState {
             None
         };
 
+        let loaded_child_objects = if self.is_fullnode(epoch_store) {
+            // We only care about this for full nodes
+            inner_temporary_store.loaded_child_objects.clone()
+        } else {
+            BTreeMap::new()
+        };
+
         // Returns coin objects for indexing for fullnode if indexing is enabled.
         let tx_coins =
             self.fullnode_only_get_tx_coins_for_indexing(&inner_temporary_store, epoch_store);
+
+        // index certificate
+        let _ = self
+            .post_process_one_tx(
+                certificate,
+                effects,
+                &inner_temporary_store.events,
+                epoch_store,
+                tx_coins,
+                &inner_temporary_store.written,
+                loaded_child_objects,
+            )
+            .await
+            .tap_err(|e| {
+                self.metrics.post_processing_total_failures.inc();
+                error!(?tx_digest, "tx post processing failed: {e}");
+            });
 
         // The insertion to epoch_store is not atomic with the insertion to the perpetual store. This is OK because
         // we insert to the epoch store first. And during lookups we always look up in the perpetual store first.
@@ -3506,7 +3522,7 @@ impl AuthorityState {
             .pending_notify_read
             .set(self.database.executed_effects_notify_read.num_pending() as i64);
 
-        Ok(tx_coins)
+        Ok(())
     }
 
     /// Get the TransactionEnvelope that currently locks the given object, if any.

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -73,10 +73,6 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
 
     assert_eq!(object.owner.get_owner_address().unwrap(), receiver);
 
-    // timestamp is recorded
-    let ts = fullnode.state().get_timestamp_ms(&digest).await?;
-    assert!(ts.is_some());
-
     Ok(())
 }
 
@@ -301,10 +297,6 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         false,
     )?;
     assert_eq!(txes.len(), 0);
-
-    // timestamp is recorded
-    let ts = node.state().get_timestamp_ms(&digest).await?;
-    assert!(ts.is_some());
 
     // This is a poor substitute for the post processing taking some time
     // Unfortunately event store writes seem to add some latency so this wait is needed
@@ -693,10 +685,6 @@ async fn test_full_node_event_read_api_ok() {
         assert_eq!(txes.len(), 1);
         assert_eq!(txes[0], digest);
     }
-
-    // timestamp is recorded
-    let ts = node.state().get_timestamp_ms(&digest).await.unwrap();
-    assert!(ts.is_some());
 
     // This is a poor substitute for the post processing taking some time
     sleep(Duration::from_millis(1000)).await;

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -155,8 +155,10 @@ pub struct IndexStoreTables {
     /// **milliseconds** since epoch 1/1/1970). A transaction digest is subjectively time stamped
     /// on a node according to the local machine time, so it varies across nodes.
     /// The timestamping happens when the node sees a txn certificate for the first time.
+    ///
+    /// DEPRECATED. DO NOT USE
     #[default_options_override_fn = "timestamps_table_default_config"]
-    timestamps: DBMap<TransactionDigest, u64>,
+    _timestamps: DBMap<TransactionDigest, u64>,
 
     /// Ordering of all indexed transactions.
     #[default_options_override_fn = "transactions_order_table_default_config"]
@@ -483,11 +485,6 @@ impl IndexStore {
             }),
         )?;
 
-        batch.insert_batch(
-            &self.tables.timestamps,
-            std::iter::once((*digest, timestamp_ms)),
-        )?;
-
         // Coin Index
         let cache_updates = self
             .index_coin(digest, &mut batch, &object_index_changes, tx_coins)
@@ -702,15 +699,6 @@ impl IndexStore {
             .loaded_child_object_versions
             .get(transaction_digest)
             .map_err(|err| err.into())
-    }
-
-    /// Returns unix timestamp for a transaction if it exists
-    pub fn get_timestamp_ms(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<u64>> {
-        let ts = self.tables.timestamps.get(transaction_digest)?;
-        Ok(ts)
     }
 
     fn get_transactions_from_index<KeyT: Clone + Serialize + DeserializeOwned + PartialEq>(

--- a/crates/sui-tool/src/db_tool/index_search.rs
+++ b/crates/sui-tool/src/db_tool/index_search.rs
@@ -87,14 +87,6 @@ pub fn search_index(
                 termination
             )
         }
-        "timestamps" => {
-            get_db_entries!(
-                db_read_only_handle.timestamps,
-                TransactionDigest::from_str,
-                start,
-                termination
-            )
-        }
         "transaction_order" => {
             get_db_entries!(
                 db_read_only_handle.transaction_order,


### PR DESCRIPTION
## Description 

1. move post processing before critical commits. This makes sure the post processing wouldn't run out of causal order.
2. change some `continue`s to panic so bugs will scream loudly.
3. pass `inner_temp_store.written` to post processing code such that latest objects become accessible without looking into DB (which is not ready at that point)
4. deprecates `timestamps` indexer column which is not meaningful and in use.

## Test Plan 

Apply this to 1.4.0 and resync from genesis. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This change is fullnode only and does not impact validator. If a fullnode serves RPC requests based on secondary indices, they may want to re-sync from genesis with this binary to calculate all the data right. There will also be a snapshot ready for consumption.