### PR TITLE
indexer: only commit latest obj version to objects

### DIFF
--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -470,3 +470,17 @@ pub fn group_and_sort_objects(objects: Vec<Object>) -> Vec<Vec<Object>> {
     }
     groups
 }
+
+pub fn dedup_objects_with_highest_version(objects: Vec<Object>) -> Vec<Object> {
+    let mut map = BTreeMap::new();
+    for object in objects {
+        map.entry(object.object_id.clone())
+            .and_modify(|e: &mut Object| {
+                if e.version < object.version {
+                    *e = object.clone();
+                }
+            })
+            .or_insert(object);
+    }
+    map.into_iter().map(|(_, v)| v).collect()
+}


### PR DESCRIPTION
## Description 

on Objects table, we do not have to commit lower versions, they are only useful for object history, where we can do separately.

## Test Plan 

test on testnet and monitor the cp per second processed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
