### PR TITLE
[tiny] Add a gauge with last_executed_checkpoint_timestamp_ms value

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 pub struct CheckpointExecutorMetrics {
     pub checkpoint_exec_sync_tps: IntGauge,
     pub last_executed_checkpoint: IntGauge,
+    pub last_executed_checkpoint_timestamp_ms: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_exec_inflight: IntGauge,
@@ -34,6 +35,12 @@ impl CheckpointExecutorMetrics {
             last_executed_checkpoint: register_int_gauge_with_registry!(
                 "last_executed_checkpoint",
                 "Last executed checkpoint",
+                registry
+            )
+            .unwrap(),
+            last_executed_checkpoint_timestamp_ms: register_int_gauge_with_registry!(
+                "last_executed_checkpoint_timestamp_ms",
+                "Last executed checkpoint timestamp ms",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -270,6 +270,9 @@ impl CheckpointExecutor {
             .unwrap();
         self.metrics.last_executed_checkpoint.set(seq as i64);
 
+        self.metrics
+            .last_executed_checkpoint_timestamp_ms
+            .set(checkpoint.timestamp_ms as i64);
         checkpoint.report_checkpoint_age_ms(&self.metrics.last_executed_checkpoint_age_ms);
     }
 


### PR DESCRIPTION
This one is more reliable to use by HAProxy to determine FN health (e.g., in case a node is stuck)

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
