### PR TITLE
Refactor get_object_read to return object with a single call to store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2493,28 +2493,27 @@ impl AuthorityState {
     }
 
     pub fn get_object_read(&self, object_id: &ObjectID) -> SuiResult<ObjectRead> {
-        let Some(obj_ref) = self.database.get_object_or_tombstone(*object_id)? else {
-            return Ok(ObjectRead::NotExists(*object_id))
+        let Some((object_key, store_object)) = self.database.get_latest_object_or_tombstone(*object_id)? else {
+            return Ok(ObjectRead::NotExists(*object_id));
         };
-
-        if !obj_ref.2.is_alive() {
-            return Ok(ObjectRead::Deleted(obj_ref));
-        }
-
-        match self.read_object_at_version(object_id, obj_ref.1)? {
-            Some((object, layout)) => Ok(ObjectRead::Exists(obj_ref, object, layout)),
-            None => {
-                error!(
-                    "Object with in parent_entry is missing from object store, datastore is \
-                     inconsistent",
-                );
-                Err(UserInputError::ObjectNotFound {
-                    object_id: *object_id,
-                    version: Some(obj_ref.1),
-                }
-                .into())
-            }
-        }
+        if let Some(object_ref) = self
+            .database
+            .perpetual_tables
+            .tombstone_reference(&object_key, &store_object)?
+        {
+            return Ok(ObjectRead::Deleted(object_ref));
+        };
+        let object = self
+            .database
+            .perpetual_tables
+            .object(&object_key, store_object)?
+            .expect("Non tombstone store object could not be converted to object");
+        let layout = self.get_object_layout(&object)?;
+        Ok(ObjectRead::Exists(
+            object.compute_object_reference(),
+            object,
+            layout,
+        ))
     }
 
     /// Chain Identifier is the digest of the genesis checkpoint.
@@ -2577,7 +2576,7 @@ impl AuthorityState {
         version: SequenceNumber,
     ) -> SuiResult<PastObjectRead> {
         // Firstly we see if the object ever existed by getting its latest data
-        let Some(obj_ref) = self.database.get_object_or_tombstone(*object_id)? else {
+        let Some(obj_ref) = self.database.get_latest_object_ref_or_tombstone(*object_id)? else {
             return Ok(PastObjectRead::ObjectNotExists(*object_id));
         };
 
@@ -2630,6 +2629,11 @@ impl AuthorityState {
             return Ok(None);
         };
 
+        let layout = self.get_object_layout(&object)?;
+        Ok(Some((object, layout)))
+    }
+
+    fn get_object_layout(&self, object: &Object) -> SuiResult<Option<MoveStructLayout>> {
         let layout = object
             .data
             .try_as_move()
@@ -2640,8 +2644,7 @@ impl AuthorityState {
                     .get_layout(object, ObjectFormatOptions::default())
             })
             .transpose()?;
-
-        Ok(Some((object, layout)))
+        Ok(layout)
     }
 
     fn get_owner_at_version(
@@ -3565,7 +3568,7 @@ impl AuthorityState {
         &self,
         object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
-        self.database.get_object_or_tombstone(object_id)
+        self.database.get_latest_object_ref_or_tombstone(object_id)
     }
 
     /// Ordinarily, protocol upgrades occur when 2f + 1 + (f *

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -644,7 +644,7 @@ impl AuthorityStore {
             (
                 idx,
                 match self
-                    .get_object_or_tombstone(key.0)
+                    .get_latest_object_ref_or_tombstone(key.0)
                     .expect("read cannot fail")
                 {
                     None => false,
@@ -1530,11 +1530,23 @@ impl AuthorityStore {
     /// being wrapped in another object.
     ///
     /// If no entry for the object_id is found, return None.
-    pub fn get_object_or_tombstone(
+    pub fn get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> Result<Option<ObjectRef>, SuiError> {
-        self.perpetual_tables.get_object_or_tombstone(object_id)
+        self.perpetual_tables
+            .get_latest_object_ref_or_tombstone(object_id)
+    }
+
+    /// Returns the latest object we have for this object_id in the objects table.
+    ///
+    /// If no entry for the object_id is found, return None.
+    pub fn get_latest_object_or_tombstone(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<Option<(ObjectKey, StoreObjectWrapper)>, SuiError> {
+        self.perpetual_tables
+            .get_latest_object_or_tombstone(object_id)
     }
 
     pub fn insert_transaction_and_effects(
@@ -1887,7 +1899,7 @@ impl ChildObjectResolver for AuthorityStore {
 
 impl ParentSync for AuthorityStore {
     fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
-        self.get_object_or_tombstone(object_id)
+        self.get_latest_object_ref_or_tombstone(object_id)
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3283,7 +3283,9 @@ async fn test_store_revert_transfer_sui() {
         Owner::AddressOwner(sender),
     );
     assert_eq!(
-        db.get_object_or_tombstone(gas_object_id).unwrap().unwrap(),
+        db.get_latest_object_ref_or_tombstone(gas_object_id)
+            .unwrap()
+            .unwrap(),
         gas_object_ref
     );
     // Transaction should not be deleted on revert in case it's needed

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -228,7 +228,7 @@ impl TestCluster {
             .sui_node
             .state()
             .db()
-            .get_object_or_tombstone(object_id)
+            .get_latest_object_ref_or_tombstone(object_id)
             .unwrap()
             .unwrap()
     }


### PR DESCRIPTION
## Description 

The current implementation of `get_object_read` reads the latest version of an object, computes its reference and then make another call to db to read the object by that version. While this is inefficient, it also can result in inconsistent behavior when aggressive pruning is enabled. After reading the latest version of an object, it could've gotten pruned and we will end up returning a user input error (while it is not really a user error). The current PR does a few small things:
1. Rename existing functions which return object reference appropriately (they all are named like `get_object_or_tombstone` while `get_object_ref_or_tombstone` makes more sense)
2. Adds a new function which return latest object i.e. `get_latest_object_or_tombstone`
3. Makes `get_object_read` return the result in a single db lookup (not really if indirect objects get enabled but we can ignore that for now)

## Test Plan 

Existing tests
