### PR TITLE
explorer: enable filtering out system transactions on testnet and devnet

### DIFF
--- a/apps/explorer/src/components/Activity/index.tsx
+++ b/apps/explorer/src/components/Activity/index.tsx
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Filter16 } from '@mysten/icons';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 // import toast from 'react-hot-toast';
 
 import { EpochsActivityTable } from './EpochsActivityTable';
 import { TransactionsActivityTable } from './TransactionsActivityTable';
 import { CheckpointsTable } from '../checkpoints/CheckpointsTable';
 // import { PlayPause } from '~/ui/PlayPause';
-import { useNetwork } from '~/context';
 import { DropdownMenu, DropdownMenuCheckboxItem } from '~/ui/DropdownMenu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
-import { Network } from '~/utils/api/DefaultRpcClient';
 
 const VALID_TABS = ['transactions', 'epochs', 'checkpoints'];
 
@@ -46,17 +44,7 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 	// };
 
 	const refetchInterval = paused ? undefined : REFETCH_INTERVAL;
-	// TODO remove network check when querying transactions with TransactionKind filter is fixed on devnet and testnet
-	const [network] = useNetwork();
-	const isTransactionKindFilterEnabled = Network.MAINNET === network || Network.LOCAL === network;
-	const [showSystemTransactions, setShowSystemTransaction] = useState(
-		!isTransactionKindFilterEnabled,
-	);
-	useEffect(() => {
-		if (!isTransactionKindFilterEnabled) {
-			setShowSystemTransaction(true);
-		}
-	}, [isTransactionKindFilterEnabled]);
+	const [showSystemTransactions, setShowSystemTransaction] = useState(false);
 
 	return (
 		<div>
@@ -68,7 +56,7 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 						<TabsTrigger value="checkpoints">Checkpoints</TabsTrigger>
 					</TabsList>
 					<div className="absolute inset-y-0 -top-1 right-0 flex items-center gap-3 text-2xl">
-						{activeTab === 'transactions' && isTransactionKindFilterEnabled ? (
+						{activeTab === 'transactions' ? (
 							<DropdownMenu
 								trigger={<Filter16 className="p-1" />}
 								content={


### PR DESCRIPTION
## Description 

currently filtering out system transactions on devnet and testnet is disabled because it's not supported from the API. Once API supports it this will enable it.

## Test Plan 

👀 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
