### PR TITLE
[protocol-upgrades] Add ability to add abilities

### DIFF
--- a/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "SuiExtraAddKeyAbility"
+version = "0.0.1"
+
+[dependencies]
+SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }
+
+[addresses]
+sui_system = "0x3"

--- a/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/sources/modules.move
@@ -13,17 +13,17 @@ module sui_system::msim_extra_1 {
         id: UID,
     }
 
-    struct AlmostObj {
+    struct AlmostObj has key {
         id: UID,
     }
 
     public fun canary(): u64 {
-        private_function(47)
+        private_function(42)
     }
 
     entry fun mint(_ctx: &mut TxContext) {}
 
-    entry fun entry_fun(_x: u64) {}
+    entry fun entry_fun() {}
 
     fun private_function(x: u64): u64 {
         private_function_2(x) + 1

--- a/crates/sui-e2e-tests/tests/framework_upgrades/add_struct_ability/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/add_struct_ability/sources/modules.move
@@ -2,12 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
     struct Type has drop, copy {
         x: u64,
     }
 
+    struct Obj has key, store {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        obj: Obj,
+    }
+
     public fun canary(): u64 {
-        private_function(41)
+        private_function(42)
+    }
+
+    entry fun mint(ctx: &mut TxContext) {
+        transfer::transfer(
+            Obj { id: object::new(ctx) },
+            tx_context::sender(ctx),
+        )
+    }
+
+    entry fun wrap(obj: Obj, ctx: &mut TxContext) {
+        transfer::transfer(
+            Wrapper { id: object::new(ctx), obj },
+            tx_context::sender(ctx),
+        )
     }
 
     entry fun entry_fun() {}

--- a/crates/sui-e2e-tests/tests/framework_upgrades/base/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/base/sources/modules.move
@@ -2,12 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
     struct Type has drop {
         x: u64,
     }
 
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
+    }
+
     public fun canary(): u64 {
         private_function(41)
+    }
+
+    entry fun mint(ctx: &mut TxContext) {
+        transfer::transfer(
+            Obj { id: object::new(ctx) },
+            tx_context::sender(ctx),
+        )
     }
 
     entry fun entry_fun() {}

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_public_function_signature/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_public_function_signature/sources/modules.move
@@ -2,13 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::UID;
+    use sui::tx_context::TxContext;
+
     struct Type has drop {
         x: u64,
+    }
+
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
     }
 
     public fun canary(): u64 {
         private_function(46)
     }
+
+    entry fun mint(_ctx: &mut TxContext) {}
 
     entry fun entry_fun() {}
 

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_ability/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_ability/sources/modules.move
@@ -2,13 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::UID;
+    use sui::tx_context::TxContext;
+
     struct Type {
         x: u64,
+    }
+
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
     }
 
     public fun canary(): u64 {
         private_function(44)
     }
+
+    entry fun mint(_ctx: &mut TxContext) {}
 
     entry fun entry_fun() {}
 

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_layout/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_layout/sources/modules.move
@@ -2,14 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::UID;
+    use sui::tx_context::TxContext;
+
     struct Type has drop {
         x: u64,
         y: u64,
     }
 
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
+    }
+
     public fun canary(): u64 {
         private_function(43)
     }
+
+    entry fun mint(_ctx: &mut TxContext) {}
 
     entry fun entry_fun() {}
 

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_type_constraint/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_type_constraint/sources/modules.move
@@ -2,13 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::UID;
+    use sui::tx_context::TxContext;
+
     struct Type has drop {
         x: u64,
+    }
+
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
     }
 
     public fun canary(): u64 {
         private_function(45)
     }
+
+    entry fun mint(_ctx: &mut TxContext) {}
 
     entry fun entry_fun() {}
 

--- a/crates/sui-e2e-tests/tests/framework_upgrades/compatible/sources/modules.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/compatible/sources/modules.move
@@ -2,8 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::msim_extra_1 {
+    use sui::object::UID;
+    use sui::tx_context::TxContext;
+
     struct Type has drop {
         x: u64
+    }
+
+    struct Obj has key {
+        id: UID,
+    }
+
+    struct AlmostObj {
+        id: UID,
     }
 
     struct NewType {
@@ -13,6 +24,8 @@ module sui_system::msim_extra_1 {
     public fun canary(): u64 {
         private_function(20, 21)
     }
+
+    entry fun mint(_ctx: &mut TxContext) {}
 
     public entry fun entry_fun() {}
 

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::compatibility::Compatibility;
-use move_binary_format::file_format::AbilitySet;
+use move_binary_format::file_format::{Ability, AbilitySet};
 use move_binary_format::CompiledModule;
 use move_core_types::gas_algebra::InternalGas;
 use once_cell::sync::Lazy;
@@ -219,7 +219,7 @@ pub async fn compare_system_package<S: ObjectStore>(
         check_struct_layout: true,
         check_friend_linking: false,
         check_private_entry_linking: true,
-        disallowed_new_abilities: AbilitySet::ALL,
+        disallowed_new_abilities: AbilitySet::singleton(Ability::Key),
         disallow_change_struct_type_params: true,
     };
 


### PR DESCRIPTION
## Description

Relax the restriction on adding new abilities to types introduced during system package upgrades -- only the `key` ability remains restricted.

This change is not guarded by a protocol config, because it is in the codepath that decides whether an system package upgrade is compatible in the first place -- i.e. if a quorum of validators do not have this change, the proposal to upgrade to a package where an existing type has additional abilities will not succeed.  This codepath is also not run on fullnodes (who assume that if a system package upgrade proposal was executed successfully, validators confirmed that the upgrade was compatible), so again, there is not a need for a feature gate in the protocol config to coordinate the launch of this change -- it is self-coordinating.

## Test Plan

Updated existing E2E tests to test the newly allowed ability and added a new one for the new restriction on `key`:

```
sui-e2e-tests$ cargo simtest
```
