### PR TITLE
[move-compiler] Keep running tests in presence of compiler warnings

### DIFF
--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -98,11 +98,13 @@ pub fn run_move_unit_tests(
         build_config,
         UnitTestingConfig {
             report_stacktrace_on_abort: true,
+            ignore_compile_warnings: true,
             ..config
         },
         sui_move_natives::all_natives(/* silent */ false),
         Some(initial_cost_schedule_for_unit_tests()),
         compute_coverage,
+        &mut std::io::sink(),
         &mut std::io::stdout(),
     )
 }

--- a/external-crates/move/move-stdlib/tests/move_unit_test.rs
+++ b/external-crates/move/move-stdlib/tests/move_unit_test.rs
@@ -38,6 +38,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
         None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
+        &mut std::io::stdout(),
     )
     .unwrap();
     if result != UnitTestResult::Success {

--- a/external-crates/move/tools/move-cli/src/base/test.rs
+++ b/external-crates/move/tools/move-cli/src/base/test.rs
@@ -120,6 +120,7 @@ impl Test {
             cost_table,
             compute_coverage,
             &mut std::io::stdout(),
+            &mut std::io::stdout(),
         )?;
 
         // Return a non-zero exit code if any test failed
@@ -137,14 +138,15 @@ pub enum UnitTestResult {
     Failure,
 }
 
-pub fn run_move_unit_tests<W: Write + Send>(
+pub fn run_move_unit_tests<CW: Write + Send, TW: Write + Send>(
     pkg_path: &Path,
     mut build_config: move_package::BuildConfig,
     mut unit_test_config: UnitTestingConfig,
     natives: Vec<NativeFunctionRecord>,
     cost_table: Option<CostTable>,
     compute_coverage: bool,
-    writer: &mut W,
+    compiler_writer: &mut CW,
+    test_writer: &mut TW,
 ) -> Result<UnitTestResult> {
     let mut test_plan = None;
     build_config.test_mode = true;
@@ -189,7 +191,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
     // Move package system, to first grab the compilation env, construct the test plan from it, and
     // then save it, before resuming the rest of the compilation and returning the results and
     // control back to the Move package system.
-    build_plan.compile_with_driver(writer, |compiler| {
+    build_plan.compile_with_driver(compiler_writer, |compiler| {
         let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
         let (_, compiler) =
             diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
@@ -240,7 +242,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
     // Run the tests. If any of the tests fail, then we don't produce a coverage report, so cleanup
     // the trace files.
     if !unit_test_config
-        .run_and_report_unit_tests(test_plan, Some(natives), cost_table, writer)
+        .run_and_report_unit_tests(test_plan, Some(natives), cost_table, test_writer)
         .unwrap()
         .1
     {


### PR DESCRIPTION
## Description 

This fixes a problem when the test runner stops running tests in presence of compiler warnings which is quite annoying for the developers.

As an added bonus, with this PR we will no longer print compilation results twice (also annoying).

## Test Plan 

All existing tests must pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

When running Move unit tests, the presence of warnings no longer prevents tests from running and the compilation results are now printed only once when executing the `sui move test` command.
