### PR TITLE
[multisig dapp] Switch to dryRun from devInspect

### DIFF
--- a/dapps/multisig-toolkit/src/components/connect.tsx
+++ b/dapps/multisig-toolkit/src/components/connect.tsx
@@ -58,7 +58,7 @@ function ConnectedButton() {
 								disconnect();
 							}}
 						>
-							Logout
+							Disconnect
 						</CommandItem>
 					</CommandGroup>
 				</Command>

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -56,11 +56,8 @@ export default function OfflineSigner() {
 				connections[currentAccount?.chains.filter((x) => x.startsWith('sui'))[0]],
 			);
 
-			const transactionBlock = TransactionBlock.from(bytes);
-
-			return await provider.devInspectTransactionBlock({
-				transactionBlock,
-				sender: currentAccount?.address,
+			return await provider.dryRunTransactionBlock({
+				transactionBlock: bytes,
 			});
 		},
 	});


### PR DESCRIPTION
## Description 

- Uses `dryRun` instead of `devInspect` to properly preview effects.
- Nit: `Logout` becomes `disconnect`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
