### PR TITLE
Schedule owned-object transactions for execution from consensus validator to reduce latency

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -68,7 +68,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_reconfig() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 1000).await;
+        let test_cluster = build_test_cluster(4, 5000).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 60).await;
     }
 
@@ -97,7 +97,7 @@ mod test {
         // TODO added to invalidate a failing test seed in CI. Remove me
         tokio::time::sleep(Duration::from_secs(1)).await;
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = Arc::new(build_test_cluster(4, 1000).await);
+        let test_cluster = Arc::new(build_test_cluster(4, 5000).await);
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -185,7 +185,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_with_crashes_and_delays() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 1000).await;
+        let test_cluster = build_test_cluster(4, 5000).await;
 
         let dead_validator_orig: Arc<Mutex<Option<DeadValidator>>> = Default::default();
 
@@ -243,7 +243,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_crashes_during_epoch_change() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 10000).await;
+        let test_cluster = build_test_cluster(4, 5000).await;
 
         let dead_validator: Arc<Mutex<Option<DeadValidator>>> = Default::default();
         let keep_alive_nodes = get_keep_alive_nodes(&test_cluster);
@@ -255,7 +255,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_checkpoint_pruning() {
-        let test_cluster = build_test_cluster(4, 1000).await;
+        let test_cluster = build_test_cluster(4, 5000).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 30).await;
 
         let swarm_dir = test_cluster.swarm.dir().join(AUTHORITIES_DB_NAME);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -964,22 +964,28 @@ impl AuthorityPerEpochStore {
     /// and verify that it allows new user certificates
     pub fn insert_pending_consensus_transactions(
         &self,
-        transaction: &ConsensusTransaction,
+        transactions: &[ConsensusTransaction],
         lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> SuiResult {
-        self.tables
-            .pending_consensus_transactions
-            .insert(&transaction.key(), transaction)?;
-        if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
-            let state = lock.expect("Must pass reconfiguration lock when storing certificate");
-            // Caller is responsible for performing graceful check
-            assert!(
-                state.should_accept_user_certs(),
-                "Reconfiguration state should allow accepting user transactions"
-            );
-            self.pending_consensus_certificates
-                .lock()
-                .insert(*cert.digest());
+        let mut batch = self.tables.pending_consensus_transactions.batch();
+        batch.insert_batch(
+            &self.tables.pending_consensus_transactions,
+            transactions.iter().map(|t| (t.key(), t)),
+        )?;
+        batch.write()?;
+
+        for transaction in transactions {
+            if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
+                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
+                // Caller is responsible for performing graceful check
+                assert!(
+                    state.should_accept_user_certs(),
+                    "Reconfiguration state should allow accepting user transactions"
+                );
+                self.pending_consensus_certificates
+                    .lock()
+                    .insert(*cert.digest());
+            }
         }
         Ok(())
     }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -550,7 +550,7 @@ impl ConsensusAdapter {
         lock: Option<&RwLockReadGuard<ReconfigState>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<JoinHandle<()>> {
-        epoch_store.insert_pending_consensus_transactions(&transaction, lock)?;
+        epoch_store.insert_pending_consensus_transactions(&[transaction.clone()], lock)?;
         Ok(self.submit_unchecked(transaction, epoch_store))
     }
 

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -98,7 +98,8 @@ impl TransactionValidator for SuiTxValidator {
                         && !epoch_store.is_tx_cert_consensus_message_processed(&certificate)?
                     {
                         // new_unchecked safety: we do not use the certs in this list until all
-                        // have had their signatures verified.
+                        // have had their signatures verified. All certs in cert_batch must be
+                        // verified by signature_verifier, or the entire batch will be rejected.
                         owned_tx_certs.push(VerifiedCertificate::new_unchecked(*certificate));
                     }
                 }

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -13,7 +13,9 @@ use crate::transaction_manager::TransactionManager;
 use async_trait::async_trait;
 use narwhal_types::{validate_batch_version, BatchAPI};
 use narwhal_worker::TransactionValidator;
+use sui_types::base_types::AuthorityName;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
+use sui_types::transaction::VerifiedCertificate;
 use tap::TapFallible;
 use tokio::runtime::Handle;
 use tracing::{info, warn};
@@ -21,14 +23,16 @@ use tracing::{info, warn};
 /// Allows verifying the validity of transactions
 #[derive(Clone)]
 pub struct SuiTxValidator {
+    name: AuthorityName,
     epoch_store: Arc<AuthorityPerEpochStore>,
     checkpoint_service: Arc<dyn CheckpointServiceNotify + Send + Sync>,
-    _transaction_manager: Arc<TransactionManager>,
+    transaction_manager: Arc<TransactionManager>,
     metrics: Arc<SuiTxValidatorMetrics>,
 }
 
 impl SuiTxValidator {
     pub fn new(
+        name: AuthorityName,
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<dyn CheckpointServiceNotify + Send + Sync>,
         transaction_manager: Arc<TransactionManager>,
@@ -39,9 +43,10 @@ impl SuiTxValidator {
             epoch_store.epoch()
         );
         Self {
+            name,
             epoch_store,
             checkpoint_service,
-            _transaction_manager: transaction_manager,
+            transaction_manager,
             metrics,
         }
     }
@@ -78,19 +83,24 @@ impl TransactionValidator for SuiTxValidator {
             .map(|tx| tx_from_bytes(tx))
             .collect::<Result<Vec<_>, _>>()?;
 
+        let epoch_store = self.epoch_store.clone();
+
+        let mut owned_tx_certs = Vec::new();
         let mut cert_batch = Vec::new();
         let mut ckpt_messages = Vec::new();
         let mut ckpt_batch = Vec::new();
         for tx in txs.into_iter() {
             match tx.kind {
                 ConsensusTransactionKind::UserTransaction(certificate) => {
-                    cert_batch.push(*certificate);
+                    cert_batch.push(*certificate.clone());
 
-                    // if !certificate.contains_shared_object() {
-                    //     // new_unchecked safety: we do not use the certs in this list until all
-                    //     // have had their signatures verified.
-                    //     owned_tx_certs.push(VerifiedCertificate::new_unchecked(*certificate));
-                    // }
+                    if !certificate.contains_shared_object()
+                        && !epoch_store.is_tx_cert_consensus_message_processed(&certificate)?
+                    {
+                        // new_unchecked safety: we do not use the certs in this list until all
+                        // have had their signatures verified.
+                        owned_tx_certs.push(VerifiedCertificate::new_unchecked(*certificate));
+                    }
                 }
                 ConsensusTransactionKind::CheckpointSignature(signature) => {
                     ckpt_messages.push(signature.clone());
@@ -104,10 +114,10 @@ impl TransactionValidator for SuiTxValidator {
         // verify the certificate signatures as a batch
         let cert_count = cert_batch.len();
         let ckpt_count = ckpt_batch.len();
-        let epoch_store = self.epoch_store.clone();
+        let epoch_store_clone = epoch_store.clone();
         Handle::current()
             .spawn_blocking(move || {
-                epoch_store
+                epoch_store_clone
                     .signature_verifier
                     .verify_certs_and_checkpoints(cert_batch, ckpt_batch)
                     .tap_err(|e| warn!("batch verification error: {}", e))
@@ -127,16 +137,27 @@ impl TransactionValidator for SuiTxValidator {
         self.metrics
             .checkpoint_signatures_verified
             .inc_by(ckpt_count as u64);
-        Ok(())
-
         // todo - we should un-comment line below once we have a way to revert those transactions at the end of epoch
         // all certificates had valid signatures, schedule them for execution prior to sequencing
         // which is unnecessary for owned object transactions.
         // It is unnecessary to write to pending_certificates table because the certs will be written
         // via Narwhal output.
-        // self.transaction_manager
-        //     .enqueue_certificates(owned_tx_certs, &self.epoch_store)
-        //     .wrap_err("Failed to schedule certificates for execution")
+        let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
+        if reconfiguration_lock.should_accept_user_certs() {
+            for cert in owned_tx_certs.iter() {
+                let transaction =
+                    ConsensusTransaction::new_certificate_message(&self.name, cert.clone().into());
+                epoch_store.insert_pending_consensus_transactions(
+                    &transaction,
+                    Some(&reconfiguration_lock),
+                )?;
+            }
+            self.transaction_manager
+                .enqueue_certificates(owned_tx_certs, &epoch_store)
+                .wrap_err("Failed to schedule certificates for execution")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -213,6 +234,7 @@ mod tests {
 
         let metrics = SuiTxValidatorMetrics::new(&Default::default());
         let validator = SuiTxValidator::new(
+            state.name,
             state.epoch_store_for_testing().clone(),
             Arc::new(CheckpointServiceNoop {}),
             state.transaction_manager().clone(),

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -72,6 +72,7 @@ pub struct QuorumDriver<A: Clone> {
     notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
     metrics: Arc<QuorumDriverMetrics>,
     max_retry_times: u8,
+    max_retry_delay: Option<Duration>,
 }
 
 impl<A: Clone> QuorumDriver<A> {
@@ -82,6 +83,7 @@ impl<A: Clone> QuorumDriver<A> {
         notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
         metrics: Arc<QuorumDriverMetrics>,
         max_retry_times: u8,
+        max_retry_delay: Option<Duration>,
     ) -> Self {
         Self {
             validators,
@@ -90,6 +92,7 @@ impl<A: Clone> QuorumDriver<A> {
             notifier,
             metrics,
             max_retry_times,
+            max_retry_delay,
         }
     }
 
@@ -143,8 +146,12 @@ impl<A: Clone> QuorumDriver<A> {
             );
             return Ok(());
         }
-        let next_retry_after =
-            Instant::now() + Duration::from_millis(200 * u64::pow(2, old_retry_times.into()));
+        let mut next_retry_after = Duration::from_millis(200 * u64::pow(2, old_retry_times.into()));
+        if let Some(max_retry_delay) = self.max_retry_delay {
+            next_retry_after = std::cmp::min(next_retry_after, max_retry_delay);
+        }
+        let next_retry_after = Instant::now() + next_retry_after;
+
         sleep_until(next_retry_after).await;
 
         let tx_cert = match tx_cert {
@@ -541,6 +548,7 @@ where
         reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
         metrics: Arc<QuorumDriverMetrics>,
         max_retry_times: u8,
+        max_retry_delay: Option<Duration>,
     ) -> Self {
         let (task_tx, task_rx) = mpsc::channel::<QuorumDriverTask>(TASK_QUEUE_SIZE);
         let (subscriber_tx, subscriber_rx) =
@@ -552,6 +560,7 @@ where
             notifier,
             metrics.clone(),
             max_retry_times,
+            max_retry_delay,
         ));
         let metrics_clone = metrics.clone();
         let processor_handle = {
@@ -612,6 +621,7 @@ where
             notifier: Arc::new(NotifyRead::new()),
             metrics: self.quorum_driver_metrics.clone(),
             max_retry_times: self.quorum_driver.max_retry_times,
+            max_retry_delay: self.quorum_driver.max_retry_delay,
         });
         let metrics = self.quorum_driver_metrics.clone();
         let processor_handle = {
@@ -792,6 +802,7 @@ pub struct QuorumDriverHandlerBuilder<A: Clone> {
     notifier: Option<Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>>,
     reconfig_observer: Option<Arc<dyn ReconfigObserver<A> + Sync + Send>>,
     max_retry_times: u8,
+    max_retry_delay: Option<Duration>,
 }
 
 impl<A> QuorumDriverHandlerBuilder<A>
@@ -805,6 +816,7 @@ where
             notifier: None,
             reconfig_observer: None,
             max_retry_times: TX_MAX_RETRY_TIMES,
+            max_retry_delay: None,
         }
     }
 
@@ -830,6 +842,13 @@ where
         self
     }
 
+    /// Used in test with short epoch durations - too long retry delays make it impossible for
+    /// transactions to ever complete when epochs are very short.
+    pub fn with_max_retry_delay(mut self, max_retry_delay: Duration) -> Self {
+        self.max_retry_delay = Some(max_retry_delay);
+        self
+    }
+
     pub fn start(self) -> QuorumDriverHandler<A> {
         QuorumDriverHandler::new(
             self.validators,
@@ -840,6 +859,7 @@ where
                 .expect("Reconfig observer is missing"),
             self.metrics,
             self.max_retry_times,
+            self.max_retry_delay,
         )
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -920,6 +920,7 @@ impl SuiNode {
                 worker_cache,
                 consensus_handler,
                 SuiTxValidator::new(
+                    state.name,
                     epoch_store,
                     checkpoint_service.clone(),
                     state.transaction_manager().clone(),


### PR DESCRIPTION
This exposed some weird test issues (reconfig tests could end up taking forever due to ever-increasing QD retry delays), hence the test and QD changes.