### PR TITLE
move: configurable host:port for source service

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -30,8 +30,16 @@ use sui_sdk::wallet_context::WalletContext;
 use sui_sdk::SuiClient;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
+pub const HOST_PORT_ENV: &str = "HOST_PORT";
 pub const SUI_SOURCE_VALIDATION_VERSION_HEADER: &str = "X-Sui-Source-Validation-Version";
 pub const SUI_SOURCE_VALIDATION_VERSION: &str = "0.0.1";
+
+pub fn host_port() -> String {
+    match option_env!("HOST_PORT") {
+        Some(v) => v.to_string(),
+        None => String::from("0.0.0.0:8000"),
+    }
+}
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -293,7 +301,7 @@ pub fn serve(app_state: AppState) -> anyhow::Result<Server<AddrIncoming, IntoMak
                     .allow_origin(tower_http::cors::Any),
             ),
         );
-    let listener = TcpListener::bind("0.0.0.0:8000")?;
+    let listener = TcpListener::bind(host_port())?;
     Ok(Server::from_tcp(listener)?.serve(app.into_make_service()))
 }
 

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -10,7 +10,7 @@ use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_sdk::wallet_context::WalletContext;
 use telemetry_subscribers::TelemetryConfig;
 
-use sui_source_validation_service::{initialize, parse_config, serve, AppState};
+use sui_source_validation_service::{host_port, initialize, parse_config, serve, AppState};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -26,7 +26,8 @@ pub async fn main() -> anyhow::Result<()> {
     let context = WalletContext::new(&sui_config, None, None).await?;
     let tmp_dir = tempfile::tempdir()?;
     let sources = initialize(&context, &package_config, tmp_dir.path()).await?;
-    info!("verification complete, serving...");
+    info!("verification complete");
+    info!("serving on {}", host_port());
     serve(AppState { sources })?
         .await
         .map_err(anyhow::Error::from)

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use sui_source_validation_service::{
-    initialize, serve, verify_packages, AppState, CloneCommand, Config, ErrorResponse,
+    host_port, initialize, serve, verify_packages, AppState, CloneCommand, Config, ErrorResponse,
     PackageSources, RepositorySource, SourceInfo, SourceResponse,
     SUI_SOURCE_VALIDATION_VERSION_HEADER,
 };
@@ -94,7 +94,8 @@ async fn test_api_route() -> anyhow::Result<()> {
     // check that serve returns expected sample code
     let json = client
         .get(format!(
-            "http://0.0.0.0:8000/api?address={address}&module={module}"
+            "http://{}/api?address={address}&module={module}",
+            host_port()
         ))
         .send()
         .await
@@ -108,7 +109,8 @@ async fn test_api_route() -> anyhow::Result<()> {
     // check server rejects bad version header
     let json = client
         .get(format!(
-            "http://0.0.0.0:8000/api?address={address}&module={module}"
+            "http://{}/api?address={address}&module={module}",
+            host_port()
         ))
         .header(SUI_SOURCE_VALIDATION_VERSION_HEADER, "bogus")
         .send()


### PR DESCRIPTION
## Description 

Makes source service configurable with a `HOST_PORT` env variable. Defaults to as before `0.0.0.0:8000`.

Stacked on https://github.com/MystenLabs/sui/pull/12958.

## Test Plan 

Tests pass when using host:port resolver function

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
