### PR TITLE
[wallet-ext] - update marketplace link to link directly to asset

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFeatureValue } from '@growthbook/growthbook-react';
 import { useGetKioskContents } from '@mysten/core';
 import { ArrowUpRight12, ArrowRight16 } from '@mysten/icons';
 import { hasPublicTransfer, formatAddress } from '@mysten/sui.js';
@@ -31,10 +30,6 @@ function NFTDetailsPage() {
 	const address = useActiveAddress();
 	const { data } = useGetKioskContents(address);
 	const isContainedInSuiKiosk = data?.kiosks.sui.some((k) => k.data?.objectId === nftId);
-	const marketplaceLinks = useFeatureValue('kiosk-marketplace-links', [
-		{ href: 'https://docs.sui.io/build/sui-kiosk', text: 'Learn more about Kiosks' },
-		{ href: 'https://sui.directory/?_project_type=marketplace', text: 'Explore Sui Marketplaces' },
-	]);
 
 	// Extract either the attributes, or use the top-level NFT fields:
 	const metaFields =
@@ -164,15 +159,18 @@ function NFTDetailsPage() {
 
 							{isContainedInSuiKiosk ? (
 								<div className="flex flex-col gap-2 mb-3">
-									{marketplaceLinks.map(({ href, text }) => (
-										<Button
-											key={href}
-											after={<ArrowUpRight12 />}
-											variant="outline"
-											href={href}
-											text={text}
-										/>
-									))}
+									<Button
+										after={<ArrowUpRight12 />}
+										variant="outline"
+										href="https://docs.sui.io/build/sui-kiosk"
+										text="Learn more about Kiosks"
+									/>
+									<Button
+										after={<ArrowUpRight12 />}
+										variant="outline"
+										href={`https://sui.hyperspace.xyz/wallet/sui/${accountAddress}?tokenAddress=${nftId}`}
+										text="Marketplace"
+									/>
 								</div>
 							) : (
 								<div className="mb-3 flex flex-1 items-end">


### PR DESCRIPTION
## Description 

Updates the Marketplace link for items in a Kiosk to link directly to the asset on Hyperspace instead of the landing

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
