### PR TITLE
[narwhal] enable randomized tests for new consensus schedule algorithm

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,8 +20,8 @@ status-level = "skip"
 fail-fast = false
 # Do not retry failing tests
 retries = 0
-# Mark tests as slow after 4 hours, kill them right after
-slow-timeout = { period = "4h", terminate-after = 1 }
+# Mark tests as slow after 7 hours, kill them right after
+slow-timeout = { period = "7h", terminate-after = 1 }
 
 [profile.simtestnightly]
 # Print out output for failing tests as soon as they fail, and also at the end

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -203,7 +203,7 @@ async fn bullshark_randomised_tests_with_config(protocol_config: ProtocolConfig)
                         run_id,
                         mode,
                         consensus_store,
-                        config
+                        &config
                     );
                 });
 
@@ -504,7 +504,7 @@ fn generate_and_run_execution_plans(
     run_id: u64,
     modes: FailureModes,
     store: Arc<ConsensusStore>,
-    protocol_config: ProtocolConfig,
+    protocol_config: &ProtocolConfig,
 ) {
     println!(
         "Running execution plans for run_id {} for rounds={}, committee={}, gc_depth={}, modes={:?}",


### PR DESCRIPTION
## Description 

Making the consensus randomized tests run for both the new and current schedule algorithm to ensure that until we enable it on production things work as expected.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
