### PR TITLE
Add checkpoint printing to db-tool

### DIFF
--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -354,6 +354,16 @@ impl fmt::Debug for CheckpointContentsDigest {
     }
 }
 
+impl std::str::FromStr for CheckpointContentsDigest {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut result = [0; 32];
+        result.copy_from_slice(&Base58::decode(s).map_err(|e| anyhow::anyhow!(e))?);
+        Ok(CheckpointContentsDigest::new(result))
+    }
+}
+
 impl fmt::LowerHex for CheckpointContentsDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)


### PR DESCRIPTION
## Description 

Adds two commands, PrintCheckpoint and PrintCheckpointContent. Both are by digest.

## Test Plan 

Tested on local db.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
