### PR TITLE
Track live object set size during expensive checks

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -52,6 +52,7 @@ const NUM_SHARDS: usize = 4096;
 struct AuthorityStoreMetrics {
     sui_conservation_check_latency: IntGauge,
     sui_conservation_live_object_count: IntGauge,
+    sui_conservation_live_object_size: IntGauge,
     sui_conservation_imbalance: IntGauge,
     sui_conservation_storage_fund: IntGauge,
     sui_conservation_storage_fund_imbalance: IntGauge,
@@ -69,6 +70,11 @@ impl AuthorityStoreMetrics {
             sui_conservation_live_object_count: register_int_gauge_with_registry!(
                 "sui_conservation_live_object_count",
                 "Number of live objects in the store",
+                registry,
+            ).unwrap(),
+            sui_conservation_live_object_size: register_int_gauge_with_registry!(
+                "sui_conservation_live_object_size",
+                "Size in bytes of live objects in the store",
                 registry,
             ).unwrap(),
             sui_conservation_imbalance: register_int_gauge_with_registry!(
@@ -1630,14 +1636,16 @@ impl AuthorityStore {
         let cur_time = Instant::now();
         let mut pending_objects = vec![];
         let mut count = 0;
+        let mut size = 0;
         let package_cache = PackageObjectCache::new(self.clone());
         let (mut total_sui, mut total_storage_rebate) = thread::scope(|s| {
             let pending_tasks = FuturesUnordered::new();
             for o in self.iter_live_object_set(false) {
                 match o {
                     LiveObject::Normal(object) => {
-                        pending_objects.push(object);
+                        size += object.object_size_for_gas_metering();
                         count += 1;
+                        pending_objects.push(object);
                         if count % 1_000_000 == 0 {
                             let mut task_objects = vec![];
                             mem::swap(&mut pending_objects, &mut task_objects);
@@ -1686,6 +1694,9 @@ impl AuthorityStore {
         self.metrics
             .sui_conservation_live_object_count
             .set(count as i64);
+        self.metrics
+            .sui_conservation_live_object_size
+            .set(size as i64);
         self.metrics
             .sui_conservation_check_latency
             .set(cur_time.elapsed().as_secs() as i64);


### PR DESCRIPTION
## Description 

We would like to track the application level object set size vs db level object set size (which we already have from rocksdb metrics i.e. objects + indirect objects sst table size).
Adding this as a part of the expensive checks.

## Test Plan 

Existing tests
