### PR TITLE
[ts-sdk] add modular exports for keypairs

### DIFF
--- a/.changeset/quick-monkeys-hang.md
+++ b/.changeset/quick-monkeys-hang.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': minor
+---
+
+Add keypair exports to allow modular imports for various keypair types

--- a/sdk/build-scripts/src/build-package.ts
+++ b/sdk/build-scripts/src/build-package.ts
@@ -105,7 +105,7 @@ async function buildImportDirectories({ exports }: PackageJSON) {
 	}
 
 	for (const [exportName, exportMap] of Object.entries(exports)) {
-		if (typeof exportMap !== 'object' || !exportName.match(/^\.\/[\w\-_]+$/)) {
+		if (typeof exportMap !== 'object' || !exportName.match(/^\.\/[\w\-_/]+$/)) {
 			continue;
 		}
 

--- a/sdk/typescript/keypairs/ed25519/package.json
+++ b/sdk/typescript/keypairs/ed25519/package.json
@@ -1,0 +1,5 @@
+{
+	"private": true,
+	"import": "../dist/esm/keypairs/ed25519/index.js",
+	"main": "../dist/cjs/keypairs/ed25519/index.js"
+}

--- a/sdk/typescript/keypairs/secp256k1/package.json
+++ b/sdk/typescript/keypairs/secp256k1/package.json
@@ -1,0 +1,5 @@
+{
+	"private": true,
+	"import": "../dist/esm/keypairs/secp256k1/index.js",
+	"main": "../dist/cjs/keypairs/secp256k1/index.js"
+}

--- a/sdk/typescript/keypairs/secp256r1/package.json
+++ b/sdk/typescript/keypairs/secp256r1/package.json
@@ -1,0 +1,5 @@
+{
+	"private": true,
+	"import": "../dist/esm/keypairs/secp256r1/index.js",
+	"main": "../dist/cjs/keypairs/secp256r1/index.js"
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -27,6 +27,21 @@
 			"source": "./src/builder/index.ts",
 			"import": "./dist/esm/builder/index.js",
 			"require": "./dist/cjs/builder/index.js"
+		},
+		"./keypairs/ed25519": {
+			"source": "./src/keypairs/ed25519/index.ts",
+			"import": "./dist/esm/keypairs/ed25519/index.js",
+			"require": "./dist/cjs/keypairs/ed25519/index.js"
+		},
+		"./keypairs/secp256k1": {
+			"source": "./src/keypairs/secp256k1/index.ts",
+			"import": "./dist/esm/keypairs/secp256k1/index.js",
+			"require": "./dist/cjs/keypairs/secp256k1/index.js"
+		},
+		"./keypairs/secp256r1": {
+			"source": "./src/keypairs/secp256r1/index.ts",
+			"import": "./dist/esm/keypairs/secp256r1/index.js",
+			"require": "./dist/cjs/keypairs/secp256r1/index.js"
 		}
 	},
 	"scripts": {

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromB64 } from '@mysten/bcs';
-import { Ed25519Keypair } from './ed25519-keypair.js';
 import { PublicKey } from './publickey.js';
-import { Secp256k1Keypair } from './secp256k1-keypair.js';
 import { SignatureScheme } from './signature.js';
 
 export const PRIVATE_KEY_SIZE = 32;
@@ -35,21 +32,4 @@ export interface Keypair {
 	getKeyScheme(): SignatureScheme;
 
 	export(): ExportedKeypair;
-}
-
-export function fromExportedKeypair(keypair: ExportedKeypair): Keypair {
-	const secretKey = fromB64(keypair.privateKey);
-	switch (keypair.schema) {
-		case 'ED25519':
-			let pureSecretKey = secretKey;
-			if (secretKey.length === LEGACY_PRIVATE_KEY_SIZE) {
-				// This is a legacy secret key, we need to strip the public key bytes and only read the first 32 bytes
-				pureSecretKey = secretKey.slice(0, PRIVATE_KEY_SIZE);
-			}
-			return Ed25519Keypair.fromSecretKey(pureSecretKey);
-		case 'Secp256k1':
-			return Secp256k1Keypair.fromSecretKey(secretKey);
-		default:
-			throw new Error(`Invalid keypair schema ${keypair.schema}`);
-	}
 }

--- a/sdk/typescript/src/cryptography/multisig.ts
+++ b/sdk/typescript/src/cryptography/multisig.ts
@@ -7,8 +7,8 @@ import {
 	SerializedSignature,
 	SignaturePubkeyPair,
 	SignatureScheme,
-	toSingleSignaturePubkeyPair,
 } from './signature.js';
+import { toSingleSignaturePubkeyPair } from './utils.js';
 import { PublicKey } from './publickey.js';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bytesToHex } from '@noble/hashes/utils';

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519PublicKey } from './ed25519-publickey.js';
-import { Secp256k1PublicKey } from './secp256k1-publickey.js';
-import { SignatureScheme } from './signature.js';
-
 /**
  * Value to be converted into public key.
  */
@@ -58,14 +54,4 @@ export interface PublicKey {
 	 * Return signature scheme flag of the public key
 	 */
 	flag(): number;
-}
-
-export function publicKeyFromSerialized(schema: SignatureScheme, pubKey: string): PublicKey {
-	if (schema === 'ED25519') {
-		return new Ed25519PublicKey(pubKey);
-	}
-	if (schema === 'Secp256k1') {
-		return new Secp256k1PublicKey(pubKey);
-	}
-	throw new Error('Unknown public key schema');
 }

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -1,16 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromB64, toB64 } from '@mysten/bcs';
-import { Ed25519PublicKey } from './ed25519-publickey.js';
-import { PublicKey } from './publickey.js';
-import { Secp256k1PublicKey } from './secp256k1-publickey.js';
-import { Secp256r1PublicKey } from './secp256r1-publickey.js';
-import { decodeMultiSig } from './multisig.js';
+import type { PublicKey } from './publickey';
 
-/**
- * A keypair used for signing transactions.
- */
 export type SignatureScheme = 'ED25519' | 'Secp256k1' | 'Secp256r1' | 'MultiSig';
 
 /**
@@ -45,61 +37,3 @@ export const SIGNATURE_FLAG_TO_SCHEME = {
 } as const;
 
 export type SignatureFlag = keyof typeof SIGNATURE_FLAG_TO_SCHEME;
-
-export function toSerializedSignature({
-	signature,
-	signatureScheme,
-	pubKey,
-}: SignaturePubkeyPair): SerializedSignature {
-	const serializedSignature = new Uint8Array(1 + signature.length + pubKey.toBytes().length);
-	serializedSignature.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
-	serializedSignature.set(signature, 1);
-	serializedSignature.set(pubKey.toBytes(), 1 + signature.length);
-	return toB64(serializedSignature);
-}
-
-/// Expects to parse a serialized signature by its signature scheme to a list of signature
-/// and public key pairs. The list is of length 1 if it is not multisig.
-export function toParsedSignaturePubkeyPair(
-	serializedSignature: SerializedSignature,
-): SignaturePubkeyPair[] {
-	const bytes = fromB64(serializedSignature);
-	const signatureScheme =
-		SIGNATURE_FLAG_TO_SCHEME[bytes[0] as keyof typeof SIGNATURE_FLAG_TO_SCHEME];
-
-	if (signatureScheme === 'MultiSig') {
-		return decodeMultiSig(serializedSignature);
-	}
-
-	const SIGNATURE_SCHEME_TO_PUBLIC_KEY = {
-		ED25519: Ed25519PublicKey,
-		Secp256k1: Secp256k1PublicKey,
-		Secp256r1: Secp256r1PublicKey,
-	};
-
-	const PublicKey = SIGNATURE_SCHEME_TO_PUBLIC_KEY[signatureScheme];
-
-	const signature = bytes.slice(1, bytes.length - PublicKey.SIZE);
-	const pubkeyBytes = bytes.slice(1 + signature.length);
-	const pubKey = new PublicKey(pubkeyBytes);
-
-	return [
-		{
-			signatureScheme,
-			signature,
-			pubKey,
-		},
-	];
-}
-
-/// Expects to parse a single signature pubkey pair from the serialized
-/// signature. Use this only if multisig is not expected.
-export function toSingleSignaturePubkeyPair(
-	serializedSignature: SerializedSignature,
-): SignaturePubkeyPair {
-	const res = toParsedSignaturePubkeyPair(serializedSignature);
-	if (res.length !== 1) {
-		throw Error('Expected a single signature');
-	}
-	return res[0];
-}

--- a/sdk/typescript/src/cryptography/utils.ts
+++ b/sdk/typescript/src/cryptography/utils.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fromB64, toB64 } from '@mysten/bcs';
+import {
+	SIGNATURE_FLAG_TO_SCHEME,
+	SIGNATURE_SCHEME_TO_FLAG,
+	SerializedSignature,
+	SignaturePubkeyPair,
+	SignatureScheme,
+} from './signature.js';
+import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
+import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
+import { Ed25519PublicKey } from '../keypairs/ed25519/publickey.js';
+import { decodeMultiSig } from './multisig.js';
+import { PublicKey } from './publickey.js';
+import { Ed25519Keypair } from '../keypairs/ed25519/keypair.js';
+import { Secp256k1Keypair } from '../keypairs/secp256k1/keypair.js';
+import { ExportedKeypair, Keypair, LEGACY_PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE } from './keypair.js';
+
+export function toSerializedSignature({
+	signature,
+	signatureScheme,
+	pubKey,
+}: SignaturePubkeyPair): SerializedSignature {
+	const serializedSignature = new Uint8Array(1 + signature.length + pubKey.toBytes().length);
+	serializedSignature.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
+	serializedSignature.set(signature, 1);
+	serializedSignature.set(pubKey.toBytes(), 1 + signature.length);
+	return toB64(serializedSignature);
+}
+
+/// Expects to parse a serialized signature by its signature scheme to a list of signature
+/// and public key pairs. The list is of length 1 if it is not multisig.
+export function toParsedSignaturePubkeyPair(
+	serializedSignature: SerializedSignature,
+): SignaturePubkeyPair[] {
+	const bytes = fromB64(serializedSignature);
+	const signatureScheme =
+		SIGNATURE_FLAG_TO_SCHEME[bytes[0] as keyof typeof SIGNATURE_FLAG_TO_SCHEME];
+
+	if (signatureScheme === 'MultiSig') {
+		return decodeMultiSig(serializedSignature);
+	}
+
+	const SIGNATURE_SCHEME_TO_PUBLIC_KEY = {
+		ED25519: Ed25519PublicKey,
+		Secp256k1: Secp256k1PublicKey,
+		Secp256r1: Secp256r1PublicKey,
+	};
+
+	const PublicKey = SIGNATURE_SCHEME_TO_PUBLIC_KEY[signatureScheme];
+
+	const signature = bytes.slice(1, bytes.length - PublicKey.SIZE);
+	const pubkeyBytes = bytes.slice(1 + signature.length);
+	const pubKey = new PublicKey(pubkeyBytes);
+
+	return [
+		{
+			signatureScheme,
+			signature,
+			pubKey,
+		},
+	];
+}
+
+/// Expects to parse a single signature pubkey pair from the serialized
+/// signature. Use this only if multisig is not expected.
+export function toSingleSignaturePubkeyPair(
+	serializedSignature: SerializedSignature,
+): SignaturePubkeyPair {
+	const res = toParsedSignaturePubkeyPair(serializedSignature);
+	if (res.length !== 1) {
+		throw Error('Expected a single signature');
+	}
+	return res[0];
+}
+
+export function publicKeyFromSerialized(schema: SignatureScheme, pubKey: string): PublicKey {
+	if (schema === 'ED25519') {
+		return new Ed25519PublicKey(pubKey);
+	}
+	if (schema === 'Secp256k1') {
+		return new Secp256k1PublicKey(pubKey);
+	}
+	throw new Error('Unknown public key schema');
+}
+
+export function fromExportedKeypair(keypair: ExportedKeypair): Keypair {
+	const secretKey = fromB64(keypair.privateKey);
+	switch (keypair.schema) {
+		case 'ED25519':
+			let pureSecretKey = secretKey;
+			if (secretKey.length === LEGACY_PRIVATE_KEY_SIZE) {
+				// This is a legacy secret key, we need to strip the public key bytes and only read the first 32 bytes
+				pureSecretKey = secretKey.slice(0, PRIVATE_KEY_SIZE);
+			}
+			return Ed25519Keypair.fromSecretKey(pureSecretKey);
+		case 'Secp256k1':
+			return Secp256k1Keypair.fromSecretKey(secretKey);
+		default:
+			throw new Error(`Invalid keypair schema ${keypair.schema}`);
+	}
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,16 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-export * from './cryptography/ed25519-keypair.js';
-export * from './cryptography/secp256k1-keypair.js';
-export * from './cryptography/secp256r1-keypair.js';
+export * from './keypairs/ed25519/index.js';
+export * from './keypairs/secp256k1/index.js';
+export * from './keypairs/secp256r1/index.js';
 export * from './cryptography/keypair.js';
-export * from './cryptography/ed25519-publickey.js';
-export * from './cryptography/secp256k1-publickey.js';
-export * from './cryptography/secp256r1-publickey.js';
 export * from './cryptography/multisig.js';
 export * from './cryptography/publickey.js';
 export * from './cryptography/mnemonics.js';
 export * from './cryptography/signature.js';
+export * from './cryptography/utils.js';
 
 export * from './providers/json-rpc-provider.js';
 

--- a/sdk/typescript/src/keypairs/ed25519/index.ts
+++ b/sdk/typescript/src/keypairs/ed25519/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './keypair.js';
+export * from './publickey.js';

--- a/sdk/typescript/src/keypairs/ed25519/keypair.ts
+++ b/sdk/typescript/src/keypairs/ed25519/keypair.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import nacl from 'tweetnacl';
-import { ExportedKeypair, Keypair, PRIVATE_KEY_SIZE } from './keypair.js';
-import { Ed25519PublicKey } from './ed25519-publickey.js';
-import { isValidHardenedPath, mnemonicToSeedHex } from './mnemonics.js';
-import { derivePath } from '../utils/ed25519-hd-key.js';
+import { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import { Ed25519PublicKey } from './publickey.js';
+import { isValidHardenedPath, mnemonicToSeedHex } from '../../cryptography/mnemonics.js';
+import { derivePath } from '../../utils/ed25519-hd-key.js';
 import { toB64 } from '@mysten/bcs';
-import { SignatureScheme } from './signature.js';
+import type { SignatureScheme } from '../../cryptography/signature.js';
+import { PRIVATE_KEY_SIZE } from '../../cryptography/keypair.js';
 
 export const DEFAULT_ED25519_DERIVATION_PATH = "m/44'/784'/0'/0'/0'";
 

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -3,9 +3,9 @@
 
 import { blake2b } from '@noble/hashes/blake2b';
 import { fromB64, toB64 } from '@mysten/bcs';
-import { bytesEqual, PublicKeyInitData } from './publickey.js';
-import { SIGNATURE_SCHEME_TO_FLAG } from './signature.js';
-import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../types/index.js';
+import { bytesEqual, PublicKeyInitData } from '../../cryptography/publickey.js';
+import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
+import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../../types/index.js';
 import { bytesToHex } from '@noble/hashes/utils';
 
 const PUBLIC_KEY_SIZE = 32;

--- a/sdk/typescript/src/keypairs/secp256k1/index.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './keypair.js';
+export * from './publickey.js';

--- a/sdk/typescript/src/keypairs/secp256k1/keypair.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/keypair.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ExportedKeypair, Keypair } from './keypair.js';
-import { PublicKey } from './publickey.js';
+import type { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import { PublicKey } from '../../cryptography/publickey.js';
 import { sha256 } from '@noble/hashes/sha256';
-import { Secp256k1PublicKey } from './secp256k1-publickey.js';
+import { Secp256k1PublicKey } from './publickey.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { isValidBIP32Path, mnemonicToSeed } from './mnemonics.js';
+import { isValidBIP32Path, mnemonicToSeed } from '../../cryptography/mnemonics.js';
 import { HDKey } from '@scure/bip32';
 import { toB64 } from '@mysten/bcs';
-import { SignatureScheme } from './signature.js';
+import type { SignatureScheme } from '../../cryptography/signature.js';
 import { bytesToHex } from '@noble/hashes/utils';
 import { blake2b } from '@noble/hashes/blake2b';
 

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -4,9 +4,9 @@
 import { fromB64, toB64 } from '@mysten/bcs';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bytesToHex } from '@noble/hashes/utils';
-import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../types/index.js';
-import { bytesEqual, PublicKey, PublicKeyInitData } from './publickey.js';
-import { SIGNATURE_SCHEME_TO_FLAG } from './signature.js';
+import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../../types/index.js';
+import { bytesEqual, PublicKey, PublicKeyInitData } from '../../cryptography/publickey.js';
+import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
 
 const SECP256K1_PUBLIC_KEY_SIZE = 33;
 

--- a/sdk/typescript/src/keypairs/secp256r1/index.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './keypair.js';
+export * from './publickey.js';

--- a/sdk/typescript/src/keypairs/secp256r1/keypair.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/keypair.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ExportedKeypair, Keypair } from './keypair.js';
-import { PublicKey } from './publickey.js';
+import type { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import { PublicKey } from '../../cryptography/publickey.js';
 import { sha256 } from '@noble/hashes/sha256';
-import { Secp256r1PublicKey } from './secp256r1-publickey.js';
+import { Secp256r1PublicKey } from './publickey.js';
 import { secp256r1 } from '@noble/curves/p256';
-import { isValidBIP32Path, mnemonicToSeed } from './mnemonics.js';
+import { isValidBIP32Path, mnemonicToSeed } from '../../cryptography/mnemonics.js';
 import { HDKey } from '@scure/bip32';
 import { toB64 } from '@mysten/bcs';
-import { SignatureScheme } from './signature.js';
+import type { SignatureScheme } from '../../cryptography/signature.js';
 import { bytesToHex } from '@noble/hashes/utils';
 import { blake2b } from '@noble/hashes/blake2b';
 

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -4,9 +4,9 @@
 import { fromB64, toB64 } from '@mysten/bcs';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bytesToHex } from '@noble/hashes/utils';
-import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../types/index.js';
-import { bytesEqual, PublicKey, PublicKeyInitData } from './publickey.js';
-import { SIGNATURE_SCHEME_TO_FLAG } from './signature.js';
+import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../../types/index.js';
+import { bytesEqual, PublicKey, PublicKeyInitData } from '../../cryptography/publickey.js';
+import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
 
 const SECP256R1_PUBLIC_KEY_SIZE = 33;
 

--- a/sdk/typescript/src/signers/raw-signer.ts
+++ b/sdk/typescript/src/signers/raw-signer.ts
@@ -3,10 +3,11 @@
 
 import { blake2b } from '@noble/hashes/blake2b';
 import { Keypair } from '../cryptography/keypair.js';
-import { SerializedSignature, toSerializedSignature } from '../cryptography/signature.js';
+import { SerializedSignature } from '../cryptography/signature.js';
 import { JsonRpcProvider } from '../providers/json-rpc-provider.js';
 import { SuiAddress } from '../types/index.js';
 import { SignerWithProvider } from './signer-with-provider.js';
+import { toSerializedSignature } from '../cryptography/utils.js';
 
 export class RawSigner extends SignerWithProvider {
 	private readonly keypair: Keypair;

--- a/sdk/typescript/src/utils/verify.ts
+++ b/sdk/typescript/src/utils/verify.ts
@@ -6,8 +6,9 @@ import nacl from 'tweetnacl';
 import { IntentScope, messageWithIntent } from './intent.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { SerializedSignature, toSingleSignaturePubkeyPair } from '../cryptography/signature.js';
+import { SerializedSignature } from '../cryptography/signature.js';
 import { blake2b } from '@noble/hashes/blake2b';
+import { toSingleSignaturePubkeyPair } from '../cryptography/utils.js';
 
 // TODO: This might actually make sense to eventually move to the `Keypair` instances themselves, as
 // it could allow the Sui.js to be tree-shaken a little better, possibly allowing keypairs that are

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -3,7 +3,7 @@
 
 import { toB64, toHEX } from '@mysten/bcs';
 import { describe, it, expect } from 'vitest';
-import { Secp256k1PublicKey } from '../../../src/cryptography/secp256k1-publickey';
+import { Secp256k1PublicKey } from '../../../src/keypairs/secp256k1/publickey';
 import { INVALID_SECP256K1_PUBLIC_KEY, VALID_SECP256K1_PUBLIC_KEY } from './secp256k1-keypair.test';
 
 // Test case generated against CLI:

--- a/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
@@ -3,7 +3,7 @@
 
 import { toB64, toHEX } from '@mysten/bcs';
 import { describe, it, expect } from 'vitest';
-import { Secp256r1PublicKey } from '../../../src/cryptography/secp256r1-publickey';
+import { Secp256r1PublicKey } from '../../../src/keypairs/secp256r1/publickey';
 import { INVALID_SECP256R1_PUBLIC_KEY, VALID_SECP256R1_PUBLIC_KEY } from './secp256r1-keypair.test';
 
 // Test case generated against CLI:


### PR DESCRIPTION
## Description 

This moves implemtations for various keypairs into a new `src/keypairs` directory and allows the associated classes to be imported directly (eg. `import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';`

Exporting these files required some refactoring because there were several utility functions defined in files needed by the keypair implementations.  These utils have been moved to a new `cryptography/utils.ts` so that the keypair implementations do not automatically import all other keypair implementations via indirect imports.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
