### PR TITLE
[sui-execution/execution_layer] Merge sub-command

### DIFF
--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -17,7 +17,7 @@ def parse_args():
     )
 
     subparsers = parser.add_subparsers(
-        description="Tools for managing cuts of the execution-layer",
+        description="Tools for managing cuts of the execution-layer.",
     )
 
     cut = subparsers.add_parser(
@@ -31,12 +31,12 @@ def parse_args():
     cut.add_argument(
         "feature",
         type=feature,
-        help="The name of the new cut to make",
+        help="The name of the new cut to make.",
     )
     cut.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the operations, without running them",
+        help="Print the operations, without running them.",
     )
 
     generate_lib = subparsers.add_parser(
@@ -52,7 +52,7 @@ def parse_args():
     generate_lib.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the operations, without running them",
+        help="Print the operations, without running them.",
     )
 
     merge = subparsers.add_parser(
@@ -60,8 +60,8 @@ def parse_args():
         help="Apply the changes made to FEATURE since it was cut, to BASE.",
     )
     merge.set_defaults(cmd="Merge", do=do_merge)
-    merge.add_argument("base", type=feature, help="The cut to merge into")
-    merge.add_argument("feature", type=feature, help="The cut to take from")
+    merge.add_argument("base", type=feature, help="The cut to merge into.")
+    merge.add_argument("feature", type=feature, help="The cut to take from.")
     merge.add_argument(
         "--dry-run",
         action="store_true",
@@ -82,7 +82,7 @@ def parse_args():
         "patch",
         help=(
             "Print a patch file representing the changes made to FEATURE "
-            "after the commit in which it was cut"
+            "after the commit in which it was cut."
         ),
     )
     patch.set_defaults(do=do_patch)

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -55,6 +55,29 @@ def parse_args():
         help="Print the operations, without running them",
     )
 
+    merge = subparsers.add_parser(
+        "merge",
+        help="Apply the changes made to FEATURE since it was cut, to BASE.",
+    )
+    merge.set_defaults(cmd="Merge", do=do_merge)
+    merge.add_argument("base", type=feature, help="The cut to merge into")
+    merge.add_argument("feature", type=feature, help="The cut to take from")
+    merge.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the patch file to apply to BASE without applying it.",
+    )
+    merge.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help=(
+            "Merge regardless of warnings that the working directory is "
+            "not clean.  If the merge fails at this point, it may be "
+            "difficult to recover from."
+        ),
+    )
+
     patch = subparsers.add_parser(
         "patch",
         help=(
@@ -87,7 +110,7 @@ def parse_args():
         "--force",
         action="store_true",
         help=(
-            "Rebase regardless of warnings of that the working directory is "
+            "Rebase regardless of warnings that the working directory is "
             "not clean.  If the rebase fails at this point, it may be "
             "difficult to recover from."
         ),
@@ -144,6 +167,44 @@ def do_generate_lib(args):
         lib_path = Path() / "sui-execution" / "src" / "lib.rs"
         with open(lib_path, mode="w") as lib:
             generate_lib(lib)
+
+
+def do_merge(args):
+    from_module = impl(args.feature)
+    if not from_module.is_file():
+        raise Exception(f"'{args.feature}' does not exist.")
+
+    to_module = impl(args.base)
+    if not to_module.is_file():
+        raise Exception(f"'{args.base}' does not exist.")
+
+    print("Calculating change...", file=stderr)
+    changes = patch(args.feature)
+    if not changes:
+        print("No changes.", file=stderr)
+        return
+
+    print("Porting feature to base...", file=stderr)
+    adapted = change_patch_directories(changes, args.feature, args.base)
+
+    if args.dry_run:
+        print(adapted)
+        return
+
+    if not args.force and not is_repo_clean():
+        raise Exception(
+            "Working directory or index is not clean, not merging.  Re-run "
+            "with --force to ignore warning."
+        )
+
+    print("Applying changes...", file=stderr)
+    subprocess.run(
+        ["git", "apply", "-"],
+        input=adapted,
+        text=True,
+        stdout=stdout,
+        stderr=stderr,
+    )
 
 
 def do_patch(args):
@@ -241,6 +302,43 @@ def patch(feature):
             *["git", "diff", f"{sha}...HEAD", "--"],
             *cut_directories(args.feature),
         ]
+    )
+
+
+def change_patch_directories(patch, feature, base):
+    """Fix-up patch referring to `feature` to refer to `base`.
+
+    Look for references to directories in cut `feature` in the
+    metadata of patch and replace them with references to the
+    equivalent directories in `base`.
+    """
+
+    def is_metadata(line):
+        return (
+            line.startswith("+++")
+            or line.startswith("---")
+            or line.startswith("diff --git")
+        )
+
+    # Mapping from directories that might appear in the patch file to
+    # the directories they should be replaced by.  Represented as a
+    # list of pairs as it will be iterated over.
+    mapping = list(
+        zip(
+            map(str, cut_directories(feature)),
+            map(str, cut_directories(base)),
+        )
+    )
+
+    def sub(line):
+        for feat, base in mapping:
+            line = line.replace(feat, base)
+        return line
+
+    return "".join(
+        (sub(line) if is_metadata(line) else line) + "\n"
+        for line in patch.splitlines()
+        if not line.startswith("index")
     )
 
 

--- a/sui-execution/README.md
+++ b/sui-execution/README.md
@@ -181,7 +181,7 @@ of two places:
 
 ## Rebasing Cuts
 
-A cut can be `rebase`-d against `latest using the following command:
+A cut can be `rebase`-d against `latest` using the following command:
 
 ```shell
 ./scripts/execution_layer.py rebase <FEATURE>
@@ -205,7 +205,7 @@ Cuts support a rudimentary form of `merge`, using patch files:
 
 The `merge` command attempts to merge the changes from `<FEATURE>`
 onto the cut at `<BASE>` (It modifies `<BASE>` and leaves `<FEATURE>`
-untouched).  Because it operates using patch files, any conflicts will
+untouched).  Because it operates using patch files, any conflicts
 result in a failure to apply the patch.  This can be resolved in two
 ways:
 

--- a/sui-execution/README.md
+++ b/sui-execution/README.md
@@ -179,9 +179,39 @@ of two places:
   them in based on the execution modules in the crate.
 
 
-## Future Improvements
+## Rebasing Cuts
 
-- The process of merging a feature cut back into `latest` is fiddly if
-  done manually.  It can be done using patch files, so it behaves
-  similarly to a `git rebase`, but this is also difficult to get
-  right, and could be automated.
+A cut can be `rebase`-d against `latest using the following command:
+
+```shell
+./scripts/execution_layer.py rebase <FEATURE>
+
+```
+
+This saves all the changes that were made to the cut after it was
+made, and replays them on a fresh cut from `latest`.  As a precaution,
+it will not run if the working directory is not clean (because if it
+goes wrong, it will be harder to recover), but this can be overridden
+with `--force`.
+
+
+## Merging Cuts
+
+Cuts support a rudimentary form of `merge`, using patch files:
+
+```shell
+./scripts/execution_layer.py merge <BASE> <FEATURE>
+```
+
+The `merge` command attempts to merge the changes from `<FEATURE>`
+onto the cut at `<BASE>` (It modifies `<BASE>` and leaves `<FEATURE>`
+untouched).  Because it operates using patch files, any conflicts will
+result in a failure to apply the patch.  This can be resolved in two
+ways:
+
+- (Recommended) If merging into `latest`, `rebase` the `<FEATURE>`
+  first, which will give you an opportunity to resolve all merge
+  conflicts during the rebase, to create a clean patch.
+- Use the `--dry-run` option of `merge` to output the patch file
+  instead of attempting to apply it, so you can manually modify it
+  (cut it into pieces, fix conflicts) before applying it.


### PR DESCRIPTION
## Description

New sub-command for script to take the changes made to one feature/snapshot since it was cut, and apply them on top of another cut.

Note: This process leaves the cut being merged in-place (doesn't delete it), and is generally less robust than the `rebase` command, because it can't do three-way merging -- it's doing straight patch application.  This is because three-way merging requires being able to identify a common ancestor which may not exist.

## Test Plan

```
sui$ ./scripts/execution_layer.py cut test_cut
sui$ git add -A && git commit -m "Test Cut"
sui$ echo "// Making a change" >> sui-execution/test_cut/sui-adapter/src/lib.rs
sui$ git add -A && git commit -m "Making a change"
sui$ ./scripts/execution_layer.py merge latest test_cut
sui$ git diff sui-execution/latest/sui-adapter/src/lib.rs
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
