### PR TITLE
[rpc] Simplify error response from execute_transaction_block of transaction_execution_api

### DIFF
--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -96,6 +96,17 @@ impl From<Error> for RpcError {
                 }
                 _ => RpcError::Call(CallError::Failed(sui_error.into())),
             },
+            Error::StateReadError(err) => match err {
+                StateReadError::Client(_) => RpcError::Call(CallError::InvalidParams(err.into())),
+                _ => {
+                    let error_object = ErrorObject::owned(
+                        jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+                        err.to_string(),
+                        None::<()>,
+                    );
+                    RpcError::Call(CallError::Custom(error_object))
+                }
+            },
             Error::QuorumDriverError(err) => match err {
                 QuorumDriverError::InvalidUserSignature(err) => {
                     let inner_error_str = match err {

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -4,8 +4,11 @@
 use fastcrypto::error::FastCryptoError;
 use hyper::header::InvalidHeaderValue;
 use jsonrpsee::core::Error as RpcError;
-use jsonrpsee::types::error::CallError;
+use jsonrpsee::types::error::{CallError, INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
 use jsonrpsee::types::ErrorObject;
+use std::collections::BTreeMap;
+use sui_types::base_types::ObjectRef;
+use sui_types::digests::TransactionDigest;
 use sui_types::error::{SuiError, SuiObjectResponseError, UserInputError};
 use sui_types::quorum_driver_types::{QuorumDriverError, NON_RECOVERABLE_ERROR_MSG};
 use thiserror::Error;
@@ -130,6 +133,94 @@ impl Error {
     }
 }
 
+pub fn match_quorum_driver_error(err: QuorumDriverError) -> RpcError {
+    match err {
+        QuorumDriverError::InvalidUserSignature(err) => {
+            let inner_error_str = match err {
+                // Use inner UserInputError's Display instead of SuiError::UserInputError, which renders UserInputError in debug format
+                SuiError::UserInputError { error } => error.to_string(),
+                _ => err.to_string(),
+            };
+
+            let error_message = format!("Invalid user signature: {inner_error_str}");
+
+            let error_object = ErrorObject::owned(INVALID_PARAMS_CODE, error_message, None::<()>);
+            RpcError::Call(CallError::Custom(error_object))
+        }
+        QuorumDriverError::TimeoutBeforeFinality
+        | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
+            let error_object =
+                ErrorObject::owned(TRANSIENT_ERROR_CODE, err.to_string(), None::<()>);
+            RpcError::Call(CallError::Custom(error_object))
+        }
+        QuorumDriverError::ObjectsDoubleUsed {
+            conflicting_txes,
+            retried_tx,
+            retried_tx_success,
+        } => {
+            let error_message = format!(
+                "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}",
+                retried_tx,
+                retried_tx_success
+            );
+
+            let mut new_map: BTreeMap<TransactionDigest, Vec<ObjectRef>> = BTreeMap::new();
+
+            for (digest, (pairs, _)) in conflicting_txes {
+                let mut new_vec = Vec::new();
+
+                for (_authority, obj_ref) in pairs {
+                    new_vec.push(obj_ref);
+                }
+
+                new_map.insert(digest, new_vec);
+            }
+
+            let error_object =
+                ErrorObject::owned(INVALID_PARAMS_CODE, error_message, Some(new_map));
+            RpcError::Call(CallError::Custom(error_object))
+        }
+        QuorumDriverError::NonRecoverableTransactionError { errors } => {
+            let mut new_errors: Vec<String> = errors
+                .into_iter()
+                .filter(|(err, _, _)| !err.is_retryable().0) // consider retryable errors as transient errors
+                .map(|(err, _, _)| {
+                    match err {
+                        // Use inner UserInputError's Display instead of SuiError::UserInputError, which renders UserInputError in debug format
+                        SuiError::UserInputError { error } => error.to_string(),
+                        _ => err.to_string(),
+                    }
+                })
+                .collect();
+
+            if new_errors.is_empty() {
+                new_errors.push(
+                    "Transient errors occurred during execution. Please try again.".to_string(),
+                );
+            }
+
+            let error_object = ErrorObject::owned(
+                INVALID_PARAMS_CODE,
+                NON_RECOVERABLE_ERROR_MSG,
+                Some(new_errors),
+            );
+            RpcError::Call(CallError::Custom(error_object))
+        }
+        QuorumDriverError::QuorumDriverInternalError(_) => {
+            let error_object = ErrorObject::owned(
+                INTERNAL_ERROR_CODE,
+                "Internal error occurred while executing transaction.",
+                None::<()>,
+            );
+            RpcError::Call(CallError::Custom(error_object))
+        }
+        QuorumDriverError::SystemOverload { .. } => {
+            let error_object = ErrorObject::owned(INTERNAL_ERROR_CODE, err.to_string(), None::<()>);
+            RpcError::Call(CallError::Custom(error_object))
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum SuiRpcInputError {
     #[error("Input contains duplicates")]
@@ -167,4 +258,215 @@ pub enum SuiRpcInputError {
 
     #[error(transparent)]
     UserInputError(#[from] UserInputError),
+}
+
+impl From<SuiRpcInputError> for RpcError {
+    fn from(e: SuiRpcInputError) -> Self {
+        RpcError::Call(CallError::InvalidParams(e.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+    use jsonrpsee::types::ErrorObjectOwned;
+    use sui_types::base_types::{random_object_ref, AuthorityName};
+    use sui_types::committee::StakeUnit;
+    use sui_types::crypto::AuthorityPublicKey;
+    use sui_types::crypto::AuthorityPublicKeyBytes;
+
+    mod match_quorum_driver_error_tests {
+        use super::*;
+
+        #[test]
+        fn test_invalid_user_signature() {
+            let quorum_driver_error =
+                QuorumDriverError::InvalidUserSignature(SuiError::InvalidSignature {
+                    error: "Test inner invalid signature".to_string(),
+                });
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32602"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect![
+                "Invalid user signature: Signature is not valid: Test inner invalid signature"
+            ];
+            expected_message.assert_eq(error_object.message());
+        }
+
+        #[test]
+        fn test_timeout_before_finality() {
+            let quorum_driver_error = QuorumDriverError::TimeoutBeforeFinality;
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32001"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Transaction timed out before reaching finality"];
+            expected_message.assert_eq(error_object.message());
+        }
+
+        #[test]
+        fn test_failed_with_transient_error_after_maximum_attempts() {
+            let quorum_driver_error =
+                QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts {
+                    total_attempts: 10,
+                };
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32001"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect![
+                "Transaction failed to reach finality with transient error after 10 attempts."
+            ];
+            expected_message.assert_eq(error_object.message());
+        }
+
+        #[test]
+        fn test_objects_double_used() {
+            use sui_types::crypto::VerifyingKey;
+            let mut conflicting_txes: BTreeMap<
+                TransactionDigest,
+                (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
+            > = BTreeMap::new();
+            let tx_digest = TransactionDigest::default();
+            let object_ref = random_object_ref();
+            let stake_unit: StakeUnit = 10;
+            let authority_name = AuthorityPublicKeyBytes([0; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
+                conflicting_txes,
+                retried_tx: Some(TransactionDigest::default()),
+                retried_tx_success: Some(true),
+            };
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32602"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction Some(TransactionDigest(11111111111111111111111111111111)), success: Some(true)"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[
+                r#"{"11111111111111111111111111111111":[["0x7da78de297e53bf42590250788d7e5e0e3ff355330ea1393d4d7dce86682ec7b",0,"11111111111111111111111111111111"]]}"#
+            ]];
+            let actual_data = error_object.data().unwrap().to_string();
+            expected_data.assert_eq(&actual_data);
+        }
+
+        #[test]
+        fn test_non_recoverable_transaction_error() {
+            let quorum_driver_error = QuorumDriverError::NonRecoverableTransactionError {
+                errors: vec![
+                    (
+                        SuiError::UserInputError {
+                            error: UserInputError::GasBalanceTooLow {
+                                gas_balance: 10,
+                                needed_gas_amount: 100,
+                            },
+                        },
+                        0,
+                        vec![],
+                    ),
+                    (
+                        SuiError::UserInputError {
+                            error: UserInputError::ObjectVersionUnavailableForConsumption {
+                                provided_obj_ref: random_object_ref(),
+                                current_version: 10.into(),
+                            },
+                        },
+                        0,
+                        vec![],
+                    ),
+                ],
+            };
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32602"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message =
+                expect!["Transaction has non recoverable errors from at least 1/3 of validators"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[
+                r#"["Balance of gas object 10 is lower than the needed amount: 100.","Object (0xcf9722a6c9421d8c5b1df13455da03d81e0372bd8ac982a3c0092112235fef14, SequenceNumber(0), o#11111111111111111111111111111111) is not available for consumption, its current version: SequenceNumber(10)."]"#
+            ]];
+            let actual_data = error_object.data().unwrap().to_string();
+            expected_data.assert_eq(&actual_data);
+        }
+
+        #[test]
+        fn test_non_recoverable_transaction_error_with_transient_errors() {
+            let quorum_driver_error = QuorumDriverError::NonRecoverableTransactionError {
+                errors: vec![
+                    (
+                        SuiError::UserInputError {
+                            error: UserInputError::ObjectNotFound {
+                                object_id: random_object_ref().0,
+                                version: None,
+                            },
+                        },
+                        0,
+                        vec![],
+                    ),
+                    (
+                        SuiError::RpcError("Hello".to_string(), "Testing".to_string()),
+                        0,
+                        vec![],
+                    ),
+                ],
+            };
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32602"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message =
+                expect!["Transaction has non recoverable errors from at least 1/3 of validators"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data =
+                expect![[r#"["Transient errors occurred during execution. Please try again."]"#]];
+            let actual_data = error_object.data().unwrap().to_string();
+            expected_data.assert_eq(&actual_data);
+        }
+
+        #[test]
+        fn test_quorum_driver_internal_error() {
+            let quorum_driver_error =
+                QuorumDriverError::QuorumDriverInternalError(SuiError::UnexpectedMessage);
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32603"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Internal error occurred while executing transaction."];
+            expected_message.assert_eq(error_object.message());
+        }
+
+        #[test]
+        fn test_system_overload() {
+            let quorum_driver_error = QuorumDriverError::SystemOverload {
+                overloaded_stake: 10,
+                errors: vec![(SuiError::UnexpectedMessage, 0, vec![])],
+            };
+
+            let rpc_error = match_quorum_driver_error(quorum_driver_error);
+
+            let error_object: ErrorObjectOwned = rpc_error.into();
+            let expected_code = expect!["-32603"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Transaction is not processed because 10 of validators by stake are overloaded with certificates pending execution."];
+            expected_message.assert_eq(error_object.message());
+        }
+    }
 }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -134,7 +134,9 @@ impl From<Error> for RpcError {
 
                     let mut new_map: BTreeMap<TransactionDigest, Vec<ObjectRef>> = BTreeMap::new();
 
-                    for (digest, (pairs, _)) in conflicting_txes {
+                    let new_map = conflicting_txes.into_iter()
+                        .map(|(digest, (pairs, _))| (digest, pairs.into_iter().map(|_, obj_ref| obj_ref).collect()))
+                        .collect::<BTreeMap<_, Vec<_>>>();
                         let mut new_vec = Vec::new();
 
                         for (_authority, obj_ref) in pairs {

--- a/crates/sui-json-rpc/src/logger.rs
+++ b/crates/sui-json-rpc/src/logger.rs
@@ -17,7 +17,7 @@ macro_rules! with_tracing {
             let result: RpcResult<_> = interim_result.map_err(|e: Error| {
                 let anyhow_error = anyhow!("{:?}", e);
 
-                let rpc_error = e.to_rpc_error();
+                let rpc_error: RpcError = e.into();
                 if !matches!(rpc_error, RpcError::Call(CallError::InvalidParams(_))) {
                     error!(error=?anyhow_error);
                 }

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use hyper::body::HttpBody;
+use jsonrpsee::types::error::{CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use hyper::body::HttpBody;
-use jsonrpsee::types::error::{CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -6,6 +6,7 @@ use jsonrpsee::types::error::{CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 
+use crate::error::TRANSIENT_ERROR_CODE;
 use crate::{CLIENT_SDK_TYPE_HEADER, CLIENT_TARGET_API_VERSION_HEADER};
 use jsonrpsee::server::logger::{HttpRequest, Logger, MethodKind, TransportProtocol};
 use jsonrpsee::types::Params;
@@ -32,6 +33,7 @@ pub struct Metrics {
     errors_by_route: IntCounterVec,
     server_errors_by_route: IntCounterVec,
     client_errors_by_route: IntCounterVec,
+    transient_errors_by_route: IntCounterVec,
     /// Client info
     client: IntCounterVec,
     /// Connection count
@@ -91,6 +93,13 @@ impl MetricsLogger {
             server_errors_by_route: register_int_counter_vec_with_registry!(
                 "server_errors_by_route",
                 "Number of server errors by route",
+                &["route"],
+                registry,
+            )
+            .unwrap(),
+            transient_errors_by_route: register_int_counter_vec_with_registry!(
+                "transient_errors_by_route",
+                "Number of transient errors by route",
                 &["route"],
                 registry,
             )
@@ -227,6 +236,11 @@ impl Logger for MetricsLogger {
             {
                 self.metrics
                     .server_errors_by_route
+                    .with_label_values(&[method_name])
+                    .inc();
+            } else if code == TRANSIENT_ERROR_CODE {
+                self.metrics
+                    .transient_errors_by_route
                     .with_label_values(&[method_name])
                     .inc();
             } else {


### PR DESCRIPTION
## Description 

Overall simplify execution-side errors on `execute_transaction_block` RPC method by informing the caller how to resolve in the error message and reducing the data we put into the `data` field.

1. (modify) QuorumDriverError::InvalidUserSignature, ::ObjectsDoubleUsed, NonRecoverableTransactionError are now considered client errors
2. (new) ::TimeoutBeforeFinality, as a transient error -32000
4. (modify) For NonRecoverableTransactionError, populate 'data' field with vector of error strings. Previously, we dump Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)> which just becomes a huge object. Transient errors are filtered out, unless they are the only error in the data field, in which case we return a generic error string and ask the caller to just try again.
6. (new) For ObjectsDoubleUsed error response, populate the `data` field with a map of transaction -> vec(object_ref)
7. unit testing to verify conversion

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
All transaction execution errors from execute_transaction_block of client-fault will now return a -32002 error code. If you encounter this error code, there is most likely something at fault in your transaction inputs.
Previously, when executing a transaction fails on the rpc, you would receive a, "Transaction has non recoverable errors from at least 1/3 of validators" after failing to execute a transaction. You will now receive an improved error message, "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: {errors}". {errors} is a string list of actionable errors. Upon remediation, you should be able to successfully retry your transaction.
