### PR TITLE
Add tool for reading consensus index; fix recover consensus index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10868,6 +10868,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
+ "narwhal-storage",
  "narwhal-types",
  "prometheus",
  "rocksdb",

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -383,6 +383,10 @@ impl AuthorityEpochTables {
         self.executed_transactions_to_checkpoint.remove(digest)?;
         Ok(())
     }
+
+    pub fn get_last_consensus_index(&self) -> SuiResult<Option<ExecutionIndicesWithHash>> {
+        Ok(self.last_consensus_index.get(&LAST_CONSENSUS_INDEX_ADDR)?)
+    }
 }
 
 pub(crate) const MUTEX_TABLE_SIZE: usize = 1024;
@@ -669,8 +673,7 @@ impl AuthorityPerEpochStore {
 
     pub fn get_last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
         self.tables
-            .last_consensus_index
-            .get(&LAST_CONSENSUS_INDEX_ADDR)
+            .get_last_consensus_index()
             .map(|x| x.unwrap_or_default())
             .map_err(SuiError::from)
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -73,7 +73,12 @@ impl<T> ConsensusHandler<T> {
         committee: Committee,
         metrics: Arc<AuthorityMetrics>,
     ) -> Self {
-        let last_seen = Mutex::new(Default::default());
+        // last_consensus_index is zero at the beginning of epoch, including for hash.
+        // It needs to be recovered on restart to ensure consistent consensus hash.
+        let last_consensus_index = epoch_store
+            .get_last_consensus_index()
+            .expect("Should be able to read last consensus index");
+        let last_seen = Mutex::new(last_consensus_index);
         let transaction_scheduler =
             AsyncTransactionScheduler::start(transaction_manager, epoch_store.clone());
         Self {

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["full"] }
 typed-store.workspace = true
 fastcrypto.workspace = true
 
+narwhal-storage.workspace = true
 narwhal-types.workspace = true
 sui-config.workspace = true
 sui-core.workspace = true

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -152,6 +152,14 @@ impl ConsensusStore {
 
         Ok(sub_dags)
     }
+
+    /// Load consensus commit with a given sequence number.
+    pub fn read_consensus_commit(
+        &self,
+        seq: &SequenceNumber,
+    ) -> StoreResult<Option<ConsensusCommit>> {
+        self.committed_sub_dags_by_index_v2.get(seq)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

Two commits related to debugging consensus:
1. Add a command in db_tool to read last consensus index and consensus commit.
2. Fix recovering consensus index on restart.

## Test Plan 

CI. Ran command on validator.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
