### PR TITLE
Disable expensive_safety_check_config in release build by default

### DIFF
--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use sui_config::local_ip_utils;
-use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_swarm_config::node_config_builder::FullnodeConfigBuilder;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -137,9 +136,6 @@ impl Env {
 
                 let node_config = FullnodeConfigBuilder::new()
                     .with_rpc_port(fullnode_rpc_port)
-                    .with_expensive_safety_check_config(
-                        ExpensiveSafetyCheckConfig::new_disable_all(),
-                    )
                     .build(&mut OsRng, &cloned_config);
                 let node = sui_swarm::memory::Node::new(node_config);
                 node.start().await.unwrap();

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -142,7 +142,8 @@ impl ValidatorConfigBuilder {
             supported_protocol_versions: self.supported_protocol_versions,
             db_checkpoint_config: Default::default(),
             indirect_objects_threshold: usize::MAX,
-            expensive_safety_check_config: ExpensiveSafetyCheckConfig::new_enable_all(),
+            // By default, expensive checks will be enabled in debug build, but not in release build.
+            expensive_safety_check_config: ExpensiveSafetyCheckConfig::default(),
             name_service_package_address: None,
             name_service_registry_id: None,
             name_service_reverse_registry_id: None,

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -77,12 +77,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -168,12 +168,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -259,12 +259,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -350,12 +350,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -441,12 +441,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -532,12 +532,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -623,12 +623,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false


### PR DESCRIPTION
## Description 

It was a mistake for me to make this enabled by default, especially given that the default config already enables it in debug build.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
