### PR TITLE
Fix broken image fallback

### DIFF
--- a/apps/explorer/src/ui/ImageIcon.tsx
+++ b/apps/explorer/src/ui/ImageIcon.tsx
@@ -43,11 +43,11 @@ export function ImageIcon({ src, label, alt = label, fallback, ...styleProps }: 
 	const [error, setError] = useState(false);
 	return (
 		<div role="img" className={imageStyle(styleProps)} aria-label={label}>
-			{error ? (
+			{error || !src || src === '' ? (
 				<FallBackAvatar fallback={fallback} />
 			) : (
 				<img
-					src={src || ''}
+					src={src}
 					alt={alt}
 					className="flex h-full w-full items-center justify-center object-contain"
 					onError={() => setError(true)}

--- a/apps/wallet/src/ui/app/shared/image-icon/index.tsx
+++ b/apps/wallet/src/ui/app/shared/image-icon/index.tsx
@@ -43,7 +43,7 @@ export function ImageIcon({ src, label, alt = label, fallback, ...styleProps }: 
 	const [error, setError] = useState(false);
 	return (
 		<div role="img" className={imageStyle(styleProps)} aria-label={label}>
-			{error ? (
+			{error || !src || src === '' ? (
 				<FallBackAvatar str={fallback} />
 			) : (
 				<img


### PR DESCRIPTION
## Description 

Whenever browsing between pages/screens in Explorer and Wallet, the fallback avatar sometime does not show. This addresses it by checking for the URL string before rendering the image 

Fixes this 
<img width="1477" alt="Screenshot 2023-06-25 at 6 54 00 PM" src="https://github.com/MystenLabs/sui/assets/126525197/b8706f58-88d0-4277-8464-6983e2b6b193">
