### PR TITLE
don't panic in invariant violation macro

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -58,9 +58,6 @@ macro_rules! exit_main {
 #[macro_export]
 macro_rules! make_invariant_violation {
     ($($args:expr),* $(,)?) => {{
-        if cfg!(debug_assertions) {
-            panic!($($args),*)
-        }
         ExecutionError::invariant_violation(format!($($args),*))
     }}
 }


### PR DESCRIPTION
## Description 

Removes panic if debug assertions are set in invariant violation macro

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
