### PR TITLE
Remove headless tabs from explorer

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -35,6 +35,7 @@
 		"@mysten/icons": "workspace:*",
 		"@mysten/sui.js": "workspace:*",
 		"@mysten/wallet-kit": "workspace:*",
+		"@radix-ui/react-tabs": "^1.0.4",
 		"@sentry/react": "^7.47.0",
 		"@tanstack/react-query": "^4.29.3",
 		"@tanstack/react-query-devtools": "^4.29.3",

--- a/apps/explorer/src/components/Activity/index.tsx
+++ b/apps/explorer/src/components/Activity/index.tsx
@@ -9,7 +9,9 @@ import { EpochsActivityTable } from './EpochsActivityTable';
 import { TransactionsActivityTable } from './TransactionsActivityTable';
 
 // import { PlayPause } from '~/ui/PlayPause';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
+
+const VALID_TABS = ['transactions', 'epochs', 'checkpoints'];
 
 type Props = {
 	initialTab?: string | null;
@@ -21,15 +23,7 @@ type Props = {
 const REFETCH_INTERVAL_SECONDS = 10;
 const REFETCH_INTERVAL = REFETCH_INTERVAL_SECONDS * 1000;
 
-const tabs: Record<string, number> = {
-	epochs: 1,
-	checkpoints: 2,
-};
-
 export function Activity({ initialTab, initialLimit, disablePagination }: Props) {
-	const [selectedIndex, setSelectedIndex] = useState(
-		initialTab && tabs[initialTab] ? tabs[initialTab] : 0,
-	);
 	const [paused] = useState(false);
 
 	// const handlePauseChange = () => {
@@ -49,13 +43,16 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 
 	return (
 		<div>
-			<TabGroup size="lg" selectedIndex={selectedIndex} onChange={setSelectedIndex}>
+			<Tabs
+				size="lg"
+				defaultValue={initialTab && VALID_TABS.includes(initialTab) ? initialTab : 'transactions'}
+			>
 				<div className="relative">
-					<TabList>
-						<Tab>Transaction Blocks</Tab>
-						<Tab>Epochs</Tab>
-						<Tab>Checkpoints</Tab>
-					</TabList>
+					<TabsList>
+						<TabsTrigger value="transactions">Transaction Blocks</TabsTrigger>
+						<TabsTrigger value="epochs">Epochs</TabsTrigger>
+						<TabsTrigger value="checkpoints">Checkpoints</TabsTrigger>
+					</TabsList>
 					<div className="absolute inset-y-0 -top-1 right-0 text-2xl">
 						{/* todo: re-enable this when rpc is stable */}
 						{/* <PlayPause
@@ -64,30 +61,28 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
                         /> */}
 					</div>
 				</div>
-				<TabPanels>
-					<TabPanel>
-						<TransactionsActivityTable
-							refetchInterval={refetchInterval}
-							initialLimit={initialLimit}
-							disablePagination={disablePagination}
-						/>
-					</TabPanel>
-					<TabPanel>
-						<EpochsActivityTable
-							refetchInterval={refetchInterval}
-							initialLimit={initialLimit}
-							disablePagination={disablePagination}
-						/>
-					</TabPanel>
-					<TabPanel>
-						<CheckpointsTable
-							refetchInterval={refetchInterval}
-							initialLimit={initialLimit}
-							disablePagination={disablePagination}
-						/>
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+				<TabsContent value="transactions">
+					<TransactionsActivityTable
+						refetchInterval={refetchInterval}
+						initialLimit={initialLimit}
+						disablePagination={disablePagination}
+					/>
+				</TabsContent>
+				<TabsContent value="epochs">
+					<EpochsActivityTable
+						refetchInterval={refetchInterval}
+						initialLimit={initialLimit}
+						disablePagination={disablePagination}
+					/>
+				</TabsContent>
+				<TabsContent value="checkpoints">
+					<CheckpointsTable
+						refetchInterval={refetchInterval}
+						initialLimit={initialLimit}
+						disablePagination={disablePagination}
+					/>
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/apps/explorer/src/components/Object/DynamicFieldsCard.tsx
+++ b/apps/explorer/src/components/Object/DynamicFieldsCard.tsx
@@ -9,7 +9,7 @@ import { UnderlyingObjectCard } from './UnderlyingObjectCard';
 import { DisclosureBox } from '~/ui/DisclosureBox';
 import { ObjectLink } from '~/ui/InternalLink';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 
 export function DynamicFieldsCard({ id }: { id: string }) {
 	const { data, isInitialLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
@@ -38,54 +38,47 @@ export function DynamicFieldsCard({ id }: { id: string }) {
 
 	return hasPages ? (
 		<div className="mt-10">
-			<TabGroup size="lg">
-				<TabList>
-					<Tab>Dynamic Fields</Tab>
-				</TabList>
-				<TabPanels>
-					<TabPanel>
-						<div className="mt-4 flex max-h-600 flex-col gap-5 overflow-auto">
-							{data.pages.map(({ data }) =>
-								// Show the field name and type is it is not an object
-								data.map((result) => (
-									<DisclosureBox
-										title={
-											<div className="flex items-center gap-1 truncate break-words text-body font-medium leading-relaxed text-steel-dark">
-												<div className="block w-full truncate break-words">
-													{typeof result.name?.value === 'object' ? (
-														<>Struct {result.name.type}</>
-													) : result.name?.value ? (
-														String(result.name.value)
-													) : null}
-												</div>
-												<ObjectLink objectId={result.objectId} />
-											</div>
-										}
-										variant="outline"
-										key={result.objectId}
-									>
-										<div className="flex flex-col divide-y divide-gray-45">
-											<UnderlyingObjectCard
-												parentId={id}
-												name={result.name}
-												dynamicFieldType={result.type}
-											/>
+			<TabHeader title="Dynamic Fields">
+				<div className="mt-4 flex max-h-600 flex-col gap-5 overflow-auto">
+					{data.pages.map(({ data }) =>
+						// Show the field name and type is it is not an object
+						data.map((result) => (
+							<DisclosureBox
+								title={
+									<div className="flex items-center gap-1 truncate break-words text-body font-medium leading-relaxed text-steel-dark">
+										<div className="block w-full truncate break-words">
+											{typeof result.name?.value === 'object' ? (
+												<>Struct {result.name.type}</>
+											) : result.name?.value ? (
+												String(result.name.value)
+											) : null}
 										</div>
-									</DisclosureBox>
-								)),
-							)}
-
-							<div ref={observerElem}>
-								{isSpinnerVisible ? (
-									<div className="mt-1 flex w-full justify-center">
-										<LoadingSpinner text="Loading data" />
+										<ObjectLink objectId={result.objectId} />
 									</div>
-								) : null}
+								}
+								variant="outline"
+								key={result.objectId}
+							>
+								<div className="flex flex-col divide-y divide-gray-45">
+									<UnderlyingObjectCard
+										parentId={id}
+										name={result.name}
+										dynamicFieldType={result.type}
+									/>
+								</div>
+							</DisclosureBox>
+						)),
+					)}
+
+					<div ref={observerElem}>
+						{isSpinnerVisible ? (
+							<div className="mt-1 flex w-full justify-center">
+								<LoadingSpinner text="Loading data" />
 							</div>
-						</div>
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+						) : null}
+					</div>
+				</div>
+			</TabHeader>
 		</div>
 	) : null;
 }

--- a/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
+++ b/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
@@ -15,7 +15,7 @@ import { getFieldTypeValue } from './utils';
 import { Banner } from '~/ui/Banner';
 import { DisclosureBox } from '~/ui/DisclosureBox';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
 import { ListItem, VerticalList } from '~/ui/VerticalList';
 
@@ -78,121 +78,114 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
 	}
 
 	return (
-		<TabGroup size="lg">
-			<TabList>
-				<Tab>Fields</Tab>
-			</TabList>
-			<TabPanels>
-				<TabPanel>
-					<div className="mt-4 flex flex-col gap-5 border-b border-gray-45">
-						<div className="flex flex-col gap-5  md:flex-row md:flex-nowrap">
-							<div className="w-full md:w-1/5">
-								<Combobox value={activeFieldName} onChange={setActiveFieldName}>
-									<div className="mt-2.5 flex w-full justify-between rounded-md border border-gray-50 py-1 pl-3 placeholder-gray-65 shadow-sm">
-										<Combobox.Input
-											onChange={(event) => {
-												setQuery(event.target.value);
-											}}
-											displayValue={() => query}
-											placeholder="Search"
-											className="w-full border-none focus:outline-0"
-										/>
-										<button className="border-none bg-inherit pr-2" type="submit">
-											<Search24 className="h-4.5 w-4.5 cursor-pointer fill-steel align-middle text-gray-60" />
-										</button>
+		<TabHeader title="Fields">
+			<div className="mt-4 flex flex-col gap-5 border-b border-gray-45">
+				<div className="flex flex-col gap-5  md:flex-row md:flex-nowrap">
+					<div className="w-full md:w-1/5">
+						<Combobox value={activeFieldName} onChange={setActiveFieldName}>
+							<div className="mt-2.5 flex w-full justify-between rounded-md border border-gray-50 py-1 pl-3 placeholder-gray-65 shadow-sm">
+								<Combobox.Input
+									onChange={(event) => {
+										setQuery(event.target.value);
+									}}
+									displayValue={() => query}
+									placeholder="Search"
+									className="w-full border-none focus:outline-0"
+								/>
+								<button className="border-none bg-inherit pr-2" type="submit">
+									<Search24 className="h-4.5 w-4.5 cursor-pointer fill-steel align-middle text-gray-60" />
+								</button>
+							</div>
+							<Combobox.Options className="absolute left-0 z-10 flex h-fit max-h-verticalListLong w-full flex-col gap-1 overflow-auto rounded-md bg-white px-2 pb-5 pt-3 shadow-moduleOption md:left-auto md:w-1/6">
+								{filteredFieldNames.length > 0 ? (
+									<div className="ml-1.5 pb-2 text-caption font-semibold uppercase text-gray-75">
+										{filteredFieldNames.length}
+										{filteredFieldNames.length === 1 ? ' Result' : ' Results'}
 									</div>
-									<Combobox.Options className="absolute left-0 z-10 flex h-fit max-h-verticalListLong w-full flex-col gap-1 overflow-auto rounded-md bg-white px-2 pb-5 pt-3 shadow-moduleOption md:left-auto md:w-1/6">
-										{filteredFieldNames.length > 0 ? (
-											<div className="ml-1.5 pb-2 text-caption font-semibold uppercase text-gray-75">
-												{filteredFieldNames.length}
-												{filteredFieldNames.length === 1 ? ' Result' : ' Results'}
-											</div>
-										) : (
-											<div className="px-3.5 pt-2 text-center text-body italic text-gray-70">
-												No results
-											</div>
-										)}
-										{filteredFieldNames?.map(({ name }) => (
-											<Combobox.Option key={name} value={name} className="list-none md:min-w-fit">
-												{({ active }) => (
-													<button
-														type="button"
-														className={clsx(
-															'mt-0.5 block w-full cursor-pointer rounded-md border px-1.5 py-2 text-left text-body',
-															active
-																? 'border-transparent bg-gray-40 text-steel-darker'
-																: 'border-transparent bg-white font-medium text-steel-darker',
-														)}
-													>
-														{name}
-													</button>
+								) : (
+									<div className="px-3.5 pt-2 text-center text-body italic text-gray-70">
+										No results
+									</div>
+								)}
+								{filteredFieldNames?.map(({ name }) => (
+									<Combobox.Option key={name} value={name} className="list-none md:min-w-fit">
+										{({ active }) => (
+											<button
+												type="button"
+												className={clsx(
+													'mt-0.5 block w-full cursor-pointer rounded-md border px-1.5 py-2 text-left text-body',
+													active
+														? 'border-transparent bg-gray-40 text-steel-darker'
+														: 'border-transparent bg-white font-medium text-steel-darker',
 												)}
-											</Combobox.Option>
-										))}
-									</Combobox.Options>
-								</Combobox>
-								<div className="max-h-600 overflow-y-auto overflow-x-clip py-3">
-									<VerticalList>
-										{normalizedStruct?.fields?.map(({ name, type }) => (
-											<div key={name} className="mt-0.5">
-												<ListItem
-													active={activeFieldName === name}
-													onClick={() => setActiveFieldName(name)}
-												>
-													<div className="flex w-full flex-1 justify-between gap-2 truncate">
-														<Text variant="body/medium" color="steel-darker" truncate>
-															{name}
-														</Text>
-
-														<Text variant="pSubtitle/normal" color="steel" truncate>
-															{getFieldTypeValue(type, objectType).displayName}
-														</Text>
-													</div>
-												</ListItem>
-											</div>
-										))}
-									</VerticalList>
-								</div>
-							</div>
-
-							<div className="grow overflow-auto border-gray-45 pt-1 md:w-3/5 md:border-l md:pl-7">
-								<div className="flex max-h-600 flex-col gap-5 overflow-y-auto pb-5">
-									{normalizedStruct?.fields.map(({ name, type }) => (
-										<ScrollToViewCard key={name} inView={name === activeFieldName}>
-											<DisclosureBox
-												title={
-													<div className="min-w-fit max-w-[60%] truncate break-words text-body font-medium leading-relaxed text-steel-dark">
-														{name}:
-													</div>
-												}
-												preview={
-													<div className="flex items-center gap-1 truncate break-all">
-														{typeof fieldsData[name] === 'object' ? (
-															<Text variant="body/medium" color="gray-90">
-																Click to view
-															</Text>
-														) : (
-															<FieldItem
-																value={fieldsData[name]}
-																truncate
-																type={type}
-																objectType={objectType}
-															/>
-														)}
-													</div>
-												}
-												variant="outline"
 											>
-												<FieldItem value={fieldsData[name]} objectType={objectType} type={type} />
-											</DisclosureBox>
-										</ScrollToViewCard>
-									))}
-								</div>
-							</div>
+												{name}
+											</button>
+										)}
+									</Combobox.Option>
+								))}
+							</Combobox.Options>
+						</Combobox>
+						<div className="max-h-600 overflow-y-auto overflow-x-clip py-3">
+							<VerticalList>
+								{normalizedStruct?.fields?.map(({ name, type }) => (
+									<div key={name} className="mt-0.5">
+										<ListItem
+											active={activeFieldName === name}
+											onClick={() => setActiveFieldName(name)}
+										>
+											<div className="flex w-full flex-1 justify-between gap-2 truncate">
+												<Text variant="body/medium" color="steel-darker" truncate>
+													{name}
+												</Text>
+
+												<Text variant="pSubtitle/normal" color="steel" truncate>
+													{getFieldTypeValue(type, objectType).displayName}
+												</Text>
+											</div>
+										</ListItem>
+									</div>
+								))}
+							</VerticalList>
 						</div>
 					</div>
-				</TabPanel>
-			</TabPanels>
-		</TabGroup>
+
+					<div className="grow overflow-auto border-gray-45 pt-1 md:w-3/5 md:border-l md:pl-7">
+						<div className="flex max-h-600 flex-col gap-5 overflow-y-auto pb-5">
+							{normalizedStruct?.fields.map(({ name, type }) => (
+								<ScrollToViewCard key={name} inView={name === activeFieldName}>
+									<DisclosureBox
+										title={
+											<div className="min-w-fit max-w-[60%] truncate break-words text-body font-medium leading-relaxed text-steel-dark">
+												{name}:
+											</div>
+										}
+										preview={
+											<div className="flex items-center gap-1 truncate break-all">
+												{typeof fieldsData[name] === 'object' ? (
+													<Text variant="body/medium" color="gray-90">
+														Click to view
+													</Text>
+												) : (
+													<FieldItem
+														value={fieldsData[name]}
+														truncate
+														type={type}
+														objectType={objectType}
+													/>
+												)}
+											</div>
+										}
+										variant="outline"
+									>
+										<FieldItem value={fieldsData[name]} objectType={objectType} type={type} />
+									</DisclosureBox>
+								</ScrollToViewCard>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+		</TabHeader>
 	);
 }

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -12,7 +12,7 @@ import { ModuleFunctionsInteraction } from './module-functions-interaction';
 
 import { useBreakpoint } from '~/hooks/useBreakpoint';
 import { SplitPanes } from '~/ui/SplitPanes';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 import { ListItem, VerticalList } from '~/ui/VerticalList';
 import { useSearchParamsMerged } from '~/ui/utils/LinkWithQuery';
 
@@ -87,28 +87,17 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
 		{
 			panel: (
 				<div key="bytecode" className="h-full grow overflow-auto border-gray-45 pt-5 md:pl-7">
-					<TabGroup size="md">
-						<TabList>
-							<Tab>Bytecode</Tab>
-						</TabList>
-						<TabPanels>
-							<TabPanel>
-								<div
-									className={clsx(
-										'overflow-auto',
-										(splitPanelOrientation === 'horizontal' || !isMediumOrAbove) &&
-											'h-verticalListLong',
-									)}
-								>
-									<ModuleViewWrapper
-										id={id}
-										modules={modules}
-										selectedModuleName={selectedModule}
-									/>
-								</div>
-							</TabPanel>
-						</TabPanels>
-					</TabGroup>
+					<TabHeader size="md" title="Bytecode">
+						<div
+							className={clsx(
+								'overflow-auto',
+								(splitPanelOrientation === 'horizontal' || !isMediumOrAbove) &&
+									'h-verticalListLong',
+							)}
+						>
+							<ModuleViewWrapper id={id} modules={modules} selectedModuleName={selectedModule} />
+						</div>
+					</TabHeader>
 				</div>
 			),
 			defaultSize: 40,
@@ -116,31 +105,24 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
 		{
 			panel: (
 				<div key="execute" className="h-full grow overflow-auto border-gray-45 pt-5 md:pl-7">
-					<TabGroup size="md">
-						<TabList>
-							<Tab>Execute</Tab>
-						</TabList>
-						<TabPanels>
-							<TabPanel>
-								<div
-									className={clsx(
-										'overflow-auto',
-										(splitPanelOrientation === 'horizontal' || !isMediumOrAbove) &&
-											'h-verticalListLong',
-									)}
-								>
-									{id && selectedModule ? (
-										<ModuleFunctionsInteraction
-											// force recreating everything when we change modules
-											key={`${id}-${selectedModule}`}
-											packageId={id}
-											moduleName={selectedModule}
-										/>
-									) : null}
-								</div>
-							</TabPanel>
-						</TabPanels>
-					</TabGroup>
+					<TabHeader size="md" title="Execute">
+						<div
+							className={clsx(
+								'overflow-auto',
+								(splitPanelOrientation === 'horizontal' || !isMediumOrAbove) &&
+									'h-verticalListLong',
+							)}
+						>
+							{id && selectedModule ? (
+								<ModuleFunctionsInteraction
+									// force recreating everything when we change modules
+									key={`${id}-${selectedModule}`}
+									packageId={id}
+									moduleName={selectedModule}
+								/>
+							) : null}
+						</div>
+					</TabHeader>
 				</div>
 			),
 			defaultSize: 60,

--- a/apps/explorer/src/components/top-packages/TopPackagesCard.tsx
+++ b/apps/explorer/src/components/top-packages/TopPackagesCard.tsx
@@ -9,7 +9,7 @@ import { TopPackagesTable } from './TopPackagesTable';
 
 import { useEnhancedRpcClient } from '~/hooks/useEnhancedRpc';
 import { FilterList } from '~/ui/FilterList';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 
 export type DateFilter = '3D' | '7D' | '30D';
 export type ApiDateFilter = 'rank3Days' | 'rank7Days' | 'rank30Days';
@@ -40,18 +40,11 @@ export function TopPackagesCard() {
 					onChange={(val) => setSelectedFilter(val)}
 				/>
 			</div>
-			<TabGroup size="lg">
-				<TabList>
-					<Tab>Popular Packages</Tab>
-				</TabList>
-				<TabPanels>
-					<TabPanel>
-						<ErrorBoundary>
-							<TopPackagesTable data={filteredData} isLoading={isLoading} />
-						</ErrorBoundary>
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+			<TabHeader title="Popular Packages">
+				<ErrorBoundary>
+					<TopPackagesTable data={filteredData} isLoading={isLoading} />
+				</ErrorBoundary>
+			</TabHeader>
 		</div>
 	);
 }

--- a/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
+++ b/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
@@ -10,7 +10,7 @@ import { genTableDataFromTxData } from './TxCardUtils';
 import { Banner } from '~/ui/Banner';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { TableCard } from '~/ui/TableCard';
-import { TabGroup, TabList, Tab, TabPanels, TabPanel } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 
 interface Props {
 	address: string;
@@ -78,16 +78,9 @@ export function TransactionsForAddress({ address, type }: Props) {
 
 	return (
 		<div data-testid="tx">
-			<TabGroup size="lg">
-				<TabList>
-					<Tab>Transaction Blocks</Tab>
-				</TabList>
-				<TabPanels>
-					<TabPanel>
-						<TableCard data={tableData.data} columns={tableData.columns} />
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+			<TabHeader title="Transaction Blocks">
+				<TableCard data={tableData.data} columns={tableData.columns} />
+			</TabHeader>
 		</div>
 	);
 }

--- a/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
+++ b/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
@@ -13,7 +13,7 @@ import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
 import { EpochLink } from '~/ui/InternalLink';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { PageHeader } from '~/ui/PageHeader';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader, Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
 
 export default function CheckpointDetail() {
@@ -38,88 +38,77 @@ export default function CheckpointDetail() {
 		<div className="flex flex-col space-y-12">
 			<PageHeader title={data.digest} type="Checkpoint" />
 			<div className="space-y-8">
-				<TabGroup as="div" size="lg">
-					<TabList>
-						<Tab>Details</Tab>
-						<Tab>Signatures</Tab>
-					</TabList>
-					<TabPanels>
-						<TabPanel>
-							<DescriptionList>
-								<DescriptionItem title="Checkpoint Sequence No.">
-									<Text variant="pBody/medium" color="steel-darker">
-										{data.sequenceNumber}
-									</Text>
-								</DescriptionItem>
-								<DescriptionItem title="Epoch">
-									<EpochLink epoch={data.epoch} />
-								</DescriptionItem>
-								<DescriptionItem title="Checkpoint Timestamp">
-									<Text variant="pBody/medium" color="steel-darker">
-										{data.timestampMs
-											? new Date(Number(data.timestampMs)).toLocaleString(undefined, {
-													month: 'short',
-													day: 'numeric',
-													year: 'numeric',
-													hour: 'numeric',
-													minute: '2-digit',
-													second: '2-digit',
-													hour12: false,
-													timeZone: 'UTC',
-													timeZoneName: 'short',
-											  })
-											: '--'}
-									</Text>
-								</DescriptionItem>
-							</DescriptionList>
-						</TabPanel>
-						<TabPanel>
-							<TabGroup>
-								<TabList>
-									<Tab>Aggregated Validator Signature</Tab>
-								</TabList>
-								<TabPanels>
-									<DescriptionList>
-										<DescriptionItem key={data.validatorSignature} title="Signature">
-											<Text variant="pBody/medium" color="steel-darker">
-												{data.validatorSignature}
-											</Text>
-										</DescriptionItem>
-									</DescriptionList>
-								</TabPanels>
-							</TabGroup>
-						</TabPanel>
-					</TabPanels>
-				</TabGroup>
-				<TabGroup as="div" size="lg">
-					<TabList>
-						<Tab>Gas & Storage Fees</Tab>
-					</TabList>
-					<TabPanels>
+				<Tabs size="lg" defaultValue="details">
+					<TabsList>
+						<TabsTrigger value="details">Details</TabsTrigger>
+						<TabsTrigger value="signatures">Signatures</TabsTrigger>
+					</TabsList>
+					<TabsContent value="details">
 						<DescriptionList>
-							<DescriptionItem title="Computation Fee">
-								<SuiAmount full amount={data.epochRollingGasCostSummary.computationCost} />
+							<DescriptionItem title="Checkpoint Sequence No.">
+								<Text variant="pBody/medium" color="steel-darker">
+									{data.sequenceNumber}
+								</Text>
 							</DescriptionItem>
-							<DescriptionItem title="Storage Fee">
-								<SuiAmount full amount={data.epochRollingGasCostSummary.storageCost} />
+							<DescriptionItem title="Epoch">
+								<EpochLink epoch={data.epoch} />
 							</DescriptionItem>
-							<DescriptionItem title="Storage Rebate">
-								<SuiAmount full amount={data.epochRollingGasCostSummary.storageRebate} />
+							<DescriptionItem title="Checkpoint Timestamp">
+								<Text variant="pBody/medium" color="steel-darker">
+									{data.timestampMs
+										? new Date(Number(data.timestampMs)).toLocaleString(undefined, {
+												month: 'short',
+												day: 'numeric',
+												year: 'numeric',
+												hour: 'numeric',
+												minute: '2-digit',
+												second: '2-digit',
+												hour12: false,
+												timeZone: 'UTC',
+												timeZoneName: 'short',
+										  })
+										: '--'}
+								</Text>
 							</DescriptionItem>
 						</DescriptionList>
-					</TabPanels>
-				</TabGroup>
+					</TabsContent>
+					<TabsContent value="signatures">
+						<Tabs defaultValue="aggregated">
+							<TabsList>
+								<TabsTrigger value="aggregated">Aggregated Validator Signature</TabsTrigger>
+							</TabsList>
+							<TabsContent value="aggregated">
+								<DescriptionList>
+									<DescriptionItem key={data.validatorSignature} title="Signature">
+										<Text variant="pBody/medium" color="steel-darker">
+											{data.validatorSignature}
+										</Text>
+									</DescriptionItem>
+								</DescriptionList>
+							</TabsContent>
+						</Tabs>
+					</TabsContent>
+				</Tabs>
 
-				<TabGroup as="div" size="lg">
-					<TabList>
-						<Tab>Checkpoint Transaction Blocks</Tab>
-					</TabList>
-					<TabPanels>
-						<div className="mt-4">
-							<CheckpointTransactionBlocks id={data.sequenceNumber} />
-						</div>
-					</TabPanels>
-				</TabGroup>
+				<TabHeader title="Gas & Storage Fees">
+					<DescriptionList>
+						<DescriptionItem title="Computation Fee">
+							<SuiAmount full amount={data.epochRollingGasCostSummary.computationCost} />
+						</DescriptionItem>
+						<DescriptionItem title="Storage Fee">
+							<SuiAmount full amount={data.epochRollingGasCostSummary.storageCost} />
+						</DescriptionItem>
+						<DescriptionItem title="Storage Rebate">
+							<SuiAmount full amount={data.epochRollingGasCostSummary.storageRebate} />
+						</DescriptionItem>
+					</DescriptionList>
+				</TabHeader>
+
+				<TabHeader title="Checkpoint Transaction Blocks">
+					<div className="mt-4">
+						<CheckpointTransactionBlocks id={data.sequenceNumber} />
+					</div>
+				</TabHeader>
 			</div>
 		</div>
 	);

--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -18,7 +18,7 @@ import { Banner } from '~/ui/Banner';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { Stats, type StatsProps } from '~/ui/Stats';
 import { TableCard } from '~/ui/TableCard';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
 import { getEpochStorageFundFlow } from '~/utils/getStorageFundFlow';
 
 function SuiStats({
@@ -116,26 +116,24 @@ export default function EpochDetail() {
 				{isCurrentEpoch ? <ValidatorStatus /> : null}
 			</div>
 
-			<TabGroup size="lg">
-				<TabList>
-					<Tab>Checkpoints</Tab>
-					<Tab>Participating Validators</Tab>
-				</TabList>
-				<TabPanels className="mt-4">
-					<TabPanel>
-						<CheckpointsTable
-							initialCursor={initialCursorPlusOne}
-							maxCursor={epochData.firstCheckpointId}
-							initialLimit={20}
-						/>
-					</TabPanel>
-					<TabPanel>
-						{validatorsTable ? (
-							<TableCard data={validatorsTable.data} columns={validatorsTable.columns} sortTable />
-						) : null}
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+			<Tabs size="lg" defaultValue="checkpoints">
+				<TabsList>
+					<TabsTrigger value="checkpoints">Checkpoints</TabsTrigger>
+					<TabsTrigger value="validators">Participating Validators</TabsTrigger>
+				</TabsList>
+				<TabsContent value="checkpoints">
+					<CheckpointsTable
+						initialCursor={initialCursorPlusOne}
+						maxCursor={epochData.firstCheckpointId}
+						initialLimit={20}
+					/>
+				</TabsContent>
+				<TabsContent value="validators">
+					{validatorsTable ? (
+						<TableCard data={validatorsTable.data} columns={validatorsTable.columns} sortTable />
+					) : null}
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/apps/explorer/src/pages/home/Home.tsx
+++ b/apps/explorer/src/pages/home/Home.tsx
@@ -13,7 +13,7 @@ import { SuiTokenCard } from '~/components/SuiTokenCard';
 import { TopPackagesCard } from '~/components/top-packages/TopPackagesCard';
 import { useNetwork } from '~/context';
 import { Card } from '~/ui/Card';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 import { Network } from '~/utils/api/DefaultRpcClient';
 
 const ValidatorMap = lazy(() => import('../../components/validator-map'));
@@ -64,18 +64,11 @@ function Home() {
 				</ErrorBoundary>
 			</div>
 			<div data-testid="validators-table" style={{ gridArea: 'validators' }} className="mt-5">
-				<TabGroup size="lg">
-					<TabList>
-						<Tab>Validators</Tab>
-					</TabList>
-					<TabPanels>
-						<TabPanel>
-							<ErrorBoundary>
-								<TopValidatorsCard limit={10} showIcon />
-							</ErrorBoundary>
-						</TabPanel>
-					</TabPanels>
-				</TabGroup>
+				<TabHeader title="Validators">
+					<ErrorBoundary>
+						<TopValidatorsCard limit={10} showIcon />
+					</ErrorBoundary>
+				</TabHeader>
 			</div>
 
 			<div style={{ gridArea: 'packages' }}>

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -20,7 +20,7 @@ import TransactionBlocksForAddress, {
 import { AddressLink, ObjectLink } from '~/ui/InternalLink';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { RadioGroup, RadioOption } from '~/ui/Radio';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader, Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
 
 const GENESIS_TX_DIGEST = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
@@ -57,44 +57,37 @@ function PkgView({ data }: { data: DataType }) {
 	return (
 		<div>
 			<div>
-				<TabGroup size="lg">
-					<TabList>
-						<Tab>Details</Tab>
-					</TabList>
-					<TabPanels>
-						<TabPanel>
-							<table className={styles.description} id="descriptionResults">
-								<tbody>
-									<tr>
-										<td>Object ID</td>
-										<td id="objectID" className={styles.objectid}>
-											<ObjectLink objectId={viewedData.id} noTruncate />
-										</td>
-									</tr>
+				<TabHeader title="Details">
+					<table className={styles.description} id="descriptionResults">
+						<tbody>
+							<tr>
+								<td>Object ID</td>
+								<td id="objectID" className={styles.objectid}>
+									<ObjectLink objectId={viewedData.id} noTruncate />
+								</td>
+							</tr>
 
-									<tr>
-										<td>Version</td>
-										<td>{viewedData.version}</td>
-									</tr>
+							<tr>
+								<td>Version</td>
+								<td>{viewedData.version}</td>
+							</tr>
 
-									{viewedData?.publisherAddress && (
-										<tr>
-											<td>Publisher</td>
-											<td id="lasttxID">
-												<AddressLink address={viewedData.publisherAddress} noTruncate />
-											</td>
-										</tr>
-									)}
-								</tbody>
-							</table>
-						</TabPanel>
-					</TabPanels>
-				</TabGroup>
+							{viewedData?.publisherAddress && (
+								<tr>
+									<td>Publisher</td>
+									<td id="lasttxID">
+										<AddressLink address={viewedData.publisherAddress} noTruncate />
+									</td>
+								</tr>
+							)}
+						</tbody>
+					</table>
+				</TabHeader>
 
-				<TabGroup size="lg">
-					<TabList>
+				<Tabs defaultValue="modules">
+					<TabsList>
 						<div className="mt-16 flex w-full justify-between">
-							<Tab>Modules</Tab>
+							<TabsTrigger value="modules">Modules</TabsTrigger>
 							<div>
 								<RadioGroup
 									className="hidden gap-0.5 md:flex"
@@ -108,19 +101,17 @@ function PkgView({ data }: { data: DataType }) {
 								</RadioGroup>
 							</div>
 						</div>
-					</TabList>
-					<TabPanels>
-						<TabPanel noGap>
-							<ErrorBoundary>
-								<PkgModulesWrapper
-									id={data.id}
-									modules={properties}
-									splitPanelOrientation={selectedSplitPanelOrientation}
-								/>
-							</ErrorBoundary>
-						</TabPanel>
-					</TabPanels>
-				</TabGroup>
+					</TabsList>
+					<TabsContent value="modules" noGap>
+						<ErrorBoundary>
+							<PkgModulesWrapper
+								id={data.id}
+								modules={properties}
+								splitPanelOrientation={selectedSplitPanelOrientation}
+							/>
+						</ErrorBoundary>
+					</TabsContent>
+				</Tabs>
 
 				<div className={styles.txsection}>
 					<ErrorBoundary>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -26,7 +26,7 @@ import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
 import { AddressLink, ObjectLink, TransactionLink } from '~/ui/InternalLink';
 import { Link } from '~/ui/Link';
 import { ObjectDetails } from '~/ui/ObjectDetails';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
 import { extractName, parseImageURL, parseObjectType } from '~/utils/objectUtils';
 
@@ -66,100 +66,86 @@ export function TokenView({ data }: { data: SuiObjectResponse }) {
 
 	return (
 		<div className="flex flex-col flex-nowrap gap-14">
-			<TabGroup size="lg">
-				<TabList>
-					<Tab>Details</Tab>
-				</TabList>
-				<TabPanels>
-					<TabPanel noGap>
-						<div className="flex flex-col md:flex-row md:divide-x md:divide-gray-45">
-							<div className="flex-1 divide-y divide-gray-45 pb-6 md:basis-2/3 md:pb-0 md:pr-10">
-								<div className="py-4 pb-7">
-									<DescriptionList>
-										{objOwner ? (
-											<DescriptionItem title="Owner" data-testid="owner">
-												{objOwner === 'Immutable' ? (
-													'Immutable'
-												) : 'Shared' in objOwner ? (
-													'Shared'
-												) : 'ObjectOwner' in objOwner ? (
-													<ObjectLink objectId={objOwner.ObjectOwner} />
-												) : (
-													<AddressLink address={objOwner.AddressOwner} />
-												)}
-											</DescriptionItem>
-										) : null}
-										<DescriptionItem title="Object ID">
-											<ObjectLink objectId={getObjectId(data)} noTruncate />
-										</DescriptionItem>
-										<DescriptionItem title="Type">
-											{/* TODO: Support module links on `ObjectLink` */}
-											<Link to={genhref(objectType)} variant="mono">
-												{trimStdLibPrefix(objectType)}
-											</Link>
-										</DescriptionItem>
-										<DescriptionItem title="Version">
-											<Text variant="body/medium" color="steel-darker">
-												{getObjectVersion(data)}
-											</Text>
-										</DescriptionItem>
-										<DescriptionItem title="Last Transaction Block Digest">
-											<TransactionLink
-												digest={getObjectPreviousTransactionDigest(data)!}
-												noTruncate
-											/>
-										</DescriptionItem>
-									</DescriptionList>
-								</div>
-								{display ? (
-									<div className="py-4 pb-7">
-										<DescriptionList>
-											<LinkOrTextDescriptionItem title="Name" value={name} />
-											<LinkOrTextDescriptionItem title="Description" value={display.description} />
-											<LinkOrTextDescriptionItem title="Creator" value={display.creator} parseUrl />
-											<LinkOrTextDescriptionItem title="Link" value={display.link} parseUrl />
-											<LinkOrTextDescriptionItem
-												title="Website"
-												value={display.project_url}
-												parseUrl
-											/>
-										</DescriptionList>
-									</div>
+			<TabHeader title="Details" noGap>
+				<div className="flex flex-col md:flex-row md:divide-x md:divide-gray-45">
+					<div className="flex-1 divide-y divide-gray-45 pb-6 md:basis-2/3 md:pb-0 md:pr-10">
+						<div className="py-4 pb-7">
+							<DescriptionList>
+								{objOwner ? (
+									<DescriptionItem title="Owner" data-testid="owner">
+										{objOwner === 'Immutable' ? (
+											'Immutable'
+										) : 'Shared' in objOwner ? (
+											'Shared'
+										) : 'ObjectOwner' in objOwner ? (
+											<ObjectLink objectId={objOwner.ObjectOwner} />
+										) : (
+											<AddressLink address={objOwner.AddressOwner} />
+										)}
+									</DescriptionItem>
 								) : null}
-								{storageRebate && (
-									<div className="py-4 pb-7">
-										<DescriptionList>
-											<DescriptionItem title="Storage Rebate">
-												<div className="leading-1 flex items-end gap-0.5">
-													<Text variant="body/medium" color="steel-darker">
-														{storageRebateFormatted}
-													</Text>
-													<Text variant="captionSmall/normal" color="steel">
-														{symbol}
-													</Text>
-												</div>
-											</DescriptionItem>
-										</DescriptionList>
-									</div>
-								)}
-							</div>
-							{imgUrl !== '' && (
-								<div className="min-w-0 border-0 border-t border-solid border-gray-45 pt-6 md:basis-1/3 md:border-t-0 md:pl-10">
-									<div className="flex flex-row flex-nowrap gap-5">
-										<ObjectDetails
-											image={imgUrl}
-											video={video}
-											name={name || display?.description || trimStdLibPrefix(objectType)}
-											type={video ? 'Video' : fileType ?? ''}
-											variant="large"
-										/>
-									</div>
-								</div>
-							)}
+								<DescriptionItem title="Object ID">
+									<ObjectLink objectId={getObjectId(data)} noTruncate />
+								</DescriptionItem>
+								<DescriptionItem title="Type">
+									{/* TODO: Support module links on `ObjectLink` */}
+									<Link to={genhref(objectType)} variant="mono">
+										{trimStdLibPrefix(objectType)}
+									</Link>
+								</DescriptionItem>
+								<DescriptionItem title="Version">
+									<Text variant="body/medium" color="steel-darker">
+										{getObjectVersion(data)}
+									</Text>
+								</DescriptionItem>
+								<DescriptionItem title="Last Transaction Block Digest">
+									<TransactionLink digest={getObjectPreviousTransactionDigest(data)!} noTruncate />
+								</DescriptionItem>
+							</DescriptionList>
 						</div>
-					</TabPanel>
-				</TabPanels>
-			</TabGroup>
+						{display ? (
+							<div className="py-4 pb-7">
+								<DescriptionList>
+									<LinkOrTextDescriptionItem title="Name" value={name} />
+									<LinkOrTextDescriptionItem title="Description" value={display.description} />
+									<LinkOrTextDescriptionItem title="Creator" value={display.creator} parseUrl />
+									<LinkOrTextDescriptionItem title="Link" value={display.link} parseUrl />
+									<LinkOrTextDescriptionItem title="Website" value={display.project_url} parseUrl />
+								</DescriptionList>
+							</div>
+						) : null}
+						{storageRebate && (
+							<div className="py-4 pb-7">
+								<DescriptionList>
+									<DescriptionItem title="Storage Rebate">
+										<div className="leading-1 flex items-end gap-0.5">
+											<Text variant="body/medium" color="steel-darker">
+												{storageRebateFormatted}
+											</Text>
+											<Text variant="captionSmall/normal" color="steel">
+												{symbol}
+											</Text>
+										</div>
+									</DescriptionItem>
+								</DescriptionList>
+							</div>
+						)}
+					</div>
+					{imgUrl !== '' && (
+						<div className="min-w-0 border-0 border-t border-solid border-gray-45 pt-6 md:basis-1/3 md:border-t-0 md:pl-10">
+							<div className="flex flex-row flex-nowrap gap-5">
+								<ObjectDetails
+									image={imgUrl}
+									video={video}
+									name={name || display?.description || trimStdLibPrefix(objectType)}
+									type={video ? 'Video' : fileType ?? ''}
+									variant="large"
+								/>
+							</div>
+						</div>
+					)}
+				</div>
+			</TabHeader>
 			<ObjectFieldsCard id={objectId} />
 			<DynamicFieldsCard id={objectId} />
 			<TransactionBlocksForAddress address={objectId} isObject />

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -15,15 +15,12 @@ import {
 
 import { DescriptionItem, DescriptionList } from '~/ui/DescriptionList';
 import { AddressLink } from '~/ui/InternalLink';
-import { Tab, TabGroup, TabList } from '~/ui/Tabs';
+import { TabHeader } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
 
 function SignaturePanel({ title, signature }: { title: string; signature: SignaturePubkeyPair }) {
 	return (
-		<TabGroup>
-			<TabList>
-				<Tab>{title}</Tab>
-			</TabList>
+		<TabHeader title={title}>
 			<DescriptionList>
 				<DescriptionItem title="Scheme" align="start" labelWidth="sm">
 					<Text variant="pBody/medium" color="steel-darker">
@@ -39,7 +36,7 @@ function SignaturePanel({ title, signature }: { title: string; signature: Signat
 					</Text>
 				</DescriptionItem>
 			</DescriptionList>
-		</TabGroup>
+		</TabHeader>
 	);
 }
 

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -27,7 +27,7 @@ import { TransactionSummary } from '~/pages/transaction-result/transaction-summa
 import { Banner } from '~/ui/Banner';
 import { PageHeader } from '~/ui/PageHeader';
 import { SplitPanes } from '~/ui/SplitPanes';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
 
 export function TransactionView({ transaction }: { transaction: SuiTransactionBlockResponse }) {
 	const isMediumOrAbove = useBreakpoint('md');
@@ -43,32 +43,30 @@ export function TransactionView({ transaction }: { transaction: SuiTransactionBl
 	const leftPane = {
 		panel: (
 			<div className="h-full overflow-y-auto rounded-2xl border border-transparent bg-gray-40 p-6 md:h-full md:max-h-screen md:p-10">
-				<TabGroup size="lg">
-					<TabList>
-						<Tab>Summary</Tab>
-						{hasEvents && <Tab>Events</Tab>}
-						{isProgrammableTransaction && <Tab>Signatures</Tab>}
-					</TabList>
-					<TabPanels>
-						<TabPanel>
+				<Tabs size="lg" defaultValue="summary">
+					<TabsList>
+						<TabsTrigger value="summary">Summary</TabsTrigger>
+						{hasEvents && <TabsTrigger value="events">Events</TabsTrigger>}
+						{isProgrammableTransaction && <TabsTrigger value="signatures">Signatures</TabsTrigger>}
+					</TabsList>
+					<TabsContent value="summary">
+						<div className="mt-10">
+							<TransactionSummary transaction={transaction} />
+						</div>
+					</TabsContent>
+					{hasEvents && (
+						<TabsContent value="events">
 							<div className="mt-10">
-								<TransactionSummary transaction={transaction} />
+								<Events events={transaction.events!} />
 							</div>
-						</TabPanel>
-						{hasEvents && (
-							<TabPanel>
-								<div className="mt-10">
-									<Events events={transaction.events!} />
-								</div>
-							</TabPanel>
-						)}
-						<TabPanel>
-							<div className="mt-10">
-								<Signatures transaction={transaction} />
-							</div>
-						</TabPanel>
-					</TabPanels>
-				</TabGroup>
+						</TabsContent>
+					)}
+					<TabsContent value="signatures">
+						<div className="mt-10">
+							<Signatures transaction={transaction} />
+						</div>
+					</TabsContent>
+				</Tabs>
 			</div>
 		),
 		minSize: 35,

--- a/apps/explorer/src/ui/FilterList.tsx
+++ b/apps/explorer/src/ui/FilterList.tsx
@@ -1,14 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Tab, TabGroup, TabList, type TabGroupProps, type TabListProps } from './Tabs';
+// TODO: This component really shouldn't use the `Tabs` component, it should just use radix,
+// and should define it's own styles since the concerns here are pretty different.
+
+import { type ComponentProps } from 'react';
+
+import { TabsList, Tabs, TabsTrigger } from './Tabs';
 
 export interface FilterListProps<T extends string = string> {
 	options: readonly T[];
 	value: T;
 	disabled?: boolean;
-	size?: TabGroupProps['size'];
-	lessSpacing?: TabListProps['lessSpacing'];
+	size?: ComponentProps<typeof Tabs>['size'];
+	lessSpacing?: ComponentProps<typeof TabsList>['lessSpacing'];
 	onChange(value: T): void;
 }
 
@@ -20,23 +25,21 @@ export function FilterList<T extends string>({
 	lessSpacing,
 	onChange,
 }: FilterListProps<T>) {
-	const selectedIndex = options.indexOf(value);
 	return (
-		<TabGroup
+		<Tabs
 			size={size}
-			selectedIndex={selectedIndex}
-			onChange={(index) => {
-				onChange(options[index]);
+			value={value}
+			onValueChange={(value) => {
+				onChange(value as T);
 			}}
 		>
-			<TabList disableBottomBorder lessSpacing={lessSpacing}>
+			<TabsList disableBottomBorder lessSpacing={lessSpacing}>
 				{options.map((option) => (
-					//@ts-expect-error disabled
-					<Tab disabled={disabled} key={option}>
+					<TabsTrigger disabled={disabled} key={option} value={option}>
 						{option}
-					</Tab>
+					</TabsTrigger>
 				))}
-			</TabList>
-		</TabGroup>
+			</TabsList>
+		</Tabs>
 	);
 }

--- a/apps/explorer/src/ui/stories/Tabs.stories.tsx
+++ b/apps/explorer/src/ui/stories/Tabs.stories.tsx
@@ -3,30 +3,28 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { TabGroup, TabList, Tab, TabPanels, TabPanel, type TabGroupProps } from '../Tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../Tabs';
 
 export default {
-	component: TabGroup,
+	component: Tabs,
 } as Meta;
 
-export const Default: StoryObj<TabGroupProps> = {
+export const Default: StoryObj<typeof Tabs> = {
 	render: (props) => (
-		<TabGroup {...props}>
-			<TabList>
-				<Tab>Tab 1</Tab>
-				<Tab>Tab 2</Tab>
-				<Tab>Tab 3</Tab>
-			</TabList>
-			<TabPanels>
-				<TabPanel>Tab Panel 1</TabPanel>
-				<TabPanel>Tab Panel 2</TabPanel>
-				<TabPanel>Tab Panel 3</TabPanel>
-			</TabPanels>
-		</TabGroup>
+		<Tabs defaultValue="1" {...props}>
+			<TabsList>
+				<TabsTrigger value="1">Tab 1</TabsTrigger>
+				<TabsTrigger value="2">Tab 2</TabsTrigger>
+				<TabsTrigger value="3">Tab 3</TabsTrigger>
+			</TabsList>
+			<TabsContent value="1">Tab Panel 1</TabsContent>
+			<TabsContent value="2">Tab Panel 2</TabsContent>
+			<TabsContent value="3">Tab Panel 3</TabsContent>
+		</Tabs>
 	),
 };
 
-export const Large: StoryObj<TabGroupProps> = {
+export const Large: StoryObj = {
 	...Default,
 	args: {
 		size: 'lg',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,16 +111,16 @@ importers:
         version: 8.4.24
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.1(postcss@8.4.24)
+        version: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
       vitest:
         specifier: ^0.32.0
-        version: 0.32.0
+        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   apps/explorer:
     dependencies:
@@ -163,6 +163,9 @@ importers:
       '@mysten/wallet-kit':
         specifier: workspace:*
         version: link:../../sdk/wallet-adapter/wallet-kit
+      '@radix-ui/react-tabs':
+        specifier: ^1.0.4
+        version: 1.0.4(@types/react-dom@18.2.5)(@types/react@18.0.35)(react-dom@18.2.0)(react@18.2.0)
       '@sentry/react':
         specifier: ^7.47.0
         version: 7.47.0(react@18.2.0)
@@ -352,7 +355,7 @@ importers:
         version: 7.0.4
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.1(postcss@8.4.24)
+        version: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -361,7 +364,7 @@ importers:
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3(@types/node@18.15.11)
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
       vite-plugin-svgr:
         specifier: ^2.4.0
         version: 2.4.0(vite@4.2.3)
@@ -653,7 +656,7 @@ importers:
         version: 8.0.1(webpack@5.79.0)
       eslint-webpack-plugin:
         specifier: ^3.2.0
-        version: 3.2.0(webpack@5.79.0)
+        version: 3.2.0(eslint@8.38.0)(webpack@5.79.0)
       git-rev-sync:
         specifier: ^3.0.2
         version: 3.0.2
@@ -792,13 +795,13 @@ importers:
         version: 8.4.24
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.1(postcss@8.4.24)
+        version: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
 
   dapps/kiosk-cli:
     dependencies:
@@ -907,13 +910,13 @@ importers:
         version: 8.4.24
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.1(postcss@8.4.24)
+        version: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
 
   dapps/sponsored-transactions:
     dependencies:
@@ -947,13 +950,13 @@ importers:
         version: 8.4.24
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.1(postcss@8.4.24)
+        version: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
 
   sdk/bcs:
     dependencies:
@@ -969,13 +972,13 @@ importers:
         version: 8.2.4
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vitest:
         specifier: ^0.32.0
-        version: 0.32.0
+        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/build-scripts:
     dependencies:
@@ -1017,7 +1020,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1045,13 +1048,13 @@ importers:
         version: 8.2.4
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vitest:
         specifier: ^0.32.0
-        version: 0.32.0
+        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/suins-toolkit:
     dependencies:
@@ -1064,7 +1067,7 @@ importers:
         version: 8.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(typescript@5.0.4)
+        version: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
@@ -1073,7 +1076,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: ^0.32.0
-        version: 0.32.0
+        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/typescript:
     dependencies:
@@ -1137,7 +1140,7 @@ importers:
         version: 0.7.0
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -1149,13 +1152,13 @@ importers:
         version: 5.0.4
       vite:
         specifier: ^4.2.3
-        version: 4.2.3(@types/node@18.15.11)
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
       vitest:
         specifier: ^0.32.0
-        version: 0.32.0
+        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
       wait-on:
         specifier: ^7.0.1
-        version: 7.0.1
+        version: 7.0.1(debug@4.3.4)
 
   sdk/wallet-adapter/adapters/all-wallets:
     dependencies:
@@ -1168,7 +1171,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1184,7 +1187,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1203,7 +1206,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1225,7 +1228,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1262,7 +1265,7 @@ importers:
         version: 4.0.0(vite@4.2.3)
       vite:
         specifier: ^4.2.3
-        version: 4.2.3(@types/node@18.15.11)
+        version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
 
   sdk/wallet-adapter/site:
     dependencies:
@@ -1274,10 +1277,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.8.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.8.0(next@13.3.0)(nextra@2.8.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1336,7 +1339,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1355,7 +1358,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1371,7 +1374,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
+        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -1392,8 +1395,8 @@ packages:
       '@amplitude/types': 1.10.2
       '@babel/parser': 7.21.4
       '@babel/traverse': 7.21.4
-      '@oclif/command': 1.8.26
-      '@oclif/config': 1.18.9
+      '@oclif/command': 1.8.26(supports-color@8.1.1)
+      '@oclif/config': 1.18.9(supports-color@8.1.1)
       '@oclif/errors': 1.3.6
       '@oclif/parser': 3.8.11
       '@oclif/plugin-autocomplete': 0.3.0
@@ -1410,7 +1413,7 @@ packages:
       chalk: 2.4.2
       client-oauth2: 4.3.3
       conf: 6.2.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       dotenv: 8.6.0
       fs-extra: 8.1.0
       get-port: 5.1.1
@@ -1578,7 +1581,7 @@ packages:
       '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.5.3
@@ -1688,7 +1691,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 7.5.3
@@ -2959,7 +2962,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2977,7 +2980,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3554,7 +3557,7 @@ packages:
       '@devicefarmer/adbkit-monkey': 1.2.1
       bluebird: 3.7.2
       commander: 9.5.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       node-forge: 1.3.1
       split: 1.0.1
     transitivePeerDependencies:
@@ -4012,7 +4015,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.5.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -4168,7 +4171,7 @@ packages:
     peerDependencies:
       tailwindcss: ^3.0
     dependencies:
-      tailwindcss: 3.3.1(postcss@8.4.24)
+      tailwindcss: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
 
   /@hookform/resolvers@3.0.1(react-hook-form@7.43.9):
     resolution: {integrity: sha512-n5oOt0cLw9mQNW3/k9zWaPsNWQcc0k6Jpc7XUrg2Q/AqqsHp3IVa1juqHCxczXI6uXHBa69ILc4pdtsRGyuzsw==}
@@ -4183,7 +4186,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4311,7 +4314,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.0.4)
       typescript: 5.0.4
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -4567,7 +4570,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.8
       '@xmldom/xmldom': 0.8.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       headers-polyfill: 3.1.2
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
@@ -4824,20 +4827,6 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /@oclif/command@1.8.26:
-    resolution: {integrity: sha512-IT9kOLFRMc3s6KJ1FymsNjbHShI211eVgAg+JMiDVl8LXwOJxYe8ybesgL1kpV9IUFByOBwZKNG2mmrVeNBHPg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@oclif/config': 1.18.9
-      '@oclif/errors': 1.3.6
-      '@oclif/help': 1.0.7
-      '@oclif/parser': 3.8.11
-      debug: 4.3.4
-      semver: 7.5.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@oclif/command@1.8.26(supports-color@8.1.1):
     resolution: {integrity: sha512-IT9kOLFRMc3s6KJ1FymsNjbHShI211eVgAg+JMiDVl8LXwOJxYe8ybesgL1kpV9IUFByOBwZKNG2mmrVeNBHPg==}
     engines: {node: '>=12.0.0'}
@@ -4858,21 +4847,7 @@ packages:
     dependencies:
       '@oclif/errors': 1.3.6
       '@oclif/parser': 3.8.11
-      debug: 4.3.4
-      globby: 11.1.0
-      is-wsl: 2.2.0
-      tslib: 2.5.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@oclif/config@1.18.9:
-    resolution: {integrity: sha512-CGABvY60IbzK3kecDekCQS4T7fvpraBHV3nvYDtehrqljbMxtTeeJkFJVLbBnZnwzD2u1ApQX/Zggja3lyCoJA==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@oclif/errors': 1.3.6
-      '@oclif/parser': 3.8.11
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-wsl: 2.2.0
       tslib: 2.5.2
@@ -4916,23 +4891,6 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /@oclif/help@1.0.7:
-    resolution: {integrity: sha512-wrkoLFiwzzeq9fAy4TQB19BLO+wvmppUPuTj8As+RwGiAGqpKqfsrDMFFTFy+dFMMwArwqaOPUMna7xTjaKUyg==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@oclif/config': 1.18.9
-      '@oclif/errors': 1.3.6
-      chalk: 4.1.2
-      indent-string: 4.0.0
-      lodash: 4.17.21
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      widest-line: 3.1.0
-      wrap-ansi: 6.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@oclif/help@1.0.7(supports-color@8.1.1):
     resolution: {integrity: sha512-wrkoLFiwzzeq9fAy4TQB19BLO+wvmppUPuTj8As+RwGiAGqpKqfsrDMFFTFy+dFMMwArwqaOPUMna7xTjaKUyg==}
     engines: {node: '>=8.0.0'}
@@ -4968,11 +4926,11 @@ packages:
     resolution: {integrity: sha512-gCuIUCswvoU1BxDDvHSUGxW8rFagiacle8jHqE49+WnuniXD/N8NmJvnzmlNyc8qLE192CnKK+qYyAF+vaFQBg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@oclif/command': 1.8.26
-      '@oclif/config': 1.18.9
+      '@oclif/command': 1.8.26(supports-color@8.1.1)
+      '@oclif/config': 1.18.9(supports-color@8.1.1)
       chalk: 4.1.2
       cli-ux: 5.6.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 9.0.1
       moment: 2.29.4
     transitivePeerDependencies:
@@ -4983,10 +4941,10 @@ packages:
     resolution: {integrity: sha512-QuSiseNRJygaqAdABYFWn/H1CwIZCp9zp/PLid6yXvy6VcQV7OenEFF5XuYaCvSARe2Tg9r8Jqls5+fw1A9CbQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@oclif/command': 1.8.26
+      '@oclif/command': 1.8.26(supports-color@8.1.1)
       '@oclif/config': 1.18.2
       '@oclif/errors': 1.3.5
-      '@oclif/help': 1.0.7
+      '@oclif/help': 1.0.7(supports-color@8.1.1)
       chalk: 4.1.2
       indent-string: 4.0.0
       lodash: 4.17.21
@@ -5003,13 +4961,13 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       '@oclif/color': 0.1.2
-      '@oclif/command': 1.8.26
-      '@oclif/config': 1.18.9
+      '@oclif/command': 1.8.26(supports-color@8.1.1)
+      '@oclif/config': 1.18.9(supports-color@8.1.1)
       '@oclif/errors': 1.3.6
       '@types/semver': 7.3.13
       cli-ux: 5.6.7
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       filesize: 6.4.0
       fs-extra: 9.0.1
       http-call: 5.3.0
@@ -5025,11 +4983,11 @@ packages:
     resolution: {integrity: sha512-q8q0NIneVCwIAJzglUMsl3EbXR/H5aPDk6g+qs7uF0tToxe07SWSONoNaKPzViwRWvYChMPjL77/rXyW1HVn4A==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@oclif/command': 1.8.26
-      '@oclif/config': 1.18.9
+      '@oclif/command': 1.8.26(supports-color@8.1.1)
+      '@oclif/config': 1.18.9(supports-color@8.1.1)
       '@oclif/errors': 1.3.6
       chalk: 4.1.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 9.0.1
       http-call: 5.3.0
       lodash: 4.17.21
@@ -6658,7 +6616,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.23.1
       typescript: 5.0.4
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7278,7 +7236,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -7329,7 +7287,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - supports-color
@@ -7834,7 +7792,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.3.1(postcss@8.4.24)
+      tailwindcss: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
     dev: true
 
   /@tailwindcss/forms@0.5.3(tailwindcss@3.3.1):
@@ -7843,7 +7801,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.1(postcss@8.4.24)
+      tailwindcss: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
 
   /@tanstack/eslint-plugin-query@4.29.4:
     resolution: {integrity: sha512-dKWigue+8KV9BaKLq5yUu4wUYCendpvEve8lc3YyD634MQJ/joK7nJXiMfAEHY5Bwnh00Y3ZTBJ6YNtAz4CbVQ==}
@@ -7977,12 +7935,12 @@ packages:
       '@testing-library/dom': 9.2.0
     dev: true
 
-  /@theguild/remark-mermaid@0.0.3(react@18.2.0):
-    resolution: {integrity: sha512-fccVR6o4UPUztrBjdUhM4ahwx+X7YHhoxsUoXv2vI07vz4dq+I03Ot0SjuZzDA/H7engxcb8ZxzCUEkZgGr/2g==}
+  /@theguild/remark-mermaid@0.0.1(react@18.2.0):
+    resolution: {integrity: sha512-MbLi7CIn25r0MypN1yaTrvuQHBE/UXy/DKfVjaLlXx5ut4PasOwzGIJihzM4d9kqNADJKilHpQWcd66ivbvJEQ==}
     peerDependencies:
       react: ^18.2.0
     dependencies:
-      mermaid: 10.2.3
+      mermaid: 10.2.1
       react: 18.2.0
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
@@ -8544,7 +8502,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.9
       '@typescript-eslint/type-utils': 5.59.9(eslint@8.38.0)
       '@typescript-eslint/utils': 5.59.9(eslint@8.38.0)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.38.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -8581,7 +8539,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.8
       '@typescript-eslint/types': 5.59.8
       '@typescript-eslint/typescript-estree': 5.59.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.38.0
     transitivePeerDependencies:
       - supports-color
@@ -8623,7 +8581,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.9
       '@typescript-eslint/utils': 5.59.9(eslint@8.38.0)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.38.0
       tsutils: 3.21.0
     transitivePeerDependencies:
@@ -8656,7 +8614,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.33.1
       '@typescript-eslint/visitor-keys': 5.33.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -8676,7 +8634,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.8
       '@typescript-eslint/visitor-keys': 5.59.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -8696,7 +8654,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.9
       '@typescript-eslint/visitor-keys': 5.59.9
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -8936,7 +8894,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8951,7 +8909,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       react-refresh: 0.14.0
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9374,7 +9332,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9783,15 +9741,6 @@ packages:
   /axe-core@4.6.3:
     resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
     engines: {node: '>=4'}
-    dev: true
-
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.1
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /axios@0.27.2(debug@4.3.4):
@@ -11623,17 +11572,6 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -11645,7 +11583,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -11846,7 +11783,7 @@ packages:
     resolution: {integrity: sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==}
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12260,7 +12197,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.17.19
     transitivePeerDependencies:
       - supports-color
@@ -12685,7 +12622,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin@3.2.0(webpack@5.79.0):
+  /eslint-webpack-plugin@3.2.0(eslint@8.38.0)(webpack@5.79.0):
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -12693,6 +12630,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.37.0
+      eslint: 8.38.0
       jest-worker: 28.1.3
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -12715,7 +12653,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -12764,7 +12702,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -13301,16 +13239,6 @@ packages:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
     dev: false
 
-  /follow-redirects@1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: true
-
   /follow-redirects@1.15.1(debug@4.3.4):
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
     engines: {node: '>=4.0'}
@@ -13320,7 +13248,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     dev: true
 
   /for-each@0.3.3:
@@ -14087,7 +14015,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -14327,7 +14254,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       content-type: 1.0.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -14369,7 +14296,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14379,7 +14306,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16174,8 +16101,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  /mermaid@10.2.3:
-    resolution: {integrity: sha512-cMVE5s9PlQvOwfORkyVpr5beMsLdInrycAosdr+tpZ0WFjG4RJ/bUHST7aTgHNJbujHkdBRAm+N50P3puQOfPw==}
+  /mermaid@10.2.1:
+    resolution: {integrity: sha512-gziwXLuAidRxPJxcA0LqPhToirGZ2J2gD+UrDEtGNeKb98BtcQde28UUcCUCmNplkQOwE7oynrzKcMe9i29AMw==}
     dependencies:
       '@braintree/sanitize-url': 6.0.2
       cytoscape: 3.25.0
@@ -16529,7 +16456,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -16942,11 +16869,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.8.0(next@13.3.0)(nextra@2.8.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-JoSAILDVp0GxeVWWZBFGoRijE2RcjZcXrMa47Fssi254T5wF+gm0HvEOSwrTaKaPaUL+IfshAiKglvXNKGzbNw==}
+  /nextra-theme-docs@2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-C2DtoGH15q22t4r2JC89lvvajmnyiqsv3PaqHJpoHRlF2eR5giuLhZC5Oahb9AENRDcnUIUvqVi/8NlfiIM0yQ==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.8.0
+      nextra: 2.7.1
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -16961,15 +16888,15 @@ packages:
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.8.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.8.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-WyRNzw1IM/eF3M1H3LSsbZH97QsYYgj8upjx0f8hY6GspmPyPRAvBBscmXRt+7vye2oIYjfVwSiD1rj9amqq9Q==}
+  /nextra@2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-qchTb7XSm357XAHf9MV9UlUSGolPEPE8iFnC/9KMwvhIoE4seyPYWMrnH84XraZCcGERvy9TrkFD30VE7Qv1MA==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -16979,7 +16906,7 @@ packages:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
       '@napi-rs/simple-git': 0.1.8
-      '@theguild/remark-mermaid': 0.0.3(react@18.2.0)
+      '@theguild/remark-mermaid': 0.0.1(react@18.2.0)
       clsx: 1.2.1
       github-slugger: 2.0.0
       graceful-fs: 4.2.11
@@ -16992,7 +16919,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       rehype-katex: 6.0.3
-      rehype-pretty-code: 0.9.9(shiki@0.14.2)
+      rehype-pretty-code: 0.9.4(shiki@0.14.2)
       remark-gfm: 3.0.1
       remark-math: 5.1.1
       remark-reading-time: 2.0.1
@@ -18107,38 +18034,6 @@ packages:
       postcss: 8.4.24
     dev: true
 
-  /postcss-load-config@3.1.4:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.2.2
-    dev: true
-
-  /postcss-load-config@3.1.4(postcss@8.4.24):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      postcss: 8.4.24
-      yaml: 2.2.2
-
   /postcss-load-config@3.1.4(postcss@8.4.24)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -18155,24 +18050,6 @@ packages:
       postcss: 8.4.24
       ts-node: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
       yaml: 2.2.2
-    dev: false
-
-  /postcss-load-config@3.1.4(ts-node@10.9.1):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      ts-node: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
-      yaml: 2.2.2
-    dev: true
 
   /postcss-loader@7.2.4(@types/node@18.15.11)(postcss@8.4.24)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.79.0):
     resolution: {integrity: sha512-F88rpxxNspo5hatIc+orYwZDtHFaVFOSIVAx+fBfJC1GmhWbVmPWtmg2gXKE1OxJbneOSGn8PWdIwsZFcruS+w==}
@@ -18724,7 +18601,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -19406,13 +19283,12 @@ packages:
       unist-util-visit: 4.1.2
     dev: false
 
-  /rehype-pretty-code@0.9.9(shiki@0.14.2):
-    resolution: {integrity: sha512-mlU2Qgupn9MMK31CTmWk0Ie5Vp0od+jh2vCkGDBMlPAMeAvYASn6Ois6xRmosutMT4yH/COc3R4r/PELpuUoWg==}
-    engines: {node: '>=16'}
+  /rehype-pretty-code@0.9.4(shiki@0.14.2):
+    resolution: {integrity: sha512-3m4aQT15n8C+UizcZL0enaahoZwCDm5K1qKQ3DGgHE7U8l/DEEEJ/hm+uDe9yyK4sxVOSfZcRIMHrpJwLQi+Rg==}
+    engines: {node: ^12.16.0 || >=13.2.0}
     peerDependencies:
       shiki: '*'
     dependencies:
-      '@types/hast': 2.3.4
       hash-obj: 4.0.0
       parse-numeric-range: 1.3.0
       shiki: 0.14.2
@@ -20227,7 +20103,7 @@ packages:
       arg: 5.0.2
       bluebird: 3.7.2
       check-more-types: 2.24.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
@@ -20649,7 +20525,7 @@ packages:
       colord: 2.9.3
       cosmiconfig: 7.1.0
       css-functions-list: 3.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.2.12
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -20740,7 +20616,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-hyperlinks@2.2.0:
     resolution: {integrity: sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==}
@@ -20802,42 +20677,8 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
     dependencies:
-      tailwindcss: 3.3.1(postcss@8.4.24)
+      tailwindcss: 3.3.1(postcss@8.4.24)(ts-node@10.9.1)
     dev: false
-
-  /tailwindcss@3.3.1(postcss@8.4.24):
-    resolution: {integrity: sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==}
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.18.2
-      lilconfig: 2.1.0
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.24
-      postcss-import: 14.1.0(postcss@8.4.24)
-      postcss-js: 4.0.1(postcss@8.4.24)
-      postcss-load-config: 3.1.4(postcss@8.4.24)
-      postcss-nested: 6.0.0(postcss@8.4.24)
-      postcss-selector-parser: 6.0.11
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.2
-      sucrase: 3.29.0
-    transitivePeerDependencies:
-      - ts-node
 
   /tailwindcss@3.3.1(postcss@8.4.24)(ts-node@10.9.1):
     resolution: {integrity: sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==}
@@ -20872,7 +20713,6 @@ packages:
       sucrase: 3.29.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
 
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -21226,36 +21066,6 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-node@10.9.1(typescript@5.0.4):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.0.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
   /ts-retry-promise@0.7.0:
     resolution: {integrity: sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==}
     engines: {node: '>=6'}
@@ -21319,48 +21129,12 @@ packages:
       bundle-require: 4.0.1(esbuild@0.17.19)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.17.19
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
-      resolve-from: 5.0.0
-      rollup: 3.23.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
-      tree-kill: 1.2.2
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
-  /tsup@6.7.0(typescript@5.0.4):
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.19)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.19
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.9.1)
       resolve-from: 5.0.0
       rollup: 3.23.1
       source-map: 0.8.0-beta.0
@@ -22063,34 +21837,13 @@ packages:
       vfile-message: 3.1.4
     dev: false
 
-  /vite-node@0.32.0(@types/node@18.15.11):
-    resolution: {integrity: sha512-220P/y8YacYAU+daOAqiGEFXx2A8AwjadDzQqos6wSukjvvTWNqleJSwoUn0ckyNdjHIKoxn93Nh1vWBqEKr3Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      mlly: 1.2.0
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      vite: 4.2.3(@types/node@18.15.11)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@0.32.0(@types/node@18.15.11)(sass@1.62.0):
     resolution: {integrity: sha512-220P/y8YacYAU+daOAqiGEFXx2A8AwjadDzQqos6wSukjvvTWNqleJSwoUn0ckyNdjHIKoxn93Nh1vWBqEKr3Q==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -22112,7 +21865,7 @@ packages:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
       connect-history-api-fallback: 1.6.0
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     dev: false
 
   /vite-plugin-svgr@2.4.0(vite@4.2.3):
@@ -22122,7 +21875,7 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.0.2
       '@svgr/core': 6.5.1
-      vite: 4.2.3(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -22136,79 +21889,13 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.0.4)
       vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  /vite@4.2.3:
-    resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      resolve: 1.22.2
-      rollup: 3.23.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.2.3(@types/node@18.15.11):
-    resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.15.11
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      resolve: 1.22.2
-      rollup: 3.23.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   /vite@4.2.3(@types/node@18.15.11)(sass@1.62.0):
     resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
@@ -22243,71 +21930,6 @@ packages:
       sass: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
-
-  /vitest@0.32.0:
-    resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.5
-      '@types/chai-subset': 1.3.3
-      '@types/node': 18.15.11
-      '@vitest/expect': 0.32.0
-      '@vitest/runner': 0.32.0
-      '@vitest/snapshot': 0.32.0
-      '@vitest/spy': 0.32.0
-      '@vitest/utils': 0.32.0
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      concordance: 5.0.4
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      std-env: 3.3.2
-      strip-literal: 1.0.1
-      tinybench: 2.5.0
-      tinypool: 0.5.0
-      vite: 4.2.3(@types/node@18.15.11)
-      vite-node: 0.32.0(@types/node@18.15.11)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3):
     resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
@@ -22354,7 +21976,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       happy-dom: 9.5.0
       local-pkg: 0.4.3
       magic-string: 0.30.0
@@ -22365,8 +21987,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 4.2.3(@types/node@18.15.11)
-      vite-node: 0.32.0(@types/node@18.15.11)
+      vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
+      vite-node: 0.32.0(@types/node@18.15.11)(sass@1.62.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -22421,7 +22043,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       happy-dom: 9.5.0
       local-pkg: 0.4.3
       magic-string: 0.30.0
@@ -22455,19 +22077,6 @@ packages:
     engines: {node: '>= 4.0.0', npm: '>= 3.0.0'}
     dependencies:
       parse5: 3.0.3
-    dev: true
-
-  /wait-on@7.0.1:
-    resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      axios: 0.27.2
-      joi: 17.7.0
-      lodash: 4.17.21
-      minimist: 1.2.8
-      rxjs: 7.8.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /wait-on@7.0.1(debug@4.3.4):


### PR DESCRIPTION
## Description 

This moves the explorer to use Radix tabs instead of headless. This will be our new a11y solution that we can use everywhere.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
