### PR TITLE
[Narwhal] remove config for external consensus

### DIFF
--- a/crates/sui-swarm-config/tests/snapshot_tests.rs
+++ b/crates/sui-swarm-config/tests/snapshot_tests.rs
@@ -136,10 +136,6 @@ fn network_config_snapshot_matches() {
             consensus_config.internal_worker_address = Some(Multiaddr::empty());
             consensus_config
                 .narwhal_config
-                .consensus_api_grpc
-                .socket_addr = Multiaddr::empty();
-            consensus_config
-                .narwhal_config
                 .prometheus_metrics
                 .socket_addr = metrics_addr;
             consensus_config

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -39,10 +39,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -133,10 +129,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -227,10 +219,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -321,10 +309,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -415,10 +399,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -509,10 +489,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -603,10 +579,6 @@ validator_configs:
           payload_synchronize_timeout: 30000ms
           payload_availability_timeout: 30000ms
           handler_certificate_deliver_timeout: 30000ms
-        consensus_api_grpc:
-          socket_addr: ""
-          get_collections_timeout: 5000ms
-          remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -33,12 +33,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -123,12 +117,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -213,12 +201,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -303,12 +285,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -393,12 +369,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -483,12 +453,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234
@@ -573,12 +537,6 @@ validator_configs:
         sync_retry_nodes: 3
         batch_size: 5000000
         max_batch_delay: 100ms
-        block_synchronizer:
-          range_synchronize_timeout: 30000ms
-          certificates_synchronize_timeout: 30000ms
-          payload_synchronize_timeout: 30000ms
-          payload_availability_timeout: 30000ms
-          handler_certificate_deliver_timeout: 30000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
           socket_addr: /ip4/127.0.0.1/tcp/1234

--- a/narwhal/Docker/validators/parameters.json
+++ b/narwhal/Docker/validators/parameters.json
@@ -1,10 +1,5 @@
 {
     "batch_size": 500000,
-    "consensus_api_grpc": {
-        "get_collections_timeout": "5_000ms",
-        "remove_collections_timeout": "5_000ms",
-        "socket_addr": "/ip4/0.0.0.0/tcp/8000/http"
-    },
     "gc_depth": 50,
     "header_num_of_batches_threshold": 32,
     "max_header_num_of_batches": 1000,

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -53,11 +53,6 @@ node_params = {
         'payload_availability_timeout': '30s',
         'handler_certificate_deliver_timeout': '30s'
     },
-    "consensus_api_grpc": {
-        "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-        "get_collections_timeout": "5_000ms",
-        "remove_collections_timeout": "5_000ms"
-    },
     'max_concurrent_requests': 500_000
 }
 ```

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -46,13 +46,6 @@ node_params = {
     'sync_retry_nodes': 3,
     'batch_size': 500_000,
     'max_batch_delay': '100ms',
-    'block_synchronizer': {
-        'range_synchronize_timeout': '30s',
-        'certificates_synchronize_timeout': '30s',
-        'payload_synchronize_timeout': '30s',
-        'payload_availability_timeout': '30s',
-        'handler_certificate_deliver_timeout': '30s'
-    },
     'max_concurrent_requests': 500_000
 }
 ```

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -40,11 +40,6 @@ def local(ctx, debug=True):
             'payload_availability_timeout': '2_000ms',
             'handler_certificate_deliver_timeout': '2_000ms'
         },
-        "consensus_api_grpc": {
-            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-            "get_collections_timeout": "5_000ms",
-            "remove_collections_timeout": "5_000ms"
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
@@ -88,11 +83,6 @@ def smoke(ctx, debug=True, release=False):
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms',
             'handler_certificate_deliver_timeout': '2_000ms'
-        },
-        "consensus_api_grpc": {
-            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-            "get_collections_timeout": "5_000ms",
-            "remove_collections_timeout": "5_000ms"
         },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
@@ -139,11 +129,6 @@ def failpoints(ctx, debug=True):
             'payload_availability_timeout': '2_000ms',
             'handler_certificate_deliver_timeout': '2_000ms'
         },
-        "consensus_api_grpc": {
-            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-            "get_collections_timeout": "5_000ms",
-            "remove_collections_timeout": "5_000ms"
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
@@ -181,12 +166,6 @@ def demo(ctx, debug=True):
             "handler_certificate_deliver_timeout": "2_000ms",
             "payload_availability_timeout": "2_000ms",
             "payload_synchronize_timeout": "2_000ms"
-        },
-        "consensus_api_grpc": {
-            "get_collections_timeout": "5_000ms",
-            "remove_collections_timeout": "5_000ms",
-            # Use a random available local port.
-            "socket_addr": "/ip4/0.0.0.0/tcp/0/http"
         },
         "gc_depth": 50,  # rounds
         'header_num_of_batches_threshold': 32,
@@ -312,11 +291,6 @@ def remote(ctx, debug=False):
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms',
             'handler_certificate_deliver_timeout': '2_000ms'
-        },
-        "consensus_api_grpc": {
-            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-            "get_collections_timeout": "5_000ms",
-            "remove_collections_timeout": "5_000ms"
         },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -33,13 +33,6 @@ def local(ctx, debug=True):
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
-        'block_synchronizer': {
-            'range_synchronize_timeout': '30_000ms',
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms',
-            'handler_certificate_deliver_timeout': '2_000ms'
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
@@ -77,13 +70,6 @@ def smoke(ctx, debug=True, release=False):
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
-        'block_synchronizer': {
-            'range_synchronize_timeout': '30_000ms',
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms',
-            'handler_certificate_deliver_timeout': '2_000ms'
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
@@ -122,13 +108,6 @@ def failpoints(ctx, debug=True):
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
-        'block_synchronizer': {
-            'range_synchronize_timeout': '30_000ms',
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms',
-            'handler_certificate_deliver_timeout': '2_000ms'
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
@@ -160,13 +139,6 @@ def demo(ctx, debug=True):
     }
     node_params = {
         "batch_size": 500000,
-        "block_synchronizer": {
-            'range_synchronize_timeout': '30_000ms',
-            "certificates_synchronize_timeout": "2_000ms",
-            "handler_certificate_deliver_timeout": "2_000ms",
-            "payload_availability_timeout": "2_000ms",
-            "payload_synchronize_timeout": "2_000ms"
-        },
         "gc_depth": 50,  # rounds
         'header_num_of_batches_threshold': 32,
         "max_header_num_of_batches": 1000,
@@ -285,13 +257,6 @@ def remote(ctx, debug=False):
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
-        'block_synchronizer': {
-            'range_synchronize_timeout': '30_000ms',
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms',
-            'handler_certificate_deliver_timeout': '2_000ms'
-        },
         'max_concurrent_requests': 500_000,
         'prometheus_metrics': {
             "socket_addr": "/ip4/0.0.0.0/tcp/0/http"

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -157,9 +157,6 @@ pub struct Parameters {
         default = "Parameters::default_max_batch_delay"
     )]
     pub max_batch_delay: Duration,
-    /// The parameters for the block synchronizer
-    #[serde(default = "BlockSynchronizerParameters::default")]
-    pub block_synchronizer: BlockSynchronizerParameters,
     /// The maximum number of concurrent requests for messages accepted from an un-trusted entity
     #[serde(default = "Parameters::default_max_concurrent_requests")]
     pub max_concurrent_requests: usize,
@@ -299,83 +296,6 @@ impl PrometheusMetricsParameters {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
-pub struct BlockSynchronizerParameters {
-    /// The timeout configuration for synchronizing certificate digests from a starting round.
-    #[serde(
-        with = "duration_format",
-        default = "BlockSynchronizerParameters::default_range_synchronize_timeout"
-    )]
-    pub range_synchronize_timeout: Duration,
-    /// The timeout configuration when requesting certificates from peers.
-    #[serde(
-        with = "duration_format",
-        default = "BlockSynchronizerParameters::default_certificates_synchronize_timeout"
-    )]
-    pub certificates_synchronize_timeout: Duration,
-    /// Timeout when has requested the payload for a certificate and is
-    /// waiting to receive them.
-    #[serde(
-        with = "duration_format",
-        default = "BlockSynchronizerParameters::default_payload_synchronize_timeout"
-    )]
-    pub payload_synchronize_timeout: Duration,
-    /// The timeout configuration when for when we ask the other peers to
-    /// discover who has the payload available for the dictated certificates.
-    #[serde(
-        with = "duration_format",
-        default = "BlockSynchronizerParameters::default_payload_availability_timeout"
-    )]
-    pub payload_availability_timeout: Duration,
-    /// When a certificate is fetched on the fly from peers, it is submitted
-    /// from the block synchronizer handler for further processing to core
-    /// to validate and ensure parents are available and history is causal
-    /// complete. This property is the timeout while we wait for core to
-    /// perform this processes and the certificate to become available to
-    /// the handler to consume.
-    #[serde(
-        with = "duration_format",
-        default = "BlockSynchronizerParameters::default_handler_certificate_deliver_timeout"
-    )]
-    pub handler_certificate_deliver_timeout: Duration,
-}
-
-impl BlockSynchronizerParameters {
-    fn default_range_synchronize_timeout() -> Duration {
-        Duration::from_secs(30)
-    }
-    fn default_certificates_synchronize_timeout() -> Duration {
-        Duration::from_secs(30)
-    }
-    fn default_payload_synchronize_timeout() -> Duration {
-        Duration::from_secs(30)
-    }
-    fn default_payload_availability_timeout() -> Duration {
-        Duration::from_secs(30)
-    }
-    fn default_handler_certificate_deliver_timeout() -> Duration {
-        Duration::from_secs(30)
-    }
-}
-
-impl Default for BlockSynchronizerParameters {
-    fn default() -> Self {
-        Self {
-            range_synchronize_timeout:
-                BlockSynchronizerParameters::default_range_synchronize_timeout(),
-            certificates_synchronize_timeout:
-                BlockSynchronizerParameters::default_certificates_synchronize_timeout(),
-            payload_synchronize_timeout:
-                BlockSynchronizerParameters::default_payload_synchronize_timeout(),
-            payload_availability_timeout:
-                BlockSynchronizerParameters::default_payload_availability_timeout(),
-            handler_certificate_deliver_timeout:
-                BlockSynchronizerParameters::default_handler_certificate_deliver_timeout(),
-        }
-    }
-}
-
 impl Default for Parameters {
     fn default() -> Self {
         Self {
@@ -388,7 +308,6 @@ impl Default for Parameters {
             sync_retry_nodes: Parameters::default_sync_retry_nodes(),
             batch_size: Parameters::default_batch_size(),
             max_batch_delay: Parameters::default_max_batch_delay(),
-            block_synchronizer: BlockSynchronizerParameters::default(),
             max_concurrent_requests: Parameters::default_max_concurrent_requests(),
             prometheus_metrics: PrometheusMetricsParameters::default(),
             network_admin_server: NetworkAdminServerParameters::default(),
@@ -432,35 +351,6 @@ impl Parameters {
         info!(
             "Max batch delay set to {} ms",
             self.max_batch_delay.as_millis()
-        );
-        info!(
-            "Synchronize range timeout set to {} s",
-            self.block_synchronizer.range_synchronize_timeout.as_secs()
-        );
-        info!(
-            "Synchronize certificates timeout set to {} s",
-            self.block_synchronizer
-                .certificates_synchronize_timeout
-                .as_secs()
-        );
-        info!(
-            "Payload (batches) availability timeout set to {} s",
-            self.block_synchronizer
-                .payload_availability_timeout
-                .as_secs()
-        );
-        info!(
-            "Synchronize payload (batches) timeout set to {} s",
-            self.block_synchronizer
-                .payload_synchronize_timeout
-                .as_secs()
-        );
-
-        info!(
-            "Handler certificate deliver timeout set to {} s",
-            self.block_synchronizer
-                .handler_certificate_deliver_timeout
-                .as_secs()
         );
         info!(
             "Max concurrent requests set to {}",

--- a/narwhal/config/tests/config_tests.rs
+++ b/narwhal/config/tests/config_tests.rs
@@ -188,12 +188,6 @@ fn parameters_import_snapshot_matches() {
          "sync_retry_nodes": 3,
          "batch_size": 500000,
          "max_batch_delay": "100ms",
-         "block_synchronizer": {
-             "range_synchronize_timeout": "30s",
-             "certificates_synchronize_timeout": "2s",
-             "payload_synchronize_timeout": "3_000ms",
-             "payload_availability_timeout": "4_000ms"
-         },
          "max_concurrent_requests": 500000,
          "prometheus_metrics": {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"

--- a/narwhal/config/tests/config_tests.rs
+++ b/narwhal/config/tests/config_tests.rs
@@ -19,8 +19,7 @@
 // 2. Review, accept or reject changes.
 
 use config::{
-    ConsensusAPIGrpcParameters, Import, NetworkAdminServerParameters, Parameters,
-    PrometheusMetricsParameters, Stake,
+    Import, NetworkAdminServerParameters, Parameters, PrometheusMetricsParameters, Stake,
 };
 use crypto::PublicKey;
 use insta::assert_json_snapshot;
@@ -161,11 +160,7 @@ fn parameters_snapshot_matches() {
     // and in Sui (prod config + shared object bench base). If this test breaks,
     // config needs to change in all of these.
 
-    // We avoid defaults that randomly bind to a random port
-    let consensus_api_grpc_parameters = ConsensusAPIGrpcParameters {
-        socket_addr: "/ip4/127.0.0.1/tcp/8081/http".parse().unwrap(),
-        ..ConsensusAPIGrpcParameters::default()
-    };
+    // Avoid default which bind to random ports.
     let prometheus_metrics_parameters = PrometheusMetricsParameters {
         socket_addr: "/ip4/127.0.0.1/tcp/8081/http".parse().unwrap(),
     };
@@ -175,7 +170,6 @@ fn parameters_snapshot_matches() {
     };
 
     let parameters = Parameters {
-        consensus_api_grpc: consensus_api_grpc_parameters,
         prometheus_metrics: prometheus_metrics_parameters,
         network_admin_server: network_admin_server_parameters,
         ..Parameters::default()
@@ -199,11 +193,6 @@ fn parameters_import_snapshot_matches() {
              "certificates_synchronize_timeout": "2s",
              "payload_synchronize_timeout": "3_000ms",
              "payload_availability_timeout": "4_000ms"
-         },
-         "consensus_api_grpc": {
-             "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-             "get_collections_timeout": "5_000ms",
-             "remove_collections_timeout": "5_000ms"
          },
          "max_concurrent_requests": 500000,
          "prometheus_metrics": {

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -12,13 +12,6 @@ expression: parameters
   "sync_retry_nodes": 3,
   "batch_size": 5000000,
   "max_batch_delay": "100ms",
-  "block_synchronizer": {
-    "range_synchronize_timeout": "30000ms",
-    "certificates_synchronize_timeout": "30000ms",
-    "payload_synchronize_timeout": "30000ms",
-    "payload_availability_timeout": "30000ms",
-    "handler_certificate_deliver_timeout": "30000ms"
-  },
   "max_concurrent_requests": 500000,
   "prometheus_metrics": {
     "socket_addr": "/ip4/127.0.0.1/tcp/8081/http"

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -19,11 +19,6 @@ expression: parameters
     "payload_availability_timeout": "30000ms",
     "handler_certificate_deliver_timeout": "30000ms"
   },
-  "consensus_api_grpc": {
-    "socket_addr": "/ip4/127.0.0.1/tcp/8081/http",
-    "get_collections_timeout": "5000ms",
-    "remove_collections_timeout": "5000ms"
-  },
   "max_concurrent_requests": 500000,
   "prometheus_metrics": {
     "socket_addr": "/ip4/127.0.0.1/tcp/8081/http"

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -19,11 +19,6 @@ expression: params
     "payload_availability_timeout": "4000ms",
     "handler_certificate_deliver_timeout": "30000ms"
   },
-  "consensus_api_grpc": {
-    "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
-    "get_collections_timeout": "5000ms",
-    "remove_collections_timeout": "5000ms"
-  },
   "max_concurrent_requests": 500000,
   "prometheus_metrics": {
     "socket_addr": "/ip4/127.0.0.1/tcp/0/http"

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -12,13 +12,6 @@ expression: params
   "sync_retry_nodes": 3,
   "batch_size": 500000,
   "max_batch_delay": "100ms",
-  "block_synchronizer": {
-    "range_synchronize_timeout": "30000ms",
-    "certificates_synchronize_timeout": "2000ms",
-    "payload_synchronize_timeout": "3000ms",
-    "payload_availability_timeout": "4000ms",
-    "handler_certificate_deliver_timeout": "30000ms"
-  },
   "max_concurrent_requests": 500000,
   "prometheus_metrics": {
     "socket_addr": "/ip4/127.0.0.1/tcp/0/http"

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -28,10 +28,6 @@ consensus-config:
       payload_synchronize_timeout: 30000ms
       payload_availability_timeout: 30000ms
       handler_certificate_deliver_timeout: 30000ms
-    consensus_api_grpc:
-      socket_addr: /ip4/127.0.0.1/tcp/44579/http
-      get_collections_timeout: 5000ms
-      remove_collections_timeout: 5000ms
     max_concurrent_requests: 500000
     prometheus_metrics:
       socket_addr: /ip4/127.0.0.1/tcp/33291/http

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -22,12 +22,6 @@ consensus-config:
     sync_retry_nodes: 3
     batch_size: 500000
     max_batch_delay: 100ms
-    block_synchronizer:
-      range_synchronize_timeout: 30000ms
-      certificates_synchronize_timeout: 30000ms
-      payload_synchronize_timeout: 30000ms
-      payload_availability_timeout: 30000ms
-      handler_certificate_deliver_timeout: 30000ms
     max_concurrent_requests: 500000
     prometheus_metrics:
       socket_addr: /ip4/127.0.0.1/tcp/33291/http


### PR DESCRIPTION
## Description 

Remove configs that are no longer used.

## Test Plan 

CI.
Deployed to private testnet, restarted sui-node (no longer supporting consensus grpc api and block synchronizer settings) with the deleted settings added back.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
