### PR TITLE
[Explorer]: Update CopyToClipboard Icon

### DIFF
--- a/apps/explorer/src/ui/CopyToClipboard.tsx
+++ b/apps/explorer/src/ui/CopyToClipboard.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCopyToClipboard } from '@mysten/core';
-import { Copy12, Copy16, CopyNew24 } from '@mysten/icons';
+import { Copy12, Copy16, Copy18 } from '@mysten/icons';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { toast } from 'react-hot-toast';
 
@@ -36,7 +36,7 @@ export interface CopyToClipboardProps extends IconStylesProps {
 const ICON_SIZES = {
 	sm: Copy12,
 	md: Copy16,
-	lg: CopyNew24,
+	lg: Copy18,
 };
 
 export function CopyToClipboard({

--- a/apps/explorer/src/ui/PageHeader.tsx
+++ b/apps/explorer/src/ui/PageHeader.tsx
@@ -55,7 +55,7 @@ export function PageHeader({ title, subtitle, type, status }: PageHeaderProps) {
 				</Heading>
 			</div>
 			<div className="flex flex-col gap-2 lg:flex-row">
-				<div className="flex min-w-0 items-start gap-2">
+				<div className="flex min-w-0 items-center gap-2">
 					<div className="min-w-0 break-words">
 						<Heading as="h2" variant="heading2/semibold" color="gray-90" mono>
 							{title}

--- a/apps/icons/src/Copy18.tsx
+++ b/apps/icons/src/Copy18.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { SVGProps } from 'react';
+const SvgCopy18 = (props: SVGProps<SVGSVGElement>) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="1em"
+		height="1em"
+		fill="none"
+		viewBox="0 0 19 19"
+		{...props}
+	>
+		<rect
+			width={13.227}
+			height={13.227}
+			x={0.75}
+			y={5.023}
+			stroke="#A0B6C3"
+			strokeWidth={1.5}
+			rx={2.25}
+		/>
+		<path
+			stroke="#A0B6C3"
+			strokeWidth={1.5}
+			d="M4.91 3.455V3a2 2 0 0 1 2-2H16a2 2 0 0 1 2 2v9.09a2 2 0 0 1-2 2h-.454"
+		/>
+	</svg>
+);
+export default SvgCopy18;

--- a/apps/icons/src/index.ts
+++ b/apps/icons/src/index.ts
@@ -56,6 +56,7 @@ export { default as Coins16 } from "./Coins16";
 export { default as Coins24 } from "./Coins24";
 export { default as Copy12 } from "./Copy12";
 export { default as Copy16 } from "./Copy16";
+export { default as Copy18 } from "./Copy18";
 export { default as CopyArchiveDoNotUse16 } from "./CopyArchiveDoNotUse16";
 export { default as CopyArchiveDoNotUse24 } from "./CopyArchiveDoNotUse24";
 export { default as CopyNew24 } from "./CopyNew24";

--- a/apps/icons/svgs/copy_18.svg
+++ b/apps/icons/svgs/copy_18.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0.75" y="5.02271" width="13.2273" height="13.2273" rx="2.25" stroke="#A0B6C3" stroke-width="1.5"/>
+    <path d="M4.90918 3.45455V3C4.90918 1.89543 5.80461 1 6.90918 1H16.0001C17.1047 1 18.0001 1.89543 18.0001 3V12.0909C18.0001 13.1955 17.1047 14.0909 16.0001 14.0909H15.5455" stroke="#A0B6C3" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Description 

https://mysten.atlassian.net/browse/APPS-1375
- Update `CopyToClipboard` with `lg` being Copy18

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
