### PR TITLE
[move][transactional tests] Add dev-inspect support

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.exp
@@ -1,0 +1,44 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-33:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5274400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 35-37:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 39-39:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, value: 0u64}
+
+task 4 'programmable'. lines 41-42:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2257200,  storage_rebate: 2234628, non_refundable_storage_fee: 22572
+
+task 5 'view-object'. lines 44-47:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, value: 112u64}
+
+task 6 'programmable'. lines 49-50:
+mutated: object(_), object(2,0)
+gas summary: computation_cost: 500000, storage_cost: 2257200,  storage_rebate: 1256508, non_refundable_storage_fee: 12692
+
+task 7 'programmable'. lines 52-56:
+mutated: object(_), object(2,0)
+gas summary: computation_cost: 500000, storage_cost: 2257200,  storage_rebate: 1256508, non_refundable_storage_fee: 12692
+
+task 8 'programmable'. lines 58-59:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 2, instruction: 8, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 2, instruction: 8, function_name: Some("check") }, 0) in command 0
+
+task 9 'programmable'. lines 61-62:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 2, instruction: 8, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 2, instruction: 8, function_name: Some("check") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.move
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// load an object at an old version
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct S has key, store {
+        id: UID,
+        value: u64
+    }
+
+    public fun new(ctx: &mut TxContext): S {
+        S {
+            id: object::new(ctx),
+            value: 0,
+        }
+    }
+
+    public fun set(s: &mut S, value: u64) {
+        s.value = value
+    }
+
+    public fun check(s: &S, expected: u64) {
+        assert!(s.value == expected, 0);
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,0
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,0)@2 0 --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,0)@3 112 --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,0)@2 112 --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,0)@3 0 --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -80,6 +80,9 @@ pub async fn send_and_confirm_transaction_with_execution_error(
 
     if with_shared {
         send_consensus(authority, &certificate).await;
+        if let Some(fullnode) = fullnode {
+            send_consensus(fullnode, &certificate).await;
+        }
     }
 
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -11,7 +11,7 @@ use move_core_types::u256::U256;
 use move_core_types::value::{MoveStruct, MoveValue};
 use move_symbol_pool::Symbol;
 use move_transactional_test_runner::tasks::SyntaxChoice;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{SequenceNumber, SuiAddress};
 use sui_types::move_package::UpgradePolicy;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -88,6 +88,8 @@ pub struct ProgrammableTransactionCommand {
     pub gas_budget: Option<u64>,
     #[clap(long = "gas-price")]
     pub gas_price: Option<u64>,
+    #[clap(long = "dev-inspect")]
+    pub dev_inspect: bool,
     #[clap(
         long = "inputs",
         parse(try_from_str = ParsedValue::parse),
@@ -159,14 +161,14 @@ pub enum SuiSubcommand {
 
 #[derive(Debug)]
 pub enum SuiExtraValueArgs {
-    Object(FakeID),
+    Object(FakeID, Option<SequenceNumber>),
     Digest(String),
 }
 
 pub enum SuiValue {
     MoveValue(MoveValue),
-    Object(FakeID),
-    ObjVec(Vec<FakeID>),
+    Object(FakeID, Option<SequenceNumber>),
+    ObjVec(Vec<(FakeID, Option<SequenceNumber>)>),
     Digest(String),
 }
 
@@ -194,7 +196,15 @@ impl SuiExtraValueArgs {
             FakeID::Known(address.into())
         };
         parser.advance(ValueToken::RParen)?;
-        Ok(SuiExtraValueArgs::Object(fake_id))
+        let version = if let Some(ValueToken::AtSign) = parser.peek_tok() {
+            parser.advance(ValueToken::AtSign)?;
+            let v_str = parser.advance(ValueToken::Number)?;
+            let (v, _) = parse_u64(v_str)?;
+            Some(SequenceNumber::from_u64(v))
+        } else {
+            None
+        };
+        Ok(SuiExtraValueArgs::Object(fake_id, version))
     }
 
     fn parse_digest_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
@@ -213,27 +223,36 @@ impl SuiValue {
     fn assert_move_value(self) -> MoveValue {
         match self {
             SuiValue::MoveValue(v) => v,
-            SuiValue::Object(_) => panic!("unexpected nested Sui object in args"),
+            SuiValue::Object(_, _) => panic!("unexpected nested Sui object in args"),
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
         }
     }
 
-    fn assert_object(self) -> FakeID {
+    fn assert_object(self) -> (FakeID, Option<SequenceNumber>) {
         match self {
             SuiValue::MoveValue(_) => panic!("unexpected nested non-object value in args"),
-            SuiValue::Object(v) => v,
+            SuiValue::Object(id, version) => (id, version),
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
         }
     }
 
-    fn object_arg(fake_id: FakeID, test_adapter: &SuiTestAdapter) -> anyhow::Result<ObjectArg> {
+    fn object_arg(
+        fake_id: FakeID,
+        version: Option<SequenceNumber>,
+        test_adapter: &SuiTestAdapter,
+    ) -> anyhow::Result<ObjectArg> {
         let id = match test_adapter.fake_to_real_object_id(fake_id) {
             Some(id) => id,
             None => bail!("INVALID TEST. Unknown object, object({})", fake_id),
         };
-        let obj = match test_adapter.validator.database.get_object(&id) {
+        let obj_res = if let Some(v) = version {
+            test_adapter.validator.database.get_object_by_key(&id, v)
+        } else {
+            test_adapter.validator.database.get_object(&id)
+        };
+        let obj = match obj_res {
             Ok(Some(obj)) => obj,
             Err(_) | Ok(None) => bail!("INVALID TEST. Could not load object argument {}", id),
         };
@@ -254,7 +273,9 @@ impl SuiValue {
 
     pub(crate) fn into_call_arg(self, test_adapter: &SuiTestAdapter) -> anyhow::Result<CallArg> {
         Ok(match self {
-            SuiValue::Object(fake_id) => CallArg::Object(Self::object_arg(fake_id, test_adapter)?),
+            SuiValue::Object(fake_id, version) => {
+                CallArg::Object(Self::object_arg(fake_id, version, test_adapter)?)
+            }
             SuiValue::MoveValue(v) => CallArg::Pure(v.simple_serialize().unwrap()),
             SuiValue::ObjVec(_) => bail!("obj vec is not supported as an input"),
             SuiValue::Digest(pkg) => {
@@ -275,7 +296,7 @@ impl SuiValue {
         match self {
             SuiValue::ObjVec(vec) => builder.make_obj_vec(
                 vec.iter()
-                    .map(|fake_id| Self::object_arg(*fake_id, test_adapter))
+                    .map(|(fake_id, version)| Self::object_arg(*fake_id, *version, test_adapter))
                     .collect::<Result<Vec<ObjectArg>, _>>()?,
             ),
             value => {
@@ -304,7 +325,7 @@ impl ParsableValue for SuiExtraValueArgs {
     }
 
     fn concrete_vector(elems: Vec<Self::ConcreteValue>) -> anyhow::Result<Self::ConcreteValue> {
-        if !elems.is_empty() && matches!(elems[0], SuiValue::Object(_)) {
+        if !elems.is_empty() && matches!(elems[0], SuiValue::Object(_, _)) {
             Ok(SuiValue::ObjVec(
                 elems.into_iter().map(SuiValue::assert_object).collect(),
             ))
@@ -336,7 +357,7 @@ impl ParsableValue for SuiExtraValueArgs {
         _mapping: &impl Fn(&str) -> Option<move_core_types::account_address::AccountAddress>,
     ) -> anyhow::Result<Self::ConcreteValue> {
         match self {
-            SuiExtraValueArgs::Object(id) => Ok(SuiValue::Object(id)),
+            SuiExtraValueArgs::Object(id, version) => Ok(SuiValue::Object(id, version)),
             SuiExtraValueArgs::Digest(pkg) => Ok(SuiValue::Digest(pkg)),
         }
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -45,15 +45,15 @@ use sui_core::authority::{
 use sui_framework::BuiltInFramework;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_json_rpc::api::QUERY_MAX_RESULT_LIMIT;
-use sui_json_rpc_types::EventFilter;
+use sui_json_rpc_types::{
+    DevInspectResults, EventFilter, SuiExecutionStatus, SuiTransactionBlockEffectsAPI,
+};
 use sui_protocol_config::{Chain, ProtocolConfig};
-use sui_types::effects::TransactionEffectsAPI;
-use sui_types::execution_status::ExecutionStatus;
-use sui_types::storage::ObjectStore;
 use sui_types::transaction::Command;
 use sui_types::transaction::ProgrammableTransaction;
 use sui_types::DEEPBOOK_PACKAGE_ID;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
+use sui_types::{base_types::SequenceNumber, effects::TransactionEffectsAPI};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, SUI_ADDRESS_LENGTH},
     crypto::{get_key_pair_from_rng, AccountKeyPair},
@@ -65,6 +65,8 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use sui_types::{clock::Clock, SUI_SYSTEM_ADDRESS};
+use sui_types::{crypto::get_authority_key_pair, storage::ObjectStore};
+use sui_types::{execution_status::ExecutionStatus, transaction::TransactionKind};
 use sui_types::{gas::GasCostSummary, object::GAS_VALUE_FOR_TESTING};
 use sui_types::{id::UID, DEEPBOOK_ADDRESS};
 use sui_types::{
@@ -102,6 +104,7 @@ const GAS_FOR_TESTING: u64 = GAS_VALUE_FOR_TESTING;
 
 pub struct SuiTestAdapter<'a> {
     pub(crate) validator: Arc<AuthorityState>,
+    pub(crate) fullnode: Arc<AuthorityState>,
     pub(crate) compiled_state: CompiledState<'a>,
     /// For upgrades: maps an upgraded package name to the original package name.
     package_upgrade_mapping: BTreeMap<Symbol, Symbol>,
@@ -308,7 +311,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         }
 
         let object_ids = objects.iter().map(|obj| obj.id()).collect::<Vec<_>>();
-        let validator = {
+        let (validator, fullnode) = {
             let dir = tempfile::TempDir::new().unwrap();
             let network_config =
                 sui_swarm_config::network_config_builder::ConfigBuilder::new(&dir).build();
@@ -320,14 +323,22 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             let authority_key = &keypair;
             let state = TestAuthorityBuilder::new()
                 .with_genesis_and_keypair(genesis, authority_key)
+                .with_protocol_config(protocol_config.clone())
+                .build()
+                .await;
+            let fullnode_key_pair = get_authority_key_pair().1;
+            let fullnode = TestAuthorityBuilder::new()
+                .with_keypair(&fullnode_key_pair)
                 .with_protocol_config(protocol_config)
                 .build()
                 .await;
             state.insert_genesis_objects(&objects).await;
-            state
+            fullnode.insert_genesis_objects(&objects).await;
+            (state, fullnode)
         };
         let mut test_adapter = Self {
             validator,
+            fullnode,
             compiled_state: CompiledState::new(
                 named_address_mapping,
                 pre_compiled_deps,
@@ -425,7 +436,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             .created
             .iter()
             .find_map(|id| {
-                let object = self.get_object(id).unwrap();
+                let object = self.get_object(id, None).unwrap();
                 let package = object.data.try_as_package()?;
                 if package
                     .serialized_module_map()
@@ -455,7 +466,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         }
         let output = self.object_summary_output(&summary, /* summarize */ false);
         let published_modules = self
-            .get_object(&created_package)
+            .get_object(&created_package, None)
             .unwrap()
             .data
             .try_as_package()
@@ -556,7 +567,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             data,
         } = task;
         macro_rules! get_obj {
-            ($fake_id:ident) => {{
+            ($fake_id:ident, $version:expr) => {{
                 let id = match self.fake_to_real_object_id($fake_id) {
                     None => bail!(
                         "task {}, lines {}-{}. Unbound fake id {}",
@@ -567,10 +578,13 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     ),
                     Some(res) => res,
                 };
-                match self.get_object(&id) {
+                match self.get_object(&id, $version) {
                     Err(_) => return Ok(Some(format!("No object at id {}", $fake_id))),
                     Ok(obj) => obj,
                 }
+            }};
+            ($fake_id:ident) => {{
+                get_obj!($fake_id, None)
             }};
         }
         match command {
@@ -614,7 +628,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 gas_budget,
             }) => {
                 let mut builder = ProgrammableTransactionBuilder::new();
-                let obj_arg = SuiValue::Object(fake_id).into_argument(&mut builder, self)?;
+                let obj_arg = SuiValue::Object(fake_id, None).into_argument(&mut builder, self)?;
                 let recipient = match self.accounts.get(&recipient) {
                     Some(test_account) => test_account.address,
                     None => panic!("Unbound account {}", recipient),
@@ -647,6 +661,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 sender,
                 gas_budget,
                 gas_price,
+                dev_inspect,
                 inputs,
             }) => {
                 let inputs = self.compiled_state().resolve_args(inputs)?;
@@ -682,18 +697,33 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                         )
                     })
                     .collect::<anyhow::Result<Vec<Command>>>()?;
-                let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
-                let gas_price = gas_price.unwrap_or(self.gas_price);
-                let transaction = self.sign_txn(sender, |sender, gas| {
-                    TransactionData::new_programmable(
-                        sender,
-                        vec![gas],
-                        ProgrammableTransaction { inputs, commands },
-                        gas_budget,
-                        gas_price,
-                    )
-                });
-                let summary = self.execute_txn(transaction).await?;
+                let summary = if !dev_inspect {
+                    let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
+                    let gas_price = gas_price.unwrap_or(self.gas_price);
+                    let transaction = self.sign_txn(sender, |sender, gas| {
+                        TransactionData::new_programmable(
+                            sender,
+                            vec![gas],
+                            ProgrammableTransaction { inputs, commands },
+                            gas_budget,
+                            gas_price,
+                        )
+                    });
+                    self.execute_txn(transaction).await?
+                } else {
+                    assert!(
+                        gas_budget.is_none(),
+                        "Meaningless to set gas budget with dev-inspect"
+                    );
+                    let sender_address = self.get_sender(sender).address;
+                    let transaction =
+                        TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+                            inputs,
+                            commands,
+                        });
+                    self.dev_inspect(sender_address, transaction, gas_price)
+                        .await?
+                };
                 let output = self.object_summary_output(&summary, /* summarize */ false);
                 Ok(output)
             }
@@ -868,12 +898,12 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let state = self.compiled_state();
                 let input = input.into_concrete_value(&|s| Some(state.resolve_named_address(s)))?;
                 let (value, package) = match input {
-                    SuiValue::Object(fake_id) => {
+                    SuiValue::Object(fake_id, version) => {
                         let id = match self.fake_to_real_object_id(fake_id) {
                             Some(id) => id,
                             None => bail!("INVALID TEST. Unknown object, object({})", fake_id),
                         };
-                        let obj = self.get_object(&id)?;
+                        let obj = self.get_object(&id, version)?;
                         let package = obj.data.try_as_package().map(|package| {
                             package
                                 .serialized_module_map()
@@ -956,7 +986,8 @@ impl<'a> SuiTestAdapter<'a> {
 
         let mut builder = ProgrammableTransactionBuilder::new();
 
-        SuiValue::Object(upgrade_capability).into_argument(&mut builder, self)?; // Argument::Input(0)
+        // Argument::Input(0)
+        SuiValue::Object(upgrade_capability, None).into_argument(&mut builder, self)?;
         let upgrade_arg = builder.pure(policy).unwrap();
         let digest: Vec<u8> = MovePackage::compute_digest_for_modules_and_deps(
             &modules_bytes,
@@ -999,7 +1030,7 @@ impl<'a> SuiTestAdapter<'a> {
             .created
             .iter()
             .find_map(|id| {
-                let object = self.get_object(id).unwrap();
+                let object = self.get_object(id, None).unwrap();
                 let package = object.data.try_as_package()?;
                 Some(package.id())
             })
@@ -1024,23 +1055,27 @@ impl<'a> SuiTestAdapter<'a> {
     }
 
     fn sign_txn(
-        &mut self,
+        &self,
         sender: Option<String>,
         txn_data: impl FnOnce(/* sender */ SuiAddress, /* gas */ ObjectRef) -> TransactionData,
     ) -> VerifiedTransaction {
-        let test_account = match sender {
+        let test_account = self.get_sender(sender);
+        let gas_payment = self
+            .get_object(&test_account.gas, None)
+            .unwrap()
+            .compute_object_reference();
+        let data = txn_data(test_account.address, gas_payment);
+        to_sender_signed_transaction(data, &test_account.key_pair)
+    }
+
+    fn get_sender(&self, sender: Option<String>) -> &TestAccount {
+        match sender {
             Some(n) => match self.accounts.get(&n) {
                 Some(test_account) => test_account,
                 None => panic!("Unbound account {}", n),
             },
             None => &self.default_account,
-        };
-        let gas_payment = self
-            .get_object(&test_account.gas)
-            .unwrap()
-            .compute_object_reference();
-        let data = txn_data(test_account.address, gas_payment);
-        to_sender_signed_transaction(data, &test_account.key_pair)
+        }
     }
 
     async fn execute_txn(
@@ -1054,7 +1089,7 @@ impl<'a> SuiTestAdapter<'a> {
             .contains_shared_object();
         let (txn, effects, error_opt) = send_and_confirm_transaction_with_execution_error(
             &self.validator,
-            None,
+            Some(&self.fullnode),
             transaction,
             with_shared,
         )
@@ -1148,8 +1183,86 @@ impl<'a> SuiTestAdapter<'a> {
         }
     }
 
-    fn get_object(&self, id: &ObjectID) -> anyhow::Result<Object> {
-        match self.validator.database.get_object(id) {
+    async fn dev_inspect(
+        &mut self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> anyhow::Result<TxnSummary> {
+        let results = self
+            .fullnode
+            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .await?;
+        let DevInspectResults {
+            effects, events, ..
+        } = results;
+        let mut created_ids: Vec<_> = effects.created().iter().map(|o| o.object_id()).collect();
+        let mut mutated_ids: Vec<_> = effects.mutated().iter().map(|o| o.object_id()).collect();
+        let mut unwrapped_ids: Vec<_> = effects.unwrapped().iter().map(|o| o.object_id()).collect();
+        let mut deleted_ids: Vec<_> = effects.deleted().iter().map(|o| o.object_id).collect();
+        let mut unwrapped_then_deleted_ids: Vec<_> = effects
+            .unwrapped_then_deleted()
+            .iter()
+            .map(|o| o.object_id)
+            .collect();
+        let mut wrapped_ids: Vec<_> = effects.wrapped().iter().map(|o| o.object_id).collect();
+        let gas_summary = effects.gas_cost_summary();
+
+        // make sure objects that have previously not been in storage get assigned a fake id.
+        let mut might_need_fake_id: Vec<_> = created_ids
+            .iter()
+            .chain(unwrapped_ids.iter())
+            .copied()
+            .collect();
+
+        // Use a stable sort before assigning fake ids, so test output remains stable.
+        might_need_fake_id.sort_by_key(|id| self.get_object_sorting_key(id));
+        for id in might_need_fake_id {
+            self.enumerate_fake(id);
+        }
+
+        // Treat unwrapped objects as writes (even though sometimes this is the first time we can
+        // refer to them at their id in storage).
+
+        // sort by fake id
+        created_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+        mutated_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+        unwrapped_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+        deleted_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+        unwrapped_then_deleted_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+        wrapped_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
+
+        match effects.status() {
+            SuiExecutionStatus::Success { .. } => {
+                let events = events
+                    .data
+                    .into_iter()
+                    .map(|sui_event| sui_event.into())
+                    .collect();
+                Ok(TxnSummary {
+                    events,
+                    gas_summary: gas_summary.clone(),
+                    created: created_ids,
+                    mutated: mutated_ids,
+                    unwrapped: unwrapped_ids,
+                    deleted: deleted_ids,
+                    unwrapped_then_deleted: unwrapped_then_deleted_ids,
+                    wrapped: wrapped_ids,
+                })
+            }
+            SuiExecutionStatus::Failure { error } => Err(anyhow::anyhow!(self.stabilize_str(
+                format!("Transaction Effects Status: {error}\nExecution Error: {error}",)
+            ))),
+        }
+    }
+
+    fn get_object(&self, id: &ObjectID, version: Option<SequenceNumber>) -> anyhow::Result<Object> {
+        let obj_res = if let Some(v) = version {
+            self.validator.database.get_object_by_key(id, v)
+        } else {
+            self.validator.database.get_object(id)
+        };
+        match obj_res {
             Ok(Some(obj)) => Ok(obj),
             Ok(None) | Err(_) => Err(anyhow!("INVALID TEST! Unable to find object {id}")),
         }
@@ -1158,7 +1271,7 @@ impl<'a> SuiTestAdapter<'a> {
     // stable way of sorting objects by type. Does not however, produce a stable sorting
     // between objects of the same type
     fn get_object_sorting_key(&self, id: &ObjectID) -> String {
-        match &self.get_object(id).unwrap().data {
+        match &self.get_object(id, None).unwrap().data {
             object::Data::Move(obj) => self.stabilize_str(format!("{}", obj.type_())),
             object::Data::Package(pkg) => pkg
                 .serialized_module_map()


### PR DESCRIPTION
## Description 

- Added minimal dev-inspect support for programmable transactions

## Test Plan 

- Added a new test. 
- I will use more extensively in #12055 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
