### PR TITLE
[ts-sdk] Add new keypair methods

### DIFF
--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -3,6 +3,7 @@
 
 import type { PublicKey } from './publickey.js';
 import type { SignatureScheme } from './signature.js';
+import { IntentScope, messageWithIntent } from '../utils/intent.js';
 
 export const PRIVATE_KEY_SIZE = 32;
 export const LEGACY_PRIVATE_KEY_SIZE = 64;
@@ -12,24 +13,49 @@ export type ExportedKeypair = {
 	privateKey: string;
 };
 
+interface SignedMessage {
+	bytes: Uint8Array;
+	signature: Uint8Array;
+}
+
 /**
- * A keypair used for signing transactions.
+ * TODO: Document
  */
-export interface Keypair {
+export abstract class Keypair {
+	abstract sign(bytes: Uint8Array): Promise<Uint8Array>;
+
+	async signWithIntent(bytes: Uint8Array, intent: IntentScope): Promise<SignedMessage> {
+		const intentMessage = messageWithIntent(intent, bytes);
+		const signature = await this.sign(intentMessage);
+
+		return {
+			bytes: intentMessage,
+			signature,
+		};
+	}
+
+	async signTransactionBlock(bytes: Uint8Array) {
+		return this.signWithIntent(bytes, IntentScope.TransactionData);
+	}
+
+	async signMessage(bytes: Uint8Array) {
+		return this.signWithIntent(bytes, IntentScope.PersonalMessage);
+	}
+
 	/**
 	 * The public key for this keypair
 	 */
-	getPublicKey(): PublicKey;
+	abstract getPublicKey(): PublicKey;
 
 	/**
-	 * Return the signature for the data
+	 * Return the signature for the data.
+	 * Prefer the async verion {@link sign}, as this method will be deprecated in a future release.
 	 */
-	signData(data: Uint8Array): Uint8Array;
+	abstract signData(data: Uint8Array): Uint8Array;
 
 	/**
 	 * Get the key scheme of the keypair: Secp256k1 or ED25519
 	 */
-	getKeyScheme(): SignatureScheme;
-
-	export(): ExportedKeypair;
+	abstract getKeyScheme(): SignatureScheme;
+	abstract export(): ExportedKeypair;
 }

--- a/sdk/typescript/src/keypairs/ed25519/keypair.ts
+++ b/sdk/typescript/src/keypairs/ed25519/keypair.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import nacl from 'tweetnacl';
-import type { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import type { ExportedKeypair } from '../../cryptography/keypair.js';
 import { Ed25519PublicKey } from './publickey.js';
 import { isValidHardenedPath, mnemonicToSeedHex } from '../../cryptography/mnemonics.js';
 import { derivePath } from '../../utils/ed25519-hd-key.js';
 import { toB64 } from '@mysten/bcs';
 import type { SignatureScheme } from '../../cryptography/signature.js';
-import { PRIVATE_KEY_SIZE } from '../../cryptography/keypair.js';
+import { PRIVATE_KEY_SIZE, Keypair } from '../../cryptography/keypair.js';
 
 export const DEFAULT_ED25519_DERIVATION_PATH = "m/44'/784'/0'/0'/0'";
 
@@ -25,7 +25,7 @@ export interface Ed25519KeypairData {
 /**
  * An Ed25519 Keypair used for signing transactions.
  */
-export class Ed25519Keypair implements Keypair {
+export class Ed25519Keypair extends Keypair {
 	private keypair: Ed25519KeypairData;
 
 	/**
@@ -35,6 +35,7 @@ export class Ed25519Keypair implements Keypair {
 	 * @param keypair Ed25519 keypair
 	 */
 	constructor(keypair?: Ed25519KeypairData) {
+		super();
 		if (keypair) {
 			this.keypair = keypair;
 		} else {
@@ -105,6 +106,10 @@ export class Ed25519Keypair implements Keypair {
 	 */
 	getPublicKey(): Ed25519PublicKey {
 		return new Ed25519PublicKey(this.keypair.publicKey);
+	}
+
+	async sign(data: Uint8Array) {
+		return this.signData(data);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256k1/keypair.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/keypair.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import type { ExportedKeypair } from '../../cryptography/keypair.js';
+import { Keypair } from '../../cryptography/keypair.js';
 import type { PublicKey } from '../../cryptography/publickey.js';
 import { sha256 } from '@noble/hashes/sha256';
 import { Secp256k1PublicKey } from './publickey.js';
@@ -26,7 +27,7 @@ export interface Secp256k1KeypairData {
 /**
  * An Secp256k1 Keypair used for signing transactions.
  */
-export class Secp256k1Keypair implements Keypair {
+export class Secp256k1Keypair extends Keypair {
 	private keypair: Secp256k1KeypairData;
 
 	/**
@@ -36,6 +37,7 @@ export class Secp256k1Keypair implements Keypair {
 	 * @param keypair secp256k1 keypair
 	 */
 	constructor(keypair?: Secp256k1KeypairData) {
+		super();
 		if (keypair) {
 			this.keypair = keypair;
 		} else {
@@ -105,6 +107,10 @@ export class Secp256k1Keypair implements Keypair {
 	 */
 	getPublicKey(): PublicKey {
 		return new Secp256k1PublicKey(this.keypair.publicKey);
+	}
+
+	async sign(data: Uint8Array) {
+		return this.signData(data);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256r1/keypair.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/keypair.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ExportedKeypair, Keypair } from '../../cryptography/keypair.js';
+import type { ExportedKeypair } from '../../cryptography/keypair.js';
+import { Keypair } from '../../cryptography/keypair.js';
 import type { PublicKey } from '../../cryptography/publickey.js';
 import { sha256 } from '@noble/hashes/sha256';
 import { Secp256r1PublicKey } from './publickey.js';
@@ -26,7 +27,7 @@ export interface Secp256r1KeypairData {
 /**
  * An Secp256r1 Keypair used for signing transactions.
  */
-export class Secp256r1Keypair implements Keypair {
+export class Secp256r1Keypair extends Keypair {
 	private keypair: Secp256r1KeypairData;
 
 	/**
@@ -36,6 +37,7 @@ export class Secp256r1Keypair implements Keypair {
 	 * @param keypair Secp256r1 keypair
 	 */
 	constructor(keypair?: Secp256r1KeypairData) {
+		super();
 		if (keypair) {
 			this.keypair = keypair;
 		} else {
@@ -105,6 +107,10 @@ export class Secp256r1Keypair implements Keypair {
 	 */
 	getPublicKey(): PublicKey {
 		return new Secp256r1PublicKey(this.keypair.publicKey);
+	}
+
+	async sign(data: Uint8Array) {
+		return this.signData(data);
 	}
 
 	/**


### PR DESCRIPTION
## Description 

This adds new keypair methods.
- All sign methods will be async for the best compatibility with keypair types. This makes it possible to implement things like a Ledger Keypair.
- Add new `signTransactionBlock` and `signMessage` methods to make keypairs more useful on their own, and centralize intent logic alongside signing.
- Move keypair to be an abstract class so that it can include base methods that don't need to be implemented in every keypair.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
