### PR TITLE
add diag printing in local replay

### DIFF
--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -169,11 +169,11 @@ pub async fn execute_replay_command(
             )
             .await?;
 
-            if show_effects {
-                println!("{:#?}", sandbox_state.local_exec_effects);
-            }
             if diag {
                 println!("{:#?}", sandbox_state.pre_exec_diag);
+            }
+            if show_effects {
+                println!("{:#?}", sandbox_state.local_exec_effects);
             }
 
             sandbox_state.check_effects()?;

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -41,6 +41,8 @@ pub enum ReplayToolCommand {
         tx_digest: String,
         #[clap(long, short)]
         show_effects: bool,
+        #[clap(long, short)]
+        diag: bool,
     },
 
     /// Replay a transaction from a node state dump
@@ -154,6 +156,7 @@ pub async fn execute_replay_command(
         ReplayToolCommand::ReplayTransaction {
             tx_digest,
             show_effects,
+            diag,
         } => {
             let tx_digest = TransactionDigest::from_str(&tx_digest)?;
             info!("Executing tx: {}", tx_digest);
@@ -168,6 +171,9 @@ pub async fn execute_replay_command(
 
             if show_effects {
                 println!("{:#?}", sandbox_state.local_exec_effects);
+            }
+            if diag {
+                println!("{:#?}", sandbox_state.pre_exec_diag);
             }
 
             sandbox_state.check_effects()?;

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -52,6 +52,11 @@ pub struct OnChainTransactionInfo {
     pub reference_gas_price: u64,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct DiagInfo {
+    pub loaded_child_objects: Vec<(ObjectID, VersionNumber)>,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error, Clone)]
 pub enum ReplayEngineError {


### PR DESCRIPTION
## Description 

Print diag info in replay. For now it only prints loaded child object versions

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
