### PR TITLE
[narwhal] make bad nodes stake configurable via the protocol config

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1408,6 +1408,7 @@
                 "buffer_stake_for_protocol_upgrade_bps": {
                   "u64": "5000"
                 },
+                "consensus_bad_nodes_stake_threshold": null,
                 "crypto_invalid_arguments_cost": {
                   "u64": "100"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -710,6 +710,10 @@ pub struct ProtocolConfig {
 
     /// === Execution Version ===
     execution_version: Option<u64>,
+
+    // Dictates the threshold (percentage of stake) that is used to calculate the "bad" nodes to be
+    // swapped when creating the consensus schedule.
+    consensus_bad_nodes_stake_threshold: Option<f64>,
 }
 
 // feature flags
@@ -1175,6 +1179,7 @@ impl ProtocolConfig {
                 gas_rounding_step: None,
 
                 execution_version: None,
+                consensus_bad_nodes_stake_threshold: None
                 // When adding a new constant, set it to None in the earliest version, like this:
                 // new_constant: None,
             },
@@ -1387,6 +1392,10 @@ impl ProtocolConfig {
     }
     pub fn set_narwhal_new_leader_election_schedule(&mut self, val: bool) {
         self.feature_flags.narwhal_new_leader_election_schedule = val;
+    }
+
+    pub fn set_consensus_bad_nodes_stake_threshold(&mut self, val: f64) {
+        self.consensus_bad_nodes_stake_threshold = Some(val);
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1370,9 +1370,11 @@ impl ProtocolConfig {
     pub fn set_zklogin_auth(&mut self, val: bool) {
         self.feature_flags.zklogin_auth = val
     }
+
     pub fn set_max_tx_gas_for_testing(&mut self, max_tx_gas: u64) {
         self.max_tx_gas = Some(max_tx_gas)
     }
+
     pub fn set_execution_version_for_testing(&mut self, version: u64) {
         self.execution_version = Some(version)
     }
@@ -1382,6 +1384,9 @@ impl ProtocolConfig {
     #[cfg(msim)]
     pub fn set_simplified_unwrap_then_delete(&mut self, val: bool) {
         self.feature_flags.simplified_unwrap_then_delete = val
+    }
+    pub fn set_narwhal_new_leader_election_schedule(&mut self, val: bool) {
+        self.feature_flags.narwhal_new_leader_election_schedule = val;
     }
 }
 

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -190,15 +190,6 @@ impl Committee {
         NonZeroU64::new(2 * total_votes / 3 + 1).unwrap()
     }
 
-    /*
-
-    N = 3f + 1
-
-    N - 1 = 3f
-    (N - 1) / 3 = f = 100 -1 / 3 = 99 / 3 = 33
-
-     */
-
     fn calculate_validity_threshold(&self) -> NonZeroU64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -190,6 +190,15 @@ impl Committee {
         NonZeroU64::new(2 * total_votes / 3 + 1).unwrap()
     }
 
+    /*
+
+    N = 3f + 1
+
+    N - 1 = 3f
+    (N - 1) / 3 = f = 100 -1 / 3 = 99 / 3 = 33
+
+     */
+
     fn calculate_validity_threshold(&self) -> NonZeroU64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
@@ -10,6 +9,7 @@ use crate::{
 };
 use config::{Committee, Stake};
 use fastcrypto::hash::Hash;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use storage::ConsensusStore;
 use sui_protocol_config::ProtocolConfig;
@@ -320,11 +320,7 @@ impl Bullshark {
 
     /// Order the past leaders that we didn't already commit. It orders the leaders from the one
     /// of the older (smaller) round to the newest round.
-    pub fn order_leaders(
-        &self,
-        leader: &Certificate,
-        state: &ConsensusState,
-    ) -> VecDeque<Certificate> {
+    fn order_leaders(&self, leader: &Certificate, state: &ConsensusState) -> VecDeque<Certificate> {
         let mut to_commit = VecDeque::new();
         to_commit.push_front(leader.clone());
 

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -411,6 +411,7 @@ impl Bullshark {
                     &self.committee,
                     leader_round,
                     reputation_scores,
+                    self.protocol_config.consensus_bad_nodes_stake_threshold(),
                 ));
 
             return true;

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -223,26 +223,26 @@ impl LeaderSchedule {
 
         // TODO: split the leader election logic for testing from the production code.
         cfg_if::cfg_if! {
-        if #[cfg(test)] {
-            // We apply round robin in leader election. Since we expect round to be an even number,
-            // 2, 4, 6, 8... it can't work well for leader election as we'll omit leaders. Thus
-            // we can always divide by 2 to get a monotonically incremented sequence,
-            // 2/2 = 1, 4/2 = 2, 6/2 = 3, 8/2 = 4  etc, and then do minus 1 so we can always
-            // start with base zero 0.
-            let next_leader = (round/2 - 1) as usize % self.committee.size();
-            let authorities = self.committee.authorities().collect::<Vec<_>>();
+            if #[cfg(test)] {
+                // We apply round robin in leader election. Since we expect round to be an even number,
+                // 2, 4, 6, 8... it can't work well for leader election as we'll omit leaders. Thus
+                // we can always divide by 2 to get a monotonically incremented sequence,
+                // 2/2 = 1, 4/2 = 2, 6/2 = 3, 8/2 = 4  etc, and then do minus 1 so we can always
+                // start with base zero 0.
+                let next_leader = (round/2 - 1) as usize % self.committee.size();
+                let authorities = self.committee.authorities().collect::<Vec<_>>();
 
-            let leader: Authority = (*authorities.get(next_leader).unwrap()).clone();
-            let table = self.leader_swap_table.read();
+                let leader: Authority = (*authorities.get(next_leader).unwrap()).clone();
+                let table = self.leader_swap_table.read();
 
-            table.swap(&leader.id(), round).unwrap_or(leader)
-        } else {
-            // Elect the leader in a stake-weighted choice seeded by the round
-            let leader = self.committee.leader(round);
+                table.swap(&leader.id(), round).unwrap_or(leader)
+            } else {
+                // Elect the leader in a stake-weighted choice seeded by the round
+                let leader = self.committee.leader(round);
 
-            let table = self.leader_swap_table.read();
-            table.swap(&leader.id(), round).unwrap_or(leader)
-        }
+                let table = self.leader_swap_table.read();
+                table.swap(&leader.id(), round).unwrap_or(leader)
+            }
         }
     }
 

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -155,14 +155,14 @@ impl LeaderSchedule {
         }
     }
 
+    /// Restores the LeaderSchedule by using the storage. It will attempt to retrieve the last committed
+    /// "final" ReputationScores and use them to create build a LeaderSwapTable to use for the LeaderSchedule.
     pub fn from_store(
         committee: Committee,
         store: Arc<ConsensusStore>,
         protocol_config: ProtocolConfig,
     ) -> Self {
-        // restore the final ReputationScores to create a LeaderSwapTable. If not found then fallback
-        // to default swap table.
-        // Only try to restore when the new leader election schedule is enabled, other fallback to
+        // Only try to restore when the new leader election schedule is enabled, otherwise fallback to
         // default swap table, which basically means there will be no swaps.
         let table = if protocol_config.narwhal_new_leader_election_schedule() {
             store

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -279,9 +279,6 @@ pub struct ConsensusState {
     pub last_committed: HashMap<AuthorityIdentifier, Round>,
     /// The last committed sub dag. If value is None, it means that we haven't committed any sub dag yet.
     pub last_committed_sub_dag: Option<CommittedSubDag>,
-    /// Holds the set of good and bad nodes - as per the last calculated reputation scores - and
-    /// performs a necessary swap to ensure that only good leaders will be elected
-    pub leader_swap_table: LeaderSwapTable,
     /// Keeps the latest committed certificate (and its parents) for every authority. Anything older
     /// must be regularly cleaned up through the function `update`.
     pub dag: Dag,
@@ -295,7 +292,6 @@ impl ConsensusState {
             last_round: ConsensusRound::default(),
             gc_depth,
             last_committed: Default::default(),
-            leader_swap_table: Default::default(),
             dag: Default::default(),
             last_committed_sub_dag: None,
             metrics,
@@ -351,7 +347,6 @@ impl ConsensusState {
             last_round,
             last_committed: recovered_last_committed,
             last_committed_sub_dag,
-            leader_swap_table: Default::default(),
             dag,
             metrics,
         }

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -168,7 +168,11 @@ impl LeaderSchedule {
             store
                 .read_latest_commit_with_final_reputation_scores()
                 .map_or(LeaderSwapTable::default(), |commit| {
-                    LeaderSwapTable::new(&committee, &commit.reputation_score())
+                    LeaderSwapTable::new(
+                        &committee,
+                        commit.leader_round(),
+                        &commit.reputation_score(),
+                    )
                 })
         } else {
             LeaderSwapTable::default()

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -70,14 +70,21 @@ impl Debug for LeaderSwapTable {
 }
 
 impl LeaderSwapTable {
-    // constructs a new table based on the provided reputation scores.
-    pub fn new(committee: &Committee, round: Round, reputation_scores: &ReputationScores) -> Self {
+    // constructs a new table based on the provided reputation scores. The `bad_nodes_stake_threshold` designates the
+    // total (by stake) nodes that will be considered as "bad" based on their scores and will be replaced by good nodes.
+    pub fn new(
+        committee: &Committee,
+        round: Round,
+        reputation_scores: &ReputationScores,
+        bad_nodes_stake_threshold: f64,
+    ) -> Self {
         assert!(reputation_scores.final_of_schedule, "Only reputation scores that have been calculated on the end of a schedule are accepted");
 
         // calculating the good nodes
         let good_nodes = Self::retrieve_first_nodes(
             committee,
             reputation_scores.authorities_by_score_desc().into_iter(),
+            bad_nodes_stake_threshold,
         );
 
         // calculating the bad nodes
@@ -88,6 +95,7 @@ impl LeaderSwapTable {
                 .authorities_by_score_desc()
                 .into_iter()
                 .rev(),
+            bad_nodes_stake_threshold,
         )
         .into_iter()
         .map(|authority| (authority.id(), authority))
@@ -133,12 +141,15 @@ impl LeaderSwapTable {
         None
     }
 
-    // Retrieves the first f by stake nodes provided by the iterator `authorities`. It's the
-    // caller's responsibility to ensure that the elements of the `authorities` input is already
-    // sorted.
+    // Retrieves the first nodes provided by the iterator `authorities` until the `stake_threshold` has been
+    // reached. The `stake_threshold` should be between [0, 1] and expresses the percentage of stake that is
+    // considered the cutoff. Basically we keep adding to the response authorities until the sum of the stake
+    // reaches the `stake_threshold`. It's the caller's responsibility to ensure that the elements of the `authorities`
+    // input is already sorted.
     fn retrieve_first_nodes(
         committee: &Committee,
         authorities: impl Iterator<Item = (AuthorityIdentifier, u64)>,
+        stake_threshold: f64,
     ) -> Vec<Authority> {
         let mut filtered_authorities = Vec::new();
 
@@ -146,9 +157,9 @@ impl LeaderSwapTable {
         for (authority_id, _score) in authorities {
             stake += committee.stake_by_id(authority_id);
 
-            // if by adding the authority we have reached validity, then we exit so we make sure that
-            // we gather < f + 1
-            if committee.reached_validity(stake) {
+            // if the total accumulated stake has surpassed the stake threshold then we omit this
+            // last authority and we exit the loop.
+            if stake > (stake_threshold * committee.total_stake() as f64) as Stake {
                 break;
             }
             filtered_authorities.push(committee.authority_safe(&authority_id).to_owned());
@@ -192,6 +203,7 @@ impl LeaderSchedule {
                         &committee,
                         commit.leader_round(),
                         &commit.reputation_score(),
+                        protocol_config.consensus_bad_nodes_stake_threshold(),
                     )
                 })
         } else {

--- a/narwhal/consensus/src/lib.rs
+++ b/narwhal/consensus/src/lib.rs
@@ -62,4 +62,8 @@ pub enum Outcome {
 
     // Processed Certificate triggered a commit.
     Commit,
+
+    // When the schedule has changed during a commit, then this is return with everything that has
+    // been committed so far.
+    ScheduleChanged,
 }

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -106,6 +106,7 @@ async fn commit_one_with_leader_schedule_change() {
             protocol_config: {
                 let mut config: ProtocolConfig = latest_protocol_version();
                 config.set_narwhal_new_leader_election_schedule(true);
+                config.set_consensus_bad_nodes_stake_threshold(0.33);
                 config
             },
             rounds: 11,
@@ -258,6 +259,7 @@ async fn not_enough_support_with_leader_schedule_change() {
 
     let mut config: ProtocolConfig = latest_protocol_version();
     config.set_narwhal_new_leader_election_schedule(true);
+    config.set_consensus_bad_nodes_stake_threshold(0.33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let gc_depth = 50;

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -74,7 +74,11 @@ async fn test_consensus_recovery_with_bullshark() {
 
     let gc_depth = 50;
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let leader_schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
+    let leader_schedule = LeaderSchedule::from_store(
+        committee.clone(),
+        consensus_store.clone(),
+        latest_protocol_version(),
+    );
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
@@ -172,13 +176,18 @@ async fn test_consensus_recovery_with_bullshark() {
     let consensus_store = storage.consensus_store;
     let certificate_store = storage.certificate_store;
 
+    let leader_schedule = LeaderSchedule::from_store(
+        committee.clone(),
+        consensus_store.clone(),
+        latest_protocol_version(),
+    );
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
-        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        leader_schedule,
     );
 
     let consensus_handle = Consensus::spawn(

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -335,6 +335,8 @@ async fn test_leader_swap_table() {
     // GIVEN
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
+    let mut protocol_config: ProtocolConfig = latest_protocol_version();
+    protocol_config.set_consensus_bad_nodes_stake_threshold(0.33);
 
     // the authority ids
     let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
@@ -346,7 +348,12 @@ async fn test_leader_swap_table() {
         scores.add_score(*id, score as u64);
     }
 
-    let table = LeaderSwapTable::new(&committee, 2, &scores);
+    let table = LeaderSwapTable::new(
+        &committee,
+        2,
+        &scores,
+        protocol_config.consensus_bad_nodes_stake_threshold(),
+    );
 
     // Only one bad authority should be calculated since all have equal stake
     assert_eq!(table.bad_nodes.len(), 1);
@@ -381,7 +388,12 @@ async fn test_leader_swap_table() {
     }
 
     // We expect the first 3 authorities (f) to be amongst the bad nodes
-    let table = LeaderSwapTable::new(&committee, 2, &scores);
+    let table = LeaderSwapTable::new(
+        &committee,
+        2,
+        &scores,
+        protocol_config.consensus_bad_nodes_stake_threshold(),
+    );
 
     assert_eq!(table.bad_nodes.len(), 3);
     assert!(table.bad_nodes.contains_key(&authority_ids[0]));
@@ -406,6 +418,8 @@ async fn test_leader_schedule() {
     // GIVEN
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
+    let mut protocol_config: ProtocolConfig = latest_protocol_version();
+    protocol_config.set_consensus_bad_nodes_stake_threshold(0.33);
 
     // the authority ids
     let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
@@ -427,7 +441,12 @@ async fn test_leader_schedule() {
     }
 
     // Update the schedule
-    let table = LeaderSwapTable::new(&committee, 2, &scores);
+    let table = LeaderSwapTable::new(
+        &committee,
+        2,
+        &scores,
+        protocol_config.consensus_bad_nodes_stake_threshold(),
+    );
     schedule.update_leader_swap_table(table.clone());
 
     // Now call the leader for round 2 again. It should be swapped with another node
@@ -504,6 +523,7 @@ async fn test_leader_schedule_from_store() {
     // WHEN flag is enabled for the new schedule algorithm
     let mut protocol_config = ProtocolConfig::get_for_max_version();
     protocol_config.set_narwhal_new_leader_election_schedule(true);
+    protocol_config.set_consensus_bad_nodes_stake_threshold(0.33);
     let schedule = LeaderSchedule::from_store(committee, store, protocol_config);
 
     // THEN the stored schedule should be returned and eventually the low score leader should be

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -362,12 +362,11 @@ impl PrimaryNodeInner {
             .recovered_consensus_output
             .inc_by(num_sub_dags);
 
-        // TODO: restore the LeaderSchedule when recovering from storage to ensure that the correct one
-        // will be used
-        // Using a LeaderSwapTable::default() will just adhere to the original schedule without any swaps.
-        // That means, whatever authority is elected for a round from the Committee::leader method, that's the
-        // one that will be used.
-        let leader_schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
+        let leader_schedule = LeaderSchedule::from_store(
+            committee.clone(),
+            store.consensus_store.clone(),
+            protocol_config.clone(),
+        );
 
         // Spawn the consensus core who only sequences transactions.
         let ordering_engine = Bullshark::new(

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -6,6 +6,7 @@ use config::AuthorityIdentifier;
 use std::collections::HashMap;
 use store::rocks::{open_cf, DBMap, MetricConf, ReadWriteOptions};
 use store::{reopen, Map, TypedStoreError};
+use tracing::debug;
 use types::{
     CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2, Round,
     SequenceNumber,
@@ -160,13 +161,101 @@ impl ConsensusStore {
     ) -> StoreResult<Option<ConsensusCommit>> {
         self.committed_sub_dags_by_index_v2.get(seq)
     }
+
+    /// Reads from storage the latest commit sub dag where its ReputationScores are marked as "final".
+    /// If none exists yet then this method will return None.
+    pub fn read_latest_commit_with_final_reputation_scores(&self) -> Option<ConsensusCommit> {
+        for commit in self
+            .committed_sub_dags_by_index_v2
+            .unbounded_iter()
+            .skip_to_last()
+            .reverse()
+            .map(|(_, sub_dag)| sub_dag)
+        {
+            // found a final of schedule score, so we'll return that
+            if commit.reputation_score().final_of_schedule {
+                debug!(
+                    "Found latest final reputation scores: {:?} from commit {:?}",
+                    commit.reputation_score(),
+                    commit.sub_dag_index()
+                );
+                return Some(commit);
+            }
+        }
+        debug!("No final reputation scores have been found");
+        None
+    }
 }
 
 #[cfg(test)]
 mod test {
     use crate::ConsensusStore;
+    use std::collections::HashMap;
     use store::Map;
-    use types::{CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2, TimestampMs};
+    use test_utils::CommitteeFixture;
+    use types::{
+        Certificate, CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2,
+        ReputationScores, TimestampMs,
+    };
+
+    #[tokio::test]
+    async fn test_read_latest_final_reputation_scores() {
+        // GIVEN
+        let store = ConsensusStore::new_for_tests();
+        let fixture = CommitteeFixture::builder().build();
+        let committee = fixture.committee();
+
+        // AND we add some commits without any final scores
+        for sequence_number in 0..10 {
+            let sub_dag = CommittedSubDag::new(
+                vec![],
+                Certificate::default(),
+                sequence_number,
+                ReputationScores::new(&committee),
+                None,
+            );
+
+            store
+                .write_consensus_state(&HashMap::new(), &sub_dag)
+                .unwrap();
+        }
+
+        // WHEN we try to read the final schedule. The one of sub dag sequence 12 should be returned
+        let commit = store.read_latest_commit_with_final_reputation_scores();
+
+        // THEN no commit is returned
+        assert!(commit.is_none());
+
+        // AND when adding more commits with some final scores amongst them
+        for sequence_number in 10..=20 {
+            let mut scores = ReputationScores::new(&committee);
+
+            // we mark the sequence 14 & 20 committed sub dag as with final schedule
+            if sequence_number == 14 || sequence_number == 20 {
+                scores.final_of_schedule = true;
+            }
+
+            let sub_dag = CommittedSubDag::new(
+                vec![],
+                Certificate::default(),
+                sequence_number,
+                scores,
+                None,
+            );
+
+            store
+                .write_consensus_state(&HashMap::new(), &sub_dag)
+                .unwrap();
+        }
+
+        // WHEN we try to read the final schedule. The one of sub dag sequence 20 should be returned
+        let commit = store
+            .read_latest_commit_with_final_reputation_scores()
+            .unwrap();
+
+        assert!(commit.reputation_score().final_of_schedule);
+        assert_eq!(commit.sub_dag_index(), 20)
+    }
 
     #[tokio::test]
     async fn test_v1_v2_backwards_compatibility() {


### PR DESCRIPTION
## Description 

Introduce the consensus_bad_nodes_stake_threshold property to configure the amount of nodes (by stake) that are considered bad and should be swapped with the good ones in the leader schedule.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
