### PR TITLE
rpc & indexer: add tx query filter for multi tx kinds

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -56,3 +56,4 @@ CREATE INDEX transactions_timestamp_ms ON transactions (timestamp_ms);
 CREATE INDEX transactions_sender ON transactions (sender);
 CREATE INDEX transactions_checkpoint_sequence_number ON transactions (checkpoint_sequence_number);
 CREATE INDEX transactions_execution_success ON transactions (execution_success);
+CREATE INDEX transactions_transaction_kind ON transactions (transaction_kind);

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -224,8 +224,22 @@ impl<S: IndexerStore> IndexerApi<S> {
                     .get_transaction_sequence_by_digest(cursor_str, is_descending)
                     .await?;
                 self.state
-                    .get_transaction_page_by_transaction_kind(
-                        tx_kind_name,
+                    .get_transaction_page_by_transaction_kinds(
+                        vec![tx_kind_name],
+                        indexer_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
+            }
+            Some(TransactionFilter::TransactionKindIn(tx_kind_names)) => {
+                let indexer_seq_number = self
+                    .state
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_transaction_kinds(
+                        tx_kind_names,
                         indexer_seq_number,
                         limit + 1,
                         is_descending,

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -11,7 +11,7 @@ use crate::errors::IndexerError;
 use crate::schema::transactions;
 use crate::types::TemporaryTransactionBlockResponseStore;
 
-#[derive(Clone, Debug, Queryable, Insertable)]
+#[derive(Clone, Debug, Queryable, Insertable, QueryableByName)]
 #[diesel(table_name = transactions)]
 pub struct Transaction {
     #[diesel(deserialize_as = i64)]

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -108,9 +108,9 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    async fn get_transaction_page_by_transaction_kind(
+    async fn get_transaction_page_by_transaction_kinds(
         &self,
-        kind: String,
+        kind_names: Vec<String>,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -882,37 +882,43 @@ impl IndexerStore for PgIndexerStore {
         }).context(&format!("Failed reading transaction digests with checkpoint_sequence_number {checkpoint_sequence_number:?} and start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    async fn get_transaction_page_by_transaction_kind(
+    async fn get_transaction_page_by_transaction_kinds(
         &self,
-        kind: String,
+        kind_names: Vec<String>,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError> {
-        read_only_blocking!(&self.blocking_cp, |conn| {
-            let mut boxed_query = transactions::dsl::transactions
-                .filter(transactions::dsl::transaction_kind.eq(kind.clone()))
-                .into_boxed();
+        if kind_names.is_empty() {
+            return Err(IndexerError::InvalidArgumentError(
+                "kind_names cannot be empty".to_string(),
+            ));
+        }
+
+        let kind_sub_query = kind_names
+            .iter()
+            .map(|kind_name| format!("transaction_kind = '{}'", kind_name))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let sql_query = format!(
+            "SELECT * FROM transactions
+             WHERE ({}) {}
+             ORDER BY id {} LIMIT {}",
+            kind_sub_query,
             if let Some(start_sequence) = start_sequence {
                 if is_descending {
-                    boxed_query = boxed_query.filter(transactions::dsl::id.lt(start_sequence));
+                    format!("AND id < {}", start_sequence)
                 } else {
-                    boxed_query = boxed_query.filter(transactions::dsl::id.gt(start_sequence));
+                    format!("AND id > {}", start_sequence)
                 }
-            }
-
-            if is_descending {
-                boxed_query
-                    .order(transactions::dsl::id.desc())
-                    .limit((limit) as i64)
-                    .load::<Transaction>(conn)
             } else {
-               boxed_query
-                    .order(transactions::dsl::id.asc())
-                    .limit((limit) as i64)
-                    .load::<Transaction>(conn)
-            }
-        }).context(&format!("Failed reading transaction digests with kind {kind} and start_sequence {start_sequence:?} and limit {limit}"))
+                "".to_string()
+            },
+            if is_descending { "DESC" } else { "ASC" },
+            limit
+        );
+        read_only_blocking!(&self.blocking_cp, |conn| diesel::sql_query(sql_query).load::<Transaction>(conn))
+            .context(&format!("Failed reading transactions with kinds {kind_names:?} and start_sequence {start_sequence:?} and limit {limit}"))
     }
 
     async fn get_transaction_page_by_sender_address(

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1671,6 +1671,8 @@ pub enum TransactionFilter {
     FromOrToAddress { addr: SuiAddress },
     /// Query by transaction kind
     TransactionKind(String),
+    /// Query transactions of any given kind in the input.
+    TransactionKindIn(Vec<String>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -1707,6 +1709,9 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
             TransactionFilter::TransactionKind(kind) => item.input.kind().to_string() == *kind,
+            TransactionFilter::TransactionKindIn(kinds) => {
+                kinds.contains(&item.input.kind().to_string())
+            }
             // these filters are not supported, rpc will reject these filters on subscription
             TransactionFilter::Checkpoint(_) => false,
             TransactionFilter::FromOrToAddress { addr: _ } => false,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -10322,6 +10322,22 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "Query transactions of any given kind in the input.",
+            "type": "object",
+            "required": [
+              "TransactionKindIn"
+            ],
+            "properties": {
+              "TransactionKindIn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },


### PR DESCRIPTION
## Description 

Per @pchrysochoidis 's feature request, we want to change the tx kind to support a vector of tx kinds, such that on Explorer homepage, we can filter out "system txes"

To be backward compatible, I leave the existing filter and added a new one.

## Test Plan 
test locally by running
```
cargo run --bin sui-indexer -- --db-url "postgres://vultradmin:AVNS_89ViETEZVMEu8DAs7vB@vultr-prod-b2e14800-a4aa-42f4-a3cb-b383940eb14b-vultr-prod-628e.vultrdb.com:16751/defaultdb" --rpc-client-url http://ewr-mnt-rpc-03.mainnet.sui.io:9000 --rpc-server-worker --rpc-server-url 127.0.0.1 --rpc-server-port 3030 --migrated-methods query_transaction_blocks
```

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "TransactionKindIn": ["ProgrammableTransaction", "ConsensusCommitPrologue"]
            }
        },
        "C1FDTh7cJDe3JsHS4VxzntcQEyAJHWnaxgMqHehB79kU",
        5,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"DUTocRaesdotoDiRrA2N3Wm6exr6UDwA2UVmetJggaKr","timestampMs":"1681578573405","checkpoint":"161662"},{"digest":"CHZoyt3VfPDY56b3x71yiu6VurvDG9aiHFVtWBpBgfgM","timestampMs":"1681578574401","checkpoint":"161663"},{"digest":"BeTnKaMSt3m9gBvRanLdqLQrBFQhDBBkF6X4nRmikSPa","timestampMs":"1681578575417","checkpoint":"161664"},{"digest":"AVUdA3oosmz4TPaot1GbDCZgrCCpX7dKbYjmFEEqk25E","timestampMs":"1681578576375","checkpoint":"161665"},{"digest":"BCaWRgUwqnFQk8NzeBE76SjsFjJ6MGR8y1VHMbcDKRio","timestampMs":"1681578577425","checkpoint":"161666"}],"nextCursor":"BCaWRgUwqnFQk8NzeBE76SjsFjJ6MGR8y1VHMbcDKRio","hasNextPage":true},"id":1}%       


curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "TransactionKind": "ProgrammableTransaction"
            }
        },
        null,
        5,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"4KLhsn5CTuDJREQvkrTePznsCexrNgA3pYAdohNwwgav","timestampMs":"1681427749692","checkpoint":"29111"},{"digest":"GuN6UZHLgb2q6ApJMisvfgduMSMyWCqnajBZB96dXX3D","timestampMs":"1681430253413","checkpoint":"31332"},{"digest":"ESV1NY1SY47TSEy85LxRfQaVc1rs9v1FGBg7Qd1a8Xtw","timestampMs":"1681432083797","checkpoint":"32960"},{"digest":"7hjPyk2USjBjEPEJ2JLiKG4cYq3AmsGfB3VEE94YvBsX","timestampMs":"1681528734854","checkpoint":"117864"},{"digest":"C1FDTh7cJDe3JsHS4VxzntcQEyAJHWnaxgMqHehB79kU","timestampMs":"1681578573405","checkpoint":"161662"}],"nextCursor":"C1FDTh7cJDe3JsHS4VxzntcQEyAJHWnaxgMqHehB79kU","hasNextPage":true},"id":1}%      
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
