### PR TITLE
Add documentation for clear method and a safe clear method

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -373,7 +373,7 @@ impl AuthorityEpochTables {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> SuiResult {
         // TODO: Add new tables that get added to the db automatically
-        self.executed_transactions_to_checkpoint.clear()?;
+        self.executed_transactions_to_checkpoint.unsafe_clear()?;
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -399,18 +399,18 @@ impl AuthorityPerpetualTables {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> SuiResult {
         // TODO: Add new tables that get added to the db automatically
-        self.objects.clear()?;
-        self.indirect_move_objects.clear()?;
-        self.owned_object_transaction_locks.clear()?;
-        self.executed_effects.clear()?;
-        self.events.clear()?;
-        self.executed_transactions_to_checkpoint.clear()?;
-        self.root_state_hash_by_epoch.clear()?;
-        self.epoch_start_configuration.clear()?;
-        self.pruned_checkpoint.clear()?;
-        self.expected_network_sui_amount.clear()?;
-        self.expected_storage_fund_imbalance.clear()?;
-        self.object_per_epoch_marker_table.clear()?;
+        self.objects.unsafe_clear()?;
+        self.indirect_move_objects.unsafe_clear()?;
+        self.owned_object_transaction_locks.unsafe_clear()?;
+        self.executed_effects.unsafe_clear()?;
+        self.events.unsafe_clear()?;
+        self.executed_transactions_to_checkpoint.unsafe_clear()?;
+        self.root_state_hash_by_epoch.unsafe_clear()?;
+        self.epoch_start_configuration.unsafe_clear()?;
+        self.pruned_checkpoint.unsafe_clear()?;
+        self.expected_network_sui_amount.unsafe_clear()?;
+        self.expected_storage_fund_imbalance.unsafe_clear()?;
+        self.object_per_epoch_marker_table.unsafe_clear()?;
         self.objects
             .rocksdb
             .flush()

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -135,6 +135,13 @@ impl<'a, K: Serialize, V> Iter<'a, K, V> {
         self
     }
 
+    /// Seeks to the first key in the database (at this column family).
+    pub fn seek_to_first(mut self) -> Self {
+        self.is_initialized = true;
+        self.db_iter.seek_to_first();
+        self
+    }
+
     /// Will make the direction of the iteration reverse and will
     /// create a new `RevIter` to consume. Every call to `next` method
     /// will give the next element from the end.

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1726,11 +1726,29 @@ where
         Ok(())
     }
 
+    /// This method first drops the existing column family and then creates a new one
+    /// with the same name. The two operations are not atomic and hence it is possible
+    /// to get into a race condition where the column family has been dropped but new
+    /// one is not created yet
     #[instrument(level = "trace", skip_all, err)]
-    fn clear(&self) -> Result<(), TypedStoreError> {
+    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
         let _ = self.rocksdb.drop_cf(&self.cf);
         self.rocksdb
             .create_cf(self.cf.clone(), &default_db_options().options)?;
+        Ok(())
+    }
+
+    /// Deletes all entries in the db map using a single delete range operation
+    #[instrument(level = "trace", skip_all, err)]
+    fn delete_all(&self) -> Result<(), TypedStoreError> {
+        let mut iter = self.unbounded_iter().seek_to_first();
+        let first_key = iter.next().map(|(k, _v)| k);
+        let last_key = iter.skip_to_last().next().map(|(k, _v)| k);
+        if let Some((first_key, last_key)) = first_key.zip(last_key) {
+            let mut batch = self.batch();
+            batch.delete_range(self, &first_key, &last_key)?;
+            batch.write()?;
+        }
         Ok(())
     }
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -556,7 +556,7 @@ async fn test_clear() {
     )
     .expect("Failed to open storage");
     // Test clear of empty map
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
 
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
     let mut insert_batch = db.batch();
@@ -568,15 +568,15 @@ async fn test_clear() {
 
     // Check we have multiple entries
     assert!(db.safe_iter().count() > 1);
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
     assert_eq!(db.safe_iter().count(), 0);
     // Clear again to ensure safety when clearing empty map
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
     assert_eq!(db.safe_iter().count(), 0);
     // Clear with one item
     let _ = db.insert(&1, &"e".to_string());
     assert_eq!(db.safe_iter().count(), 1);
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
     assert_eq!(db.safe_iter().count(), 0);
 }
 
@@ -741,7 +741,7 @@ async fn test_is_empty() {
 
     // Test empty map is truly empty
     assert!(db.is_empty());
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
     assert!(db.is_empty());
 
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -757,7 +757,7 @@ async fn test_is_empty() {
     assert!(!db.is_empty());
 
     // Clear again to ensure empty works after clearing
-    let _ = db.clear();
+    let _ = db.unsafe_clear();
     assert_eq!(db.safe_iter().count(), 0);
     assert!(db.is_empty());
 }

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -259,7 +259,13 @@ where
         Ok(())
     }
 
-    fn clear(&self) -> Result<(), Self::Error> {
+    fn unsafe_clear(&self) -> Result<(), Self::Error> {
+        let mut locked = self.rows.write().unwrap();
+        locked.clear();
+        Ok(())
+    }
+
+    fn delete_all(&self) -> Result<(), TypedStoreError> {
         let mut locked = self.rows.write().unwrap();
         locked.clear();
         Ok(())
@@ -712,7 +718,7 @@ mod test {
         let db: TestDB<i32, String> = TestDB::open();
 
         // Test clear of empty map
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
 
         let keys_vals = (0..101).map(|i| (i, i.to_string()));
         let mut wb = db.batch();
@@ -723,15 +729,15 @@ mod test {
 
         // Check we have multiple entries
         assert!(db.safe_iter().count() > 1);
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
         assert_eq!(db.safe_iter().count(), 0);
         // Clear again to ensure safety when clearing empty map
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
         assert_eq!(db.safe_iter().count(), 0);
         // Clear with one item
         let _ = db.insert(&1, &"e".to_string());
         assert_eq!(db.safe_iter().count(), 1);
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
         assert_eq!(db.safe_iter().count(), 0);
     }
 
@@ -741,7 +747,7 @@ mod test {
 
         // Test empty map is truly empty
         assert!(db.is_empty());
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
         assert!(db.is_empty());
 
         let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -756,7 +762,7 @@ mod test {
         assert!(!db.is_empty());
 
         // Clear again to ensure empty works after clearing
-        let _ = db.clear();
+        let _ = db.unsafe_clear();
         assert_eq!(db.safe_iter().count(), 0);
         assert!(db.is_empty());
     }

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -63,7 +63,10 @@ where
     fn remove(&self, key: &K) -> Result<(), Self::Error>;
 
     /// Removes every key-value pair from the map.
-    fn clear(&self) -> Result<(), Self::Error>;
+    fn unsafe_clear(&self) -> Result<(), Self::Error>;
+
+    /// Uses delete range on the entire key range
+    fn delete_all(&self) -> Result<(), TypedStoreError>;
 
     /// Returns true if the map is empty, otherwise false.
     fn is_empty(&self) -> bool;

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -657,9 +657,9 @@ impl<T: Cache> CertificateStore<T> {
     pub fn clear(&self) -> StoreResult<()> {
         fail_point!("narwhal-store-before-write");
 
-        self.certificates_by_id.clear()?;
-        self.certificate_id_by_round.clear()?;
-        self.certificate_id_by_origin.clear()?;
+        self.certificates_by_id.unsafe_clear()?;
+        self.certificate_id_by_round.unsafe_clear()?;
+        self.certificate_id_by_origin.unsafe_clear()?;
 
         fail_point!("narwhal-store-after-write");
         Ok(())

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -54,9 +54,9 @@ impl ConsensusStore {
 
     /// Clear the store.
     pub fn clear(&self) -> StoreResult<()> {
-        self.last_committed.clear()?;
-        self.committed_sub_dags_by_index.clear()?;
-        self.committed_sub_dags_by_index_v2.clear()?;
+        self.last_committed.unsafe_clear()?;
+        self.committed_sub_dags_by_index.unsafe_clear()?;
+        self.committed_sub_dags_by_index_v2.unsafe_clear()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

Add documentation for `clear` method in typed store and a `safe_clear` method. The method `safe_clear` takes a simple approach to prevent race from happening by letting the user pass in the lock to guard the critical section

## Test Plan 

Existing tests
