### PR TITLE
Cherrypick #12717 into release 1.4.0

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -109,7 +109,7 @@ use sui_types::{
     transaction::*,
     SUI_SYSTEM_ADDRESS,
 };
-use sui_types::{is_system_package, TypeTag, SUI_CLOCK_OBJECT_ID};
+use sui_types::{is_system_package, TypeTag};
 use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
@@ -762,7 +762,7 @@ impl AuthorityState {
         // this function, in order to prevent a byzantine validator from
         // giving us incorrect effects.
         effects: &VerifiedCertifiedTransactionEffects,
-        objects: Vec<Object>,
+        _objects: Vec<Object>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         assert!(self.is_fullnode(epoch_store));
@@ -778,29 +778,6 @@ impl AuthorityState {
                 err: "effects/tx digest mismatch".to_string()
             }
         );
-
-        // Lock this down to 0x6 before we pin child versions in effects
-        // Also, this logic is incompatible with TransactionManager AvailableObjectCache,
-        // so SUI_CLOCK_OBJECT_ID is currently excluded from the cache.
-        let objects = objects
-            .into_iter()
-            .filter(|o| o.id() == SUI_CLOCK_OBJECT_ID)
-            .collect::<Vec<_>>();
-        if !objects.is_empty() {
-            debug!(
-                "inserting objects to object store before executing a tx: {:?}",
-                objects
-                    .iter()
-                    .map(|o| (o.id(), o.version()))
-                    .collect::<Vec<_>>()
-            );
-            self.database
-                .fullnode_fast_path_insert_objects_to_object_store_maybe(&objects)?;
-            self.transaction_manager().fastpath_objects_available(
-                objects.iter().map(InputKey::from).collect(),
-                epoch_store,
-            );
-        }
 
         if transaction.contains_shared_object() {
             epoch_store

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -793,7 +793,7 @@ impl AuthorityStore {
     /// to the object store, this would cause the reference counting to be incorrect.
     ///
     /// TODO: handle this in a more resilient way.
-    pub(crate) fn fullnode_fast_path_insert_objects_to_object_store_maybe(
+    pub(crate) fn _fullnode_fast_path_insert_objects_to_object_store_maybe(
         &self,
         objects: &Vec<Object>,
     ) -> SuiResult {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -401,12 +401,10 @@ impl ValidatorService {
                 TransactionEvents::default()
             };
 
-            let fastpath_input_objects = state.load_fastpath_input_objects(&signed_effects)?;
-
             return Ok(Some(HandleCertificateResponseV2 {
                 signed_effects: signed_effects.into_inner(),
                 events,
-                fastpath_input_objects,
+                fastpath_input_objects: vec![], // fastpath is unused for now
             }));
         }
 
@@ -483,7 +481,6 @@ impl ValidatorService {
         let effects = state
             .execute_certificate(&certificate, &epoch_store)
             .await?;
-        let fastpath_input_objects = state.load_fastpath_input_objects(&effects)?;
         let events = if let Some(event_digest) = effects.events_digest() {
             state.get_transaction_events(event_digest)?
         } else {
@@ -492,7 +489,7 @@ impl ValidatorService {
         Ok(Some(HandleCertificateResponseV2 {
             signed_effects: effects.into_inner(),
             events,
-            fastpath_input_objects,
+            fastpath_input_objects: vec![], // fastpath is unused for now
         }))
     }
 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -10,6 +10,7 @@ use std::{
 use lru::LruCache;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::{base_types::TransactionDigest, error::SuiResult};
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
@@ -17,7 +18,6 @@ use sui_types::{
     digests::TransactionEffectsDigest,
     transaction::{TransactionDataAPI, VerifiedCertificate},
 };
-use sui_types::{executable_transaction::VerifiedExecutableTransaction, SUI_CLOCK_OBJECT_ID};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, trace, warn};
 
@@ -221,12 +221,6 @@ impl AvailableObjectsCache {
     }
 
     fn insert(&mut self, object: &InputKey) {
-        // Clock object has "fastpath" enabled where a higher version object can be inserted,
-        // skipping over missing versions. This violates the assumption of AvailableObjectsCache.
-        // So no clock object can be cached.
-        if object.0 == SUI_CLOCK_OBJECT_ID {
-            return;
-        }
         self.cache.insert(object);
         if self.unbounded_cache_enabled == 0 {
             self.cache.shrink();
@@ -689,7 +683,7 @@ impl TransactionManager {
     /// Notifies TransactionManager that the given objects are available in the objects table.
     /// Useful when transactions associated with the objects are not known, e.g. after checking
     /// object availability from storage, or for testing.
-    pub(crate) fn fastpath_objects_available(
+    pub(crate) fn _fastpath_objects_available(
         &self,
         input_keys: Vec<InputKey>,
         epoch_store: &AuthorityPerEpochStore,

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -44,7 +44,6 @@ use sui_types::transaction::{
 use sui_types::utils::{
     to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
 };
-use sui_types::SUI_CLOCK_OBJECT_ID;
 use test_utils::authority::test_and_configure_authority_configs;
 use test_utils::network::TestClusterBuilder;
 use test_utils::transaction::{wait_for_all_txes, wait_for_tx};
@@ -1151,6 +1150,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+// Object fast path should be disabled and unused.
 #[sim_test]
 async fn test_pass_back_clock_object() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
@@ -1212,7 +1212,7 @@ async fn test_pass_back_clock_object() -> Result<(), anyhow::Error> {
             objects,
         },
     ) = rx.recv().await.unwrap().unwrap();
-    assert!(objects.iter().any(|o| o.id() == SUI_CLOCK_OBJECT_ID));
+    assert!(objects.is_empty(), "{objects:?}");
     Ok(())
 }
 

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -201,16 +201,10 @@ impl From<HandleCertificateResponseV2> for HandleCertificateResponse {
 pub struct HandleCertificateResponseV2 {
     pub signed_effects: SignedTransactionEffects,
     pub events: TransactionEvents,
-    /// The validator may return some of the input objects that were used by this transaction, in
-    /// order to facilitate lower latency local execution for the full node client that requested
-    /// the transaction execution.
-    ///
-    /// Typically this list contains only the version (if any) of the Clock object that was used by the
-    /// transaction - without returning it here, the client has no choice but to wait for
-    /// checkpoint sync to provide the input clock.
-    ///
-    /// The validator may return other objects via this list in the future. However, this
-    /// is only intended for small objects.
+    /// Unused and ignored right now.
+    /// But in future the validator may return some of the input objects, e.g.  clock or other
+    /// small objects, that were used by this transaction, in order to facilitate lower latency
+    /// local execution for the full node client that requested the transaction execution.
     pub fastpath_input_objects: Vec<Object>,
 }
 


### PR DESCRIPTION
## Description 

The previous workaround for the object fast path needs to be fixed.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
