### PR TITLE
[sui-execution] Test to make sure generated lib.rs is not changed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,9 @@ jobs:
       - name: rustdoc
         run: |
           cargo doc --workspace --no-deps
+      - name: sui-execution
+        run: |
+          ./scripts/execution_layer.py generate-lib
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -30,9 +30,7 @@ def parse_args():
         "cut",
         help=(
             "Create a new copy of execution-related crates, and add them to "
-            "the workspace.  Assigning an execution layer version to the new "
-            "copy and implementing the Execution and Verifier traits in "
-            "crates/sui-execution must be done manually as a follow-up."
+            "the workspace."
         ),
     )
 
@@ -42,6 +40,18 @@ def parse_args():
         type=feature,
         help="The name of the new cut to make",
     )
+
+    generate_lib = subparsers.add_parser(
+        "generate-lib",
+        help=(
+            "Generate `sui-execution/src/lib.rs` based on the current set of "
+            "execution crates (i.e. without adding a new one).  Prints out "
+            "what the contents of `lib.rs` would be without actually writing "
+            "out to the file, if --dry-run flag is supplied."
+        ),
+    )
+
+    generate_lib.set_defaults(do=do_generate_lib)
 
     return parser.parse_args()
 
@@ -66,7 +76,7 @@ def do_cut(args):
     impl_module = Path() / "sui-execution" / "src" / (args.feature + ".rs")
     if impl_module.is_file():
         raise RuntimeError(
-            f"Impl module for '{args.feature}' already exists at '{impl_module}'"
+            f"Impl for '{args.feature}' already exists at '{impl_module}'"
         )
 
     print("Cutting new release", file=stderr)
@@ -79,8 +89,20 @@ def do_cut(args):
     clean_up_cut(args.feature)
     update_toml(args.feature)
     generate_impls(args.feature, impl_module)
-    generate_lib()
+
+    with open(Path() / "sui-execution" / "src" / "lib.rs") as lib:
+        generate_lib(lib)
+
     run(["cargo", "hakari", "generate"])
+
+
+def do_generate_lib(args):
+    if args.dry_run:
+        generate_lib(stdout)
+    else:
+        lib_path = Path() / "sui-execution" / "src" / "lib.rs"
+        with open(lib_path, mode="w") as lib:
+            generate_lib(lib)
 
 
 def run(command):
@@ -145,11 +167,11 @@ def generate_impls(feature, copy):
             copy.write(line)
 
 
-def generate_lib():
+def generate_lib(output_file):
     """Expose all `Executor` and `Verifier` impls via lib.rs
 
-    Generates and overwrites sui-execution/src/lib.rs to assign a numeric
-    execution version for every trait that assigns an execution version.
+    Generates the contents of sui-execution/src/lib.rs to assign a numeric
+    execution version for every module that implements an execution version.
 
     Version snapshots (whose names follow the pattern `/v[0-9]+/`) are assigned
     versions according to their names (v0 gets 0, v1 gets 1, etc).
@@ -158,12 +180,12 @@ def generate_lib():
 
     Feature snapshots (all other snapshots) are assigned versions starting with
     `u64::MAX` and going down, in the order they were created (as measured by
-    git commit timestamps)"""
+    git commit timestamps)
 
-    src = Path() / "sui-execution" / "src"
-    actual_path = src / "lib.rs"
-    template_path = src / "lib.template.rs"
+    The generated contents are written out to `output_file` (an IO device).
+    """
 
+    template_path = Path() / "sui-execution" / "src" / "lib.template.rs"
     cuts = discover_cuts()
 
     with open(template_path, mode="r") as template_file:
@@ -205,15 +227,14 @@ def generate_lib():
         else:
             raise AssertionError(f"Don't know how to substitute {var}")
 
-    with open(actual_path, mode="w") as actual_file:
-        actual_file.write(
-            re.sub(
-                r"^(\s*)// \$([A-Z_]+)$",
-                substitute,
-                template,
-                flags=re.MULTILINE,
-            ),
-        )
+    output_file.write(
+        re.sub(
+            r"^(\s*)// \$([A-Z_]+)$",
+            substitute,
+            template,
+            flags=re.MULTILINE,
+        ),
+    )
 
 
 # Modules in `sui-execution` that don't count as "cuts" (they are


### PR DESCRIPTION
Add a step to the rust `test` workflow to regenerate `lib.rs`, so that if the PR has inadvertantly introduced a manual change to this module, the `change-files` step will identify that and complain.

Test Plan:

Lints and formatters:

```
$ flake8 scripts/execution_layer.py
$ black scripts/execution_layer.py
```

Diff the generated (`--dy-run`) contents before and after generating `lib.rs` for real.  If there was a difference before, it should be gone after generation runs for real:

```
$ diff -u ./sui-execution/src/lib.rs \
  <(./scripts/execution_layer.py --dry-run generate-lib)
$ ./scripts/execution_layer.py generate-lib
$ diff -u ./sui-execution/src/lib.rs \
  <(./scripts/execution_layer.py --dry-run generate-lib)
```

Check in CI that the step runs and catches a discrepency -- fix the discrepency and notice CI finishes successfully.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
