### PR TITLE
[wallet]: add refetchInterval to useGetDelegatedStake

### DIFF
--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -12,5 +12,6 @@ export function useGetDelegatedStake(address: string): UseQueryResult<DelegatedS
 		queryKey: ['validator', address],
 		queryFn: () => rpc.getStakes({ owner: address }),
 		staleTime: 10 * 1000,
+		refetchInterval: 1000,
 	});
 }

--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -12,6 +12,6 @@ export function useGetDelegatedStake(address: string): UseQueryResult<DelegatedS
 		queryKey: ['validator', address],
 		queryFn: () => rpc.getStakes({ owner: address }),
 		staleTime: 10 * 1000,
-		refetchInterval: 1000,
+		refetchInterval: 30 * 1000,
 	});
 }

--- a/apps/wallet/tests/staking.spec.ts
+++ b/apps/wallet/tests/staking.spec.ts
@@ -7,7 +7,7 @@ import { createWallet } from './utils/auth';
 const TEST_TIMEOUT = 45 * 1000;
 const STAKE_AMOUNT = 100;
 
-test('staking', async ({ page, extensionUrl }) => {
+test.skip('staking', async ({ page, extensionUrl }) => {
 	test.setTimeout(TEST_TIMEOUT);
 
 	await createWallet(page, extensionUrl);

--- a/apps/wallet/tests/staking.spec.ts
+++ b/apps/wallet/tests/staking.spec.ts
@@ -7,7 +7,7 @@ import { createWallet } from './utils/auth';
 const TEST_TIMEOUT = 45 * 1000;
 const STAKE_AMOUNT = 100;
 
-test.skip('staking', async ({ page, extensionUrl }) => {
+test('staking', async ({ page, extensionUrl }) => {
 	test.setTimeout(TEST_TIMEOUT);
 
 	await createWallet(page, extensionUrl);


### PR DESCRIPTION
## Description 

Current problem. The button does not dynamically refetch.
https://mysten-labs.slack.com/archives/C042YF60NH2/p1687923874438029
https://mysten.atlassian.net/browse/APPS-1370

![unstaking](https://github.com/MystenLabs/sui/assets/127577476/a0a8cf6b-80e4-4c26-863c-3cf1056e8aba)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
