### PR TITLE
indexer fix: fromOrTO address filter fetch limit

### DIFF
--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -215,7 +215,7 @@ impl<S: IndexerStore> IndexerApi<S> {
                     .get_recipient_sequence_by_digest(cursor_str, is_descending)
                     .await?;
                 self.state
-                    .get_transaction_page_by_address(addr, start_sequence, limit, is_descending)
+                    .get_transaction_page_by_address(addr, start_sequence, limit + 1, is_descending)
                     .await
             }
             Some(TransactionFilter::TransactionKind(tx_kind_name)) => {

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1119,13 +1119,9 @@ impl IndexerStore for PgIndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError> {
         let sql_query = format!(
-            "SELECT transaction_digest as digest_name FROM (
-                SELECT transaction_digest, max(id) AS max_id
-                FROM recipients
-                WHERE recipient = '{}' OR sender = '{}'
-                {} GROUP BY transaction_digest
-                ORDER BY max_id {} LIMIT {}
-            ) AS t",
+            "SELECT transaction_digest as digest_name FROM recipients
+             WHERE recipient = '{}' OR sender = '{}' {}
+             ORDER BY id {} LIMIT {};",
             address,
             address,
             if let Some(start_sequence) = start_sequence {


### PR DESCRIPTION
## Description 
- quick fix for FromOrTo address, we need to fetch limit + 1 to check if we have next page, I missed that
- the FromOrTo query no longer needs GROUP BY tx_digest after de-duping (tx_digest, recipient) on the writing path, so I simplify the query a bit as well.

## Test Plan 

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "FromOrToAddress": {"addr": "0xa7536c86055012cb7753fdb08ecb6c8bf1eb735ad75a2e1980309070123d5ef6"}
            }
        },
        null,
        20,
        false
    ]
}' | jq
```

run this query and make sure the cursor and hasNextPage is set properly 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
