### PR TITLE
move: source service supports standalone directory

### DIFF
--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -1,4 +1,6 @@
 [[packages]]
+source = "Repository"
+[packages.values]
 repository = "https://github.com/mystenlabs/sui"
 branch = "mainnet-v1.3.1"
 paths = [


### PR DESCRIPTION
## Description 

Previously the source service config only supports cloning a repository containing packages. This PR creates a variant on the type of source input to also support verifying and service packages directly from a local directory. 

I'm adding this after it got tedious to keep cloning repo paths, and as we move forward to trigger syncing / re-verifying upgraded packages, it's handed to have the source service to additionally accept a local path as well. At this point it's mostly intended for ease of testing and debugging.

There is a small increase in config schema complexity for specifying the kind of source input, and worth the hassle IMO.

## Test Plan 

Updated unit test to parse variant.