### PR TITLE
[Multisig dapp] Adds a preview effects button

### DIFF
--- a/dapps/multisig-toolkit/src/components/connect.tsx
+++ b/dapps/multisig-toolkit/src/components/connect.tsx
@@ -11,7 +11,7 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 function ConnectedButton() {
-	const { accounts, currentAccount, selectAccount } = useWalletKit();
+	const { accounts, currentAccount, selectAccount, disconnect } = useWalletKit();
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -36,6 +36,7 @@ function ConnectedButton() {
 							<CommandItem
 								key={account.address}
 								value={account.address}
+								className="cursor-pointer"
 								onSelect={() => {
 									selectAccount(account);
 									setOpen(false);
@@ -50,6 +51,8 @@ function ConnectedButton() {
 								{formatAddress(account.address)}
 							</CommandItem>
 						))}
+
+						<CommandItem className="cursor-pointer" onSelect={(()=>{disconnect()})}>Logout</CommandItem>
 					</CommandGroup>
 				</Command>
 			</PopoverContent>

--- a/dapps/multisig-toolkit/src/components/connect.tsx
+++ b/dapps/multisig-toolkit/src/components/connect.tsx
@@ -52,7 +52,14 @@ function ConnectedButton() {
 							</CommandItem>
 						))}
 
-						<CommandItem className="cursor-pointer" onSelect={(()=>{disconnect()})}>Logout</CommandItem>
+						<CommandItem
+							className="cursor-pointer"
+							onSelect={() => {
+								disconnect();
+							}}
+						>
+							Logout
+						</CommandItem>
 					</CommandGroup>
 				</Command>
 			</PopoverContent>

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -17,7 +17,7 @@ import {
 import { useWalletKit } from '@mysten/wallet-kit';
 import { AlertCircle, Terminal } from 'lucide-react';
 import { useMutation } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function OfflineSigner() {
 	const { currentAccount, signTransactionBlock } = useWalletKit();
@@ -49,7 +49,7 @@ export default function OfflineSigner() {
 		error,
 		reset,
 	} = useMutation({
-		mutationKey: ['dry-run', currentAccount],
+		mutationKey: ['dry-run'],
 		mutationFn: async () => {
 			if (!currentAccount?.chains[0]) throw new Error('No chain detected for the account.');
 			const provider = new JsonRpcProvider(connections[currentAccount?.chains.filter(x => x.startsWith('sui'))[0]]);

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -49,10 +49,10 @@ export default function OfflineSigner() {
 		error,
 		reset,
 	} = useMutation({
-		mutationKey: ['dry-run'],
+		mutationKey: ['dry-run', currentAccount],
 		mutationFn: async () => {
 			if (!currentAccount?.chains[0]) throw new Error('No chain detected for the account.');
-			const provider = new JsonRpcProvider(connections[currentAccount?.chains[0]]);
+			const provider = new JsonRpcProvider(connections[currentAccount?.chains.filter(x => x.startsWith('sui'))[0]]);
 
 			const transactionBlock = TransactionBlock.from(bytes);
 
@@ -125,11 +125,11 @@ export default function OfflineSigner() {
 					<div className="border text-mono break-all rounded p-4">{data?.signature}</div>
 				</TabsContent>
 			</Tabs>
-			{error && (
+			{error as Error && (
 				<Alert variant="default">
 					<AlertCircle className="h-4 w-4" />
 					<AlertTitle>Error</AlertTitle>
-					<AlertDescription>{error.message}</AlertDescription>
+					<AlertDescription>{(error as Error).message}</AlertDescription>
 				</Alert>
 			)}
 		</div>

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -17,7 +17,7 @@ import {
 import { useWalletKit } from '@mysten/wallet-kit';
 import { AlertCircle, Terminal } from 'lucide-react';
 import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export default function OfflineSigner() {
 	const { currentAccount, signTransactionBlock } = useWalletKit();
@@ -52,7 +52,9 @@ export default function OfflineSigner() {
 		mutationKey: ['dry-run'],
 		mutationFn: async () => {
 			if (!currentAccount?.chains[0]) throw new Error('No chain detected for the account.');
-			const provider = new JsonRpcProvider(connections[currentAccount?.chains.filter(x => x.startsWith('sui'))[0]]);
+			const provider = new JsonRpcProvider(
+				connections[currentAccount?.chains.filter((x) => x.startsWith('sui'))[0]],
+			);
 
 			const transactionBlock = TransactionBlock.from(bytes);
 
@@ -125,7 +127,7 @@ export default function OfflineSigner() {
 					<div className="border text-mono break-all rounded p-4">{data?.signature}</div>
 				</TabsContent>
 			</Tabs>
-			{error as Error && (
+			{(error as Error) && (
 				<Alert variant="default">
 					<AlertCircle className="h-4 w-4" />
 					<AlertTitle>Error</AlertTitle>


### PR DESCRIPTION
## Description 

- Adds a preview effects button to run a `devInspect` for the tx data (helpful to verify there are no errors & check the expected outcome).
- Adds a logout option.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
