### PR TITLE
[easy] improve comments

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -266,19 +266,24 @@ impl ConsensusTransactionOrdering {
 /// - Initialize the field to `None` in prior protocol versions.
 /// - Initialize the field to `Some(val)` for your new protocol version.
 /// - Add a public getter that simply unwraps the field.
-/// - A public getter of the form `field(&self) -> field_type` will be automatically generated for you.
+/// - Two public getters of the form `field(&self) -> field_type`
+///     and `field_as_option(&self) -> Option<field_type>` will be automatically generated for you.
 /// Example for a field: `new_constant: Option<u64>`
 /// ```rust,ignore
 ///      pub fn new_constant(&self) -> u64 {
 ///         self.new_constant.expect(Self::CONSTANT_ERR_MSG)
 ///     }
+///      pub fn new_constant_as_option(&self) -> Option<u64> {
+///         self.new_constant.expect(Self::CONSTANT_ERR_MSG)
+///     }
 /// ```
-/// This way, if the constant is accessed in a protocol version in which it is not defined, the
-/// validator will crash. (Crashing is necessary because this type of error would almost always
-/// result in forking if not prevented here).
-///
+/// With `pub fn new_constant(&self) -> u64`, if the constant is accessed in a protocol version
+/// in which it is not defined, the validator will crash. (Crashing is necessary because
+/// this type of error would almost always result in forking if not prevented here).
+/// If you don't want the validator to crash, you can use the
+/// `pub fn new_constant_as_option(&self) -> Option<u64>` getter, which will
+/// return `None` if the field is not defined at that version.
 /// - If you want a customized getter, you can add a method in the impl.
-///     For example see `max_size_written_objects_as_option`
 #[skip_serializing_none]
 #[derive(Clone, Serialize, Debug, ProtocolConfigGetters)]
 pub struct ProtocolConfig {


### PR DESCRIPTION
## Description 

Just improves the comments to mention the `_as_option` getters which are generated.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
