### PR TITLE
[storage] Add per-epoch object marker table for shared object deletion and transfer-to-object

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3486,6 +3486,7 @@ impl AuthorityState {
                 inner_temporary_store,
                 &certificate.clone().into_unsigned(),
                 effects,
+                epoch_store.epoch(),
             )
             .await
             .tap_ok(|_| {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -938,6 +938,7 @@ impl AuthorityStore {
         inner_temporary_store: InnerTemporaryStore,
         transaction: &VerifiedTransaction,
         effects: &TransactionEffects,
+        epoch_id: EpochId,
     ) -> SuiResult {
         let _locks = self
             .acquire_read_locks_for_indirect_objects(&inner_temporary_store)
@@ -954,8 +955,13 @@ impl AuthorityStore {
 
         // Add batched writes for objects and locks.
         let effects_digest = effects.digest();
-        self.update_objects_and_locks(&mut write_batch, inner_temporary_store)
-            .await?;
+        self.update_objects_and_locks(
+            &mut write_batch,
+            inner_temporary_store,
+            transaction,
+            epoch_id,
+        )
+        .await?;
 
         // Store the signed effects of the transaction
         // We can't write this until after sequencing succeeds (which happens in
@@ -1015,6 +1021,8 @@ impl AuthorityStore {
         &self,
         write_batch: &mut DBBatch,
         inner_temporary_store: InnerTemporaryStore,
+        _transaction: &VerifiedTransaction,
+        _epoch_id: EpochId,
     ) -> SuiResult {
         let InnerTemporaryStore {
             objects,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -10,6 +10,7 @@ use sui_types::accumulator::Accumulator;
 use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::TransactionEffects;
+use sui_types::storage::MarkerKind;
 use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::util::{empty_compaction_filter, reference_count_merge_operator};
 use typed_store::rocks::{
@@ -118,6 +119,13 @@ pub struct AuthorityPerpetualTables {
     /// This could be non-zero due to bugs in earlier protocol versions.
     /// This number is the result of storage_fund_balance - sum(storage_rebate).
     pub(crate) expected_storage_fund_imbalance: DBMap<(), i64>,
+
+    /// Table that stores the set of received objects and deleted shared objects and the version at
+    /// which they were received. This is used to prevent possible race conditions around receiving
+    /// objects (since they are not locked by the transaction manager) and for tracking shared
+    /// objects that have been deleted. This table is meant to be pruned per-epoch, and all
+    /// previous epochs other than the current epoch may be pruned safely.
+    pub(crate) object_per_epoch_marker_table: DBMap<(EpochId, ObjectKey, MarkerKind), ()>,
 }
 
 impl AuthorityPerpetualTables {
@@ -402,6 +410,7 @@ impl AuthorityPerpetualTables {
         self.pruned_checkpoint.clear()?;
         self.expected_network_sui_amount.clear()?;
         self.expected_storage_fund_imbalance.clear()?;
+        self.object_per_epoch_marker_table.clear()?;
         self.objects
             .rocksdb
             .flush()

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -53,6 +53,16 @@ pub enum DeleteKind {
     Wrap,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub enum MarkerKind {
+    /// An object was received at the given version in the transaction and is no longer able
+    /// to be received at that version in subequent transactions.
+    Received,
+    /// A shared object was deleted by the transaction and is no longer able to be accessed or
+    /// used in subsequent transactions.
+    SharedObjectDeleted,
+}
+
 /// DeleteKind together with the old sequence number prior to the deletion, if available.
 /// For normal deletion and wrap, we always will consult the object store to obtain the old sequence number.
 /// For UnwrapThenDelete however, in the old protocol where simplified_unwrap_then_delete is false,


### PR DESCRIPTION
## Description 

This adds a new table to the ``PerpetualTables` that holds the set of received and shared deleted objects during the epoch.

This table is not currently used anywhere and is unused. However, both shared-object deletion #12623 and transfer-to-object #12611 PRs rely on this table. 

This table can be pruned at epoch boundaries so the table key contains the epoch ID.

@laura-makdah and I have discussed and we're happy to either land this soon, or to wait until one or the other above PRs is ready to land and land this change at the same time. Either way this change on its own should be fine to land any time as the new table is not used anywhere yet.

## Test Plan 

Not tested yet -- functionality will be tested in the two PRs being built on top of this.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
