### PR TITLE
Update devInspectTransactionBlock and dryRunTransactionBlock documentation. 

### DIFF
--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -40,9 +40,16 @@ pub trait WriteApi {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse>;
 
-    /// Runs the transaction in dev-inspect mode. Which allows for nearly any
-    /// transaction (or Move call) with any arguments. Detailed results are
-    /// provided, including both the transaction effects and any return values.
+    /// Simulates running the transaction, even one that would be normally
+    /// impossible, against the current state of the network. Nearly any
+    /// transaction (or Move call) with any arguments can run in dev-inspect;
+    /// transaction inputs are not checked, entry function verification is
+    /// skipped, values can be left unused, and returns are not validated.
+    /// Detailed results are provided, including both the transaction effects
+    /// and any return values. Dev-inspect is provided to aid in understanding
+    /// the effects of any possible action against the current network state.
+    /// See dryRunTransactionBlock for a more faithful simulation of what would
+    /// happen if the transaction were actually run.
     #[method(name = "devInspectTransactionBlock")]
     async fn dev_inspect_transaction_block(
         &self,
@@ -55,8 +62,11 @@ pub trait WriteApi {
         epoch: Option<BigInt<u64>>,
     ) -> RpcResult<DevInspectResults>;
 
-    /// Return transaction execution effects including the gas cost summary,
-    /// while the effects are not committed to the chain.
+    /// Simulate running the transaction, including all normally applied
+    /// checks, without actually running it. This is useful for estimating
+    /// the gas fees of a transaction before running it, but can also be used
+    /// to determine the side-effects of a transaction without actually running
+    /// it.
     #[method(name = "dryRunTransactionBlock")]
     async fn dry_run_transaction_block(
         &self,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -145,7 +145,7 @@
           "name": "Write API"
         }
       ],
-      "description": "Return transaction execution effects including the gas cost summary, while the effects are not committed to the chain.",
+      "description": "Simulate running the transaction, including all normally applied checks, without actually running it. This is useful for estimating the gas fees of a transaction before running it, but can also be used to determine the side-effects of a transaction without actually running it.",
       "params": [
         {
           "name": "tx_bytes",
@@ -164,7 +164,7 @@
       },
       "examples": [
         {
-          "name": "Dry runs a transaction block to get back estimated gas fees and other potential effects.",
+          "name": "Simulate running the transaction, including all normally applied checks, without actually running it. This is useful for estimating the gas fees of a transaction before running it, but can also be used to determine the side-effects of a transaction without actually running it.",
           "params": [
             {
               "name": "tx_bytes",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -22,7 +22,7 @@
           "name": "Write API"
         }
       ],
-      "description": "Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.",
+      "description": "Simulates running the transaction, even one that would be normally impossible, against the current state of the network. Nearly any transaction (or Move call) with any arguments can run in dev-inspect; transaction inputs are not checked, entry function verification is skipped, values can be left unused, and returns are not validated. Detailed results are provided, including both the transaction effects and any return values. Dev-inspect is provided to aid in understanding the effects of any possible action against the current network state. See dryRunTransactionBlock for a more faithful simulation of what would happen if the transaction were actually run.",
       "params": [
         {
           "name": "sender_address",
@@ -63,7 +63,7 @@
       },
       "examples": [
         {
-          "name": "Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.",
+          "name": "Simulates running the transaction, even one that would be normally impossible, against the current state of the network. Nearly any transaction (or Move call) with any arguments can run in dev-inspect; transaction inputs are not checked, entry function verification is skipped, values can be left unused, and returns are not validated. Detailed results are provided, including both the transaction effects and any return values. Dev-inspect is provided to aid in understanding the effects of any possible action against the current network state. See dryRunTransactionBlock for a more faithful simulation of what would happen if the transaction were actually run.",
           "params": [
             {
               "name": "sender_address",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -273,7 +273,7 @@ impl RpcExampleProvider {
         Examples::new(
             "sui_dryRunTransactionBlock",
             vec![ExamplePairing::new(
-                "Dry runs a transaction block to get back estimated gas fees and other potential effects.",
+                "Simulate running the transaction, including all normally applied checks, without actually running it. This is useful for estimating the gas fees of a transaction before running it, but can also be used to determine the side-effects of a transaction without actually running it.",
                 vec![
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
                 ],
@@ -296,7 +296,7 @@ impl RpcExampleProvider {
         Examples::new(
             "sui_devInspectTransactionBlock",
             vec![ExamplePairing::new(
-                "Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.",
+                "Simulates running the transaction, even one that would be normally impossible, against the current state of the network. Nearly any transaction (or Move call) with any arguments can run in dev-inspect; transaction inputs are not checked, entry function verification is skipped, values can be left unused, and returns are not validated. Detailed results are provided, including both the transaction effects and any return values. Dev-inspect is provided to aid in understanding the effects of any possible action against the current network state. See dryRunTransactionBlock for a more faithful simulation of what would happen if the transaction were actually run.",
                 vec![
                     ("sender_address", json!(SuiAddress::from(ObjectID::new(self.rng.gen())))),
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),

--- a/sdk/typescript/src/client/index.ts
+++ b/sdk/typescript/src/client/index.ts
@@ -532,9 +532,16 @@ export class SuiClient {
 	}
 
 	/**
-	 * Runs the transaction block in dev-inspect mode. Which allows for nearly any
-	 * transaction (or Move call) with any arguments. Detailed results are
-	 * provided, including both the transaction effects and any return values.
+	 * Simulates running the transaction, even one that would be normally 
+	 * impossible, against the current state of the network. Nearly any 
+	 * transaction (or Move call) with any arguments can run in dev-inspect; 
+	 * transaction inputs are not checked, entry function verification is 
+	 * skipped, values can be left unused, and returns are not validated. 
+	 * Detailed results are provided, including both the transaction effects 
+	 * and any return values. Dev-inspect is provided to aid in understanding
+	 * the effects of any possible action against the current network state. 
+	 * See dryRunTransactionBlock for a more faithful simulation of what would
+	 * happen if the transaction were actually run.
 	 */
 	async devInspectTransactionBlock(input: {
 		transactionBlock: TransactionBlock | string | Uint8Array;

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -149,9 +149,16 @@ export abstract class SignerWithProvider implements Signer {
 	}
 
 	/**
-	 * Runs the transaction in dev-inpsect mode. Which allows for nearly any
-	 * transaction (or Move call) with any arguments. Detailed results are
-	 * provided, including both the transaction effects and any return values.
+	 * Simulates running the transaction, even one that would be normally 
+	 * impossible, against the current state of the network. Nearly any 
+	 * transaction (or Move call) with any arguments can run in dev-inspect; 
+	 * transaction inputs are not checked, entry function verification is 
+	 * skipped, values can be left unused, and returns are not validated. 
+	 * Detailed results are provided, including both the transaction effects 
+	 * and any return values. Dev-inspect is provided to aid in understanding
+	 * the effects of any possible action against the current network state. 
+	 * See dryRunTransactionBlock for a more faithful simulation of what would
+	 * happen if the transaction were actually run.
 	 */
 	async devInspectTransactionBlock(
 		input: Omit<Parameters<JsonRpcProvider['devInspectTransactionBlock']>[0], 'sender'>,


### PR DESCRIPTION
## Description 

Update the documentation for the JSON RPC endpoints sui_devInspectTransactionBlock and sui_dryRunTransactionBlock to have more comprehensive descriptions of the differences and effects of both RPCs.

## Test Plan 

This change only touches documentation. 
