### PR TITLE
Fix comment about protocol config versions

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -51,12 +51,13 @@ const MAX_PROTOCOL_VERSION: u64 = 18;
 //             to no longer consult the object store when generating unwrapped_then_deleted in the
 //             effects; this also allows us to stop including wrapped tombstones in accumulator.
 //             Add self-matching prevention for deepbook.
-// Version 17: Introduce execution layer versioning, preserve all existing behaviour in v0.
+// Version 17: Enable upgraded multisig support.
+// Version 18: Introduce execution layer versioning, preserve all existing behaviour in v0.
 //             Gas minimum charges moved to be a multiplier over the reference gas price. In this
 //             protocol version the multiplier is the same as the lowest bucket of computation
 //             such that the minimum transaction cost is the same as the minimum computation
 //             bucket.
-//             Add a feature flag to indicate the changes semantics of `base_tx_cost_fixed`
+//             Add a feature flag to indicate the changes semantics of `base_tx_cost_fixed`.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);


### PR DESCRIPTION
## Description 

As titled, things got out of sync

## Test Plan 

This is it

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
