### PR TITLE
[TS SDK] fix for waitForTransactionBlock method

### DIFF
--- a/.changeset/quick-rocks-begin.md
+++ b/.changeset/quick-rocks-begin.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Fix unhandled rejections thrown by waitForTransaction

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -53,6 +53,7 @@ import {
 	ObjectRead,
 	ResolvedNameServiceNames,
 	ProtocolConfig,
+	getExecutionStatus,
 } from '../types/index.js';
 import type { DynamicFieldName } from '../types/dynamic_fields.js';
 import { DynamicFieldPage } from '../types/dynamic_fields.js';
@@ -852,7 +853,7 @@ export class JsonRpcProvider {
 		  signal?.throwIfAborted();
 		  try {
 			let sync = await this.getTransactionBlock(input);
-			if (sync.effects?.status.status === "success") blockRetrieved = true;
+			if (getExecutionStatus(sync)?.status === "success") blockRetrieved = true;
 			return sync;
 		  } catch (e) {
 			console.error("Error", e);

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -48,6 +48,17 @@ describe('Transaction Reading API', () => {
 			expect(waited.digest).toEqual(digest);
 		});
 
+		it('abort signal doesnt throw after transaction is received', async () => {
+			const { digest } = await setupTransaction();
+
+			const waited = await toolbox.provider.waitForTransactionBlock({ digest });
+			const secondWait = await toolbox.provider.waitForTransactionBlock({ digest, timeout: 2000 });
+			// wait for timeout to expire incase it causes an unhandled rejection
+			await new Promise((resolve) => setTimeout(resolve, 2100));
+			expect(waited.digest).toEqual(digest);
+			expect(secondWait.digest).toEqual(digest);
+		});
+
 		it('can be aborted using the signal', async () => {
 			const { digest } = await setupTransaction();
 


### PR DESCRIPTION
## Description 

**Initially described here:** https://mysten-labs.slack.com/archives/C03GYL579PD/p1688117346350449
**What was the issue:** Timeout error is thrown after the timeout period has ended while block has been successfully received.

This PR contains a potential fix for the `waitForTransactionBlock` method.
Additions:
- Introduced a new `blockRetrieved` boolean
- If the block has been retrieved does no longer reject
- Additional condition for loop re-entrance to ensure that the block has not been already retrieved

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
