### PR TITLE
explorer: fix gas reference price graph

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/Graph.tsx
+++ b/apps/explorer/src/components/GasPriceCard/Graph.tsx
@@ -89,6 +89,7 @@ export function Graph({ data, width, height, selectedUnit }: GraphProps) {
 		totalMaxTicksForWidth < 1 ? 1 : totalMaxTicksForWidth,
 	);
 	const firstElementY = adjData.length ? yScale(Number(adjData[0].referenceGasPrice)) : null;
+	const firstElementX = adjData.length ? xScale(adjData[0].epoch) : null;
 	const lastElementX = adjData.length ? xScale(adjData[adjData.length - 1].epoch) : null;
 	const lastElementY = adjData.length
 		? yScale(Number(adjData[adjData.length - 1].referenceGasPrice))
@@ -150,18 +151,24 @@ export function Graph({ data, width, height, selectedUnit }: GraphProps) {
 					fillOpacity="0.1"
 					stroke="transparent"
 				/>
-				{firstElementY !== null ? (
+				{firstElementY !== null && firstElementX !== null ? (
 					<>
 						<rect
 							x="0"
 							y={firstElementY}
-							width={SIDE_MARGIN}
+							width={firstElementX}
 							fill="#F2BD24"
 							fillOpacity="0.1"
 							stroke="transparent"
 							height={graphButton - firstElementY}
 						/>
-						<line x1="0" y1={firstElementY} x2={SIDE_MARGIN} y2={firstElementY} stroke="#F2BD24" />
+						<line
+							x1="0"
+							y1={firstElementY}
+							x2={firstElementX}
+							y2={firstElementY}
+							stroke="#F2BD24"
+						/>
 					</>
 				) : null}
 				{lastElementX !== null && lastElementY !== null ? (
@@ -169,7 +176,7 @@ export function Graph({ data, width, height, selectedUnit }: GraphProps) {
 						<rect
 							x={lastElementX}
 							y={lastElementY}
-							width={SIDE_MARGIN}
+							width={width - lastElementX}
 							fill="#F2BD24"
 							fillOpacity="0.1"
 							stroke="transparent"
@@ -178,7 +185,7 @@ export function Graph({ data, width, height, selectedUnit }: GraphProps) {
 						<line
 							x1={lastElementX}
 							y1={lastElementY}
-							x2={lastElementX + SIDE_MARGIN}
+							x2={width}
 							y2={lastElementY}
 							stroke="#F2BD24"
 						/>


### PR DESCRIPTION
## Description 

* fix rendering the graph when there is only one epoch data available

| before | after |
| -- | -- |
| <img width="476" alt="Screenshot 2023-06-30 at 13 02 50" src="https://github.com/MystenLabs/sui/assets/10210143/67c0ee14-682f-4e54-8f20-cb64d680e738"> | <img width="476" alt="Screenshot 2023-06-30 at 13 03 42" src="https://github.com/MystenLabs/sui/assets/10210143/98e59571-6acd-4b64-8ae6-34b115fb4560"> |

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
