### PR TITLE
[QuorumDriver] Limit inflight transactions

### DIFF
--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -760,7 +760,6 @@ where
     ) {
         let limit = Arc::new(Semaphore::new(TASK_QUEUE_SIZE));
         while let Some(task) = task_receiver.recv().await {
-            let limit = limit.clone();
             // hold semaphore permit until task completes. unwrap ok because we never close
             // the semaphore in this context.
             let limit = limit.clone();

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -16,7 +16,7 @@ use futures::future::{select, Either, Future};
 use futures::FutureExt;
 use mysten_common::sync::notify_read::NotifyRead;
 use mysten_metrics::histogram::{Histogram, HistogramVec};
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{spawn_logged_monitored_task, spawn_monitored_task};
 use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
 use prometheus::{
@@ -62,7 +62,7 @@ pub struct TransactiondOrchestrator<A: Clone> {
 }
 
 impl TransactiondOrchestrator<NetworkAuthorityClient> {
-    pub async fn new_with_network_clients(
+    pub fn new_with_network_clients(
         validator_state: Arc<AuthorityState>,
         reconfig_channel: Receiver<SuiSystemState>,
         parent_path: &Path,
@@ -90,8 +90,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
             parent_path,
             prometheus_registry,
             observer,
-        )
-        .await)
+        ))
     }
 }
 
@@ -100,7 +99,7 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
     OnsiteReconfigObserver: ReconfigObserver<A>,
 {
-    pub async fn new(
+    pub fn new(
         validators: Arc<AuthorityAggregator<A>>,
         validator_state: Arc<AuthorityState>,
         parent_path: &Path,
@@ -137,7 +136,7 @@ where
                 .await;
             })
         };
-        Self::schedule_txes_in_log(&pending_tx_log, &quorum_driver_handler).await;
+        Self::schedule_txes_in_log(pending_tx_log.clone(), quorum_driver_handler.clone());
         Self {
             quorum_driver_handler,
             validator_state,
@@ -519,26 +518,37 @@ where
         )
     }
 
-    async fn schedule_txes_in_log(
-        pending_tx_log: &Arc<WritePathPendingTransactionLog>,
-        quorum_driver: &Arc<QuorumDriverHandler<A>>,
+    fn schedule_txes_in_log(
+        pending_tx_log: Arc<WritePathPendingTransactionLog>,
+        quorum_driver: Arc<QuorumDriverHandler<A>>,
     ) {
-        let pending_txes = pending_tx_log.load_all_pending_transactions();
-        for tx in pending_txes {
-            // TODO: ideally pending_tx_log would not contain VerifiedTransaction, but that
-            // requires a migration.
-            let tx = tx.into_inner();
-            let tx_digest = *tx.digest();
-            // It's not impossible we fail to enqueue a task but that's not the end of world.
-            if let Err(err) = quorum_driver.submit_transaction_no_ticket(tx).await {
-                error!(
-                    ?tx_digest,
-                    "Failed to enqueue transaction in pending_tx_log, err: {err:?}"
-                );
-            } else {
-                info!(?tx_digest, "Enqueued transaction in pending_tx_log");
+        spawn_logged_monitored_task!(async move {
+            let pending_txes = pending_tx_log.load_all_pending_transactions();
+            info!(
+                "Recovering {} pending transactions from pending_tx_log.",
+                pending_txes.len()
+            );
+            for (i, tx) in pending_txes.into_iter().enumerate() {
+                // TODO: ideally pending_tx_log would not contain VerifiedTransaction, but that
+                // requires a migration.
+                let tx = tx.into_inner();
+                let tx_digest = *tx.digest();
+                // It's not impossible we fail to enqueue a task but that's not the end of world.
+                if let Err(err) = quorum_driver.submit_transaction_no_ticket(tx).await {
+                    warn!(
+                        ?tx_digest,
+                        "Failed to enqueue transaction from pending_tx_log, err: {err:?}"
+                    );
+                } else {
+                    debug!(?tx_digest, "Enqueued transaction from pending_tx_log");
+                    if (i + 1) % 1000 == 0 {
+                        info!("Enqueued {} transactions from pending_tx_log.", i + 1);
+                    }
+                }
             }
-        }
+            // Transactions will be cleaned up in loop_execute_finalized_tx_locally() after they
+            // produce effects.
+        });
     }
 
     pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -26,7 +26,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
     let orchestrator = handle
-        .with_async(|node| {
+        .with(|node| {
             TransactiondOrchestrator::new_with_network_clients(
                 node.state(),
                 node.subscribe_to_epoch_change(),
@@ -34,7 +34,6 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
                 &registry,
             )
         })
-        .await
         .unwrap();
 
     let txn_count = 4;
@@ -101,7 +100,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     let registry = Registry::new();
     // Start orchestrator inside container so that it will be properly shutdown.
     let orchestrator = handle
-        .with_async(|node| {
+        .with(|node| {
             TransactiondOrchestrator::new_with_network_clients(
                 node.state(),
                 node.subscribe_to_epoch_change(),
@@ -109,7 +108,6 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
                 &registry,
             )
         })
-        .await
         .unwrap();
 
     let txn_count = 2;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -496,8 +496,7 @@ impl SuiNode {
                     end_of_epoch_receiver,
                     &config.db_path(),
                     &prometheus_registry,
-                )
-                .await?,
+                )?,
             ))
         } else {
             None


### PR DESCRIPTION
## Description 

Currently `QuorumDriver` has a few queue length limits, but they are not effective at e2e back pressure. A Semaphore is added to rate limit # of inflight transactions in QuorumDriver.

The limit is set to be the same as TASK_QUEUE_LIMIT. This limit is decreased from 10k to 2k. It can be increased after AuthorityAggregator stores less duplicated data. And it can be turned into an environment variable in future.

Move TransactionOrchestrator recovery into an async task, since recovery should not block other parts of the system.

## Test Plan 

CI. Deployed to a fullnode with large backlog in TransactionOrchestrator and helped it recover.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
