### PR TITLE
[Kiosk SDK] Adds support for attaching rules to Transfer Policy

### DIFF
--- a/.changeset/tender-cows-flash.md
+++ b/.changeset/tender-cows-flash.md
@@ -1,0 +1,5 @@
+---
+'@mysten/kiosk': minor
+---
+
+Adds support for attaching royalty rule and kiosk lock rule to a transfer policy.

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -20,49 +20,28 @@ You can also use your preferred package manager, such as yarn or pnpm.
 Here are some indicative examples on how to use the kiosk SDK.
 
 <details>
-<summary>Find an addresses' owned kiosk(s)</summary>
+<summary>Find the kiosks owned by an address</summary>
 
 ```typescript
 import { getOwnedKiosks } from '@mysten/kiosk';
 import { SuiClient } from '@mysten/sui.js/client';
 
-const provider = new JsonRpcProvider(
-	new Connection({ fullnode: 'https://fullnode.testnet.sui.io:443' }),
-);
-
-// You could use these to fetch the contents for each kiosk, or use the `kioskOwnerCap` data for other actions.
-const getUserKiosks = async () => {
-	const address = `0xAddress`;
-	const { data } = await getOwnedKiosks(provider, address);
-	console.log(data); // kioskOwnerCaps:[], kioskIds: []
-};
-```
-
-</details>
-
-<details>
-<summary>Find an addresses' owned kiosk(s)</summary>
-
-```typescript
-import { fetchKiosk } from '@mysten/kiosk';
-import { Connection, JsonRpcProvider } from '@mysten/sui.js';
-
 const client = new SuiClient(
-	url: 'https://fullnode.testnet.sui.io:443',
+  url: 'https://fullnode.testnet.sui.io:443',
 );
+
 
 // You could use these to fetch the contents for each kiosk, or use the `kioskOwnerCap` data for other actions.
 const getUserKiosks = async () => {
 	const address = `0xAddress`;
-	const { data } = await getOwnedKiosks(provider, address);
+	const { data } = await getOwnedKiosks(client, address);
 	console.log(data); // kioskOwnerCaps:[], kioskIds: []
 };
 ```
 
 </details>
 
-<details>
-<summary>Getting the listings & items by the kiosk's id</summary>
+<summary>Getting the listings & items by the kiosk's ID</summary>
 
 ```typescript
 import { fetchKiosk } from '@mysten/kiosk';
@@ -229,13 +208,11 @@ const withdraw = async () => {
 
 <summary>Create a Transfer Policy for a Type</summary>
 
-You can only create a TransferPolicy for packages that you own the `publisher` Object.
+You can create a TransferPolicy only for packages for which you own the `publisher` object.
 
-It's recommended (unless you have a more advanced use case) to create only one transfer policy per type, or make sure that all transfer policies have the same rules.
+As a best practice, you should use a single Transfer policy per type (T). If you use more than one policy for a type, and the rules for each differ, anyone that meets the conditions for any of the attached policies can purchase an asset from a kiosk. You can't specify which policy applies to a specific asset for the type when there is more than one policy attached. When someone meets the conditions that are easiest to meet, they are allowed to purchase and transfer the asset.
 
-If you have multiple transfer policies, someone could purchase an item of that Type from a kiosk by using the easiest (to resolve) rules.
-
-You could extend the following snippet to do a check before creating the transfer policy, by using the `queryTransferPolicy` function, similar to the `purchaseAndResolvePolicies` example.
+Before you create a transfer policy, you can use the `queryTransferpolicy` function to check the transfer policy associated with a type. This is similar to the `purchaseAndResolvePolicies` example above.
 
 ```typescript
 import { createTransferPolicy } from '@mysten/kiosk';
@@ -261,7 +238,7 @@ const createPolicyForType = async () => {
 
 <details>
 
-<summary>Attach Rules (Royalty, Kiosk Lock) to the Transfer Policy</summary>
+<summary>Attach Royalty and Lock rules to a Transfer policy</summary>
 
 ```typescript
 import {

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -41,6 +41,7 @@ const getUserKiosks = async () => {
 
 </details>
 
+<details>
 <summary>Getting the listings & items by the kiosk's ID</summary>
 
 ```typescript

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -264,7 +264,12 @@ const createPolicyForType = async () => {
 <summary>Attach Rules (Royalty, Kiosk Lock) to the Transfer Policy</summary>
 
 ```typescript
-import { createTransferPolicy, attachKioskLockRule, testnetEnvironment } from '@mysten/kiosk';
+import {
+	createTransferPolicy,
+	attachKioskLockRule,
+	attachRoyaltyRule,
+	testnetEnvironment,
+} from '@mysten/kiosk';
 import { TransactionBlock } from '@mysten/sui.js';
 
 // Attaches a royalty rule of 1% or 0.1 SUI (whichever is bigger)

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -211,9 +211,15 @@ const withdraw = async () => {
 
 You can create a TransferPolicy only for packages for which you own the `publisher` object.
 
-As a best practice, you should use a single Transfer policy per type (T). If you use more than one policy for a type, and the rules for each differ, anyone that meets the conditions for any of the attached policies can purchase an asset from a kiosk. You can't specify which policy applies to a specific asset for the type when there is more than one policy attached. When someone meets the conditions that are easiest to meet, they are allowed to purchase and transfer the asset.
+As a best practice, you should use a single Transfer policy per type (T). If you use more than one
+policy for a type, and the rules for each differ, anyone that meets the conditions for any of the
+attached policies can purchase an asset from a kiosk. You can't specify which policy applies to a
+specific asset for the type when there is more than one policy attached. When someone meets the
+conditions that are easiest to meet, they are allowed to purchase and transfer the asset.
 
-Before you create a transfer policy, you can use the `queryTransferpolicy` function to check the transfer policy associated with a type. This is similar to the `purchaseAndResolvePolicies` example above.
+Before you create a transfer policy, you can use the `queryTransferpolicy` function to check the
+transfer policy associated with a type. This is similar to the `purchaseAndResolvePolicies` example
+above.
 
 ```typescript
 import { createTransferPolicy } from '@mysten/kiosk';

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -253,6 +253,7 @@ import {
 	attachKioskLockRule,
 	attachRoyaltyRule,
 	testnetEnvironment,
+	percentageToBasisPoints,
 } from '@mysten/kiosk';
 import { TransactionBlock } from '@mysten/sui.js';
 
@@ -264,7 +265,7 @@ const attachStrongRoyalties = async () => {
 	const transferPolicyCap = 'transferPolicyCapId'; // the transferPolicyCap for that policy.
 
 	// royalties configuration.
-	const percentage = 100; // 1%
+	const percentage = 2.55; // 2.55%
 	const minAmount = 100_000_000; // 0.1 SUI.
 
 	// the environment on which we're referecing the rules package.
@@ -274,7 +275,15 @@ const attachStrongRoyalties = async () => {
 	const tx = new TransactionBlock();
 
 	attachKioskLockRule(tx, type, policyId, policyCapId, enviroment);
-	attachRoyaltyRule(tx, type, policyId, policyCapId, percentage, minAmount, enviroment);
+	attachRoyaltyRule(
+		tx,
+		type,
+		policyId,
+		policyCapId,
+		percentageToBasisPoints(percentage),
+		minAmount,
+		enviroment,
+	);
 
 	// ... continue to sign and execute the transaction
 	// ...

--- a/sdk/kiosk/src/index.ts
+++ b/sdk/kiosk/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from './tx/kiosk';
 export * from './tx/transfer-policy';
+export * from './tx/rules';
 export * from './query/kiosk';
 export * from './bcs';
 export * from './utils';

--- a/sdk/kiosk/src/tx/rules.ts
+++ b/sdk/kiosk/src/tx/rules.ts
@@ -7,8 +7,10 @@ import { getRulePackageAddress, objArg } from '../utils';
 
 /**
  *  Adds the Kiosk Royalty rule to the Transfer Policy.
- *  You cna provide the percentage, as well as a minimum amount.
+ *  You can pass the percentage, as well as a minimum amount.
  *  The royalty that will be paid is the MAX(percentage, minAmount).
+ * 	You can pass 0 in either value if you want only percentage royalty, or a fixed amount fee.
+ * 	(but you should define at least one of them for the rule to make sense).
  */
 export const attachRoyaltyRule = (
 	tx: TransactionBlock,
@@ -33,6 +35,7 @@ export const attachRoyaltyRule = (
 
 /**
  * Adds the Kiosk Lock Rule to the Transfer Policy.
+ * This Rule forces buyer to lock the item in the kiosk, preserving strong royalties.
  */
 export const attachKioskLockRule = (
 	tx: TransactionBlock,

--- a/sdk/kiosk/src/tx/rules.ts
+++ b/sdk/kiosk/src/tx/rules.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TransactionBlock } from '@mysten/sui.js';
+import { ObjectArgument, RulesEnvironmentParam } from '../types';
+import { getRulePackageAddress, objArg } from '../utils';
+
+/**
+ *  Adds the Kiosk Royalty rule to the Transfer Policy.
+ *  You cna provide the percentage, as well as a minimum amount.
+ *  The royalty that will be paid is the MAX(percentage, minAmount).
+ */
+export const attachRoyaltyRule = (
+	tx: TransactionBlock,
+	type: string,
+	policy: ObjectArgument,
+	policyCap: ObjectArgument,
+	percentage: number | string,
+	min_amount: number | string,
+	environment: RulesEnvironmentParam,
+) => {
+	tx.moveCall({
+		target: `${getRulePackageAddress(environment)}::royalty_rule::add`,
+		typeArguments: [type],
+		arguments: [
+			objArg(tx, policy),
+			objArg(tx, policyCap),
+			tx.pure(percentage, 'u16'),
+			tx.pure(min_amount, 'u64'),
+		],
+	});
+};
+
+/**
+ * Adds the Kiosk Lock Rule to the Transfer Policy.
+ */
+export const attachKioskLockRule = (
+	tx: TransactionBlock,
+	type: string,
+	policy: ObjectArgument,
+	policyCap: ObjectArgument,
+	environment: RulesEnvironmentParam,
+) => {
+	tx.moveCall({
+		target: `${getRulePackageAddress(environment)}::kiosk_lock_rule::add`,
+		typeArguments: [type],
+		arguments: [objArg(tx, policy), objArg(tx, policyCap)],
+	});
+};

--- a/sdk/kiosk/src/tx/rules.ts
+++ b/sdk/kiosk/src/tx/rules.ts
@@ -25,7 +25,7 @@ export function attachRoyaltyRule(
 	environment: RulesEnvironmentParam,
 ) {
 	if (Number(percentageBps) < 0 || Number(percentageBps) > 10_000)
-		throw new Error('Invalid basis point percentage.');
+		throw new Error('Invalid basis point percentage. Use a value between [0,10000].');
 
 	tx.moveCall({
 		target: `${getRulePackageAddress(environment)}::royalty_rule::add`,

--- a/sdk/kiosk/src/tx/rules.ts
+++ b/sdk/kiosk/src/tx/rules.ts
@@ -15,7 +15,7 @@ import { getRulePackageAddress, objArg } from '../utils';
  * 	@param percentageBps The royalty percentage in basis points. Use `percentageToBasisPoints` helper to convert from percentage [0,100].
  * 	@param minAmount The minimum royalty amount per request in MIST.
  */
-export const attachRoyaltyRule = (
+export function attachRoyaltyRule(
 	tx: TransactionBlock,
 	type: string,
 	policy: ObjectArgument,
@@ -23,7 +23,7 @@ export const attachRoyaltyRule = (
 	percentageBps: number | string, // this is in basis points.
 	minAmount: number | string,
 	environment: RulesEnvironmentParam,
-) => {
+) {
 	if (Number(percentageBps) < 0 || Number(percentageBps) > 10_000)
 		throw new Error('Invalid basis point percentage.');
 
@@ -37,22 +37,22 @@ export const attachRoyaltyRule = (
 			tx.pure(minAmount, 'u64'),
 		],
 	});
-};
+}
 
 /**
  * Adds the Kiosk Lock Rule to the Transfer Policy.
  * This Rule forces buyer to lock the item in the kiosk, preserving strong royalties.
  */
-export const attachKioskLockRule = (
+export function attachKioskLockRule(
 	tx: TransactionBlock,
 	type: string,
 	policy: ObjectArgument,
 	policyCap: ObjectArgument,
 	environment: RulesEnvironmentParam,
-) => {
+) {
 	tx.moveCall({
 		target: `${getRulePackageAddress(environment)}::kiosk_lock_rule::add`,
 		typeArguments: [type],
 		arguments: [objArg(tx, policy), objArg(tx, policyCap)],
 	});
-};
+}

--- a/sdk/kiosk/src/tx/rules.ts
+++ b/sdk/kiosk/src/tx/rules.ts
@@ -11,24 +11,30 @@ import { getRulePackageAddress, objArg } from '../utils';
  *  The royalty that will be paid is the MAX(percentage, minAmount).
  * 	You can pass 0 in either value if you want only percentage royalty, or a fixed amount fee.
  * 	(but you should define at least one of them for the rule to make sense).
+ *
+ * 	@param percentageBps The royalty percentage in basis points. Use `percentageToBasisPoints` helper to convert from percentage [0,100].
+ * 	@param minAmount The minimum royalty amount per request in MIST.
  */
 export const attachRoyaltyRule = (
 	tx: TransactionBlock,
 	type: string,
 	policy: ObjectArgument,
 	policyCap: ObjectArgument,
-	percentage: number | string,
-	min_amount: number | string,
+	percentageBps: number | string, // this is in basis points.
+	minAmount: number | string,
 	environment: RulesEnvironmentParam,
 ) => {
+	if (Number(percentageBps) < 0 || Number(percentageBps) > 10_000)
+		throw new Error('Invalid basis point percentage.');
+
 	tx.moveCall({
 		target: `${getRulePackageAddress(environment)}::royalty_rule::add`,
 		typeArguments: [type],
 		arguments: [
 			objArg(tx, policy),
 			objArg(tx, policyCap),
-			tx.pure(percentage, 'u16'),
-			tx.pure(min_amount, 'u64'),
+			tx.pure(percentageBps, 'u16'),
+			tx.pure(minAmount, 'u64'),
 		],
 	});
 };

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -198,3 +198,15 @@ export async function getAllDynamicFields(
 
 	return data;
 }
+
+/**
+ * Converts a number to basis points.
+ * Supports up to 2 decimal points.
+ * E.g 9.95 -> 995
+ * @param percentage A percentage amount in the range [0, 100] including decimals.
+ */
+export function percentageToBasisPoints(percentage: number) {
+	if (percentage < 0 || percentage > 100)
+		throw new Error('Percentage needs to be in the [0,100] range.');
+	return Math.ceil(percentage * 100);
+}


### PR DESCRIPTION
## Description 

This PR adds support to attaching rules (royalty + kiosk lock) on a Transfer Policy. 
It also extends the README to add some more examples on how to use these.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
