### PR TITLE
[sui-execution/execution_layer] rebase and patch sub-commands

### DIFF
--- a/sui-execution/cut/src/args.rs
+++ b/sui-execution/cut/src/args.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{self, bail, Result};
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -42,6 +42,10 @@ pub(crate) struct Args {
     /// location, including any suffixes)
     #[arg(short, long = "package")]
     pub packages: Vec<String>,
+
+    /// Don't make changes to the workspace.
+    #[arg(long="no-workspace-update", action=ArgAction::SetFalse)]
+    pub workspace_update: bool,
 
     /// Don't execute the cut, just display it.
     #[arg(long)]


### PR DESCRIPTION
## Description 

Adds two commands to `execution_layer.py` -- `patch` and `rebase`.  The former prints the patch of all changes that were applied to a cut after it was created, and the latte builds rebasing on top of that by saving that patch, re-generating the feature based on `latest` and then applying that patch (merging if necessary).

This change also required an update to the `cut` binary, to allow for the creation of a cut without updating the workspace (the relevant modules would already be part of the workspace expect in the complicated edge case of rebasing over a new execution layer being added to `latest` which should be rare enough to handle manually).

## Test Plan 

```
sui$ ./scripts/execution_layer.py patch v0
sui$ ./scripts/execution_layer.py patch doesnt_exist
sui$ ./scripts/execution_layer.py cut test
sui$ ./scripts/execution_layer.py patch test
sui$ ./scripts/execution_layer.py rebase v0
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
