### PR TITLE
move: remove unwrap in source service

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -46,9 +46,7 @@ pub async fn verify_package(
         print_diags_to_stderr: false,
         lint: false,
     };
-    let compiled_package = build_config
-        .build(package_path.as_ref().to_path_buf())
-        .unwrap();
+    let compiled_package = build_config.build(package_path.as_ref().to_path_buf())?;
 
     BytecodeSourceVerifier::new(client.read_api())
         .verify_package(


### PR DESCRIPTION
## Description 

Just a quick fix up to get better errors (avoids hard panic on build errors if we don't find deps).

## Test Plan 

Manual, does not functionally changing feature behavior.