### PR TITLE
Create View for creating musig addresses in multisig-toolkit

### DIFF
--- a/dapps/multisig-toolkit/src/components/header.tsx
+++ b/dapps/multisig-toolkit/src/components/header.tsx
@@ -7,6 +7,7 @@ import { NavLink } from 'react-router-dom';
 const links = [
 	{ to: '/offline-signer', label: 'Offline Signer' },
 	{ to: '/signature-analyzer', label: 'Signature Analyzer' },
+	{ to: '/multisig-address', label: 'MultiSig Address' },
 ];
 
 export function Header() {

--- a/dapps/multisig-toolkit/src/routes/index.tsx
+++ b/dapps/multisig-toolkit/src/routes/index.tsx
@@ -4,6 +4,7 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import OfflineSigner from './offline-signer';
 import SignatureAnalyzer from './signature-analyzer';
+import MultiSigAddress from './multisig-address';
 import { Root } from './root';
 
 export const router = createBrowserRouter([
@@ -22,6 +23,10 @@ export const router = createBrowserRouter([
 			{
 				path: 'signature-analyzer',
 				element: <SignatureAnalyzer />,
+			},
+			{
+				path: 'multisig-address',
+				element: <MultiSigAddress />,
 			},
 		],
 	},

--- a/dapps/multisig-toolkit/src/routes/index.tsx
+++ b/dapps/multisig-toolkit/src/routes/index.tsx
@@ -6,6 +6,7 @@ import OfflineSigner from './offline-signer';
 import SignatureAnalyzer from './signature-analyzer';
 import MultiSigAddress from './multisig-address';
 import { Root } from './root';
+import MultiSigAddressGenerator from './multisig-address';
 
 export const router = createBrowserRouter([
 	{
@@ -26,7 +27,7 @@ export const router = createBrowserRouter([
 			},
 			{
 				path: 'multisig-address',
-				element: <MultiSigAddress />,
+				element: <MultiSigAddressGenerator />,
 			},
 		],
 	},

--- a/dapps/multisig-toolkit/src/routes/index.tsx
+++ b/dapps/multisig-toolkit/src/routes/index.tsx
@@ -4,7 +4,6 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import OfflineSigner from './offline-signer';
 import SignatureAnalyzer from './signature-analyzer';
-import MultiSigAddress from './multisig-address';
 import { Root } from './root';
 import MultiSigAddressGenerator from './multisig-address';
 

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+	SIGNATURE_SCHEME_TO_FLAG,
+	SignaturePubkeyPair,
+	publicKeyFromSerialized,
+	toB64,
+	toParsedSignaturePubkeyPair,
+} from '@mysten/sui.js';
+import { AlertCircle } from 'lucide-react';
+import { useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+
+
+import { useForm, useFieldArray, Controller, useWatch, FieldValues } from "react-hook-form";
+
+
+let renderCount = 0;
+
+export default function MultiSigAddress() {
+  const { register, control, handleSubmit, reset, watch } = useForm({
+    defaultValues: {
+      test: [{ firstName: "Bill", lastName: "Luo" }]
+    }
+  });
+  const {
+    fields,
+    append,
+    prepend,
+    remove,
+    swap,
+    move,
+    insert,
+    replace
+  } = useFieldArray({
+    control,
+    name: "test"
+  });
+
+  const onSubmit = (data: FieldValues) => console.log("data", data);
+
+  // if you want to control your fields with watch
+  // const watchResult = watch("test");
+  // console.log(watchResult);
+
+  // The following is useWatch example
+  // console.log(useWatch({ name: "test", control }));
+
+  renderCount++;
+
+  return (
+    <form 
+      className="flex flex-col gap-4"
+      onSubmit={handleSubmit(onSubmit)}>
+      <h1>MultiSig Address Generator</h1>
+      <p>The following demo allow you to create Sui MultiSig addressesd, prepend items</p>
+      <span className="counter">Render Count: {renderCount}</span>
+      <ul>
+        {fields.map((item, index) => {
+          return (
+            <li key={item.id}>
+              <input
+                {...register(`test.${index}.firstName`, { required: true })}
+              />
+
+              <Controller
+                render={({ field }) => <input {...field} />}
+                name={`test.${index}.lastName`}
+                control={control}
+              />
+              <Button type="button" onClick={() => remove(index)}>
+                Delete
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+      <section>
+        <Button
+          type="button"
+          onClick={() => {
+            append({ firstName: "appendBill", lastName: "appendLuo" });
+          }}
+        >
+          append
+        </Button>
+        <Button
+          type="button"
+          onClick={() =>
+            prepend({
+              firstName: "prependFirstName",
+              lastName: "prependLastName"
+            })
+          }
+        >
+          prepend
+        </Button>
+        <Button
+          type="button"
+          onClick={() =>
+            insert(2, {
+              firstName: "insertFirstName",
+              lastName: "insertLastName"
+            })
+          }
+        >
+          insert at
+        </Button>
+
+        <Button type="button" onClick={() => swap(1, 2)}>
+          swap
+        </Button>
+
+        <Button type="button" onClick={() => move(1, 2)}>
+          move
+        </Button>
+
+        <Button
+          type="button"
+          onClick={() =>
+            replace([
+              {
+                firstName: "test1",
+                lastName: "test1"
+              },
+              {
+                firstName: "test2",
+                lastName: "test2"
+              }
+            ])
+          }
+        >
+          replace
+        </Button>
+
+        <Button type="button" onClick={() => remove(1)}>
+          remove at
+        </Button>
+
+        <Button
+          type="button"
+          onClick={() =>
+            reset({
+              test: [{ firstName: "Bill", lastName: "Luo" }]
+            })
+          }
+        >
+          reset
+        </Button>
+      </section>
+
+      <input type="submit" />
+    </form>
+  );
+}
+

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -54,13 +54,18 @@ export default function MultiSigAddress() {
   renderCount++;
 
   return (
+    
+		<div className="flex flex-col gap-4">
+			<h2 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
+				MultiSig Address Creator
+			</h2>
+    
+    
     <form 
       className="flex flex-col gap-4"
       onSubmit={handleSubmit(onSubmit)}>
-      <h1>MultiSig Address Generator</h1>
-      <p>The following demo allow you to create Sui MultiSig addressesd, prepend items</p>
-      <span className="counter">Render Count: {renderCount}</span>
-      <ul>
+      <p>The following demo allow you to create Sui MultiSig addresses.</p>
+      <ul className="grid w-full gap-1.5">
         {fields.map((item, index) => {
           return (
             <li key={item.id}>
@@ -156,6 +161,7 @@ export default function MultiSigAddress() {
 
       <input type="submit" />
     </form>
+    </div>
   );
 }
 

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -6,12 +6,12 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
 	PubkeyWeightPair,
-	SIGNATURE_SCHEME_TO_FLAG,
-	SignaturePubkeyPair,
 	publicKeyFromSerialized,
+  SIGNATURE_FLAG_TO_SCHEME,
 	toB64,
 	toMultiSigAddress,
-	toParsedSignaturePubkeyPair,
+  SignatureScheme,
+  fromB64,
 } from '@mysten/sui.js';
 import { AlertCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -50,7 +50,17 @@ export default function MultiSigAddress() {
 
 		let pks: PubkeyWeightPair[] = [];
 		data.pubKeys.forEach((item: any) => {
-			pks.push({ pubKey: item.pubKey, weight: Number(item.weight) });
+      console.log(item.pubKey);
+      const pkBytes = fromB64(item.pubKey);
+      const flag: number = pkBytes[0];
+      console.log(flag);
+      const rawPkBytes = toB64(pkBytes.slice(1));
+      const schemeFlag = (SIGNATURE_FLAG_TO_SCHEME as {[key: number]: string})[flag]
+      const scheme = schemeFlag as SignatureScheme;
+
+      const pk = publicKeyFromSerialized(scheme, rawPkBytes);
+      console.log(pk);
+      pks.push({ pubKey: pk, weight: Number(1) });
 		});
 		const multisigSuiAddress = toMultiSigAddress(pks, 1);
 		console.log('multisigSuiAddress', multisigSuiAddress);

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -5,10 +5,12 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
+	PubkeyWeightPair,
 	SIGNATURE_SCHEME_TO_FLAG,
 	SignaturePubkeyPair,
 	publicKeyFromSerialized,
 	toB64,
+	toMultiSigAddress,
 	toParsedSignaturePubkeyPair,
 } from '@mysten/sui.js';
 import { AlertCircle } from 'lucide-react';
@@ -16,152 +18,125 @@ import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 
+import { useForm, useFieldArray, Controller, useWatch, FieldValues } from 'react-hook-form';
 
-import { useForm, useFieldArray, Controller, useWatch, FieldValues } from "react-hook-form";
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 
+const schema = z.object({
+	threshold: z
+		.number({ invalid_type_error: 'Age field is required.' })
+		.min(1, { message: 'threshold must be at least 3 characters.' }),
+});
+
+type FormData = z.infer<typeof schema>;
 
 let renderCount = 0;
 
 export default function MultiSigAddress() {
-  const { register, control, handleSubmit, reset, watch } = useForm({
-    defaultValues: {
-      test: [{ firstName: "Bill", lastName: "Luo" }]
-    }
-  });
-  const {
-    fields,
-    append,
-    prepend,
-    remove,
-    swap,
-    move,
-    insert,
-    replace
-  } = useFieldArray({
-    control,
-    name: "test"
-  });
+	const { register, control, handleSubmit } = useForm({
+		defaultValues: {
+			pubKeys: [{ pubKey: 'Signature Bytes', weight: '' }],
+		},
+	});
+	const { fields, append, remove } = useFieldArray({
+		control,
+		name: 'pubKeys',
+	});
 
-  const onSubmit = (data: FieldValues) => console.log("data", data);
+	// Perform generation of multisig address
+	const onSubmit = (data: FieldValues) => {
+		console.log('data', data);
 
-  // if you want to control your fields with watch
-  // const watchResult = watch("test");
-  // console.log(watchResult);
+		let pks: PubkeyWeightPair[] = [];
+		data.pubKeys.forEach((item: any) => {
+			pks.push({ pubKey: item.pubKey, weight: Number(item.weight) });
+		});
+		const multisigSuiAddress = toMultiSigAddress(pks, 1);
+		console.log('multisigSuiAddress', multisigSuiAddress);
+	};
 
-  // The following is useWatch example
-  // console.log(useWatch({ name: "test", control }));
+	// if you want to control your fields with watch
+	// const watchResult = watch("pubKeys");
+	// console.log(watchResult);
 
-  renderCount++;
+	// The following is useWatch example
+	// console.log(useWatch({ name: "pubKeys", control }));
 
-  return (
-    
+	renderCount++;
+
+	return (
 		<div className="flex flex-col gap-4">
 			<h2 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
 				MultiSig Address Creator
 			</h2>
-    
-    
-    <form 
-      className="flex flex-col gap-4"
-      onSubmit={handleSubmit(onSubmit)}>
-      <p>The following demo allow you to create Sui MultiSig addresses.</p>
-      <ul className="grid w-full gap-1.5">
-        {fields.map((item, index) => {
-          return (
-            <li key={item.id}>
-              <input
-                {...register(`test.${index}.firstName`, { required: true })}
-              />
 
-              <Controller
-                render={({ field }) => <input {...field} />}
-                name={`test.${index}.lastName`}
-                control={control}
-              />
-              <Button type="button" onClick={() => remove(index)}>
-                Delete
-              </Button>
-            </li>
-          );
-        })}
-      </ul>
-      <section>
-        <Button
-          type="button"
-          onClick={() => {
-            append({ firstName: "appendBill", lastName: "appendLuo" });
-          }}
-        >
-          append
-        </Button>
-        <Button
-          type="button"
-          onClick={() =>
-            prepend({
-              firstName: "prependFirstName",
-              lastName: "prependLastName"
-            })
-          }
-        >
-          prepend
-        </Button>
-        <Button
-          type="button"
-          onClick={() =>
-            insert(2, {
-              firstName: "insertFirstName",
-              lastName: "insertLastName"
-            })
-          }
-        >
-          insert at
-        </Button>
+			<form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+				<p>The following demo allow you to create Sui MultiSig addresses.</p>
+				<ul className="grid w-full gap-1.5">
+					{fields.map((item, index) => {
+						return (
+							<li key={item.id}>
+								<input
+									className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+									{...register(`pubKeys.${index}.pubKey`, { required: true })}
+								/>
 
-        <Button type="button" onClick={() => swap(1, 2)}>
-          swap
-        </Button>
+								<input
+									className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+									type="number"
+									{...register(`pubKeys.${index}.weight`, { required: true })}
+								/>
 
-        <Button type="button" onClick={() => move(1, 2)}>
-          move
-        </Button>
+								{/* <Controller
+									render={({ field }) => (
+										<input
+											className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+											{...field}
+										/>
+									)}
+									name={`pubKeys.${index}.weight`}
+									control={control}
+								/> */}
+								<Button
+									className="min-h-[80px] rounded-md border border-input px-3 py-2 text-sm padding-2"
+									type="button"
+									onClick={() => remove(index)}
+								>
+									Delete
+								</Button>
+							</li>
+						);
+					})}
+				</ul>
+				<section>
+					<Button
+						type="button"
+						onClick={() => {
+							append({ pubKey: 'Signature Bytes', weight: '' });
+						}}
+					>
+						New PubKey
+					</Button>
+				</section>
 
-        <Button
-          type="button"
-          onClick={() =>
-            replace([
-              {
-                firstName: "test1",
-                lastName: "test1"
-              },
-              {
-                firstName: "test2",
-                lastName: "test2"
-              }
-            ])
-          }
-        >
-          replace
-        </Button>
+				{/* <input
+					{...register('threshold', { valueAsNumber: true })}
+					id="threshold"
+					type="number"
+					className="form-control"
+				/> */}
 
-        <Button type="button" onClick={() => remove(1)}>
-          remove at
-        </Button>
-
-        <Button
-          type="button"
-          onClick={() =>
-            reset({
-              test: [{ firstName: "Bill", lastName: "Luo" }]
-            })
-          }
-        >
-          reset
-        </Button>
-      </section>
-
-      <input type="submit" />
-    </form>
-    </div>
-  );
+				<Button
+					type="submit"
+					onClick={() => {
+						console.log('fields', fields);
+					}}
+				>
+					Submit
+				</Button>
+			</form>
+		</div>
+	);
 }
-
+// Add also Threshold

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -23,6 +23,13 @@ import { useForm, useFieldArray, Controller, useWatch, FieldValues } from 'react
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
+/*
+Pubkeys for playing with
+ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq
+ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP
+*/
+
+
 const schema = z.object({
 	threshold: z
 		.number({ invalid_type_error: 'Age field is required.' })
@@ -33,7 +40,43 @@ type FormData = z.infer<typeof schema>;
 
 let renderCount = 0;
 
-export default function MultiSigAddress() {
+//function MultiSigAddress({ signature, index }: ) {
+//	const suiAddress = signature.publicKey.toSuiAddress();
+//
+//	const pubkey_base64_sui_format = signature.publicKey.toSuiPublicKey();
+//
+//	const pubkey = signature.publicKey.toBase64();
+//	const scheme = signature.signatureScheme.toString();
+//
+//	const details = [
+//		{ label: 'Signature Public Key', value: pubkey },
+//		{ label: 'Sui Format Public Key ( flag | pk )', value: pubkey_base64_sui_format },
+//		{ label: 'Sui Address', value: suiAddress },
+//		{ label: 'Signature', value: toB64(signature.signature) },
+//	];
+//
+//	return (
+//		<Card>
+//			<CardHeader>
+//				<CardTitle>Signature #{index}</CardTitle>
+//				<CardDescription>{scheme}</CardDescription>
+//			</CardHeader>
+//			<CardContent>
+//				<div className="flex flex-col gap-2">
+//					{details.map(({ label, value }, index) => (
+//						<div key={index} className="flex flex-col gap-1.5">
+//							<div className="font-bold">{label}</div>
+//							<div className="bg-muted rounded text-sm font-mono p-2 break-all">{value}</div>
+//						</div>
+//					))}
+//				</div>
+//			</CardContent>
+//		</Card>
+//	);
+//}
+
+export default function MultiSigAddressGenerator() {
+	const [msAddress, setMSAddress] = useState('');
 	const { register, control, handleSubmit } = useForm({
 		defaultValues: {
 			pubKeys: [{ pubKey: 'Sui Pubkey', weight: '' }],
@@ -50,20 +93,21 @@ export default function MultiSigAddress() {
 
 		let pks: PubkeyWeightPair[] = [];
 		data.pubKeys.forEach((item: any) => {
-      console.log(item.pubKey);
-      const pkBytes = fromB64(item.pubKey);
-      const flag: number = pkBytes[0];
-      console.log(flag);
-      const rawPkBytes = toB64(pkBytes.slice(1));
-      const schemeFlag = (SIGNATURE_FLAG_TO_SCHEME as {[key: number]: string})[flag]
-      const scheme = schemeFlag as SignatureScheme;
+			console.log(item.pubKey);
+			const pkBytes = fromB64(item.pubKey);
+			const flag: number = pkBytes[0];
+			console.log(flag);
+			const rawPkBytes = toB64(pkBytes.slice(1));
+			const schemeFlag = (SIGNATURE_FLAG_TO_SCHEME as {[key: number]: string})[flag]
+			const scheme = schemeFlag as SignatureScheme;
 
-      const pk = publicKeyFromSerialized(scheme, rawPkBytes);
-      console.log(pk);
-      pks.push({ pubKey: pk, weight: Number(1) });
+			const pk = publicKeyFromSerialized(scheme, rawPkBytes);
+			console.log(pk);
+			pks.push({ pubKey: pk, weight: Number(1) });
 		});
 		const multisigSuiAddress = toMultiSigAddress(pks, 1);
 		console.log('multisigSuiAddress', multisigSuiAddress);
+		setMSAddress(multisigSuiAddress);
 	};
 
 	// if you want to control your fields with watch
@@ -146,6 +190,9 @@ export default function MultiSigAddress() {
 					Submit
 				</Button>
 			</form>
+		<div>
+			{msAddress && <p className="text-danger">{msAddress}</p>}
+		</div>
 		</div>
 	);
 }

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -189,7 +189,17 @@ export default function MultiSigAddressGenerator() {
 					Submit
 				</Button>
 			</form>
-			<div>{msAddress && <p className="text-danger">{msAddress}</p>}</div>
+			{msAddress && <Card key={msAddress}>
+				<CardHeader>
+					<CardTitle>Sui MultiSig Address</CardTitle>
+					<CardDescription>https://docs.sui.io/testnet/learn/cryptography/sui-multisig</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<div className="flex flex-col gap-2">
+						<div className="bg-muted rounded text-sm font-mono p-2 break-all">{msAddress}</div>
+					</div>
+				</CardContent>
+			</Card>}
 		</div>
 	);
 }

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -36,7 +36,7 @@ let renderCount = 0;
 export default function MultiSigAddress() {
 	const { register, control, handleSubmit } = useForm({
 		defaultValues: {
-			pubKeys: [{ pubKey: 'Signature Bytes', weight: '' }],
+			pubKeys: [{ pubKey: 'Sui Pubkey', weight: '' }],
 		},
 	});
 	const { fields, append, remove } = useFieldArray({
@@ -123,7 +123,7 @@ export default function MultiSigAddress() {
 					<Button
 						type="button"
 						onClick={() => {
-							append({ pubKey: 'Signature Bytes', weight: '' });
+							append({ pubKey: 'Sui Pubkey', weight: '' });
 						}}
 					>
 						New PubKey

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -16,58 +16,11 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 
 import { useForm, useFieldArray, FieldValues } from 'react-hook-form';
 
-import { z } from 'zod';
-
 /*
 Pubkeys for playing with
 ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq
 ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP
 */
-
-const schema = z.object({
-	threshold: z
-		.number({ invalid_type_error: 'Age field is required.' })
-		.min(1, { message: 'threshold must be at least 3 characters.' }),
-});
-
-type FormData = z.infer<typeof schema>;
-
-let renderCount = 0;
-
-//function MultiSigAddress({ signature, index }: ) {
-//	const suiAddress = signature.publicKey.toSuiAddress();
-//
-//	const pubkey_base64_sui_format = signature.publicKey.toSuiPublicKey();
-//
-//	const pubkey = signature.publicKey.toBase64();
-//	const scheme = signature.signatureScheme.toString();
-//
-//	const details = [
-//		{ label: 'Signature Public Key', value: pubkey },
-//		{ label: 'Sui Format Public Key ( flag | pk )', value: pubkey_base64_sui_format },
-//		{ label: 'Sui Address', value: suiAddress },
-//		{ label: 'Signature', value: toB64(signature.signature) },
-//	];
-//
-//	return (
-//		<Card>
-//			<CardHeader>
-//				<CardTitle>Signature #{index}</CardTitle>
-//				<CardDescription>{scheme}</CardDescription>
-//			</CardHeader>
-//			<CardContent>
-//				<div className="flex flex-col gap-2">
-//					{details.map(({ label, value }, index) => (
-//						<div key={index} className="flex flex-col gap-1.5">
-//							<div className="font-bold">{label}</div>
-//							<div className="bg-muted rounded text-sm font-mono p-2 break-all">{value}</div>
-//						</div>
-//					))}
-//				</div>
-//			</CardContent>
-//		</Card>
-//	);
-//}
 
 export default function MultiSigAddressGenerator() {
 	const [msAddress, setMSAddress] = useState('');

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -7,11 +7,11 @@ import { Textarea } from '@/components/ui/textarea';
 import {
 	PubkeyWeightPair,
 	publicKeyFromSerialized,
-  SIGNATURE_FLAG_TO_SCHEME,
+	SIGNATURE_FLAG_TO_SCHEME,
 	toB64,
 	toMultiSigAddress,
-  SignatureScheme,
-  fromB64,
+	SignatureScheme,
+	fromB64,
 } from '@mysten/sui.js';
 import { AlertCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -28,7 +28,6 @@ Pubkeys for playing with
 ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq
 ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP
 */
-
 
 const schema = z.object({
 	threshold: z
@@ -98,7 +97,7 @@ export default function MultiSigAddressGenerator() {
 			const flag: number = pkBytes[0];
 			console.log(flag);
 			const rawPkBytes = toB64(pkBytes.slice(1));
-			const schemeFlag = (SIGNATURE_FLAG_TO_SCHEME as {[key: number]: string})[flag]
+			const schemeFlag = (SIGNATURE_FLAG_TO_SCHEME as { [key: number]: string })[flag];
 			const scheme = schemeFlag as SignatureScheme;
 
 			const pk = publicKeyFromSerialized(scheme, rawPkBytes);
@@ -190,9 +189,7 @@ export default function MultiSigAddressGenerator() {
 					Submit
 				</Button>
 			</form>
-		<div>
-			{msAddress && <p className="text-danger">{msAddress}</p>}
-		</div>
+			<div>{msAddress && <p className="text-danger">{msAddress}</p>}</div>
 		</div>
 	);
 }

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -102,8 +102,9 @@ export default function MultiSigAddressGenerator() {
 
 			const pk = publicKeyFromSerialized(scheme, rawPkBytes);
 			console.log(pk);
-			pks.push({ pubKey: pk, weight: Number(1) });
+			pks.push({ pubKey: pk, weight: item.weight });
 		});
+		console.log('pks:', pks);
 		const multisigSuiAddress = toMultiSigAddress(pks, 1);
 		console.log('multisigSuiAddress', multisigSuiAddress);
 		setMSAddress(multisigSuiAddress);

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -175,9 +175,9 @@ export default function MultiSigAddressGenerator() {
 					</Button>
 				</section>
 				<section>
-					<div>
-						<p>MultiSig Threshold Value</p>
-					</div>
+					<label className="form-label min-h-[80px] rounded-md border text-sm px-3 py-2 ring-offset-background">
+						MultiSig Threshold Value:
+					</label>
 					<input
 						className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 						type="number"

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -66,8 +66,6 @@ export default function MultiSigAddressGenerator() {
 	// The following is useWatch example
 	// console.log(useWatch({ name: "pubKeys", control }));
 
-	renderCount++;
-
 	return (
 		<div className="flex flex-col gap-4">
 			<h2 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -79,6 +79,7 @@ export default function MultiSigAddressGenerator() {
 	const { register, control, handleSubmit } = useForm({
 		defaultValues: {
 			pubKeys: [{ pubKey: 'Sui Pubkey', weight: '' }],
+			threshold: 1,
 		},
 	});
 	const { fields, append, remove } = useFieldArray({
@@ -105,7 +106,7 @@ export default function MultiSigAddressGenerator() {
 			pks.push({ pubKey: pk, weight: item.weight });
 		});
 		console.log('pks:', pks);
-		const multisigSuiAddress = toMultiSigAddress(pks, 1);
+		const multisigSuiAddress = toMultiSigAddress(pks, data.threshold);
 		console.log('multisigSuiAddress', multisigSuiAddress);
 		setMSAddress(multisigSuiAddress);
 	};
@@ -173,6 +174,13 @@ export default function MultiSigAddressGenerator() {
 						New PubKey
 					</Button>
 				</section>
+				<section>
+					<input
+						className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+						type="number"
+						{...register(`threshold`, { valueAsNumber: true, required: true })}
+					/>
+				</section>
 
 				{/* <input
 					{...register('threshold', { valueAsNumber: true })}
@@ -204,4 +212,27 @@ export default function MultiSigAddressGenerator() {
 		</div>
 	);
 }
-// Add also Threshold
+
+/* 
+➜  multisig-toolkit git:(jnaulty/multisig-create-address) ✗ sui keytool multi-sig-address --pks ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP --weights 1 2 --threshold 2
+MultiSig address: 0x27b17213bc702893bb3e92ba84071589a6331f35f066ad15b666b9527a288c16
+Participating parties:
+                Sui Address                 |                Public Key (Base64)                 | Weight
+----------------------------------------------------------------------------------------------------
+ 0x504f656b7bc467f6eb1d05dc26447477921f05e5ea88c5715682ad28835268ce | ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq  |   1   
+ 0x611f6a023c5d1c98b4de96e9da64daffaeb372fed0176536168908e50f6e07c0 | ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP  |   2   
+➜  multisig-toolkit git:(jnaulty/multisig-create-address) ✗ sui keytool multi-sig-address --pks ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP --weights 1 1 --threshold 2
+MultiSig address: 0x9134bd58a25a6b48811d1c65770dd1d01e113931ed35c13f1a3c26ed7eccf9bc
+Participating parties:
+                Sui Address                 |                Public Key (Base64)                 | Weight
+----------------------------------------------------------------------------------------------------
+ 0x504f656b7bc467f6eb1d05dc26447477921f05e5ea88c5715682ad28835268ce | ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq  |   1   
+ 0x611f6a023c5d1c98b4de96e9da64daffaeb372fed0176536168908e50f6e07c0 | ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP  |   1   
+➜  multisig-toolkit git:(jnaulty/multisig-create-address) ✗ sui keytool multi-sig-address --pks ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP --weights 1 1 --threshold 1
+MultiSig address: 0xda3f8c1ba647d63b89a396a64eeac835d25a59323a1b8fd4697424f62374b0de
+Participating parties:
+                Sui Address                 |                Public Key (Base64)                 | Weight
+----------------------------------------------------------------------------------------------------
+ 0x504f656b7bc467f6eb1d05dc26447477921f05e5ea88c5715682ad28835268ce | ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq  |   1   
+ 0x611f6a023c5d1c98b4de96e9da64daffaeb372fed0176536168908e50f6e07c0 | ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP  |   1  
+ */

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import {
 	PubkeyWeightPair,
 	publicKeyFromSerialized,
@@ -13,15 +11,12 @@ import {
 	SignatureScheme,
 	fromB64,
 } from '@mysten/sui.js';
-import { AlertCircle } from 'lucide-react';
 import { useState } from 'react';
-import { Label } from '@/components/ui/label';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 
-import { useForm, useFieldArray, Controller, useWatch, FieldValues } from 'react-hook-form';
+import { useForm, useFieldArray, FieldValues } from 'react-hook-form';
 
 import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
 
 /*
 Pubkeys for playing with
@@ -130,12 +125,8 @@ export default function MultiSigAddressGenerator() {
 				<p>The following demo allow you to create Sui MultiSig addresses.</p>
 				<code>
 					Sui Pubkeys for playing with
-					<p>
-						ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq
-					</p>
-					<p>
-						ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP
-					</p>
+					<p>ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq</p>
+					<p>ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP</p>
 				</code>
 				<ul className="grid w-full gap-1.5">
 					{fields.map((item, index) => {
@@ -210,17 +201,21 @@ export default function MultiSigAddressGenerator() {
 					Submit
 				</Button>
 			</form>
-			{msAddress && <Card key={msAddress}>
-				<CardHeader>
-					<CardTitle>Sui MultiSig Address</CardTitle>
-					<CardDescription>https://docs.sui.io/testnet/learn/cryptography/sui-multisig</CardDescription>
-				</CardHeader>
-				<CardContent>
-					<div className="flex flex-col gap-2">
-						<div className="bg-muted rounded text-sm font-mono p-2 break-all">{msAddress}</div>
-					</div>
-				</CardContent>
-			</Card>}
+			{msAddress && (
+				<Card key={msAddress}>
+					<CardHeader>
+						<CardTitle>Sui MultiSig Address</CardTitle>
+						<CardDescription>
+							https://docs.sui.io/testnet/learn/cryptography/sui-multisig
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<div className="flex flex-col gap-2">
+							<div className="bg-muted rounded text-sm font-mono p-2 break-all">{msAddress}</div>
+						</div>
+					</CardContent>
+				</Card>
+			)}
 		</div>
 	);
 }

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -128,6 +128,15 @@ export default function MultiSigAddressGenerator() {
 
 			<form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
 				<p>The following demo allow you to create Sui MultiSig addresses.</p>
+				<code>
+					Sui Pubkeys for playing with
+					<p>
+						ABr818VXt+6PLPRoA7QnsHBfRpKJdWZPjt7ppiTl6Fkq
+					</p>
+					<p>
+						ANRdB4M6Hj73R+gRM4N6zUPNidLuatB9uccOzHBc/0bP
+					</p>
+				</code>
 				<ul className="grid w-full gap-1.5">
 					{fields.map((item, index) => {
 						return (

--- a/dapps/multisig-toolkit/src/routes/multisig-address.tsx
+++ b/dapps/multisig-toolkit/src/routes/multisig-address.tsx
@@ -175,6 +175,9 @@ export default function MultiSigAddressGenerator() {
 					</Button>
 				</section>
 				<section>
+					<div>
+						<p>MultiSig Threshold Value</p>
+					</div>
 					<input
 						className="min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 						type="number"


### PR DESCRIPTION
## Description 

Add a tab to the multisig-toolkit for creating Sui MultiSig Addresses 'on-the-fly' ✈️  
Ref #12932

## Test Plan 

* Get PubKeys!
```
  AB3VXSdvFq6ym0ulqnVNuEI9xxI5b8RY21azMU6ybWp1
  ADue3nTTYz9pE75pMKEnnLIrcTSS/c0uwr6WEU5nz4RM
  AIPVXOb2rbm8dX0LBL4PEgN4HPQDpwUIHpIy2THr/it1
```

* run locally `pnpm run dev`
* goto [localhost:5173/multisig-address](http://localhost:5173/multisig-address)
* add pubkeys and weights
* create!
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
