### PR TITLE
Reduce archive file size for fast startup

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -398,7 +398,7 @@ impl SuiNode {
                 FileCompression::Zstd,
                 StorageFormat::Blob,
                 Duration::from_secs(600),
-                1024 * 1024 * 1024,
+                256 * 1024 * 1024,
                 &prometheus_registry,
             )
             .await?;


### PR DESCRIPTION
## Description 

Reducing the max file size to 256 MB so we can have fast startup time when reading archive. Otherwise sometimes files could get large enough that it takes a while to download them.

