### PR TITLE
use backup url for dump replay

### DIFF
--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -648,7 +648,7 @@ impl NodeStateDumpFetcher {
     ) -> Self {
         let mut s = Self::from(node_state_dump);
         s.backup_remote_fetcher = backup_remote_fetcher;
-        return s;
+        s
     }
 }
 

--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -599,11 +599,14 @@ pub fn extract_epoch_and_version(ev: SuiEvent) -> Result<(u64, u64), ReplayEngin
     Err(ReplayEngineError::UnexpectedEventFormat { event: ev })
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NodeStateDumpFetcher {
     pub node_state_dump: NodeStateDump,
     pub object_ref_pool: BTreeMap<(ObjectID, SequenceNumber), Object>,
     pub latest_object_version_pool: BTreeMap<ObjectID, Object>,
+
+    // Used when we need to fetch data from remote such as
+    pub backup_remote_fetcher: Option<RemoteFetcher>,
 }
 
 impl From<NodeStateDump> for NodeStateDumpFetcher {
@@ -633,7 +636,19 @@ impl From<NodeStateDump> for NodeStateDumpFetcher {
             node_state_dump,
             object_ref_pool,
             latest_object_version_pool,
+            backup_remote_fetcher: None,
         }
+    }
+}
+
+impl NodeStateDumpFetcher {
+    pub fn new(
+        node_state_dump: NodeStateDump,
+        backup_remote_fetcher: Option<RemoteFetcher>,
+    ) -> Self {
+        let mut s = Self::from(node_state_dump);
+        s.backup_remote_fetcher = backup_remote_fetcher;
+        return s;
     }
 }
 
@@ -644,7 +659,7 @@ impl DataFetcher for NodeStateDumpFetcher {
         objects: &[(ObjectID, SequenceNumber)],
     ) -> Result<Vec<Object>, ReplayEngineError> {
         let mut resp = vec![];
-        objects.iter().try_for_each(|(id, version)| {
+        match objects.iter().try_for_each(|(id, version)| {
             if let Some(obj) = self.object_ref_pool.get(&(*id, *version)) {
                 resp.push(obj.clone());
                 return Ok(());
@@ -653,8 +668,15 @@ impl DataFetcher for NodeStateDumpFetcher {
                 id: *id,
                 version: *version,
             })
-        })?;
-        Ok(resp)
+        }) {
+            Ok(_) => return Ok(resp),
+            Err(e) => {
+                if let Some(backup_remote_fetcher) = &self.backup_remote_fetcher {
+                    return backup_remote_fetcher.multi_get_versioned(objects).await;
+                }
+                return Err(e);
+            }
+        };
     }
 
     async fn multi_get_latest(
@@ -662,14 +684,21 @@ impl DataFetcher for NodeStateDumpFetcher {
         objects: &[ObjectID],
     ) -> Result<Vec<Object>, ReplayEngineError> {
         let mut resp = vec![];
-        objects.iter().try_for_each(|id| {
+        match objects.iter().try_for_each(|id| {
             if let Some(obj) = self.latest_object_version_pool.get(id) {
                 resp.push(obj.clone());
                 return Ok(());
             }
             Err(ReplayEngineError::ObjectNotExist { id: *id })
-        })?;
-        Ok(resp)
+        }) {
+            Ok(_) => return Ok(resp),
+            Err(e) => {
+                if let Some(backup_remote_fetcher) = &self.backup_remote_fetcher {
+                    return backup_remote_fetcher.multi_get_latest(objects).await;
+                }
+                return Err(e);
+            }
+        };
     }
 
     async fn get_checkpoint_txs(

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -131,7 +131,7 @@ pub async fn execute_replay_command(
             None
         }
         ReplayToolCommand::ReplayDump { path, show_effects } => {
-            let mut lx = LocalExec::new_for_state_dump(&path).await?;
+            let mut lx = LocalExec::new_for_state_dump(&path, rpc_url).await?;
             let (sandbox_state, node_dump_state) = lx.execute_state_dump(safety).await?;
             if show_effects {
                 println!("{:#?}", sandbox_state.local_exec_effects);

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -397,14 +397,29 @@ impl LocalExec {
         })
     }
 
-    pub async fn new_for_state_dump(path: &str) -> Result<Self, ReplayEngineError> {
+    pub async fn new_for_state_dump(
+        path: &str,
+        backup_rpc_url: Option<String>,
+    ) -> Result<Self, ReplayEngineError> {
         // Use a throwaway metrics registry for local execution.
         let registry = prometheus::Registry::new();
         let metrics = Arc::new(LimitsMetrics::new(&registry));
 
         let state = NodeStateDump::read_from_file(&PathBuf::from(path))?;
         let current_protocol_version = state.protocol_version;
-        let fetcher = NodeStateDumpFetcher::from(state);
+        let fetcher = match backup_rpc_url {
+            Some(url) => NodeStateDumpFetcher::new(
+                state,
+                Some(RemoteFetcher::new(
+                    SuiClientBuilder::default()
+                        .request_timeout(RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD)
+                        .max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
+                        .build(url)
+                        .await?,
+                )),
+            ),
+            None => NodeStateDumpFetcher::new(state, None),
+        };
 
         Ok(Self {
             client: None,


### PR DESCRIPTION
## Description 

When a package is upgraded we dont have all the packages in its linkage table so we might need to fetch that over rpc. This PR adds a backup rpc url option for fetching data when its absent in node state dump.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
