### PR TITLE
indexer easy: re-enable object history population

### DIFF
--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -69,53 +69,53 @@ CREATE INDEX objects_history_old_owner_index ON objects_history (old_owner_type,
 CREATE TABLE objects_history_fast_path_partition_0 PARTITION OF objects_history FOR VALUES FROM (-1) TO (0);
 CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 
--- CREATE OR REPLACE FUNCTION objects_modified_func() RETURNS TRIGGER AS
--- $body$
--- BEGIN
---     IF (TG_OP = 'INSERT') THEN
---         INSERT INTO objects_history
---         VALUES (NEW.epoch, NEW.checkpoint, NEW.object_id, NEW.version, NEW.object_digest, NEW.owner_type,
---                 NEW.owner_address, NULL, NULL,
---                 NEW.initial_shared_version,
---                 NEW.previous_transaction, NEW.object_type, NEW.object_status, NEW.has_public_transfer,
---                 NEW.storage_rebate, NEW.bcs);
---         RETURN NEW;
---     ELSEIF (TG_OP = 'UPDATE') THEN
---         INSERT INTO objects_history
---         VALUES (NEW.epoch, NEW.checkpoint, NEW.object_id, NEW.version, NEW.object_digest, NEW.owner_type,
---                 NEW.owner_address, OLD.owner_type, OLD.owner_address,
---                 NEW.initial_shared_version,
---                 NEW.previous_transaction, NEW.object_type, NEW.object_status, NEW.has_public_transfer,
---                 NEW.storage_rebate, NEW.bcs);
---         -- MUSTFIX(gegaowp): we cannot update checkpoint in-place, b/c checkpoint is a partition key,
---         -- we need to prune old data in this partition periodically, like pruning old epochs upon new epoch.
---         RETURN NEW;
---     ELSIF (TG_OP = 'DELETE') THEN
---         -- object deleted from the main table, archive the history for that object
---         DELETE FROM objects_history WHERE object_id = old.object_id;
---         RETURN OLD;
---     ELSE
---         RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - Other action occurred: %, at %',TG_OP,NOW();
---         RETURN NULL;
---     END IF;
+CREATE OR REPLACE FUNCTION objects_modified_func() RETURNS TRIGGER AS
+$body$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO objects_history
+        VALUES (NEW.epoch, NEW.checkpoint, NEW.object_id, NEW.version, NEW.object_digest, NEW.owner_type,
+                NEW.owner_address, NULL, NULL,
+                NEW.initial_shared_version,
+                NEW.previous_transaction, NEW.object_type, NEW.object_status, NEW.has_public_transfer,
+                NEW.storage_rebate, NEW.bcs);
+        RETURN NEW;
+    ELSEIF (TG_OP = 'UPDATE') THEN
+        INSERT INTO objects_history
+        VALUES (NEW.epoch, NEW.checkpoint, NEW.object_id, NEW.version, NEW.object_digest, NEW.owner_type,
+                NEW.owner_address, OLD.owner_type, OLD.owner_address,
+                NEW.initial_shared_version,
+                NEW.previous_transaction, NEW.object_type, NEW.object_status, NEW.has_public_transfer,
+                NEW.storage_rebate, NEW.bcs);
+        -- MUSTFIX(gegaowp): we cannot update checkpoint in-place, b/c checkpoint is a partition key,
+        -- we need to prune old data in this partition periodically, like pruning old epochs upon new epoch.
+        RETURN NEW;
+    ELSIF (TG_OP = 'DELETE') THEN
+        -- object deleted from the main table, archive the history for that object
+        DELETE FROM objects_history WHERE object_id = old.object_id;
+        RETURN OLD;
+    ELSE
+        RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - Other action occurred: %, at %',TG_OP,NOW();
+        RETURN NULL;
+    END IF;
 
--- EXCEPTION
---     WHEN data_exception THEN
---         RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [DATA EXCEPTION] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
---         RETURN NULL;
---     WHEN unique_violation THEN
---         RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [UNIQUE] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
---         RETURN NULL;
---     WHEN OTHERS THEN
---         RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [OTHER] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
---         RETURN NULL;
--- END;
--- $body$
---     LANGUAGE plpgsql;
+EXCEPTION
+    WHEN data_exception THEN
+        RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [DATA EXCEPTION] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
+        RETURN NULL;
+    WHEN unique_violation THEN
+        RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [UNIQUE] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
+        RETURN NULL;
+    WHEN OTHERS THEN
+        RAISE WARNING '[OBJECTS_MODIFIED_FUNC] - UDF ERROR [OTHER] - SQLSTATE: %, SQLERRM: %',SQLSTATE,SQLERRM;
+        RETURN NULL;
+END;
+$body$
+    LANGUAGE plpgsql;
 
--- CREATE TRIGGER objects_history
---     AFTER INSERT OR UPDATE OR DELETE
---     ON objects
---     FOR EACH ROW
--- EXECUTE PROCEDURE objects_modified_func();
+CREATE TRIGGER objects_history
+    AFTER INSERT OR UPDATE OR DELETE
+    ON objects
+    FOR EACH ROW
+EXECUTE PROCEDURE objects_modified_func();
 


### PR DESCRIPTION
## Description 

title

## Test Plan 

local run and make sure object history will be populated.

TODO:
- will set up testing DB on mainnet & testnet to see the storage consumption

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
