### PR TITLE
indexer: partition & parallel commit for objects

### DIFF
--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -35,11 +35,20 @@ CREATE TABLE objects
     has_public_transfer    BOOLEAN       NOT NULL,
     storage_rebate         BIGINT        NOT NULL,
     bcs                    bcs_bytes[]   NOT NULL
-);
+) PARTITION BY HASH (object_id);
 CREATE INDEX objects_owner_address ON objects (owner_type, owner_address);
 CREATE INDEX objects_tx_digest ON objects (previous_transaction);
+CREATE TABLE objects_partition_0 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 0);
+CREATE TABLE objects_partition_1 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 1);
+CREATE TABLE objects_partition_2 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 2);
+CREATE TABLE objects_partition_3 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 3);
+CREATE TABLE objects_partition_4 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 4);
+CREATE TABLE objects_partition_5 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 5);
+CREATE TABLE objects_partition_6 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 6);
+CREATE TABLE objects_partition_7 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 7);
+CREATE TABLE objects_partition_8 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 8);
+CREATE TABLE objects_partition_9 PARTITION OF objects FOR VALUES WITH (MODULUS 10, REMAINDER 9);
 
--- NOTE(gegaowp): remove object history so that it will not be created over DB reset / migration run.
 CREATE TABLE objects_history
 (
     epoch                  BIGINT        NOT NULL,

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -32,6 +32,18 @@ mod diesel_marco {
                 .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))
         }};
     }
+
+    macro_rules! read_write_blocking {
+        ($pool:expr, $query:expr) => {{
+            let mut pg_pool_conn = crate::get_pg_pool_connection($pool)?;
+            pg_pool_conn
+                .build_transaction()
+                .read_write()
+                .run($query)
+                .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))
+        }};
+    }
     pub(crate) use read_only_blocking;
+    pub(crate) use read_write_blocking;
     pub(crate) use transactional_blocking;
 }


### PR DESCRIPTION
## Description 

Objects table commits get slower when the table sizes grows, this is very noticeable on testnet backfill.
This PR tries to optimize the object ingestion speed via
- spawn tokio tasks to ingest in parallel for object commits that do not have to be done sequentially.
- build 10 objects partitions to reduce BTree size of one table

## Test Plan 

local run & experiment on testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
