### PR TITLE
indexer: checkpoint metrics processor

### DIFF
--- a/crates/sui-indexer/migrations/2023-07-06-182806_checkpoint_metrics/down.sql
+++ b/crates/sui-indexer/migrations/2023-07-06-182806_checkpoint_metrics/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS checkpoint_metrics;

--- a/crates/sui-indexer/migrations/2023-07-06-182806_checkpoint_metrics/up.sql
+++ b/crates/sui-indexer/migrations/2023-07-06-182806_checkpoint_metrics/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE checkpoint_metrics
+(
+    checkpoint                                     BIGINT PRIMARY KEY,
+    epoch                                               BIGINT NOT NULL,   
+    real_time_tps                                       FLOAT8 NOT NULL,
+    peak_tps_30d                                        FLOAT8 NOT NULL, 
+    rolling_total_transactions                          BIGINT NOT NULL,
+    rolling_total_transaction_blocks                    BIGINT NOT NULL,
+    rolling_total_successful_transactions               BIGINT NOT NULL,
+    rolling_total_successful_transaction_blocks         BIGINT NOT NULL
+);

--- a/crates/sui-indexer/src/models/checkpoint_metrics.rs
+++ b/crates/sui-indexer/src/models/checkpoint_metrics.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::prelude::*;
+use diesel::sql_types::Float8;
+
+use crate::schema::checkpoint_metrics;
+
+#[derive(Queryable, Insertable, Debug, Clone)]
+#[diesel(table_name = checkpoint_metrics)]
+pub struct CheckpointMetrics {
+    pub checkpoint: i64,
+    pub epoch: i64,
+    pub real_time_tps: f64,
+    pub peak_tps_30d: f64,
+    pub rolling_total_transactions: i64,
+    pub rolling_total_transaction_blocks: i64,
+    pub rolling_total_successful_transactions: i64,
+    pub rolling_total_successful_transaction_blocks: i64,
+}
+
+impl Default for CheckpointMetrics {
+    fn default() -> Self {
+        Self {
+            // -1 to differentiate from first checkpoint of sequence 0
+            checkpoint: -1,
+            epoch: 0,
+            real_time_tps: 0.0,
+            peak_tps_30d: 0.0,
+            rolling_total_transactions: 0,
+            rolling_total_transaction_blocks: 0,
+            rolling_total_successful_transactions: 0,
+            rolling_total_successful_transaction_blocks: 0,
+        }
+    }
+}
+
+#[derive(Debug, QueryableByName)]
+pub struct Tps {
+    #[diesel(sql_type = Float8)]
+    pub tps: f64,
+}

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -29,6 +29,11 @@ pub struct Checkpoint {
     pub total_computation_cost: i64,
     pub total_storage_cost: i64,
     pub total_storage_rebate: i64,
+    // NOTE: we should use the following formula as tps_total_transactions for TPS calculation:
+    // total_successful_transactions + total_transaction_blocks - total_successful_transaction_blocks
+    // such that:
+    /// - a successful transaction block is counted as (number of commands in the block);
+    /// - a failed transaction block is counted as 1.
     pub total_transaction_blocks: i64,
     pub total_transactions: i64,
     pub total_successful_transaction_blocks: i64,

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod addresses;
+pub mod checkpoint_metrics;
 pub mod checkpoints;
 pub mod epoch;
 pub mod events;

--- a/crates/sui-indexer/src/processors/checkpoint_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors/checkpoint_metrics_processor.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use tracing::{info, warn};
+
+use crate::errors::IndexerError;
+use crate::store::IndexerStore;
+
+const CHECKPOINT_METRICS_BATCH_SIZE: usize = 100;
+const DB_COMMIT_RETRY_INTERVAL_IN_MILLIS: u64 = 100;
+
+pub struct CheckpointMetricsProcessor<S> {
+    pub store: S,
+}
+
+impl<S> CheckpointMetricsProcessor<S>
+where
+    S: IndexerStore + Sync + Send + 'static,
+{
+    pub fn new(store: S) -> CheckpointMetricsProcessor<S> {
+        Self { store }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer checkpoint metrics async processor started...");
+        let mut last_cp_metrics = self
+            .store
+            .get_latest_checkpoint_metrics()
+            .await
+            .unwrap_or_default();
+        let mut last_processed_cp = last_cp_metrics.checkpoint;
+        // process another batch of events, 100 checkpoints at a time, otherwise sleep for 3 seconds
+        loop {
+            let latest_checkpoint = self.store.get_latest_checkpoint_sequence_number().await?;
+            if latest_checkpoint >= last_processed_cp + CHECKPOINT_METRICS_BATCH_SIZE as i64 {
+                let checkpoints = self
+                    .store
+                    .get_indexer_checkpoints(last_processed_cp, CHECKPOINT_METRICS_BATCH_SIZE)
+                    .await?;
+
+                let cp_metrics = self
+                    .store
+                    .calculate_checkpoint_metrics(
+                        last_processed_cp + CHECKPOINT_METRICS_BATCH_SIZE as i64,
+                        &last_cp_metrics,
+                        &checkpoints,
+                    )
+                    .await?;
+
+                let mut cp_metrics_commit_res =
+                    self.store.persist_checkpoint_metrics(&cp_metrics).await;
+                while let Err(e) = cp_metrics_commit_res {
+                    warn!("Failed to commit checkpoint metrics to DB: {}", e);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(
+                        DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
+                    ))
+                    .await;
+                    cp_metrics_commit_res =
+                        self.store.persist_checkpoint_metrics(&cp_metrics).await;
+                }
+                info!(
+                    "Processed checkpoint metrics for checkpoint {}",
+                    cp_metrics.checkpoint
+                );
+                last_processed_cp += CHECKPOINT_METRICS_BATCH_SIZE as i64;
+                last_cp_metrics = cp_metrics;
+            } else {
+                tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+                continue;
+            }
+        }
+    }
+}

--- a/crates/sui-indexer/src/processors/mod.rs
+++ b/crates/sui-indexer/src/processors/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod address_processor;
+pub mod checkpoint_metrics_processor;
 pub mod object_processor;
 pub mod processor_orchestrator;

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -69,6 +69,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    checkpoint_metrics (checkpoint) {
+        checkpoint -> Int8,
+        epoch -> Int8,
+        real_time_tps -> Float8,
+        peak_tps_30d -> Float8,
+        rolling_total_transactions -> Int8,
+        rolling_total_transaction_blocks -> Int8,
+        rolling_total_successful_transactions -> Int8,
+        rolling_total_successful_transaction_blocks -> Int8,
+    }
+}
+
+diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Int8,
         checkpoint_digest -> Varchar,
@@ -339,6 +352,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     addresses,
     at_risk_validators,
     changed_objects,
+    checkpoint_metrics,
     checkpoints,
     epochs,
     events,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -21,6 +21,7 @@ use sui_types::storage::ObjectStore;
 use crate::errors::IndexerError;
 use crate::metrics::IndexerMetrics;
 use crate::models::addresses::{ActiveAddress, Address, AddressStats};
+use crate::models::checkpoint_metrics::CheckpointMetrics;
 use crate::models::checkpoints::Checkpoint;
 use crate::models::epoch::DBEpochInfo;
 use crate::models::events::Event;
@@ -42,6 +43,12 @@ pub trait IndexerStore {
         cursor: Option<CheckpointId>,
         limit: usize,
     ) -> Result<Vec<RpcCheckpoint>, IndexerError>;
+    async fn get_indexer_checkpoint(&self) -> Result<Checkpoint, IndexerError>;
+    async fn get_indexer_checkpoints(
+        &self,
+        cursor: i64,
+        limit: usize,
+    ) -> Result<Vec<Checkpoint>, IndexerError>;
     async fn get_checkpoint_sequence_number(
         &self,
         digest: CheckpointDigest,
@@ -267,6 +274,27 @@ pub trait IndexerStore {
         &self,
         descending_order: Option<bool>,
     ) -> Result<Vec<AddressStats>, IndexerError>;
+
+    /// methods for checkpoint metrics
+    async fn calculate_checkpoint_metrics(
+        &self,
+        current_checkpoint: i64,
+        last_checkpoint_metrics: &CheckpointMetrics,
+        checkpoints: &[Checkpoint],
+    ) -> Result<CheckpointMetrics, IndexerError>;
+    async fn persist_checkpoint_metrics(
+        &self,
+        checkpoint_metrics: &CheckpointMetrics,
+    ) -> Result<(), IndexerError>;
+    async fn get_latest_checkpoint_metrics(&self) -> Result<CheckpointMetrics, IndexerError>;
+
+    /// TPS related methods
+    async fn calculate_real_time_tps(&self, current_checkpoint: i64) -> Result<f64, IndexerError>;
+    async fn calculate_peak_tps_30d(
+        &self,
+        current_checkpoint: i64,
+        current_timestamp_ms: i64,
+    ) -> Result<f64, IndexerError>;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -132,7 +132,7 @@ pub trait ReadApi {
         transaction_digest: TransactionDigest,
     ) -> RpcResult<Vec<SuiEvent>>;
 
-    /// Return the total number of transactions known to the server.
+    /// Return the total number of transaction blocks known to the server.
     #[method(name = "getTotalTransactionBlocks")]
     async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt<u64>>;
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1863,7 +1863,7 @@
           "name": "Read API"
         }
       ],
-      "description": "Return the total number of transactions known to the server.",
+      "description": "Return the total number of transaction blocks known to the server.",
       "params": [],
       "result": {
         "name": "BigInt<u64>",


### PR DESCRIPTION
## Description 

This PR added a new async processor for checkpoint metrics, it will be useful
- 30D peak TPS will be updated each 100 checkpoints instead of one epoch
- we will have TPS & peak TPS time series data, which can be used for TPS charts
- tx block count -> tx count, which will show higher numbers that are consistent with TPS formula

## Test Plan 

local run and make sure that the new table can be populated as expected.

cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url http://ewr-suifn-y71v1.devnet.sui.io:9000 --fullnode-sync-worker --reset-db

![Screenshot 2023-07-06 at 5 25 08 PM](https://github.com/MystenLabs/sui/assets/106119108/6cd9a645-2d25-4c52-bdda-28c64b3af9a3)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
