### PR TITLE
indexer: populate queried tx based on options again

### DIFF
--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use futures::future::join_all;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::types::SubscriptionResult;
@@ -12,15 +13,13 @@ use jsonrpsee::{RpcModule, SubscriptionSink};
 
 use move_core_types::identifier::Identifier;
 use sui_core::event_handler::SubscriptionHandler;
-use sui_json_rpc::api::{
-    validate_limit, IndexerApiClient, IndexerApiServer, QUERY_MAX_RESULT_LIMIT,
-};
+use sui_json_rpc::api::{cap_page_limit, IndexerApiClient, IndexerApiServer};
 use sui_json_rpc::indexer_api::spawn_subscription;
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page, SuiObjectDataFilter,
-    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseQuery, TransactionBlocksPage, TransactionFilter,
+    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponseQuery,
+    TransactionBlocksPage, TransactionFilter,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -72,56 +71,32 @@ impl<S: IndexerStore> IndexerApi<S> {
         limit: Option<usize>,
         descending_order: Option<bool>,
     ) -> Result<TransactionBlocksPage, IndexerError> {
-        let limit = validate_limit(limit, *QUERY_MAX_RESULT_LIMIT)?;
+        let limit = cap_page_limit(limit);
         let is_descending = descending_order.unwrap_or_default();
         let cursor_str = cursor.map(|digest| digest.to_string());
-        let mut tx_digests_from_db = match query.filter {
+        let mut tx_vec_from_db = match query.filter {
             None => {
                 let indexer_seq_number = self
                     .state
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)
                     .await?;
-                let tx_vec = self
-                    .state
+                self.state
                     .get_all_transaction_page(indexer_seq_number, limit + 1, is_descending)
-                    .await?;
-                tx_vec
-                    .into_iter()
-                    .map(|tx| {
-                        tx.transaction_digest.parse().map_err(|e| {
-                            IndexerError::InsertableParsingError(format!(
-                                "Failed to parse transaction digest {} : {:?}",
-                                tx.transaction_digest, e
-                            ))
-                        })
-                    })
-                    .collect::<Result<Vec<TransactionDigest>, _>>()?
+                    .await
             }
             Some(TransactionFilter::Checkpoint(checkpoint_id)) => {
                 let indexer_seq_number = self
                     .state
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)
                     .await?;
-                let tx_vec = self
-                    .state
+                self.state
                     .get_transaction_page_by_checkpoint(
                         checkpoint_id as i64,
                         indexer_seq_number,
                         limit + 1,
                         is_descending,
                     )
-                    .await?;
-                tx_vec
-                    .into_iter()
-                    .map(|tx| {
-                        tx.transaction_digest.parse().map_err(|e| {
-                            IndexerError::InsertableParsingError(format!(
-                                "Failed to parse transaction digest {} : {:?}",
-                                tx.transaction_digest, e
-                            ))
-                        })
-                    })
-                    .collect::<Result<Vec<TransactionDigest>, _>>()?
+                    .await
             }
             Some(TransactionFilter::MoveFunction {
                 package,
@@ -157,7 +132,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                         limit + 1,
                         is_descending,
                     )
-                    .await?
+                    .await
             }
             Some(TransactionFilter::InputObject(input_obj_id)) => {
                 let input_obj_seq = self
@@ -172,7 +147,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                         limit + 1,
                         is_descending,
                     )
-                    .await?
+                    .await
             }
             Some(TransactionFilter::ChangedObject(mutated_obj_id)) => {
                 let indexer_seq_number = self
@@ -187,7 +162,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                         limit + 1,
                         is_descending,
                     )
-                    .await?
+                    .await
             }
             // NOTE: more efficient to run this query over transactions table
             Some(TransactionFilter::FromAddress(sender_address)) => {
@@ -195,26 +170,14 @@ impl<S: IndexerStore> IndexerApi<S> {
                     .state
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)
                     .await?;
-                let tx_vec = self
-                    .state
+                self.state
                     .get_transaction_page_by_sender_address(
                         sender_address.to_string(),
                         indexer_seq_number,
                         limit + 1,
                         is_descending,
                     )
-                    .await?;
-                tx_vec
-                    .into_iter()
-                    .map(|tx| {
-                        tx.transaction_digest.parse().map_err(|e| {
-                            IndexerError::InsertableParsingError(format!(
-                                "Failed to parse transaction digest {} : {:?}",
-                                tx.transaction_digest, e
-                            ))
-                        })
-                    })
-                    .collect::<Result<Vec<TransactionDigest>, _>>()?
+                    .await
             }
             Some(TransactionFilter::ToAddress(recipient_address)) => {
                 let recipient_seq_number = self
@@ -229,7 +192,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                         limit + 1,
                         is_descending,
                     )
-                    .await?
+                    .await
             }
             Some(TransactionFilter::FromAndToAddress { from, to }) => {
                 let recipient_seq_number = self
@@ -244,7 +207,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                         limit + 1,
                         is_descending,
                     )
-                    .await?
+                    .await
             }
             Some(TransactionFilter::FromOrToAddress { addr }) => {
                 let start_sequence = self
@@ -253,47 +216,53 @@ impl<S: IndexerStore> IndexerApi<S> {
                     .await?;
                 self.state
                     .get_transaction_page_by_address(addr, start_sequence, limit, is_descending)
-                    .await?
+                    .await
             }
             Some(TransactionFilter::TransactionKind(tx_kind_name)) => {
                 let indexer_seq_number = self
                     .state
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)
                     .await?;
-                let tx_vec = self
-                    .state
+                self.state
                     .get_transaction_page_by_transaction_kind(
                         tx_kind_name,
                         indexer_seq_number,
                         limit + 1,
                         is_descending,
                     )
-                    .await?;
-                tx_vec
-                    .into_iter()
-                    .map(|tx| {
-                        tx.transaction_digest.parse().map_err(|e| {
-                            IndexerError::InsertableParsingError(format!(
-                                "Failed to parse transaction digest {} : {:?}",
-                                tx.transaction_digest, e
-                            ))
-                        })
-                    })
-                    .collect::<Result<Vec<TransactionDigest>, _>>()?
+                    .await
             }
-        };
+        }?;
 
-        let has_next_page = tx_digests_from_db.len() > limit;
-        tx_digests_from_db.truncate(limit);
-        let next_cursor = tx_digests_from_db.last().cloned();
+        let has_next_page = tx_vec_from_db.len() > limit;
+        tx_vec_from_db.truncate(limit);
+        let next_cursor = tx_vec_from_db
+            .last()
+            .cloned()
+            .map(|tx| {
+                let digest = tx.transaction_digest;
+                let tx_digest: Result<TransactionDigest, _> = digest.parse();
+                tx_digest.map_err(|e| {
+                    IndexerError::SerdeError(format!(
+                        "Failed to deserialize transaction digest: {:?} with error {:?}",
+                        digest, e
+                    ))
+                })
+            })
+            .transpose()?
+            .map_or(cursor, Some);
 
-        let sui_tx_resps = tx_digests_from_db
+        let tx_resp_futures = tx_vec_from_db.into_iter().map(|tx| {
+            self.state
+                .compose_sui_transaction_block_response(tx, query.options.as_ref())
+        });
+        let sui_tx_resp_vec = join_all(tx_resp_futures)
+            .await
             .into_iter()
-            .map(SuiTransactionBlockResponse::new)
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Page {
-            data: sui_tx_resps,
+            data: sui_tx_resp_vec,
             next_cursor,
             has_next_page,
         })
@@ -322,7 +291,7 @@ impl<S: IndexerStore> IndexerApi<S> {
             None => Ok((address, None)),
         }?;
         let options = options.unwrap_or_default();
-        let limit = validate_limit(limit, *QUERY_MAX_RESULT_LIMIT)?;
+        let limit = cap_page_limit(limit);
 
         // NOTE: fetch one more object to check if there is next page
         let mut objects = self

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -11,7 +11,7 @@ use sui_json_rpc_types::{
     SuiTransactionBlockResponseOptions,
 };
 use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, SuiAddress, VersionNumber};
-use sui_types::digests::{CheckpointDigest, TransactionDigest};
+use sui_types::digests::CheckpointDigest;
 use sui_types::error::SuiError;
 use sui_types::event::EventID;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -131,7 +131,7 @@ pub trait IndexerStore {
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
-    ) -> Result<Vec<TransactionDigest>, IndexerError>;
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     // `address` can be either sender or recipient address of the transaction
     async fn get_transaction_page_by_address(
@@ -140,7 +140,7 @@ pub trait IndexerStore {
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
-    ) -> Result<Vec<TransactionDigest>, IndexerError>;
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     async fn get_transaction_page_by_input_object(
         &self,
@@ -149,7 +149,7 @@ pub trait IndexerStore {
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
-    ) -> Result<Vec<TransactionDigest>, IndexerError>;
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     async fn get_transaction_page_by_changed_object(
         &self,
@@ -158,7 +158,7 @@ pub trait IndexerStore {
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
-    ) -> Result<Vec<TransactionDigest>, IndexerError>;
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     async fn get_transaction_page_by_move_call(
         &self,
@@ -168,7 +168,7 @@ pub trait IndexerStore {
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
-    ) -> Result<Vec<TransactionDigest>, IndexerError>;
+    ) -> Result<Vec<Transaction>, IndexerError>;
 
     async fn get_transaction_sequence_by_digest(
         &self,


### PR DESCRIPTION
## Description 

- I was dumb and thought that we only need digests, but playing production traffic showed otherwise :(
this PR is essentially reverting #12657 other than some minor changes.

- also fixed the issue that tx fetched from `transactions` table does not follow the input digest order
- also changed `valdiate_limit` to `cap_page_limit` to be consistent with FN.


## Test Plan 

compare Explorer traffic hitting FN RPC and testing indexer RPC
```
curl --location --request POST https://explorer-rpc.mainnet.sui.io:443 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "ToAddress": "0x64c86d82898f3baf4078034cf7a49ba2cab5e21eda043c9e30c509a9dcfbcbbc"
            },
            "options": {
                "showInput": true,
                "showEffects": true
            }
        },
        null,
        1,
        false
    ]
}'
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
