### PR TITLE
[explorer][ts-sdk] add new toSuiPublicKey method and show the Sui Public Key in the signatures tab

### DIFF
--- a/.changeset/lovely-clocks-visit.md
+++ b/.changeset/lovely-clocks-visit.md
@@ -2,4 +2,4 @@
 '@mysten/sui.js': minor
 ---
 
-Add new toSuiPublicKey method for retrieving the Sui representation of a raw public key
+Add toSuiPublicKey method for retrieving the Sui representation of a raw public key

--- a/.changeset/lovely-clocks-visit.md
+++ b/.changeset/lovely-clocks-visit.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': minor
+---
+
+Add new toSuiPublicKey method for retrieving the Sui representation of a raw public key

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -27,13 +27,13 @@ function SignaturePanel({ title, signature }: { title: string; signature: Signat
 						{signature.signatureScheme}
 					</Text>
 				</DescriptionItem>
+				<DescriptionItem title="Address" align="start" labelWidth="sm">
+					<AddressLink noTruncate address={signature.pubKey.toSuiAddress()} />
+				</DescriptionItem>
 				<DescriptionItem title="Sui Public Key" align="start" labelWidth="sm">
 					<Text variant="pBody/medium" color="steel-darker">
 						{signature.pubKey.toSuiPublicKey()}
 					</Text>
-				</DescriptionItem>
-				<DescriptionItem title="Address" align="start" labelWidth="sm">
-					<AddressLink noTruncate address={signature.pubKey.toSuiAddress()} />
 				</DescriptionItem>
 				<DescriptionItem title="Signature" align="start" labelWidth="sm">
 					<Text variant="pBody/medium" color="steel-darker">

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -27,9 +27,9 @@ function SignaturePanel({ title, signature }: { title: string; signature: Signat
 						{signature.signatureScheme}
 					</Text>
 				</DescriptionItem>
-				<DescriptionItem title="Public Key" align="start" labelWidth="sm">
+				<DescriptionItem title="Sui Public Key" align="start" labelWidth="sm">
 					<Text variant="pBody/medium" color="steel-darker">
-						{signature.pubKey.toString()}
+						{signature.pubKey.toSuiPublicKey()}
 					</Text>
 				</DescriptionItem>
 				<DescriptionItem title="Address" align="start" labelWidth="sm">

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -27,6 +27,11 @@ function SignaturePanel({ title, signature }: { title: string; signature: Signat
 						{signature.signatureScheme}
 					</Text>
 				</DescriptionItem>
+				<DescriptionItem title="Public Key" align="start" labelWidth="sm">
+					<Text variant="pBody/medium" color="steel-darker">
+						{signature.pubKey.toString()}
+					</Text>
+				</DescriptionItem>
 				<DescriptionItem title="Address" align="start" labelWidth="sm">
 					<AddressLink noTruncate address={signature.pubKey.toSuiAddress()} />
 				</DescriptionItem>

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -51,7 +51,9 @@ export interface PublicKey {
 	toSuiAddress(): string;
 
 	/**
-	 * Return the Sui representation of the public key
+	 * Return the Sui representation of the public key encoded in
+	 * base-64. A Sui public key is formed by the concatenation
+	 * of the scheme flag with the raw bytes of the public key
 	 */
 	toSuiPublicKey(): string;
 

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -51,6 +51,11 @@ export interface PublicKey {
 	toSuiAddress(): string;
 
 	/**
+	 * Return the Sui representation of the public key
+	 */
+	toSuiPublicKey(): string;
+
+	/**
 	 * Return signature scheme flag of the public key
 	 */
 	flag(): number;

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -80,6 +80,16 @@ export class Ed25519PublicKey {
 	}
 
 	/**
+	 * Return the Sui representation of the public key
+	 */
+	toSuiPublicKey(): string {
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		suiPublicKey.set([this.flag()]);
+		suiPublicKey.set(this.data, 1);
+		return toB64(suiPublicKey);
+	}
+
+	/**
 	 * Return the Sui address associated with this Ed25519 public key
 	 */
 	flag(): number {

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -82,7 +82,7 @@ export class Ed25519PublicKey {
 	/**
 	 * Return the Sui representation of the public key encoded in
 	 * base-64. A Sui public key is formed by the concatenation
-	 * of the scheme flag with the raw bytes of the public key.
+	 * of the scheme flag with the raw bytes of the public key
 	 */
 	toSuiPublicKey(): string {
 		const suiPublicKey = new Uint8Array(this.data.length + 1);

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -70,11 +70,12 @@ export class Ed25519PublicKey {
 	 * Return the Sui address associated with this Ed25519 public key
 	 */
 	toSuiAddress(): string {
-		const suiPublicKey = this.toSuiPublicKey();
-
+		let tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
+		tmp.set([SIGNATURE_SCHEME_TO_FLAG['ED25519']]);
+		tmp.set(this.toBytes(), 1);
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -82,10 +83,10 @@ export class Ed25519PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(PUBLIC_KEY_SIZE + 1);
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return new Ed25519PublicKey(suiPublicKey);
+		return toB64(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -80,10 +80,12 @@ export class Ed25519PublicKey {
 	}
 
 	/**
-	 * Return the Sui representation of the public key
+	 * Return the Sui representation of the public key encoded in
+	 * base-64. A Sui public key is formed by the concatenation
+	 * of the scheme flag with the raw bytes of the public key.
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(this.data.length + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
 		return toB64(suiPublicKey);

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -70,12 +70,11 @@ export class Ed25519PublicKey {
 	 * Return the Sui address associated with this Ed25519 public key
 	 */
 	toSuiAddress(): string {
-		let tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['ED25519']]);
-		tmp.set(this.toBytes(), 1);
+		const suiPublicKey = this.toSuiPublicKey();
+
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -83,10 +82,10 @@ export class Ed25519PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(PUBLIC_KEY_SIZE + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return toB64(suiPublicKey);
+		return new Ed25519PublicKey(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -70,11 +70,12 @@ export class Secp256k1PublicKey implements PublicKey {
 	 * Return the Sui address associated with this Secp256k1 public key
 	 */
 	toSuiAddress(): string {
-		const suiPublicKey = this.toSuiPublicKey();
-
+		let tmp = new Uint8Array(SECP256K1_PUBLIC_KEY_SIZE + 1);
+		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256k1']]);
+		tmp.set(this.toBytes(), 1);
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -82,10 +83,10 @@ export class Secp256k1PublicKey implements PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(SECP256K1_PUBLIC_KEY_SIZE + 1);
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return new Secp256k1PublicKey(suiPublicKey);
+		return toB64(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -80,6 +80,16 @@ export class Secp256k1PublicKey implements PublicKey {
 	}
 
 	/**
+	 * Return the Sui representation of the public key
+	 */
+	toSuiPublicKey(): string {
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		suiPublicKey.set([this.flag()]);
+		suiPublicKey.set(this.data, 1);
+		return toB64(suiPublicKey);
+	}
+
+	/**
 	 * Return the Sui address associated with this Secp256k1 public key
 	 */
 	flag(): number {

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -70,12 +70,11 @@ export class Secp256k1PublicKey implements PublicKey {
 	 * Return the Sui address associated with this Secp256k1 public key
 	 */
 	toSuiAddress(): string {
-		let tmp = new Uint8Array(SECP256K1_PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256k1']]);
-		tmp.set(this.toBytes(), 1);
+		const suiPublicKey = this.toSuiPublicKey();
+
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -83,10 +82,10 @@ export class Secp256k1PublicKey implements PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(SECP256K1_PUBLIC_KEY_SIZE + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return toB64(suiPublicKey);
+		return new Secp256k1PublicKey(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -80,10 +80,12 @@ export class Secp256k1PublicKey implements PublicKey {
 	}
 
 	/**
-	 * Return the Sui representation of the public key
+	 * Return the Sui representation of the public key encoded in
+	 * base-64. A Sui public key is formed by the concatenation
+	 * of the scheme flag with the raw bytes of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(this.data.length + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
 		return toB64(suiPublicKey);

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -80,6 +80,16 @@ export class Secp256r1PublicKey implements PublicKey {
 	}
 
 	/**
+	 * Return the Sui representation of the public key
+	 */
+	toSuiPublicKey(): string {
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		suiPublicKey.set([this.flag()]);
+		suiPublicKey.set(this.data, 1);
+		return toB64(suiPublicKey);
+	}
+
+	/**
 	 * Return the Sui address associated with this Secp256r1 public key
 	 */
 	flag(): number {

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -80,10 +80,12 @@ export class Secp256r1PublicKey implements PublicKey {
 	}
 
 	/**
-	 * Return the Sui representation of the public key
+	 * Return the Sui representation of the public key encoded in
+	 * base-64. A Sui public key is formed by the concatenation
+	 * of the scheme flag with the raw bytes of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(this.data.length + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
 		return toB64(suiPublicKey);

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -70,11 +70,12 @@ export class Secp256r1PublicKey implements PublicKey {
 	 * Return the Sui address associated with this Secp256r1 public key
 	 */
 	toSuiAddress(): string {
-		const suiPublicKey = this.toSuiPublicKey();
-
+		let tmp = new Uint8Array(SECP256R1_PUBLIC_KEY_SIZE + 1);
+		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256r1']]);
+		tmp.set(this.toBytes(), 1);
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -82,10 +83,10 @@ export class Secp256r1PublicKey implements PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(SECP256R1_PUBLIC_KEY_SIZE + 1);
+		const suiPublicKey = new Uint8Array(1 + this.data.length);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return new Secp256r1PublicKey(suiPublicKey);
+		return toB64(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -70,12 +70,11 @@ export class Secp256r1PublicKey implements PublicKey {
 	 * Return the Sui address associated with this Secp256r1 public key
 	 */
 	toSuiAddress(): string {
-		let tmp = new Uint8Array(SECP256R1_PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256r1']]);
-		tmp.set(this.toBytes(), 1);
+		const suiPublicKey = this.toSuiPublicKey();
+
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(suiPublicKey, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -83,10 +82,10 @@ export class Secp256r1PublicKey implements PublicKey {
 	 * Return the Sui representation of the public key
 	 */
 	toSuiPublicKey(): string {
-		const suiPublicKey = new Uint8Array(1 + this.data.length);
+		const suiPublicKey = new Uint8Array(SECP256R1_PUBLIC_KEY_SIZE + 1);
 		suiPublicKey.set([this.flag()]);
 		suiPublicKey.set(this.data, 1);
-		return toB64(suiPublicKey);
+		return new Secp256r1PublicKey(suiPublicKey);
 	}
 
 	/**

--- a/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
@@ -8,20 +8,23 @@ import { Ed25519PublicKey } from '../../../src';
 // cargo build --bin sui
 // ../sui/target/debug/sui client new-address ed25519
 // ../sui/target/debug/sui keytool list
-let TEST_CASES = new Map<string, string>([
-	[
-		'UdGRWooy48vGTs0HBokIis5NK+DUjiWc9ENUlcfCCBE=',
-		'0xd77a6cd55073e98d4029b1b0b8bd8d88f45f343dad2732fc9a7965094e635c55',
-	],
-	[
-		'0PTAfQmNiabgbak9U/stWZzKc5nsRqokda2qnV2DTfg=',
-		'0x7e8fd489c3d3cd9cc7cbcc577dc5d6de831e654edd9997d95c412d013e6eea23',
-	],
-	[
-		'6L/l0uhGt//9cf6nLQ0+24Uv2qanX/R6tn7lWUJX1Xk=',
-		'0x3a1b4410ebe9c3386a429c349ba7929aafab739c277f97f32622b971972a14a2',
-	],
-]);
+const TEST_CASES = [
+	{
+		rawPublicKey: 'UdGRWooy48vGTs0HBokIis5NK+DUjiWc9ENUlcfCCBE=',
+		suiPublicKey: 'AFHRkVqKMuPLxk7NBwaJCIrOTSvg1I4lnPRDVJXHwggR',
+		suiAddress: '0xd77a6cd55073e98d4029b1b0b8bd8d88f45f343dad2732fc9a7965094e635c55',
+	},
+	{
+		rawPublicKey: '0PTAfQmNiabgbak9U/stWZzKc5nsRqokda2qnV2DTfg=',
+		suiPublicKey: 'AND0wH0JjYmm4G2pPVP7LVmcynOZ7EaqJHWtqp1dg034',
+		suiAddress: '0x7e8fd489c3d3cd9cc7cbcc577dc5d6de831e654edd9997d95c412d013e6eea23',
+	},
+	{
+		rawPublicKey: '6L/l0uhGt//9cf6nLQ0+24Uv2qanX/R6tn7lWUJX1Xk=',
+		suiPublicKey: 'AOi/5dLoRrf//XH+py0NPtuFL9qmp1/0erZ+5VlCV9V5',
+		suiAddress: '0x3a1b4410ebe9c3386a429c349ba7929aafab739c277f97f32622b971972a14a2',
+	},
+];
 
 const VALID_KEY_BASE64 = 'Uz39UFseB/B38iBwjesIU1JZxY6y+TRL9P84JFw41W4=';
 
@@ -68,10 +71,15 @@ describe('Ed25519PublicKey', () => {
 		expect(new Ed25519PublicKey(key.toBytes()).equals(key)).toBe(true);
 	});
 
-	TEST_CASES.forEach((address, base64) => {
-		it(`toSuiAddress from base64 public key ${address}`, () => {
-			const key = new Ed25519PublicKey(base64);
-			expect(key.toSuiAddress()).toEqual(address);
+	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {
+		it(`toSuiAddress from base64 public key ${suiAddress}`, () => {
+			const key = new Ed25519PublicKey(rawPublicKey);
+			expect(key.toSuiAddress()).toEqual(suiAddress);
+		});
+
+		it(`toSuiPublicKey from base64 public key ${suiAddress}`, () => {
+			const key = new Ed25519PublicKey(rawPublicKey);
+			expect(key.toSuiPublicKey()).toEqual(suiPublicKey);
 		});
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -10,24 +10,29 @@ import { INVALID_SECP256K1_PUBLIC_KEY, VALID_SECP256K1_PUBLIC_KEY } from './secp
 // cargo build --bin sui
 // ../sui/target/debug/sui client new-address secp256k1
 // ../sui/target/debug/sui keytool list
-let SECP_TEST_CASES = new Map<string, string>([
-	[
-		'AwTC3jVFRxXc3RJIFgoQcv486QdqwYa8vBp4bgSq0gsI',
-		'0xcdce00b4326fb908fdac83c35bcfbda323bfcc0618b47c66ccafbdced850efaa',
-	],
-	[
-		'A1F2CtldIGolO92Pm9yuxWXs5E07aX+6ZEHAnSuKOhii',
-		'0xb588e58ed8967b6a6f9dbce76386283d374cf7389fb164189551257e32b023b2',
-	],
-	[
-		'Ak5rsa5Od4T6YFN/V3VIhZ/azMMYPkUilKQwc+RiaId+',
-		'0x694dd74af1e82b968822a82fb5e315f6d20e8697d5d03c0b15e0178c1a1fcfa0',
-	],
-	[
-		'A4XbJ3fLvV/8ONsnLHAW1nORKsoCYsHaXv9FK1beMtvY',
-		'0x78acc6ca0003457737d755ade25a6f3a144e5e44ed6f8e6af4982c5cc75e55e7',
-	],
-]);
+const TEST_CASES = [
+	{
+		rawPublicKey: 'AwTC3jVFRxXc3RJIFgoQcv486QdqwYa8vBp4bgSq0gsI',
+		suiPublicKey: 'AQMEwt41RUcV3N0SSBYKEHL+POkHasGGvLwaeG4EqtILCA==',
+		suiAddress: '0xcdce00b4326fb908fdac83c35bcfbda323bfcc0618b47c66ccafbdced850efaa',
+	},
+	{
+		rawPublicKey: 'A1F2CtldIGolO92Pm9yuxWXs5E07aX+6ZEHAnSuKOhii',
+		suiPublicKey: 'AQNRdgrZXSBqJTvdj5vcrsVl7ORNO2l/umRBwJ0rijoYog==',
+		suiAddress: '0xb588e58ed8967b6a6f9dbce76386283d374cf7389fb164189551257e32b023b2',
+	},
+	{
+		rawPublicKey: 'Ak5rsa5Od4T6YFN/V3VIhZ/azMMYPkUilKQwc+RiaId+',
+		suiPublicKey: 'AQJOa7GuTneE+mBTf1d1SIWf2szDGD5FIpSkMHPkYmiHfg==',
+		suiAddress: '0x694dd74af1e82b968822a82fb5e315f6d20e8697d5d03c0b15e0178c1a1fcfa0',
+	},
+	{
+		rawPublicKey: 'A4XbJ3fLvV/8ONsnLHAW1nORKsoCYsHaXv9FK1beMtvY',
+		suiPublicKey: 'AQOF2yd3y71f/DjbJyxwFtZzkSrKAmLB2l7/RStW3jLb2A==',
+		suiAddress: '0x78acc6ca0003457737d755ade25a6f3a144e5e44ed6f8e6af4982c5cc75e55e7',
+	},
+];
+
 describe('Secp256k1PublicKey', () => {
 	it('invalid', () => {
 		expect(() => {
@@ -67,10 +72,15 @@ describe('Secp256k1PublicKey', () => {
 		expect(new Secp256k1PublicKey(key.toBytes()).equals(key)).toBe(true);
 	});
 
-	SECP_TEST_CASES.forEach((address, base64) => {
-		it(`toSuiAddress from base64 public key ${address}`, () => {
-			const key = new Secp256k1PublicKey(base64);
-			expect(key.toSuiAddress()).toEqual(address);
+	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {
+		it(`toSuiAddress from base64 public key ${suiAddress}`, () => {
+			const key = new Secp256k1PublicKey(rawPublicKey);
+			expect(key.toSuiAddress()).toEqual(suiAddress);
+		});
+
+		it(`toSuiPublicKey from base64 public key ${suiAddress}`, () => {
+			const key = new Secp256k1PublicKey(rawPublicKey);
+			expect(key.toSuiPublicKey()).toEqual(suiPublicKey);
 		});
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -72,5 +72,10 @@ describe('Secp256k1PublicKey', () => {
 			const key = new Secp256k1PublicKey(base64);
 			expect(key.toSuiAddress()).toEqual(address);
 		});
+
+		it(`toSuiPublicKey from base64 public key ${address}`, () => {
+			const key = new Secp256k1PublicKey(base64);
+			expect(key.toSuiPublicKey()).toEqual(base64);
+		});
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -72,10 +72,5 @@ describe('Secp256k1PublicKey', () => {
 			const key = new Secp256k1PublicKey(base64);
 			expect(key.toSuiAddress()).toEqual(address);
 		});
-
-		it(`toSuiPublicKey from base64 public key ${address}`, () => {
-			const key = new Secp256k1PublicKey(base64);
-			expect(key.toSuiPublicKey()).toEqual(base64);
-		});
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
@@ -10,12 +10,14 @@ import { INVALID_SECP256R1_PUBLIC_KEY, VALID_SECP256R1_PUBLIC_KEY } from './secp
 // cargo build --bin sui
 // ../sui/target/debug/sui client new-address secp256r1
 // ../sui/target/debug/sui keytool list
-let SECP_TEST_CASES = new Map<string, string>([
-	[
-		'A8Ju2r5X3EZ3aYuZzH+Ofs6cd1j2WOwY7lhoJQenulBl',
-		'0xafd0f5a4f41c5770c201879518740b83743164ed2445016fbba9ae98e04af8a5',
-	],
-]);
+const TEST_CASES = [
+	{
+		rawPublicKey: 'A8Ju2r5X3EZ3aYuZzH+Ofs6cd1j2WOwY7lhoJQenulBl',
+		suiPublicKey: 'AgPCbtq+V9xGd2mLmcx/jn7OnHdY9ljsGO5YaCUHp7pQZQ==',
+		suiAddress: '0xafd0f5a4f41c5770c201879518740b83743164ed2445016fbba9ae98e04af8a5',
+	},
+];
+
 describe('Secp256r1PublicKey', () => {
 	it('invalid', () => {
 		expect(() => {
@@ -55,10 +57,15 @@ describe('Secp256r1PublicKey', () => {
 		expect(new Secp256r1PublicKey(key.toBytes()).equals(key)).toBe(true);
 	});
 
-	SECP_TEST_CASES.forEach((address, base64) => {
-		it(`toSuiAddress from base64 public key ${address}`, () => {
-			const key = new Secp256r1PublicKey(base64);
-			expect(key.toSuiAddress()).toEqual(address);
+	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {
+		it(`toSuiAddress from base64 public key ${suiAddress}`, () => {
+			const key = new Secp256r1PublicKey(rawPublicKey);
+			expect(key.toSuiAddress()).toEqual(suiAddress);
+		});
+
+		it(`toSuiPublicKey from base64 public key ${suiAddress}`, () => {
+			const key = new Secp256r1PublicKey(rawPublicKey);
+			expect(key.toSuiPublicKey()).toEqual(suiPublicKey);
 		});
 	});
 });


### PR DESCRIPTION
## Description 
Context in https://mysten-labs.slack.com/archives/C032676BWGN/p1689180202585399?thread_ts=1689178418.872779&cid=C032676BWGN

<img width="475" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/307ecbd7-3238-45b9-8d47-3deb2b14f967">

## Test Plan 
- I confirmed the toSuiPublicKey output matches the output from the Sui Signature Analyzer
- Automated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
