### PR TITLE
[Narwhal] compute and log ConsensusOutput digest

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -191,13 +191,18 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
             .consensus_committed_subdags
             .with_label_values(&[&leader_author.to_string()])
             .inc();
-        for (cert, batches) in consensus_output.batches {
+        for (cert, batches) in consensus_output
+            .sub_dag
+            .certificates
+            .iter()
+            .zip(consensus_output.batches.iter())
+        {
             let author = cert.header().author();
             self.metrics
                 .consensus_committed_certificates
                 .with_label_values(&[&author.to_string()])
                 .inc();
-            let output_cert = Arc::new(cert);
+            let output_cert = Arc::new(cert.clone());
             for batch in batches {
                 self.metrics.consensus_handler_processed_batches.inc();
                 for serialized_transaction in batch.transactions() {

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -29,7 +29,7 @@ struct NoOpExecutionState {
 #[async_trait::async_trait]
 impl ExecutionState for NoOpExecutionState {
     async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
-        for (_, batches) in consensus_output.batches {
+        for batches in consensus_output.batches {
             for batch in batches {
                 for transaction in batch.transactions().iter() {
                     assert_eq!(

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -274,7 +274,6 @@ impl Subscriber {
         // consensus output
         for cert in &sub_dag.certificates {
             let mut output_batches = Vec::with_capacity(cert.header().payload().len());
-            let output_cert = cert.clone();
 
             inner
                 .metrics
@@ -298,9 +297,7 @@ impl Subscriber {
                 );
                 output_batches.push(batch.clone());
             }
-            subscriber_output
-                .batches
-                .push((output_cert, output_batches));
+            subscriber_output.batches.push(output_batches);
         }
         subscriber_output
     }

--- a/narwhal/node/src/execution_state.rs
+++ b/narwhal/node/src/execution_state.rs
@@ -21,7 +21,7 @@ impl SimpleExecutionState {
 #[async_trait]
 impl ExecutionState for SimpleExecutionState {
     async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
-        for (_, batches) in consensus_output.batches {
+        for batches in consensus_output.batches {
             for batch in batches {
                 for transaction in batch.transactions().iter() {
                     if let Err(err) = self

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -5,7 +5,7 @@
 use crate::{Batch, Certificate, CertificateAPI, CertificateDigest, HeaderAPI, Round, TimestampMs};
 use config::{AuthorityIdentifier, Committee};
 use enum_dispatch::enum_dispatch;
-use fastcrypto::hash::Hash;
+use fastcrypto::hash::{Digest, Hash, HashFunction};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -21,8 +21,21 @@ pub type SequenceNumber = u64;
 /// It is sent to the the ExecutionState handle_consensus_transactions
 pub struct ConsensusOutput {
     pub sub_dag: Arc<CommittedSubDag>,
-    /// Order of each Vec<Batch> item matches the order of certificates in the CommittedSubDag.
+    /// Matches certificates in the `sub_dag` one-to-one.
     pub batches: Vec<Vec<Batch>>,
+}
+
+impl Hash<{ crypto::DIGEST_LENGTH }> for ConsensusOutput {
+    type TypedDigest = ConsensusOutputDigest;
+
+    fn digest(&self) -> ConsensusOutputDigest {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        hasher.update(self.sub_dag.digest());
+        self.batches.iter().flatten().for_each(|b| {
+            hasher.update(b.digest());
+        });
+        ConsensusOutputDigest(hasher.finalize().into())
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
@@ -119,6 +132,35 @@ impl CommittedSubDag {
             return *self.leader.header().created_at();
         }
         self.commit_timestamp
+    }
+}
+
+impl Hash<{ crypto::DIGEST_LENGTH }> for CommittedSubDag {
+    type TypedDigest = ConsensusOutputDigest;
+
+    fn digest(&self) -> ConsensusOutputDigest {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        // Instead of hashing serialized CommittedSubDag, hash the certificate digests instead.
+        // Signatures in the certificates are not part of the commitment.
+        for cert in &self.certificates {
+            hasher.update(cert.digest());
+        }
+        hasher.update(self.leader.digest());
+        hasher.update(
+            bcs::to_bytes(&self.sub_dag_index).unwrap_or_else(|_| {
+                panic!("Serialization of {} should not fail", self.sub_dag_index)
+            }),
+        );
+        hasher.update(bcs::to_bytes(&self.reputation_score).unwrap_or_else(|_| {
+            panic!(
+                "Serialization of {:?} should not fail",
+                self.reputation_score
+            )
+        }));
+        hasher.update(bcs::to_bytes(&self.commit_timestamp).unwrap_or_else(|_| {
+            panic!("Serialization of {} should not fail", self.commit_timestamp)
+        }));
+        ConsensusOutputDigest(hasher.finalize().into())
     }
 }
 
@@ -359,6 +401,22 @@ impl CommittedSubDagShell {
 
 /// Shutdown token dropped when a task is properly shut down.
 pub type ShutdownToken = mpsc::Sender<()>;
+
+// Digest of ConsususOutput and CommittedSubDag
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ConsensusOutputDigest([u8; crypto::DIGEST_LENGTH]);
+
+impl AsRef<[u8]> for ConsensusOutputDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<ConsensusOutputDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
+    fn from(d: ConsensusOutputDigest) -> Self {
+        Digest::new(d.0)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -21,7 +21,8 @@ pub type SequenceNumber = u64;
 /// It is sent to the the ExecutionState handle_consensus_transactions
 pub struct ConsensusOutput {
     pub sub_dag: Arc<CommittedSubDag>,
-    pub batches: Vec<(Certificate, Vec<Batch>)>,
+    /// Order of each Vec<Batch> item matches the order of certificates in the CommittedSubDag.
+    pub batches: Vec<Vec<Batch>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -347,6 +347,12 @@ impl From<BatchDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
     }
 }
 
+impl AsRef<[u8]> for BatchDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl BatchDigest {
     pub fn new(val: [u8; crypto::DIGEST_LENGTH]) -> BatchDigest {
         BatchDigest(val)


### PR DESCRIPTION
## Description 

Currently there is no simple way to check the consistency of ConsensusOutput among validator. The integrity hash is only calculated after some processings in consensus handler. Add a way to calculate ConsensusOutput digest and log it for every consensus commit.

After having more confidence in the value, we can commit to the digest in CheckpointSummary.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
