### PR TITLE
[move-compiler][sui-mode] Add entry function signature checks

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -19,6 +19,7 @@ use move_binary_format::{
 };
 use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule};
 use move_compiler::{
+    cfgir::visitor::AbstractInterpreterVisitor,
     compiled_unit::{
         AnnotatedCompiledModule, AnnotatedCompiledScript, CompiledUnitEnum, NamedCompiledModule,
     },
@@ -131,7 +132,8 @@ impl BuildConfig {
         let mut fn_info = None;
         let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
             let (files, units_res) = if lint {
-                let lint_visitors = vec![ShareOwnedVerifier.into(), SelfTransferVerifier.into()];
+                let lint_visitors =
+                    vec![ShareOwnedVerifier.visitor(), SelfTransferVerifier.visitor()];
                 compiler.add_visitors(lint_visitors).build()?
             } else {
                 compiler.build()?

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -8,8 +8,11 @@ use move_command_line_common::{
     testing::{add_update_baseline_fix, format_diff, read_env_update_baseline},
 };
 use move_compiler::{
-    cfgir::visitor::AbstractInterpreterVisitor, command_line::compiler::move_check_for_errors,
-    shared::NumericalAddress, Compiler, PASS_PARSER,
+    cfgir::visitor::AbstractInterpreterVisitor,
+    command_line::compiler::move_check_for_errors,
+    editions::Flavor,
+    shared::{NumericalAddress, PackageConfig},
+    Compiler, PASS_PARSER,
 };
 
 use sui_move_build::linters::{
@@ -43,6 +46,10 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         default_testing_addresses(),
     )
     .add_visitors(lint_visitors)
+    .set_default_config(PackageConfig {
+        flavor: Flavor::Sui,
+        ..PackageConfig::default()
+    })
     .run::<PASS_PARSER>()?;
 
     let diags = move_check_for_errors(comments_and_compiler_res);

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -8,7 +8,8 @@ use move_command_line_common::{
     testing::{add_update_baseline_fix, format_diff, read_env_update_baseline},
 };
 use move_compiler::{
-    command_line::compiler::move_check_for_errors, shared::NumericalAddress, Compiler, PASS_PARSER,
+    cfgir::visitor::AbstractInterpreterVisitor, command_line::compiler::move_check_for_errors,
+    shared::NumericalAddress, Compiler, PASS_PARSER,
 };
 
 use sui_move_build::linters::{
@@ -35,7 +36,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
 
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
-    let lint_visitors = vec![ShareOwnedVerifier.into(), SelfTransferVerifier.into()];
+    let lint_visitors = vec![ShareOwnedVerifier.visitor(), SelfTransferVerifier.visitor()];
     let (files, comments_and_compiler_res) = Compiler::from_files(
         targets,
         vec![MOVE_STDLIB_PATH.to_string(), SUI_FRAMEWORK_PATH.to_string()],

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.mvir
@@ -18,7 +18,7 @@ module 0x0.m {
 
 }
 
-// valid, while T doesn't have store, and might it later, we require it to be annotated
+// invalid, T doesn't have store so Obj is not an object
 
 //# publish
 module 0x0.m {

--- a/doc/src/build/move/index.md
+++ b/doc/src/build/move/index.md
@@ -58,7 +58,7 @@ When you define a module, specify the module name (`coin`) preceded by the name 
 
 For example, if you have a published package "P", you cannot publish an entirely different package also named "P". At the same time you can have module "P1::M1", "P2::M1", and "P1::M2" but not another, say, "P1::M1" in the system at the same time.
 
-While you can't name different packages the same, you can upgrade a package on chain with updated code using the same package name.  
+While you can't name different packages the same, you can upgrade a package on chain with updated code using the same package name.
 
 In addition to having a presence at the source code level, as discussed in [Sui Move code organization](#move-code-organization), a
 package in Sui is also a Sui object and must have a unique numeric ID in addition to a unique name, which is assigned in the manifest file:

--- a/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
@@ -395,7 +395,7 @@ fn add_drop_ability_tip(context: &Context, diag: &mut Diagnostic, st: SingleType
             t
         ),
     };
-    crate::typing::core::ability_not_satisified_tips(
+    crate::typing::core::ability_not_satisfied_tips(
         &crate::typing::core::Subst::empty(),
         diag,
         Ability_::Drop,

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -30,17 +30,12 @@ pub trait AbstractInterpreterVisitor {
         context: &CFGContext,
         cfg: &ImmForwardCFG,
     ) -> Diagnostics;
-}
 
-impl<V: AbstractInterpreterVisitor + 'static> From<V> for AbsIntVisitorObj {
-    fn from(value: V) -> Self {
-        Box::new(value)
-    }
-}
-
-impl<V: AbstractInterpreterVisitor + 'static> From<V> for Visitor {
-    fn from(value: V) -> Self {
-        Visitor::AbsIntVisitor(Box::new(value))
+    fn visitor(self) -> Visitor
+    where
+        Self: 'static + Sized,
+    {
+        Visitor::AbsIntVisitor(Box::new(self))
     }
 }
 

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -519,6 +519,22 @@ impl BuiltinFunction_ {
     }
 }
 
+impl TypeName_ {
+    pub fn is(
+        &self,
+        address: impl AsRef<str>,
+        module: impl AsRef<str>,
+        name: impl AsRef<str>,
+    ) -> bool {
+        match self {
+            TypeName_::Builtin(_) | TypeName_::Multiple(_) => false,
+            TypeName_::ModuleType(mident, n) => {
+                mident.value.is(address, module) && n == name.as_ref()
+            }
+        }
+    }
+}
+
 impl Type_ {
     pub fn builtin_(b: BuiltinTypeName, ty_args: Vec<Type>) -> Type_ {
         use BuiltinTypeName_ as B;

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::visitor::AbsIntVisitorObj,
+    cfgir::visitor::{AbsIntVisitorObj, AbstractInterpreterVisitor},
     command_line as cli,
     diagnostics::{
         codes::{Category, Severity, WarningFilter, WARNING_FILTER_ATTR},
@@ -12,7 +12,7 @@ use crate::{
     editions::{Edition, Flavor},
     naming::ast::ModuleDefinition,
     sui_mode,
-    typing::visitor::TypingVisitorObj,
+    typing::visitor::{TypingVisitor, TypingVisitorObj},
 };
 use clap::*;
 use move_ir_types::location::*;
@@ -199,7 +199,10 @@ impl CompilationEnv {
         package_configs: BTreeMap<Symbol, PackageConfig>,
         default_config: Option<PackageConfig>,
     ) -> Self {
-        visitors.extend([sui_mode::id_leak::IDLeakVerifier.into()]);
+        visitors.extend([
+            sui_mode::id_leak::IDLeakVerifier.visitor(),
+            sui_mode::typing::SuiTypeChecks.visitor(),
+        ]);
         Self {
             flags,
             warning_filter: vec![],

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 
 use crate::{
     cfgir::{
@@ -24,9 +25,24 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    FRESH_ID_FUNCTIONS, FUNCTIONS_TO_SKIP, ID_LEAK_DIAG, OBJECT_MODULE_NAME, SUI_ADDR_NAME,
+    CLOCK_MODULE_NAME, ID_LEAK_DIAG, OBJECT_MODULE_NAME, OBJECT_NEW_UID_FROM_HASH, SUI_ADDR_NAME,
+    SUI_CLOCK_CREATE, SUI_SYSTEM_ADDR_NAME, SUI_SYSTEM_CREATE, SUI_SYSTEM_MODULE_NAME,
     UID_TYPE_NAME,
 };
+
+pub const FRESH_ID_FUNCTIONS: &[(Symbol, Symbol, Symbol)] = &[
+    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW),
+    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW_UID_FROM_HASH),
+    (SUI_ADDR_NAME, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT),
+];
+pub const FUNCTIONS_TO_SKIP: &[(Symbol, Symbol, Symbol)] = &[
+    (
+        SUI_SYSTEM_ADDR_NAME,
+        SUI_SYSTEM_MODULE_NAME,
+        SUI_SYSTEM_CREATE,
+    ),
+    (SUI_ADDR_NAME, CLOCK_MODULE_NAME, SUI_CLOCK_CREATE),
+];
 
 //**************************************************************************************************
 // types

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -6,39 +6,65 @@ use move_symbol_pool::Symbol;
 use crate::diagnostics::codes::{custom, DiagnosticInfo, Severity};
 
 pub mod id_leak;
+pub mod typing;
 
-const SUI_ADDR_NAME: Symbol = symbol!("sui");
-const OBJECT_MODULE_NAME: Symbol = symbol!("object");
-const OBJECT_NEW: Symbol = symbol!("new");
-const OBJECT_NEW_UID_FROM_HASH: Symbol = symbol!("new_uid_from_hash");
-const TEST_SCENARIO_MODULE_NAME: Symbol = symbol!("test_scenario");
-const TS_NEW_OBJECT: Symbol = symbol!("new_object");
-const UID_TYPE_NAME: Symbol = symbol!("UID");
+pub const INIT_FUNCTION_NAME: Symbol = symbol!("init");
 
-const SUI_SYSTEM_ADDR_NAME: Symbol = symbol!("sui_system");
-const SUI_SYSTEM_MODULE_NAME: Symbol = symbol!("sui_system");
-const SUI_SYSTEM_CREATE: Symbol = symbol!("create");
-const CLOCK_MODULE_NAME: Symbol = symbol!("clock");
-const SUI_CLOCK_CREATE: Symbol = symbol!("create");
+pub const STD_ADDR_NAME: Symbol = symbol!("std");
+pub const OPTION_MODULE_NAME: Symbol = symbol!("option");
+pub const OPTION_TYPE_NAME: Symbol = symbol!("Option");
+pub const UTF_MODULE_NAME: Symbol = symbol!("string");
+pub const UTF_TYPE_NAME: Symbol = symbol!("String");
+pub const ASCII_MODULE_NAME: Symbol = symbol!("ascii");
+pub const ASCII_TYPE_NAME: Symbol = symbol!("String");
 
-const FRESH_ID_FUNCTIONS: &[(Symbol, Symbol, Symbol)] = &[
-    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW),
-    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW_UID_FROM_HASH),
-    (SUI_ADDR_NAME, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT),
-];
-const FUNCTIONS_TO_SKIP: &[(Symbol, Symbol, Symbol)] = &[
-    (
-        SUI_SYSTEM_ADDR_NAME,
-        SUI_SYSTEM_MODULE_NAME,
-        SUI_SYSTEM_CREATE,
-    ),
-    (SUI_ADDR_NAME, CLOCK_MODULE_NAME, SUI_CLOCK_CREATE),
-];
+pub const SUI_ADDR_NAME: Symbol = symbol!("sui");
+pub const OBJECT_MODULE_NAME: Symbol = symbol!("object");
+pub const OBJECT_NEW: Symbol = symbol!("new");
+pub const OBJECT_NEW_UID_FROM_HASH: Symbol = symbol!("new_uid_from_hash");
+pub const TEST_SCENARIO_MODULE_NAME: Symbol = symbol!("test_scenario");
+pub const TS_NEW_OBJECT: Symbol = symbol!("new_object");
+pub const UID_TYPE_NAME: Symbol = symbol!("UID");
+pub const ID_TYPE_NAME: Symbol = symbol!("ID");
+pub const TX_CONTEXT_MODULE_NAME: Symbol = symbol!("tx_context");
+pub const TX_CONTEXT_TYPE_NAME: Symbol = symbol!("TxContext");
 
-const ID_LEAK_DIAG: DiagnosticInfo = custom(
-    "Sui ",
+pub const SUI_SYSTEM_ADDR_NAME: Symbol = symbol!("sui_system");
+pub const SUI_SYSTEM_MODULE_NAME: Symbol = symbol!("sui_system");
+pub const SUI_SYSTEM_CREATE: Symbol = symbol!("create");
+pub const CLOCK_MODULE_NAME: Symbol = symbol!("clock");
+pub const CLOCK_TYPE_NAME: Symbol = symbol!("Clock");
+pub const SUI_CLOCK_CREATE: Symbol = symbol!("create");
+
+//**************************************************************************************************
+// Diagnostics
+//**************************************************************************************************
+
+pub const SUI_DIAG_PREFIX: &str = "Sui ";
+
+// Categories
+pub const ID_LEAK_CATEGORY: u8 = 1;
+pub const TYPING: u8 = 2;
+
+pub const ID_LEAK_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
     Severity::NonblockingError,
-    /* category */ 1,
+    /* category */ ID_LEAK_CATEGORY,
     /* code */ 1,
     "invalid object construction",
+);
+
+pub const SCRIPT_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 1,
+    "scripts are not supported",
+);
+pub const ENTRY_FUN_SIGNATURE_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 2,
+    "invalid 'entry' function signature",
 );

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -1,0 +1,434 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_ir_types::location::Loc;
+
+use crate::{
+    diag,
+    editions::Flavor,
+    expansion::ast::{AbilitySet, ModuleIdent},
+    naming::ast::{BuiltinTypeName_, FunctionSignature, TParam, Type, TypeName_, Type_, Var},
+    parser::ast::{Ability_, FunctionName},
+    shared::CompilationEnv,
+    sui_mode::{
+        ASCII_MODULE_NAME, ASCII_TYPE_NAME, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME,
+        ENTRY_FUN_SIGNATURE_DIAG, ID_TYPE_NAME, OBJECT_MODULE_NAME, OPTION_MODULE_NAME,
+        OPTION_TYPE_NAME, SCRIPT_DIAG, STD_ADDR_NAME, SUI_ADDR_NAME, UTF_MODULE_NAME,
+        UTF_TYPE_NAME,
+    },
+    typing::{
+        ast as T,
+        core::{ability_not_satisified_tips, ProgramInfo, Subst},
+        visitor::TypingVisitor,
+    },
+};
+
+use super::{TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME};
+
+//**************************************************************************************************
+// Visitor
+//**************************************************************************************************
+
+pub struct SuiTypeChecks;
+
+impl TypingVisitor for SuiTypeChecks {
+    fn visit(&mut self, env: &mut CompilationEnv, info: &ProgramInfo, prog: &mut T::Program) {
+        program(env, info, prog)
+    }
+}
+
+//**************************************************************************************************
+// Context
+//**************************************************************************************************
+
+#[allow(unused)]
+struct Context<'a> {
+    env: &'a mut CompilationEnv,
+    info: &'a ProgramInfo,
+    current_module: ModuleIdent,
+    in_test: bool,
+}
+
+impl<'a> Context<'a> {
+    fn new(
+        env: &'a mut CompilationEnv,
+        info: &'a ProgramInfo,
+        current_module: ModuleIdent,
+    ) -> Self {
+        Context {
+            env,
+            current_module,
+            info,
+            in_test: false,
+        }
+    }
+}
+
+//**************************************************************************************************
+// Entry
+//**************************************************************************************************
+
+pub fn program(env: &mut CompilationEnv, info: &ProgramInfo, prog: &T::Program) {
+    let T::Program { modules, scripts } = prog;
+    for script in scripts.values() {
+        let config = env.package_config(script.package_name);
+        if config.flavor != Flavor::Sui {
+            continue;
+        }
+
+        // TODO point to PTB docs?
+        let msg = "'scripts' are not supported on Sui. \
+        Consider removing or refactoring into a 'module'";
+        env.add_diag(diag!(SCRIPT_DIAG, (script.loc, msg)))
+    }
+    for (mident, mdef) in modules.key_cloned_iter() {
+        module(env, info, mident, mdef);
+    }
+}
+
+fn module(
+    env: &mut CompilationEnv,
+    info: &ProgramInfo,
+    mident: ModuleIdent,
+    mdef: &T::ModuleDefinition,
+) {
+    let config = env.package_config(mdef.package_name);
+    if config.flavor != Flavor::Sui {
+        return;
+    }
+
+    // Skip non-source, dependency modules
+    if !mdef.is_source_module {
+        return;
+    }
+
+    let mut context = Context::new(env, info, mident);
+    for (name, fdef) in mdef.functions.key_cloned_iter() {
+        function(&mut context, name, fdef);
+    }
+}
+
+//**************************************************************************************************
+// Functions
+//**************************************************************************************************
+
+fn function(context: &mut Context, name: FunctionName, fdef: &T::Function) {
+    let T::Function {
+        visibility: _,
+        signature,
+        acquires: _,
+        body: _,
+        warning_filter: _,
+        index: _,
+        attributes: _,
+        entry,
+    } = fdef;
+    if let Some(entry_loc) = entry {
+        entry_signature(context, *entry_loc, name, signature);
+    }
+}
+
+//**************************************************************************************************
+// entry types
+//**************************************************************************************************
+
+fn entry_signature(
+    context: &mut Context,
+    entry_loc: Loc,
+    name: FunctionName,
+    signature: &FunctionSignature,
+) {
+    let FunctionSignature {
+        type_parameters: _,
+        parameters,
+        return_type,
+    } = signature;
+    let all_non_ctx_parameters = match parameters.last() {
+        Some((_, last_param_ty)) if tx_context_kind(last_param_ty) != TxContextKind::None => {
+            &parameters[0..parameters.len() - 1]
+        }
+        _ => &parameters,
+    };
+    entry_param(context, entry_loc, name, all_non_ctx_parameters);
+    entry_return(context, entry_loc, name, return_type);
+}
+
+fn tx_context_kind(sp!(_, last_param_ty_): &Type) -> TxContextKind {
+    let (is_mut, inner_ty) = match last_param_ty_ {
+        Type_::Ref(is_mut, inner_ty) => (*is_mut, &inner_ty.value),
+        _ => return TxContextKind::None,
+    };
+    let inner_name = match inner_ty {
+        Type_::Apply(_, sp!(_, n_), _) => n_,
+        _ => return TxContextKind::None,
+    };
+    if inner_name.is(SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME) {
+        if is_mut {
+            TxContextKind::Mutable
+        } else {
+            TxContextKind::Immutable
+        }
+    } else {
+        TxContextKind::None
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum TxContextKind {
+    // No TxContext
+    None,
+    // &mut TxContext
+    Mutable,
+    // &TxContext
+    Immutable,
+}
+
+fn entry_param(
+    context: &mut Context,
+    entry_loc: Loc,
+    name: FunctionName,
+    parameters: &[(Var, Type)],
+) {
+    for (var, ty) in parameters {
+        entry_param_ty(context, entry_loc, name, var, ty);
+    }
+}
+
+/// A valid entry param type is
+/// - A primitive (including strings, ID, and object)
+/// - A vector of primitives (including nested vectors)
+///
+/// - An object
+/// - A reference to an object
+/// - A vector of objects
+fn entry_param_ty(
+    context: &mut Context,
+    entry_loc: Loc,
+    name: FunctionName,
+    param: &Var,
+    param_ty: &Type,
+) {
+    let is_mut_clock = is_mut_clock(param_ty);
+    // TODO better error message for cases such as `MyObject<InnerTypeWithoutStore>`
+    // which should give a contextual error about `MyObject` having `key`, but the instantiation
+    // `MyObject<InnerTypeWithoutStore>` not having `key` due to `InnerTypeWithoutStore` not having
+    // `store`
+    let is_valid = is_entry_primitive_ty(param_ty) || is_entry_object_ty(param_ty);
+    if is_mut_clock || !is_valid {
+        let pmsg = format!(
+            "Invalid 'entry' parameter type for parameter '{}'",
+            param.value.name
+        );
+        let tmsg = if is_mut_clock {
+            format!(
+                "{a}::{m}::{n} must be passed by immutable reference, e.g. '&{a}::{m}::{n}'",
+                a = SUI_ADDR_NAME,
+                m = CLOCK_MODULE_NAME,
+                n = CLOCK_TYPE_NAME,
+            )
+        } else {
+            "'entry' parameters must be primitives (by-value), vectors of primitives, objects \
+            (by-reference or by-value), or vectors of objects"
+                .to_owned()
+        };
+        let emsg = format!("'{name}' was declared 'entry' here");
+        context.env.add_diag(diag!(
+            ENTRY_FUN_SIGNATURE_DIAG,
+            (param.loc, pmsg),
+            (param_ty.loc, tmsg),
+            (entry_loc, emsg)
+        ));
+    }
+}
+
+fn is_mut_clock(param_ty: &Type) -> bool {
+    match &param_ty.value {
+        Type_::Ref(/* mut */ false, _) => false,
+        Type_::Ref(/* mut */ true, t) => is_mut_clock(t),
+        Type_::Apply(_, sp!(_, n_), _) => n_.is(SUI_ADDR_NAME, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME),
+        Type_::Unit
+        | Type_::Param(_)
+        | Type_::Var(_)
+        | Type_::Anything
+        | Type_::UnresolvedError => false,
+    }
+}
+
+fn is_entry_primitive_ty(param_ty: &Type) -> bool {
+    use BuiltinTypeName_ as B;
+    use TypeName_ as N;
+
+    match &param_ty.value {
+        // A bit of a hack since no primitive has key
+        Type_::Param(tp) => !tp.abilities.has_ability_(Ability_::Key),
+        // nonsensical, but no error needed
+        Type_::Apply(_, sp!(_, N::Multiple(_)), ts) => ts.iter().all(is_entry_primitive_ty),
+        // Simple recursive cases
+        Type_::Ref(_, t) => is_entry_primitive_ty(t),
+        Type_::Apply(_, sp!(_, N::Builtin(sp!(_, B::Vector))), targs) => {
+            debug_assert!(targs.len() == 1);
+            is_entry_primitive_ty(&targs[0])
+        }
+
+        // custom "primitives"
+        Type_::Apply(_, sp!(_, n), targs)
+            if n.is(STD_ADDR_NAME, ASCII_MODULE_NAME, ASCII_TYPE_NAME)
+                || n.is(STD_ADDR_NAME, UTF_MODULE_NAME, UTF_TYPE_NAME)
+                || n.is(SUI_ADDR_NAME, OBJECT_MODULE_NAME, ID_TYPE_NAME) =>
+        {
+            debug_assert!(targs.is_empty());
+            true
+        }
+        Type_::Apply(_, sp!(_, n), targs)
+            if n.is(STD_ADDR_NAME, OPTION_MODULE_NAME, OPTION_TYPE_NAME) =>
+        {
+            debug_assert!(targs.len() == 1);
+            is_entry_primitive_ty(&targs[0])
+        }
+
+        // primitives
+        Type_::Apply(_, sp!(_, N::Builtin(_)), targs) => {
+            debug_assert!(targs.is_empty());
+            true
+        }
+
+        // Non primitive
+        Type_::Apply(_, sp!(_, N::ModuleType(_, _)), _) => false,
+        Type_::Unit => false,
+
+        // Error case nothing to do
+        Type_::UnresolvedError | Type_::Anything | Type_::Var(_) => true,
+    }
+}
+
+fn is_entry_object_ty(param_ty: &Type) -> bool {
+    use BuiltinTypeName_ as B;
+    use TypeName_ as N;
+    match &param_ty.value {
+        Type_::Ref(_, t) => is_entry_object_ty_inner(t),
+        Type_::Apply(_, sp!(_, N::Builtin(sp!(_, B::Vector))), targs) => {
+            debug_assert!(targs.len() == 1);
+            is_entry_object_ty_inner(&targs[0])
+        }
+        _ => is_entry_object_ty_inner(param_ty),
+    }
+}
+
+fn is_entry_object_ty_inner(param_ty: &Type) -> bool {
+    use TypeName_ as N;
+    match &param_ty.value {
+        Type_::Param(tp) => tp.abilities.has_ability_(Ability_::Key),
+        // nonsensical, but no error needed
+        Type_::Apply(_, sp!(_, N::Multiple(_)), ts) => ts.iter().all(is_entry_object_ty_inner),
+        // Simple recursive cases, shouldn't be hit but no need to error
+        Type_::Ref(_, t) => is_entry_object_ty_inner(t),
+
+        // Objects
+        Type_::Apply(Some(abilities), _, _) => abilities.has_ability_(Ability_::Key),
+
+        // Error case nothing to do
+        Type_::UnresolvedError | Type_::Anything | Type_::Var(_) | Type_::Unit => true,
+        // Unreachable cases
+        Type_::Apply(None, _, _) => unreachable!("ICE abilities should have been expanded"),
+    }
+}
+
+fn entry_return(
+    context: &mut Context,
+    entry_loc: Loc,
+    name: FunctionName,
+    return_type @ sp!(tloc, return_type_): &Type,
+) {
+    match return_type_ {
+        // unit is fine, nothing to do
+        Type_::Unit => (),
+        Type_::Ref(_, _) => {
+            let fmsg = format!("Invalid return type for entry function '{}'", name);
+            let tmsg = "Expected a non-reference type";
+            context.env.add_diag(diag!(
+                ENTRY_FUN_SIGNATURE_DIAG,
+                (entry_loc, fmsg),
+                (*tloc, tmsg)
+            ))
+        }
+        Type_::Param(tp) => {
+            if !tp.abilities.has_ability_(Ability_::Drop) {
+                let declared_loc_opt = Some(tp.user_specified_name.loc);
+                let declared_abilities = tp.abilities.clone();
+                invalid_entry_return_ty(
+                    context,
+                    entry_loc,
+                    name,
+                    return_type,
+                    declared_loc_opt,
+                    &declared_abilities,
+                    std::iter::empty(),
+                )
+            }
+        }
+        Type_::Apply(Some(abilities), sp!(_, tn_), ty_args) => {
+            if !abilities.has_ability_(Ability_::Drop) {
+                let (declared_loc_opt, declared_abilities) = match tn_ {
+                    TypeName_::Multiple(_) => (None, AbilitySet::collection(*tloc)),
+                    TypeName_::ModuleType(m, n) => (
+                        Some(context.info.struct_declared_loc(m, n)),
+                        context.info.struct_declared_abilities(m, n).clone(),
+                    ),
+                    TypeName_::Builtin(b) => (None, b.value.declared_abilities(b.loc)),
+                };
+                invalid_entry_return_ty(
+                    context,
+                    entry_loc,
+                    name,
+                    return_type,
+                    declared_loc_opt,
+                    &declared_abilities,
+                    ty_args.iter().map(|ty_arg| (ty_arg, get_abilities(ty_arg))),
+                )
+            }
+        }
+        // Error case nothing to do
+        Type_::UnresolvedError | Type_::Anything | Type_::Var(_) => (),
+        // Unreachable cases
+        Type_::Apply(None, _, _) => unreachable!("ICE abilities should have been expanded"),
+    }
+}
+
+fn get_abilities(sp!(loc, ty_): &Type) -> AbilitySet {
+    use Type_ as T;
+    let loc = *loc;
+    match ty_ {
+        T::UnresolvedError | T::Anything => AbilitySet::all(loc),
+        T::Unit => AbilitySet::collection(loc),
+        T::Ref(_, _) => AbilitySet::references(loc),
+        T::Param(TParam { abilities, .. }) | Type_::Apply(Some(abilities), _, _) => {
+            abilities.clone()
+        }
+        T::Var(_) | Type_::Apply(None, _, _) => {
+            unreachable!("ICE abilities should have been expanded")
+        }
+    }
+}
+
+fn invalid_entry_return_ty<'a>(
+    context: &mut Context,
+    entry_loc: Loc,
+    name: FunctionName,
+    ty: &Type,
+    declared_loc_opt: Option<Loc>,
+    declared_abilities: &AbilitySet,
+    ty_args: impl IntoIterator<Item = (&'a Type, AbilitySet)>,
+) {
+    let fmsg = format!("Invalid return type for entry function '{}'", name);
+    let mut diag = diag!(ENTRY_FUN_SIGNATURE_DIAG, (entry_loc, fmsg));
+    ability_not_satisified_tips(
+        &Subst::empty(),
+        &mut diag,
+        Ability_::Drop,
+        ty,
+        declared_loc_opt,
+        declared_abilities,
+        ty_args,
+    );
+    context.env.add_diag(diag)
+}

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     typing::{
         ast as T,
-        core::{ability_not_satisified_tips, ProgramInfo, Subst},
+        core::{ability_not_satisfied_tips, ProgramInfo, Subst},
         visitor::TypingVisitor,
     },
 };
@@ -154,16 +154,14 @@ fn entry_signature(
 }
 
 fn tx_context_kind(sp!(_, last_param_ty_): &Type) -> TxContextKind {
-    let (is_mut, inner_ty) = match last_param_ty_ {
-        Type_::Ref(is_mut, inner_ty) => (*is_mut, &inner_ty.value),
-        _ => return TxContextKind::None,
+    let Type_::Ref(is_mut, inner_ty) = last_param_ty_ else {
+        return TxContextKind::None
     };
-    let inner_name = match inner_ty {
-        Type_::Apply(_, sp!(_, n_), _) => n_,
-        _ => return TxContextKind::None,
+    let Type_::Apply(_, sp!(_, inner_name), _) = &inner_ty.value else {
+        return TxContextKind::None
     };
     if inner_name.is(SUI_ADDR_NAME, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME) {
-        if is_mut {
+        if *is_mut {
             TxContextKind::Mutable
         } else {
             TxContextKind::Immutable
@@ -421,7 +419,7 @@ fn invalid_entry_return_ty<'a>(
 ) {
     let fmsg = format!("Invalid return type for entry function '{}'", name);
     let mut diag = diag!(ENTRY_FUN_SIGNATURE_DIAG, (entry_loc, fmsg));
-    ability_not_satisified_tips(
+    ability_not_satisfied_tips(
         &Subst::empty(),
         &mut diag,
         Ability_::Drop,

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -57,6 +57,8 @@ pub struct ModuleInfo {
     pub constants: UniqueMap<ConstantName, ConstantInfo>,
 }
 
+pub struct ProgramInfo(UniqueMap<ModuleIdent, ModuleInfo>);
+
 pub struct LoopInfo(LoopInfo_);
 
 enum LoopInfo_ {
@@ -66,7 +68,7 @@ enum LoopInfo_ {
 }
 
 pub struct Context<'env> {
-    pub modules: UniqueMap<ModuleIdent, ModuleInfo>,
+    pub modules: ProgramInfo,
     pub env: &'env mut CompilationEnv,
 
     pub current_module: Option<ModuleIdent>,
@@ -82,6 +84,52 @@ pub struct Context<'env> {
 
     /// collects all called functions in the current module
     pub called_fns: BTreeSet<Symbol>,
+}
+
+impl ProgramInfo {
+    fn module(&self, m: &ModuleIdent) -> &ModuleInfo {
+        self.0.get(m).expect("ICE should have failed in naming")
+    }
+
+    fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
+        let minfo = self.module(m);
+        minfo
+            .structs
+            .get(n)
+            .expect("ICE should have failed in naming")
+    }
+
+    pub fn struct_declared_abilities(&self, m: &ModuleIdent, n: &StructName) -> &AbilitySet {
+        &self.struct_definition(m, n).abilities
+    }
+
+    pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &StructName) -> Loc {
+        let minfo = self.module(m);
+        *minfo
+            .structs
+            .get_loc(n)
+            .expect("ICE should have failed in naming")
+    }
+
+    pub fn struct_type_parameters(
+        &self,
+        m: &ModuleIdent,
+        n: &StructName,
+    ) -> &Vec<StructTypeParameter> {
+        &self.struct_definition(m, n).type_parameters
+    }
+
+    pub fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
+        self.module(m)
+            .functions
+            .get(n)
+            .expect("ICE should have failed in naming")
+    }
+
+    pub fn constant_info(&mut self, m: &ModuleIdent, n: &ConstantName) -> &ConstantInfo {
+        let constants = &self.module(m).constants;
+        constants.get(n).expect("ICE should have failed in naming")
+    }
 }
 
 impl<'env> Context<'env> {
@@ -131,7 +179,7 @@ impl<'env> Context<'env> {
             constraints: vec![],
             locals: UniqueMap::new(),
             loop_info: LoopInfo(LoopInfo_::NotInLoop),
-            modules,
+            modules: ProgramInfo(modules),
             env,
             called_fns: BTreeSet::new(),
         }
@@ -247,40 +295,27 @@ impl<'env> Context<'env> {
     }
 
     fn module_info(&self, m: &ModuleIdent) -> &ModuleInfo {
-        self.modules
-            .get(m)
-            .expect("ICE should have failed in naming")
+        self.modules.module(m)
     }
 
     fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
-        let minfo = self.module_info(m);
-        minfo
-            .structs
-            .get(n)
-            .expect("ICE should have failed in naming")
+        self.modules.struct_definition(m, n)
     }
 
     pub fn struct_declared_abilities(&self, m: &ModuleIdent, n: &StructName) -> &AbilitySet {
-        &self.struct_definition(m, n).abilities
+        self.modules.struct_declared_abilities(m, n)
     }
 
     pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &StructName) -> Loc {
-        let minfo = self.module_info(m);
-        *minfo
-            .structs
-            .get_loc(n)
-            .expect("ICE should have failed in naming")
+        self.modules.struct_declared_loc(m, n)
     }
 
     pub fn struct_tparams(&self, m: &ModuleIdent, n: &StructName) -> &Vec<StructTypeParameter> {
-        &self.struct_definition(m, n).type_parameters
+        self.modules.struct_type_parameters(m, n)
     }
 
     fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
-        self.module_info(m)
-            .functions
-            .get(n)
-            .expect("ICE should have failed in naming")
+        self.modules.function_info(m, n)
     }
 
     fn constant_info(&mut self, m_opt: &Option<ModuleIdent>, n: &ConstantName) -> &ConstantInfo {
@@ -466,7 +501,7 @@ fn error_format_impl_(b_: &Type_, subst: &Subst, nested: bool) -> String {
 // Type utils
 //**************************************************************************************************
 
-pub fn infer_abilities(context: &Context, subst: &Subst, ty: Type) -> AbilitySet {
+pub fn infer_abilities(context: &ProgramInfo, subst: &Subst, ty: Type) -> AbilitySet {
     use Type_ as T;
     let loc = ty.loc;
     match unfold_type(subst, ty).value {
@@ -483,7 +518,7 @@ pub fn infer_abilities(context: &Context, subst: &Subst, ty: Type) -> AbilitySet
                     let declared_abilities = context.struct_declared_abilities(m, n).clone();
                     let non_phantom_ty_args = ty_args
                         .into_iter()
-                        .zip(context.struct_tparams(m, n))
+                        .zip(context.struct_type_parameters(m, n))
                         .filter(|(_, param)| !param.is_phantom)
                         .map(|(arg, _)| arg)
                         .collect::<Vec<_>>();
@@ -853,7 +888,7 @@ fn solve_ability_constraint(
     constraints: AbilitySet,
 ) {
     let ty = unfold_type(&context.subst, ty);
-    let ty_abilities = infer_abilities(context, &context.subst, ty.clone());
+    let ty_abilities = infer_abilities(&context.modules, &context.subst, ty.clone());
 
     let (declared_loc_opt, declared_abilities, ty_args) = debug_abilities_info(context, &ty);
     for constraint in constraints {
@@ -874,7 +909,7 @@ fn solve_ability_constraint(
             declared_loc_opt,
             &declared_abilities,
             ty_args.iter().map(|ty_arg| {
-                let abilities = infer_abilities(context, &context.subst, ty_arg.clone());
+                let abilities = infer_abilities(&context.modules, &context.subst, ty_arg.clone());
                 (ty_arg, abilities)
             }),
         );

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -901,7 +901,7 @@ fn solve_ability_constraint(
             None => format!("'{}' constraint not satisifed", constraint),
         };
         let mut diag = diag!(AbilitySafety::Constraint, (loc, constraint_msg));
-        ability_not_satisified_tips(
+        ability_not_satisfied_tips(
             &context.subst,
             &mut diag,
             constraint.value,
@@ -925,7 +925,7 @@ fn solve_ability_constraint(
     }
 }
 
-pub fn ability_not_satisified_tips<'a>(
+pub fn ability_not_satisfied_tips<'a>(
     subst: &Subst,
     diag: &mut Diagnostic,
     constraint: Ability_,

--- a/external-crates/move/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/move-compiler/src/typing/expand.rs
@@ -72,7 +72,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
         Apply(Some(_), sp!(_, TypeName_::Builtin(_)), tys) => types(context, tys),
         Apply(Some(_), _, _) => panic!("ICE expanding pre expanded type"),
         Apply(None, _, _) => {
-            let abilities = core::infer_abilities(context, &context.subst, ty.clone());
+            let abilities = core::infer_abilities(&context.modules, &context.subst, ty.clone());
             match &mut ty.value {
                 Apply(abilities_opt, _, tys) => {
                     *abilities_opt = Some(abilities);
@@ -143,7 +143,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         E::Use(v) => {
             let from_user = false;
             let var = *v;
-            let abs = core::infer_abilities(context, &context.subst, e.ty.clone());
+            let abs = core::infer_abilities(&context.modules, &context.subst, e.ty.clone());
             e.exp.value = if abs.has_ability_(Ability_::Copy) {
                 E::Copy { from_user, var }
             } else {

--- a/external-crates/move/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/move-compiler/src/typing/visitor.rs
@@ -1,10 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::expansion::ast::ModuleIdent;
-use crate::shared::unique_map::UniqueMap;
+use crate::command_line::compiler::Visitor;
 use crate::shared::CompilationEnv;
-use crate::typing::{ast as T, core::ModuleInfo};
+use crate::typing::{ast as T, core::ProgramInfo};
 
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
 
@@ -12,7 +11,20 @@ pub trait TypingVisitor {
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
-        module_info: &UniqueMap<ModuleIdent, ModuleInfo>,
+        program_info: &ProgramInfo,
         program: &mut T::Program,
     );
+
+    fn visitor(self) -> Visitor
+    where
+        Self: 'static + Sized,
+    {
+        Visitor::TypingVisitor(Box::new(self))
+    }
+}
+
+impl<V: TypingVisitor + 'static> From<V> for TypingVisitorObj {
+    fn from(value: V) -> Self {
+        Box::new(value)
+    }
 }

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_functions.unused.exp
@@ -1,4 +1,12 @@
 warning[W09008]: unused function
+  ┌─ tests/move_check/typing/unused_functions.move:3:9
+  │
+3 │     fun init() {
+  │         ^^^^ The non-'public', non-'entry' function 'init' is never called. Consider removing it.
+  │
+  = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09008]: unused function
    ┌─ tests/move_check/typing/unused_functions.move:11:9
    │
 11 │     fun unused_private() {}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_mut.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_mut.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/clock_mut.move:4:35
+  │
+4 │     public entry fun no_clock_mut(_: &mut sui::clock::Clock) {
+  │            -----                  ^  ---------------------- sui::clock::Clock must be passed by immutable reference, e.g. '&sui::clock::Clock'
+  │            │                      │   
+  │            │                      Invalid 'entry' parameter type for parameter '_'
+  │            'no_clock_mut' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_mut.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_mut.move
@@ -1,0 +1,19 @@
+// invalid, Clock by mutable reference
+
+module a::m {
+    public entry fun no_clock_mut(_: &mut sui::clock::Clock) {
+        abort 0
+    }
+}
+
+module sui::clock {
+    struct Clock has key {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_ref.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_ref.move
@@ -1,0 +1,19 @@
+// valid, Clock by immutable reference
+
+module a::m {
+    public entry fun yes_clock_ref(_: &sui::clock::Clock) {
+        abort 0
+    }
+}
+
+module sui::clock {
+    struct Clock has key {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_val.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_val.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/clock_val.move:4:35
+  │
+4 │     public entry fun no_clock_val(_: sui::clock::Clock) {
+  │            -----                  ^  ----------------- sui::clock::Clock must be passed by immutable reference, e.g. '&sui::clock::Clock'
+  │            │                      │   
+  │            │                      Invalid 'entry' parameter type for parameter '_'
+  │            'no_clock_val' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_val.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/clock_val.move
@@ -1,0 +1,19 @@
+// invalid, Clock by value
+
+module a::m {
+    public entry fun no_clock_val(_: sui::clock::Clock) {
+        abort 0
+    }
+}
+
+module sui::clock {
+    struct Clock has key {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_and_generic_object_params.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_and_generic_object_params.move
@@ -1,0 +1,18 @@
+module a::m {
+    use sui::object;
+    struct Obj<T> has key {
+        id: object::UID,
+        value: T,
+    }
+
+    public entry fun foo<T0: key, T1: store>(_: T0, _: Obj<T1>) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_mut_ref_vector.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_mut_ref_vector.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/generic_obj_mut_ref_vector.move:5:32
+  │
+5 │     public entry fun no<T:key>(_: &mut vector<T>) {
+  │            -----               ^  -------------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │                   │   
+  │            │                   Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_mut_ref_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_mut_ref_vector.move
@@ -1,0 +1,9 @@
+// invalid, a mutable reference to vector of objects
+
+module a::m {
+
+    public entry fun no<T:key>(_: &mut vector<T>) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_ref_vector.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_ref_vector.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/generic_obj_ref_vector.move:4:32
+  │
+4 │     public entry fun no<T:key>(_: &vector<T>) {
+  │            -----               ^  ---------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │                   │   
+  │            │                   Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_ref_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_obj_ref_vector.move
@@ -1,0 +1,8 @@
+// invalid, a mutable reference to vector of objects
+
+module a::m {
+    public entry fun no<T:key>(_: &vector<T>) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_param_after_primitive.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_param_after_primitive.move
@@ -1,0 +1,16 @@
+module a::m {
+    use sui::object;
+    struct Obj has key {
+        id: object::UID,
+    }
+    public entry fun foo<T>(_: Obj, _: u64, _: T) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_invalid.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_invalid.exp
@@ -1,0 +1,18 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/generic_with_key_invalid.move:6:31
+  │
+6 │     public entry fun t<T:key>(_: option::Option<T>) {
+  │            -----              ^  ----------------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │                  │   
+  │            │                  Invalid 'entry' parameter type for parameter '_'
+  │            't' was declared 'entry' here
+
+error[Sui E02002]: invalid 'entry' function signature
+   ┌─ tests/sui_mode/entry_points/generic_with_key_invalid.move:10:32
+   │
+10 │     public entry fun t2<T:key>(_: vector<option::Option<T>>) {
+   │            -----               ^  ------------------------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+   │            │                   │   
+   │            │                   Invalid 'entry' parameter type for parameter '_'
+   │            't2' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_invalid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_invalid.move
@@ -1,0 +1,14 @@
+// invalid, type parameters with key are not valid when nested as no primitive has key
+
+module a::m {
+    use std::option;
+
+    public entry fun t<T:key>(_: option::Option<T>) {
+        abort 0
+    }
+
+    public entry fun t2<T:key>(_: vector<option::Option<T>>) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_valid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/generic_with_key_valid.move
@@ -1,0 +1,8 @@
+// valid, type parameters with key are valid as long as they are not nested
+
+module a::m {
+    public entry fun yes<T:key>(_: T, _: &T, _: &mut T) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/id.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/id.move
@@ -1,0 +1,20 @@
+// valid, ID is allowed
+
+module a::m {
+    use sui::object;
+
+    public entry fun yes<T>(
+        _: object::ID,
+        _: vector<object::ID>,
+        _: vector<vector<object::ID>>,
+    ) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct ID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_generic_vector_param.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_generic_vector_param.move
@@ -1,0 +1,6 @@
+// can have nested primitive vectors
+module a::m {
+    public entry fun foo<T>(_: vector<vector<T>>) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_key_generic_vector_param.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_key_generic_vector_param.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/nested_key_generic_vector_param.move:3:34
+  │
+3 │     public entry fun foo<T: key>(_: vector<vector<T>>) {
+  │            -----                 ^  ----------------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │                     │   
+  │            │                     Invalid 'entry' parameter type for parameter '_'
+  │            'foo' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_key_generic_vector_param.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/nested_key_generic_vector_param.move
@@ -1,0 +1,6 @@
+// cannot have nested object vectors
+module a::m {
+    public entry fun foo<T: key>(_: vector<vector<T>>) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/non_key_struct.move:6:25
+  │
+6 │     public entry fun no(_: S) {
+  │            -----        ^  - 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │            │   
+  │            │            Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct.move
@@ -1,0 +1,9 @@
+// invalid, non key structs are not supported
+
+module a::m {
+    struct S has copy, drop, store { value: u64 }
+
+    public entry fun no(_: S) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic.exp
@@ -1,0 +1,18 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/non_key_struct_generic.move:9:25
+  │
+9 │     public entry fun t1(_: Obj<NoStore>) {
+  │            -----        ^  ------------ 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │            │   
+  │            │            Invalid 'entry' parameter type for parameter '_'
+  │            't1' was declared 'entry' here
+
+error[Sui E02002]: invalid 'entry' function signature
+   ┌─ tests/sui_mode/entry_points/non_key_struct_generic.move:14:28
+   │
+14 │     public entry fun t2<T>(_: Obj<T>) {
+   │            -----           ^  ------ 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+   │            │               │   
+   │            │               Invalid 'entry' parameter type for parameter '_'
+   │            't2' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic.move
@@ -1,0 +1,24 @@
+// invalid as NoStore doesn't have store, so Obj doesn't have key
+
+module a::m {
+    use sui::object;
+
+    struct Obj<T> has key { id: object::UID, value: T }
+    struct NoStore has copy, drop { value: u64 }
+
+    public entry fun t1(_: Obj<NoStore>) {
+        abort 0
+    }
+
+    // valid, while T doesn't have store, and might it later, we require it to be annotated
+    public entry fun t2<T>(_: Obj<T>) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic_valid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_generic_valid.move
@@ -1,0 +1,17 @@
+// valid, T has store, thus Obj has key
+
+module a::m {
+    use sui::object;
+
+    struct Obj<T> has key { id: object::UID, value: T }
+
+    public entry fun no<T: store>(_: Obj<T>) {
+        abort 0
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_vector.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_vector.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/non_key_struct_vector.move:6:25
+  │
+6 │     public entry fun no(_: vector<S>) {
+  │            -----        ^  --------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │            │   
+  │            │            Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/non_key_struct_vector.move
@@ -1,0 +1,10 @@
+// invalid, non key structs are not supported, even in vectors
+
+module a::m {
+    struct S has copy, drop, store { value: u64 }
+
+    public entry fun no(_: vector<S>) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_mut_ref_vector.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_mut_ref_vector.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/obj_mut_ref_vector.move:8:25
+  │
+8 │     public entry fun no(_: &mut vector<S>) {
+  │            -----        ^  -------------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │            │   
+  │            │            Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_mut_ref_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_mut_ref_vector.move
@@ -1,0 +1,17 @@
+// invalid, a mutable reference to vector of objects
+
+module a::m {
+    use sui::object;
+
+    struct S has key { id: object::UID }
+
+    public entry fun no(_: &mut vector<S>) {
+        abort 0
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_ref_vector.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_ref_vector.exp
@@ -1,0 +1,9 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/obj_ref_vector.move:8:25
+  │
+8 │     public entry fun no(_: &vector<S>) {
+  │            -----        ^  ---------- 'entry' parameters must be primitives (by-value), vectors of primitives, objects (by-reference or by-value), or vectors of objects
+  │            │            │   
+  │            │            Invalid 'entry' parameter type for parameter '_'
+  │            'no' was declared 'entry' here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_ref_vector.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/obj_ref_vector.move
@@ -1,0 +1,18 @@
+// invalid, a reference to vector of objects
+
+module a::m {
+    use sui::object;
+
+    struct S has key { id: object::UID }
+
+    public entry fun no(_: &vector<S>) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/ok.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/ok.move
@@ -1,0 +1,16 @@
+// TxContext by immutable or mutable ref
+
+module a::m {
+    use sui::tx_context;
+    public entry fun f(_: &tx_context::TxContext) {
+        abort 0
+    }
+
+    public entry fun t2(_: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/option.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/option.move
@@ -1,0 +1,16 @@
+// valid, option of primitives is allowed
+
+module a::m {
+    use std::option;
+
+    public entry fun yes<T>(
+        _: option::Option<u64>,
+        _: option::Option<option::Option<u64>>,
+        _: option::Option<vector<u64>>,
+        _: vector<option::Option<u64>>,
+        _: option::Option<option::Option<T>>,
+    ) {
+        abort 0
+    }
+
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/optional_txn_context.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/optional_txn_context.move
@@ -1,0 +1,18 @@
+// TxContext does not have to be present
+
+module a::m {
+    public entry fun t() {
+        abort 0
+    }
+
+    struct Obj has key { id: sui::object::UID }
+    public entry fun t2(_: bool, _: &mut Obj) {
+        abort 0
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values.move
@@ -1,0 +1,24 @@
+// return values from entry functions must have drop
+
+module a::m {
+    public entry fun t0(): u64 {
+        abort 0
+    }
+
+    public entry fun t1(): (u64, u8) {
+        abort 0
+    }
+
+    public entry fun t2(): vector<u8> {
+        abort 0
+    }
+
+    struct Droppable has drop { flag: bool }
+    public entry fun t3(): Droppable {
+        abort 0
+    }
+
+    public entry fun t4(): (vector<Droppable>, u64) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values_invalid.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values_invalid.exp
@@ -1,0 +1,46 @@
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/return_values_invalid.move:4:12
+  │
+4 │     public entry fun t0(): &u8 {
+  │            ^^^^^           --- Expected a non-reference type
+  │            │                
+  │            Invalid return type for entry function 't0'
+
+error[Sui E02002]: invalid 'entry' function signature
+  ┌─ tests/sui_mode/entry_points/return_values_invalid.move:7:12
+  │
+7 │     public entry fun t1(): &mut u8 {
+  │            ^^^^^           ------- Expected a non-reference type
+  │            │                
+  │            Invalid return type for entry function 't1'
+
+error[Sui E02002]: invalid 'entry' function signature
+   ┌─ tests/sui_mode/entry_points/return_values_invalid.move:14:12
+   │
+13 │     struct Copyable has copy, store {}
+   │            -------- To satisfy the constraint, the 'drop' ability would need to be added here
+14 │     public entry fun t3(): Copyable {
+   │            ^^^^^           -------- The type '(a=0x42)::m::Copyable' does not have the ability 'drop'
+   │            │                
+   │            Invalid return type for entry function 't3'
+
+error[Sui E02002]: invalid 'entry' function signature
+   ┌─ tests/sui_mode/entry_points/return_values_invalid.move:18:12
+   │
+17 │     struct Obj has key, store { id: sui::object::UID }
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+18 │     public entry fun t4(): Obj {
+   │            ^^^^^           --- The type '(a=0x42)::m::Obj' does not have the ability 'drop'
+   │            │                
+   │            Invalid return type for entry function 't4'
+
+error[Sui E02002]: invalid 'entry' function signature
+   ┌─ tests/sui_mode/entry_points/return_values_invalid.move:21:12
+   │
+21 │     public entry fun t5(): vector<Obj> {
+   │            ^^^^^           -----------
+   │            │               │      │
+   │            │               │      The type 'vector<(a=0x42)::m::Obj>' can have the ability 'drop' but the type argument '(a=0x42)::m::Obj' does not have the required ability 'drop'
+   │            │               The type 'vector<(a=0x42)::m::Obj>' does not have the ability 'drop'
+   │            Invalid return type for entry function 't5'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values_invalid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/return_values_invalid.move
@@ -1,0 +1,30 @@
+// return values from entry functions must have drop
+
+module a::m {
+    public entry fun t0(): &u8 {
+        abort 0
+    }
+    public entry fun t1(): &mut u8 {
+        abort 0
+    }
+    public entry fun t2(): (u64,&u8,u8) {
+        abort 0
+    }
+    struct Copyable has copy, store {}
+    public entry fun t3(): Copyable {
+        abort 0
+    }
+    struct Obj has key, store { id: sui::object::UID }
+    public entry fun t4(): Obj {
+        abort 0
+    }
+    public entry fun t5(): vector<Obj> {
+        abort 0
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_generic_vector_param.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_generic_vector_param.move
@@ -1,0 +1,5 @@
+module a::m {
+    public entry fun foo<T>(_: vector<T>) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param.move
@@ -1,0 +1,12 @@
+module a::m {
+    use sui::tx_context;
+
+    public entry fun foo<T>(_: T, _: &mut tx_context::TxContext) {
+        abort 0
+    }
+
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param_generic_object.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param_generic_object.move
@@ -1,0 +1,22 @@
+module a::m {
+    use sui::object;
+    use sui::tx_context;
+    struct Obj<T> has key {
+        id: object::UID,
+        value: T,
+    }
+    public entry fun foo<T: store>(_: Obj<T>, _: &mut tx_context::TxContext) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param_key.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/single_type_param_key.move
@@ -1,0 +1,18 @@
+// type parameters can have key
+module a::m {
+    use sui::tx_context;
+
+    public entry fun t1<T: key>(_: T, _: &mut tx_context::TxContext) {
+        abort 0
+    }
+    public entry fun t2<T: key>(_: &T, _: &mut tx_context::TxContext) {
+        abort 0
+    }
+    public entry fun t3<T: key>(_: &mut T, _: &mut tx_context::TxContext) {
+        abort 0
+    }
+
+}
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/entry_points/string.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/entry_points/string.move
@@ -1,0 +1,29 @@
+// valid, ASCII and UTF strings is allowed
+
+module a::m {
+    use sui::tx_context;
+    use std::ascii;
+    use std::string;
+
+    public entry fun yes_ascii<T>(
+        _: ascii::String,
+        _: vector<ascii::String>,
+        _: vector<vector<ascii::String>>,
+        _: &mut tx_context::TxContext,
+    ) {
+        abort 0
+    }
+
+    public entry fun yes_utf8<T>(
+        _: string::String,
+        _: vector<string::String>,
+        _: vector<vector<string::String>>,
+        _: &mut tx_context::TxContext,
+    ) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/unused_function.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/unused_function.move
@@ -1,0 +1,4 @@
+// init is unused but does not error because we are in Sui mode
+module a::m {
+    fun init() {}
+}

--- a/external-crates/move/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/move-symbol-pool/src/lib.rs
@@ -60,6 +60,15 @@ static_symbols!(
     "sui_system",
     "create",
     "clock",
+    "option",
+    "Option",
+    "string",
+    "ascii",
+    "String",
+    "Clock",
+    "tx_context",
+    "TxContext",
+    "ID",
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

- Ported entry function signature checks to the compiler guarded by sui-mode

## Test Plan 

- Ported tests
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

The Sui Move toolchain will now provide diagnostics (in the form of errors) for incorrect `entry` function signatures at the source language level.
