### PR TITLE
chore: reorder protocol version 17, 18

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1288,8 +1288,12 @@ impl ProtocolConfig {
             }
             17 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
+                cfg.feature_flags.upgraded_multisig_supported = true;
+                cfg
+            }
+            18 => {
+                let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.execution_version = Some(1);
-
                 // Following flags are implied by this execution version.  Once support for earlier
                 // protocol versions is dropped, these flags can be removed:
                 // cfg.feature_flags.package_upgrades = true;
@@ -1298,11 +1302,6 @@ impl ProtocolConfig {
                 // cfg.feature_flags.loaded_child_objects_fixed = true;
                 // cfg.feature_flags.ban_entry_init = true;
                 // cfg.feature_flags.pack_digest_hash_modules = true;
-                cfg
-            }
-            18 => {
-                let mut cfg = Self::get_for_version_impl(version - 1, chain);
-                cfg.feature_flags.upgraded_multisig_supported = true;
                 cfg.feature_flags.txn_base_cost_as_multiplier = true;
                 // this is a multiplier of the gas price
                 cfg.base_tx_cost_fixed = Some(1_000);

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
@@ -20,6 +20,7 @@ feature_flags:
   narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -181,5 +182,4 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
-execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
@@ -21,6 +21,7 @@ feature_flags:
   narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -182,5 +183,4 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
-execution_version: 1
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
@@ -22,6 +22,7 @@ feature_flags:
   zklogin_auth: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -183,5 +184,4 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
-execution_version: 1
 


### PR DESCRIPTION
## Description 

to match with https://github.com/MystenLabs/sui/pull/12837, execution_version will go out with v18 (in 1.5.0) whereas the multisig feature flag will be released with 1.4.2 in v17. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
