### PR TITLE
[explorer]: add suins domain name to txn page

### DIFF
--- a/apps/explorer/src/components/GasBreakdown/index.tsx
+++ b/apps/explorer/src/components/GasBreakdown/index.tsx
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CoinFormat, type TransactionSummary, useFormatCoin } from '@mysten/core';
+import {
+	CoinFormat,
+	type TransactionSummary,
+	useFormatCoin,
+	useResolveSuiNSName,
+} from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import { Heading, Text } from '@mysten/ui';
 
@@ -90,6 +95,7 @@ interface GasBreakdownProps {
 
 export function GasBreakdown({ summary }: GasBreakdownProps) {
 	const gasData = summary?.gas;
+	const { data: suinsDomainName } = useResolveSuiNSName(gasData?.owner);
 
 	if (!gasData) {
 		return null;
@@ -121,7 +127,7 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
 						<Text variant="pBody/medium" color="steel-darker">
 							Paid by
 						</Text>
-						<AddressLink address={owner} />
+						<AddressLink label={suinsDomainName || undefined} address={owner} />
 					</div>
 				)}
 

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
@@ -6,6 +6,7 @@ import {
 	CoinFormat,
 	useFormatCoin,
 	type BalanceChange,
+	useResolveSuiNSName,
 } from '@mysten/core';
 import { Heading, Text } from '@mysten/ui';
 
@@ -58,6 +59,7 @@ function BalanceChangeEntry({ change }: { change: BalanceChange }) {
 
 function BalanceChangeCard({ changes, owner }: { changes: BalanceChange[]; owner: string }) {
 	const coinTypesSet = new Set(changes.map((change) => change.coinType));
+	const { data: suinsDomainName } = useResolveSuiNSName(owner);
 
 	return (
 		<TransactionBlockCard
@@ -79,7 +81,7 @@ function BalanceChangeCard({ changes, owner }: { changes: BalanceChange[]; owner
 							Owner
 						</Text>
 						<Text variant="pBody/medium" color="hero-dark">
-							<AddressLink address={owner} />
+							<AddressLink label={suinsDomainName || undefined} address={owner} />
 						</Text>
 					</div>
 				) : null

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
@@ -7,6 +7,7 @@ import {
 	type ObjectChangesByOwner,
 	type ObjectChangeSummary,
 	type SuiObjectChangeTypes,
+	useResolveSuiNSName,
 } from '@mysten/core';
 import { ChevronRight12 } from '@mysten/icons';
 import {
@@ -233,6 +234,32 @@ interface ObjectChangeEntriesCardsProps {
 	type: SuiObjectChangeTypes;
 }
 
+function ObjectChangeEntriesCardFooter({
+	ownerType,
+	ownerAddress,
+}: {
+	ownerType: string;
+	ownerAddress: string;
+}) {
+	const { data: suinsDomainName } = useResolveSuiNSName(ownerAddress);
+
+	return (
+		<div className="flex flex-wrap items-center justify-between">
+			<Text variant="pBody/medium" color="steel-dark">
+				Owner
+			</Text>
+
+			{ownerType === 'AddressOwner' && (
+				<AddressLink label={suinsDomainName || undefined} address={ownerAddress} />
+			)}
+
+			{ownerType === 'ObjectOwner' && <ObjectLink objectId={ownerAddress} />}
+
+			{ownerType === 'Shared' && <ObjectLink objectId={ownerAddress} label="Shared" />}
+		</div>
+	);
+}
+
 export function ObjectChangeEntriesCards({ data, type }: ObjectChangeEntriesCardsProps) {
 	if (!data) return null;
 
@@ -248,19 +275,10 @@ export function ObjectChangeEntriesCards({ data, type }: ObjectChangeEntriesCard
 						shadow
 						footer={
 							renderFooter && (
-								<div className="flex flex-wrap items-center justify-between">
-									<Text variant="pBody/medium" color="steel-dark">
-										Owner
-									</Text>
-
-									{changes.ownerType === 'AddressOwner' && <AddressLink address={ownerAddress} />}
-
-									{changes.ownerType === 'ObjectOwner' && <ObjectLink objectId={ownerAddress} />}
-
-									{changes.ownerType === 'Shared' && (
-										<ObjectLink objectId={ownerAddress} label="Shared" />
-									)}
-								</div>
+								<ObjectChangeEntriesCardFooter
+									ownerType={changes.ownerType}
+									ownerAddress={ownerAddress}
+								/>
 							)
 						}
 					>


### PR DESCRIPTION
## Description 

- https://mysten.atlassian.net/browse/APPS-1372
- https://explorer-git-apps-1372-mysten-labs.vercel.app/txblock/BuwodPXcBAR2kNRdxovM5S4S3praGppChuFCdbt44ZMo

<img width="442" alt="Screenshot 2023-06-28 at 10 33 16 AM" src="https://github.com/MystenLabs/sui/assets/127577476/3853fe57-7712-491b-9ccc-2bcd621a43a9">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
