### PR TITLE
move: source service defaults to open CORS policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10677,6 +10677,8 @@ dependencies = [
  "test-cluster",
  "tokio",
  "toml 0.7.4",
+ "tower",
+ "tower-http",
  "tracing",
  "url",
  "workspace-hack",

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -37,6 +37,8 @@ move-compiler.workspace = true
 move-core-types.workspace = true
 move-symbol-pool.workspace = true
 telemetry-subscribers.workspace = true
+tower.workspace = true
+tower-http.workspace = true
 workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{ffi::OsString, fs, path::Path, process::Command};
@@ -11,11 +12,11 @@ use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use axum::routing::{get, IntoMakeService};
 use axum::{Json, Router, Server};
+use hyper::http::Method;
 use hyper::server::conn::AddrIncoming;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
-use std::net::TcpListener;
-use sui_sdk::SuiClient;
+use tower::ServiceBuilder;
 use tracing::info;
 use url::Url;
 
@@ -26,6 +27,7 @@ use move_symbol_pool::Symbol;
 use sui_move::build::resolve_lock_file_path;
 use sui_move_build::{BuildConfig, SuiPackageHooks};
 use sui_sdk::wallet_context::WalletContext;
+use sui_sdk::SuiClient;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
 #[derive(Deserialize, Debug)]
@@ -279,7 +281,15 @@ pub struct AppState {
 }
 
 pub fn serve(app_state: AppState) -> anyhow::Result<Server<AddrIncoming, IntoMakeService<Router>>> {
-    let app = Router::new().route("/api", get(api_route).with_state(Arc::new(app_state)));
+    let app = Router::new()
+        .route("/api", get(api_route).with_state(Arc::new(app_state)))
+        .layer(
+            ServiceBuilder::new().layer(
+                tower_http::cors::CorsLayer::new()
+                    .allow_methods([Method::GET])
+                    .allow_origin(tower_http::cors::Any),
+            ),
+        );
     let listener = TcpListener::bind("0.0.0.0:8000")?;
     Ok(Server::from_tcp(listener)?.serve(app.into_make_service()))
 }


### PR DESCRIPTION
## Description 

Main motivation for this is to unblock any frontend development against the service and make talking to it convenient, like I did in [a POC](https://github.com/MystenLabs/sui/commit/252c00ccccbf83fdd166c8d704d728f4681456a8). Based on [FE folk's recommendation](https://mysten-labs.slack.com/archives/C032676BWGN/p1688675848596469?thread_ts=1688675490.432769&cid=C032676BWGN) we don't need to restrict CORS for this service (it is unauthed). My own sense is that we can leave it open to start and in prod (without explicitly encouraging third-party use).

## Test Plan 

Tested in [POC branch](https://github.com/MystenLabs/sui/commit/252c00ccccbf83fdd166c8d704d728f4681456a8) with frontend code. Bit of a hassle to do in a unit test, but maybe possible with some `reqwest` wangling, which I punted on.