### PR TITLE
[transactional-tests] Publish correct framework based on protocol version in the transactional test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10974,6 +10974,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-framework",
+ "sui-framework-snapshot",
  "sui-json-rpc",
  "sui-json-rpc-types",
  "sui-protocol-config",

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -40,6 +40,7 @@ sui-types = { workspace = true, features = ["test-utils"]}
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 sui-json-rpc-types.workspace = true
 sui-json-rpc.workspace = true
+sui-framework-snapshot.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true


### PR DESCRIPTION
## Description 

Previously when you specified a specific protocol version in a transactional test this wouldn't change or select the correct framework for that protocol version. This now fetches the correct framework objects based on the protocol version from the framework snapshots.

## Test Plan 

Make sure existing tests still pass, and that the tests that were failing because of this in the transfer-to-object PR are passing. 

