### PR TITLE
[Ts sdk] Removing coin_locked_until_epoch from SDK since it is no longer in usage

### DIFF
--- a/sdk/typescript/src/framework/framework.ts
+++ b/sdk/typescript/src/framework/framework.ts
@@ -149,8 +149,6 @@ export type DelegationData = SuiMoveObject & {
 			id: string;
 			version: number;
 		};
-		// TODO (jian): clean up after 0.34
-		coin_locked_until_epoch: Option<SuiMoveObject>;
 		ending_epoch: Option<number>;
 	};
 };

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -62,8 +62,7 @@ export const Checkpoint = object({
 	epochRollingGasCostSummary: GasCostSummary,
 	timestampMs: string(),
 	endOfEpochData: optional(EndOfEpochData),
-	// TODO(jian): remove optional after 0.30.0 is released
-	validatorSignature: optional(ValidatorSignature),
+	validatorSignature: ValidatorSignature,
 	transactions: array(TransactionDigest),
 	checkpointCommitments: array(CheckpointCommitment),
 });

--- a/sdk/typescript/src/types/coin.ts
+++ b/sdk/typescript/src/types/coin.ts
@@ -12,8 +12,6 @@ export const CoinStruct = object({
 	version: string(),
 	digest: TransactionDigest,
 	balance: string(),
-	// TODO (jian): remove this when we move to 0.34
-	lockedUntilEpoch: optional(nullable(number())),
 	previousTransaction: TransactionDigest,
 });
 


### PR DESCRIPTION
## Description 

Removing coin_locked_until_epoch field from SDK since we no longer use it. 
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
