### PR TITLE
[move-compiler] A workaround to avoid spurious warning for module initializers

### DIFF
--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -2301,7 +2301,11 @@ fn gen_unused_warnings(context: &mut Context, mdef: &T::ModuleDefinition) {
                 // functions with #[test] attribute are implicitly used
                 continue;
             }
-
+            if name.as_str() == "init" {
+                // a Sui-specific hack (until we can implement this properly on the Sui side to
+                // avoid signaling that the init function is unused (not called by the runtime)
+                continue;
+            }
             context
                 .env
                 .add_warning_filter_scope(fun.warning_filter.clone());

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -2302,8 +2302,8 @@ fn gen_unused_warnings(context: &mut Context, mdef: &T::ModuleDefinition) {
                 continue;
             }
             if name.as_str() == "init" {
-                // a Sui-specific hack (until we can implement this properly on the Sui side to
-                // avoid signaling that the init function is unused (not called by the runtime)
+                // a Sui-specific hack (until we can implement this properly on the Sui side) to
+                // avoid signaling that the init function is unused (not called by the runtime
                 continue;
             }
             context

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.move
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.move
@@ -1,4 +1,8 @@
 module 0x42::unused_functions {
+
+    fun init() {
+    }
+
     public fun f() {
         used_private()
     }

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.unused.exp
@@ -1,8 +1,8 @@
 warning[W09008]: unused function
-  ┌─ tests/move_check/typing/unused_functions.move:7:9
-  │
-7 │     fun unused_private() {}
-  │         ^^^^^^^^^^^^^^ The non-'public', non-'entry' function 'unused_private' is never called. Consider removing it.
-  │
-  = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   ┌─ tests/move_check/typing/unused_functions.move:11:9
+   │
+11 │     fun unused_private() {}
+   │         ^^^^^^^^^^^^^^ The non-'public', non-'entry' function 'unused_private' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 


### PR DESCRIPTION
## Description 

This is a temporary workaround (until we can do this properly on the Sui side) to avoid signaling that a module initializer is unused (and thus implying that it is not called by the runtime).

## Test Plan 

A test has been added

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

No longer signal that a module initializer function is unused.
