### PR TITLE
[ts-sdk] Update e2e tests to use SuiClient and Keypairs instead of Provider and RawSigner

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -43,6 +43,6 @@
 		"tailwindcss": "^3.3.1",
 		"typescript": "^5.0.4",
 		"vite": "^4.2.3",
-		"vitest": "^0.32.0"
+		"vitest": "^0.33.0"
 	}
 }

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -107,7 +107,7 @@
 		"typescript": "^5.0.4",
 		"vite": "^4.2.3",
 		"vite-plugin-svgr": "^2.4.0",
-		"vitest": "^0.32.0"
+		"vitest": "^0.33.0"
 	},
 	"browserslist": {
 		"production": [

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -101,7 +101,7 @@
 		"typescript": "^5.0.4",
 		"vite": "^4.2.3",
 		"vite-tsconfig-paths": "^4.2.0",
-		"vitest": "^0.32.0",
+		"vitest": "^0.33.0",
 		"web-ext": "^7.6.1",
 		"webpack": "^5.79.0",
 		"webpack-cli": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   apps/explorer:
     dependencies:
@@ -393,8 +393,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(vite@4.2.3)
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   apps/icons:
     devDependencies:
@@ -680,7 +680,7 @@ importers:
         version: 8.0.1(webpack@5.79.0)
       eslint-webpack-plugin:
         specifier: ^4.0.1
-        version: 4.0.1(eslint@8.43.0)(webpack@5.79.0)
+        version: 4.0.1(webpack@5.79.0)
       git-rev-sync:
         specifier: ^3.0.2
         version: 3.0.2
@@ -748,8 +748,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(typescript@5.0.4)(vite@4.2.3)
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(happy-dom@9.5.0)(playwright@1.32.3)(sass@1.62.0)
+        specifier: ^0.33.0
+        version: 0.33.0(happy-dom@9.5.0)(playwright@1.32.3)(sass@1.62.0)
       web-ext:
         specifier: ^7.6.1
         version: 7.6.1
@@ -993,13 +993,13 @@ importers:
         version: 8.2.4
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
+        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/build-scripts:
     dependencies:
@@ -1069,13 +1069,13 @@ importers:
         version: 8.2.4
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
+        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/suins-toolkit:
     dependencies:
@@ -1096,8 +1096,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
 
   sdk/typescript:
     dependencies:
@@ -1164,7 +1164,7 @@ importers:
         version: 0.7.0
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@5.0.4)
+        version: 6.7.0(typescript@5.0.4)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -1178,8 +1178,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
       vitest:
-        specifier: ^0.32.0
-        version: 0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
+        specifier: ^0.33.0
+        version: 0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3)
       wait-on:
         specifier: ^7.0.1
         version: 7.0.1(debug@4.3.4)
@@ -4260,14 +4260,14 @@ packages:
     resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@sinclair/typebox': 0.24.28
+      '@sinclair/typebox': 0.24.51
     dev: true
 
-  /@jest/schemas@29.4.3:
-    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
+  /@jest/schemas@29.6.0:
+    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@sinclair/typebox': 0.25.24
+      '@sinclair/typebox': 0.27.8
     dev: true
 
   /@jest/transform@29.5.0:
@@ -4320,7 +4320,7 @@ packages:
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.4.3
+      '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.15.11
@@ -6273,12 +6273,12 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@sinclair/typebox@0.24.28:
-    resolution: {integrity: sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==}
+  /@sinclair/typebox@0.24.51:
+    resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
     dev: true
 
-  /@sinclair/typebox@0.25.24:
-    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
   /@sindresorhus/is@0.14.0:
@@ -7018,7 +7018,7 @@ packages:
     dependencies:
       '@storybook/node-logger': 7.0.20
       '@storybook/types': 7.0.20
-      '@types/node': 16.18.23
+      '@types/node': 16.18.38
       '@types/pretty-hrtime': 1.0.1
       chalk: 4.1.2
       esbuild: 0.17.19
@@ -7512,7 +7512,7 @@ packages:
       '@storybook/types': 7.0.20
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
-      '@types/node': 16.18.23
+      '@types/node': 16.18.38
       acorn: 7.4.1
       acorn-jsx: 5.3.2(acorn@7.4.1)
       acorn-walk: 7.2.0
@@ -8468,6 +8468,10 @@ packages:
     resolution: {integrity: sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==}
     dev: true
 
+  /@types/node@16.18.38:
+    resolution: {integrity: sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==}
+    dev: true
+
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
 
@@ -9030,35 +9034,34 @@ packages:
       - supports-color
     dev: true
 
-  /@vitest/expect@0.32.0:
-    resolution: {integrity: sha512-VxVHhIxKw9Lux+O9bwLEEk2gzOUe93xuFHy9SzYWnnoYZFYg1NfBtnfnYWiJN7yooJ7KNElCK5YtA7DTZvtXtg==}
+  /@vitest/expect@0.33.0:
+    resolution: {integrity: sha512-sVNf+Gla3mhTCxNJx+wJLDPp/WcstOe0Ksqz4Vec51MmgMth/ia0MGFEkIZmVGeTL5HtjYR4Wl/ZxBxBXZJTzQ==}
     dependencies:
-      '@vitest/spy': 0.32.0
-      '@vitest/utils': 0.32.0
+      '@vitest/spy': 0.33.0
+      '@vitest/utils': 0.33.0
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner@0.32.0:
-    resolution: {integrity: sha512-QpCmRxftHkr72xt5A08xTEs9I4iWEXIOCHWhQQguWOKE4QH7DXSKZSOFibuwEIMAD7G0ERvtUyQn7iPWIqSwmw==}
+  /@vitest/runner@0.33.0:
+    resolution: {integrity: sha512-UPfACnmCB6HKRHTlcgCoBh6ppl6fDn+J/xR8dTufWiKt/74Y9bHci5CKB8tESSV82zKYtkBJo9whU3mNvfaisg==}
     dependencies:
-      '@vitest/utils': 0.32.0
-      concordance: 5.0.4
+      '@vitest/utils': 0.33.0
       p-limit: 4.0.0
-      pathe: 1.1.0
+      pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@0.32.0:
-    resolution: {integrity: sha512-yCKorPWjEnzpUxQpGlxulujTcSPgkblwGzAUEL+z01FTUg/YuCDZ8dxr9sHA08oO2EwxzHXNLjQKWJ2zc2a19Q==}
+  /@vitest/snapshot@0.33.0:
+    resolution: {integrity: sha512-tJjrl//qAHbyHajpFvr8Wsk8DIOODEebTu7pgBrP07iOepR5jYkLFiqLq2Ltxv+r0uptUb4izv1J8XBOwKkVYA==}
     dependencies:
-      magic-string: 0.30.0
-      pathe: 1.1.0
-      pretty-format: 27.5.1
+      magic-string: 0.30.1
+      pathe: 1.1.1
+      pretty-format: 29.6.1
     dev: true
 
-  /@vitest/spy@0.32.0:
-    resolution: {integrity: sha512-MruAPlM0uyiq3d53BkwTeShXY0rYEfhNGQzVO5GHBmmX3clsxcWp79mMnkOVcV244sNTeDcHbcPFWIjOI4tZvw==}
+  /@vitest/spy@0.33.0:
+    resolution: {integrity: sha512-Kv+yZ4hnH1WdiAkPUQTpRxW8kGtH8VRTnus7ZTGovFYM1ZezJpvGtb9nPIjPnptHbsyIAxYZsEpVPYgtpjGnrg==}
     dependencies:
-      tinyspy: 2.1.0
+      tinyspy: 2.1.1
     dev: true
 
   /@vitest/ui@0.30.1:
@@ -9081,12 +9084,12 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@vitest/utils@0.32.0:
-    resolution: {integrity: sha512-53yXunzx47MmbuvcOPpLaVljHaeSu1G2dHdmy7+9ngMnQIkBQcvwOcoclWFnxDMxFbnq8exAfh3aKSZaK71J5A==}
+  /@vitest/utils@0.33.0:
+    resolution: {integrity: sha512-pF1w22ic965sv+EN6uoePkAOTkAPWM03Ri/jXNyMIKBb/XHLDPfhLvf/Fa9g0YECevAIz56oVYXhodLvLQ/awA==}
     dependencies:
-      concordance: 5.0.4
+      diff-sequences: 29.4.3
       loupe: 2.3.6
-      pretty-format: 27.5.1
+      pretty-format: 29.6.1
     dev: true
 
   /@wallet-standard/app@1.0.1:
@@ -9328,12 +9331,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.8.2):
+  /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.9.0):
@@ -9355,6 +9358,12 @@ packages:
 
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -11696,6 +11705,11 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: true
 
+  /diff-sequences@29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -12553,7 +12567,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin@4.0.1(eslint@8.43.0)(webpack@5.79.0):
+  /eslint-webpack-plugin@4.0.1(webpack@5.79.0):
     resolution: {integrity: sha512-fUFcXpui/FftGx3NzvWgLZXlLbu+m74sUxGEgxgoxYcUtkIQbS6SdNNZkS99m5ycb23TfoNYrDpp1k/CK5j6Hw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -12561,7 +12575,6 @@ packages:
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.37.0
-      eslint: 8.43.0
       jest-worker: 29.5.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -12670,8 +12683,8 @@ packages:
     resolution: {integrity: sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -12679,8 +12692,8 @@ packages:
     resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -13582,7 +13595,7 @@ packages:
       https-proxy-agent: 5.0.1
       mri: 1.2.0
       node-fetch-native: 1.1.0
-      pathe: 1.1.0
+      pathe: 1.1.1
       tar: 6.1.13
     transitivePeerDependencies:
       - supports-color
@@ -15696,8 +15709,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+  /magic-string@0.30.1:
+    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -16606,13 +16619,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /mlly@1.2.0:
-    resolution: {integrity: sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==}
+  /mlly@1.4.0:
+    resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
     dependencies:
-      acorn: 8.8.2
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      ufo: 1.1.1
+      acorn: 8.10.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      ufo: 1.1.2
     dev: true
 
   /moment@2.29.4:
@@ -17619,6 +17632,10 @@ packages:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
+
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -17729,12 +17746,12 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /pkg-types@1.0.2:
-    resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.2.0
-      pathe: 1.1.0
+      mlly: 1.4.0
+      pathe: 1.1.1
     dev: true
 
   /pkg-up@3.1.0:
@@ -18042,6 +18059,23 @@ packages:
       postcss: 8.4.24
       ts-node: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
       yaml: 2.2.2
+
+  /postcss-load-config@3.1.4(ts-node@10.9.1):
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      ts-node: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
+      yaml: 2.2.2
+    dev: true
 
   /postcss-loader@7.2.4(@types/node@18.15.11)(postcss@8.4.24)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.79.0):
     resolution: {integrity: sha512-F88rpxxNspo5hatIc+orYwZDtHFaVFOSIVAx+fBfJC1GmhWbVmPWtmg2gXKE1OxJbneOSGn8PWdIwsZFcruS+w==}
@@ -18446,6 +18480,15 @@ packages:
     dependencies:
       '@jest/schemas': 28.1.3
       ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
+  /pretty-format@29.6.1:
+    resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -20128,8 +20171,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /std-env@3.3.2:
-    resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
+  /std-env@3.3.3:
+    resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
     dev: true
 
   /stop-iteration-iterator@1.0.0:
@@ -20401,7 +20444,7 @@ packages:
   /strip-literal@1.0.1:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
     dev: true
 
   /style-loader@3.3.2(webpack@5.79.0):
@@ -20834,7 +20877,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@jridgewell/source-map': 0.3.3
-      acorn: 8.8.2
+      acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -20902,13 +20945,13 @@ packages:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
-  /tinypool@0.5.0:
-    resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
+  /tinypool@0.6.0:
+    resolution: {integrity: sha512-FdswUUo5SxRizcBc6b1GSuLpLjisa8N8qMyYoP3rl+bym+QauhtJP5bvZY1ytt8krKGmMLYIRl36HBZfeAoqhQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@2.1.0:
-    resolution: {integrity: sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==}
+  /tinyspy@2.1.1:
+    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -21137,6 +21180,42 @@ packages:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}
 
   /tsup@6.7.0(ts-node@10.9.1)(typescript@5.0.4):
+    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.1(esbuild@0.17.19)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4(supports-color@8.1.1)
+      esbuild: 0.17.19
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      resolve-from: 5.0.0
+      rollup: 3.23.1
+      source-map: 0.8.0-beta.0
+      sucrase: 3.29.0
+      tree-kill: 1.2.2
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsup@6.7.0(typescript@5.0.4):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -21396,8 +21475,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /ufo@1.1.1:
-    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
+  /ufo@1.1.2:
+    resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
     dev: true
 
   /uglify-js@3.17.4:
@@ -21592,7 +21671,7 @@ packages:
   /unplugin@0.10.2:
     resolution: {integrity: sha512-6rk7GUa4ICYjae5PrAllvcDeuT8pA9+j5J5EkxbMFaV+SalHhxZ7X2dohMzu6C3XzsMT+6jwR/+pwPNR3uK9MA==}
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.6
@@ -21866,15 +21945,15 @@ packages:
       vfile-message: 3.1.4
     dev: false
 
-  /vite-node@0.32.0(@types/node@18.15.11)(sass@1.62.0):
-    resolution: {integrity: sha512-220P/y8YacYAU+daOAqiGEFXx2A8AwjadDzQqos6wSukjvvTWNqleJSwoUn0ckyNdjHIKoxn93Nh1vWBqEKr3Q==}
+  /vite-node@0.33.0(@types/node@18.15.11)(sass@1.62.0):
+    resolution: {integrity: sha512-19FpHYbwWWxDr73ruNahC+vtEdza52kA90Qb3La98yZ0xULqV8A5JLNPUff0f5zID4984tW7l3DH2przTJUZSw==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
-      mlly: 1.2.0
-      pathe: 1.1.0
+      mlly: 1.4.0
+      pathe: 1.1.1
       picocolors: 1.0.0
       vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
     transitivePeerDependencies:
@@ -21960,8 +22039,8 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitest@0.32.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3):
-    resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
+  /vitest@0.33.0(@vitest/ui@0.30.1)(happy-dom@9.5.0)(playwright@1.32.3):
+    resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -21994,30 +22073,29 @@ packages:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 18.15.11
-      '@vitest/expect': 0.32.0
-      '@vitest/runner': 0.32.0
-      '@vitest/snapshot': 0.32.0
-      '@vitest/spy': 0.32.0
+      '@vitest/expect': 0.33.0
+      '@vitest/runner': 0.33.0
+      '@vitest/snapshot': 0.33.0
+      '@vitest/spy': 0.33.0
       '@vitest/ui': 0.30.1
-      '@vitest/utils': 0.32.0
-      acorn: 8.8.2
+      '@vitest/utils': 0.33.0
+      acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      concordance: 5.0.4
       debug: 4.3.4(supports-color@8.1.1)
       happy-dom: 9.5.0
       local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.0
+      magic-string: 0.30.1
+      pathe: 1.1.1
       picocolors: 1.0.0
       playwright: 1.32.3
-      std-env: 3.3.2
+      std-env: 3.3.3
       strip-literal: 1.0.1
       tinybench: 2.5.0
-      tinypool: 0.5.0
+      tinypool: 0.6.0
       vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
-      vite-node: 0.32.0(@types/node@18.15.11)(sass@1.62.0)
+      vite-node: 0.33.0(@types/node@18.15.11)(sass@1.62.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -22028,8 +22106,8 @@ packages:
       - terser
     dev: true
 
-  /vitest@0.32.0(happy-dom@9.5.0)(playwright@1.32.3)(sass@1.62.0):
-    resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
+  /vitest@0.33.0(happy-dom@9.5.0)(playwright@1.32.3)(sass@1.62.0):
+    resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -22062,29 +22140,28 @@ packages:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 18.15.11
-      '@vitest/expect': 0.32.0
-      '@vitest/runner': 0.32.0
-      '@vitest/snapshot': 0.32.0
-      '@vitest/spy': 0.32.0
-      '@vitest/utils': 0.32.0
-      acorn: 8.8.2
+      '@vitest/expect': 0.33.0
+      '@vitest/runner': 0.33.0
+      '@vitest/snapshot': 0.33.0
+      '@vitest/spy': 0.33.0
+      '@vitest/utils': 0.33.0
+      acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      concordance: 5.0.4
       debug: 4.3.4(supports-color@8.1.1)
       happy-dom: 9.5.0
       local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.0
+      magic-string: 0.30.1
+      pathe: 1.1.1
       picocolors: 1.0.0
       playwright: 1.32.3
-      std-env: 3.3.2
+      std-env: 3.3.3
       strip-literal: 1.0.1
       tinybench: 2.5.0
-      tinypool: 0.5.0
+      tinypool: 0.6.0
       vite: 4.2.3(@types/node@18.15.11)(sass@1.62.0)
-      vite-node: 0.32.0(@types/node@18.15.11)(sass@1.62.0)
+      vite-node: 0.33.0(@types/node@18.15.11)(sass@1.62.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/sdk/bcs/package.json
+++ b/sdk/bcs/package.json
@@ -67,7 +67,7 @@
 		"size-limit": "^8.2.4",
 		"tsup": "^6.7.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.32.0"
+		"vitest": "^0.33.0"
 	},
 	"dependencies": {
 		"bs58": "^5.0.0"

--- a/sdk/ledgerjs-hw-app-sui/package.json
+++ b/sdk/ledgerjs-hw-app-sui/package.json
@@ -67,6 +67,6 @@
 		"size-limit": "^8.2.4",
 		"tsup": "^6.7.0",
 		"typescript": "^5.0.4",
-		"vitest": "^0.32.0"
+		"vitest": "^0.33.0"
 	}
 }

--- a/sdk/suins-toolkit/package.json
+++ b/sdk/suins-toolkit/package.json
@@ -43,7 +43,7 @@
         "ts-node": "^10.9.1",
         "tsup": "^6.7.0",
         "typescript": "^5.0.4",
-        "vitest": "^0.32.0"
+        "vitest": "^0.33.0"
     },
     "dependencies": {
         "@mysten/sui.js": "workspace:*"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -126,7 +126,7 @@
 		"typedoc": "^0.24.1",
 		"typescript": "^5.0.4",
 		"vite": "^4.2.3",
-		"vitest": "^0.32.0",
+		"vitest": "^0.33.0",
 		"wait-on": "^7.0.1"
 	},
 	"dependencies": {

--- a/sdk/typescript/src/cryptography/index.ts
+++ b/sdk/typescript/src/cryptography/index.ts
@@ -6,4 +6,4 @@ export * from './mnemonics.js';
 export * from './intent.js';
 
 export { PublicKey } from './publickey.js';
-export { BaseSigner as Signer, Keypair, ExportedKeypair } from './keypair.js';
+export { BaseSigner as Signer, Keypair, type ExportedKeypair } from './keypair.js';

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { PublicKey } from './publickey.js';
+import type { SerializedSignature } from './signature.js';
+import { toSerializedSignature } from './signature.js';
 import type { SignatureScheme } from './signature.js';
 import { IntentScope, messageWithIntent } from './intent.js';
+import { blake2b } from '@noble/hashes/blake2b';
 
 export const PRIVATE_KEY_SIZE = 32;
 export const LEGACY_PRIVATE_KEY_SIZE = 64;
@@ -15,7 +18,7 @@ export type ExportedKeypair = {
 
 interface SignedMessage {
 	bytes: Uint8Array;
-	signature: Uint8Array;
+	signature: SerializedSignature;
 }
 
 /**
@@ -26,11 +29,17 @@ export abstract class BaseSigner {
 
 	async signWithIntent(bytes: Uint8Array, intent: IntentScope): Promise<SignedMessage> {
 		const intentMessage = messageWithIntent(intent, bytes);
-		const signature = await this.sign(intentMessage);
+		const digest = blake2b(intentMessage, { dkLen: 32 });
+
+		const signature = toSerializedSignature({
+			signature: await this.sign(digest),
+			signatureScheme: this.getKeyScheme(),
+			pubKey: this.getPublicKey(),
+		});
 
 		return {
-			bytes: intentMessage,
 			signature,
+			bytes,
 		};
 	}
 
@@ -42,25 +51,30 @@ export abstract class BaseSigner {
 		return this.signWithIntent(bytes, IntentScope.PersonalMessage);
 	}
 
+	toSuiAddress(): string {
+		return this.getPublicKey().toSuiAddress();
+	}
+
 	/**
 	 * Return the signature for the data.
 	 * Prefer the async verion {@link sign}, as this method will be deprecated in a future release.
 	 */
 	abstract signData(data: Uint8Array): Uint8Array;
+
+	/**
+	 * Get the key scheme of the keypair: Secp256k1 or ED25519
+	 */
+	abstract getKeyScheme(): SignatureScheme;
+
+	/**
+	 * The public key for this keypair
+	 */
+	abstract getPublicKey(): PublicKey;
 }
 
 /**
  * TODO: Document
  */
 export abstract class Keypair extends BaseSigner {
-	/**
-	 * The public key for this keypair
-	 */
-	abstract getPublicKey(): PublicKey;
-
-	/**
-	 * Get the key scheme of the keypair: Secp256k1 or ED25519
-	 */
-	abstract getKeyScheme(): SignatureScheme;
 	abstract export(): ExportedKeypair;
 }

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { toB64 } from '@mysten/bcs';
 import type { PublicKey } from './publickey.js';
 
 export type SignatureScheme = 'ED25519' | 'Secp256k1' | 'Secp256r1' | 'MultiSig';
@@ -37,3 +38,16 @@ export const SIGNATURE_FLAG_TO_SCHEME = {
 } as const;
 
 export type SignatureFlag = keyof typeof SIGNATURE_FLAG_TO_SCHEME;
+
+export function toSerializedSignature({
+	signature,
+	signatureScheme,
+	pubKey,
+}: SignaturePubkeyPair): SerializedSignature {
+	const pubKeyBytes = pubKey.toBytes();
+	const serializedSignature = new Uint8Array(1 + signature.length + pubKeyBytes.length);
+	serializedSignature.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
+	serializedSignature.set(signature, 1);
+	serializedSignature.set(pubKeyBytes, 1 + signature.length);
+	return toB64(serializedSignature);
+}

--- a/sdk/typescript/src/cryptography/utils.ts
+++ b/sdk/typescript/src/cryptography/utils.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-disable import/no-cycle */
 
-import { fromB64, toB64 } from '@mysten/bcs';
+import { fromB64 } from '@mysten/bcs';
 import type { SerializedSignature, SignaturePubkeyPair, SignatureScheme } from './signature.js';
-import { SIGNATURE_FLAG_TO_SCHEME, SIGNATURE_SCHEME_TO_FLAG } from './signature.js';
+import { SIGNATURE_FLAG_TO_SCHEME } from './signature.js';
 import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
 import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
 import { Ed25519PublicKey } from '../keypairs/ed25519/publickey.js';
@@ -14,18 +14,6 @@ import { Ed25519Keypair } from '../keypairs/ed25519/keypair.js';
 import { Secp256k1Keypair } from '../keypairs/secp256k1/keypair.js';
 import type { ExportedKeypair, Keypair } from './keypair.js';
 import { LEGACY_PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE } from './keypair.js';
-
-export function toSerializedSignature({
-	signature,
-	signatureScheme,
-	pubKey,
-}: SignaturePubkeyPair): SerializedSignature {
-	const serializedSignature = new Uint8Array(1 + signature.length + pubKey.toBytes().length);
-	serializedSignature.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
-	serializedSignature.set(signature, 1);
-	serializedSignature.set(pubKey.toBytes(), 1 + signature.length);
-	return toB64(serializedSignature);
-}
 
 /// Expects to parse a serialized signature by its signature scheme to a list of signature
 /// and public key pairs. The list is of length 1 if it is not multisig.

--- a/sdk/typescript/src/framework/sui-system-state.ts
+++ b/sdk/typescript/src/framework/sui-system-state.ts
@@ -6,6 +6,7 @@ import { TransactionBlock } from '../builder/index.js';
 import type { JsonRpcProvider } from '../providers/json-rpc-provider.js';
 import type { ObjectId, SuiAddress } from '../types/index.js';
 import { getObjectReference, SUI_SYSTEM_ADDRESS } from '../types/index.js';
+import type { SuiClient } from '../client/index.js';
 
 /**
  * Address of the Sui System object.
@@ -30,7 +31,7 @@ export class SuiSystemStateUtil {
 	 * @param gasBudget omittable only for DevInspect mode
 	 */
 	public static async newRequestAddStakeTxn(
-		provider: JsonRpcProvider,
+		client: JsonRpcProvider | SuiClient,
 		coins: ObjectId[],
 		amount: bigint,
 		validatorAddress: SuiAddress,
@@ -43,7 +44,7 @@ export class SuiSystemStateUtil {
 			target: `${SUI_SYSTEM_ADDRESS}::${SUI_SYSTEM_MODULE_NAME}::${ADD_STAKE_FUN_NAME}`,
 			arguments: [tx.object(SUI_SYSTEM_STATE_OBJECT_ID), coin, tx.pure(validatorAddress)],
 		});
-		const coinObjects = await provider.multiGetObjects({
+		const coinObjects = await client.multiGetObjects({
 			ids: coins,
 			options: {
 				showOwner: true,

--- a/sdk/typescript/src/signers/raw-signer.ts
+++ b/sdk/typescript/src/signers/raw-signer.ts
@@ -3,17 +3,18 @@
 
 import { blake2b } from '@noble/hashes/blake2b';
 import type { Keypair } from '../cryptography/keypair.js';
+import { toSerializedSignature } from '../cryptography/signature.js';
 import type { SerializedSignature } from '../cryptography/signature.js';
 import type { JsonRpcProvider } from '../providers/json-rpc-provider.js';
 import type { SuiAddress } from '../types/index.js';
 import { SignerWithProvider } from './signer-with-provider.js';
-import { toSerializedSignature } from '../cryptography/utils.js';
+import type { SuiClient } from '../client/index.js';
 
 export class RawSigner extends SignerWithProvider {
 	private readonly keypair: Keypair;
 
-	constructor(keypair: Keypair, provider: JsonRpcProvider) {
-		super(provider);
+	constructor(keypair: Keypair, client: JsonRpcProvider | SuiClient) {
+		super(client);
 		this.keypair = keypair;
 	}
 
@@ -34,7 +35,7 @@ export class RawSigner extends SignerWithProvider {
 		});
 	}
 
-	connect(provider: JsonRpcProvider): SignerWithProvider {
-		return new RawSigner(this.keypair, provider);
+	connect(client: SuiClient | JsonRpcProvider): SignerWithProvider {
+		return new RawSigner(this.keypair, client);
 	}
 }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -19,11 +19,19 @@ import { getTotalGasUsedUpperBound } from '../types/index.js';
 import { IntentScope, messageWithIntent } from '../cryptography/intent.js';
 import type { Signer } from './signer.js';
 import type { SignedTransaction, SignedMessage } from './types.js';
+import type { SuiClient } from '../client/index.js';
 
 ///////////////////////////////
 // Exported Abstracts
 export abstract class SignerWithProvider implements Signer {
-	readonly provider: JsonRpcProvider;
+	/**
+	 * @deprecated Use `client` instead.
+	 */
+	get provider(): JsonRpcProvider | SuiClient {
+		return this.client;
+	}
+
+	readonly client: JsonRpcProvider | SuiClient;
 
 	///////////////////
 	// Sub-classes MUST implement these
@@ -38,7 +46,7 @@ export abstract class SignerWithProvider implements Signer {
 
 	// Returns a new instance of the Signer, connected to provider.
 	// This MAY throw if changing providers is not supported.
-	abstract connect(provider: JsonRpcProvider): SignerWithProvider;
+	abstract connect(client: SuiClient | JsonRpcProvider): SignerWithProvider;
 
 	///////////////////
 	// Sub-classes MAY override these
@@ -50,11 +58,15 @@ export abstract class SignerWithProvider implements Signer {
 	 * @deprecated Use `@mysten/sui.js/faucet` instead.
 	 */
 	async requestSuiFromFaucet(httpHeaders?: HttpHeaders) {
-		return this.provider.requestSuiFromFaucet(await this.getAddress(), httpHeaders);
+		if (!('requestSuiFromFaucet' in this.client)) {
+			throw new Error('To request SUI from faucet, please use @mysten/sui.js/faucet instead');
+		}
+
+		return this.client.requestSuiFromFaucet(await this.getAddress(), httpHeaders);
 	}
 
-	constructor(provider: JsonRpcProvider) {
-		this.provider = provider;
+	constructor(client: JsonRpcProvider | SuiClient) {
+		this.client = client;
 	}
 
 	/**
@@ -77,7 +89,7 @@ export abstract class SignerWithProvider implements Signer {
 			// NOTE: This allows for signing transactions with mis-matched senders, which is important for sponsored transactions.
 			transactionBlock.setSenderIfNotSet(await this.getAddress());
 			return await transactionBlock.build({
-				provider: this.provider,
+				client: this.client,
 			});
 		}
 		if (transactionBlock instanceof Uint8Array) {
@@ -124,7 +136,7 @@ export abstract class SignerWithProvider implements Signer {
 			transactionBlock: input.transactionBlock,
 		});
 
-		return await this.provider.executeTransactionBlock({
+		return await this.client.executeTransactionBlock({
 			transactionBlock: transactionBlockBytes,
 			signature,
 			options: input.options,
@@ -173,7 +185,7 @@ export abstract class SignerWithProvider implements Signer {
 		if (TransactionBlock.is(input.transactionBlock)) {
 			input.transactionBlock.setSenderIfNotSet(await this.getAddress());
 			dryRunTxBytes = await input.transactionBlock.build({
-				provider: this.provider,
+				client: this.client,
 			});
 		} else if (typeof input.transactionBlock === 'string') {
 			dryRunTxBytes = fromB64(input.transactionBlock);
@@ -183,7 +195,7 @@ export abstract class SignerWithProvider implements Signer {
 			throw new Error('Unknown transaction format');
 		}
 
-		return this.provider.dryRunTransactionBlock({
+		return this.client.dryRunTransactionBlock({
 			transactionBlock: dryRunTxBytes,
 		});
 	}

--- a/sdk/typescript/test/e2e/checkpoint.test.ts
+++ b/sdk/typescript/test/e2e/checkpoint.test.ts
@@ -12,12 +12,12 @@ describe('Checkpoints Reading API', () => {
 	});
 
 	it('Get latest checkpoint sequence number', async () => {
-		const checkpointSequenceNumber = await toolbox.provider.getLatestCheckpointSequenceNumber();
+		const checkpointSequenceNumber = await toolbox.client.getLatestCheckpointSequenceNumber();
 		expect(BigInt(checkpointSequenceNumber)).toBeGreaterThan(0);
 	});
 
 	it('gets checkpoint by id', async () => {
-		const resp = await toolbox.provider.getCheckpoint({ id: '0' });
+		const resp = await toolbox.client.getCheckpoint({ id: '0' });
 		expect(resp.digest.length).greaterThan(0);
 		expect(resp.transactions.length).greaterThan(0);
 		expect(resp.epoch).not.toBeNull();
@@ -28,14 +28,14 @@ describe('Checkpoints Reading API', () => {
 	});
 
 	it('get checkpoint contents by digest', async () => {
-		const checkpoint_resp = await toolbox.provider.getCheckpoint({ id: '0' });
+		const checkpoint_resp = await toolbox.client.getCheckpoint({ id: '0' });
 		const digest = checkpoint_resp.digest;
-		const resp = await toolbox.provider.getCheckpoint({ id: digest });
+		const resp = await toolbox.client.getCheckpoint({ id: digest });
 		expect(checkpoint_resp).toEqual(resp);
 	});
 
 	it('getCheckpoints', async () => {
-		const checkpoints = await toolbox.provider.getCheckpoints({
+		const checkpoints = await toolbox.client.getCheckpoints({
 			descendingOrder: false,
 			limit: 1,
 		});
@@ -44,7 +44,7 @@ describe('Checkpoints Reading API', () => {
 		expect(checkpoints.data.length).toEqual(1);
 		expect(checkpoints.hasNextPage).toBeTruthy();
 
-		const checkpoints1 = await toolbox.provider.getCheckpoints({
+		const checkpoints1 = await toolbox.client.getCheckpoints({
 			cursor: checkpoints.nextCursor!,
 			limit: 1,
 			descendingOrder: false,

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -16,7 +16,7 @@ describe('Test Coin Metadata', () => {
 	});
 
 	it('Test accessing coin metadata', async () => {
-		const coinMetadata = (await toolbox.signer.provider.getCoinMetadata({
+		const coinMetadata = (await toolbox.client.getCoinMetadata({
 			coinType: `${packageId}::test::TEST`,
 		}))!;
 		expect(coinMetadata.decimals).to.equal(2);

--- a/sdk/typescript/test/e2e/coin-read.test.ts
+++ b/sdk/typescript/test/e2e/coin-read.test.ts
@@ -19,31 +19,31 @@ describe('CoinRead API', () => {
 	});
 
 	it('Get coins with/without type', async () => {
-		const suiCoins = await toolbox.provider.getCoins({
+		const suiCoins = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 		});
 		expect(suiCoins.data.length).toEqual(5);
 
-		const testCoins = await toolbox.provider.getCoins({
+		const testCoins = await toolbox.client.getCoins({
 			owner: publishToolbox.address(),
 			coinType: testType,
 		});
 		expect(testCoins.data.length).toEqual(2);
 
-		const allCoins = await toolbox.provider.getAllCoins({
+		const allCoins = await toolbox.client.getAllCoins({
 			owner: toolbox.address(),
 		});
 		expect(allCoins.data.length).toEqual(5);
 		expect(allCoins.hasNextPage).toEqual(false);
 
-		const publisherAllCoins = await toolbox.provider.getAllCoins({
+		const publisherAllCoins = await toolbox.client.getAllCoins({
 			owner: publishToolbox.address(),
 		});
 		expect(publisherAllCoins.data.length).toEqual(3);
 		expect(publisherAllCoins.hasNextPage).toEqual(false);
 
 		//test paging with limit
-		const someSuiCoins = await toolbox.provider.getCoins({
+		const someSuiCoins = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 			limit: 3,
 		});
@@ -52,14 +52,14 @@ describe('CoinRead API', () => {
 	});
 
 	it('Get balance with/without type', async () => {
-		const suiBalance = await toolbox.provider.getBalance({
+		const suiBalance = await toolbox.client.getBalance({
 			owner: toolbox.address(),
 		});
 		expect(suiBalance.coinType).toEqual('0x2::sui::SUI');
 		expect(suiBalance.coinObjectCount).toEqual(5);
 		expect(Number(suiBalance.totalBalance)).toBeGreaterThan(0);
 
-		const testBalance = await toolbox.provider.getBalance({
+		const testBalance = await toolbox.client.getBalance({
 			owner: publishToolbox.address(),
 			coinType: testType,
 		});
@@ -67,14 +67,14 @@ describe('CoinRead API', () => {
 		expect(testBalance.coinObjectCount).toEqual(2);
 		expect(Number(testBalance.totalBalance)).toEqual(11);
 
-		const allBalances = await toolbox.provider.getAllBalances({
+		const allBalances = await toolbox.client.getAllBalances({
 			owner: publishToolbox.address(),
 		});
 		expect(allBalances.length).toEqual(2);
 	});
 
 	it('Get total supply', async () => {
-		const testSupply = await toolbox.provider.getTotalSupply({
+		const testSupply = await toolbox.client.getTotalSupply({
 			coinType: testType,
 		});
 		expect(Number(testSupply.value)).toEqual(11);

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -15,7 +15,7 @@ describe('Dynamic Fields Reading API', () => {
 		const packagePath = __dirname + '/./data/dynamic_fields';
 		({ packageId } = await publishPackage(packagePath, toolbox));
 
-		await toolbox.provider
+		await toolbox.client
 			.getOwnedObjects({
 				owner: toolbox.address(),
 				options: { showType: true },
@@ -28,13 +28,13 @@ describe('Dynamic Fields Reading API', () => {
 	});
 
 	it('get all dynamic fields', async () => {
-		const dynamicFields = await toolbox.provider.getDynamicFields({
+		const dynamicFields = await toolbox.client.getDynamicFields({
 			parentId: parentObjectId,
 		});
 		expect(dynamicFields.data.length).toEqual(2);
 	});
 	it('limit response in page', async () => {
-		const dynamicFields = await toolbox.provider.getDynamicFields({
+		const dynamicFields = await toolbox.client.getDynamicFields({
 			parentId: parentObjectId,
 			limit: 1,
 		});
@@ -42,12 +42,12 @@ describe('Dynamic Fields Reading API', () => {
 		expect(dynamicFields.nextCursor).not.toEqual(null);
 	});
 	it('go to next cursor', async () => {
-		return await toolbox.provider
+		return await toolbox.client
 			.getDynamicFields({ parentId: parentObjectId, limit: 1 })
 			.then(async function (dynamicFields) {
 				expect(dynamicFields.nextCursor).not.toEqual(null);
 
-				const dynamicFieldsCursor = await toolbox.provider.getDynamicFields({
+				const dynamicFieldsCursor = await toolbox.client.getDynamicFields({
 					parentId: parentObjectId,
 					cursor: dynamicFields.nextCursor,
 				});
@@ -55,13 +55,13 @@ describe('Dynamic Fields Reading API', () => {
 			});
 	});
 	it('get dynamic object field', async () => {
-		const dynamicFields = await toolbox.provider.getDynamicFields({
+		const dynamicFields = await toolbox.client.getDynamicFields({
 			parentId: parentObjectId,
 		});
 		for (const data of dynamicFields.data) {
 			const objName = data.name;
 
-			const object = await toolbox.provider.getDynamicFieldObject({
+			const object = await toolbox.client.getDynamicFieldObject({
 				parentId: parentObjectId,
 				name: objName,
 			});

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -15,8 +15,9 @@ describe('Test Move call with strings', () => {
 			target: `${packageId}::entry_point_types::${funcName}`,
 			arguments: [tx.pure(str), tx.pure(len)],
 		});
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
 			transactionBlock: tx,
+			signer: toolbox.keypair,
 			options: {
 				showEffects: true,
 			},

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -2,31 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { RawSigner, getExecutionStatusType, SuiSystemStateUtil, SUI_TYPE_ARG } from '../../src';
+import { getExecutionStatusType, SuiSystemStateUtil, SUI_TYPE_ARG } from '../../src';
 import { setup, TestToolbox } from './utils/setup';
+import { Keypair } from '../../src/cryptography';
+import { SuiClient } from '../../src/client';
 
 const DEFAULT_STAKE_AMOUNT = 1000000000;
 
 describe('Governance API', () => {
 	let toolbox: TestToolbox;
-	let signer: RawSigner;
 
 	beforeAll(async () => {
 		toolbox = await setup();
-		signer = new RawSigner(toolbox.keypair, toolbox.provider);
 	});
 
 	it('test requestAddStake', async () => {
-		const result = await addStake(signer);
+		const result = await addStake(toolbox.client, toolbox.keypair);
 		expect(getExecutionStatusType(result)).toEqual('success');
 	});
 
 	it('test getDelegatedStakes', async () => {
-		await addStake(signer);
-		const stakes = await toolbox.provider.getStakes({
+		await addStake(toolbox.client, toolbox.keypair);
+		const stakes = await toolbox.client.getStakes({
 			owner: toolbox.address(),
 		});
-		const stakesById = await toolbox.provider.getStakesByIds({
+		const stakesById = await toolbox.client.getStakesByIds({
 			stakedSuiIds: [stakes[0].stakes[0].stakedSuiId],
 		});
 		expect(stakes.length).greaterThan(0);
@@ -38,34 +38,35 @@ describe('Governance API', () => {
 	});
 
 	it('test getCommitteeInfo', async () => {
-		const committeeInfo = await toolbox.provider.getCommitteeInfo({
+		const committeeInfo = await toolbox.client.getCommitteeInfo({
 			epoch: '0',
 		});
 		expect(committeeInfo.validators?.length).greaterThan(0);
 	});
 
 	it('test getLatestSuiSystemState', async () => {
-		await toolbox.provider.getLatestSuiSystemState();
+		await toolbox.client.getLatestSuiSystemState();
 	});
 });
 
-async function addStake(signer: RawSigner) {
-	const coins = await signer.provider.getCoins({
-		owner: await signer.getAddress(),
+async function addStake(client: SuiClient, signer: Keypair) {
+	const coins = await client.getCoins({
+		owner: await signer.getPublicKey().toSuiAddress(),
 		coinType: SUI_TYPE_ARG,
 	});
 
-	const system = await signer.provider.getLatestSuiSystemState();
+	const system = await client.getLatestSuiSystemState();
 	const validators = system.activeValidators;
 
 	const tx = await SuiSystemStateUtil.newRequestAddStakeTxn(
-		signer.provider,
+		client,
 		[coins.data[0].coinObjectId],
 		BigInt(DEFAULT_STAKE_AMOUNT),
 		validators[0].suiAddress,
 	);
 
-	return await signer.signAndExecuteTransactionBlock({
+	return await client.signAndExecuteTransactionBlock({
+		signer,
 		transactionBlock: tx,
 		options: {
 			showEffects: true,

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -21,7 +21,8 @@ describe('Test ID as args to entry functions', () => {
 			target: `${packageId}::test::test_id`,
 			arguments: [tx.pure('0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee')],
 		});
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 			options: {
 				showEffects: true,
@@ -36,7 +37,8 @@ describe('Test ID as args to entry functions', () => {
 			target: `${packageId}::test::test_id_non_mut`,
 			arguments: [tx.pure('0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee')],
 		});
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 			options: {
 				showEffects: true,

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -14,38 +14,38 @@ describe('Object id/Address/Transaction digest validation', () => {
 	//Test that with invalid object id/address/digest, functions will throw an error before making a request to the rpc server
 	it('Test all functions with invalid Sui Address', async () => {
 		//empty id
-		expect(toolbox.provider.getOwnedObjects({ owner: '' })).rejects.toThrowError(
+		expect(toolbox.client.getOwnedObjects({ owner: '' })).rejects.toThrowError(
 			/Invalid Sui address/,
 		);
 	});
 
 	it('Test all functions with invalid Object Id', async () => {
 		//empty id
-		expect(toolbox.provider.getObject({ id: '' })).rejects.toThrowError(/Invalid Sui Object id/);
+		expect(toolbox.client.getObject({ id: '' })).rejects.toThrowError(/Invalid Sui Object id/);
 
 		//more than 20bytes
 		expect(
-			toolbox.provider.getDynamicFields({
+			toolbox.client.getDynamicFields({
 				parentId: '0x0000000000000000000000004ce52ee7b659b610d59a1ced129291b3d0d4216322',
 			}),
 		).rejects.toThrowError(/Invalid Sui Object id/);
 
 		//wrong batch request
 		let objectIds = ['0xBABE', '0xCAFE', '0xWRONG', '0xFACE'];
-		expect(toolbox.provider.multiGetObjects({ ids: objectIds })).rejects.toThrowError(
+		expect(toolbox.client.multiGetObjects({ ids: objectIds })).rejects.toThrowError(
 			/Invalid Sui Object id 0xWRONG/,
 		);
 	});
 
 	it('Test all functions with invalid Transaction Digest', async () => {
 		//empty digest
-		expect(toolbox.provider.getTransactionBlock({ digest: '' })).rejects.toThrowError(
+		expect(toolbox.client.getTransactionBlock({ digest: '' })).rejects.toThrowError(
 			/Invalid Transaction digest/,
 		);
 
 		//wrong batch request
 		let digests = ['AQ7FA8JTGs368CvMkXj2iFz2WUWwzP6AAWgsLpPLxUmr', 'wrong'];
-		expect(toolbox.provider.multiGetTransactionBlocks({ digests })).rejects.toThrowError(
+		expect(toolbox.client.multiGetTransactionBlocks({ digests })).rejects.toThrowError(
 			/Invalid Transaction digest wrong/,
 		);
 	});

--- a/sdk/typescript/test/e2e/normalized-modules.test.ts
+++ b/sdk/typescript/test/e2e/normalized-modules.test.ts
@@ -18,7 +18,7 @@ describe('Normalized modules API', () => {
 	});
 
 	it('Get Move function arg types', async () => {
-		const argTypes = await toolbox.provider.getMoveFunctionArgTypes({
+		const argTypes = await toolbox.client.getMoveFunctionArgTypes({
 			package: DEFAULT_PACKAGE,
 			module: DEFAULT_MODULE,
 			function: DEFAULT_FUNCTION,
@@ -31,14 +31,14 @@ describe('Normalized modules API', () => {
 	});
 
 	it('Get Normalized Modules by packages', async () => {
-		const modules = await toolbox.provider.getNormalizedMoveModulesByPackage({
+		const modules = await toolbox.client.getNormalizedMoveModulesByPackage({
 			package: DEFAULT_PACKAGE,
 		});
 		expect(Object.keys(modules)).contains(DEFAULT_MODULE);
 	});
 
 	it('Get Normalized Move Module', async () => {
-		const normalized = await toolbox.provider.getNormalizedMoveModule({
+		const normalized = await toolbox.client.getNormalizedMoveModule({
 			package: DEFAULT_PACKAGE,
 			module: DEFAULT_MODULE,
 		});
@@ -46,7 +46,7 @@ describe('Normalized modules API', () => {
 	});
 
 	it('Get Normalized Move Function', async () => {
-		const normalized = await toolbox.provider.getNormalizedMoveFunction({
+		const normalized = await toolbox.client.getNormalizedMoveFunction({
 			package: DEFAULT_PACKAGE,
 			module: DEFAULT_MODULE,
 			function: DEFAULT_FUNCTION,
@@ -55,7 +55,7 @@ describe('Normalized modules API', () => {
 	});
 
 	it('Get Normalized Move Struct ', async () => {
-		const struct = await toolbox.provider.getNormalizedMoveStruct({
+		const struct = await toolbox.client.getNormalizedMoveStruct({
 			package: DEFAULT_PACKAGE,
 			module: DEFAULT_MODULE,
 			struct: DEFAULT_STRUCT,

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -17,7 +17,7 @@ describe('Test Object Display Standard', () => {
 
 	it('Test getting Display fields with error object', async () => {
 		const resp = (
-			await toolbox.provider.getOwnedObjects({
+			await toolbox.client.getOwnedObjects({
 				owner: toolbox.address(),
 				options: { showDisplay: true, showType: true },
 				filter: { StructType: `${packageId}::boars::Boar` },
@@ -26,7 +26,7 @@ describe('Test Object Display Standard', () => {
 		const data = resp[0].data as SuiObjectData;
 		const boarId = data.objectId;
 		const display = getObjectDisplay(
-			await toolbox.provider.getObject({
+			await toolbox.client.getObject({
 				id: boarId,
 				options: { showDisplay: true },
 			}),
@@ -58,7 +58,7 @@ describe('Test Object Display Standard', () => {
 		const coin = (await toolbox.getGasObjectsOwnedByAddress())[0].data as SuiObjectData;
 		const coinId = coin.objectId;
 		const display = getObjectDisplay(
-			await toolbox.provider.getObject({
+			await toolbox.client.getObject({
 				id: coinId,
 				options: { showDisplay: true },
 			}),

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -23,7 +23,8 @@ describe('Test Move call with a vector of objects as input', () => {
 			target: `${packageId}::entry_point_vector::mint`,
 			arguments: [tx.pure(String(val))],
 		});
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 			options: {
 				showEffects: true,
@@ -43,7 +44,8 @@ describe('Test Move call with a vector of objects as input', () => {
 			target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
 			arguments: [vec],
 		});
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 			options: {
 				showEffects: true,
@@ -88,7 +90,8 @@ describe('Test Move call with a vector of objects as input', () => {
 			arguments: [tx.object(coinIDs[0]), vec],
 		});
 		tx.setGasPayment([coin]);
-		const result = await toolbox.signer.signAndExecuteTransactionBlock({
+		const result = await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 			options: {
 				showEffects: true,

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -19,7 +19,7 @@ describe('Object Reading API', () => {
 	});
 
 	it('Get Owned Objects', async () => {
-		const gasObjects = await toolbox.provider.getOwnedObjects({
+		const gasObjects = await toolbox.client.getOwnedObjects({
 			owner: toolbox.address(),
 		});
 		expect(gasObjects.data.length).to.greaterThan(0);
@@ -31,7 +31,7 @@ describe('Object Reading API', () => {
 		const objectInfos = await Promise.all(
 			gasObjects.map((gasObject) => {
 				const details = gasObject.data as SuiObjectData;
-				return toolbox.provider.getObject({
+				return toolbox.client.getObject({
 					id: details.objectId,
 					options: { showType: true },
 				});
@@ -49,7 +49,7 @@ describe('Object Reading API', () => {
 			const details = gasObject.data as SuiObjectData;
 			return details.objectId;
 		});
-		const objectInfos = await toolbox.provider.multiGetObjects({
+		const objectInfos = await toolbox.client.multiGetObjects({
 			ids: gasObjectIds,
 			options: {
 				showType: true,
@@ -64,7 +64,7 @@ describe('Object Reading API', () => {
 	});
 
 	it('handles trying to get non-existent old objects', async () => {
-		const res = await toolbox.provider.tryGetPastObject({
+		const res = await toolbox.client.tryGetPastObject({
 			id: normalizeSuiAddress('0x9999'),
 			version: 0,
 		});
@@ -73,12 +73,12 @@ describe('Object Reading API', () => {
 	});
 
 	it('can read live versions', async () => {
-		const { data } = await toolbox.provider.getCoins({
+		const { data } = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 			coinType: SUI_TYPE_ARG,
 		});
 
-		const res = await toolbox.provider.tryGetPastObject({
+		const res = await toolbox.client.tryGetPastObject({
 			id: data[0].coinObjectId,
 			version: Number(data[0].version),
 		});
@@ -87,12 +87,12 @@ describe('Object Reading API', () => {
 	});
 
 	it('handles trying to get a newer version than the latest version', async () => {
-		const { data } = await toolbox.provider.getCoins({
+		const { data } = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 			coinType: SUI_TYPE_ARG,
 		});
 
-		const res = await toolbox.provider.tryGetPastObject({
+		const res = await toolbox.client.tryGetPastObject({
 			id: data[0].coinObjectId,
 			version: Number(data[0].version) + 1,
 		});
@@ -101,12 +101,12 @@ describe('Object Reading API', () => {
 	});
 
 	it('handles fetching versions that do not exist', async () => {
-		const { data } = await toolbox.provider.getCoins({
+		const { data } = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 			coinType: SUI_TYPE_ARG,
 		});
 
-		const res = await toolbox.provider.tryGetPastObject({
+		const res = await toolbox.client.tryGetPastObject({
 			id: data[0].coinObjectId,
 			// NOTE: This works because we know that this is a fresh coin that hasn't been modified:
 			version: Number(data[0].version) - 1,
@@ -116,7 +116,7 @@ describe('Object Reading API', () => {
 	});
 
 	it('can find old versions of objects', async () => {
-		const { data } = await toolbox.provider.getCoins({
+		const { data } = await toolbox.client.getCoins({
 			owner: toolbox.address(),
 			coinType: SUI_TYPE_ARG,
 		});
@@ -125,11 +125,12 @@ describe('Object Reading API', () => {
 		// Transfer the entire gas object:
 		tx.transferObjects([tx.gas], tx.pure(normalizeSuiAddress('0x2')));
 
-		await toolbox.signer.signAndExecuteTransactionBlock({
+		await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
 			transactionBlock: tx,
 		});
 
-		const res = await toolbox.provider.tryGetPastObject({
+		const res = await toolbox.client.tryGetPastObject({
 			id: data[0].coinObjectId,
 			// NOTE: This works because we know that this is a fresh coin that hasn't been modified:
 			version: Number(data[0].version),

--- a/sdk/typescript/test/e2e/protocol-config.test.ts
+++ b/sdk/typescript/test/e2e/protocol-config.test.ts
@@ -6,6 +6,6 @@ import { setup } from './utils/setup';
 
 it('can fetch protocol config', async () => {
 	const toolbox = await setup();
-	const config = await toolbox.provider.getProtocolConfig();
+	const config = await toolbox.client.getProtocolConfig();
 	expect(config).toBeTypeOf('object');
 });

--- a/sdk/typescript/test/e2e/read-events.test.ts
+++ b/sdk/typescript/test/e2e/read-events.test.ts
@@ -13,14 +13,14 @@ describe('Event Reading API', () => {
 
 	it('Get All Events', async () => {
 		// TODO: refactor so that we can provide None here to signify there's no filter
-		const allEvents = await toolbox.provider.queryEvents({
+		const allEvents = await toolbox.client.queryEvents({
 			query: { All: [] },
 		});
 		expect(allEvents.data.length).to.greaterThan(0);
 	});
 
 	it('Get all event paged', async () => {
-		const page1 = await toolbox.provider.queryEvents({
+		const page1 = await toolbox.client.queryEvents({
 			query: { All: [] },
 			limit: 2,
 		});
@@ -28,7 +28,7 @@ describe('Event Reading API', () => {
 	});
 
 	it('Get events by sender paginated', async () => {
-		const query1 = await toolbox.provider.queryEvents({
+		const query1 = await toolbox.client.queryEvents({
 			query: { Sender: toolbox.address() },
 			limit: 2,
 		});

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setup, TestToolbox } from './utils/setup';
+import { GasData } from '../../src';
 
 describe('Invoke any RPC endpoint', () => {
 	let toolbox: TestToolbox;
@@ -12,21 +13,23 @@ describe('Invoke any RPC endpoint', () => {
 	});
 
 	it('suix_getOwnedObjects', async () => {
-		const gasObjectsExpected = await toolbox.provider.getOwnedObjects({
+		const gasObjectsExpected = await toolbox.client.getOwnedObjects({
 			owner: toolbox.address(),
 		});
-		const gasObjects = await toolbox.provider.call('suix_getOwnedObjects', [toolbox.address()]);
+		const gasObjects = await toolbox.client.call<{ data: GasData }>('suix_getOwnedObjects', [
+			toolbox.address(),
+		]);
 		expect(gasObjects.data).toStrictEqual(gasObjectsExpected.data);
 	});
 
 	it('sui_getObjectOwnedByAddress Error', async () => {
-		expect(toolbox.provider.call('suix_getOwnedObjects', [])).rejects.toThrowError();
+		expect(toolbox.client.call('suix_getOwnedObjects', [])).rejects.toThrowError();
 	});
 
 	it('suix_getCommitteeInfo', async () => {
-		const committeeInfoExpected = await toolbox.provider.getCommitteeInfo();
+		const committeeInfoExpected = await toolbox.client.getCommitteeInfo();
 
-		const committeeInfo = await toolbox.provider.call('suix_getCommitteeInfo', []);
+		const committeeInfo = await toolbox.client.call('suix_getCommitteeInfo', []);
 
 		expect(committeeInfo).toStrictEqual(committeeInfoExpected);
 	});

--- a/sdk/typescript/test/e2e/subscribe.test.ts
+++ b/sdk/typescript/test/e2e/subscribe.test.ts
@@ -11,7 +11,7 @@ test('subscribeTransaction', async () => {
 	expect(
 		// eslint-disable-next-line no-async-promise-executor
 		new Promise(async (resolve) => {
-			await toolbox.provider.subscribeTransaction({
+			await toolbox.client.subscribeTransaction({
 				filter: { FromAddress: toolbox.address() },
 				onMessage() {
 					resolve(true);
@@ -21,7 +21,8 @@ test('subscribeTransaction', async () => {
 			const tx = new TransactionBlock();
 			const [coin] = tx.splitCoins(tx.gas, [tx.pure(1)]);
 			tx.transferObjects([coin], tx.pure(toolbox.address()));
-			await toolbox.signer.signAndExecuteTransactionBlock({
+			await toolbox.client.signAndExecuteTransactionBlock({
+				signer: toolbox.keypair,
 				transactionBlock: tx,
 			});
 		}),

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -36,7 +36,7 @@ describe('Transaction Serialization and deserialization', () => {
 	async function serializeAndDeserialize(tx: TransactionBlock, mutable: boolean[]) {
 		tx.setSender(await toolbox.address());
 		const transactionBlockBytes = await tx.build({
-			provider: toolbox.provider,
+			client: toolbox.client,
 		});
 		const deserializedTxnBuilder = TransactionBlockDataBuilder.fromBytes(transactionBlockBytes);
 		expect(

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -9,18 +9,17 @@ import {
 	Ed25519Keypair,
 	getPublishedObjectChanges,
 	getExecutionStatusType,
-	JsonRpcProvider,
 	localnetConnection,
-	Connection,
 	Coin,
 	TransactionBlock,
-	RawSigner,
 	SuiAddress,
 	ObjectId,
 	UpgradePolicy,
 } from '../../../src';
 import { retry } from 'ts-retry-promise';
-import { FaucetRateLimitError } from '../../../src/faucet';
+import { FaucetRateLimitError, requestSuiFromFaucetV0 } from '../../../src/faucet';
+import { SuiClient } from '../../../src/client';
+import { Keypair } from '../../../src/cryptography';
 
 const TEST_ENDPOINTS = localnetConnection;
 const DEFAULT_FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? TEST_ENDPOINTS.faucet;
@@ -36,13 +35,11 @@ export const DEFAULT_SEND_AMOUNT = 1000;
 
 export class TestToolbox {
 	keypair: Ed25519Keypair;
-	provider: JsonRpcProvider;
-	signer: RawSigner;
+	client: SuiClient;
 
-	constructor(keypair: Ed25519Keypair, provider: JsonRpcProvider) {
+	constructor(keypair: Ed25519Keypair, client: SuiClient) {
 		this.keypair = keypair;
-		this.provider = provider;
-		this.signer = new RawSigner(this.keypair, this.provider);
+		this.client = client;
 	}
 
 	address() {
@@ -51,7 +48,7 @@ export class TestToolbox {
 
 	// TODO(chris): replace this with provider.getCoins instead
 	async getGasObjectsOwnedByAddress() {
-		const objects = await this.provider.getOwnedObjects({
+		const objects = await this.client.getOwnedObjects({
 			owner: this.address(),
 			options: {
 				showType: true,
@@ -63,25 +60,21 @@ export class TestToolbox {
 	}
 
 	public async getActiveValidators() {
-		return (await this.provider.getLatestSuiSystemState()).activeValidators;
+		return (await this.client.getLatestSuiSystemState()).activeValidators;
 	}
 }
 
-export function getProvider(): JsonRpcProvider {
-	return new JsonRpcProvider(
-		new Connection({
-			fullnode: DEFAULT_FULLNODE_URL,
-			faucet: DEFAULT_FAUCET_URL,
-		}),
-		{},
-	);
+export function getClient(): SuiClient {
+	return new SuiClient({
+		url: DEFAULT_FULLNODE_URL,
+	});
 }
 
 export async function setup() {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
-	const provider = getProvider();
-	await retry(() => provider.requestSuiFromFaucet(address), {
+	const client = getClient();
+	await retry(() => requestSuiFromFaucetV0({ host: DEFAULT_FAUCET_URL, recipient: address }), {
 		backoff: 'EXPONENTIAL',
 		// overall timeout in 60 seconds
 		timeout: 1000 * 60,
@@ -89,7 +82,7 @@ export async function setup() {
 		retryIf: (error: any) => !(error instanceof FaucetRateLimitError),
 		logger: (msg) => console.warn('Retrying requesting from faucet: ' + msg),
 	});
-	return new TestToolbox(keypair, provider);
+	return new TestToolbox(keypair, client);
 }
 
 export async function publishPackage(packagePath: string, toolbox?: TestToolbox) {
@@ -116,10 +109,11 @@ export async function publishPackage(packagePath: string, toolbox?: TestToolbox)
 	});
 
 	// Transfer the upgrade capability to the sender so they can upgrade the package later if they want.
-	tx.transferObjects([cap], tx.pure(await toolbox.signer.getAddress()));
+	tx.transferObjects([cap], tx.pure(await toolbox.address()));
 
-	const publishTxn = await toolbox.signer.signAndExecuteTransactionBlock({
+	const publishTxn = await toolbox.client.signAndExecuteTransactionBlock({
 		transactionBlock: tx,
+		signer: toolbox.keypair,
 		options: {
 			showEffects: true,
 			showObjectChanges: true,
@@ -134,7 +128,7 @@ export async function publishPackage(packagePath: string, toolbox?: TestToolbox)
 
 	expect(packageId).toBeTypeOf('string');
 
-	console.info(`Published package ${packageId} from address ${await toolbox.signer.getAddress()}}`);
+	console.info(`Published package ${packageId} from address ${toolbox.address()}}`);
 
 	return { packageId, publishTxn };
 }
@@ -182,8 +176,9 @@ export async function upgradePackage(
 		arguments: [cap, receipt],
 	});
 
-	const result = await toolbox.signer.signAndExecuteTransactionBlock({
+	const result = await toolbox.client.signAndExecuteTransactionBlock({
 		transactionBlock: tx,
+		signer: toolbox.keypair,
 		options: {
 			showEffects: true,
 			showObjectChanges: true,
@@ -203,7 +198,8 @@ export function getRandomAddresses(n: number): SuiAddress[] {
 }
 
 export async function paySui(
-	signer: RawSigner,
+	client: SuiClient,
+	signer: Keypair,
 	numRecipients: number = 1,
 	recipients?: SuiAddress[],
 	amounts?: number[],
@@ -219,8 +215,8 @@ export async function paySui(
 	coinId =
 		coinId ??
 		(
-			await signer.provider.getCoins({
-				owner: await signer.getAddress(),
+			await client.getCoins({
+				owner: signer.getPublicKey().toSuiAddress(),
 				coinType: '0x2::sui::SUI',
 			})
 		).data[0].coinObjectId;
@@ -230,8 +226,9 @@ export async function paySui(
 		tx.transferObjects([coin], tx.pure(recipient));
 	});
 
-	const txn = await signer.signAndExecuteTransactionBlock({
+	const txn = await client.signAndExecuteTransactionBlock({
 		transactionBlock: tx,
+		signer,
 		options: {
 			showEffects: true,
 			showObjectChanges: true,
@@ -242,7 +239,8 @@ export async function paySui(
 }
 
 export async function executePaySuiNTimes(
-	signer: RawSigner,
+	client: SuiClient,
+	signer: Keypair,
 	nTimes: number,
 	numRecipientsPerTxn: number = 1,
 	recipients?: SuiAddress[],
@@ -251,7 +249,7 @@ export async function executePaySuiNTimes(
 	const txns = [];
 	for (let i = 0; i < nTimes; i++) {
 		// must await here to make sure the txns are executed in order
-		txns.push(await paySui(signer, numRecipientsPerTxn, recipients, amounts));
+		txns.push(await paySui(client, signer, numRecipientsPerTxn, recipients, amounts));
 	}
 	return txns;
 }


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
