### PR TITLE
[sui-execution/v1] Clean-up LinkageInfo

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1264,6 +1264,10 @@ impl ProtocolConfig {
             17 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.execution_version = Some(1);
+
+                // Following flags are implied by this execution version.  Once support for earlier
+                // protocol versions is dropped, these flags can be removed:
+                // cfg.feature_flags.package_upgrades = true;
                 cfg
             }
             // Use this template when making changes:

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -118,15 +118,9 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
         gas_coin_opt: Option<ObjectID>,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
-        let init_linkage = if protocol_config.package_upgrades_supported() {
-            LinkageInfo::Unset
-        } else {
-            LinkageInfo::Universal
-        };
-
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -54,7 +54,7 @@ use sui_types::{
     execution_status::CommandArgumentError,
 };
 
-use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
+use super::linkage_view::{LinkageView, SavedLinkage};
 
 sui_macros::checked_arithmetic! {
 
@@ -120,7 +120,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     ) -> Result<Self, ExecutionError> {
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::programmable_transactions::context::new_session_for_linkage;
-use crate::programmable_transactions::{
-    context::load_type,
-    linkage_view::{LinkageInfo, LinkageView},
-};
+use crate::programmable_transactions::{context::load_type, linkage_view::LinkageView};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -35,10 +32,8 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let session = new_session_for_linkage(
-            vm,
-            LinkageView::new(Box::new(NullSuiResolver(state_view)), LinkageInfo::Unset),
-        );
+        let session =
+            new_session_for_linkage(vm, LinkageView::new(Box::new(NullSuiResolver(state_view))));
         Self { session }
     }
 }


### PR DESCRIPTION
## Description

Now that execution v1+ doesn't need to support running without package upgrades enabled, `LinkageInfo` can be simplified. In particular, `LinkageInfo::Universal` is no longer necessary, and the remaining two enum variants can be replaced by a struct, wrapped in an `Option`.

## Test Plan

All existing tests.

## Stack

- #12740 