### PR TITLE
[ConsensusHandler] panic on deserialization failure

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -14,6 +14,7 @@ use crate::scoring_decision::update_low_scoring_authorities;
 use crate::transaction_manager::TransactionManager;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use fastcrypto::hash::Hash as _Hash;
 use fastcrypto::traits::ToFromBytes;
 use lru::LruCache;
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
@@ -207,12 +208,11 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
                     ) {
                         Ok(transaction) => transaction,
                         Err(err) => {
-                            // This should be prevented by batch verification, hence `error` log level
-                            error!(
-                                    "Ignoring unexpected malformed transaction (failed to deserialize) from {}: {}",
-                                    author, err
-                                );
-                            continue;
+                            // This should have been prevented by Narwhal batch verification.
+                            panic!(
+                                "Unexpected malformed transaction (failed to deserialize): {}\nCertificate={:?} BatchDigest={:?} Transaction={:?}",
+                                err, output_cert, batch.digest(), serialized_transaction
+                            );
                         }
                     };
                     self.metrics


### PR DESCRIPTION
## Description 

A fork can happen if the failure is ignored and the process should not continue.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
