### PR TITLE
[kiosk] Adds a "personal kiosk" extension and a rule

### DIFF
--- a/kiosk/sources/extensions/owned_kiosk.move
+++ b/kiosk/sources/extensions/owned_kiosk.move
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Description:
+///
+module kiosk::owned_kiosk {
+    use std::option::{Self, Option};
+    use sui::transfer;
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+    use sui::object::{Self, ID, UID};
+    use sui::tx_context::{sender, TxContext};
+    use sui::dynamic_field as df;
+
+    const EIncorrectCapObject: u64 = 0;
+    const EIncorrectOwnedObject: u64 = 1;
+
+    /// A key-only wrapper for the KioskOwnerCap. Makes sure that the Kiosk can
+    /// not be traded altogether with its contents.
+    struct OwnedKiosk has key {
+        id: UID,
+        cap: Option<KioskOwnerCap>
+    }
+
+    /// The hot potato making sure the KioskOwnerCap is returned after borrowing.
+    struct Borrow { cap_id: ID, owned_id: ID }
+
+    /// The dynamic field to mark the Kiosk as owned (to allow guaranteed owner
+    /// checks through the Kiosk).
+    struct OwnerMarker has copy, store, drop {}
+
+    /// Wrap the KioskOwnerCap making the Kiosk "owned" and non-transferable.
+    public fun new(kiosk: &mut Kiosk, cap: KioskOwnerCap, ctx: &mut TxContext) {
+        let owner = sender(ctx);
+
+        // set the owner property of the Kiosk
+        kiosk::set_owner(kiosk, &cap, ctx);
+
+        // add the owner marker to the Kiosk; uses `_as_owner` to always pass,
+        // even if Kiosk "allow_extensions" is set to false
+        df::add(
+            kiosk::uid_mut_as_owner(kiosk, &cap),
+            OwnerMarker {},
+            owner
+        );
+
+        // wrap the Cap in the OwnedKiosk
+        transfer::transfer(OwnedKiosk {
+            id: object::new(ctx),
+            cap: option::some(cap)
+        }, sender(ctx));
+    }
+
+    /// Borrow the KioskOwnerCap from the OwnedKiosk object; Borrow hot-potato
+    /// makes sure that the Cap is returned via `return_cap` call.
+    public fun borrow_cap(self: &mut OwnedKiosk): (KioskOwnerCap, Borrow) {
+        let cap = option::extract(&mut self.cap);
+        let id = object::id(&cap);
+
+        (cap, Borrow {
+            owned_id: object::id(self),
+            cap_id: id
+        })
+    }
+
+    /// Return the Cap to the OwnedKiosk object.
+    public fun return_cap(self: &mut OwnedKiosk, cap: KioskOwnerCap, borrow: Borrow) {
+        let Borrow { owned_id, cap_id } = borrow;
+        assert!(object::id(self) == owned_id, EIncorrectOwnedObject);
+        assert!(object::id(&cap) == cap_id, EIncorrectCapObject);
+
+        option::fill(&mut self.cap, cap)
+    }
+
+    /// Check if the Kiosk is "owned".
+    public fun is_owned(kiosk: &Kiosk): bool {
+        df::exists_(kiosk::uid(kiosk), OwnerMarker {})
+    }
+}

--- a/kiosk/sources/rules/owned_kiosk_rule.move
+++ b/kiosk/sources/rules/owned_kiosk_rule.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module kiosk::owned_kiosk_rule {
+    use sui::kiosk::{Self, Kiosk};
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferPolicyCap,
+        TransferRequest
+    };
+
+    use kiosk::owned_kiosk;
+
+    /// An item hasn't been placed into the Kiosk before the call.
+    const EItemNotInKiosk: u64 = 0;
+    /// The Kiosk is not owned; the OwnerMarker is not present.
+    const EKioskNotOwned: u64 = 1;
+
+    /// The Rule checking that the Kiosk is an owned one.
+    struct Rule has drop {}
+
+    /// Add the "owned" rule to the KioskOwnerCap.
+    public fun add<T>(policy: &mut TransferPolicy<T>, cap: &TransferPolicyCap<T>) {
+        policy::add_rule(Rule {}, policy, cap, true)
+    }
+
+    /// Make sure that the destination Kiosk has the Owner key. Item is already
+    /// placed by the time this check is performed - otherwise fails.
+    public fun confirm<T>(kiosk: &Kiosk, request: &mut TransferRequest<T>) {
+        assert!(kiosk::has_item(kiosk, policy::item(request)), EItemNotInKiosk);
+        assert!(owned_kiosk::is_owned(kiosk), EKioskNotOwned);
+
+        policy::add_receipt(Rule {}, request)
+    }
+
+}

--- a/kiosk/sources/rules/personal_kiosk_rule.move
+++ b/kiosk/sources/rules/personal_kiosk_rule.move
@@ -1,7 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module kiosk::owned_kiosk_rule {
+/// Description:
+/// This module defines a Rule which checks that the Kiosk is "personal" meaning
+/// that the owner cannot change. By default, `KioskOwnerCap` can be transferred
+/// and owned by an application therefore the owner of the Kiosk is not fixed.
+///
+/// Configuration:
+/// - None
+///
+/// Use cases:
+/// - Strong royalty enforcement - personal Kiosks cannot be transferred with
+/// the assets inside which means that the item will never change the owner.
+///
+/// Notes:
+/// - Combination of `kiosk_lock_rule` and `personal_kiosk_rule` can be used to
+/// enforce policies on every trade (item can be transferred only through a
+/// trade + Kiosk is fixed to the owner).
+///
+module kiosk::personal_kiosk_rule {
     use sui::kiosk::{Self, Kiosk};
     use sui::transfer_policy::{
         Self as policy,
@@ -10,7 +27,7 @@ module kiosk::owned_kiosk_rule {
         TransferRequest
     };
 
-    use kiosk::owned_kiosk;
+    use kiosk::personal_kiosk;
 
     /// An item hasn't been placed into the Kiosk before the call.
     const EItemNotInKiosk: u64 = 0;
@@ -27,11 +44,10 @@ module kiosk::owned_kiosk_rule {
 
     /// Make sure that the destination Kiosk has the Owner key. Item is already
     /// placed by the time this check is performed - otherwise fails.
-    public fun confirm<T>(kiosk: &Kiosk, request: &mut TransferRequest<T>) {
+    public fun prove<T>(kiosk: &Kiosk, request: &mut TransferRequest<T>) {
         assert!(kiosk::has_item(kiosk, policy::item(request)), EItemNotInKiosk);
-        assert!(owned_kiosk::is_owned(kiosk), EKioskNotOwned);
+        assert!(personal_kiosk::is_personal(kiosk), EKioskNotOwned);
 
         policy::add_receipt(Rule {}, request)
     }
-
 }

--- a/kiosk/tests/extensions/personal_kiosk_tests.move
+++ b/kiosk/tests/extensions/personal_kiosk_tests.move
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Tests for the `personal_kiosk` module.
+module kiosk::personal_kiosk_tests {
+    use sui::transfer::public_share_object as share;
+    use sui::kiosk_test_utils::{Self as test};
+    use sui::tx_context::sender;
+    use sui::kiosk;
+
+    use kiosk::personal_kiosk;
+
+    #[test]
+    fun new_and_transfer() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
+        let p_cap = personal_kiosk::new(&mut kiosk, kiosk_cap, ctx);
+        personal_kiosk::transfer_to_sender(p_cap, ctx);
+        share(kiosk)
+    }
+
+    #[test]
+    fun new_borrow() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
+        let p_cap = personal_kiosk::new(&mut kiosk, kiosk_cap, ctx);
+
+        assert!(kiosk::has_access(
+            &mut kiosk,
+            personal_kiosk::borrow(&p_cap)
+        ), 0);
+
+        assert!(kiosk::has_access(
+            &mut kiosk,
+            personal_kiosk::borrow_mut(&mut p_cap)
+        ), 0);
+
+        let (kiosk_cap, borrow) = personal_kiosk::borrow_val(&mut p_cap);
+
+        assert!(kiosk::has_access(&mut kiosk, &kiosk_cap), 0);
+        assert!(kiosk::has_access(&mut kiosk, &mut kiosk_cap), 0);
+
+        personal_kiosk::return_val(&mut p_cap, kiosk_cap, borrow);
+        personal_kiosk::transfer_to_sender(p_cap, ctx);
+
+        assert!(personal_kiosk::owner(&kiosk) == sender(ctx), 1);
+        share(kiosk)
+    }
+
+    #[test, expected_failure(abort_code = kiosk::personal_kiosk::EIncorrectCapObject)]
+    fun borrow_replace_cap_fail() {
+        let ctx = &mut test::ctx();
+        let (kiosk_1, cap_1) = test::get_kiosk(ctx);
+        let p_cap_1 = personal_kiosk::new(&mut kiosk_1, cap_1, ctx);
+
+        let (kiosk_2, cap_2) = test::get_kiosk(ctx);
+        let p_cap_2 = personal_kiosk::new(&mut kiosk_2, cap_2, ctx);
+
+        let (_kiosk_cap_1, borrow_1) = personal_kiosk::borrow_val(&mut p_cap_1);
+        let (kiosk_cap_2, _borrow_2) = personal_kiosk::borrow_val(&mut p_cap_2);
+
+        personal_kiosk::return_val(&mut p_cap_1, kiosk_cap_2, borrow_1);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = kiosk::personal_kiosk::EIncorrectOwnedObject)]
+    fun borrow_replace_target_fail() {
+        let ctx = &mut test::ctx();
+        let (kiosk_1, cap_1) = test::get_kiosk(ctx);
+        let p_cap_1 = personal_kiosk::new(&mut kiosk_1, cap_1, ctx);
+
+        let (kiosk_2, cap_2) = test::get_kiosk(ctx);
+        let p_cap_2 = personal_kiosk::new(&mut kiosk_2, cap_2, ctx);
+
+        let (kiosk_cap_1, borrow_1) = personal_kiosk::borrow_val(&mut p_cap_1);
+        let (_kiosk_cap_2, _borrow_2) = personal_kiosk::borrow_val(&mut p_cap_2);
+
+        personal_kiosk::return_val(&mut p_cap_2, kiosk_cap_1, borrow_1);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = kiosk::personal_kiosk::EKioskNotOwned)]
+    fun owner_fail() {
+        let (kiosk, _cap) = test::get_kiosk(&mut test::ctx());
+        let _owner = personal_kiosk::owner(&kiosk);
+        abort 1337
+    }
+}


### PR DESCRIPTION
## Description 

- Adds a "personal_kiosk" extension which locks the Kiosk at the address making the KioskOwnerCap non-transferable.
- Only updates the Mysten Kiosk package, no changes to the Framework required

## Notes

- This approach gives more certainty for marketplaces when they want to show the seller's address
- Gives a guaranteed way to check the owner through the Kiosk
- Optional requirement by creators, assumed to be added by default together with the lock policy in the strong-enforcement scenario

## Test Plan 

- features tests for the extension

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- 