### PR TITLE
[explorer] add ids to make elements searchable

### DIFF
--- a/apps/explorer/src/components/Activity/EpochsActivityTable.tsx
+++ b/apps/explorer/src/components/Activity/EpochsActivityTable.tsx
@@ -61,7 +61,7 @@ export function EpochsActivityTable({
 					colWidths={['100px', '120px', '40px', '204px', '90px', '38px']}
 				/>
 			) : (
-				<div>
+				<div id="epochs-table-content">
 					<TableCard data={cardData.data} columns={cardData.columns} />
 				</div>
 			)}

--- a/apps/explorer/src/components/Activity/TransactionsActivityTable.tsx
+++ b/apps/explorer/src/components/Activity/TransactionsActivityTable.tsx
@@ -49,7 +49,7 @@ export function TransactionsActivityTable({
 					Failed to load Transactions
 				</div>
 			)}
-			<div className="flex flex-col space-y-5 text-left xl:pr-10">
+			<div id="transactions-table-content" className="flex flex-col space-y-5 text-left xl:pr-10">
 				{isLoading || isFetching || !cardData ? (
 					<PlaceholderTable
 						rowCount={limit}

--- a/apps/explorer/src/components/Activity/index.tsx
+++ b/apps/explorer/src/components/Activity/index.tsx
@@ -48,9 +48,9 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 			>
 				<div className="relative">
 					<TabsList>
-						<TabsTrigger value="transactions">Transaction Blocks</TabsTrigger>
-						<TabsTrigger value="epochs">Epochs</TabsTrigger>
-						<TabsTrigger value="checkpoints">Checkpoints</TabsTrigger>
+						<TabsTrigger id="transactions-tab" value="transactions">Transaction Blocks</TabsTrigger>
+						<TabsTrigger id="epochs-tab" value="epochs">Epochs</TabsTrigger>
+						<TabsTrigger id="checkpoints-tab" value="checkpoints">Checkpoints</TabsTrigger>
 					</TabsList>
 					<div className="absolute inset-y-0 -top-1 right-0 text-2xl">
 						{/* todo: re-enable this when rpc is stable */}
@@ -74,7 +74,7 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 						disablePagination={disablePagination}
 					/>
 				</TabsContent>
-				<TabsContent value="checkpoints">
+				<TabsContent  value="checkpoints">
 					<CheckpointsTable
 						refetchInterval={refetchInterval}
 						initialLimit={initialLimit}

--- a/apps/explorer/src/components/HomeMetrics/Checkpoint.tsx
+++ b/apps/explorer/src/components/HomeMetrics/Checkpoint.tsx
@@ -14,7 +14,9 @@ export function Checkpoint() {
 			unavailable={isLoading}
 			size="sm"
 		>
-			{data?.currentCheckpoint ? BigInt(data?.currentCheckpoint).toLocaleString() : null}
+			<div id="checkpoint-stat">
+				{data?.currentCheckpoint ? BigInt(data?.currentCheckpoint).toLocaleString() : null}
+			</div>
 		</StatsWrapper>
 	);
 }

--- a/apps/explorer/src/components/HomeMetrics/NetworkTPS.tsx
+++ b/apps/explorer/src/components/HomeMetrics/NetworkTPS.tsx
@@ -14,7 +14,7 @@ export function NetworkTPS() {
 			<Heading color="steel-darker" variant="heading4/semibold">
 				Network TPS
 			</Heading>
-			<div className="mt-8 flex gap-8">
+			<div id="tps-stats" className="mt-8 flex gap-8">
 				<StatsWrapper
 					size="sm"
 					label="TPS Now / Peak 30D"

--- a/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
+++ b/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
@@ -73,7 +73,7 @@ export function CheckpointsTable({
 					colWidths={['100px', '120px', '204px', '90px', '38px']}
 				/>
 			) : (
-				<div>
+				<div id="checkpoints-table-content">
 					<TableCard data={cardData.data} columns={cardData.columns} />
 				</div>
 			)}

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -129,7 +129,7 @@ export default function ValidatorMap({ minHeight }: Props) {
 						</Text>
 					</div>
 
-					<div className="flex gap-6">
+					<div id="validator-map-validator-count" className="flex gap-6">
 						<NodeStat title="Validators">
 							{isLoading && <Placeholder width="60px" height="0.8em" />}
 							{

--- a/apps/explorer/src/pages/home/Home.tsx
+++ b/apps/explorer/src/pages/home/Home.tsx
@@ -62,7 +62,12 @@ function Home() {
 					<Activity initialLimit={TRANSACTIONS_LIMIT} disablePagination />
 				</ErrorBoundary>
 			</div>
-			<div data-testid="validators-table" style={{ gridArea: 'validators' }} className="mt-5">
+			<div
+				id="validators-table"
+				data-testid="validators-table"
+				style={{ gridArea: 'validators' }}
+				className="mt-5"
+			>
 				<TabHeader title="Validators">
 					<ErrorBoundary>
 						<TopValidatorsCard limit={10} showIcon />
@@ -70,7 +75,7 @@ function Home() {
 				</TabHeader>
 			</div>
 
-			<div style={{ gridArea: 'packages' }}>
+			<div id="top-packages-table" style={{ gridArea: 'packages' }}>
 				<TopPackagesCard />
 			</div>
 		</div>


### PR DESCRIPTION
I am prototyping some external scraping tooling to assess explorer liveness and these ids will make it easier to understand. 

We could use other properties to identify these elements but I think element id is the easiest one to get us moving in the near term.

## Test Plan 

```
» pnpm explorer test

> sui-monorepo@ explorer /Users/jkjensen/mysten/sui
> pnpm --filter ./apps/explorer "test"


> sui-explorer@ test /Users/jkjensen/mysten/sui/apps/explorer
> pnpm test:unit


> sui-explorer@ test:unit /Users/jkjensen/mysten/sui/apps/explorer
> vitest run


 RUN  v0.32.0 /Users/jkjensen/mysten/sui/apps/explorer

 ✓ src/pages/transaction-result/programmable-transaction-view/__test__/utils.test.ts (3)
 ✓ src/__tests__/unit.test.ts (5)

 Test Files  2 passed (2)
      Tests  8 passed (8)
   Start at  14:11:38
   Duration  914ms (transform 397ms, setup 0ms, collect 609ms, tests 8ms, environment 162ms, prepare 113ms)

```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
