### PR TITLE
Cherrypick #12682 to v1.4.0 release

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -780,6 +780,8 @@ impl AuthorityState {
         );
 
         // Lock this down to 0x6 before we pin child versions in effects
+        // Also, this logic is incompatible with TransactionManager AvailableObjectCache,
+        // so SUI_CLOCK_OBJECT_ID is currently excluded from the cache.
         let objects = objects
             .into_iter()
             .filter(|o| o.id() == SUI_CLOCK_OBJECT_ID)


### PR DESCRIPTION
## Description 

This avoids fullnodes from crashing when it is lagging behind and executing a transaction using clock input.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
