### PR TITLE
[ci] fix changeset-version script

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,5 @@ packages:
     - 'apps/**'
     - 'dapps/**'
     - '!**/dist/**'
+    - '!sdk/typescript/*'
     - '!sdk/typescript/*/**'


### PR DESCRIPTION
## Description 

The changeset-version script is failing because of new package.json files created for modular exports in the typescript sdk.  This will hopefully fix the issue.

## Test Plan 

Merge the PR and see if it fixes the issue, this has not been reproduced locally.

The error on main only complains about sdk/typescript/builder/package.json, and does not have issues with the packages inside keypairs, which makes me think there is a difference between how glob patterns are matched locally vs CI for `manypkg check`.  

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
