### PR TITLE
[wallet-ext] - fix incorrect label in gas summary

### DIFF
--- a/apps/wallet/src/ui/app/shared/transaction-summary/cards/GasSummary.tsx
+++ b/apps/wallet/src/ui/app/shared/transaction-summary/cards/GasSummary.tsx
@@ -6,10 +6,12 @@ import { formatAddress } from '@mysten/sui.js';
 import { Text } from '../../text';
 import ExplorerLink from '_src/ui/app/components/explorer-link';
 import { ExplorerLinkType } from '_src/ui/app/components/explorer-link/ExplorerLinkType';
+import { useActiveAddress } from '_src/ui/app/hooks';
 import { GAS_TYPE_ARG } from '_src/ui/app/redux/slices/sui-objects/Coin';
 
 export function GasSummary({ gasSummary }: { gasSummary?: GasSummaryType }) {
 	const [gas, symbol] = useFormatCoin(gasSummary?.totalGas, GAS_TYPE_ARG);
+	const address = useActiveAddress();
 
 	if (!gasSummary) return null;
 
@@ -20,11 +22,15 @@ export function GasSummary({ gasSummary }: { gasSummary?: GasSummaryType }) {
 					Gas Fees
 				</Text>
 			</div>
-			<div className="flex flex-col items-center gap-1 w-full px-4 py-3">
-				<div className="flex w-full items-center justify-between">
-					<Text color="steel-dark" variant="pBody" weight="medium">
-						You Paid
-					</Text>
+			<div className="flex flex-col items-center gap-2 w-full px-4 py-3">
+				<div className="flex w-full items-center justify-start">
+					{address === gasSummary?.owner && (
+						<div className="mr-auto">
+							<Text color="steel-dark" variant="pBody" weight="medium">
+								You Paid
+							</Text>
+						</div>
+					)}
 					<Text color="steel-darker" variant="pBody" weight="medium">
 						{gasSummary?.isSponsored ? '0' : gas} {symbol}
 					</Text>
@@ -32,7 +38,7 @@ export function GasSummary({ gasSummary }: { gasSummary?: GasSummaryType }) {
 				{gasSummary?.isSponsored && gasSummary.owner && (
 					<>
 						<div className="flex w-full justify-between">
-							<Text color="steel-dark" variant="bodySmall">
+							<Text color="steel-dark" variant="pBody" weight="medium">
 								Paid by Sponsor
 							</Text>
 							<Text color="steel-darker" variant="pBody" weight="medium">
@@ -40,7 +46,7 @@ export function GasSummary({ gasSummary }: { gasSummary?: GasSummaryType }) {
 							</Text>
 						</div>
 						<div className="flex w-full justify-between">
-							<Text color="steel-dark" variant="bodySmall">
+							<Text color="steel-dark" variant="pBody" weight="medium">
 								Sponsor
 							</Text>
 							<ExplorerLink


### PR DESCRIPTION
## Description 

Fixes the 'You Paid' label showing in Gas Summary when wallet owner did not actually pay. 

Also addresses a few small styling tweaks

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
