### PR TITLE
explorer: fix gas price graph overflowing rounded card

### DIFF
--- a/apps/explorer/src/ui/Card.tsx
+++ b/apps/explorer/src/ui/Card.tsx
@@ -4,7 +4,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ReactNode } from 'react';
 
-const cardStyles = cva(null, {
+const cardStyles = cva('overflow-hidden', {
 	variants: {
 		bg: {
 			default: 'bg-gray-40',


### PR DESCRIPTION
## Description 

* hide Card overflow to avoid content being visible outside of the rounded corners of the Card

| before | after |
| -- | -- |
| <img width="471" alt="Screenshot 2023-07-06 at 15 34 23" src="https://github.com/MystenLabs/sui/assets/10210143/f8c00187-154c-4ad8-a553-9493b4094617"> | <img width="471" alt="Screenshot 2023-07-06 at 15 34 40" src="https://github.com/MystenLabs/sui/assets/10210143/cf6c6fcf-91a7-4b74-b26e-c13d9532bf3b"> |
| <img width="35" alt="Screenshot 2023-07-06 at 15 39 28" src="https://github.com/MystenLabs/sui/assets/10210143/44f78546-afe9-45d7-a61c-fccacbc23bc5"> | <img width="35" alt="Screenshot 2023-07-06 at 15 39 16" src="https://github.com/MystenLabs/sui/assets/10210143/64473eff-f271-471f-84d4-cdf60c96db5d"> |


## Test Plan 

👀 👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
