### PR TITLE
[move-compiler] Simple typed AST visitor

### DIFF
--- a/external-crates/move/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/move-compiler/src/command_line/compiler.rs
@@ -14,7 +14,9 @@ use crate::{
         CompilationEnv, Flags, IndexedPackagePath, NamedAddressMap, NamedAddressMaps,
         NumericalAddress, PackageConfig, PackagePaths,
     },
-    to_bytecode, typing, unit_test, verification,
+    to_bytecode,
+    typing::{self, visitor::TypingVisitorObj},
+    unit_test, verification,
 };
 use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
@@ -89,6 +91,7 @@ pub struct FullyCompiledProgram {
 }
 
 pub enum Visitor {
+    TypingVisitor(TypingVisitorObj),
     AbsIntVisitor(AbsIntVisitorObj),
 }
 

--- a/external-crates/move/move-compiler/src/typing/mod.rs
+++ b/external-crates/move/move-compiler/src/typing/mod.rs
@@ -9,3 +9,4 @@ mod globals;
 mod infinite_instantiations;
 mod recursive_structs;
 pub(crate) mod translate;
+pub mod visitor;

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -44,7 +44,13 @@ pub fn program(
     assert!(context.constraints.is_empty());
     recursive_structs::modules(context.env, &modules);
     infinite_instantiations::modules(context.env, &modules);
-    T::Program { modules, scripts }
+    let module_info = context.modules;
+    let mut prog = T::Program { modules, scripts };
+    for v in &compilation_env.visitors().typing {
+        let mut v = v.borrow_mut();
+        v.visit(compilation_env, &module_info, &mut prog);
+    }
+    prog
 }
 
 fn modules(

--- a/external-crates/move/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/move-compiler/src/typing/visitor.rs
@@ -1,0 +1,18 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::expansion::ast::ModuleIdent;
+use crate::shared::unique_map::UniqueMap;
+use crate::shared::CompilationEnv;
+use crate::typing::{ast as T, core::ModuleInfo};
+
+pub type TypingVisitorObj = Box<dyn TypingVisitor>;
+
+pub trait TypingVisitor {
+    fn visit(
+        &mut self,
+        env: &mut CompilationEnv,
+        module_info: &UniqueMap<ModuleIdent, ModuleInfo>,
+        program: &mut T::Program,
+    );
+}


### PR DESCRIPTION
## Description 

- Simple hook for adding visitors on the typed AST

## Test Plan 

Not yet used

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
