### PR TITLE
[ts-sdk] Fix deserialization of expiration epoch in transaction builder

### DIFF
--- a/.changeset/honest-scissors-clap.md
+++ b/.changeset/honest-scissors-clap.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Fix bug that prevented deserializing transaction blocks with a set expiration

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -158,7 +158,7 @@ const BCS_SPEC: TypeSchema = {
 		},
 		TransactionExpiration: {
 			None: null,
-			Epoch: BCS.U64,
+			Epoch: 'unsafe_u64',
 		},
 		TransactionData: {
 			V1: 'TransactionDataV1',
@@ -211,6 +211,12 @@ bcs.registerType(
 		let bytes = reader.readVec((reader) => reader.read8());
 		return new TextDecoder().decode(new Uint8Array(bytes));
 	},
+);
+
+bcs.registerType(
+	'unsafe_u64',
+	(writer, data) => writer.write64(data),
+	(reader) => Number.parseInt(reader.read64(), 10),
 );
 
 export { bcs };

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -88,4 +88,10 @@ describe('Transaction Serialization and deserialization', () => {
 		});
 		await serializeAndDeserialize(tx, [true]);
 	});
+
+	it('Transaction with expiration', async () => {
+		const tx = new TransactionBlock();
+		tx.setExpiration({ Epoch: 100 });
+		await serializeAndDeserialize(tx, []);
+	});
 });


### PR DESCRIPTION
## Description 

Fixes #12739 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
