### PR TITLE
[sui-execution] Move compatibility check impl into execution layer 

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1264,6 +1264,10 @@ impl ProtocolConfig {
             17 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.execution_version = Some(1);
+
+                // Following flags are implied by this execution version.  Once support for earlier
+                // protocol versions is dropped, these flags can be removed:
+                // cfg.feature_flags.package_upgrades = true;
                 cfg
             }
             // Use this template when making changes:

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -118,15 +118,9 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
         gas_coin_opt: Option<ObjectID>,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
-        let init_linkage = if protocol_config.package_upgrades_supported() {
-            LinkageInfo::Unset
-        } else {
-            LinkageInfo::Universal
-        };
-
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -54,7 +54,7 @@ use sui_types::{
     execution_status::CommandArgumentError,
 };
 
-use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
+use super::linkage_view::{LinkageView, SavedLinkage};
 
 sui_macros::checked_arithmetic! {
 
@@ -120,7 +120,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     ) -> Result<Self, ExecutionError> {
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -9,9 +9,10 @@ use std::{
 
 use move_binary_format::{
     access::ModuleAccess,
+    compatibility::{Compatibility, InclusionCheck},
     errors::{Location, PartialVMResult, VMResult},
     file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
-    CompiledModule,
+    normalized, CompiledModule,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -686,29 +687,61 @@ fn check_compatibility<'a>(
 
     let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
     for (name, cur_module) in current_normalized {
-        let msg = format!("Existing module {name} not found in next version of package");
         let Some(new_module) = new_normalized.remove(&name) else {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
                 },
-                msg,
+                format!("Existing module {name} not found in next version of package"),
             ));
         };
 
-        if let Err(e) =
-            policy.check_compatibility(&cur_module, &new_module, context.protocol_config)
-        {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PackageUpgradeError {
-                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
-                },
-                e,
-            ));
-        }
+        check_module_compatibility(
+            &policy,
+            context.protocol_config,
+            &cur_module,
+            &new_module,
+        )?;
     }
 
     Ok(())
+}
+
+fn check_module_compatibility(
+    policy: &UpgradePolicy,
+    protocol_config: &ProtocolConfig,
+    cur_module: &normalized::Module,
+    new_module: &normalized::Module,
+) -> Result<(), ExecutionError> {
+    match policy {
+        UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
+        UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
+        UpgradePolicy::Compatible => {
+            let disallowed_new_abilities = if protocol_config.disallow_adding_abilities_on_upgrade() {
+                AbilitySet::ALL
+            } else {
+                AbilitySet::EMPTY
+            };
+
+            let compatibility = Compatibility {
+                check_struct_and_pub_function_linking: true,
+                check_struct_layout: true,
+                check_friend_linking: false,
+                check_private_entry_linking: false,
+                disallowed_new_abilities,
+                disallow_change_struct_type_params: protocol_config
+                    .disallow_change_struct_type_params_on_upgrade(),
+            };
+
+            compatibility.check(cur_module, new_module)
+        }
+    }
+    .map_err(|e| ExecutionError::new_with_source(
+        ExecutionErrorKind::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+        },
+        e,
+    ))
 }
 
 fn fetch_package(

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::programmable_transactions::context::new_session_for_linkage;
-use crate::programmable_transactions::{
-    context::load_type,
-    linkage_view::{LinkageInfo, LinkageView},
-};
+use crate::programmable_transactions::{context::load_type, linkage_view::LinkageView};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -35,10 +32,8 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let session = new_session_for_linkage(
-            vm,
-            LinkageView::new(Box::new(NullSuiResolver(state_view)), LinkageInfo::Unset),
-        );
+        let session =
+            new_session_for_linkage(vm, LinkageView::new(Box::new(NullSuiResolver(state_view))));
         Self { session }
     }
 }


### PR DESCRIPTION
## Description

This change allows us to clean-up protocol config use in the later versions of the execution layer (to follow).

## Test Plan

All existing tests

## Stack

- #12740 
- #12741 