### PR TITLE
[sui-system] add store to StakedSui and PTB friendly staking fun

### DIFF
--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -34,6 +34,9 @@
 -  [Function `pool_token_exchange_rate_at_epoch`](#0x3_staking_pool_pool_token_exchange_rate_at_epoch)
 -  [Function `pending_stake_amount`](#0x3_staking_pool_pending_stake_amount)
 -  [Function `pending_stake_withdraw_amount`](#0x3_staking_pool_pending_stake_withdraw_amount)
+-  [Function `exchange_rates`](#0x3_staking_pool_exchange_rates)
+-  [Function `sui_amount`](#0x3_staking_pool_sui_amount)
+-  [Function `pool_token_amount`](#0x3_staking_pool_pool_token_amount)
 -  [Function `is_preactive_at_epoch`](#0x3_staking_pool_is_preactive_at_epoch)
 -  [Function `get_sui_amount`](#0x3_staking_pool_get_sui_amount)
 -  [Function `get_token_amount`](#0x3_staking_pool_get_token_amount)
@@ -1187,6 +1190,78 @@ Returns the total withdrawal from the staking pool this epoch.
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_pending_stake_withdraw_amount">pending_stake_withdraw_amount</a>(<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>): u64 {
     <a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.pending_total_sui_withdraw
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_staking_pool_exchange_rates"></a>
+
+## Function `exchange_rates`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_exchange_rates">exchange_rates</a>(pool: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>): &<a href="../../../.././build/Sui/docs/table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_exchange_rates">exchange_rates</a>(pool: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>): &Table&lt;u64, <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a>&gt; {
+    &pool.exchange_rates
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_staking_pool_sui_amount"></a>
+
+## Function `sui_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_sui_amount">sui_amount</a>(exchange_rate: &<a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_sui_amount">sui_amount</a>(exchange_rate: &<a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a>): u64 {
+    exchange_rate.sui_amount
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_staking_pool_pool_token_amount"></a>
+
+## Function `pool_token_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_pool_token_amount">pool_token_amount</a>(exchange_rate: &<a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_pool_token_amount">pool_token_amount</a>(exchange_rate: &<a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a>): u64 {
+    exchange_rate.pool_token_amount
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -189,7 +189,7 @@ Struct representing the exchange rate of the stake pool token to SUI.
 A self-custodial object holding the staked SUI tokens.
 
 
-<pre><code><b>struct</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> <b>has</b> store, key
 </code></pre>
 
 
@@ -459,7 +459,7 @@ Create a new, empty staking pool.
 Request to stake to a staking pool. The stake starts counting at the beginning of the next epoch,
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>, stake: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, staker: <b>address</b>, stake_activation_epoch: u64, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>, stake: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, stake_activation_epoch: u64, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>
 </code></pre>
 
 
@@ -471,10 +471,9 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(
     pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>,
     stake: Balance&lt;SUI&gt;,
-    staker: <b>address</b>,
     stake_activation_epoch: u64,
     ctx: &<b>mut</b> TxContext
-) {
+) : <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
     <b>let</b> sui_amount = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_value">balance::value</a>(&stake);
     <b>assert</b>!(!<a href="staking_pool.md#0x3_staking_pool_is_inactive">is_inactive</a>(pool), <a href="staking_pool.md#0x3_staking_pool_EDelegationToInactivePool">EDelegationToInactivePool</a>);
     <b>assert</b>!(sui_amount &gt; 0, <a href="staking_pool.md#0x3_staking_pool_EDelegationOfZeroSui">EDelegationOfZeroSui</a>);
@@ -485,7 +484,7 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
         principal: stake,
     };
     pool.pending_stake = pool.pending_stake + sui_amount;
-    <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer_transfer">transfer::transfer</a>(staked_sui, staker);
+    staked_sui
 }
 </code></pre>
 
@@ -498,7 +497,7 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
 ## Function `request_withdraw_stake`
 
 Request to withdraw the given stake plus rewards from a staking pool.
-Both the principal and corresponding rewards in SUI are withdrawn and transferred to the staker.
+Both the principal and corresponding rewards in SUI are withdrawn.
 A proportional amount of pool token withdraw is recorded and processed at epoch change time.
 
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -53,6 +53,7 @@ the SuiSystemStateInner version, or vice versa.
 -  [Function `request_set_commission_rate`](#0x3_sui_system_request_set_commission_rate)
 -  [Function `set_candidate_validator_commission_rate`](#0x3_sui_system_set_candidate_validator_commission_rate)
 -  [Function `request_add_stake`](#0x3_sui_system_request_add_stake)
+-  [Function `request_add_stake_non_entry`](#0x3_sui_system_request_add_stake_non_entry)
 -  [Function `request_add_stake_mul_coin`](#0x3_sui_system_request_add_stake_mul_coin)
 -  [Function `request_withdraw_stake`](#0x3_sui_system_request_withdraw_stake)
 -  [Function `request_withdraw_stake_non_entry`](#0x3_sui_system_request_withdraw_stake_non_entry)
@@ -510,6 +511,37 @@ Add stake to a validator's staking pool.
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
+    <b>let</b> staked_sui = <a href="sui_system.md#0x3_sui_system_request_add_stake_non_entry">request_add_stake_non_entry</a>(wrapper, stake, validator_address, ctx);
+    <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_sui_system_request_add_stake_non_entry"></a>
+
+## Function `request_add_stake_non_entry`
+
+The non-entry version of <code>request_add_stake</code>, which returns the staked SUI instead of transferring it to the sender.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_request_add_stake_non_entry">request_add_stake_non_entry</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, stake: <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_request_add_stake_non_entry">request_add_stake_non_entry</a>(
+    wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>,
+    stake: Coin&lt;SUI&gt;,
+    validator_address: <b>address</b>,
+    ctx: &<b>mut</b> TxContext,
+): StakedSui {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">sui_system_state_inner::request_add_stake</a>(self, stake, validator_address, ctx)
 }
@@ -543,7 +575,8 @@ Add stake to a validator's staking pool using multiple coins.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">sui_system_state_inner::request_add_stake_mul_coin</a>(self, stakes, stake_amount, validator_address, ctx)
+    <b>let</b> staked_sui = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">sui_system_state_inner::request_add_stake_mul_coin</a>(self, stakes, stake_amount, validator_address, ctx);
+    <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
 }
 </code></pre>
 
@@ -555,7 +588,7 @@ Add stake to a validator's staking pool using multiple coins.
 
 ## Function `request_withdraw_stake`
 
-Withdraw some portion of a stake from a validator's staking pool.
+Withdraw stake from a validator's staking pool.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x3_sui_system_request_withdraw_stake">request_withdraw_stake</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, staked_sui: <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -79,6 +79,7 @@ the SuiSystemStateInner version, or vice versa.
 -  [Function `update_validator_next_epoch_network_pubkey`](#0x3_sui_system_update_validator_next_epoch_network_pubkey)
 -  [Function `update_candidate_validator_network_pubkey`](#0x3_sui_system_update_candidate_validator_network_pubkey)
 -  [Function `pool_exchange_rates`](#0x3_sui_system_pool_exchange_rates)
+-  [Function `active_validator_addresses`](#0x3_sui_system_active_validator_addresses)
 -  [Function `advance_epoch`](#0x3_sui_system_advance_epoch)
 -  [Function `load_system_state`](#0x3_sui_system_load_system_state)
 -  [Function `load_system_state_mut`](#0x3_sui_system_load_system_state_mut)
@@ -1315,6 +1316,32 @@ Getter of the pool token exchange rate of a staking pool. Works for both active 
 ): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">sui_system_state_inner::pool_exchange_rates</a>(self, pool_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_sui_system_active_validator_addresses"></a>
+
+## Function `active_validator_addresses`
+
+Getter returning addresses of the currently active validators.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_active_validator_addresses">active_validator_addresses</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): <a href="">vector</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_active_validator_addresses">active_validator_addresses</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): <a href="">vector</a>&lt;<b>address</b>&gt; {
+    <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(wrapper);
+    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">sui_system_state_inner::active_validator_addresses</a>(self)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -78,6 +78,7 @@ the SuiSystemStateInner version, or vice versa.
 -  [Function `update_candidate_validator_worker_pubkey`](#0x3_sui_system_update_candidate_validator_worker_pubkey)
 -  [Function `update_validator_next_epoch_network_pubkey`](#0x3_sui_system_update_validator_next_epoch_network_pubkey)
 -  [Function `update_candidate_validator_network_pubkey`](#0x3_sui_system_update_candidate_validator_network_pubkey)
+-  [Function `pool_exchange_rates`](#0x3_sui_system_pool_exchange_rates)
 -  [Function `advance_epoch`](#0x3_sui_system_advance_epoch)
 -  [Function `load_system_state`](#0x3_sui_system_load_system_state)
 -  [Function `load_system_state_mut`](#0x3_sui_system_load_system_state_mut)
@@ -90,6 +91,7 @@ the SuiSystemStateInner version, or vice versa.
 <b>use</b> <a href="../../../.././build/Sui/docs/dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="../../../.././build/Sui/docs/table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="stake_subsidy.md#0x3_stake_subsidy">0x3::stake_subsidy</a>;
@@ -1284,6 +1286,35 @@ Update candidate validator's public key of network key.
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
     <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_pubkey">sui_system_state_inner::update_candidate_validator_network_pubkey</a>(self, network_pubkey, ctx)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_sui_system_pool_exchange_rates"></a>
+
+## Function `pool_exchange_rates`
+
+Getter of the pool token exchange rate of a staking pool. Works for both active and inactive pools.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_pool_exchange_rates">pool_exchange_rates</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, pool_id: &<a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a>): &<a href="../../../.././build/Sui/docs/table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_pool_exchange_rates">pool_exchange_rates</a>(
+    wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>,
+    pool_id: &ID
+): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
+    <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
+    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">sui_system_state_inner::pool_exchange_rates</a>(self, pool_id)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -1224,7 +1224,7 @@ This function is used to set new commission rate for candidate validators
 Add stake to a validator's staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stake: <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stake: <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>
 </code></pre>
 
 
@@ -1238,13 +1238,13 @@ Add stake to a validator's staking pool.
     stake: Coin&lt;SUI&gt;,
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
-) {
+) : StakedSui {
     <a href="validator_set.md#0x3_validator_set_request_add_stake">validator_set::request_add_stake</a>(
         &<b>mut</b> self.validators,
         validator_address,
         <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_into_balance">coin::into_balance</a>(stake),
         ctx,
-    );
+    )
 }
 </code></pre>
 
@@ -1259,7 +1259,7 @@ Add stake to a validator's staking pool.
 Add stake to a validator's staking pool using multiple coins.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stakes: <a href="">vector</a>&lt;<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stakes: <a href="">vector</a>&lt;<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>
 </code></pre>
 
 
@@ -1274,9 +1274,9 @@ Add stake to a validator's staking pool using multiple coins.
     stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;,
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
-) {
+) : StakedSui {
     <b>let</b> <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a> = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_extract_coin_balance">extract_coin_balance</a>(stakes, stake_amount, ctx);
-    <a href="validator_set.md#0x3_validator_set_request_add_stake">validator_set::request_add_stake</a>(&<b>mut</b> self.validators, validator_address, <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a>, ctx);
+    <a href="validator_set.md#0x3_validator_set_request_add_stake">validator_set::request_add_stake</a>(&<b>mut</b> self.validators, validator_address, <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a>, ctx)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -60,6 +60,7 @@
 -  [Function `get_reporters_of`](#0x3_sui_system_state_inner_get_reporters_of)
 -  [Function `get_storage_fund_total_balance`](#0x3_sui_system_state_inner_get_storage_fund_total_balance)
 -  [Function `get_storage_fund_object_rebates`](#0x3_sui_system_state_inner_get_storage_fund_object_rebates)
+-  [Function `pool_exchange_rates`](#0x3_sui_system_state_inner_pool_exchange_rates)
 -  [Function `extract_coin_balance`](#0x3_sui_system_state_inner_extract_coin_balance)
 -  [Module Specification](#@Module_Specification_1)
 
@@ -2504,6 +2505,34 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     <a href="storage_fund.md#0x3_storage_fund_total_object_storage_rebates">storage_fund::total_object_storage_rebates</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_sui_system_state_inner_pool_exchange_rates"></a>
+
+## Function `pool_exchange_rates`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">pool_exchange_rates</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, pool_id: &<a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a>): &<a href="../../../.././build/Sui/docs/table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">pool_exchange_rates</a>(
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
+    pool_id: &ID
+): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
+    <b>let</b> validators = &<b>mut</b> self.validators;
+    <a href="validator_set.md#0x3_validator_set_pool_exchange_rates">validator_set::pool_exchange_rates</a>(validators, pool_id)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -61,6 +61,7 @@
 -  [Function `get_storage_fund_total_balance`](#0x3_sui_system_state_inner_get_storage_fund_total_balance)
 -  [Function `get_storage_fund_object_rebates`](#0x3_sui_system_state_inner_get_storage_fund_object_rebates)
 -  [Function `pool_exchange_rates`](#0x3_sui_system_state_inner_pool_exchange_rates)
+-  [Function `active_validator_addresses`](#0x3_sui_system_state_inner_active_validator_addresses)
 -  [Function `extract_coin_balance`](#0x3_sui_system_state_inner_extract_coin_balance)
 -  [Module Specification](#@Module_Specification_1)
 
@@ -2533,6 +2534,31 @@ Returns all the validators who are currently reporting <code>addr</code>
 ): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
     <b>let</b> validators = &<b>mut</b> self.validators;
     <a href="validator_set.md#0x3_validator_set_pool_exchange_rates">validator_set::pool_exchange_rates</a>(validators, pool_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_sui_system_state_inner_active_validator_addresses"></a>
+
+## Function `active_validator_addresses`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">active_validator_addresses</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): <a href="">vector</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">active_validator_addresses</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): <a href="">vector</a>&lt;<b>address</b>&gt; {
+    <b>let</b> <a href="validator_set.md#0x3_validator_set">validator_set</a> = &self.validators;
+    <a href="validator_set.md#0x3_validator_set_active_validator_addresses">validator_set::active_validator_addresses</a>(<a href="validator_set.md#0x3_validator_set">validator_set</a>)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -85,6 +85,7 @@
 -  [Function `effectuate_staged_metadata`](#0x3_validator_effectuate_staged_metadata)
 -  [Function `validate_metadata`](#0x3_validator_validate_metadata)
 -  [Function `validate_metadata_bcs`](#0x3_validator_validate_metadata_bcs)
+-  [Function `get_staking_pool_ref`](#0x3_validator_get_staking_pool_ref)
 -  [Function `new_from_metadata`](#0x3_validator_new_from_metadata)
 
 
@@ -2856,6 +2857,30 @@ Aborts if validator metadata is valid
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>true</b>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_validator_get_staking_pool_ref"></a>
+
+## Function `get_staking_pool_ref`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x3_validator_get_staking_pool_ref">get_staking_pool_ref</a>(self: &<a href="validator.md#0x3_validator_Validator">validator::Validator</a>): &<a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x3_validator_get_staking_pool_ref">get_staking_pool_ref</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>) : &StakingPool {
+    &self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>
+}
 </code></pre>
 
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -81,6 +81,7 @@
 <b>use</b> <a href="../../../.././build/Sui/docs/sui.md#0x2_sui">0x2::sui</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/table.md#0x2_table">0x2::table</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/table_vec.md#0x2_table_vec">0x2::table_vec</a>;
+<b>use</b> <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/vec_map.md#0x2_vec_map">0x2::vec_map</a>;
 <b>use</b> <a href="../../../.././build/Sui/docs/vec_set.md#0x2_vec_set">0x2::vec_set</a>;
@@ -880,7 +881,7 @@ of the epoch.
 Aborts in case the staking amount is smaller than MIN_STAKING_THRESHOLD
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>, stake: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, validator_address: <b>address</b>, stake: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>
 </code></pre>
 
 
@@ -894,11 +895,11 @@ Aborts in case the staking amount is smaller than MIN_STAKING_THRESHOLD
     validator_address: <b>address</b>,
     stake: Balance&lt;SUI&gt;,
     ctx: &<b>mut</b> TxContext,
-) {
+) : StakedSui {
     <b>let</b> sui_amount = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_value">balance::value</a>(&stake);
     <b>assert</b>!(sui_amount &gt;= <a href="validator_set.md#0x3_validator_set_MIN_STAKING_THRESHOLD">MIN_STAKING_THRESHOLD</a>, <a href="validator_set.md#0x3_validator_set_EStakingBelowThreshold">EStakingBelowThreshold</a>);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_candidate_or_active_validator_mut">get_candidate_or_active_validator_mut</a>(self, validator_address);
-    <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, stake, <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx);
+    <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, stake, <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx)
 }
 </code></pre>
 
@@ -2638,7 +2639,8 @@ The staking rewards are shared with the stakers while the storage fund ones are 
         // Add rewards <b>to</b> the <a href="validator.md#0x3_validator">validator</a>. Don't try and distribute rewards though <b>if</b> the payout is zero.
         <b>if</b> (<a href="../../../.././build/Sui/docs/balance.md#0x2_balance_value">balance::value</a>(&validator_reward) &gt; 0) {
             <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(<a href="validator.md#0x3_validator">validator</a>);
-            <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, validator_reward, validator_address, ctx);
+            <b>let</b> rewards_stake = <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, validator_reward, validator_address, ctx);
+            <a href="../../../.././build/Sui/docs/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(rewards_stake, validator_address);
         } <b>else</b> {
             <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(validator_reward);
         };

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -29,6 +29,7 @@
 -  [Function `validator_stake_amount`](#0x3_validator_set_validator_stake_amount)
 -  [Function `validator_staking_pool_id`](#0x3_validator_set_validator_staking_pool_id)
 -  [Function `staking_pool_mappings`](#0x3_validator_set_staking_pool_mappings)
+-  [Function `pool_exchange_rates`](#0x3_validator_set_pool_exchange_rates)
 -  [Function `next_epoch_validator_count`](#0x3_validator_set_next_epoch_validator_count)
 -  [Function `is_active_validator_by_sui_address`](#0x3_validator_set_is_active_validator_by_sui_address)
 -  [Function `is_duplicate_with_active_validator`](#0x3_validator_set_is_duplicate_with_active_validator)
@@ -1371,6 +1372,41 @@ gas price, weighted by stake.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_staking_pool_mappings">staking_pool_mappings</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>): &Table&lt;ID, <b>address</b>&gt; {
     &self.staking_pool_mappings
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_validator_set_pool_exchange_rates"></a>
+
+## Function `pool_exchange_rates`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_pool_exchange_rates">pool_exchange_rates</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">validator_set::ValidatorSet</a>, pool_id: &<a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a>): &<a href="../../../.././build/Sui/docs/table.md#0x2_table_Table">table::Table</a>&lt;u64, <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">staking_pool::PoolTokenExchangeRate</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_pool_exchange_rates">pool_exchange_rates</a>(
+    self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, pool_id: &ID
+) : &Table&lt;u64, PoolTokenExchangeRate&gt; {
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> =
+        // If the pool id is recorded in the mapping, then it must be either candidate or active.
+        <b>if</b> (<a href="../../../.././build/Sui/docs/table.md#0x2_table_contains">table::contains</a>(&self.staking_pool_mappings, *pool_id)) {
+            <b>let</b> validator_address = *<a href="../../../.././build/Sui/docs/table.md#0x2_table_borrow">table::borrow</a>(&self.staking_pool_mappings, *pool_id);
+            <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_ref">get_active_or_pending_or_candidate_validator_ref</a>(self, validator_address, <a href="validator_set.md#0x3_validator_set_ANY_VALIDATOR">ANY_VALIDATOR</a>)
+        } <b>else</b> { // otherwise it's inactive
+            <b>let</b> wrapper = <a href="../../../.././build/Sui/docs/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inactive_validators, *pool_id);
+            <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+        };
+    <a href="staking_pool.md#0x3_staking_pool_exchange_rates">staking_pool::exchange_rates</a>(<a href="validator.md#0x3_validator_get_staking_pool_ref">validator::get_staking_pool_ref</a>(<a href="validator.md#0x3_validator">validator</a>))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -69,6 +69,7 @@
 -  [Function `active_validators`](#0x3_validator_set_active_validators)
 -  [Function `is_validator_candidate`](#0x3_validator_set_is_validator_candidate)
 -  [Function `is_inactive_validator`](#0x3_validator_set_is_inactive_validator)
+-  [Function `active_validator_addresses`](#0x3_validator_set_active_validator_addresses)
 -  [Module Specification](#@Module_Specification_1)
 
 
@@ -2856,6 +2857,39 @@ Returns true if the staking pool identified by <code>staking_pool_id</code> is o
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_is_inactive_validator">is_inactive_validator</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, staking_pool_id: ID): bool {
     <a href="../../../.././build/Sui/docs/table.md#0x2_table_contains">table::contains</a>(&self.inactive_validators, staking_pool_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x3_validator_set_active_validator_addresses"></a>
+
+## Function `active_validator_addresses`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_active_validator_addresses">active_validator_addresses</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">validator_set::ValidatorSet</a>): <a href="">vector</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator_set.md#0x3_validator_set_active_validator_addresses">active_validator_addresses</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>): <a href="">vector</a>&lt;<b>address</b>&gt; {
+    <b>let</b> vs = &self.active_validators;
+    <b>let</b> res = <a href="">vector</a>[];
+    <b>let</b> i = 0;
+    <b>let</b> length = <a href="_length">vector::length</a>(vs);
+    <b>while</b> (i &lt; length) {
+        <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(<a href="_borrow">vector::borrow</a>(vs, i));
+        <a href="_push_back">vector::push_back</a>(&<b>mut</b> res, validator_address);
+        i = i + 1;
+    };
+    res
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -380,6 +380,18 @@ module sui_system::staking_pool {
         staking_pool.pending_total_sui_withdraw
     }
 
+    public(friend) fun exchange_rates(pool: &StakingPool): &Table<u64, PoolTokenExchangeRate> {
+        &pool.exchange_rates
+    }
+
+    public fun sui_amount(exchange_rate: &PoolTokenExchangeRate): u64 {
+        exchange_rate.sui_amount
+    }
+
+    public fun pool_token_amount(exchange_rate: &PoolTokenExchangeRate): u64 {
+        exchange_rate.pool_token_amount
+    }
+
     /// Returns true if the provided staking pool is preactive at the provided epoch.
     fun is_preactive_at_epoch(pool: &StakingPool, epoch: u64): bool{
         // Either the pool is currently preactive or the pool's starting epoch is later than the provided epoch.

--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -77,7 +77,7 @@ module sui_system::staking_pool {
     }
 
     /// A self-custodial object holding the staked SUI tokens.
-    struct StakedSui has key {
+    struct StakedSui has key, store {
         id: UID,
         /// ID of the staking pool we are staking with.
         pool_id: ID,
@@ -113,10 +113,9 @@ module sui_system::staking_pool {
     public(friend) fun request_add_stake(
         pool: &mut StakingPool,
         stake: Balance<SUI>,
-        staker: address,
         stake_activation_epoch: u64,
         ctx: &mut TxContext
-    ) {
+    ) : StakedSui {
         let sui_amount = balance::value(&stake);
         assert!(!is_inactive(pool), EDelegationToInactivePool);
         assert!(sui_amount > 0, EDelegationOfZeroSui);
@@ -127,11 +126,11 @@ module sui_system::staking_pool {
             principal: stake,
         };
         pool.pending_stake = pool.pending_stake + sui_amount;
-        transfer::transfer(staked_sui, staker);
+        staked_sui
     }
 
     /// Request to withdraw the given stake plus rewards from a staking pool.
-    /// Both the principal and corresponding rewards in SUI are withdrawn and transferred to the staker.
+    /// Both the principal and corresponding rewards in SUI are withdrawn.
     /// A proportional amount of pool token withdraw is recorded and processed at epoch change time.
     public(friend) fun request_withdraw_stake(
         pool: &mut StakingPool,

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -253,7 +253,7 @@ module sui_system::sui_system {
     ): StakedSui {
         let self = load_system_state_mut(wrapper);
         sui_system_state_inner::request_add_stake(self, stake, validator_address, ctx)
-}
+    }
 
     /// Add stake to a validator's staking pool using multiple coins.
     public entry fun request_add_stake_mul_coin(

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -47,16 +47,17 @@ module sui_system::sui_system {
     use sui::sui::SUI;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
+    use sui::object::ID;
+    use sui::table::Table;
     use sui_system::validator::Validator;
     use sui_system::validator_cap::UnverifiedValidatorOperationCap;
     use sui_system::sui_system_state_inner::{Self, SystemParameters, SuiSystemStateInnerV2};
     use sui_system::stake_subsidy::StakeSubsidy;
+    use sui_system::staking_pool::PoolTokenExchangeRate;
     use std::option;
     use sui::dynamic_field;
 
     #[test_only] use sui::balance;
-    #[test_only] use sui::object::ID;
-    #[test_only] use sui::table::Table;
     #[test_only] use sui_system::validator_set::ValidatorSet;
     #[test_only] use sui_system::validator_set;
     #[test_only] use sui::vec_set::VecSet;
@@ -515,6 +516,15 @@ module sui_system::sui_system {
     ) {
         let self = load_system_state_mut(self);
         sui_system_state_inner::update_candidate_validator_network_pubkey(self, network_pubkey, ctx)
+    }
+
+    /// Getter of the pool token exchange rate of a staking pool. Works for both active and inactive pools.
+    public fun pool_exchange_rates(
+        wrapper: &mut SuiSystemState,
+        pool_id: &ID
+    ): &Table<u64, PoolTokenExchangeRate>  {
+        let self = load_system_state_mut(wrapper);
+        sui_system_state_inner::pool_exchange_rates(self, pool_id)
     }
 
     /// This function should be called at the end of an epoch, and advances the system to the next epoch.

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -239,9 +239,20 @@ module sui_system::sui_system {
         validator_address: address,
         ctx: &mut TxContext,
     ) {
+        let staked_sui = request_add_stake_non_entry(wrapper, stake, validator_address, ctx);
+        transfer::public_transfer(staked_sui, tx_context::sender(ctx));
+    }
+
+    /// The non-entry version of `request_add_stake`, which returns the staked SUI instead of transferring it to the sender.
+    public fun request_add_stake_non_entry(
+        wrapper: &mut SuiSystemState,
+        stake: Coin<SUI>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ): StakedSui {
         let self = load_system_state_mut(wrapper);
         sui_system_state_inner::request_add_stake(self, stake, validator_address, ctx)
-    }
+}
 
     /// Add stake to a validator's staking pool using multiple coins.
     public entry fun request_add_stake_mul_coin(
@@ -252,10 +263,11 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_stake_mul_coin(self, stakes, stake_amount, validator_address, ctx)
+        let staked_sui = sui_system_state_inner::request_add_stake_mul_coin(self, stakes, stake_amount, validator_address, ctx);
+        transfer::public_transfer(staked_sui, tx_context::sender(ctx));
     }
 
-    /// Withdraw some portion of a stake from a validator's staking pool.
+    /// Withdraw stake from a validator's staking pool.
     public entry fun request_withdraw_stake(
         wrapper: &mut SuiSystemState,
         staked_sui: StakedSui,

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -527,6 +527,12 @@ module sui_system::sui_system {
         sui_system_state_inner::pool_exchange_rates(self, pool_id)
     }
 
+    /// Getter returning addresses of the currently active validators.
+    public fun active_validator_addresses(wrapper: &mut SuiSystemState): vector<address> {
+        let self = load_system_state(wrapper);
+        sui_system_state_inner::active_validator_addresses(self)
+    }
+
     /// This function should be called at the end of an epoch, and advances the system to the next epoch.
     /// It does the following things:
     /// 1. Add storage charge to the storage fund.

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -507,13 +507,13 @@ module sui_system::sui_system_state_inner {
         stake: Coin<SUI>,
         validator_address: address,
         ctx: &mut TxContext,
-    ) {
+    ) : StakedSui {
         validator_set::request_add_stake(
             &mut self.validators,
             validator_address,
             coin::into_balance(stake),
             ctx,
-        );
+        )
     }
 
     /// Add stake to a validator's staking pool using multiple coins.
@@ -523,9 +523,9 @@ module sui_system::sui_system_state_inner {
         stake_amount: option::Option<u64>,
         validator_address: address,
         ctx: &mut TxContext,
-    ) {
+    ) : StakedSui {
         let balance = extract_coin_balance(stakes, stake_amount, ctx);
-        validator_set::request_add_stake(&mut self.validators, validator_address, balance, ctx);
+        validator_set::request_add_stake(&mut self.validators, validator_address, balance, ctx)
     }
 
     /// Withdraw some portion of a stake from a validator's staking pool.

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -1047,6 +1047,11 @@ module sui_system::sui_system_state_inner {
         validator_set::pool_exchange_rates(validators, pool_id)
     }
 
+    public(friend) fun active_validator_addresses(self: &SuiSystemStateInnerV2): vector<address> {
+        let validator_set = &self.validators;
+        validator_set::active_validator_addresses(validator_set)
+    }
+
     /// Extract required Balance from vector of Coin<SUI>, transfer the remainder back to sender.
     fun extract_coin_balance(coins: vector<Coin<SUI>>, amount: option::Option<u64>, ctx: &mut TxContext): Balance<SUI> {
         let merged_coin = vector::pop_back(&mut coins);

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -14,6 +14,7 @@ module sui_system::sui_system_state_inner {
     use sui_system::validator_cap::{Self, UnverifiedValidatorOperationCap, ValidatorOperationCap};
     use sui_system::stake_subsidy::{Self, StakeSubsidy};
     use sui_system::storage_fund::{Self, StorageFund};
+    use sui_system::staking_pool::PoolTokenExchangeRate;
     use sui::vec_map::{Self, VecMap};
     use sui::vec_set::{Self, VecSet};
     use std::option;
@@ -1036,6 +1037,14 @@ module sui_system::sui_system_state_inner {
 
     public(friend) fun get_storage_fund_object_rebates(self: &SuiSystemStateInnerV2): u64 {
         storage_fund::total_object_storage_rebates(&self.storage_fund)
+    }
+
+    public(friend) fun pool_exchange_rates(
+        self: &mut SuiSystemStateInnerV2,
+        pool_id: &ID
+    ): &Table<u64, PoolTokenExchangeRate>  {
+        let validators = &mut self.validators;
+        validator_set::pool_exchange_rates(validators, pool_id)
     }
 
     /// Extract required Balance from vector of Coin<SUI>, transfer the remainder back to sender.

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -14,6 +14,7 @@ module sui_system::validator {
     use std::option::{Option, Self};
     use sui_system::staking_pool::{Self, PoolTokenExchangeRate, StakedSui, StakingPool};
     use std::string::{Self, String};
+    use sui::transfer;
     use sui::url::Url;
     use sui::url;
     use sui::event;
@@ -302,12 +303,12 @@ module sui_system::validator {
         stake: Balance<SUI>,
         staker_address: address,
         ctx: &mut TxContext,
-    ) {
+    ) : StakedSui {
         let stake_amount = balance::value(&stake);
         assert!(stake_amount > 0, EInvalidStakeAmount);
         let stake_epoch = tx_context::epoch(ctx) + 1;
-        staking_pool::request_add_stake(
-            &mut self.staking_pool, stake, staker_address, stake_epoch, ctx
+        let staked_sui = staking_pool::request_add_stake(
+            &mut self.staking_pool, stake, stake_epoch, ctx
         );
         // Process stake right away if staking pool is preactive.
         if (staking_pool::is_preactive(&self.staking_pool)) {
@@ -323,6 +324,7 @@ module sui_system::validator {
                 amount: stake_amount,
             }
         );
+        staked_sui
     }
 
     /// Request to add stake to the validator's staking pool at genesis
@@ -336,13 +338,14 @@ module sui_system::validator {
         let stake_amount = balance::value(&stake);
         assert!(stake_amount > 0, EInvalidStakeAmount);
 
-        staking_pool::request_add_stake(
+        let staked_sui = staking_pool::request_add_stake(
             &mut self.staking_pool,
             stake,
-            staker_address,
             0, // epoch 0 -- genesis
             ctx
         );
+
+        transfer::public_transfer(staked_sui, staker_address);
 
         // Process stake right away
         staking_pool::process_pending_stake(&mut self.staking_pool);

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -878,8 +878,7 @@ module sui_system::validator {
         // TODO: specify actual function behavior
      }
 
-    #[test_only]
-    public fun get_staking_pool_ref(self: &Validator) : &StakingPool {
+    public(friend) fun get_staking_pool_ref(self: &Validator) : &StakingPool {
         &self.staking_pool
     }
 

--- a/crates/sui-framework/packages/sui-system/sources/validator_set.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_set.move
@@ -1253,8 +1253,7 @@ module sui_system::validator_set {
         table::contains(&self.inactive_validators, staking_pool_id)
     }
 
-    #[test_only]
-    public fun active_validator_addresses(self: &ValidatorSet): vector<address> {
+    public(friend) fun active_validator_addresses(self: &ValidatorSet): vector<address> {
         let vs = &self.active_validators;
         let res = vector[];
         let i = 0;

--- a/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
@@ -53,12 +53,13 @@ module sui_system::validator_set_tests {
         let scenario = &mut scenario_val;
         {
             let ctx1 = test_scenario::ctx(scenario);
-            validator_set::request_add_stake(
+            let stake = validator_set::request_add_stake(
                 &mut validator_set,
                 @0x1,
                 coin::into_balance(coin::mint_for_testing(500 * MIST_PER_SUI, ctx1)),
                 ctx1,
             );
+            transfer::public_transfer(stake, @0x1);
             // Adding stake to existing active validator during the epoch
             // should not change total stake.
             assert!(validator_set::total_stake(&validator_set) == 100 * MIST_PER_SUI, 0);
@@ -162,12 +163,13 @@ module sui_system::validator_set_tests {
         let scenario = &mut scenario_val;
         let ctx1 = test_scenario::ctx(scenario);
 
-        validator_set::request_add_stake(
+        let stake = validator_set::request_add_stake(
             &mut validator_set,
             @0x1,
             balance::create_for_testing(MIST_PER_SUI - 1), // 1 MIST lower than the threshold
             ctx1,
         );
+        transfer::public_transfer(stake, @0x1);
         test_utils::destroy(validator_set);
         test_scenario::end(scenario_val);
     }
@@ -186,12 +188,13 @@ module sui_system::validator_set_tests {
         let scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
         let ctx1 = test_scenario::ctx(scenario);
-        validator_set::request_add_stake(
+        let stake = validator_set::request_add_stake(
             &mut validator_set,
             @0x1,
             balance::create_for_testing(MIST_PER_SUI), // min possible stake
             ctx1,
         );
+        transfer::public_transfer(stake, @0x1);
 
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
         assert!(validator_set::total_stake(&validator_set) == 101 * MIST_PER_SUI, 0);
@@ -224,12 +227,13 @@ module sui_system::validator_set_tests {
         test_scenario::next_tx(scenario, @0x42);
         {
             let ctx = test_scenario::ctx(scenario);
-            validator_set::request_add_stake(
+            let stake = validator_set::request_add_stake(
                 &mut validator_set,
                 @0x2,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
             );
+            transfer::public_transfer(stake, @0x42);
             // Adding stake to a preactive validator should not change total stake.
             assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
         };
@@ -265,12 +269,13 @@ module sui_system::validator_set_tests {
         test_scenario::next_tx(scenario, @0x42);
         {
             let ctx = test_scenario::ctx(scenario);
-            validator_set::request_add_stake(
+            let stake = validator_set::request_add_stake(
                 &mut validator_set,
                 @0x2,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
             );
+            transfer::public_transfer(stake, @0x42);
             // Adding stake to a preactive validator should not change total stake.
             assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
         };
@@ -357,12 +362,13 @@ module sui_system::validator_set_tests {
         test_scenario::next_tx(scenario, @0x42);
         {
             let ctx = test_scenario::ctx(scenario);
-            validator_set::request_add_stake(
+            let stake = validator_set::request_add_stake(
                 &mut validator_set,
                 @0x4,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
             );
+            transfer::public_transfer(stake, @0x42);
         };
 
         // So only @0x2 will be kicked out.

--- a/crates/sui-framework/packages/sui-system/tests/validator_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_tests.move
@@ -107,7 +107,8 @@ module sui_system::validator_tests {
         {
             let ctx = test_scenario::ctx(scenario);
             let new_stake = coin::into_balance(coin::mint_for_testing(30_000_000_000, ctx));
-            validator::request_add_stake(&mut validator, new_stake, sender, ctx);
+            let stake = validator::request_add_stake(&mut validator, new_stake, sender, ctx);
+            transfer::public_transfer(stake, sender);
 
             assert!(validator::total_stake(&validator) == 10_000_000_000, 0);
             assert!(validator::pending_stake_amount(&validator) == 30_000_000_000, 0);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "18",
+              "maxSupportedProtocolVersion": "19",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 18;
+const MAX_PROTOCOL_VERSION: u64 = 19;
 
 // Record history of protocol version allocations here:
 //
@@ -58,6 +58,7 @@ const MAX_PROTOCOL_VERSION: u64 = 18;
 //             such that the minimum transaction cost is the same as the minimum computation
 //             bucket.
 //             Add a feature flag to indicate the changes semantics of `base_tx_cost_fixed`.
+// Version 19: Changes to sui-system package to enable liquid staking.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1324,6 +1325,7 @@ impl ProtocolConfig {
                 cfg.base_tx_cost_fixed = Some(1_000);
                 cfg
             }
+            19 => Self::get_for_version_impl(version - 1, chain),
             // Use this template when making changes:
             //
             //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_19.snap
@@ -1,0 +1,187 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 19
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_19.snap
@@ -1,0 +1,188 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 19
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_19.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_19.snap
@@ -1,0 +1,189 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 19
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 18
+  protocol_version: 19
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 18
+protocol_version: 19
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xbc33d2e5c49afc1c1a9aeb606b5045285d62690045828621fc261b92ca044cb3"
+            id: "0xd3d51e2d57e5df140251e00d71bf7d82ff71b6d49df2a56ab402873bb4fc3371"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x424a382efc96d984bcff9b1fe86e49e15f0a400b9379f0e3d1e8c97d593a3c4b"
+      operation_cap_id: "0xf260673303abe4dcc212850f8e51a11dfe2841decb23a9dd3da862c6b08a3122"
       gas_price: 1000
       staking_pool:
-        id: "0x465b5b1e707a9d21c904271b55a38d9cd3907199e326b2df6f007c24137749f1"
+        id: "0x44575b55456f8968d14ed1368bc61d23e46885eb4ae699894ed270b6b241bc02"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xfa04aab675f2d5c61ffcb5e46aae28180ba77fa451449d1387348e3a636a0c68"
+          id: "0x46386bca9782f650d3728f948ce7ad3c8e3d7f30137840a75ac267f7962f890f"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xcbe6f3cb9b5c0b9bf844b7ed7869c3db76536a9a460972482dd3b7cb7f92462b"
+            id: "0x16c0c484d653b6820a0f2da36b5d6510c1a1a67190913488ee5bb2c47ea7ccb1"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x7b9cd1165db6ca5241f2bdfc38261dbb8bb58b76fe94bae4df9068ee20316e07"
+          id: "0x0e716b8beccc7a8410a7a012eeea1dfd0ce3d7106be2e94a39d10abb62d0844e"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x86adf3cfca174b0e4f090acb6b052b2829b3703305f8011700ee979e74063187"
+      id: "0x1714324b0981ebb175ceb770b07a4f15f395c31a3b6ead4569c1cd1986a4a536"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xe9d8f670db5dc0709ced9637228b87c638ec4bab3696f7e813ba5657be1e61b5"
+    id: "0x19ad6908b48ed48b00a54fabea0c0ce81e11d04b25d24e5d6859d65e5398d338"
     size: 1
   inactive_validators:
-    id: "0x8f1f5b046a5af0d52762f0ef38280af3a338645389f18089466d67e159c29c46"
+    id: "0xecd95fe2dde7ca060104e865f577ca33e13b4f60e3c4bd1f2be55cbec876cb48"
     size: 0
   validator_candidates:
-    id: "0x9b6d0ed963c8967d811a757ce710f37bb9af8f0618ab16191f76a8caef8b3ea5"
+    id: "0x80ae4e037599e2855ad209e2808bbab30b2fff9bae631309ac69a5f5bcb33356"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x4b8cc15efb002e2c85c95cbf66e75b5c3b71542436a794df35a9e3993abb484e"
+      id: "0x9b4055b5988cd196587ef4920c20ef9e66e8613c03a8f0239186c56de8a755ac"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xd18abc8eb691d5072fcb6baaac319974c83d6d7d8a8a6e9cafbdfcf141800702"
+      id: "0x5472d101013fec664acfa542568340bc9a05df7180531b93dcefb196f6fccdcd"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x5eba9713cc76bdc9dd38cb398e350ca2267ed49760e15c552511d083d80576b2"
+      id: "0x75e7c566c704c6fad638f5d507fa5a875e26668d3f2e8c1e274648a13217813a"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x63e0f3b038b1e50c782e99f3e6308ceb6b4008072dfa2fe2d6d060c4df49a057"
+    id: "0xd86d7ec3f1e33cd969fcd812e96b4f5e46685578b55fa6e3a9ed2ab917743ec1"
   size: 0
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xd3d51e2d57e5df140251e00d71bf7d82ff71b6d49df2a56ab402873bb4fc3371"
+            id: "0xf8a184f47a02f39515822ada6c98922858bbf3232deff7d69df81d663f01e6c9"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf260673303abe4dcc212850f8e51a11dfe2841decb23a9dd3da862c6b08a3122"
+      operation_cap_id: "0xb8d26d943a3de74e05b4387a6f03c2b2be5a6b2728fa8857ea7f26e43ccc943e"
       gas_price: 1000
       staking_pool:
-        id: "0x44575b55456f8968d14ed1368bc61d23e46885eb4ae699894ed270b6b241bc02"
+        id: "0x441ffdb74e4617e724e938f1b4f4638a50825768b33636896802caa55c5759ec"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x46386bca9782f650d3728f948ce7ad3c8e3d7f30137840a75ac267f7962f890f"
+          id: "0x062ab1ff0ddc4d2bb931295d47a0ad617c0084118ad75d2cfa6b8f768f19100e"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x16c0c484d653b6820a0f2da36b5d6510c1a1a67190913488ee5bb2c47ea7ccb1"
+            id: "0x8a9b770c494365b399e0742149aa9386e193ea8c662da46968236d239368aa08"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x0e716b8beccc7a8410a7a012eeea1dfd0ce3d7106be2e94a39d10abb62d0844e"
+          id: "0x5a85555e9b9c940bd6c3fd1604b70f538736a2457895c4e12c722d21907321ba"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x1714324b0981ebb175ceb770b07a4f15f395c31a3b6ead4569c1cd1986a4a536"
+      id: "0x3f36ca65c1f133b910c082a4fb9d18ff4ac3b0a80c5e256a5f15283a90543074"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x19ad6908b48ed48b00a54fabea0c0ce81e11d04b25d24e5d6859d65e5398d338"
+    id: "0x3b86d87266cf490617791f8cd38f1ecfe800bf38a139c1daa53aeda0dc9a27a1"
     size: 1
   inactive_validators:
-    id: "0xecd95fe2dde7ca060104e865f577ca33e13b4f60e3c4bd1f2be55cbec876cb48"
+    id: "0x6a6ed0b85137d99da1b8794750646b1c93db11e5e8227cb37219ab4540363bf3"
     size: 0
   validator_candidates:
-    id: "0x80ae4e037599e2855ad209e2808bbab30b2fff9bae631309ac69a5f5bcb33356"
+    id: "0xebc1dcfef9a5c4329d1e6c0c9186fcebf7502823fd1328cab7f60647280bee88"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x9b4055b5988cd196587ef4920c20ef9e66e8613c03a8f0239186c56de8a755ac"
+      id: "0x4b59d5babe873bf610b29b03e21ebdfc7bb5ca4f81c86a4c818e1718a5a09bd6"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x5472d101013fec664acfa542568340bc9a05df7180531b93dcefb196f6fccdcd"
+      id: "0xf8761b5f15562fa1f7bb9d9cb45334cd9e3164af39d84ad1c2a89d86783d5a83"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x75e7c566c704c6fad638f5d507fa5a875e26668d3f2e8c1e274648a13217813a"
+      id: "0xb8ffa70fc19a6c0ac04314f319d60bc10dd33484a8e4e4c158df05bfa57825d9"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xd86d7ec3f1e33cd969fcd812e96b4f5e46685578b55fa6e3a9ed2ab917743ec1"
+    id: "0x511ae6bd059482cd3a87e87fa7c7bc4e7004890b36b150ecdd0cdc9875277ff8"
   size: 0
 


### PR DESCRIPTION
## Description 

Implemented [SIP-6](https://github.com/AftermathFinance/sips/blob/main/sips/sip-6.md):
- Added `store` ability to `StakedSui` object
- Added a PTB-friendly version of `request_add_stake`
- Added getters for pool token exchange rates and active validator addresses

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This release adds the `store` ability to the `StakedSui` object. With `store` ability, stake objects can be transferred freely and wrapped in other objects, making it possible to implement liquid staking derivatives. To make staking more atomically composable with other on-chain actions,  we also added a new PTB-friendly staking function `request_add_stake_non_entry` that stakes SUI tokens with a given validator and returns the `StakedSui` object as the return value. Public getters are added for active validators' addresses and the pool token exchange rate of each validator's staking pool. These additions allow developers to better interact with the staking module in their contract.

These changes are the result of proposal [SIP-6](https://github.com/AftermathFinance/sips/blob/main/sips/sip-6.md). Please refer to the SIP for more detailed information and motivation around the changes.

