### PR TITLE
use type in event struct to overcome package identity crisis

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -103,7 +103,9 @@ impl SuiEvent {
         let bcs = contents.to_vec();
 
         let move_struct = Event::move_event_to_move_struct(&type_, &contents, resolver)?;
-        let (type_, field) = type_and_fields_from_move_struct(&type_, move_struct);
+        // We do not use the output `type_` because it may suffer from the identity crisis
+        // from package upgrades. Instead, we use `type_` stored in the Event itself.
+        let (_type_, field) = type_and_fields_from_move_struct(&type_, move_struct);
 
         Ok(SuiEvent {
             id: EventID {


### PR DESCRIPTION
## Description 

When we query events with `MoveEventTypes`, and a. it has a type params and the type had a package upgrade, the type params in results will return the initial package v.s. the emitting package.

@amnn  explained it well:
I think the problem originates from here:
https://github.com/amnn/sui/blob/869c2c3b80e3b632d7a978bb53851023b4d10ce7/crates/sui-json-rpc-types/src/sui_event.rs#L88
(Converting from Event to SuiEvent)
Event -- which I believe is the type that the execution engine produces (and is stored in the perpetual tables), should contain the correct IDs in its type, but when we call Event::move_event_to_move_struct, and then type_and_fields_from_move_struct it runs it through this code:
https://github.com/amnn/sui/blob/869c2c3b80e3b632d7a978bb53851023b4d10ce7/external-crates/move/tools/move-bytecode-utils/src/layout.rs#L359
And the way this code resolves types is as follows:
https://github.com/amnn/sui/blob/869c2c3b80e3b632d7a978bb53851023b4d10ce7/external-crates/move/tools/move-bytecode-utils/src/layout.rs#L556
it loads the module that declares the type, and asks that type for the struct def of the module.
This has the unfortunate effect of undoing the remapping that the execution engine does, because even if the event says the type is v2::foo::Foo, it will load v2::foo and ask it for the definition of Foo.  Unfortunately v2::foo has a bit of an identity crisis and thinks it's v1::foo so the definition it returns is v1::foo::Foo.

The fix is to use the `type_` from the `Event` stored in the authority store, which is correct.

## Test Plan 

tested locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Event query bug fix - Use type in event struct to overcome package identity crisis