### PR TITLE
Do not use alternate server name on Sui Node

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -728,18 +728,14 @@ impl SuiNode {
             anemo_config.quic = Some(quic_config);
 
             let server_name = format!("sui-{}", chain_identifier);
-            let alt_server_name = "sui";
             let network = Network::bind(config.p2p_config.listen_address)
                 .server_name(&server_name)
-                // TODO remove alternate_server_name once transition stabilizes
-                .alternate_server_name(alt_server_name)
                 .private_key(config.network_key_pair().copy().private().0.to_bytes())
                 .config(anemo_config)
                 .outbound_request_layer(outbound_layer)
                 .start(service)?;
             info!(
                 server_name = server_name,
-                alt_server_name = alt_server_name,
                 "P2p network started on {}",
                 network.local_addr()
             );


### PR DESCRIPTION
## Description 

Now that we are a couple of protocol upgrades ahead of introducing `alternate_server_name`, it's safe to remove it.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Do not use alternate server name on Sui Node
