### PR TITLE
[move-compiler] Added self transfer linter

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -52,7 +52,7 @@ use sui_types::{
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
 
-use crate::linters::share_owned::ShareOwnedVerifier;
+use crate::linters::{self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier};
 
 #[cfg(test)]
 #[path = "unit_tests/build_tests.rs"]
@@ -131,7 +131,7 @@ impl BuildConfig {
         let mut fn_info = None;
         let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
             let (files, units_res) = if lint {
-                let lint_visitors = vec![ShareOwnedVerifier.into()];
+                let lint_visitors = vec![ShareOwnedVerifier.into(), SelfTransferVerifier.into()];
                 compiler.add_visitors(lint_visitors).build()?
             } else {
                 compiler.build()?

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod self_transfer;
 pub mod share_owned;

--- a/crates/sui-move-build/src/linters/self_transfer.rs
+++ b/crates/sui-move-build/src/linters/self_transfer.rs
@@ -1,0 +1,213 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This analysis flags transfers of an object to tx_context::sender(). Such objects should be
+//! returned from the function instead
+
+use move_ir_types::location::*;
+
+use move_compiler::{
+    cfgir::{
+        absint::JoinResult,
+        ast::Program,
+        visitor::{
+            LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
+        },
+        CFGContext, MemberName,
+    },
+    diag,
+    diagnostics::{
+        codes::{custom, DiagnosticInfo, Severity},
+        Diagnostic, Diagnostics,
+    },
+    hlir::ast::{Command, Exp, LValue, Label, ModuleCall, Type, Type_, Var},
+};
+use move_symbol_pool::Symbol;
+use std::collections::BTreeMap;
+
+const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
+    ("sui", "transfer", "public_transfer"),
+    ("sui", "transfer", "transfer"),
+];
+
+const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
+    "Lint ",
+    Severity::Warning,
+    /* category */ 1,
+    /* code */ 1,
+    "non-composable transfer to sender",
+);
+
+//**************************************************************************************************
+// types
+//**************************************************************************************************
+
+pub struct SelfTransferVerifier;
+
+pub struct SelfTransferVerifierAI {
+    fn_name: Symbol,
+    fn_ret_loc: Loc,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Value {
+    /// an address read from tx_context:sender()
+    SenderAddress,
+    #[default]
+    Other,
+}
+
+pub struct ExecutionContext {
+    diags: Diagnostics,
+}
+
+#[derive(Clone, Debug)]
+pub struct State {
+    locals: BTreeMap<Var, LocalState<Value>>,
+}
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl SimpleAbsIntConstructor for SelfTransferVerifier {
+    type AI<'a> = SelfTransferVerifierAI;
+
+    fn new<'a>(
+        _program: &'a Program,
+        context: &'a CFGContext<'a>,
+        _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
+    ) -> Option<Self::AI<'a>> {
+        let Some(_) = &context.module else {
+            return None
+        };
+
+        let MemberName::Function(name) = context.member else {
+            return None;
+        };
+
+        if name.value.as_str() == "init" {
+            // do not lint module initializers, since they do not have the option of returning
+            // values, and the entire purpose of this linter is to encourage folks to return
+            // values instead of using transfer
+            return None;
+        }
+        Some(SelfTransferVerifierAI {
+            fn_name: name.value,
+            fn_ret_loc: context.signature.return_type.loc,
+        })
+    }
+}
+
+impl SimpleAbsInt for SelfTransferVerifierAI {
+    type State = State;
+    type ExecutionContext = ExecutionContext;
+
+    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+        diags
+    }
+
+    fn start_command(&self, _: &mut State) -> ExecutionContext {
+        ExecutionContext {
+            diags: Diagnostics::new(),
+        }
+    }
+
+    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+        let ExecutionContext { diags } = context;
+        diags
+    }
+
+    fn exp_custom(
+        &self,
+        _context: &mut ExecutionContext,
+        _state: &mut State,
+        _e: &Exp,
+    ) -> Option<Vec<Value>> {
+        None
+    }
+
+    fn call_custom(
+        &self,
+        context: &mut ExecutionContext,
+        _state: &mut State,
+        loc: &Loc,
+        return_ty: &Type,
+        f: &ModuleCall,
+        args: Vec<Value>,
+    ) -> Option<Vec<Value>> {
+        if TRANSFER_FUNCTIONS
+            .iter()
+            .any(|(addr, module, fun)| f.is(addr, module, fun))
+            && args[1] == Value::SenderAddress
+        {
+            let msg = format!(
+                "Transfer of an object to `tx_context::sender()` in function {}",
+                self.fn_name
+            );
+            let uid_msg = "Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.";
+            let d = diag!(SELF_TRANSFER_DIAG, (*loc, msg), (self.fn_ret_loc, uid_msg));
+            context.add_diag(d);
+            return Some(vec![]);
+        }
+        if f.is("sui", "tx_context", "sender") {
+            return Some(vec![Value::SenderAddress]);
+        }
+        Some(match &return_ty.value {
+            Type_::Unit => vec![],
+            Type_::Single(_) => vec![Value::Other],
+            Type_::Multiple(types) => vec![Value::Other; types.len()],
+        })
+    }
+
+    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
+        false
+    }
+
+    fn lvalue_custom(
+        &self,
+        _context: &mut ExecutionContext,
+        _state: &mut State,
+        _l: &LValue,
+        _value: &Value,
+    ) -> bool {
+        false
+    }
+}
+
+impl SimpleDomain for State {
+    type Value = Value;
+
+    fn new(context: &CFGContext, mut locals: BTreeMap<Var, LocalState<Value>>) -> Self {
+        for (v, _) in &context.signature.parameters {
+            let local_state = locals.get_mut(v).unwrap();
+            if let LocalState::Available(loc, _) = local_state {
+                *local_state = LocalState::Available(*loc, Value::Other);
+            }
+        }
+        State { locals }
+    }
+
+    fn locals_mut(&mut self) -> &mut BTreeMap<Var, LocalState<Value>> {
+        &mut self.locals
+    }
+
+    fn locals(&self) -> &BTreeMap<Var, LocalState<Value>> {
+        &self.locals
+    }
+
+    fn join_value(v1: &Value, v2: &Value) -> Value {
+        match (v1, v2) {
+            (Value::SenderAddress, Value::SenderAddress) => Value::SenderAddress,
+            (Value::Other, _) | (_, Value::Other) => Value::Other,
+        }
+    }
+
+    fn join_impl(&mut self, _: &Self, _: &mut JoinResult) {}
+}
+
+impl SimpleExecutionContext for ExecutionContext {
+    fn add_diag(&mut self, diag: Diagnostic) {
+        self.diags.add(diag)
+    }
+}

--- a/crates/sui-move-build/tests/linter/self_transfer.exp
+++ b/crates/sui-move-build/tests/linter/self_transfer.exp
@@ -4,7 +4,10 @@ warning[Lint W01001]: non-composable transfer to sender
 22 │     public fun public_transfer_bad(ctx: &mut TxContext) {
    │                ------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
 23 │         transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function public_transfer_bad
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                                       │
+   │         │                                                       Transaction sender address coming from here
+   │         Transfer of an object to transaction sender address in function public_transfer_bad
 
 warning[Lint W01001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:27:9
@@ -12,7 +15,10 @@ warning[Lint W01001]: non-composable transfer to sender
 26 │     public fun private_transfer_bad(ctx: &mut TxContext) {
    │                -------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
 27 │         transfer::transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function private_transfer_bad
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                                │
+   │         │                                                Transaction sender address coming from here
+   │         Transfer of an object to transaction sender address in function private_transfer_bad
 
 warning[Lint W01001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:31:9
@@ -20,14 +26,19 @@ warning[Lint W01001]: non-composable transfer to sender
 30 │     public fun private_transfer_no_store_bad(ctx: &mut TxContext) {
    │                ----------------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
 31 │         transfer::transfer(S2 { id: object::new(ctx), }, tx_context::sender(ctx))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function private_transfer_no_store_bad
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                                │
+   │         │                                                Transaction sender address coming from here
+   │         Transfer of an object to transaction sender address in function private_transfer_no_store_bad
 
 warning[Lint W01001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:37:9
    │
 34 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
    │                ---------------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
-   ·
+35 │         let sender = tx_context::sender(ctx);
+   │                      ----------------------- Transaction sender address coming from here
+36 │         let another_sender = sender;
 37 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function transfer_through_assigns_bad
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to transaction sender address in function transfer_through_assigns_bad
 

--- a/crates/sui-move-build/tests/linter/self_transfer.exp
+++ b/crates/sui-move-build/tests/linter/self_transfer.exp
@@ -1,0 +1,33 @@
+warning[Lint W01001]: non-composable transfer to sender
+   ┌─ tests/linter/self_transfer.move:23:9
+   │
+22 │     public fun public_transfer_bad(ctx: &mut TxContext) {
+   │                ------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
+23 │         transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function public_transfer_bad
+
+warning[Lint W01001]: non-composable transfer to sender
+   ┌─ tests/linter/self_transfer.move:27:9
+   │
+26 │     public fun private_transfer_bad(ctx: &mut TxContext) {
+   │                -------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
+27 │         transfer::transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function private_transfer_bad
+
+warning[Lint W01001]: non-composable transfer to sender
+   ┌─ tests/linter/self_transfer.move:31:9
+   │
+30 │     public fun private_transfer_no_store_bad(ctx: &mut TxContext) {
+   │                ----------------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
+31 │         transfer::transfer(S2 { id: object::new(ctx), }, tx_context::sender(ctx))
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function private_transfer_no_store_bad
+
+warning[Lint W01001]: non-composable transfer to sender
+   ┌─ tests/linter/self_transfer.move:37:9
+   │
+34 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
+   │                ---------------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
+   ·
+37 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to `tx_context::sender()` in function transfer_through_assigns_bad
+

--- a/crates/sui-move-build/tests/linter/self_transfer.move
+++ b/crates/sui-move-build/tests/linter/self_transfer.move
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module 0x42::test {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct S1 has key, store {
+        id: UID
+    }
+
+    struct S2 has key {
+        id: UID
+    }
+
+    fun init(ctx: &mut TxContext) {
+        transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx));
+        transfer::transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx));
+    }
+
+    public fun public_transfer_bad(ctx: &mut TxContext) {
+        transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
+    }
+
+    public fun private_transfer_bad(ctx: &mut TxContext) {
+        transfer::transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
+    }
+
+    public fun private_transfer_no_store_bad(ctx: &mut TxContext) {
+        transfer::transfer(S2 { id: object::new(ctx), }, tx_context::sender(ctx))
+    }
+
+    public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
+        let sender = tx_context::sender(ctx);
+        let another_sender = sender;
+        transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
+    }
+
+    public fun transfer_to_param_ok(a: address, ctx: &mut TxContext) {
+        transfer::public_transfer(S1 { id: object::new(ctx), }, a);
+        transfer::transfer(S1 { id: object::new(ctx), }, a);
+    }
+
+    public fun conditional_transfer_ok(b: bool, a: address, ctx: &mut TxContext) {
+        let xfer_address = if (b) { a } else { tx_context::sender(ctx) };
+        transfer::public_transfer(S1 { id: object::new(ctx), }, xfer_address);
+        transfer::transfer(S1 { id: object::new(ctx), }, xfer_address);
+    }
+}

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -11,7 +11,9 @@ use move_compiler::{
     command_line::compiler::move_check_for_errors, shared::NumericalAddress, Compiler, PASS_PARSER,
 };
 
-use sui_move_build::linters::share_owned::ShareOwnedVerifier;
+use sui_move_build::linters::{
+    self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
+};
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
 const MOVE_STDLIB_PATH: &str = "../sui-framework/packages/move-stdlib";
@@ -33,7 +35,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
 
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
-    let lint_visitors = vec![ShareOwnedVerifier.into()];
+    let lint_visitors = vec![ShareOwnedVerifier.into(), SelfTransferVerifier.into()];
     let (files, comments_and_compiler_res) = Compiler::from_files(
         targets,
         vec![MOVE_STDLIB_PATH.to_string(), SUI_FRAMEWORK_PATH.to_string()],

--- a/external-crates/move/move-ir/types/src/location.rs
+++ b/external-crates/move/move-ir/types/src/location.rs
@@ -43,6 +43,14 @@ impl Loc {
         }
     }
 
+    pub const fn invalid() -> Loc {
+        Loc {
+            file_hash: FileHash::empty(),
+            start: 0,
+            end: 0,
+        }
+    }
+
     pub fn file_hash(self) -> FileHash {
         self.file_hash
     }

--- a/sui_programmability/examples/basics/sources/object_basics.move
+++ b/sui_programmability/examples/basics/sources/object_basics.move
@@ -37,6 +37,7 @@ module basics::object_basics {
         transfer::public_freeze_object(o)
     }
 
+    #[no_lint]
     public entry fun set_value(o: &mut Object, value: u64) {
         o.value = value;
     }

--- a/sui_programmability/examples/basics/sources/sandwich.move
+++ b/sui_programmability/examples/basics/sources/sandwich.move
@@ -11,15 +11,15 @@ module basics::sandwich {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Ham has key {
+    struct Ham has key, store {
         id: UID
     }
 
-    struct Bread has key {
+    struct Bread has key, store {
         id: UID
     }
 
-    struct Sandwich has key {
+    struct Sandwich has key, store {
         id: UID,
     }
 
@@ -58,38 +58,38 @@ module basics::sandwich {
     }
 
     /// Exchange `c` for some ham
-    public entry fun buy_ham(
+    public fun buy_ham(
         grocery: &mut Grocery,
         c: Coin<SUI>,
         ctx: &mut TxContext
-    ) {
+    ): Ham {
         let b = coin::into_balance(c);
         assert!(balance::value(&b) == HAM_PRICE, EInsufficientFunds);
         balance::join(&mut grocery.profits, b);
-        transfer::transfer(Ham { id: object::new(ctx) }, tx_context::sender(ctx))
+        Ham { id: object::new(ctx) }
     }
 
     /// Exchange `c` for some bread
-    public entry fun buy_bread(
+    public fun buy_bread(
         grocery: &mut Grocery,
         c: Coin<SUI>,
         ctx: &mut TxContext
-    ) {
+    ): Bread {
         let b = coin::into_balance(c);
         assert!(balance::value(&b) == BREAD_PRICE, EInsufficientFunds);
         balance::join(&mut grocery.profits, b);
-        transfer::transfer(Bread { id: object::new(ctx) }, tx_context::sender(ctx))
+        Bread { id: object::new(ctx) }
     }
 
     /// Combine the `ham` and `bread` into a delicious sandwich
-    public entry fun make_sandwich(
+    public fun make_sandwich(
         ham: Ham, bread: Bread, ctx: &mut TxContext
-    ) {
+    ): Sandwich {
         let Ham { id: ham_id } = ham;
         let Bread { id: bread_id } = bread;
         object::delete(ham_id);
         object::delete(bread_id);
-        transfer::transfer(Sandwich { id: object::new(ctx) }, tx_context::sender(ctx))
+        Sandwich { id: object::new(ctx) }
     }
 
     /// See the profits of a grocery
@@ -98,15 +98,13 @@ module basics::sandwich {
     }
 
     /// Owner of the grocery can collect profits by passing his capability
-    public entry fun collect_profits(_cap: &GroceryOwnerCapability, grocery: &mut Grocery, ctx: &mut TxContext) {
+    public fun collect_profits(_cap: &GroceryOwnerCapability, grocery: &mut Grocery, ctx: &mut TxContext): Coin<SUI> {
         let amount = balance::value(&grocery.profits);
 
         assert!(amount > 0, ENoProfits);
 
         // Take a transferable `Coin` from a `Balance`
-        let coin = coin::take(&mut grocery.profits, amount, ctx);
-
-        transfer::public_transfer(coin, tx_context::sender(ctx));
+        coin::take(&mut grocery.profits, amount, ctx)
     }
 
     #[test_only]
@@ -117,10 +115,13 @@ module basics::sandwich {
 
 #[test_only]
 module basics::test_sandwich {
-    use basics::sandwich::{Self, Grocery, GroceryOwnerCapability, Bread, Ham};
+    use basics::sandwich::{Self, Grocery, GroceryOwnerCapability};
     use sui::test_scenario;
     use sui::coin::{Self};
     use sui::sui::SUI;
+    use sui::transfer;
+    use sui::test_utils;
+    use sui::tx_context;
 
     #[test]
     fun test_make_sandwich() {
@@ -140,27 +141,21 @@ module basics::test_sandwich {
             let grocery = &mut grocery_val;
             let ctx = test_scenario::ctx(scenario);
 
-            sandwich::buy_ham(
+            let ham = sandwich::buy_ham(
                 grocery,
                 coin::mint_for_testing<SUI>(10, ctx),
                 ctx
             );
 
-            sandwich::buy_bread(
+            let bread = sandwich::buy_bread(
                 grocery,
                 coin::mint_for_testing<SUI>(2, ctx),
                 ctx
             );
+            let sandwich = sandwich::make_sandwich(ham, bread, ctx);
 
             test_scenario::return_shared( grocery_val);
-        };
-
-        test_scenario::next_tx(scenario, the_guy);
-        {
-            let ham = test_scenario::take_from_sender<Ham>(scenario);
-            let bread = test_scenario::take_from_sender<Bread>(scenario);
-
-            sandwich::make_sandwich(ham, bread, test_scenario::ctx(scenario));
+            transfer::public_transfer(sandwich, tx_context::sender(ctx))
         };
 
         test_scenario::next_tx(scenario, owner);
@@ -170,11 +165,12 @@ module basics::test_sandwich {
             let capability = test_scenario::take_from_sender<GroceryOwnerCapability>(scenario);
 
             assert!(sandwich::profits(grocery) == 12, 0);
-            sandwich::collect_profits(&capability, grocery, test_scenario::ctx(scenario));
+            let profits = sandwich::collect_profits(&capability, grocery, test_scenario::ctx(scenario));
             assert!(sandwich::profits(grocery) == 0, 0);
 
             test_scenario::return_to_sender(scenario, capability);
             test_scenario::return_shared(grocery_val);
+            test_utils::destroy(profits)
         };
         test_scenario::end(scenario_val);
     }


### PR DESCRIPTION
## Description 

This implements a linter warning to be displayed when a function transfers an object to the sender of the transaction instead of returning it from a function. 

It brings linter support based on the Move compiler to the same level as the initial attempt to implement linters based on the Move model (https://github.com/MystenLabs/sui/pull/11212)

## Test Plan 

A test has been added

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
When building Move code, additional linter warnings related to transferring objects to the transaction sender may appear. The goal of this linter is to encourage developers to return object from functions rather than transferring them to the transaction sender in order to increase composability of functions in programmable transaction blocks by allowing callers to directly use the returned object.