### PR TITLE
[sui-execution/v1] Hard code pack digest hash modules

### DIFF
--- a/crates/sui-framework-tests/src/metered_verifier.rs
+++ b/crates/sui-framework-tests/src/metered_verifier.rs
@@ -31,7 +31,6 @@ fn test_metered_move_bytecode_verifier() {
     // Default case should pass
     let r = run_metered_move_bytecode_verifier(
         &compiled_modules,
-        &ProtocolConfig::get_for_max_version(),
         &metered_verifier_config,
         &mut meter,
         &bytecode_verifier_metrics,
@@ -122,7 +121,6 @@ fn test_metered_move_bytecode_verifier() {
     let timer_start = Instant::now();
     let r = run_metered_move_bytecode_verifier(
         &compiled_modules,
-        &ProtocolConfig::get_for_max_version(),
         &metered_verifier_config,
         &mut meter,
         &bytecode_verifier_metrics,
@@ -225,7 +223,6 @@ fn test_metered_move_bytecode_verifier() {
 
         run_metered_move_bytecode_verifier(
             modules,
-            &protocol_config,
             &metered_verifier_config,
             &mut meter,
             &bytecode_verifier_metrics,
@@ -251,7 +248,6 @@ fn test_meter_system_packages() {
     for system_package in BuiltInFramework::iter_system_packages() {
         run_metered_move_bytecode_verifier(
             &system_package.modules(),
-            &ProtocolConfig::get_for_max_version(),
             &metered_verifier_config,
             &mut meter,
             &bytecode_verifier_metrics,
@@ -336,7 +332,6 @@ fn test_build_and_verify_programmability_examples() {
         let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
         run_metered_move_bytecode_verifier(
             &modules,
-            &ProtocolConfig::get_for_max_version(),
             &metered_verifier_config,
             &mut meter,
             &bytecode_verifier_metrics,

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -43,7 +43,6 @@ use move_package::{
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
-use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
@@ -218,12 +217,7 @@ pub fn build_from_resolution_graph(
                     error: err.to_string(),
                 }
             })?;
-            // TODO make this configurable
-            sui_bytecode_verifier::sui_verify_module_unmetered(
-                &ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown),
-                m,
-                &fn_info,
-            )?;
+            sui_bytecode_verifier::sui_verify_module_unmetered(m, &fn_info)?;
         }
         // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker
     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1271,6 +1271,7 @@ impl ProtocolConfig {
                 // cfg.feature_flags.disallow_adding_abilities_on_upgrade = true;
                 // cfg.feature_flags.disallow_change_struct_type_params_on_upgrade = true;
                 // cfg.feature_flags.loaded_child_objects_fixed = true;
+                // cfg.feature_flags.ban_entry_init = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1272,6 +1272,7 @@ impl ProtocolConfig {
                 // cfg.feature_flags.disallow_change_struct_type_params_on_upgrade = true;
                 // cfg.feature_flags.loaded_child_objects_fixed = true;
                 // cfg.feature_flags.ban_entry_init = true;
+                // cfg.feature_flags.pack_digest_hash_modules = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1264,6 +1264,10 @@ impl ProtocolConfig {
             17 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.execution_version = Some(1);
+
+                // Following flags are implied by this execution version.  Once support for earlier
+                // protocol versions is dropped, these flags can be removed:
+                // cfg.feature_flags.package_upgrades = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1270,6 +1270,7 @@ impl ProtocolConfig {
                 // cfg.feature_flags.package_upgrades = true;
                 // cfg.feature_flags.disallow_adding_abilities_on_upgrade = true;
                 // cfg.feature_flags.disallow_change_struct_type_params_on_upgrade = true;
+                // cfg.feature_flags.loaded_child_objects_fixed = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1268,6 +1268,8 @@ impl ProtocolConfig {
                 // Following flags are implied by this execution version.  Once support for earlier
                 // protocol versions is dropped, these flags can be removed:
                 // cfg.feature_flags.package_upgrades = true;
+                // cfg.feature_flags.disallow_adding_abilities_on_upgrade = true;
+                // cfg.feature_flags.disallow_change_struct_type_params_on_upgrade = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -789,7 +789,6 @@ impl SuiClientCommands {
                 println!("Running bytecode verifier for {} modules", modules.len());
                 run_metered_move_bytecode_verifier(
                     &modules,
-                    &protocol_config,
                     &metered_verifier_config,
                     &mut meter,
                     &bytecode_verifier_metrics,

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -177,7 +177,6 @@ pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
 #[instrument(level = "trace", skip_all)]
 pub fn run_metered_move_bytecode_verifier(
     modules: &[CompiledModule],
-    protocol_config: &ProtocolConfig,
     verifier_config: &VerifierConfig,
     meter: &mut impl Meter,
     metrics: &Arc<BytecodeVerifierMetrics>,
@@ -207,7 +206,6 @@ pub fn run_metered_move_bytecode_verifier(
                 });
             };
         } else if let Err(err) = sui_verify_module_metered_check_timeout_only(
-            protocol_config,
             module,
             &BTreeMap::new(),
             meter,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -118,15 +118,9 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
         gas_coin_opt: Option<ObjectID>,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
-        let init_linkage = if protocol_config.package_upgrades_supported() {
-            LinkageInfo::Unset
-        } else {
-            LinkageInfo::Universal
-        };
-
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -54,7 +54,7 @@ use sui_types::{
     execution_status::CommandArgumentError,
 };
 
-use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
+use super::linkage_view::{LinkageView, SavedLinkage};
 
 sui_macros::checked_arithmetic! {
 
@@ -120,7 +120,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     ) -> Result<Self, ExecutionError> {
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), LinkageInfo::Unset);
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
         let mut tmp_session = new_session(
             vm,
             linkage,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -860,7 +860,6 @@ fn publish_and_verify_modules(
         // Run Sui bytecode verifier, which runs some additional checks that assume the Move
         // bytecode verifier has passed.
         sui_verifier::verifier::sui_verify_module_unmetered(
-            context.protocol_config,
             module,
             &BTreeMap::new(),
         )?;

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -9,9 +9,10 @@ use std::{
 
 use move_binary_format::{
     access::ModuleAccess,
+    compatibility::{Compatibility, InclusionCheck},
     errors::{Location, PartialVMResult, VMResult},
     file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
-    CompiledModule,
+    normalized, CompiledModule,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -686,29 +687,61 @@ fn check_compatibility<'a>(
 
     let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
     for (name, cur_module) in current_normalized {
-        let msg = format!("Existing module {name} not found in next version of package");
         let Some(new_module) = new_normalized.remove(&name) else {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
                 },
-                msg,
+                format!("Existing module {name} not found in next version of package"),
             ));
         };
 
-        if let Err(e) =
-            policy.check_compatibility(&cur_module, &new_module, context.protocol_config)
-        {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PackageUpgradeError {
-                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
-                },
-                e,
-            ));
-        }
+        check_module_compatibility(
+            &policy,
+            context.protocol_config,
+            &cur_module,
+            &new_module,
+        )?;
     }
 
     Ok(())
+}
+
+fn check_module_compatibility(
+    policy: &UpgradePolicy,
+    protocol_config: &ProtocolConfig,
+    cur_module: &normalized::Module,
+    new_module: &normalized::Module,
+) -> Result<(), ExecutionError> {
+    match policy {
+        UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
+        UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
+        UpgradePolicy::Compatible => {
+            let disallowed_new_abilities = if protocol_config.disallow_adding_abilities_on_upgrade() {
+                AbilitySet::ALL
+            } else {
+                AbilitySet::EMPTY
+            };
+
+            let compatibility = Compatibility {
+                check_struct_and_pub_function_linking: true,
+                check_struct_layout: true,
+                check_friend_linking: false,
+                check_private_entry_linking: false,
+                disallowed_new_abilities,
+                disallow_change_struct_type_params: protocol_config
+                    .disallow_change_struct_type_params_on_upgrade(),
+            };
+
+            compatibility.check(cur_module, new_module)
+        }
+    }
+    .map_err(|e| ExecutionError::new_with_source(
+        ExecutionErrorKind::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+        },
+        e,
+    ))
 }
 
 fn fetch_package(

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -577,10 +577,11 @@ fn execute_move_upgrade<Mode: ExecutionMode>(
     }
 
     // Check digest.
+    let hash_modules = true;
     let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
         &module_bytes,
         &dep_ids,
-        context.protocol_config.package_digest_hash_module(),
+        hash_modules,
     )
     .to_vec();
     if computed_digest != upgrade_ticket.digest {

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::programmable_transactions::context::new_session_for_linkage;
-use crate::programmable_transactions::{
-    context::load_type,
-    linkage_view::{LinkageInfo, LinkageView},
-};
+use crate::programmable_transactions::{context::load_type, linkage_view::LinkageView};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -35,10 +32,8 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let session = new_session_for_linkage(
-            vm,
-            LinkageView::new(Box::new(NullSuiResolver(state_view)), LinkageInfo::Unset),
-        );
+        let session =
+            new_session_for_linkage(vm, LinkageView::new(Box::new(NullSuiResolver(state_view))));
         Self { session }
     }
 }

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -133,9 +133,6 @@ pub struct ObjectRuntime<'a> {
     pub(crate) state: ObjectRuntimeState,
     // whether or not this TX is gas metered
     is_metered: bool,
-    // FIXED BEHAVIOR if true, correctly take the loaded object versions from the object store
-    // LEGACY if false, recalculate the loaded child object versions from child object changes
-    loaded_child_objects_fixed: bool,
 
     pub(crate) constants: LocalProtocolConfig,
     pub(crate) metrics: Arc<LimitsMetrics>,
@@ -202,7 +199,6 @@ impl<'a> ObjectRuntime<'a> {
                 events: vec![],
             },
             is_metered,
-            loaded_child_objects_fixed: protocol_config.loaded_child_objects_fixed(),
             constants: LocalProtocolConfig::new(protocol_config),
             metrics,
         }
@@ -393,7 +389,6 @@ impl<'a> ObjectRuntime<'a> {
             external_transfers,
             loaded_child_objects,
             child_effects,
-            self.loaded_child_objects_fixed,
         )
     }
 
@@ -434,19 +429,10 @@ impl ObjectRuntimeState {
         mut self,
         by_value_inputs: BTreeSet<ObjectID>,
         external_transfers: BTreeSet<ObjectID>,
-        mut loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
         child_object_effects: BTreeMap<ObjectID, ChildObjectEffect>,
-        loaded_child_objects_fixed: bool,
     ) -> Result<RuntimeResults, ExecutionError> {
         let mut wrapped_children = BTreeSet::new();
-        if !loaded_child_objects_fixed {
-            loaded_child_objects = BTreeMap::new();
-            for (child, child_object_effect) in &child_object_effects {
-                if let Some(version) = child_object_effect.loaded_version {
-                    loaded_child_objects.insert(*child, version);
-                }
-            }
-        }
         for (child, child_object_effect) in child_object_effects {
             let ChildObjectEffect {
                 owner: parent,

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -72,7 +72,6 @@ pub fn end_transaction(
         BTreeSet::new(),
         BTreeMap::new(),
         BTreeMap::new(),
-        false,
     );
     let RuntimeResults {
         writes,

--- a/sui-execution/latest/sui-verifier/src/entry_points_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/entry_points_verifier.rs
@@ -8,7 +8,6 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_bytecode_utils::format_signature_token;
-use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{TxContext, TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
     clock::Clock,
@@ -37,7 +36,6 @@ use crate::{verification_failure, INIT_FN_NAME};
 ///   - The transaction context parameter must be the last parameter
 /// - The function cannot have any return values
 pub fn verify_module(
-    config: &ProtocolConfig,
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
 ) -> Result<(), ExecutionError> {
@@ -54,7 +52,7 @@ pub fn verify_module(
         }
 
         if name == INIT_FN_NAME {
-            verify_init_function(config, module, func_def).map_err(verification_failure)?;
+            verify_init_function(module, func_def).map_err(verification_failure)?;
             continue;
         }
 
@@ -105,11 +103,7 @@ fn verify_init_not_called(
 }
 
 /// Checks if this module has a conformant `init`
-fn verify_init_function(
-    config: &ProtocolConfig,
-    module: &CompiledModule,
-    fdef: &FunctionDefinition,
-) -> Result<(), String> {
+fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> Result<(), String> {
     let view = &BinaryIndexedView::Module(module);
 
     if fdef.visibility != Visibility::Private {
@@ -120,7 +114,7 @@ fn verify_init_function(
         ));
     }
 
-    if config.ban_entry_init() && fdef.is_entry {
+    if fdef.is_entry {
         return Err(format!(
             "{}. '{}' cannot be 'entry'",
             module.self_id(),

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -188,15 +188,9 @@ impl executor::Executor for Executor {
 impl<'m> verifier::Verifier for Verifier<'m> {
     fn meter_compiled_modules(
         &mut self,
-        protocol_config: &ProtocolConfig,
+        _protocol_config: &ProtocolConfig,
         modules: &[CompiledModule],
     ) -> SuiResult<()> {
-        run_metered_move_bytecode_verifier(
-            modules,
-            protocol_config,
-            &self.config,
-            &mut self.meter,
-            self.metrics,
-        )
+        run_metered_move_bytecode_verifier(modules, &self.config, &mut self.meter, self.metrics)
     }
 }


### PR DESCRIPTION
## Description

We can't get rid of the alternate implementation of digest calculation
until we drop support for protocol version 16 and below, but this is
one of the steps towards that.

## Test Plan

Existing tests

## Stack

- #12740
- #12741 
- #12742 
- #12774 
- #12776 
- #12784 