### PR TITLE
[3/n][transfer-to-object] Add SDK support for receiving objects

### DIFF
--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -9,11 +9,13 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, ensure, Ok};
 use async_trait::async_trait;
 use futures::future::join_all;
+use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::file_format::SignatureToken;
+use move_binary_format::file_format_common::VERSION_MAX;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
 
-use sui_json::{resolve_move_function_args, ResolvedCallArg, SuiJsonValue};
+use sui_json::{is_receiving_argument, resolve_move_function_args, ResolvedCallArg, SuiJsonValue};
 use sui_json_rpc_types::{
     RPCTransactionRequestParams, SuiData, SuiObjectDataOptions, SuiObjectResponse, SuiRawData,
     SuiTypeTag,
@@ -325,6 +327,8 @@ impl TransactionBuilder {
         id: ObjectID,
         objects: &mut BTreeMap<ObjectID, Object>,
         is_mutable_ref: bool,
+        view: &BinaryIndexedView<'_>,
+        arg_type: &SignatureToken,
     ) -> Result<ObjectArg, anyhow::Error> {
         let response = self
             .0
@@ -335,6 +339,9 @@ impl TransactionBuilder {
         let obj_ref = obj.compute_object_reference();
         let owner = obj.owner;
         objects.insert(id, obj);
+        if is_receiving_argument(view, arg_type) {
+            return Ok(ObjectArg::Receiving(obj_ref));
+        }
         Ok(match owner {
             Owner::Shared {
                 initial_shared_version,
@@ -385,6 +392,8 @@ impl TransactionBuilder {
 
         let mut args = Vec::new();
         let mut objects = BTreeMap::new();
+        let module = package.deserialize_module(module, VERSION_MAX, true)?;
+        let view = BinaryIndexedView::Module(&module);
         for (arg, expected_type) in json_args_and_tokens {
             args.push(match arg {
                 ResolvedCallArg::Pure(p) => builder.input(CallArg::Pure(p)),
@@ -394,6 +403,8 @@ impl TransactionBuilder {
                         id,
                         &mut objects,
                         matches!(expected_type, SignatureToken::MutableReference(_)),
+                        &view,
+                        &expected_type,
                     )
                     .await?,
                 )),
@@ -402,8 +413,14 @@ impl TransactionBuilder {
                     let mut object_ids = vec![];
                     for id in v {
                         object_ids.push(
-                            self.get_object_arg(id, &mut objects, /* is_mutable_ref */ false)
-                                .await?,
+                            self.get_object_arg(
+                                id,
+                                &mut objects,
+                                /* is_mutable_ref */ false,
+                                &view,
+                                &expected_type,
+                            )
+                            .await?,
                         )
                     }
                     builder.make_obj_vec(object_ids)

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
 use std::io::Read;
 use std::os::unix::prelude::FileExt;
+use std::str::FromStr;
 use std::{fmt::Write, fs::read_dir, path::PathBuf, str, thread, time::Duration};
 
 use expect_test::expect;
@@ -629,6 +631,387 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     for obj_id in obj_ids {
         get_parsed_object_assert_existence(obj_id, context).await;
     }
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_receive_argument() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("tto");
+    let build_config = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path,
+        build_config,
+        gas: Some(gas_obj_id),
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+        lint: false,
+    }
+    .execute(context)
+    .await?;
+
+    let owned_obj_ids = if let SuiClientCommandResult::Publish(response) = resp {
+        let x = response.effects.unwrap();
+        x.created().to_vec()
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    // Check the objects
+    for OwnedObjectRef { reference, .. } in &owned_obj_ids {
+        get_parsed_object_assert_existence(reference.object_id, context).await;
+    }
+
+    let package_id = owned_obj_ids
+        .into_iter()
+        .find(|OwnedObjectRef { owner, .. }| owner == &Owner::Immutable)
+        .expect("Must find published package ID")
+        .reference;
+
+    // Start and then receive the object
+    let start_call_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "start".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    let (parent, child) = if let SuiClientCommandResult::Call(response) = start_call_result {
+        let created = response.effects.unwrap().created().to_vec();
+        let owners: BTreeSet<ObjectID> = created
+            .iter()
+            .flat_map(|refe| {
+                refe.owner
+                    .get_address_owner_address()
+                    .ok()
+                    .map(|x| x.into())
+            })
+            .collect();
+        let child = created
+            .iter()
+            .find(|refe| !owners.contains(&refe.reference.object_id))
+            .unwrap();
+        let parent = created
+            .iter()
+            .find(|refe| owners.contains(&refe.reference.object_id))
+            .unwrap();
+        (parent.reference.clone(), child.reference.clone())
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    let receive_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "receiver".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![
+            SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
+            SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),
+        ],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    if let SuiClientCommandResult::Call(response) = receive_result {
+        assert!(response.effects.unwrap().into_status().is_ok());
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("tto");
+    let build_config = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path,
+        build_config,
+        gas: Some(gas_obj_id),
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+        lint: false,
+    }
+    .execute(context)
+    .await?;
+
+    let owned_obj_ids = if let SuiClientCommandResult::Publish(response) = resp {
+        let x = response.effects.unwrap();
+        x.created().to_vec()
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    // Check the objects
+    for OwnedObjectRef { reference, .. } in &owned_obj_ids {
+        get_parsed_object_assert_existence(reference.object_id, context).await;
+    }
+
+    let package_id = owned_obj_ids
+        .into_iter()
+        .find(|OwnedObjectRef { owner, .. }| owner == &Owner::Immutable)
+        .expect("Must find published package ID")
+        .reference;
+
+    // Start and then receive the object
+    let start_call_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "start".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    let (parent, child) = if let SuiClientCommandResult::Call(response) = start_call_result {
+        let created = response.effects.unwrap().created().to_vec();
+        let owners: BTreeSet<ObjectID> = created
+            .iter()
+            .flat_map(|refe| {
+                refe.owner
+                    .get_address_owner_address()
+                    .ok()
+                    .map(|x| x.into())
+            })
+            .collect();
+        let child = created
+            .iter()
+            .find(|refe| !owners.contains(&refe.reference.object_id))
+            .unwrap();
+        let parent = created
+            .iter()
+            .find(|refe| owners.contains(&refe.reference.object_id))
+            .unwrap();
+        (parent.reference.clone(), child.reference.clone())
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    let receive_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "invalid_call_immut_ref".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![
+            SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
+            SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),
+        ],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    if let SuiClientCommandResult::Call(response) = receive_result {
+        assert!(response.effects.unwrap().into_status().is_ok());
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("tto");
+    let build_config = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path,
+        build_config,
+        gas: Some(gas_obj_id),
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+        lint: false,
+    }
+    .execute(context)
+    .await?;
+
+    let owned_obj_ids = if let SuiClientCommandResult::Publish(response) = resp {
+        let x = response.effects.unwrap();
+        x.created().to_vec()
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    // Check the objects
+    for OwnedObjectRef { reference, .. } in &owned_obj_ids {
+        get_parsed_object_assert_existence(reference.object_id, context).await;
+    }
+
+    let package_id = owned_obj_ids
+        .into_iter()
+        .find(|OwnedObjectRef { owner, .. }| owner == &Owner::Immutable)
+        .expect("Must find published package ID")
+        .reference;
+
+    // Start and then receive the object
+    let start_call_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "start".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    let (parent, child) = if let SuiClientCommandResult::Call(response) = start_call_result {
+        let created = response.effects.unwrap().created().to_vec();
+        let owners: BTreeSet<ObjectID> = created
+            .iter()
+            .flat_map(|refe| {
+                refe.owner
+                    .get_address_owner_address()
+                    .ok()
+                    .map(|x| x.into())
+            })
+            .collect();
+        let child = created
+            .iter()
+            .find(|refe| !owners.contains(&refe.reference.object_id))
+            .unwrap();
+        let parent = created
+            .iter()
+            .find(|refe| owners.contains(&refe.reference.object_id))
+            .unwrap();
+        (parent.reference.clone(), child.reference.clone())
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    let receive_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "tto".to_string(),
+        function: "invalid_call_mut_ref".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![
+            SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
+            SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),
+        ],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    if let SuiClientCommandResult::Call(response) = receive_result {
+        assert!(response.effects.unwrap().into_status().is_ok());
+    } else {
+        unreachable!("Invalid response");
+    };
 
     Ok(())
 }

--- a/crates/sui/tests/data/tto/Move.toml
+++ b/crates/sui/tests/data/tto/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tto"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+tto =  "0x0"

--- a/crates/sui/tests/data/tto/sources/tto1.move
+++ b/crates/sui/tests/data/tto/sources/tto1.move
@@ -18,8 +18,6 @@ module tto::tto {
         let a = A { id: object::new(ctx) };
         let a_address = object::id_address(&a);
         let b = B { id: object::new(ctx) };
-        let c = B { id: object::new(ctx) };
-        transfer::share_object(c);
         transfer::public_transfer(a, tx_context::sender(ctx));
         transfer::public_transfer(b, a_address);
     }
@@ -29,21 +27,6 @@ module tto::tto {
         transfer::public_transfer(b, @tto);
     }
 
-    public entry fun deleter(parent: &mut A, x: Receiving<B>) {
-        let B { id } = transfer::receive(&mut parent.id, x);
-        object::delete(id);
-    }
-
-    public fun return_(parent: &mut A, x: Receiving<B>): B {
-        transfer::receive(&mut parent.id, x)
-    }
-
-    public entry fun delete_(b: B) {
-        let B { id } = b;
-        object::delete(id);
-    }
-
     public fun invalid_call_immut_ref(_parent: &mut A, _x: &Receiving<B>) { }
     public fun invalid_call_mut_ref(_parent: &mut A, _x: &mut Receiving<B>) { }
-    public fun dropper(_parent: &mut A, _x: Receiving<B>) { }
 }

--- a/sdk/typescript/src/bcs/index.ts
+++ b/sdk/typescript/src/bcs/index.ts
@@ -36,7 +36,10 @@ export type SharedObjectRef = {
 /**
  * An object argument.
  */
-export type ObjectArg = { ImmOrOwned: SuiObjectRefType } | { Shared: SharedObjectRef };
+export type ObjectArg =
+	| { ImmOrOwned: SuiObjectRefType }
+	| { Shared: SharedObjectRef }
+	| { Receiving: SuiObjectRefType };
 
 /**
  * A pure argument.
@@ -203,6 +206,7 @@ const SharedObjectRef = bcs.struct('SharedObjectRef', {
 const ObjectArg = bcs.enum('ObjectArg', {
 	ImmOrOwned: SuiObjectRef,
 	Shared: SharedObjectRef,
+	Receiving: SuiObjectRef,
 });
 
 const CallArg = bcs.enum('CallArg', {

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -20,6 +20,7 @@ const ObjectArg = union([
 			mutable: boolean(),
 		}),
 	}),
+	object({ Receiving: SuiObjectRef }),
 ]);
 
 export const PureCallArg = object({ Pure: array(integer()) });
@@ -70,6 +71,17 @@ export const Inputs = {
 			},
 		};
 	},
+	ReceivingRef({ objectId, digest, version }: SuiObjectRef): ObjectCallArg {
+		return {
+			Object: {
+				Receiving: {
+					digest,
+					version,
+					objectId: normalizeSuiAddress(objectId),
+				},
+			},
+		};
+	},
 };
 
 export function getIdFromCallArg(arg: string | ObjectCallArg) {
@@ -79,6 +91,11 @@ export function getIdFromCallArg(arg: string | ObjectCallArg) {
 	if ('ImmOrOwned' in arg.Object) {
 		return normalizeSuiAddress(arg.Object.ImmOrOwned.objectId);
 	}
+
+	if ('Receiving' in arg.Object) {
+		return normalizeSuiAddress(arg.Object.Receiving.objectId);
+	}
+
 	return normalizeSuiAddress(arg.Object.Shared.objectId);
 }
 

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -63,11 +63,10 @@ export type CheckpointCommitment = {
 	ECMHLiveObjectSetDigest: ECMHLiveObjectSetDigest;
 };
 export type CheckpointId = string | string;
-/** Necessary value for claim. */
+/** A claim consists of value and index_mod_4. */
 export interface Claim {
-	index_mod_4: number;
-	name: string;
-	value_base64: string;
+	indexMod4: number;
+	value: string;
 }
 export interface CoinStruct {
 	balance: string;
@@ -799,6 +798,9 @@ export type SuiArgument =
 	| {
 			NestedResult: [number, number];
 	  };
+export interface SuiAuthenticatorStateExpire {
+	min_epoch: string;
+}
 export type SuiCallArg =
 	| {
 			type: 'object';
@@ -815,10 +817,24 @@ export type SuiCallArg =
 			objectType: 'sharedObject';
 	  }
 	| {
+			type: 'object';
+			digest: string;
+			objectId: string;
+			objectType: 'receiving';
+			version: string;
+	  }
+	| {
 			type: 'pure';
 			value: unknown;
 			valueType?: string | null;
 	  };
+export interface SuiChangeEpoch {
+	computation_charge: string;
+	epoch: string;
+	epoch_start_timestamp_ms: string;
+	storage_charge: string;
+	storage_rebate: string;
+}
 export interface CoinMetadata {
 	/** Number of decimal places the coin uses. */
 	decimals: number;
@@ -833,6 +849,14 @@ export interface CoinMetadata {
 	/** Symbol for the token */
 	symbol: string;
 }
+export type SuiEndOfEpochTransactionKind =
+	| 'AuthenticatorStateCreate'
+	| {
+			ChangeEpoch: SuiChangeEpoch;
+	  }
+	| {
+			AuthenticatorStateExpire: SuiAuthenticatorStateExpire;
+	  };
 export interface SuiExecutionResult {
 	/** The value of any arguments that were mutably borrowed. Non-mut borrowed values are not included */
 	mutableReferenceOutputs?: [SuiArgument, number[], string][];
@@ -1289,12 +1313,16 @@ export type SuiTransactionBlockKind =
 			 * failure of the entire programmable transaction block.
 			 */
 			transactions: SuiTransaction[];
-	  } /** An transaction which updates global authenticator state */
+	  } /** A transaction which updates global authenticator state */
 	| {
 			epoch: string;
 			kind: 'AuthenticatorStateUpdate';
 			new_active_jwks: SuiActiveJwk[];
 			round: string;
+	  } /** The transaction which occurs only at the end of the epoch */
+	| {
+			kind: 'EndOfEpochTransaction';
+			transactions: SuiEndOfEpochTransactionKind[];
 	  };
 export interface SuiTransactionBlockResponse {
 	balanceChanges?: BalanceChange[] | null;
@@ -1407,19 +1435,19 @@ export interface ValidatorsApy {
 /** An zk login authenticator with all the necessary fields. */
 export interface ZkLoginAuthenticator {
 	inputs: ZkLoginInputs;
-	max_epoch: string;
-	user_signature: Signature;
+	maxEpoch: string;
+	userSignature: Signature;
 }
-/** All inputs required for the zk login proof verification and other auxiliary inputs. */
+/** All inputs required for the zk login proof verification and other public inputs. */
 export interface ZkLoginInputs {
-	address_seed: string;
-	claims: Claim[];
-	header_base64: string;
-	proof_points: ZkLoginProof;
+	addressSeed: string;
+	headerBase64: string;
+	issBase64Details: Claim;
+	proofPoints: ZkLoginProof;
 }
-/** The zk login proof. */
+/** The struct for zk login proof. */
 export interface ZkLoginProof {
-	pi_a: string[];
-	pi_b: string[][];
-	pi_c: string[];
+	a: string[];
+	b: string[][];
+	c: string[];
 }

--- a/sdk/typescript/test/e2e/data/tto/Move.toml
+++ b/sdk/typescript/test/e2e/data/tto/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tto"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+tto =  "0x0"

--- a/sdk/typescript/test/e2e/data/tto/sources/tto1.move
+++ b/sdk/typescript/test/e2e/data/tto/sources/tto1.move
@@ -1,0 +1,46 @@
+module tto::tto {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer::{Self, Receiving};
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    struct B has key, store {
+        id: UID,
+    }
+
+    public fun start(ctx: &mut TxContext) {
+        let a = A { id: object::new(ctx) };
+        let a_address = object::id_address(&a);
+        let b = B { id: object::new(ctx) };
+        let c = B { id: object::new(ctx) };
+        transfer::share_object(c);
+        transfer::public_transfer(a, tx_context::sender(ctx));
+        transfer::public_transfer(b, a_address);
+    }
+
+    public entry fun receiver(parent: &mut A, x: Receiving<B>) {
+        let b = transfer::receive(&mut parent.id, x);
+        transfer::public_transfer(b, @tto);
+    }
+
+    public entry fun deleter(parent: &mut A, x: Receiving<B>) {
+        let B { id } = transfer::receive(&mut parent.id, x);
+        object::delete(id);
+    }
+
+    public fun return_(parent: &mut A, x: Receiving<B>): B {
+        transfer::receive(&mut parent.id, x)
+    }
+
+    public entry fun delete_(b: B) {
+        let B { id } = b;
+        object::delete(id);
+    }
+
+    public fun invalid_call_immut_ref(_parent: &mut A, _x: &Receiving<B>) { }
+    public fun invalid_call_mut_ref(_parent: &mut A, _x: &mut Receiving<B>) { }
+    public fun dropper(_parent: &mut A, _x: Receiving<B>) { }
+}

--- a/sdk/typescript/test/e2e/receive-object.test.ts
+++ b/sdk/typescript/test/e2e/receive-object.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { TransactionBlock } from '../../src/builder';
+import { OwnedObjectRef, SuiClient } from '../../src/client';
+import type { Keypair } from '../../src/cryptography';
+import { publishPackage, setup, TestToolbox } from './utils/setup';
+
+function getOwnerAddress(o: OwnedObjectRef): string | undefined {
+	// const owner = getObjectOwner(o);
+	if (typeof o.owner == 'object' && 'AddressOwner' in o.owner) {
+		return o.owner.AddressOwner;
+	} else {
+		return undefined;
+	}
+}
+
+describe('Transfer to Object', () => {
+	let toolbox: TestToolbox;
+	let packageId: string;
+	let parentObjectId: OwnedObjectRef;
+	let receiveObjectId: OwnedObjectRef;
+	let sharedObjectId: string;
+
+	beforeAll(async () => {
+		const packagePath = __dirname + '/./data/tto';
+		({ packageId } = await publishPackage(packagePath));
+	});
+
+	beforeEach(async () => {
+		toolbox = await setup();
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::start`,
+			typeArguments: [],
+			arguments: [],
+		});
+		const x = await validateTransaction(toolbox.client, toolbox.keypair, tx);
+		const y = (x.effects?.created)!.map((o) => getOwnerAddress(o))!;
+		receiveObjectId = (x.effects?.created)!.filter(
+			(o) => !y.includes(o.reference.objectId) && getOwnerAddress(o) !== undefined,
+		)[0];
+		parentObjectId = (x.effects?.created)!.filter(
+			(o) => y.includes(o.reference.objectId) && getOwnerAddress(o) !== undefined,
+		)[0];
+		const sharedObject = (x.effects?.created)!.filter((o) => getOwnerAddress(o) === undefined)[0];
+		sharedObjectId = sharedObject.reference.objectId;
+	});
+
+	it('Basic Receive: receive and then transfer', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::receiver`,
+			typeArguments: [],
+			arguments: [
+				tx.object(parentObjectId.reference.objectId),
+				tx.object(receiveObjectId.reference.objectId),
+			],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
+	it('Basic Receive: receive and then delete', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::deleter`,
+			typeArguments: [],
+			arguments: [
+				tx.object(parentObjectId.reference.objectId),
+				tx.object(receiveObjectId.reference.objectId),
+			],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
+	it('receive + return, then delete', async () => {
+		const tx = new TransactionBlock();
+		const b = tx.moveCall({
+			target: `${packageId}::tto::return_`,
+			typeArguments: [],
+			arguments: [
+				tx.object(parentObjectId.reference.objectId),
+				tx.object(receiveObjectId.reference.objectId),
+			],
+		});
+		tx.moveCall({
+			target: `${packageId}::tto::delete_`,
+			typeArguments: [],
+			arguments: [b],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
+	it('Basic Receive: &Receiving arg type', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::invalid_call_immut_ref`,
+			typeArguments: [],
+			arguments: [
+				tx.object(parentObjectId.reference.objectId),
+				tx.object(receiveObjectId.reference.objectId),
+			],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
+	it('Basic Receive: &mut Receiving arg type', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::invalid_call_mut_ref`,
+			typeArguments: [],
+			arguments: [
+				tx.object(parentObjectId.reference.objectId),
+				tx.object(receiveObjectId.reference.objectId),
+			],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
+	it.fails('Trying to pass shared object as receiving argument', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::tto::receiver`,
+			typeArguments: [],
+			arguments: [tx.object(parentObjectId.reference.objectId), tx.object(sharedObjectId)],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+});
+
+async function validateTransaction(client: SuiClient, signer: Keypair, tx: TransactionBlock) {
+	tx.setSenderIfNotSet(signer.getPublicKey().toSuiAddress());
+	const localDigest = await tx.getDigest({ client });
+	const result = await client.signAndExecuteTransactionBlock({
+		signer,
+		transactionBlock: tx,
+		options: {
+			showEffects: true,
+		},
+	});
+	expect(localDigest).toEqual(result.digest);
+	expect(result.effects?.status.status).toEqual('success');
+	return result;
+}


### PR DESCRIPTION
## Description 

Adds support for constructing and sending transactions using the new `Receiving` transaction argument in the typescript and Rust SDKs.

The bottom commit adds typescript support and the top commit adds Rust SDK support (and has already been reviewed and approved). 

## Test Plan 

Added a number of additional tests to the typescript SDK to make sure `receiving` arguments are handled correctly.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Support has been added to both Typescript and Rust SDKs to construct transactions to receive previously-sent objects using the new transfer-to-object functionality and `Receiving` transaction argument. This functionality is currently only enabled in devnet. 
