### PR TITLE
[move-compiler] Add ID leak verifier to sui mode

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -174,18 +174,15 @@ impl BuildConfig {
     pub fn resolution_graph(mut self, path: &Path) -> SuiResult<ResolvedGraph> {
         use move_compiler::editions::Flavor;
 
-        if let Some(flavor) = &self.config.default_flavor {
-            if flavor != &Flavor::Sui {
-                return Err(SuiError::ModuleBuildFailure {
-                    error: format!(
-                        "The flavor of the Move compiler cannot be overridden with anything but \
+        let flavor = self.config.default_flavor.get_or_insert(Flavor::Sui);
+        if flavor != &Flavor::Sui {
+            return Err(SuiError::ModuleBuildFailure {
+                error: format!(
+                    "The flavor of the Move compiler cannot be overridden with anything but \
                         \"{}\", but the default override was set to: \"{flavor}\"",
-                        Flavor::Sui,
-                    ),
-                });
-            }
-        } else {
-            self.config.default_flavor = Some(Flavor::Sui);
+                    Flavor::Sui,
+                ),
+            });
         }
 
         if self.print_diags_to_stderr {

--- a/crates/sui-move-build/src/linters/self_transfer.rs
+++ b/crates/sui-move-build/src/linters/self_transfer.rs
@@ -21,6 +21,7 @@ use move_compiler::{
         Diagnostic, Diagnostics,
     },
     hlir::ast::{Command, Exp, LValue, Label, ModuleCall, Type, Type_, Var},
+    shared::CompilationEnv,
 };
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
@@ -76,6 +77,7 @@ impl SimpleAbsIntConstructor for SelfTransferVerifier {
     type AI<'a> = SelfTransferVerifierAI;
 
     fn new<'a>(
+        _env: &CompilationEnv,
         _program: &'a Program,
         context: &'a CFGContext<'a>,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,

--- a/crates/sui-move-build/src/linters/share_owned.rs
+++ b/crates/sui-move-build/src/linters/share_owned.rs
@@ -26,7 +26,7 @@ use move_compiler::{
         Type_, Var,
     },
     parser::ast::Ability_,
-    shared::Identifier,
+    shared::{CompilationEnv, Identifier},
 };
 use std::collections::BTreeMap;
 
@@ -77,6 +77,7 @@ impl SimpleAbsIntConstructor for ShareOwnedVerifier {
     type AI<'a> = ShareOwnedVerifierAI;
 
     fn new<'a>(
+        _env: &CompilationEnv,
         _program: &'a Program,
         context: &'a CFGContext<'a>,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,

--- a/external-crates/move/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/move-compiler/src/cfgir/translate.rs
@@ -762,7 +762,7 @@ fn visit_function(
     let mut ds = Diagnostics::new();
     for visitor in &context.env.visitors().abs_int {
         let mut v = visitor.borrow_mut();
-        ds.extend(v.verify(prog, &function_context, &cfg));
+        ds.extend(v.verify(&context.env, prog, &function_context, &cfg));
     }
     context.env.add_diags(ds)
 }

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -16,6 +16,7 @@ use crate::{
         Command, Command_, Exp, ExpListItem, LValue, LValue_, Label, ModuleCall, Type, Type_,
         UnannotatedExp_, Var,
     },
+    shared::CompilationEnv,
 };
 use move_ir_types::location::*;
 
@@ -24,6 +25,7 @@ pub type AbsIntVisitorObj = Box<dyn AbstractInterpreterVisitor>;
 pub trait AbstractInterpreterVisitor {
     fn verify(
         &mut self,
+        env: &CompilationEnv,
         program: &cfgir::ast::Program,
         context: &CFGContext,
         cfg: &ImmForwardCFG,
@@ -163,6 +165,7 @@ pub trait SimpleAbsIntConstructor: Sized {
     /// Given the initial state/domain, construct a new abstract interpreter.
     /// Return None if it should not be run given this context
     fn new<'a>(
+        env: &CompilationEnv,
         program: &'a cfgir::ast::Program,
         context: &'a CFGContext<'a>,
         init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
@@ -170,6 +173,7 @@ pub trait SimpleAbsIntConstructor: Sized {
 
     fn verify(
         &mut self,
+        env: &CompilationEnv,
         program: &cfgir::ast::Program,
         context: &CFGContext,
         cfg: &ImmForwardCFG,
@@ -192,7 +196,7 @@ pub trait SimpleAbsIntConstructor: Sized {
             );
         }
         let mut init_state = <Self::AI<'_> as SimpleAbsInt>::State::new(context, locals);
-        let Some(mut ai) = Self::new(program, context, &mut init_state) else {
+        let Some(mut ai) = Self::new(env, program, context, &mut init_state) else {
             return Diagnostics::new();
         };
         let (final_state, ds) = ai.analyze_function(cfg, init_state);
@@ -461,10 +465,11 @@ impl<V: SimpleAbsInt> AbstractInterpreter for V {}
 impl<V: SimpleAbsIntConstructor> AbstractInterpreterVisitor for V {
     fn verify(
         &mut self,
+        env: &CompilationEnv,
         program: &cfgir::ast::Program,
         context: &CFGContext,
         cfg: &ImmForwardCFG,
     ) -> Diagnostics {
-        SimpleAbsIntConstructor::verify(self, program, context, cfg)
+        SimpleAbsIntConstructor::verify(self, env, program, context, cfg)
     }
 }

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -401,9 +401,9 @@ fn module_(
     } = mdef;
     let attributes = flatten_attributes(context, AttributePosition::Module, attributes);
     let mut warning_filter = warning_filter(context, &attributes);
-    if let Some(config) = context.env.package_config(package_name) {
-        warning_filter.union(&config.warning_filter)
-    }
+    let config = context.env.package_config(package_name);
+    warning_filter.union(&config.warning_filter);
+
     context.env.add_warning_filter_scope(warning_filter.clone());
     assert!(context.address.is_none());
     assert!(address.is_none());
@@ -499,9 +499,9 @@ fn script_(context: &mut Context, package_name: Option<Symbol>, pscript: P::Scri
 
     let attributes = flatten_attributes(context, AttributePosition::Script, attributes);
     let mut warning_filter = warning_filter(context, &attributes);
-    if let Some(config) = context.env.package_config(package_name) {
-        warning_filter.union(&config.warning_filter)
-    }
+    let config = context.env.package_config(package_name);
+    warning_filter.union(&config.warning_filter);
+
     context.env.add_warning_filter_scope(warning_filter.clone());
     let new_scope = uses(context, puses);
     let old_aliases = context.aliases.add_and_shadow_all(new_scope);

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -1,30 +1,32 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_symbol_pool::Symbol;
+
 use crate::diagnostics::codes::{custom, DiagnosticInfo, Severity};
 
 pub mod id_leak;
 
-const SUI_ADDR_NAME: &str = "sui";
-const OBJECT_MODULE_NAME: &str = "object";
-const OBJECT_NEW: &str = "new";
-const OBJECT_NEW_UID_FROM_HASH: &str = "new_uid_from_hash";
-const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
-const TS_NEW_OBJECT: &str = "new_object";
-const UID_TYPE_NAME: &str = "UID";
+const SUI_ADDR_NAME: Symbol = symbol!("sui");
+const OBJECT_MODULE_NAME: Symbol = symbol!("object");
+const OBJECT_NEW: Symbol = symbol!("new");
+const OBJECT_NEW_UID_FROM_HASH: Symbol = symbol!("new_uid_from_hash");
+const TEST_SCENARIO_MODULE_NAME: Symbol = symbol!("test_scenario");
+const TS_NEW_OBJECT: Symbol = symbol!("new_object");
+const UID_TYPE_NAME: Symbol = symbol!("UID");
 
-const SUI_SYSTEM_ADDR_NAME: &str = "sui_system";
-const SUI_SYSTEM_MODULE_NAME: &str = "sui_system";
-const SUI_SYSTEM_CREATE: &str = "create";
-const CLOCK_MODULE_NAME: &str = "clock";
-const SUI_CLOCK_CREATE: &str = "create";
+const SUI_SYSTEM_ADDR_NAME: Symbol = symbol!("sui_system");
+const SUI_SYSTEM_MODULE_NAME: Symbol = symbol!("sui_system");
+const SUI_SYSTEM_CREATE: Symbol = symbol!("create");
+const CLOCK_MODULE_NAME: Symbol = symbol!("clock");
+const SUI_CLOCK_CREATE: Symbol = symbol!("create");
 
-const FRESH_ID_FUNCTIONS: &[(&str, &str, &str)] = &[
+const FRESH_ID_FUNCTIONS: &[(Symbol, Symbol, Symbol)] = &[
     (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW),
     (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW_UID_FROM_HASH),
     (SUI_ADDR_NAME, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT),
 ];
-const FUNCTIONS_TO_SKIP: &[(&str, &str, &str)] = &[
+const FUNCTIONS_TO_SKIP: &[(Symbol, Symbol, Symbol)] = &[
     (
         SUI_SYSTEM_ADDR_NAME,
         SUI_SYSTEM_MODULE_NAME,

--- a/external-crates/move/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/move-compiler/tests/move_check_testsuite.rs
@@ -11,7 +11,8 @@ use move_command_line_common::{
 use move_compiler::{
     command_line::compiler::move_check_for_errors,
     diagnostics::*,
-    shared::{Flags, NumericalAddress},
+    editions::Flavor,
+    shared::{Flags, NumericalAddress, PackageConfig},
     Compiler, PASS_PARSER,
 };
 
@@ -22,22 +23,43 @@ const TEST_EXT: &str = "unit_test";
 const VERIFICATION_EXT: &str = "verification";
 const UNUSED_EXT: &str = "unused";
 
-fn default_testing_addresses() -> BTreeMap<String, NumericalAddress> {
-    let mapping = [
+const SUI_MODE_DIR: &str = "sui_mode";
+
+fn default_testing_addresses(flavor: Flavor) -> BTreeMap<String, NumericalAddress> {
+    let mut mapping = vec![
         ("std", "0x1"),
+        ("sui", "0x2"),
         ("M", "0x1"),
         ("A", "0x42"),
         ("B", "0x42"),
         ("K", "0x19"),
-        ("Async", "0x20"),
+        ("a", "0x42"),
+        ("b", "0x42"),
+        ("k", "0x19"),
     ];
+    if flavor == Flavor::Sui {
+        mapping.extend([("sui", "0x2"), ("sui_system", "0x3")]);
+    }
     mapping
-        .iter()
+        .into_iter()
         .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
         .collect()
 }
 
 fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
+    let flavor = if path.components().any(|c| c.as_os_str() == SUI_MODE_DIR) {
+        Flavor::Sui
+    } else {
+        Flavor::default()
+    };
+    let config = PackageConfig {
+        flavor,
+        ..PackageConfig::default()
+    };
+    testsuite(path, config)
+}
+
+fn testsuite(path: &Path, mut config: PackageConfig) -> datatest_stable::Result<()> {
     // A test is marked that it should also be compiled in test mode by having a `path.unit_test`
     // file.
     if path.with_extension(TEST_EXT).exists() {
@@ -51,12 +73,16 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
             path.with_extension("").to_string_lossy(),
             OUT_EXT
         );
+        let mut config = config.clone();
+        config
+            .warning_filter
+            .union(&WarningFilters::unused_function_warnings_filter());
         run_test(
             path,
             Path::new(&test_exp_path),
             Path::new(&test_out_path),
             Flags::testing(),
-            true,
+            config,
         )?;
     }
 
@@ -73,12 +99,16 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
             path.with_extension("").to_string_lossy(),
             OUT_EXT
         );
+        let mut config = config.clone();
+        config
+            .warning_filter
+            .union(&WarningFilters::unused_function_warnings_filter());
         run_test(
             path,
             Path::new(&verification_exp_path),
             Path::new(&verification_out_path),
             Flags::verification(),
-            true,
+            config,
         )?;
     }
 
@@ -99,7 +129,7 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
             Path::new(&unused_exp_path),
             Path::new(&unused_out_path),
             Flags::empty(),
-            false,
+            config.clone(),
         )?;
     }
 
@@ -107,39 +137,37 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let out_path = path.with_extension(OUT_EXT);
 
     let flags = Flags::empty();
-    run_test(path, &exp_path, &out_path, flags, true)?;
+
+    config
+        .warning_filter
+        .union(&WarningFilters::unused_function_warnings_filter());
+    run_test(path, &exp_path, &out_path, flags, config)?;
     Ok(())
 }
 
 // Runs all tests under the test/testsuite directory.
-fn run_test(
+pub fn run_test(
     path: &Path,
     exp_path: &Path,
     out_path: &Path,
     flags: Flags,
-    suppress_unused: bool,
+    default_config: PackageConfig,
 ) -> anyhow::Result<()> {
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
-
-    let warning_filter = if suppress_unused {
-        Some(WarningFilters::unused_function_warnings_filter())
-    } else {
-        None
-    };
 
     let (files, comments_and_compiler_res) = Compiler::from_files(
         targets,
         move_stdlib::move_stdlib_files(),
-        default_testing_addresses(),
+        default_testing_addresses(default_config.flavor),
     )
     .set_flags(flags)
-    .set_warning_filter(warning_filter)
+    .set_default_config(default_config)
     .run::<PASS_PARSER>()?;
     let diags = move_check_for_errors(comments_and_compiler_res);
 
     let has_diags = !diags.is_empty();
     let diag_buffer = if has_diags {
-        move_compiler::diagnostics::report_diagnostics_to_buffer(&files, diags)
+        report_diagnostics_to_buffer(&files, diags)
     } else {
         vec![]
     };
@@ -193,4 +221,4 @@ fn run_test(
     }
 }
 
-datatest_stable::harness!(move_check_testsuite, "tests/move_check", r".*\.move$");
+datatest_stable::harness!(move_check_testsuite, "tests/", r".*\.move$");

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/direct_leak_through_call.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/direct_leak_through_call.move
@@ -1,0 +1,25 @@
+// allowed since no object is being created with the UID
+
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    public fun transfer(_: UID) {
+        abort 0
+    }
+
+    public fun foo(f: Foo) {
+        let Foo { id } = f;
+        transfer(id);
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/indirect_leak_through_call.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/indirect_leak_through_call.exp
@@ -1,0 +1,9 @@
+error[Sui E01001]: invalid object construction
+   ┌─ tests/sui_mode/id_leak/indirect_leak_through_call.move:15:18
+   │
+15 │         transfer(Foo { id });
+   │                  ^^^^^^^^^^
+   │                  │     │
+   │                  │     The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
+   │                  Invalid object creation without a newly created UID.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/indirect_leak_through_call.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/indirect_leak_through_call.move
@@ -1,0 +1,44 @@
+// not allowed since Foo is not packed with a fresh UID
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    fun transfer(_: Foo) {
+        abort 0
+    }
+
+    public fun foo(f: Foo) {
+        let Foo { id } = f;
+        transfer(Foo { id });
+    }
+
+}
+
+// allowed since no packing occurs
+module k::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    fun transfer(_: UID) {
+        abort 0
+    }
+
+    public fun foo(f: Foo) {
+        let Foo { id } = f;
+        transfer(id);
+    }
+
+}
+
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/infinite_loop.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/infinite_loop.move
@@ -1,0 +1,59 @@
+// Modules with infinite loops to stress the ID leak verifier
+module a::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct Obj has key {
+        id: UID,
+    }
+
+    public entry fun loop_forever(ctx: &mut TxContext) {
+        let obj = Obj { id:  object::new(ctx) };
+        let Obj { id: uid } = obj;
+        loop {
+            object::delete(uid);
+            uid = object::new(ctx);
+        }
+    }
+
+    public entry fun loop_forever_2(ctx: &mut TxContext) {
+        let obj = Obj { id:  object::new(ctx) };
+        let Obj { id: uid } = obj;
+        loop {
+            object::delete(uid);
+            obj = Obj { id: object::new(ctx) };
+            loop {
+                Obj { id: uid } = obj;
+                object::delete(uid);
+                uid = object::new(ctx);
+                break
+            }
+        }
+    }
+}
+
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+    public fun new(_: &mut sui::tx_context::TxContext): UID {
+        abort 0
+    }
+    public fun delete(_: UID) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+    public fun sender(_: &TxContext): address {
+        @0
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/loop.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/loop.move
@@ -1,0 +1,48 @@
+// allowed, even though a bit pointless
+module a::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer::transfer;
+
+    struct Obj has key {
+        id: UID
+    }
+
+    public entry fun transmute(ctx: &mut TxContext) {
+        let i = 0;
+        let id = object::new(ctx);
+        while (i <= 10) {
+            object::delete(id);
+            id = object::new(ctx);
+            i = i + 1;
+        };
+        let obj = Obj { id };
+        transfer(obj, tx_context::sender(ctx))
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+    public fun new(_: &mut sui::tx_context::TxContext): UID {
+        abort 0
+    }
+    public fun delete(_: UID) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+    public fun sender(_: &TxContext): address {
+        @0
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_call_with_borrow_field.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_call_with_borrow_field.exp
@@ -1,0 +1,9 @@
+error[Sui E01001]: invalid object construction
+   ┌─ tests/sui_mode/id_leak/through_call_with_borrow_field.move:11:9
+   │
+11 │         Object { id }
+   │         ^^^^^^^^^^^^^
+   │         │        │
+   │         │        The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
+   │         Invalid object creation without a newly created UID.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_call_with_borrow_field.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_call_with_borrow_field.move
@@ -1,0 +1,33 @@
+// not allowed, the call tries to make a new UID
+module a::m {
+    use sui::object::UID;
+    use sui::transfer::transfer;
+
+    struct S has copy, drop { f: u64 }
+
+    struct Object has key { id: UID }
+
+    public fun new(id: UID): Object {
+        Object { id }
+    }
+
+    public entry fun foo(obj: Object) {
+        let s = S { f: 0 };
+        let Object { id } = obj;
+        _ = &s.f;
+        transfer(new(id), @42);
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_direct_return.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_direct_return.move
@@ -1,0 +1,19 @@
+// allowed, no object is being made with the UID
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    public fun foo(f: Foo): UID {
+        let Foo { id } = f;
+        id
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_indirect_return.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_indirect_return.exp
@@ -1,0 +1,9 @@
+error[Sui E01001]: invalid object construction
+   ┌─ tests/sui_mode/id_leak/through_indirect_return.move:11:9
+   │
+11 │         Foo { id }
+   │         ^^^^^^^^^^
+   │         │     │
+   │         │     The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
+   │         Invalid object creation without a newly created UID.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_indirect_return.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_indirect_return.move
@@ -1,0 +1,20 @@
+// not allowed, a new object is being made with the UID
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    public fun foo(f: Foo): Foo {
+        let Foo { id } = f;
+        Foo { id }
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_pack.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_pack.exp
@@ -1,0 +1,9 @@
+error[Sui E01001]: invalid object construction
+   ┌─ tests/sui_mode/id_leak/through_pack.move:22:17
+   │
+22 │         let c = C { id };
+   │                 ^^^^^^^^
+   │                 │   │
+   │                 │   The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
+   │                 Invalid object creation without a newly created UID.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_pack.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_pack.move
@@ -1,0 +1,65 @@
+// not allowed since C is not packed with a fresh UID
+module b::test {
+    use sui::object::UID;
+    use sui::transfer::transfer;
+
+    struct A has key {
+        id: UID
+    }
+
+    struct C has key {
+        id: UID
+    }
+
+    struct B {
+        id: UID
+    }
+
+    public entry fun test(x: A) {
+        let A { id } = x;
+        let b = B { id };
+        let B { id } = b;
+        let c = C { id };
+        transfer(c, @1);
+    }
+}
+
+// allowed since Bar does not have key
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    struct Bar {
+        id: UID,
+        v: u64,
+    }
+
+    public fun foo(f: Foo) {
+        let Foo { id } = f;
+        let _b = Bar { id, v: 0 };
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+    public fun sender(_: &TxContext): address {
+        @0
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_reference.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_reference.exp
@@ -1,0 +1,12 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/sui_mode/id_leak/through_reference.move:11:10
+   │
+ 9 │     public fun foo(f: Foo, ref: &mut UID) {
+   │                                      --- The type '(sui=0x2)::object::UID' does not have the ability 'drop'
+10 │         let Foo { id } = f;
+11 │         *ref = id;
+   │          ^^^ Invalid mutation. Mutation requires the 'drop' ability as the old value is destroyed
+   ·
+17 │     struct UID has store {
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_reference.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_reference.move
@@ -1,0 +1,20 @@
+// cannot assign to UID reference
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    public fun foo(f: Foo, ref: &mut UID) {
+        let Foo { id } = f;
+        *ref = id;
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/through_vector.move
@@ -1,0 +1,20 @@
+// allowed, anything can be done with a UID after unpacking, as long as it isn't repacked
+module a::m {
+    use sui::object::UID;
+
+    struct Foo has key {
+        id: UID,
+    }
+
+    public fun foo(f: Foo, v: &mut vector<UID>) {
+        let Foo { id } = f;
+        std::vector::push_back(v, id)
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/transmute.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/transmute.exp
@@ -1,0 +1,9 @@
+error[Sui E01001]: invalid object construction
+   ┌─ tests/sui_mode/id_leak/transmute.move:17:19
+   │
+17 │         let dog = Dog { id };
+   │                   ^^^^^^^^^^
+   │                   │     │
+   │                   │     The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
+   │                   Invalid object creation without a newly created UID.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/id_leak/transmute.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/id_leak/transmute.move
@@ -1,0 +1,40 @@
+// not allowed, it re-uses an ID in a new object
+module a::m {
+    use sui::object::UID;
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer::transfer;
+
+    struct Cat has key {
+        id: UID,
+    }
+
+    struct Dog has key {
+        id: UID,
+    }
+
+    public fun transmute(cat: Cat, ctx: &mut TxContext) {
+        let Cat { id } = cat;
+        let dog = Dog { id };
+        transfer(dog, tx_context::sender(ctx));
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+    public fun sender(_: &TxContext): address {
+        @0
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/move-symbol-pool/src/lib.rs
@@ -50,6 +50,16 @@ static_symbols!(
     "legacy",
     "2024",
     "alpha",
+    "sui",
+    "object",
+    "new",
+    "new_uid_from_hash",
+    "test_scenario",
+    "new_object",
+    "UID",
+    "sui_system",
+    "create",
+    "clock",
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

- Integrated existing ID leak verifier to sui mode
- Added sui-mode tests

## Test Plan 

- Ported MVIR tests

## Stack 

#12868
#12614

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

The Move compiler will now error for improper usage of sui::object::UID when destroying objects. Before this change, the error occurred when checking the bytecode of the module after compilation, so this change is intended to improve the user experience around these errors. 