### PR TITLE
Make bench driver terminate on time

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -203,16 +203,17 @@ impl BenchDriver {
         start_time: Instant,
         interval: Interval,
         gas_used: u64,
+        increment_by_value: u64,
         progress_bar: Arc<ProgressBar>,
     ) {
         match interval {
             Interval::Count(count) => {
-                progress_bar.inc(1);
+                progress_bar.inc(increment_by_value);
                 if progress_bar.position() >= count {
                     progress_bar.finish_and_clear();
                 }
             }
-            Interval::Time(Duration::MAX) => progress_bar.inc(1),
+            Interval::Time(Duration::MAX) => progress_bar.inc(increment_by_value),
             Interval::Time(duration) => {
                 let elapsed_secs = (Instant::now() - start_time).as_secs();
                 progress_bar.set_position(std::cmp::min(duration.as_secs(), elapsed_secs));
@@ -373,6 +374,10 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                             latency_histogram.reset();
                         }
                         _ = request_interval.tick() => {
+                            BenchDriver::update_progress(*start_time, run_duration, total_gas_used, 0, progress_cloned.clone());
+                            if progress_cloned.is_finished() {
+                                break;
+                            }
 
                             // If a retry is available send that
                             // (sending retries here subjects them to our rate limit)
@@ -483,7 +488,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                             match op {
                                 NextOp::Retry(b) => {
                                     retry_queue.push_back(b);
-                                    BenchDriver::update_progress(*start_time, run_duration, total_gas_used, progress_cloned.clone());
+                                    BenchDriver::update_progress(*start_time, run_duration, total_gas_used, 1, progress_cloned.clone());
                                     if progress_cloned.is_finished() {
                                         break;
                                     }
@@ -495,7 +500,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                     total_gas_used += gas_used;
                                     free_pool.push_back(payload);
                                     latency_histogram.saturating_record(latency.as_millis().try_into().unwrap());
-                                    BenchDriver::update_progress(*start_time, run_duration, total_gas_used, progress_cloned.clone());
+                                    BenchDriver::update_progress(*start_time, run_duration, total_gas_used, 1, progress_cloned.clone());
                                     if progress_cloned.is_finished() {
                                         break;
                                     }


### PR DESCRIPTION
## Description 

Bench driver only terminates when a response comes back (it checks for duration elapsed only in the response handler). However, quorum driver has internal retries with exponential backoff and a response may not even come back or come very late when there are errors. We can fix the above by checking for duration elapsed in request tick handler.
## Test Plan 

Existing tests
