### PR TITLE
Do not use VerifiedTransaction type on clients

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -110,7 +110,7 @@ impl BenchmarkBank {
             amounts[0],
         );
 
-        let verified_tx = make_pay_sui_transaction(
+        let tx = make_pay_sui_transaction(
             init_coin.0,
             vec![],
             recipient_addresses,
@@ -121,10 +121,7 @@ impl BenchmarkBank {
             MAX_BUDGET,
         );
 
-        let effects = self
-            .proxy
-            .execute_transaction_block(verified_tx.into())
-            .await?;
+        let effects = self.proxy.execute_transaction_block(tx).await?;
 
         if !effects.is_ok() {
             effects.print_gas_summary();
@@ -166,7 +163,7 @@ impl BenchmarkBank {
     async fn create_init_coin(&mut self, amount: u64, gas_price: u64) -> Result<Gas> {
         info!("Creating initilization coin of value {amount}...");
 
-        let verified_tx = make_transfer_sui_transaction(
+        let tx = make_transfer_sui_transaction(
             self.primary_coin.0,
             self.primary_coin.1,
             Some(amount),
@@ -175,10 +172,7 @@ impl BenchmarkBank {
             gas_price,
         );
 
-        let effects = self
-            .proxy
-            .execute_transaction_block(verified_tx.into())
-            .await?;
+        let effects = self.proxy.execute_transaction_block(tx).await?;
 
         if !effects.is_ok() {
             effects.print_gas_summary();

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -31,7 +31,7 @@ use crate::ValidatorProxy;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
-use sui_types::transaction::{TransactionDataAPI, VerifiedTransaction};
+use sui_types::transaction::{Transaction, TransactionDataAPI};
 use sysinfo::{CpuExt, System, SystemExt};
 use tokio::sync::Barrier;
 use tokio::{time, time::Instant};
@@ -149,7 +149,7 @@ struct Stats {
     pub bench_stats: BenchmarkStats,
 }
 
-type RetryType = Box<(VerifiedTransaction, Box<dyn Payload>)>;
+type RetryType = Box<(Transaction, Box<dyn Payload>)>;
 
 enum NextOp {
     Response {
@@ -385,7 +385,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 let committee_cloned = Arc::new(worker.proxy.clone_committee());
                                 let start = Arc::new(Instant::now());
                                 let res = worker.proxy
-                                    .execute_transaction_block(b.0.clone().into())
+                                    .execute_transaction_block(b.0.clone())
                                     .then(|res| async move  {
                                         match res {
                                             Ok(effects) => {
@@ -441,7 +441,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 // TODO: clone committee for each request is not ideal.
                                 let committee_cloned = Arc::new(worker.proxy.clone_committee());
                                 let res = worker.proxy
-                                    .execute_transaction_block(tx.clone().into())
+                                    .execute_transaction_block(tx.clone())
                                 .then(|res| async move {
                                     match res {
                                         Ok(effects) => {

--- a/crates/sui-benchmark/src/in_memory_wallet.rs
+++ b/crates/sui-benchmark/src/in_memory_wallet.rs
@@ -8,7 +8,7 @@ use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
     crypto::AccountKeyPair,
     object::Owner,
-    transaction::{CallArg, TransactionData, TransactionDataAPI, VerifiedTransaction},
+    transaction::{CallArg, Transaction, TransactionData, TransactionDataAPI},
     utils::to_sender_signed_transaction,
 };
 
@@ -124,7 +124,7 @@ impl InMemoryWallet {
         self.accounts.get(addr).map(|a| a.owned.values())
     }
 
-    pub fn create_tx(&self, data: TransactionData) -> VerifiedTransaction {
+    pub fn create_tx(&self, data: TransactionData) -> Transaction {
         let sender = data.sender();
         to_sender_signed_transaction(data, self.accounts.get(&sender).unwrap().key.as_ref())
     }
@@ -139,7 +139,7 @@ impl InMemoryWallet {
         arguments: Vec<CallArg>,
         gas_budget: u64,
         gas_price: u64,
-    ) -> VerifiedTransaction {
+    ) -> Transaction {
         let account = self.account(&sender).unwrap();
         let data = TransactionData::new_move_call(
             sender,
@@ -166,7 +166,7 @@ impl InMemoryWallet {
         arguments: Vec<BenchMoveCallArg>,
         gas_budget: u64,
         gas_price: u64,
-    ) -> VerifiedTransaction {
+    ) -> Transaction {
         let account = self.account(&sender).unwrap();
         move_call_pt_impl(
             sender,
@@ -214,7 +214,7 @@ pub fn move_call_pt_impl(
     gas_ref: &ObjectRef,
     gas_budget: u64,
     gas_price: u64,
-) -> VerifiedTransaction {
+) -> Transaction {
     let mut builder = ProgrammableTransactionBuilder::new();
     let args = convert_move_call_args(&arguments, &mut builder);
 

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -359,7 +359,6 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
             return self.execute_bench_transaction(tx).await;
         }
         let tx_digest = *tx.digest();
-        let tx = tx.verify()?;
         let mut retry_cnt = 0;
         while retry_cnt < 3 {
             let ticket = self.qd.submit_transaction(tx.clone()).await?;
@@ -721,7 +720,6 @@ impl ValidatorProxy for FullNodeProxy {
 
     async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
         let tx_digest = *tx.digest();
-        let tx = tx.verify()?;
         let mut retry_cnt = 0;
         while retry_cnt < 10 {
             // Fullnode could time out after WAIT_FOR_FINALITY_TIMEOUT (30s) in TransactionOrchestrator

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -11,9 +11,7 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::crypto::{AccountKeyPair, KeypairTraits};
 use sui_types::object::Owner;
-use sui_types::transaction::{
-    TransactionData, VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
-};
+use sui_types::transaction::{Transaction, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 
@@ -41,7 +39,7 @@ pub fn make_pay_tx(
     gas: ObjectRef,
     keypair: &AccountKeyPair,
     gas_price: u64,
-) -> Result<VerifiedTransaction> {
+) -> Result<Transaction> {
     let pay = TransactionData::new_pay(
         sender,
         input_coins,
@@ -64,10 +62,7 @@ pub async fn publish_basics_package(
     let transaction = TestTransactionBuilder::new(sender, gas, gas_price)
         .publish_examples("basics")
         .build_and_sign(keypair);
-    let effects = proxy
-        .execute_transaction_block(transaction.into())
-        .await
-        .unwrap();
+    let effects = proxy.execute_transaction_block(transaction).await.unwrap();
     effects
         .created()
         .iter()

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -19,7 +19,7 @@ use sui_types::object::Owner;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     crypto::get_key_pair,
-    transaction::VerifiedTransaction,
+    transaction::Transaction,
 };
 use tracing::{debug, error};
 
@@ -70,7 +70,7 @@ impl Payload for BatchPaymentTestPayload {
         self.num_payments += self.state.num_addresses();
     }
 
-    fn make_transaction(&mut self) -> VerifiedTransaction {
+    fn make_transaction(&mut self) -> Transaction {
         let addrs = self.state.addresses().cloned().collect::<Vec<SuiAddress>>();
         let num_recipients = addrs.len();
         let sender = if self.num_payments == 0 {

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -17,7 +17,7 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::gas_coin::MIST_PER_SUI;
-use sui_types::transaction::VerifiedTransaction;
+use sui_types::transaction::Transaction;
 use tracing::error;
 
 #[derive(Debug)]
@@ -54,7 +54,7 @@ impl Payload for DelegationTestPayload {
     /// delegation flow is split into two phases
     /// first `make_transaction` call creates separate coin object for future delegation
     /// followup call creates delegation transaction itself
-    fn make_transaction(&mut self) -> VerifiedTransaction {
+    fn make_transaction(&mut self) -> Transaction {
         match self.coin {
             Some(coin) => TestTransactionBuilder::new(
                 self.sender,

--- a/crates/sui-benchmark/src/workloads/payload.rs
+++ b/crates/sui-benchmark/src/workloads/payload.rs
@@ -3,7 +3,7 @@
 
 use crate::ExecutionEffects;
 use std::fmt::Display;
-use sui_types::transaction::VerifiedTransaction;
+use sui_types::transaction::Transaction;
 
 /// A Payload is a transaction wrapper of a particular type (transfer object, shared counter, etc).
 /// Calling `make_transaction()` on a payload produces the transaction it is wrapping. Once that
@@ -11,5 +11,5 @@ use sui_types::transaction::VerifiedTransaction;
 /// effect by invoking `make_new_payload(effects)`
 pub trait Payload: Send + Sync + std::fmt::Debug + Display {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
-    fn make_transaction(&mut self) -> VerifiedTransaction;
+    fn make_transaction(&mut self) -> Transaction;
 }

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -20,7 +20,7 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::crypto::get_key_pair;
 use sui_types::{
     base_types::{ObjectDigest, ObjectID, SequenceNumber},
-    transaction::VerifiedTransaction,
+    transaction::Transaction,
 };
 use tracing::{debug, error, info};
 
@@ -51,7 +51,7 @@ impl Payload for SharedCounterTestPayload {
         }
         self.gas.0 = effects.gas_object().0;
     }
-    fn make_transaction(&mut self) -> VerifiedTransaction {
+    fn make_transaction(&mut self) -> Transaction {
         let rgp = self
             .system_state_observer
             .state
@@ -220,10 +220,7 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
                 .build_and_sign(keypair.as_ref());
             let proxy_ref = proxy.clone();
             futures.push(async move {
-                if let Ok(effects) = proxy_ref
-                    .execute_transaction_block(transaction.into())
-                    .await
-                {
+                if let Ok(effects) = proxy_ref.execute_transaction_block(transaction).await {
                     effects.created()[0].0
                 } else {
                     panic!("Failed to create shared counter!");

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -20,7 +20,7 @@ use sui_core::test_utils::make_transfer_object_transaction;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair},
-    transaction::VerifiedTransaction,
+    transaction::Transaction,
 };
 
 /// TODO: This should be the amount that is being transferred instead of MAX_GAS.
@@ -65,7 +65,7 @@ impl Payload for TransferObjectTestPayload {
         self.transfer_to = recipient;
         self.gas = updated_gas;
     }
-    fn make_transaction(&mut self) -> VerifiedTransaction {
+    fn make_transaction(&mut self) -> Transaction {
         let (gas_obj, _, keypair) = self.gas.iter().find(|x| x.1 == self.transfer_from).unwrap();
         make_transfer_object_transaction(
             self.transfer_object,

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -26,7 +26,7 @@ use sui_sdk::SuiClient;
 use sui_types::gas_coin::GasCoin;
 use sui_types::{
     base_types::SuiAddress,
-    transaction::{Transaction, TransactionData, VerifiedTransaction},
+    transaction::{Transaction, TransactionData},
 };
 use test_case::{
     coin_index_test::CoinIndexTest, coin_merge_split_test::CoinMergeSplitTest,
@@ -127,7 +127,7 @@ impl TestContext {
 
     /// See `make_transactions_with_wallet_context` for potential caveats
     /// of this helper function.
-    pub async fn make_transactions(&self, max_txn_num: usize) -> Vec<VerifiedTransaction> {
+    pub async fn make_transactions(&self, max_txn_num: usize) -> Vec<Transaction> {
         self.get_wallet()
             .batch_make_transfer_transactions(max_txn_num)
             .await
@@ -155,9 +155,7 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver_api()
             .execute_transaction_block(
-                Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature])
-                    .verify()
-                    .unwrap(),
+                Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature]),
                 SuiTransactionBlockResponseOptions::new()
                     .with_object_changes()
                     .with_balance_changes()

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4052,6 +4052,13 @@ impl AuthorityState {
         Ok(new_epoch_store)
     }
 
+    pub fn verify_transaction(&self, tx: Transaction) -> SuiResult<VerifiedTransaction> {
+        self.load_epoch_store_one_call_per_task()
+            .signature_verifier
+            .verify_tx(tx.data())
+            .map(|_| VerifiedTransaction::new_from_verified(tx))
+    }
+
     #[cfg(test)]
     pub(crate) fn iter_live_object_set_for_testing(
         &self,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4052,6 +4052,8 @@ impl AuthorityState {
         Ok(new_epoch_store)
     }
 
+    // TODO: when we add stateful authenticators, we may need to take care that this function is
+    // reconfig safe (i.e. cannot be called concurrently with reconfiguration).
     pub fn verify_transaction(&self, tx: Transaction) -> SuiResult<VerifiedTransaction> {
         self.load_epoch_store_one_call_per_task()
             .signature_verifier

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -211,6 +211,7 @@ pub async fn init_state_with_ids_and_expensive_checks<
 }
 
 pub fn init_transfer_transaction(
+    authority_state: &AuthorityState,
     sender: SuiAddress,
     secret: &AccountKeyPair,
     recipient: SuiAddress,
@@ -218,7 +219,7 @@ pub fn init_transfer_transaction(
     gas_object_ref: ObjectRef,
     gas_budget: u64,
     gas_price: u64,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(
         recipient,
         object_ref,
@@ -227,7 +228,8 @@ pub fn init_transfer_transaction(
         gas_budget,
         gas_price,
     );
-    to_sender_signed_transaction(data, secret)
+    let tx = to_sender_signed_transaction(data, secret);
+    authority_state.verify_transaction(tx).unwrap()
 }
 
 pub fn init_certified_transfer_transaction(
@@ -240,6 +242,7 @@ pub fn init_certified_transfer_transaction(
 ) -> VerifiedCertificate {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let transfer_transaction = init_transfer_transaction(
+        authority_state,
         sender,
         secret,
         recipient,
@@ -248,7 +251,7 @@ pub fn init_certified_transfer_transaction(
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-    init_certified_transaction(transfer_transaction, authority_state)
+    init_certified_transaction(transfer_transaction.into(), authority_state)
 }
 
 pub fn init_certified_transaction(

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -49,9 +49,9 @@ use sui_types::effects::{
     VerifiedCertifiedTransactionEffects,
 };
 use sui_types::messages_grpc::{
-    HandleCertificateResponseV2, ObjectInfoRequest, PlainTransactionInfoResponse,
-    TransactionInfoRequest,
+    HandleCertificateResponseV2, ObjectInfoRequest, TransactionInfoRequest,
 };
+use sui_types::messages_safe_client::PlainTransactionInfoResponse;
 use tap::TapFallible;
 use tokio::time::{sleep, timeout};
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1112,7 +1112,7 @@ where
     /// Submits the transaction to a quorum of validators to make a certificate.
     pub async fn process_transaction(
         &self,
-        transaction: VerifiedTransaction,
+        transaction: Transaction,
     ) -> Result<ProcessTransactionResult, AggregatorProcessTransactionError> {
         // Now broadcast the transaction to all authorities.
         let tx_digest = transaction.digest();
@@ -1779,7 +1779,7 @@ where
 
     pub async fn execute_transaction_block(
         &self,
-        transaction: &VerifiedTransaction,
+        transaction: &Transaction,
     ) -> Result<VerifiedCertifiedTransactionEffects, anyhow::Error> {
         let tx_guard = GaugeGuard::acquire(&self.metrics.inflight_transactions);
         let result = self

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -346,13 +346,9 @@ impl ValidatorService {
         let _handle_tx_metrics_guard = metrics.handle_transaction_latency.start_timer();
 
         let tx_verif_metrics_guard = metrics.tx_verification_latency.start_timer();
-        let transaction = epoch_store
-            .signature_verifier
-            .verify_tx(transaction.data())
-            .map(|_| VerifiedTransaction::new_from_verified(transaction))
-            .tap_err(|_| {
-                metrics.signature_errors.inc();
-            })?;
+        let transaction = state.verify_transaction(transaction).tap_err(|_| {
+            metrics.signature_errors.inc();
+        })?;
         drop(tx_verif_metrics_guard);
 
         let tx_digest = transaction.digest();

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -33,7 +33,7 @@ use mysten_common::sync::notify_read::{NotifyRead, Registration};
 use mysten_metrics::{spawn_monitored_task, GaugeGuard};
 use std::fmt::Write;
 use sui_types::error::{SuiError, SuiResult};
-use sui_types::messages_grpc::PlainTransactionInfoResponse;
+use sui_types::messages_safe_client::PlainTransactionInfoResponse;
 use sui_types::transaction::{Transaction, VerifiedCertificate};
 
 use self::reconfig_observer::ReconfigObserver;

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -15,12 +15,9 @@ use sui_types::crypto::{deterministic_random_account_key, get_key_pair, AccountK
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::{generate_test_gas_objects, Object};
 use sui_types::quorum_driver_types::{QuorumDriverError, QuorumDriverResponse, QuorumDriverResult};
-use sui_types::transaction::VerifiedTransaction;
+use sui_types::transaction::Transaction;
 
-async fn setup() -> (
-    AuthorityAggregator<LocalAuthorityClient>,
-    VerifiedTransaction,
-) {
+async fn setup() -> (AuthorityAggregator<LocalAuthorityClient>, Transaction) {
     let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
     let gas_object = Object::with_owner_for_testing(sender);
     let (aggregator, authorities, genesis, _) =
@@ -45,7 +42,7 @@ fn make_tx(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
     gas_price: u64,
-) -> VerifiedTransaction {
+) -> Transaction {
     make_transfer_sui_transaction(
         gas.compute_object_reference(),
         SuiAddress::random_for_testing_only(),

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -20,9 +20,9 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::messages_grpc::{
     HandleCertificateResponse, HandleCertificateResponseV2, ObjectInfoRequest, ObjectInfoResponse,
-    PlainTransactionInfoResponse, SystemStateRequest, TransactionInfoRequest, TransactionStatus,
-    VerifiedObjectInfoResponse,
+    SystemStateRequest, TransactionInfoRequest, TransactionStatus, VerifiedObjectInfoResponse,
 };
+use sui_types::messages_safe_client::PlainTransactionInfoResponse;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{base_types::*, committee::*, fp_ensure};
 use sui_types::{

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1218,6 +1218,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
         .unwrap()
         .unwrap();
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -1243,7 +1244,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
         .unwrap();
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
-    let mut bad_signature_transfer_transaction = transfer_transaction.clone();
+    let mut bad_signature_transfer_transaction = transfer_transaction.clone().into_inner();
     *bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signatures_mut_for_testing() =
@@ -1307,6 +1308,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         .unwrap()
         .unwrap();
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -1315,9 +1317,6 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-    let transfer_transaction = authority_state
-        .verify_transaction(transfer_transaction)
-        .unwrap();
     let res = authority_state
         .handle_transaction(&epoch_store, transfer_transaction)
         .await;
@@ -1367,6 +1366,7 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         .unwrap();
 
     let unknown_sender_transfer_transaction = init_transfer_transaction(
+        &authority_state,
         unknown_address,
         &unknown_key,
         recipient,
@@ -1375,10 +1375,6 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-
-    let unknown_sender_transfer_transaction = authority_state
-        .verify_transaction(unknown_sender_transfer_transaction)
-        .unwrap();
 
     assert!(authority_state
         .handle_transaction(&epoch_store, unknown_sender_transfer_transaction)
@@ -1439,6 +1435,7 @@ async fn test_handle_transfer_transaction_ok() {
     assert!(before_object_version < after_object_version);
 
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -1464,10 +1461,6 @@ async fn test_handle_transfer_transaction_ok() {
         )
         .await
         .is_err());
-
-    let transfer_transaction = authority_state
-        .verify_transaction(transfer_transaction)
-        .unwrap();
 
     let account_info = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
@@ -1565,7 +1558,7 @@ async fn test_handle_sponsored_transaction() {
         },
     );
     let dual_signed_tx = to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key]);
-    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
+    let dual_signed_tx = VerifiedTransaction::new_unchecked(dual_signed_tx);
 
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
@@ -1659,6 +1652,7 @@ async fn test_transfer_package() {
         .unwrap();
     // We are trying to transfer the genesis package object, which is immutable.
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -1667,9 +1661,6 @@ async fn test_transfer_package() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-    let transfer_transaction = authority_state
-        .verify_transaction(transfer_transaction)
-        .unwrap();
     authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
@@ -1698,6 +1689,7 @@ async fn test_immutable_gas() {
         .unwrap()
         .unwrap();
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -1706,9 +1698,6 @@ async fn test_immutable_gas() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-    let transfer_transaction = authority_state
-        .verify_transaction(transfer_transaction)
-        .unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await;
@@ -2033,6 +2022,7 @@ async fn test_conflicting_transactions() {
         .unwrap();
 
     let tx1 = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient1,
@@ -2041,9 +2031,9 @@ async fn test_conflicting_transactions() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-    let tx1 = authority_state.verify_transaction(tx1).unwrap();
 
     let tx2 = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient2,
@@ -2052,8 +2042,6 @@ async fn test_conflicting_transactions() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
-
-    let tx2 = authority_state.verify_transaction(tx2).unwrap();
 
     // repeatedly attempt to submit conflicting transactions at the same time, and verify that
     // exactly one succeeds in every case.
@@ -2144,6 +2132,7 @@ async fn test_handle_transfer_transaction_double_spend() {
         .unwrap()
         .unwrap();
     let transfer_transaction = init_transfer_transaction(
+        &authority_state,
         sender,
         &sender_key,
         recipient,
@@ -2153,9 +2142,6 @@ async fn test_handle_transfer_transaction_double_spend() {
         rgp,
     );
 
-    let transfer_transaction = authority_state
-        .verify_transaction(transfer_transaction)
-        .unwrap();
     let signed_transaction = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -198,7 +198,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
     (
         validator,
         fullnode,
-        to_sender_signed_transaction(data, &keypair),
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(data, &keypair)),
         gas_object_id,
         shared_object_id,
     )
@@ -1243,7 +1243,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
         .unwrap();
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
-    let mut bad_signature_transfer_transaction = transfer_transaction.clone().into_inner();
+    let mut bad_signature_transfer_transaction = transfer_transaction.clone();
     *bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signatures_mut_for_testing() =
@@ -1315,6 +1315,9 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+    let transfer_transaction = authority_state
+        .verify_transaction(transfer_transaction)
+        .unwrap();
     let res = authority_state
         .handle_transaction(&epoch_store, transfer_transaction)
         .await;
@@ -1372,6 +1375,10 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+
+    let unknown_sender_transfer_transaction = authority_state
+        .verify_transaction(unknown_sender_transfer_transaction)
+        .unwrap();
 
     assert!(authority_state
         .handle_transaction(&epoch_store, unknown_sender_transfer_transaction)
@@ -1458,6 +1465,10 @@ async fn test_handle_transfer_transaction_ok() {
         .await
         .is_err());
 
+    let transfer_transaction = authority_state
+        .verify_transaction(transfer_transaction)
+        .unwrap();
+
     let account_info = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
@@ -1535,6 +1546,7 @@ async fn test_handle_sponsored_transaction() {
     );
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
+    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
 
     authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
@@ -1552,8 +1564,8 @@ async fn test_handle_sponsored_transaction() {
             budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * rgp,
         },
     );
-    let dual_signed_tx =
-        to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
+    let dual_signed_tx = to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key]);
+    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
 
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
@@ -1570,18 +1582,20 @@ async fn test_handle_sponsored_transaction() {
     );
 
     // Verify wrong gas owner gives error, using another address
+    let (wrong_owner, wrong_owner_key): (_, AccountKeyPair) = get_key_pair();
     let data = TransactionData::new_with_gas_data(
         tx_kind.clone(),
         sender,
         GasData {
             payment: vec![gas_object.compute_object_reference()],
-            owner: dbg_addr(42), // <-- wrong
+            owner: wrong_owner, // <-- wrong
             price: rgp,
             budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * rgp,
         },
     );
     let dual_signed_tx =
-        to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
+        to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &wrong_owner_key]);
+    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
@@ -1610,6 +1624,7 @@ async fn test_handle_sponsored_transaction() {
     );
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &third_party_key]);
+    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
@@ -1652,6 +1667,9 @@ async fn test_transfer_package() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+    let transfer_transaction = authority_state
+        .verify_transaction(transfer_transaction)
+        .unwrap();
     authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
@@ -1688,6 +1706,9 @@ async fn test_immutable_gas() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+    let transfer_transaction = authority_state
+        .verify_transaction(transfer_transaction)
+        .unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await;
@@ -1722,6 +1743,7 @@ async fn test_objected_owned_gas() {
     );
 
     let transaction = to_sender_signed_transaction(data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -1885,6 +1907,7 @@ async fn test_publish_non_existing_dependent_module() {
         rgp,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
+    let transaction = authority.verify_transaction(transaction).unwrap();
     let response = authority
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -2018,6 +2041,7 @@ async fn test_conflicting_transactions() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+    let tx1 = authority_state.verify_transaction(tx1).unwrap();
 
     let tx2 = init_transfer_transaction(
         sender,
@@ -2028,6 +2052,8 @@ async fn test_conflicting_transactions() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
+
+    let tx2 = authority_state.verify_transaction(tx2).unwrap();
 
     // repeatedly attempt to submit conflicting transactions at the same time, and verify that
     // exactly one succeeds in every case.
@@ -2127,6 +2153,9 @@ async fn test_handle_transfer_transaction_double_spend() {
         rgp,
     );
 
+    let transfer_transaction = authority_state
+        .verify_transaction(transfer_transaction)
+        .unwrap();
     let signed_transaction = authority_state
         .handle_transaction(&epoch_store, transfer_transaction.clone())
         .await
@@ -2202,6 +2231,7 @@ async fn test_missing_package() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -2249,6 +2279,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s1_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -2274,6 +2305,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s2_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -2299,6 +2331,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s3_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -3005,6 +3038,7 @@ async fn test_refusal_to_sign_consensus_commit_prologue() {
 
     // Sender is able to sign it.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
 
     // But the authority should refuse to handle it.
     assert!(matches!(
@@ -3042,6 +3076,7 @@ async fn test_invalid_mutable_clock_parameter() {
     .unwrap();
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
 
     let Err(e) = authority_state.handle_transaction(&epoch_store, transaction).await else {
         panic!("Expected handling transaction to fail");
@@ -3081,6 +3116,7 @@ async fn test_valid_immutable_clock_parameter() {
     .unwrap();
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -3139,12 +3175,13 @@ async fn test_transfer_sui_no_amount() {
 
     // Make sure transaction handling works as usual.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = authority_state.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction.clone())
         .await
         .unwrap();
 
-    let certificate = init_certified_transaction(transaction, &authority_state);
+    let certificate = init_certified_transaction(transaction.into(), &authority_state);
     let signed_effects = authority_state
         .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
         .await
@@ -4464,6 +4501,8 @@ async fn make_test_transaction(
 
     for authority in authorities {
         let epoch_store = authority.load_epoch_store_one_call_per_task();
+        let transaction = transaction.clone();
+        let transaction = authority.verify_transaction(transaction).unwrap();
         let response = authority
             .handle_transaction(&epoch_store, transaction.clone())
             .await

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -80,7 +80,9 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         )
         .unwrap();
 
-        let transaction = to_sender_signed_transaction(data, &keypair);
+        let transaction = authority
+            .verify_transaction(to_sender_signed_transaction(data, &keypair))
+            .unwrap();
 
         // Submit the transaction and assemble a certificate.
         let response = authority

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -23,7 +23,7 @@ use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiResult;
 use sui_types::object::{Object, Owner};
-use sui_types::transaction::{VerifiedCertificate, VerifiedTransaction};
+use sui_types::transaction::{Transaction, VerifiedCertificate};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{sleep, timeout};
 
@@ -225,7 +225,7 @@ async fn pending_exec_full() {
 async fn execute_owned_on_first_three_authorities(
     authority_clients: &[Arc<SafeClient<LocalAuthorityClient>>],
     committee: &Committee,
-    txn: &VerifiedTransaction,
+    txn: &Transaction,
 ) -> (VerifiedCertificate, TransactionEffects) {
     do_transaction(&authority_clients[0], txn).await;
     do_transaction(&authority_clients[1], txn).await;
@@ -257,7 +257,7 @@ pub async fn do_cert_with_shared_objects(
 async fn execute_shared_on_first_three_authorities(
     authority_clients: &[Arc<SafeClient<LocalAuthorityClient>>],
     committee: &Committee,
-    txn: &VerifiedTransaction,
+    txn: &Transaction,
 ) -> (VerifiedCertificate, TransactionEffects) {
     do_transaction(&authority_clients[0], txn).await;
     do_transaction(&authority_clients[1], txn).await;
@@ -437,7 +437,7 @@ async fn test_execution_with_dependencies() {
 async fn try_sign_on_first_three_authorities(
     authority_clients: &[Arc<SafeClient<LocalAuthorityClient>>],
     committee: &Committee,
-    txn: &VerifiedTransaction,
+    txn: &Transaction,
 ) -> SuiResult<VerifiedCertificate> {
     for client in authority_clients.iter().take(3) {
         client.handle_transaction(txn.clone()).await?;

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -950,6 +950,8 @@ async fn execute_transfer_with_price(
                 )
             })
     } else {
+        let tx = authority_state.verify_transaction(tx).unwrap();
+
         authority_state
             .handle_transaction(&epoch_store, tx)
             .await

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2822,7 +2822,7 @@ pub async fn build_and_try_publish_test_package(
     let transaction = to_sender_signed_transaction(data, sender_key);
 
     (
-        transaction.clone().into_inner(),
+        transaction.clone(),
         send_and_confirm_transaction(authority, transaction)
             .await
             .unwrap()

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -113,6 +113,7 @@ async fn transfer_with_account(
             vec![&sender_account.1, &sponsor_account.1],
         )
     };
+    let tx = state.verify_transaction(tx).unwrap();
     state
         .handle_transaction(&state.epoch_store_for_testing(), tx)
         .await
@@ -141,6 +142,7 @@ async fn handle_move_call_transaction(
     )
     .unwrap();
     let tx = to_sender_signed_transaction(data, &account.1);
+    let tx = state.verify_transaction(tx).unwrap();
     state
         .handle_transaction(&state.epoch_store_for_testing(), tx)
         .await
@@ -221,6 +223,7 @@ async fn test_shared_object_transaction_disabled() {
     let tx = TestTransactionBuilder::new(account.0, account.2[0], gas_price)
         .call_staking(account.2[1], SuiAddress::default())
         .build_and_sign(&account.1);
+    let tx = state.verify_transaction(tx).unwrap();
     let result = state
         .handle_transaction(&state.epoch_store_for_testing(), tx)
         .await;
@@ -243,6 +246,7 @@ async fn test_package_publish_disabled() {
     let tx = TestTransactionBuilder::new(sender, gas_object, rgp)
         .publish(path)
         .build_and_sign(keypair);
+    let tx = state.verify_transaction(tx).unwrap();
     let result = state
         .handle_transaction(&state.epoch_store_for_testing(), tx)
         .await;
@@ -422,6 +426,7 @@ async fn test_certificate_deny() {
         .build()
         .await;
     let epoch_store = state.epoch_store_for_testing();
+    let tx = state.verify_transaction(tx).unwrap();
     let signature = state
         .handle_transaction(&epoch_store, tx.clone())
         .await

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -5,6 +5,7 @@ use std::{time::Duration, vec};
 
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::transaction::VerifiedTransaction;
 use sui_types::{
     base_types::ObjectID,
     crypto::deterministic_random_account_key,
@@ -57,7 +58,7 @@ fn make_transaction(gas_object: Object, input: Vec<CallArg>) -> VerifiedExecutab
         TestTransactionBuilder::new(sender, gas_object.compute_object_reference(), rgp)
             .move_call(SUI_FRAMEWORK_PACKAGE_ID, "counter", "assert_value", input)
             .build_and_sign(&keypair);
-    VerifiedExecutableTransaction::new_system(transaction, 0)
+    VerifiedExecutableTransaction::new_system(VerifiedTransaction::new_unchecked(transaction), 0)
 }
 
 fn get_input_keys(objects: &[Object]) -> Vec<InputKey> {

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -784,7 +784,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(ExecuteTransactionRequest {
-            transaction: txn.into(),
+            transaction: txn,
             request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
         })
         .await
@@ -813,7 +813,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(ExecuteTransactionRequest {
-            transaction: txn.into(),
+            transaction: txn,
             request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
         })
         .await
@@ -1210,7 +1210,7 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
     let digest = *tx.digest();
     let _res = transaction_orchestrator
         .execute_transaction_block(ExecuteTransactionRequest {
-            transaction: tx.into(),
+            transaction: tx,
             request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
         })
         .await

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -99,7 +99,9 @@ async fn test_transaction_expiration() {
     let result = authority
         .with_async(|node| async {
             let epoch_store = node.state().epoch_store_for_testing();
-            node.state()
+            let state = node.state();
+            let expired_transaction = state.verify_transaction(expired_transaction).unwrap();
+            state
                 .handle_transaction(&epoch_store, expired_transaction)
                 .await
         })
@@ -112,9 +114,9 @@ async fn test_transaction_expiration() {
     authority
         .with_async(|node| async {
             let epoch_store = node.state().epoch_store_for_testing();
-            node.state()
-                .handle_transaction(&epoch_store, transaction)
-                .await
+            let state = node.state();
+            let transaction = state.verify_transaction(transaction).unwrap();
+            state.handle_transaction(&epoch_store, transaction).await
         })
         .await
         .unwrap();

--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -62,7 +62,7 @@ async fn _split_coins_equally(
     let resp = client
         .quorum_driver_api()
         .execute_transaction_block(
-            tx.clone(),
+            tx.clone().into(),
             SuiTransactionBlockResponseOptions::new().with_effects(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
@@ -118,7 +118,7 @@ async fn _merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), a
         client
             .quorum_driver_api()
             .execute_transaction_block(
-                tx.clone(),
+                tx.clone().into(),
                 SuiTransactionBlockResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -31,7 +31,7 @@ use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     gas_coin::GasCoin,
-    transaction::{Transaction, TransactionData, VerifiedTransaction},
+    transaction::{Transaction, TransactionData},
 };
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
@@ -350,9 +350,7 @@ impl SimpleFaucet {
             .keystore
             .sign_secure(&self.active_address, &tx_data, Intent::sui_transaction())
             .map_err(FaucetError::internal)?;
-        let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature])
-            .verify()
-            .unwrap();
+        let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
         let tx_digest = *tx.digest();
         info!(
             ?tx_digest,
@@ -487,7 +485,7 @@ impl SimpleFaucet {
 
     async fn execute_pay_sui_txn_with_retries(
         &self,
-        tx: &VerifiedTransaction,
+        tx: &Transaction,
         coin_id: ObjectID,
         recipient: SuiAddress,
         uuid: Uuid,
@@ -517,7 +515,7 @@ impl SimpleFaucet {
 
     async fn execute_pay_sui_txn(
         &self,
-        tx: &VerifiedTransaction,
+        tx: &Transaction,
         coin_id: ObjectID,
         recipient: SuiAddress,
         uuid: Uuid,

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -700,11 +700,10 @@ impl RpcExampleProvider {
         let data2 = data.clone();
 
         let tx = to_sender_signed_transaction(data, &kp);
-        let tx1 = tx.clone();
-        let signatures = tx.into_inner().tx_signatures().to_vec();
-        let raw_transaction = bcs::to_bytes(tx1.data()).unwrap();
+        let signatures = tx.data().tx_signatures().to_vec();
+        let raw_transaction = bcs::to_bytes(tx.data()).unwrap();
 
-        let tx_digest = tx1.digest();
+        let tx_digest = tx.digest();
         let object_change = ObjectChange::Transferred {
             sender: signer,
             recipient: Owner::AddressOwner(recipient),

--- a/crates/sui-oracle/src/lib.rs
+++ b/crates/sui-oracle/src/lib.rs
@@ -25,7 +25,7 @@ use sui_types::object::{Object, Owner};
 use sui_types::parse_sui_type_tag;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::quorum_driver_types::NON_RECOVERABLE_ERROR_MSG;
-use sui_types::transaction::{Argument, VerifiedTransaction};
+use sui_types::transaction::{Argument, Transaction};
 use sui_types::transaction::{Command, ObjectArg};
 use sui_types::Identifier;
 use sui_types::{
@@ -558,10 +558,7 @@ impl OnChainDataUploader {
         }
     }
 
-    async fn execute(
-        &mut self,
-        tx: VerifiedTransaction,
-    ) -> anyhow::Result<SuiTransactionBlockResponse> {
+    async fn execute(&mut self, tx: Transaction) -> anyhow::Result<SuiTransactionBlockResponse> {
         let tx_digest = tx.digest();
         let mut retry_attempts = 3;
         loop {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -130,7 +130,6 @@ pub async fn submit(
 ) -> Result<TransactionIdentifierResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
     let signed_tx: Transaction = bcs::from_bytes(&request.signed_transaction.to_vec()?)?;
-    let signed_tx = signed_tx.verify()?;
 
     let response = context
         .client

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -716,9 +716,7 @@ async fn test_transaction(
     let response = client
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(data.clone(), Intent::sui_transaction(), vec![signature])
-                .verify()
-                .unwrap(),
+            Transaction::from_data(data.clone(), Intent::sui_transaction(), vec![signature]),
             SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -778,9 +778,7 @@ pub(crate) async fn sign_and_execute(
     let transaction_response = match client
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature])
-                .verify()
-                .expect("signature error"),
+            Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature]),
             SuiTransactionBlockResponseOptions::new().with_effects(),
             Some(request_type),
         )

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -107,8 +107,7 @@ impl TicTacToe {
                     create_game_call,
                     Intent::sui_transaction(),
                     vec![signature],
-                )
-                .verify()?,
+                ),
                 SuiTransactionBlockResponseOptions::full_content(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
@@ -212,8 +211,7 @@ impl TicTacToe {
                         place_mark_call,
                         Intent::sui_transaction(),
                         vec![signature],
-                    )
-                    .verify()?,
+                    ),
                     SuiTransactionBlockResponseOptions::new().with_effects(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -42,8 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let transaction_response = sui
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(transfer_tx, Intent::sui_transaction(), vec![signature])
-                .verify()?,
+            Transaction::from_data(transfer_tx, Intent::sui_transaction(), vec![signature]),
             SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -34,7 +34,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::sui_serde::BigInt;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
-use sui_types::transaction::{TransactionData, TransactionKind, VerifiedTransaction};
+use sui_types::transaction::{Transaction, TransactionData, TransactionKind};
 
 const WAIT_FOR_LOCAL_EXECUTION_RETRY_COUNT: u8 = 3;
 
@@ -502,7 +502,7 @@ impl QuorumDriverApi {
     /// still fails, it will return an error.
     pub async fn execute_transaction_block(
         &self,
-        tx: VerifiedTransaction,
+        tx: Transaction,
         options: SuiTransactionBlockResponseOptions,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> SuiRpcResult<SuiTransactionBlockResponse> {

--- a/crates/sui-storage/src/write_path_pending_tx_log.rs
+++ b/crates/sui-storage/src/write_path_pending_tx_log.rs
@@ -102,7 +102,7 @@ mod tests {
     async fn test_pending_tx_log_basic() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
         let pending_txes = WritePathPendingTransactionLog::new(temp_dir.path().to_path_buf());
-        let tx = create_fake_transaction();
+        let tx = VerifiedTransaction::new_unchecked(create_fake_transaction());
         let tx_digest = *tx.digest();
         assert!(pending_txes
             .write_pending_transaction_maybe(&tx)
@@ -125,7 +125,9 @@ mod tests {
         pending_txes.finish_transaction(&tx_digest).unwrap();
 
         // Test writing and finishing more transactions
-        let txes: Vec<_> = (0..10).map(|_| create_fake_transaction()).collect();
+        let txes: Vec<_> = (0..10)
+            .map(|_| VerifiedTransaction::new_unchecked(create_fake_transaction()))
+            .collect();
         for tx in txes.iter().take(10) {
             assert!(pending_txes
                 .write_pending_transaction_maybe(tx)

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -10,7 +10,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::crypto::{Signature, Signer};
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::transaction::{
-    CallArg, ObjectArg, ProgrammableTransaction, Transaction, TransactionData, VerifiedTransaction,
+    CallArg, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
     DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::{TypeTag, SUI_SYSTEM_PACKAGE_ID};
@@ -269,12 +269,8 @@ impl TestTransactionBuilder {
         }
     }
 
-    pub fn build_and_sign(self, signer: &dyn Signer<Signature>) -> VerifiedTransaction {
-        VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
-            self.build(),
-            Intent::sui_transaction(),
-            vec![signer],
-        ))
+    pub fn build_and_sign(self, signer: &dyn Signer<Signature>) -> Transaction {
+        Transaction::from_data_and_signer(self.build(), Intent::sui_transaction(), vec![signer])
     }
 }
 

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -23,7 +23,7 @@ use sui_storage::object_store::ObjectStoreConfig;
 use sui_types::messages_checkpoint::{
     CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
 };
-use sui_types::transaction::{SenderSignedData, Transaction, VerifiedTransaction};
+use sui_types::transaction::{SenderSignedData, Transaction};
 
 #[derive(Parser, Clone, ValueEnum)]
 pub enum Verbosity {
@@ -417,12 +417,11 @@ impl ToolCommand {
                     &fastcrypto::encoding::Base64::decode(sender_signed_data.as_str()).unwrap(),
                 )
                 .unwrap();
-                let transaction =
-                    VerifiedTransaction::new_unchecked(Transaction::new(sender_signed_data));
+                let transaction = Transaction::new(sender_signed_data);
                 let (agg, _) = AuthorityAggregatorBuilder::from_genesis(&genesis)
                     .build()
                     .unwrap();
-                let result = agg.process_transaction(transaction.into()).await;
+                let result = agg.process_transaction(transaction).await;
                 println!("{:?}", result);
             }
         };

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -23,7 +23,7 @@ use sui_storage::object_store::ObjectStoreConfig;
 use sui_types::messages_checkpoint::{
     CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
 };
-use sui_types::transaction::{SenderSignedData, Transaction};
+use sui_types::transaction::{SenderSignedData, Transaction, VerifiedTransaction};
 
 #[derive(Parser, Clone, ValueEnum)]
 pub enum Verbosity {
@@ -417,11 +417,12 @@ impl ToolCommand {
                     &fastcrypto::encoding::Base64::decode(sender_signed_data.as_str()).unwrap(),
                 )
                 .unwrap();
-                let transaction = Transaction::new(sender_signed_data).verify().unwrap();
+                let transaction =
+                    VerifiedTransaction::new_unchecked(Transaction::new(sender_signed_data));
                 let (agg, _) = AuthorityAggregatorBuilder::from_genesis(&genesis)
                     .build()
                     .unwrap();
-                let result = agg.process_transaction(transaction).await;
+                let result = agg.process_transaction(transaction.into()).await;
                 println!("{:?}", result);
             }
         };

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -60,7 +60,7 @@ use sui_types::{
     event::Event,
     object::{self, Object, ObjectFormatOptions},
     object::{MoveObject, Owner},
-    transaction::{TransactionData, TransactionDataAPI, VerifiedTransaction},
+    transaction::{Transaction, TransactionData, TransactionDataAPI, VerifiedTransaction},
     MOVE_STDLIB_ADDRESS, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
@@ -653,7 +653,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             }) => {
                 let transaction =
                     VerifiedTransaction::new_consensus_commit_prologue(0, 0, timestamp_ms);
-                let summary = self.execute_txn(transaction).await?;
+                let summary = self.execute_txn(transaction.into()).await?;
                 let output = self.object_summary_output(&summary, /* summarize */ false);
                 Ok(output)
             }
@@ -1058,7 +1058,7 @@ impl<'a> SuiTestAdapter<'a> {
         &self,
         sender: Option<String>,
         txn_data: impl FnOnce(/* sender */ SuiAddress, /* gas */ ObjectRef) -> TransactionData,
-    ) -> VerifiedTransaction {
+    ) -> Transaction {
         let test_account = self.get_sender(sender);
         let gas_payment = self
             .get_object(&test_account.gas, None)
@@ -1078,10 +1078,7 @@ impl<'a> SuiTestAdapter<'a> {
         }
     }
 
-    async fn execute_txn(
-        &mut self,
-        transaction: VerifiedTransaction,
-    ) -> anyhow::Result<TxnSummary> {
+    async fn execute_txn(&mut self, transaction: Transaction) -> anyhow::Result<TxnSummary> {
         let with_shared = transaction
             .data()
             .intent_message()

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -52,6 +52,7 @@ pub mod message_envelope;
 pub mod messages_checkpoint;
 pub mod messages_consensus;
 pub mod messages_grpc;
+pub mod messages_safe_client;
 pub mod metrics;
 pub mod move_package;
 pub mod multisig;

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -7,9 +7,7 @@ use crate::effects::{
     SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects,
 };
 use crate::object::{Object, ObjectFormatOptions};
-use crate::transaction::{
-    SenderSignedData, SignedTransaction, VerifiedCertificate, VerifiedTransaction,
-};
+use crate::transaction::{SenderSignedData, SignedTransaction, Transaction, VerifiedCertificate};
 use move_core_types::value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -165,11 +163,7 @@ pub enum PlainTransactionInfoResponse {
         SignedTransactionEffects,
         TransactionEvents,
     ),
-    ExecutedWithoutCert(
-        VerifiedTransaction,
-        SignedTransactionEffects,
-        TransactionEvents,
-    ),
+    ExecutedWithoutCert(Transaction, SignedTransactionEffects, TransactionEvents),
 }
 
 impl PlainTransactionInfoResponse {

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -7,7 +7,7 @@ use crate::effects::{
     SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects,
 };
 use crate::object::{Object, ObjectFormatOptions};
-use crate::transaction::{SenderSignedData, SignedTransaction, Transaction, VerifiedCertificate};
+use crate::transaction::{SenderSignedData, SignedTransaction};
 use move_core_types::value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -147,33 +147,6 @@ pub struct HandleTransactionResponse {
 pub struct TransactionInfoResponse {
     pub transaction: SenderSignedData,
     pub status: TransactionStatus,
-}
-
-/// This enum represents all possible states of a response returned from
-/// the safe client. Note that [struct SignedTransaction] and
-/// [struct SignedTransactionEffects] are represented as an Envelope
-/// instead of an VerifiedEnvelope. This is because the verification is
-/// now performed by the authority aggregator as an aggregated signature,
-/// instead of in SafeClient.
-#[derive(Clone, Debug)]
-pub enum PlainTransactionInfoResponse {
-    Signed(SignedTransaction),
-    ExecutedWithCert(
-        VerifiedCertificate,
-        SignedTransactionEffects,
-        TransactionEvents,
-    ),
-    ExecutedWithoutCert(Transaction, SignedTransactionEffects, TransactionEvents),
-}
-
-impl PlainTransactionInfoResponse {
-    pub fn is_executed(&self) -> bool {
-        match self {
-            PlainTransactionInfoResponse::Signed(_) => false,
-            PlainTransactionInfoResponse::ExecutedWithCert(_, _, _)
-            | PlainTransactionInfoResponse::ExecutedWithoutCert(_, _, _) => true,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/messages_safe_client.rs
+++ b/crates/sui-types/src/messages_safe_client.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    effects::{SignedTransactionEffects, TransactionEvents},
+    transaction::{SignedTransaction, Transaction, VerifiedCertificate},
+};
+
+/// This enum represents all possible states of a response returned from
+/// the safe client. Note that [struct SignedTransaction] and
+/// [struct SignedTransactionEffects] are represented as an Envelope
+/// instead of an VerifiedEnvelope. This is because the verification is
+/// now performed by the authority aggregator as an aggregated signature,
+/// instead of in SafeClient.
+#[derive(Clone, Debug)]
+pub enum PlainTransactionInfoResponse {
+    Signed(SignedTransaction),
+    ExecutedWithCert(
+        VerifiedCertificate,
+        SignedTransactionEffects,
+        TransactionEvents,
+    ),
+    ExecutedWithoutCert(Transaction, SignedTransactionEffects, TransactionEvents),
+}
+
+impl PlainTransactionInfoResponse {
+    pub fn is_executed(&self) -> bool {
+        match self {
+            PlainTransactionInfoResponse::Signed(_) => false,
+            PlainTransactionInfoResponse::ExecutedWithCert(_, _, _)
+            | PlainTransactionInfoResponse::ExecutedWithoutCert(_, _, _) => true,
+        }
+    }
+}

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 pub type QuorumDriverResult = Result<QuorumDriverResponse, QuorumDriverError>;
 
 pub type QuorumDriverEffectsQueueResult =
-    Result<(VerifiedTransaction, QuorumDriverResponse), (TransactionDigest, QuorumDriverError)>;
+    Result<(Transaction, QuorumDriverResponse), (TransactionDigest, QuorumDriverError)>;
 
 pub const NON_RECOVERABLE_ERROR_MSG: &str =
     "Transaction has non recoverable errors from at least 1/3 of validators";

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     object::Object,
     signature::GenericSignature,
-    transaction::{Transaction, TransactionData, VerifiedTransaction},
+    transaction::{Transaction, TransactionData},
     zk_login_authenticator::ZkLoginAuthenticator,
     zk_login_util::AddressParams,
 };
@@ -65,7 +65,7 @@ where
 
 // Creates a fake sender-signed transaction for testing. This transaction will
 // not actually work.
-pub fn create_fake_transaction() -> VerifiedTransaction {
+pub fn create_fake_transaction() -> Transaction {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
@@ -111,19 +111,15 @@ pub fn make_transaction(sender: SuiAddress, kp: &SuiKeyPair, intent: Intent) -> 
 pub fn to_sender_signed_transaction(
     data: TransactionData,
     signer: &dyn Signer<Signature>,
-) -> VerifiedTransaction {
+) -> Transaction {
     to_sender_signed_transaction_with_multi_signers(data, vec![signer])
 }
 
 pub fn to_sender_signed_transaction_with_multi_signers(
     data: TransactionData,
     signers: Vec<&dyn Signer<Signature>>,
-) -> VerifiedTransaction {
-    VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
-        data,
-        Intent::sui_transaction(),
-        signers,
-    ))
+) -> Transaction {
+    Transaction::from_data_and_signer(data, Intent::sui_transaction(), signers)
 }
 
 pub fn mock_certified_checkpoint<'a>(

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -83,7 +83,7 @@ macro_rules! serialize_or_execute {
             if $serialize_signed {
                 SuiClientCommandResult::SerializedSignedTransaction(sender_signed_data)
             } else {
-                let transaction = Transaction::new(sender_signed_data).verify()?;
+                let transaction = Transaction::new(sender_signed_data);
                 let response = $context.execute_transaction_may_fail(transaction).await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
                     anyhow!("Effects from SuiTransactionBlockResult should not be empty")
@@ -1197,11 +1197,10 @@ impl SuiClientCommands {
                         .map_err(|e| anyhow!(e))?,
                     );
                 }
-                let verified =
-                    Transaction::from_generic_sig_data(data, Intent::sui_transaction(), sigs)
-                        .verify()?;
+                let transaction =
+                    Transaction::from_generic_sig_data(data, Intent::sui_transaction(), sigs);
 
-                let response = context.execute_transaction_may_fail(verified).await?;
+                let response = context.execute_transaction_may_fail(transaction).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }
             SuiClientCommands::NewEnv { alias, rpc, ws } => {

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -338,8 +338,7 @@ async fn execute_tx(
     action: &str,
 ) -> anyhow::Result<()> {
     let tx =
-        Transaction::from_data_and_signer(tx_data, Intent::sui_transaction(), vec![account_key])
-            .verify()?;
+        Transaction::from_data_and_signer(tx_data, Intent::sui_transaction(), vec![account_key]);
     info!("Executing {:?}", tx.digest());
     let tx_digest = *tx.digest();
     let resp = sui_client

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -60,7 +60,9 @@ async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
         Intent::sui_transaction(),
         vec![signature],
     ));
-    context.execute_transaction_must_succeed(signed_txn).await;
+    context
+        .execute_transaction_must_succeed(signed_txn.into())
+        .await;
     let (_, summary) = get_validator_summary(&sui_client, validator_address)
         .await?
         .unwrap();

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -9,11 +9,7 @@ use fastcrypto::encoding::{Base64, Encoding};
 use shared_crypto::intent::{Intent, IntentMessage};
 use sui_types::crypto::SuiKeyPair;
 use sui_types::transaction::TransactionData;
-use sui_types::{
-    base_types::SuiAddress,
-    crypto::Signature,
-    transaction::{Transaction, VerifiedTransaction},
-};
+use sui_types::{base_types::SuiAddress, crypto::Signature, transaction::Transaction};
 use test_cluster::TestClusterBuilder;
 
 #[tokio::test]
@@ -55,14 +51,8 @@ async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
         &IntentMessage::new(Intent::sui_transaction(), deserialized_data),
         keypair,
     );
-    let signed_txn = VerifiedTransaction::new_unchecked(Transaction::from_data(
-        data,
-        Intent::sui_transaction(),
-        vec![signature],
-    ));
-    context
-        .execute_transaction_must_succeed(signed_txn.into())
-        .await;
+    let txn = Transaction::from_data(data, Intent::sui_transaction(), vec![signature]);
+    context.execute_transaction_must_succeed(txn).await;
     let (_, summary) = get_validator_summary(&sui_client, validator_address)
         .await?
         .unwrap();

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -637,8 +637,7 @@ async fn call_0x5(
             .config
             .keystore
             .sign_secure(&sender, &tx_data, Intent::sui_transaction())?;
-    let transaction =
-        Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]).verify()?;
+    let transaction = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
     let sui_client = context.get_client().await?;
     sui_client
         .quorum_driver_api()

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -46,7 +46,7 @@ use sui_types::object::Object;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::SuiSystemStateTrait;
-use sui_types::transaction::{TransactionData, VerifiedTransaction};
+use sui_types::transaction::{Transaction, TransactionData};
 use tokio::time::{timeout, Instant};
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::info;
@@ -393,10 +393,7 @@ impl TestCluster {
     /// Also expects the effects status to be ExecutionStatus::Success.
     /// This function is recommended for transaction execution since it most resembles the
     /// production path.
-    pub async fn execute_transaction(
-        &self,
-        tx: VerifiedTransaction,
-    ) -> SuiTransactionBlockResponse {
+    pub async fn execute_transaction(&self, tx: Transaction) -> SuiTransactionBlockResponse {
         self.wallet.execute_transaction_must_succeed(tx).await
     }
 
@@ -410,7 +407,7 @@ impl TestCluster {
     /// from the execution results, and if the transaction is expected to fail.
     pub async fn execute_transaction_return_raw_effects(
         &self,
-        tx: VerifiedTransaction,
+        tx: Transaction,
     ) -> anyhow::Result<(TransactionEffects, TransactionEvents, Vec<Object>)> {
         let results = self
             .submit_transaction_to_validators(tx.clone(), &self.get_validator_pubkeys())
@@ -432,7 +429,7 @@ impl TestCluster {
     /// some tests.
     pub async fn submit_transaction_to_validators(
         &self,
-        tx: VerifiedTransaction,
+        tx: Transaction,
         pubkeys: &[AuthorityName],
     ) -> anyhow::Result<(TransactionEffects, TransactionEvents, Vec<Object>)> {
         let agg = self.authority_aggregator();

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -8,7 +8,7 @@ use crate::executor::{ExecutionResult, Executor};
 use once_cell::sync::Lazy;
 use proptest::{prelude::*, strategy::Union};
 use std::{fmt, sync::Arc};
-use sui_types::{storage::ObjectStore, transaction::VerifiedTransaction};
+use sui_types::{storage::ObjectStore, transaction::Transaction};
 
 mod account;
 mod helpers;
@@ -54,7 +54,7 @@ pub trait AUTransactionGen: fmt::Debug {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult);
+    ) -> (Transaction, ExecutionResult);
 
     /// Creates an arced version of this transaction, suitable for dynamic dispatch.
     fn arced(self) -> Arc<dyn AUTransactionGen>
@@ -70,7 +70,7 @@ impl AUTransactionGen for Arc<dyn AUTransactionGen> {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         (**self).apply(universe, exec)
     }
 }

--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -21,7 +21,7 @@ use sui_types::{
     error::{SuiError, UserInputError},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{GasData, TransactionData, TransactionKind, VerifiedTransaction},
+    transaction::{GasData, Transaction, TransactionData, TransactionKind},
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
 
@@ -176,11 +176,7 @@ impl TransactionSponsorship {
         }
     }
 
-    pub fn sign_transaction(
-        &self,
-        accounts: &AccountTriple,
-        txn: TransactionData,
-    ) -> VerifiedTransaction {
+    pub fn sign_transaction(&self, accounts: &AccountTriple, txn: TransactionData) -> Transaction {
         match self {
             TransactionSponsorship::None => {
                 to_sender_signed_transaction(txn, &accounts.account_1.initial_data.account.key)
@@ -256,7 +252,7 @@ impl AUTransactionGen for P2PTransferGenGoodGas {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         P2PTransferGenRandomGas {
             sender_receiver: self.sender_receiver.clone(),
             amount: self.amount,
@@ -271,7 +267,7 @@ impl AUTransactionGen for P2PTransferGenRandomGas {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         P2PTransferGenRandomGasRandomPriceRandomSponsorship {
             sender_receiver: self.sender_receiver.clone(),
             amount: self.amount,
@@ -289,7 +285,7 @@ impl AUTransactionGen for P2PTransferGenGasPriceInRange {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         P2PTransferGenRandomGasRandomPriceRandomSponsorship {
             sender_receiver: self.sender_receiver.clone(),
             amount: DEFAULT_TRANSFER_AMOUNT,
@@ -307,7 +303,7 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         P2PTransferGenRandomGasRandomPriceRandomSponsorship {
             sender_receiver: self.sender_receiver.clone(),
             amount: self.amount,
@@ -325,7 +321,7 @@ impl AUTransactionGen for P2PTransferGenRandGasRandPriceRandCoins {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         P2PTransferGenRandomGasRandomPriceRandomSponsorship {
             sender_receiver: self.sender_receiver.clone(),
             amount: self.amount,
@@ -395,7 +391,7 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPriceRandomSponsorship {
         &self,
         universe: &mut AccountUniverse,
         exec: &mut Executor,
-    ) -> (VerifiedTransaction, ExecutionResult) {
+    ) -> (Transaction, ExecutionResult) {
         let mut account_triple = self.sender_receiver.pick(universe);
         let (gas_coin_refs, (gas_balance, gas_object), gas_payer) =
             self.sponsorship

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -14,7 +14,7 @@ use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiError;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::object::Object;
-use sui_types::transaction::{TransactionData, VerifiedTransaction};
+use sui_types::transaction::{Transaction, TransactionData};
 use sui_types::utils::to_sender_signed_transaction;
 use tokio::runtime::Runtime;
 
@@ -104,7 +104,7 @@ impl Executor {
         self.rt.block_on(self.state.insert_genesis_objects(objects));
     }
 
-    pub fn execute_transaction(&mut self, txn: VerifiedTransaction) -> ExecutionResult {
+    pub fn execute_transaction(&mut self, txn: Transaction) -> ExecutionResult {
         self.rt
             .block_on(send_and_confirm_transaction(&self.state, None, txn))
             .map(|(_, effects)| effects.into_data().status().clone())
@@ -145,7 +145,7 @@ impl Executor {
 
     pub fn execute_transactions(
         &mut self,
-        txn: impl IntoIterator<Item = VerifiedTransaction>,
+        txn: impl IntoIterator<Item = Transaction>,
     ) -> Vec<ExecutionResult> {
         txn.into_iter()
             .map(|txn| self.execute_transaction(txn))


### PR DESCRIPTION
This PR paves the way for moving to stateful authenticators, which are generally difficult or impossible to use correctly on clients until we have better light client infrastructure.

VerifiedTransaction is intended to prevent unverified transactions from entering the validator core accidentally, so their use on clients was unnecessary to begin with.

Note that TransactionOrchestrator continues to use VerifiedTransaction - this is for two reasons:
- it has an AuthorityState handle so it is easy for it to do so even with a stateful authenticator
- it should catch bad signatures early rather than relying on validators to do that