### PR TITLE
fix: add protocol version for upgraded multisig

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -310,6 +310,15 @@ impl ValidatorService {
             .into());
         }
 
+        if !epoch_store.protocol_config().supports_upgraded_multisig()
+            && transaction.has_upgraded_multisig()
+        {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "upgraded multisig format not enabled on this network".to_string(),
+            }
+            .into());
+        }
+
         // Enforce overall transaction size limit.
         let tx_size = bcs::serialized_size(&transaction).map_err(|e| {
             SuiError::TransactionSerializationError {

--- a/crates/sui-e2e-tests/tests/multisig_upgrade_test.rs
+++ b/crates/sui-e2e-tests/tests/multisig_upgrade_test.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_core::authority_client::AuthorityAPI;
+use sui_macros::sim_test;
+use sui_types::error::{SuiError, SuiResult};
+use sui_types::utils::make_upgraded_multisig_tx;
+use test_cluster::TestClusterBuilder;
+
+async fn do_upgraded_multisig_test() -> SuiResult {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let tx = make_upgraded_multisig_tx();
+
+    test_cluster
+        .authority_aggregator()
+        .authority_clients
+        .values()
+        .next()
+        .unwrap()
+        .authority_client()
+        .handle_transaction(tx)
+        .await
+        .map(|_| ())
+}
+
+#[sim_test]
+async fn test_upgraded_multisig_feature_deny() {
+    use sui_protocol_config::ProtocolConfig;
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_upgraded_multisig_for_testing(false);
+        config
+    });
+
+    let err = do_upgraded_multisig_test().await.unwrap_err();
+
+    assert!(matches!(err, SuiError::UnsupportedFeatureError { .. }));
+}
+
+#[sim_test]
+async fn test_upgraded_multisig_feature_allow() {
+    use sui_protocol_config::ProtocolConfig;
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_upgraded_multisig_for_testing(true);
+        config
+    });
+
+    let res = do_upgraded_multisig_test().await;
+
+    // we didn't make a real transaction with a valid object, but we verify that we pass the
+    // feature gate.
+    assert!(matches!(res.unwrap_err(), SuiError::UserInputError { .. }));
+}

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "17",
+              "maxSupportedProtocolVersion": "18",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,
@@ -1366,6 +1366,7 @@
                 "package_upgrades": true,
                 "scoring_decision_with_validity_cutoff": true,
                 "simplified_unwrap_then_delete": false,
+                "upgraded_multisig_supported": false,
                 "zklogin_auth": false
               },
               "attributes": {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_18.snap
@@ -1,0 +1,186 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 18
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_18.snap
@@ -1,0 +1,187 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 18
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_18.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_18.snap
@@ -1,0 +1,188 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 18
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 17
+  protocol_version: 18
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 17
+protocol_version: 18
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xff24a10d47c774ed30fbd5ea0d2fa701ef59fcc3d94c53bbc5898ebdc7bdf563"
+            id: "0x80ab435fc80e5ffcf69dc902f5787d3bc9b3bb6034373f3e80df4c75582ddbfb"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xbb5eaee9ab9cede0a472996f1a80055be159e42c350f34680ffb0ef1106b8dfa"
+      operation_cap_id: "0x0a036748048c8f9ca7009dc3c2c84140accdf2c0dd93d0f5f55f1e357ee0496d"
       gas_price: 1000
       staking_pool:
-        id: "0x362b4b67eba2c28c445bffe7b2b9032061546c0961e9153de06cca98983f655d"
+        id: "0x1e65b3360d57ee64806290cf153e4120baeb9b903dedf4637938dfdbea870b72"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xef82a5bbc64aee169f695e3540a0eba0d3da22c3da4a50648de22e0bcf8adfd7"
+          id: "0xb12436515cdb9850905e5c60b3dabf19d0643d9a322c64a2cb9ee184eeebbc93"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x1cce2237c73ec7c9be3edd00aac74ad4927c6097375517d574b5d876b427f3ea"
+            id: "0x7adcdb57d95576af009df8a6f373e3fd7150524e7d2235d7215ade2c13722f41"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x39078a7069ea994aa11831dfe1d2f929fe99672b4830050e846710d05a0821d6"
+          id: "0xddb62d6185074dd8c3b3bb37342d28aca291cafe194d97a3f2de5136e8d4fd71"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x9ebd541488731fe181e6f69b5fd59e8fa85d272be41e77d9f76d87f26eac0ebf"
+      id: "0x21ad1aab6a7aa978fac1ef102f5d4ec519447bfaec41dba700f18eddc993f8ac"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x8ac934be4afa0fe38ad53d648906746a019d96251c5d22fbbcc0c3b87680fb24"
+    id: "0xfb2bf42c12a86ea6a094e47e051366b3c249f47b9edcf278a6846d65ee55bb12"
     size: 1
   inactive_validators:
-    id: "0xd20ad9f9bad31a826ac84614a15026d77b22aff5d6a666d957f34d952dfbd4d7"
+    id: "0x68c350f464a2f1c29868a0fbfe11ea2134c28a90dd104b5b8b7f1874a962c83a"
     size: 0
   validator_candidates:
-    id: "0xedd5ee7906e8e91b958c62f8015825c332df9f17c4a73d59631f3d34807a3cb5"
+    id: "0x38a4be51630af3fcb929f1378d87e76cc0e88e9b9bca3da80d2631558fbca6da"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x19af2f53489081c25337738817db05e2ca01fc67f4faac22df3c8e3e15c6d37c"
+      id: "0x53603fcb0154541ad7ee8920749edf2560e1c193016f35daa225e294f77f2fd7"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x1ff328491000e9d0ff743dd40a10c2ed9bb22659e3349b9dc95ee2c1f6c56fff"
+      id: "0x8fa699daf66614a76e2c03601c66e4e42f74e757e73e8380d06dda322f295e09"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xdf56cf3b92223391d6a3b5e2b60b5280caad27298b8720c9e978f4a4ae3c42a8"
+      id: "0xaf70392245af35a5524efd9ca4685813d7a360fde44afa210cb2a79aaae96e43"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xbbfb4388254d9c7f9ff7391e2f9c2bc3a8b234466f839a79779128d8d700490b"
+    id: "0xa6218025b9d093ce81a5837c4124dbee136ec718c43b1e5472648bc44fd92fce"
   size: 0
 

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -59,6 +59,10 @@ impl GenericSignature {
     pub fn is_zklogin(&self) -> bool {
         matches!(self, GenericSignature::ZkLoginAuthenticator(_))
     }
+
+    pub fn is_upgraded_multisig(&self) -> bool {
+        matches!(self, GenericSignature::MultiSig(_))
+    }
 }
 
 /// GenericSignature encodes a single signature [enum Signature] as is `flag || signature || pubkey`.

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-
 use super::{MultiSigPublicKey, ThresholdUnit, WeightUnit};
 use crate::{
     base_types::SuiAddress,
@@ -13,6 +11,7 @@ use crate::{
     multisig::{as_indices, MultiSig, MAX_SIGNER_IN_MULTISIG},
     multisig_legacy::{bitmap_to_u16, MultiSigLegacy, MultiSigPublicKeyLegacy},
     signature::{AuthenticatorTrait, AuxVerifyData, GenericSignature},
+    utils::keys,
 };
 use fastcrypto::{
     ed25519::{Ed25519KeyPair, Ed25519PrivateKey},
@@ -24,14 +23,7 @@ use once_cell::sync::OnceCell;
 use rand::{rngs::StdRng, SeedableRng};
 use roaring::RoaringBitmap;
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
-
-pub fn keys() -> Vec<SuiKeyPair> {
-    let mut seed = StdRng::from_seed([0; 32]);
-    let kp1: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair_from_rng(&mut seed).1);
-    let kp2: SuiKeyPair = SuiKeyPair::Secp256k1(get_key_pair_from_rng(&mut seed).1);
-    let kp3: SuiKeyPair = SuiKeyPair::Secp256r1(get_key_pair_from_rng(&mut seed).1);
-    vec![kp1, kp2, kp3]
-}
+use std::str::FromStr;
 
 #[test]
 fn multisig_scenarios() {


### PR DESCRIPTION
## Description 

1.4.0 accepts both legacy and upgraded multisig. 1.3.0 only accepts legacy multisig. this is to make upgraded multisig enabled only for protocol version >= 18 when all validators upgrade. 
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
