### PR TITLE
[benchmark] use TestCluster in local setup

### DIFF
--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -7,21 +7,18 @@ use crate::util::get_ed25519_keypair_from_keystore;
 use crate::{FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy};
 use anyhow::{anyhow, bail, Context, Result};
 use prometheus::Registry;
-use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
-use sui_config::local_ip_utils;
-use sui_swarm_config::node_config_builder::FullnodeConfigBuilder;
+use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{deterministic_random_account_key, AccountKeyPair};
-use sui_types::object::generate_max_test_gas_objects_with_owner;
+use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
 use sui_types::object::Owner;
-use test_utils::authority::spawn_test_authorities;
-use test_utils::authority::test_and_configure_authority_configs_with_objects;
+use test_utils::network::TestClusterBuilder;
 use tokio::runtime::Builder;
 use tokio::sync::{oneshot, Barrier};
 use tokio::time::sleep;
@@ -54,7 +51,6 @@ impl Env {
                     barrier,
                     registry,
                     opts.committee_size as usize,
-                    opts.server_metric_port,
                     opts.num_server_threads,
                 )
                 .await
@@ -80,48 +76,17 @@ impl Env {
         barrier: Arc<Barrier>,
         registry: &Registry,
         committee_size: usize,
-        server_metric_port: u16,
         num_server_threads: u64,
     ) -> Result<BenchmarkSetup> {
         info!("Running benchmark setup in local mode..");
-        let (address, keypair): (SuiAddress, AccountKeyPair) = deterministic_random_account_key();
-        let generated_gas = generate_max_test_gas_objects_with_owner(1, address);
-        let (mut network_config, generated_gas) =
-            test_and_configure_authority_configs_with_objects(committee_size, generated_gas);
-        let mut metric_port = server_metric_port;
-        for node_config in network_config.validator_configs.iter_mut() {
-            // Benchmark setup allocates very large gas objects, which will lead to overflow if we attempt
-            // to calculate the amount of SUI in the network. Hence we disable SUI conservation checks
-            // even when we are running in debug mode.
-            node_config
-                .expensive_safety_check_config
-                .force_disable_epoch_sui_conservation_check();
-            let parameters = &mut node_config
-                .consensus_config
-                .as_mut()
-                .context("Missing consensus config")?
-                .narwhal_config;
-            parameters.batch_size = 12800;
-            node_config.metrics_address = format!("127.0.0.1:{}", metric_port)
-                .parse()
-                .context("Failed to parse metric address")?;
-            metric_port += 1;
-        }
-        let config = Arc::new(network_config);
-        // bring up servers ..
-        let primary_gas = generated_gas
-            .get(0)
-            .context("No gas found at index 0")?
-            .clone();
-        // Make the client runtime wait until we are done creating genesis objects
-        let cloned_config = config.clone();
-        let fullnode_ip = local_ip_utils::localhost_for_testing();
-        let fullnode_rpc_port = local_ip_utils::get_available_port(&fullnode_ip);
-        let fullnode_barrier = Arc::new(Barrier::new(2));
-        let fullnode_barrier_clone = fullnode_barrier.clone();
+        let (primary_gas_owner, keypair): (SuiAddress, AccountKeyPair) =
+            deterministic_random_account_key();
+        let keypair = Arc::new(keypair);
+
         // spawn a thread to spin up sui nodes on the multi-threaded server runtime.
         // running forever
-        let (sender, recv) = tokio::sync::oneshot::channel::<()>();
+        let (shutdown_sender, shutdown_recv) = tokio::sync::oneshot::channel::<()>();
+        let (genesis_sender, genesis_recv) = tokio::sync::oneshot::channel();
         let join_handle = std::thread::spawn(move || {
             // create server runtime
             let server_runtime = Builder::new_multi_thread()
@@ -131,35 +96,46 @@ impl Env {
                 .build()
                 .unwrap();
             server_runtime.block_on(async move {
-                // Setup the network
-                let _validators: Vec<_> = spawn_test_authorities(&cloned_config).await;
-
-                let node_config = FullnodeConfigBuilder::new()
-                    .with_rpc_port(fullnode_rpc_port)
-                    .build(&mut OsRng, &cloned_config);
-                let node = sui_swarm::memory::Node::new(node_config);
-                node.start().await.unwrap();
-                let _fullnode = node.get_node_handle().unwrap();
-
-                fullnode_barrier_clone.wait().await;
+                let cluster = TestClusterBuilder::new()
+                    .with_accounts(vec![AccountConfig {
+                        address: Some(primary_gas_owner),
+                        // We can't use TOTAL_SUPPLY_MIST because we need to account for validator stakes in genesis allocation.
+                        gas_amounts: vec![TOTAL_SUPPLY_MIST / 2],
+                    }])
+                    .with_num_validators(committee_size)
+                    .build()
+                    .await;
+                let genesis = cluster.swarm.config().genesis.clone();
+                for v in cluster.swarm.config().validator_configs() {
+                    eprintln!(
+                        "Metric address for validator {}: {}",
+                        v.protocol_public_key().concise(),
+                        v.metrics_address
+                    );
+                }
+                let primary_gas = cluster
+                    .wallet
+                    .get_one_gas_object_owned_by_address(primary_gas_owner)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                // Send genesis and primary gas object to the main thread.
+                genesis_sender.send((genesis, primary_gas)).unwrap();
                 barrier.wait().await;
-                recv.await.expect("Unable to wait for terminate signal");
+                shutdown_recv
+                    .await
+                    .expect("Unable to wait for terminate signal");
             });
         });
-        // Let fullnode be created.
+        // Wait for the embedded reconfig observer.
         sleep(Duration::from_secs(5)).await;
-        let fullnode_rpc_url = format!("http://{fullnode_ip}:{fullnode_rpc_port}");
-        info!("Fullnode rpc url: {fullnode_rpc_url}");
-        fullnode_barrier.wait().await;
-        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
-            LocalValidatorAggregatorProxy::from_genesis(&config.genesis, registry, None).await,
-        );
-        let keypair = Arc::new(keypair);
-        let primary_gas = (primary_gas.compute_object_reference(), address, keypair);
+        let (genesis, primary_gas) = genesis_recv.await.unwrap();
+        let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
+            Arc::new(LocalValidatorAggregatorProxy::from_genesis(&genesis, registry, None).await);
         Ok(BenchmarkSetup {
             server_handle: join_handle,
-            shutdown_notifier: sender,
-            bank: BenchmarkBank::new(proxy.clone(), primary_gas),
+            shutdown_notifier: shutdown_sender,
+            bank: BenchmarkBank::new(proxy.clone(), (primary_gas, primary_gas_owner, keypair)),
             proxies: vec![proxy],
         })
     }

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use sui_config::local_ip_utils;
-use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_swarm_config::node_config_builder::FullnodeConfigBuilder;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -137,9 +136,6 @@ impl Env {
 
                 let node_config = FullnodeConfigBuilder::new()
                     .with_rpc_port(fullnode_rpc_port)
-                    .with_expensive_safety_check_config(
-                        ExpensiveSafetyCheckConfig::new_disable_all(),
-                    )
                     .build(&mut OsRng, &cloned_config);
                 let node = sui_swarm::memory::Node::new(node_config);
                 node.start().await.unwrap();

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -71,8 +71,6 @@ pub struct Opts {
     /// Default workload is 100% transfer object
     #[clap(subcommand)]
     pub run_spec: RunSpec,
-    #[clap(long, default_value = "9091", global = true)]
-    pub server_metric_port: u16,
     #[clap(long, default_value = "127.0.0.1", global = true)]
     pub client_metric_host: String,
     #[clap(long, default_value = "8081", global = true)]

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -142,7 +142,8 @@ impl ValidatorConfigBuilder {
             supported_protocol_versions: self.supported_protocol_versions,
             db_checkpoint_config: Default::default(),
             indirect_objects_threshold: usize::MAX,
-            expensive_safety_check_config: ExpensiveSafetyCheckConfig::new_enable_all(),
+            // By default, expensive checks will be enabled in debug build, but not in release build.
+            expensive_safety_check_config: ExpensiveSafetyCheckConfig::default(),
             name_service_package_address: None,
             name_service_registry_id: None,
             name_service_reverse_registry_id: None,

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -77,12 +77,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -169,12 +169,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -261,12 +261,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -353,12 +353,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -445,12 +445,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -537,12 +537,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false
@@ -629,12 +629,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: true
-      enable-deep-per-tx-sui-conservation-check: true
+      enable-epoch-sui-conservation-check: false
+      enable-deep-per-tx-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: true
+      enable-state-consistency-check: false
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: true
+      enable-move-vm-paranoid-checks: false
       enable-secondary-index-checks: false
     transaction-deny-config:
       package_publish_disabled: false

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -24,7 +24,6 @@ use crate::crypto::{default_hash, deterministic_random_account_key};
 use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult};
 use crate::error::{SuiError, SuiResult};
 use crate::gas_coin::GAS;
-use crate::gas_coin::TOTAL_SUPPLY_MIST;
 use crate::is_system_package;
 use crate::move_package::MovePackage;
 use crate::type_resolver::LayoutResolver;
@@ -1048,41 +1047,6 @@ pub fn generate_test_gas_objects() -> Vec<Object> {
     }
 
     GAS_OBJECTS.with(|v| v.clone())
-}
-
-/// Make a few test gas objects (all with the same owner).
-pub fn generate_test_gas_objects_with_owner(count: usize, owner: SuiAddress) -> Vec<Object> {
-    (0..count)
-        .map(|_i| {
-            let gas_object_id = ObjectID::random();
-            Object::with_id_owner_gas_for_testing(gas_object_id, owner, GAS_VALUE_FOR_TESTING)
-        })
-        .collect()
-}
-
-/// Make a few test gas objects (all with the same owner).
-pub fn generate_test_gas_objects_with_owner_and_value(
-    count: usize,
-    owner: SuiAddress,
-    value: u64,
-) -> Vec<Object> {
-    (0..count)
-        .map(|_i| {
-            let gas_object_id = ObjectID::random();
-            Object::with_id_owner_gas_for_testing(gas_object_id, owner, value)
-        })
-        .collect()
-}
-
-/// Make a few test gas objects (all with the same owner) with TOTAL_SUPPLY_MIST / count balance
-pub fn generate_max_test_gas_objects_with_owner(count: u64, owner: SuiAddress) -> Vec<Object> {
-    let coin_size = TOTAL_SUPPLY_MIST / count;
-    (0..count)
-        .map(|_i| {
-            let gas_object_id = ObjectID::random();
-            Object::with_id_owner_gas_for_testing(gas_object_id, owner, coin_size)
-        })
-        .collect()
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
## Description 

This PR changes benchmark setup to use TestCluster when running locally. `server_metric_port` option was removed to make this easier. Instead available ports will be picked by the code and different for each node. Some other unused test functions for generating gas objects were removed too since we want to discourage inserting genesis objects in tests.

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
