### PR TITLE
[rpc][structured-error-handling][2/n] State trait for AuthorityState, group AuthorityState-originating SuiErrors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10248,6 +10248,7 @@ name = "sui-json-rpc"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bcs",
  "cached",

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+arc-swap.workspace = true
 fastcrypto.workspace = true
 jsonrpsee.workspace = true
 jsonrpsee-proc-macros.workspace = true
@@ -54,3 +55,4 @@ cached.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 expect-test.workspace = true
+sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -1,0 +1,630 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use arc_swap::Guard;
+use async_trait::async_trait;
+use move_core_types::language_storage::TypeTag;
+use mysten_metrics::spawn_monitored_task;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use sui_core::authority::{AuthorityState, AuthorityStore};
+use sui_core::subscription_handler::SubscriptionHandler;
+use sui_json_rpc_types::{
+    Coin as SuiCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
+    SuiObjectDataFilter, TransactionFilter,
+};
+use sui_storage::indexes::TotalBalance;
+use sui_storage::key_value_store::{
+    KVStoreCheckpointData, KVStoreTransactionData, TransactionKeyValueStore,
+    TransactionKeyValueStoreTrait,
+};
+use sui_types::base_types::{
+    MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress,
+};
+use sui_types::committee::{Committee, EpochId};
+use sui_types::digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest};
+use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::effects::TransactionEffects;
+use sui_types::error::{SuiError, UserInputError};
+use sui_types::event::EventID;
+use sui_types::governance::StakedSui;
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+    VerifiedCheckpoint,
+};
+use sui_types::object::{Object, ObjectRead, PastObjectRead};
+use sui_types::storage::WriteKind;
+use sui_types::sui_serde::BigInt;
+use sui_types::sui_system_state::SuiSystemState;
+use sui_types::transaction::{Transaction, TransactionData, TransactionKind};
+use thiserror::Error;
+use tokio::task::JoinError;
+
+#[cfg(test)]
+use mockall::automock;
+
+use crate::ObjectProvider;
+
+pub type StateReadResult<T = ()> = Result<T, StateReadError>;
+
+/// Trait for AuthorityState methods commonly used by at least two api.
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait StateRead: Send + Sync {
+    async fn multi_get(
+        &self,
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> StateReadResult<KVStoreTransactionData>;
+
+    async fn multi_get_checkpoints(
+        &self,
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> StateReadResult<KVStoreCheckpointData>;
+
+    fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
+
+    fn get_past_object_read(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> StateReadResult<PastObjectRead>;
+
+    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>>;
+
+    fn load_epoch_store_one_call_per_task(&self) -> Guard<Arc<AuthorityPerEpochStore>>;
+
+    fn get_dynamic_fields(
+        &self,
+        owner: ObjectID,
+        cursor: Option<ObjectID>,
+        limit: usize,
+    ) -> StateReadResult<Vec<(ObjectID, DynamicFieldInfo)>>;
+
+    fn get_db(&self) -> Arc<AuthorityStore>;
+
+    fn get_owner_objects(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        filter: Option<SuiObjectDataFilter>,
+    ) -> StateReadResult<Vec<ObjectInfo>>;
+
+    async fn query_events(
+        &self,
+        kv_store: &Arc<TransactionKeyValueStore>,
+        query: EventFilter,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<EventID>,
+        limit: usize,
+        descending: bool,
+    ) -> StateReadResult<Vec<SuiEvent>>;
+
+    // transaction_execution_api
+    #[allow(clippy::type_complexity)]
+    async fn dry_exec_transaction(
+        &self,
+        transaction: TransactionData,
+        transaction_digest: TransactionDigest,
+    ) -> StateReadResult<(
+        DryRunTransactionBlockResponse,
+        BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
+        TransactionEffects,
+        Option<ObjectID>,
+    )>;
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> StateReadResult<DevInspectResults>;
+
+    // indexer_api
+    fn get_subscription_handler(&self) -> Arc<SubscriptionHandler>;
+
+    fn get_owner_objects_with_limit(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: usize,
+        filter: Option<SuiObjectDataFilter>,
+    ) -> StateReadResult<Vec<ObjectInfo>>;
+
+    async fn get_transactions(
+        &self,
+        kv_store: &Arc<TransactionKeyValueStore>,
+        filter: Option<TransactionFilter>,
+        cursor: Option<TransactionDigest>,
+        limit: Option<usize>,
+        reverse: bool,
+    ) -> StateReadResult<Vec<TransactionDigest>>;
+
+    fn get_dynamic_field_object_id(
+        &self,
+        owner: ObjectID,
+        name_type: TypeTag,
+        name_bcs_bytes: &[u8],
+    ) -> StateReadResult<Option<ObjectID>>;
+
+    // governance_api
+    async fn get_staked_sui(&self, owner: SuiAddress) -> StateReadResult<Vec<StakedSui>>;
+    fn get_system_state(&self) -> StateReadResult<SuiSystemState>;
+    fn get_or_latest_committee(&self, epoch: Option<BigInt<u64>>) -> StateReadResult<Committee>;
+
+    // coin_api
+    fn find_publish_txn_digest(&self, package_id: ObjectID) -> StateReadResult<TransactionDigest>;
+    fn get_owned_coins(
+        &self,
+        owner: SuiAddress,
+        cursor: (String, ObjectID),
+        limit: usize,
+        one_coin_type_only: bool,
+    ) -> StateReadResult<Vec<SuiCoin>>;
+    async fn get_executed_transaction_and_effects(
+        &self,
+        digest: TransactionDigest,
+        kv_store: Arc<TransactionKeyValueStore>,
+    ) -> StateReadResult<(Transaction, TransactionEffects)>;
+    async fn get_balance(
+        &self,
+        owner: SuiAddress,
+        coin_type: TypeTag,
+    ) -> StateReadResult<TotalBalance>;
+    async fn get_all_balance(
+        &self,
+        owner: SuiAddress,
+    ) -> StateReadResult<Arc<HashMap<TypeTag, TotalBalance>>>;
+
+    // read_api
+    fn get_verified_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> StateReadResult<VerifiedCheckpoint>;
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> StateReadResult<CheckpointContents>;
+
+    fn get_verified_checkpoint_summary_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> StateReadResult<VerifiedCheckpoint>;
+
+    fn deprecated_multi_get_transaction_checkpoint(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> StateReadResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>>;
+
+    fn deprecated_get_transaction_checkpoint(
+        &self,
+        digest: &TransactionDigest,
+    ) -> StateReadResult<Option<(EpochId, CheckpointSequenceNumber)>>;
+
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> StateReadResult<Vec<Option<VerifiedCheckpoint>>>;
+
+    fn get_total_transaction_blocks(&self) -> StateReadResult<u64>;
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> StateReadResult<Option<VerifiedCheckpoint>>;
+
+    fn get_latest_checkpoint_sequence_number(&self) -> StateReadResult<CheckpointSequenceNumber>;
+
+    fn loaded_child_object_versions(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> StateReadResult<Option<Vec<(ObjectID, SequenceNumber)>>>;
+
+    fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier>;
+}
+
+#[async_trait]
+impl StateRead for AuthorityState {
+    async fn multi_get(
+        &self,
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> StateReadResult<KVStoreTransactionData> {
+        Ok(
+            <AuthorityState as TransactionKeyValueStoreTrait>::multi_get(
+                self,
+                transactions,
+                effects,
+                events,
+            )
+            .await?,
+        )
+    }
+
+    async fn multi_get_checkpoints(
+        &self,
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> StateReadResult<KVStoreCheckpointData> {
+        Ok(
+            <AuthorityState as TransactionKeyValueStoreTrait>::multi_get_checkpoints(
+                self,
+                checkpoint_summaries,
+                checkpoint_contents,
+                checkpoint_summaries_by_digest,
+                checkpoint_contents_by_digest,
+            )
+            .await?,
+        )
+    }
+
+    fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead> {
+        Ok(self.get_object_read(object_id)?)
+    }
+
+    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
+        Ok(self.get_object(object_id).await?)
+    }
+
+    fn get_past_object_read(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> StateReadResult<PastObjectRead> {
+        Ok(self.get_past_object_read(object_id, version)?)
+    }
+
+    fn load_epoch_store_one_call_per_task(&self) -> Guard<Arc<AuthorityPerEpochStore>> {
+        self.load_epoch_store_one_call_per_task()
+    }
+
+    fn get_dynamic_fields(
+        &self,
+        owner: ObjectID,
+        cursor: Option<ObjectID>,
+        limit: usize,
+    ) -> StateReadResult<Vec<(ObjectID, DynamicFieldInfo)>> {
+        Ok(self.get_dynamic_fields(owner, cursor, limit)?)
+    }
+
+    fn get_db(&self) -> Arc<AuthorityStore> {
+        self.db()
+    }
+
+    fn get_owner_objects(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        filter: Option<SuiObjectDataFilter>,
+    ) -> StateReadResult<Vec<ObjectInfo>> {
+        Ok(self
+            .get_owner_objects_iterator(owner, cursor, filter)?
+            .collect())
+    }
+
+    async fn query_events(
+        &self,
+        kv_store: &Arc<TransactionKeyValueStore>,
+        query: EventFilter,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<EventID>,
+        limit: usize,
+        descending: bool,
+    ) -> StateReadResult<Vec<SuiEvent>> {
+        Ok(self
+            .query_events(kv_store, query, cursor, limit, descending)
+            .await?)
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn dry_exec_transaction(
+        &self,
+        transaction: TransactionData,
+        transaction_digest: TransactionDigest,
+    ) -> StateReadResult<(
+        DryRunTransactionBlockResponse,
+        BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
+        TransactionEffects,
+        Option<ObjectID>,
+    )> {
+        Ok(self
+            .dry_exec_transaction(transaction, transaction_digest)
+            .await?)
+    }
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> StateReadResult<DevInspectResults> {
+        Ok(self
+            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .await?)
+    }
+
+    fn get_subscription_handler(&self) -> Arc<SubscriptionHandler> {
+        self.subscription_handler.clone()
+    }
+
+    fn get_owner_objects_with_limit(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: usize,
+        filter: Option<SuiObjectDataFilter>,
+    ) -> StateReadResult<Vec<ObjectInfo>> {
+        Ok(self.get_owner_objects(owner, cursor, limit, filter)?)
+    }
+
+    async fn get_transactions(
+        &self,
+        kv_store: &Arc<TransactionKeyValueStore>,
+        filter: Option<TransactionFilter>,
+        cursor: Option<TransactionDigest>,
+        limit: Option<usize>,
+        reverse: bool,
+    ) -> StateReadResult<Vec<TransactionDigest>> {
+        Ok(self
+            .get_transactions(kv_store, filter, cursor, limit, reverse)
+            .await?)
+    }
+
+    fn get_dynamic_field_object_id(
+        // indexer
+        &self,
+        owner: ObjectID,
+        name_type: TypeTag,
+        name_bcs_bytes: &[u8],
+    ) -> StateReadResult<Option<ObjectID>> {
+        Ok(self.get_dynamic_field_object_id(owner, name_type, name_bcs_bytes)?)
+    }
+
+    async fn get_staked_sui(&self, owner: SuiAddress) -> StateReadResult<Vec<StakedSui>> {
+        Ok(self
+            .get_move_objects(owner, MoveObjectType::staked_sui())
+            .await?)
+    }
+    fn get_system_state(&self) -> StateReadResult<SuiSystemState> {
+        Ok(self.database.get_sui_system_state_object()?)
+    }
+    fn get_or_latest_committee(&self, epoch: Option<BigInt<u64>>) -> StateReadResult<Committee> {
+        Ok(self
+            .committee_store()
+            .get_or_latest_committee(epoch.map(|e| *e))?)
+    }
+
+    fn find_publish_txn_digest(&self, package_id: ObjectID) -> StateReadResult<TransactionDigest> {
+        Ok(self.find_publish_txn_digest(package_id)?)
+    }
+    fn get_owned_coins(
+        &self,
+        owner: SuiAddress,
+        cursor: (String, ObjectID),
+        limit: usize,
+        one_coin_type_only: bool,
+    ) -> StateReadResult<Vec<SuiCoin>> {
+        Ok(self
+            .get_owned_coins_iterator_with_cursor(owner, cursor, limit, one_coin_type_only)?
+            .map(|(coin_type, coin_object_id, coin)| SuiCoin {
+                coin_type,
+                coin_object_id,
+                version: coin.version,
+                digest: coin.digest,
+                balance: coin.balance,
+                previous_transaction: coin.previous_transaction,
+            })
+            .collect::<Vec<_>>())
+    }
+
+    async fn get_executed_transaction_and_effects(
+        &self,
+        digest: TransactionDigest,
+        kv_store: Arc<TransactionKeyValueStore>,
+    ) -> StateReadResult<(Transaction, TransactionEffects)> {
+        Ok(self
+            .get_executed_transaction_and_effects(digest, kv_store)
+            .await?)
+    }
+
+    async fn get_balance(
+        &self,
+        owner: SuiAddress,
+        coin_type: TypeTag,
+    ) -> StateReadResult<TotalBalance> {
+        Ok(self
+            .indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_balance(owner, coin_type)
+            .await?)
+    }
+
+    async fn get_all_balance(
+        &self,
+        owner: SuiAddress,
+    ) -> StateReadResult<Arc<HashMap<TypeTag, TotalBalance>>> {
+        Ok(self
+            .indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_all_balance(owner)
+            .await?)
+    }
+
+    fn get_verified_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> StateReadResult<VerifiedCheckpoint> {
+        Ok(self.get_verified_checkpoint_by_sequence_number(sequence_number)?)
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: CheckpointContentsDigest,
+    ) -> StateReadResult<CheckpointContents> {
+        Ok(self.get_checkpoint_contents(digest)?)
+    }
+
+    fn get_verified_checkpoint_summary_by_digest(
+        &self,
+        digest: CheckpointDigest,
+    ) -> StateReadResult<VerifiedCheckpoint> {
+        Ok(self.get_verified_checkpoint_summary_by_digest(digest)?)
+    }
+
+    fn deprecated_multi_get_transaction_checkpoint(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> StateReadResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
+        Ok(self
+            .database
+            .deprecated_multi_get_transaction_checkpoint(digests)?)
+    }
+
+    fn deprecated_get_transaction_checkpoint(
+        &self,
+        digest: &TransactionDigest,
+    ) -> StateReadResult<Option<(EpochId, CheckpointSequenceNumber)>> {
+        Ok(self
+            .database
+            .deprecated_get_transaction_checkpoint(digest)?)
+    }
+
+    fn multi_get_checkpoint_by_sequence_number(
+        &self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+    ) -> StateReadResult<Vec<Option<VerifiedCheckpoint>>> {
+        Ok(self.multi_get_checkpoint_by_sequence_number(sequence_numbers)?)
+    }
+
+    fn get_total_transaction_blocks(&self) -> StateReadResult<u64> {
+        Ok(self.get_total_transaction_blocks()?)
+    }
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> StateReadResult<Option<VerifiedCheckpoint>> {
+        Ok(self.get_checkpoint_by_sequence_number(sequence_number)?)
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> StateReadResult<CheckpointSequenceNumber> {
+        Ok(self.get_latest_checkpoint_sequence_number()?)
+    }
+
+    fn loaded_child_object_versions(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> StateReadResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
+        Ok(self.loaded_child_object_versions(transaction_digest)?)
+    }
+
+    fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier> {
+        Ok(self
+            .get_chain_identifier()
+            .ok_or(anyhow!("Chain identifier not found"))?)
+    }
+}
+
+/// This implementation allows `S` to be a dynamically sized type (DST) that implements ObjectProvider
+/// Valid as `S` is referenced only, and memory management is handled by `Arc`
+#[async_trait]
+impl<S: ?Sized + StateRead> ObjectProvider for Arc<S> {
+    type Error = StateReadError;
+
+    async fn get_object(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Object, Self::Error> {
+        Ok(self.get_past_object_read(id, *version)?.into_object()?)
+    }
+
+    async fn find_object_lt_or_eq_version(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Option<Object>, Self::Error> {
+        let database = self.get_db();
+        let id = *id;
+        let version = *version;
+        spawn_monitored_task!(async move { database.find_object_lt_or_eq_version(id, version) })
+            .await
+            .map_err(StateReadError::from)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum StateReadInternalError {
+    #[error(transparent)]
+    SuiError(#[from] SuiError),
+    #[error(transparent)]
+    JoinError(#[from] JoinError),
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum StateReadClientError {
+    #[error(transparent)]
+    SuiError(#[from] SuiError),
+    #[error(transparent)]
+    UserInputError(#[from] UserInputError),
+}
+
+/// `StateReadError` is the error type for callers to work with.
+/// It captures all possible errors that can occur while reading state, classifying them into two categories.
+/// Unless `StateReadError` is the final error state before returning to caller, the app may still want error context.
+/// This context is preserved in `Internal` and `Client` variants.
+#[derive(Debug, Error)]
+pub enum StateReadError {
+    // sui_json_rpc::Error will do the final conversion to generic error message
+    #[error(transparent)]
+    Internal(#[from] StateReadInternalError),
+
+    // Client errors
+    #[error(transparent)]
+    Client(#[from] StateReadClientError),
+}
+
+impl From<SuiError> for StateReadError {
+    fn from(e: SuiError) -> Self {
+        match e {
+            SuiError::IndexStoreNotAvailable
+            | SuiError::TransactionNotFound { .. }
+            | SuiError::UnsupportedFeatureError { .. }
+            | SuiError::UserInputError { .. }
+            | SuiError::WrongMessageVersion { .. } => StateReadError::Client(e.into()),
+            _ => StateReadError::Internal(e.into()),
+        }
+    }
+}
+
+impl From<UserInputError> for StateReadError {
+    fn from(e: UserInputError) -> Self {
+        StateReadError::Client(e.into())
+    }
+}
+
+impl From<JoinError> for StateReadError {
+    fn from(e: JoinError) -> Self {
+        StateReadError::Internal(e.into())
+    }
+}
+
+impl From<anyhow::Error> for StateReadError {
+    fn from(e: anyhow::Error) -> Self {
+        StateReadError::Internal(e.into())
+    }
+}

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -28,6 +28,7 @@ use crate::metrics::MetricsLogger;
 use crate::routing_layer::RoutingLayer;
 
 pub mod api;
+pub mod authority_state;
 mod balance_changes;
 pub mod coin_api;
 pub mod error;

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -221,7 +221,9 @@ impl Logger for MetricsLogger {
             .observe(req_latency_secs);
 
         if let Some(code) = error_code {
-            if code == jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE {
+            if code == jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+                || code == jsonrpsee::types::error::INTERNAL_ERROR_CODE
+            {
                 self.metrics
                     .server_errors_by_route
                     .with_label_values(&[method_name])

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -23,6 +23,7 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::sui_serde::BigInt;
 
 use crate::api::TransactionBuilderServer;
+use crate::authority_state::StateRead;
 use crate::SuiRpcModule;
 
 pub struct TransactionBuilderApi(TransactionBuilder);
@@ -34,7 +35,7 @@ impl TransactionBuilderApi {
     }
 }
 
-pub struct AuthorityStateDataReader(Arc<AuthorityState>);
+pub struct AuthorityStateDataReader(Arc<dyn StateRead>);
 
 impl AuthorityStateDataReader {
     pub fn new(state: Arc<AuthorityState>) -> Self {
@@ -52,12 +53,11 @@ impl DataReader for AuthorityStateDataReader {
         Ok(self
             .0
             // DataReader is used internally, don't need a limit
-            .get_owner_objects_iterator(
+            .get_owner_objects(
                 address,
                 None,
                 Some(SuiObjectDataFilter::StructType(object_type)),
-            )?
-            .collect())
+            )?)
     }
 
     async fn get_object_with_options(

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -36,6 +36,7 @@ use tracing::instrument;
 
 use crate::api::JsonRpcMetrics;
 use crate::api::WriteApiServer;
+use crate::authority_state::StateRead;
 use crate::error::{Error, SuiRpcInputError};
 use crate::{
     get_balance_changes_from_effect, get_object_changes, with_tracing, ObjectProviderCache,
@@ -43,7 +44,7 @@ use crate::{
 };
 
 pub struct TransactionExecutionApi {
-    state: Arc<AuthorityState>,
+    state: Arc<dyn StateRead>,
     transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
     metrics: Arc<JsonRpcMetrics>,
 }


### PR DESCRIPTION
## Description 

Part of the first set of PRs is to group the errors that are possible on the RPC today into a few categories transparently, setting us up to eventually standardize error strings and resolution. This PR specifically introduces a `State` trait which `AuthorityState` implements to centralize `AuthorityState`-originating `SuiError`s so that we can disambiguate these errors from other sources of `SuiError`. This has the added benefit of helping w/ unit test writing, as demonstrated by `coin_api` and `move_utils`.

No change has been made to error strings, but StateReadError::Internal will now code to `-32603` instead of `-32000`. But this can be negotiable too.

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Internal errors that arise while reading from authority will now return -32603 error code. Client-fault errors that arise while reading from authority will now return -32602 error code. Error strings have not been modified.