### PR TITLE
[Kiosk Rules] Adds floor price rule

### DIFF
--- a/kiosk/sources/rules/floor_price_rule.move
+++ b/kiosk/sources/rules/floor_price_rule.move
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Description:
+/// This module defines a Rule which sets the floor price for items of type T.
+///
+/// Configuration:
+/// - floor_price - the floor price in MIST.
+///
+/// Use cases:
+/// - Defining a floor price for all trades of type T.
+/// - Prevent trading of locked items with low amounts (e.g. by using purchase_cap).
+/// 
+module kiosk::floor_price_rule {
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferPolicyCap,
+        TransferRequest
+    };
+
+    /// The price was lower than the floor price.
+    const EPriceTooSmall: u64 = 0;
+
+    /// The "Rule" witness to authorize the policy.
+    struct Rule has drop {}
+
+    /// Configuration for the `Floor Price Rule`.
+    /// It holds the minimum price that an item can be sold at.
+    /// There can't be any sales with a price < than the floor_price.
+    struct Config has store, drop {
+        floor_price: u64
+    }
+
+    /// Creator action: Add the Floor Price Rule for the `T`.
+    /// Pass in the `TransferPolicy`, `TransferPolicyCap` and `floor_price`.
+    public fun add<T: key + store>(
+        policy: &mut TransferPolicy<T>,
+        cap: &TransferPolicyCap<T>,
+        floor_price: u64
+    ) {
+        policy::add_rule(Rule {}, policy, cap, Config { floor_price })
+    }
+
+    /// Buyer action: Prove that the amount is higher or equal to the floor_price.
+    public fun prove<T: key + store>(
+        policy: &mut TransferPolicy<T>,
+        request: &mut TransferRequest<T>
+    ) {
+        let config: &Config = policy::get_rule(Rule {}, policy);
+
+        assert!(policy::paid(request) >= config.floor_price, EPriceTooSmall);
+        
+        policy::add_receipt(Rule {}, request)
+    }
+}

--- a/kiosk/tests/rules/floor_price_rule_tests.move
+++ b/kiosk/tests/rules/floor_price_rule_tests.move
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module kiosk::floor_price_rule_tests {
+    use sui::tx_context::dummy as ctx;
+    use sui::transfer_policy as policy;
+    use sui::transfer_policy_tests as test;
+
+    use kiosk::floor_price_rule;
+
+    #[test]
+    fun test_floor_price_rule_default() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        let request = policy::new_request(test::fresh_id(ctx), 1_000_000_000, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+
+    #[test]
+    fun test_floor_price_rule_high_price() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        let request = policy::new_request(test::fresh_id(ctx), 100_000_000_000, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = floor_price_rule::EPriceTooSmall)]
+    fun fail_test_smaller_price() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        // Attemps a failed purchase with .99 SUI.
+        let request = policy::new_request(test::fresh_id(ctx), 999_999_999, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+}


### PR DESCRIPTION
## Description 

Adds a `floor price` rule for Rules package.

## Test Plan 

Tests are included in the PR.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
