### PR TITLE
Revert change to system transaction gas data

### DIFF
--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1038,7 +1038,7 @@ impl TransactionData {
             gas_data: GasData {
                 price: GAS_PRICE_FOR_SYSTEM_TX,
                 owner: sender,
-                payment: vec![],
+                payment: vec![(ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN)],
                 budget: 0,
             },
             expiration: TransactionExpiration::None,


### PR DESCRIPTION
this change (from #12676) broke compatibility since it was not gated - if the change was necessary we will have to put in a feature flag