### PR TITLE
[sui-execution] Hard-code package upgrades in v1

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1264,6 +1264,10 @@ impl ProtocolConfig {
             17 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.execution_version = Some(1);
+
+                // Following flags are implied by this execution version.  Once support for earlier
+                // protocol versions is dropped, these flags can be removed:
+                // cfg.feature_flags.package_upgrades = true;
                 cfg
             }
             // Use this template when making changes:

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -118,15 +118,9 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
         gas_coin_opt: Option<ObjectID>,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
-        let init_linkage = if protocol_config.package_upgrades_supported() {
-            LinkageInfo::Unset
-        } else {
-            LinkageInfo::Universal
-        };
-
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
         let mut tmp_session = new_session(
             vm,
             linkage,


### PR DESCRIPTION
## Description

Clean-up use of `package_upgrades` feature-flag (on since protocol 3) in execution v1, defaulting it to `true`.

## Test Plan

All existing tests.
