### PR TITLE
Add metrics to track data read from archives

### DIFF
--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::reader::ArchiveReader;
+use crate::reader::{ArchiveReader, ArchiveReaderMetrics};
 use crate::writer::ArchiveWriter;
 use crate::{read_manifest, verify_archive_with_local_store, write_manifest, Manifest};
 use anyhow::{anyhow, Context, Result};
@@ -94,7 +94,8 @@ async fn setup_test_state(temp_dir: PathBuf) -> anyhow::Result<TestState> {
         download_concurrency: NonZeroUsize::new(2).unwrap(),
         use_for_pruning_watermark: false,
     };
-    let archive_reader = ArchiveReader::new(archive_reader_config)?;
+    let metrics = ArchiveReaderMetrics::new(&Registry::default());
+    let archive_reader = ArchiveReader::new(archive_reader_config, &metrics)?;
     let local_store = local_store_config.make()?;
     let remote_store = remote_store_config.make()?;
     Ok(TestState {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2029,7 +2029,8 @@ impl AuthorityState {
         config: NodeConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
     ) -> anyhow::Result<()> {
-        let archive_readers = ArchiveReaderBalancer::new(config.archive_reader_config())?;
+        let archive_readers =
+            ArchiveReaderBalancer::new(config.archive_reader_config(), &Registry::default())?;
         AuthorityStorePruner::prune_checkpoints_for_eligible_epochs(
             &self.database.perpetual_tables,
             &self.checkpoint_store,

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -315,7 +315,8 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
     };
     // We will delete all checkpoints older than this checkpoint on Node 2
     let oldest_checkpoint_to_keep: u64 = 10;
-    let archive_readers = ArchiveReaderBalancer::new(vec![archive_reader_config])?;
+    let archive_readers =
+        ArchiveReaderBalancer::new(vec![archive_reader_config], &Registry::default())?;
     let archive_reader = archive_readers.pick_one_random(0..u64::MAX).await.unwrap();
     loop {
         archive_reader.sync_manifest_once().await?;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -369,7 +369,8 @@ impl SuiNode {
         // Create network
         // TODO only configure validators as seed/preferred peers for validators and not for
         // fullnodes once we've had a chance to re-work fullnode configuration generation.
-        let archive_readers = ArchiveReaderBalancer::new(config.archive_reader_config())?;
+        let archive_readers =
+            ArchiveReaderBalancer::new(config.archive_reader_config(), &prometheus_registry)?;
         let (trusted_peer_change_tx, trusted_peer_change_rx) = watch::channel(Default::default());
         let (p2p_network, discovery_handle, state_sync_handle) = Self::create_p2p_network(
             &config,

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::anyhow;
 use eyre::ContextCompat;
 use indicatif::{ProgressBar, ProgressStyle};
 use prometheus::Registry;
-use sui_archival::reader::ArchiveReader;
+use sui_archival::reader::{ArchiveReader, ArchiveReaderMetrics};
 use sui_archival::verify_archive_with_genesis_config;
 use sui_config::node::ArchiveReaderConfig;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
@@ -697,7 +697,8 @@ pub async fn state_sync_from_archive(
         download_concurrency: NonZeroUsize::new(concurrency).unwrap(),
         use_for_pruning_watermark: false,
     };
-    let archive_reader = ArchiveReader::new(archive_reader_config)?;
+    let metrics = ArchiveReaderMetrics::new(&Registry::default());
+    let archive_reader = ArchiveReader::new(archive_reader_config, &metrics)?;
     archive_reader.sync_manifest_once().await?;
     let latest_checkpoint_in_archive = archive_reader.latest_available_checkpoint().await?;
     info!(


### PR DESCRIPTION
## Description 

Add metrics to track transactions and checkpoints being served from archives.

## Test Plan 

Existing tests
