### PR TITLE
show full function name in hover; specify exec version in replay

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1324,6 +1324,10 @@ impl ProtocolConfig {
     pub fn set_max_tx_gas_for_testing(&mut self, max_tx_gas: u64) {
         self.max_tx_gas = Some(max_tx_gas)
     }
+    pub fn set_execution_version_for_testing(&mut self, version: u64) {
+        self.execution_version = Some(version)
+    }
+
     #[cfg(msim)]
     pub fn set_simplified_unwrap_then_delete(&mut self, val: bool) {
         self.feature_flags.simplified_unwrap_then_delete = val

--- a/crates/sui-replay/src/fuzz.rs
+++ b/crates/sui-replay/src/fuzz.rs
@@ -72,6 +72,7 @@ impl ReplayFuzzer {
                 &base_transaction,
                 config.expensive_safety_check_config.clone(),
                 false,
+                None,
             )
             .await?;
 

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -43,6 +43,8 @@ pub enum ReplayToolCommand {
         show_effects: bool,
         #[clap(long, short)]
         diag: bool,
+        #[clap(long, short, allow_hyphen_values = true)]
+        executor_version_override: Option<i64>,
     },
 
     /// Replay a transaction from a node state dump
@@ -157,6 +159,7 @@ pub async fn execute_replay_command(
             tx_digest,
             show_effects,
             diag,
+            executor_version_override,
         } => {
             let tx_digest = TransactionDigest::from_str(&tx_digest)?;
             info!("Executing tx: {}", tx_digest);
@@ -166,6 +169,7 @@ pub async fn execute_replay_command(
                 tx_digest,
                 safety,
                 use_authority,
+                executor_version_override,
             )
             .await?;
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -220,6 +220,9 @@ pub struct LocalExec {
     pub fetcher: Fetchers,
 
     pub diag: DiagInfo,
+    // One can optionally override the executor version
+    // -1 implies use latest version
+    pub executor_version_override: Option<i64>,
     // Retry policies due to RPC errors
     pub num_retries_for_timeout: u32,
     pub sleep_period_for_timeout: std::time::Duration,
@@ -301,18 +304,25 @@ impl LocalExec {
         tx_digest: TransactionDigest,
         expensive_safety_check_config: ExpensiveSafetyCheckConfig,
         use_authority: bool,
+        executor_version_override: Option<i64>,
     ) -> Result<ExecutionSandboxState, ReplayEngineError> {
         async fn inner_exec(
             rpc_url: String,
             tx_digest: TransactionDigest,
             expensive_safety_check_config: ExpensiveSafetyCheckConfig,
             use_authority: bool,
+            executor_version_override: Option<i64>,
         ) -> Result<ExecutionSandboxState, ReplayEngineError> {
             LocalExec::new_from_fn_url(&rpc_url)
                 .await?
                 .init_for_execution()
                 .await?
-                .execute_transaction(&tx_digest, expensive_safety_check_config, use_authority)
+                .execute_transaction(
+                    &tx_digest,
+                    expensive_safety_check_config,
+                    use_authority,
+                    executor_version_override,
+                )
                 .await
         }
 
@@ -323,6 +333,7 @@ impl LocalExec {
                 tx_digest,
                 expensive_safety_check_config.clone(),
                 use_authority,
+                executor_version_override,
             )
             .await
             {
@@ -342,6 +353,7 @@ impl LocalExec {
                 tx_digest,
                 expensive_safety_check_config.clone(),
                 use_authority,
+                executor_version_override,
             )
             .await
             {
@@ -398,6 +410,7 @@ impl LocalExec {
             num_retries_for_timeout: RPC_TIMEOUT_ERR_NUM_RETRIES,
             sleep_period_for_timeout: RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
             diag: Default::default(),
+            executor_version_override: None,
         })
     }
 
@@ -438,6 +451,7 @@ impl LocalExec {
             num_retries_for_timeout: RPC_TIMEOUT_ERR_NUM_RETRIES,
             sleep_period_for_timeout: RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD,
             diag: Default::default(),
+            executor_version_override: None,
         })
     }
 
@@ -625,7 +639,12 @@ impl LocalExec {
         let mut succeeded = 0;
         for tx in txs {
             match self
-                .execute_transaction(&tx, expensive_safety_check_config.clone(), use_authority)
+                .execute_transaction(
+                    &tx,
+                    expensive_safety_check_config.clone(),
+                    use_authority,
+                    None,
+                )
                 .await
                 .map(|q| q.check_effects())
             {
@@ -689,12 +708,14 @@ impl LocalExec {
         let gas_status =
             SuiGasStatus::new_with_budget(tx_info.gas_budget, tx_info.gas_price, protocol_config);
 
+        let ov = self.executor_version_override;
+
         // Temp store for data
         let temporary_store =
             self.to_temporary_store(tx_digest, InputObjects::new(input_objects), protocol_config);
 
         // We could probably cache the executor per protocol config
-        let executor = get_executor(protocol_config, expensive_safety_check_config);
+        let executor = get_executor(ov, protocol_config, expensive_safety_check_config);
 
         // All prep done
         let expensive_checks = true;
@@ -933,7 +954,9 @@ impl LocalExec {
         tx_digest: &TransactionDigest,
         expensive_safety_check_config: ExpensiveSafetyCheckConfig,
         use_authority: bool,
+        executor_version_override: Option<i64>,
     ) -> Result<ExecutionSandboxState, ReplayEngineError> {
+        self.executor_version_override = executor_version_override;
         if use_authority {
             self.certificate_execute(tx_digest, expensive_safety_check_config.clone())
                 .await
@@ -1844,12 +1867,27 @@ impl GetModule for LocalExec {
 // <--------------------- Util functions ----------------------->
 
 pub fn get_executor(
+    executor_version_override: Option<i64>,
     protocol_config: &ProtocolConfig,
     expensive_safety_check_config: ExpensiveSafetyCheckConfig,
 ) -> Arc<dyn Executor + Send + Sync> {
+    let protocol_config = executor_version_override
+        .map(|q| {
+            let ver = if q < 0 {
+                sui_execution::LATEST_EXECUTOR_VERSION
+            } else {
+                q as u64
+            };
+
+            let mut c = protocol_config.clone();
+            c.set_execution_version_for_testing(ver);
+            c
+        })
+        .unwrap_or(protocol_config.clone());
+
     let silent = true;
     sui_execution::executor(
-        protocol_config,
+        &protocol_config,
         expensive_safety_check_config.enable_move_vm_paranoid_checks(),
         silent,
     )

--- a/external-crates/move/move-vm/runtime/src/session.rs
+++ b/external-crates/move/move-vm/runtime/src/session.rs
@@ -101,10 +101,14 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
         #[cfg(debug_assertions)]
-        gas_meter.set_profiler(GasProfiler::init_default_cfg(
-            function_name.to_string(),
-            gas_meter.remaining_gas().into(),
-        ));
+        {
+            if gas_meter.get_profiler_mut().is_none() {
+                gas_meter.set_profiler(GasProfiler::init_default_cfg(
+                    function_name.to_string(),
+                    gas_meter.remaining_gas().into(),
+                ));
+            }
+        }
 
         let bypass_declared_entry_check = true;
         self.runtime.execute_function(

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -539,6 +539,12 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     /// Determine the object changes and collect all user events
     pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
         use crate::error::convert_vm_error;
+        // #[cfg(debug_assertions)]
+        // {
+        //     println!("Dropping exec");
+        //     if let Some(q) = self.gas_status.move_gas_status_mut().get_profiler_mut() { q.finish() }
+
+        // }
         let Self {
             protocol_config,
             metrics,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -539,12 +539,6 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     /// Determine the object changes and collect all user events
     pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
         use crate::error::convert_vm_error;
-        // #[cfg(debug_assertions)]
-        // {
-        //     println!("Dropping exec");
-        //     if let Some(q) = self.gas_status.move_gas_status_mut().get_profiler_mut() { q.finish() }
-
-        // }
         let Self {
             protocol_config,
             metrics,

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -15,6 +15,8 @@ pub mod verifier;
 mod latest;
 mod v0;
 
+pub const LATEST_EXECUTOR_VERSION: u64 = 1;
+
 pub fn executor(
     protocol_config: &ProtocolConfig,
     paranoid_type_checks: bool,


### PR DESCRIPTION
## Description 

**Added two features:**
1. When hovering, the full function name is displayed. See image.
![Screen Shot 2023-06-28 at 19 09 08](https://github.com/MystenLabs/sui/assets/93547199/12a8609f-c6dd-4cb2-936f-3c1212896d1f)


2. Specify the executor version in replay. Negative number means use latest executor version.
```
env MOVE_VM_PROFILE=1 ./target/debug/sui-tool replay tx -t AbfBmKgsx4SaMY3XuNgqZ1DAxD5riLvos6B4hhaMb8y8 -e -1
```

## Test Plan 

Manual


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
