### PR TITLE
move: source service supports multiple networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10529,7 +10529,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sui-config",
  "sui-move",
  "sui-move-build",
  "sui-sdk",

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.88"
 url = "2.3.1"
 
-sui-config = { path = "../../crates/sui-config" }
 sui-move = { path = "../../crates/sui-move", features = ["all"] }
 sui-move-build = { path = "../../crates/sui-move-build" }
 sui-sdk = { path = "../../crates/sui-sdk" }

--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -2,7 +2,21 @@
 source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
-branch = "mainnet-v1.3.1"
+branch = "framework/mainnet"
+network = "Mainnet"
+paths = [
+    "crates/sui-framework/packages/deepbook",
+    "crates/sui-framework/packages/move-stdlib",
+    "crates/sui-framework/packages/sui-framework",
+    "crates/sui-framework/packages/sui-system",
+]
+
+[[packages]]
+source = "Repository"
+[packages.values]
+repository = "https://github.com/mystenlabs/sui"
+branch = "framework/testnet"
+network = "Testnet"
 paths = [
     "crates/sui-framework/packages/deepbook",
     "crates/sui-framework/packages/move-stdlib",

--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -3,7 +3,7 @@ source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
 branch = "framework/mainnet"
-network = "Mainnet"
+network = "mainnet"
 paths = [
     "crates/sui-framework/packages/deepbook",
     "crates/sui-framework/packages/move-stdlib",
@@ -16,7 +16,7 @@ source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
 branch = "framework/testnet"
-network = "Testnet"
+network = "testnet"
 paths = [
     "crates/sui-framework/packages/deepbook",
     "crates/sui-framework/packages/move-stdlib",

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -26,13 +27,17 @@ use move_package::BuildConfig as MoveBuildConfig;
 use move_symbol_pool::Symbol;
 use sui_move::build::resolve_lock_file_path;
 use sui_move_build::{BuildConfig, SuiPackageHooks};
-use sui_sdk::wallet_context::WalletContext;
-use sui_sdk::SuiClient;
+use sui_sdk::SuiClientBuilder;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
 pub const HOST_PORT_ENV: &str = "HOST_PORT";
 pub const SUI_SOURCE_VALIDATION_VERSION_HEADER: &str = "X-Sui-Source-Validation-Version";
 pub const SUI_SOURCE_VALIDATION_VERSION: &str = "0.1";
+
+pub const MAINNET_URL: &str = "https://fullnode.mainnet.sui.io:443";
+pub const TESTNET_URL: &str = "https://fullnode.testnet.sui.io:443";
+pub const DEVNET_URL: &str = "https://fullnode.devnet.sui.io:443";
+pub const LOCALNET_URL: &str = "http://127.0.0.1:9000";
 
 pub fn host_port() -> String {
     match option_env!("HOST_PORT") {
@@ -58,11 +63,13 @@ pub struct RepositorySource {
     pub repository: String,
     pub branch: String,
     pub paths: Vec<String>,
+    pub network: Option<Network>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct DirectorySource {
     pub paths: Vec<String>,
+    pub network: Option<Network>,
 }
 
 #[derive(Debug)]
@@ -72,13 +79,38 @@ pub struct SourceInfo {
     pub source: Option<String>,
 }
 
+#[derive(Eq, PartialEq, Clone, Deserialize, Debug, Ord, PartialOrd)]
+pub enum Network {
+    Mainnet,
+    Testnet,
+    Devnet,
+    Localnet,
+}
+
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Network::Mainnet => "mainnet",
+                Network::Testnet => "testnet",
+                Network::Devnet => "devnet",
+                Network::Localnet => "localnet",
+            }
+        )
+    }
+}
+
 /// Map (package address, module name) tuples to verified source info.
 type SourceLookup = BTreeMap<(AccountAddress, Symbol), SourceInfo>;
+/// Top-level lookup that maps network to sources for corresponding on-chain networks.
+pub type NetworkLookup = BTreeMap<Network, SourceLookup>;
 
 pub async fn verify_package(
-    client: &SuiClient,
+    network: &Network,
     package_path: impl AsRef<Path>,
-) -> anyhow::Result<SourceLookup> {
+) -> anyhow::Result<(Network, SourceLookup)> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let config = resolve_lock_file_path(
         MoveBuildConfig::default(),
@@ -92,6 +124,13 @@ pub async fn verify_package(
     };
     let compiled_package = build_config.build(package_path.as_ref().to_path_buf())?;
 
+    let network_url = match network {
+        Network::Mainnet => MAINNET_URL,
+        Network::Testnet => TESTNET_URL,
+        Network::Devnet => DEVNET_URL,
+        Network::Localnet => LOCALNET_URL,
+    };
+    let client = SuiClientBuilder::default().build(network_url).await?;
     BytecodeSourceVerifier::new(client.read_api())
         .verify_package(
             &compiled_package,
@@ -116,7 +155,7 @@ pub async fn verify_package(
             }
         };
     }
-    Ok(map)
+    Ok((network.clone(), map))
 }
 
 pub fn parse_config(config_path: impl AsRef<Path>) -> anyhow::Result<Config> {
@@ -148,7 +187,10 @@ pub struct CloneCommand {
 impl CloneCommand {
     pub fn new(p: &RepositorySource, dest: &Path) -> anyhow::Result<CloneCommand> {
         let repo_name = repo_name_from_url(&p.repository)?;
-        let dest = dest.join(repo_name).into_os_string();
+        let dest = dest
+            .join(p.network.as_ref().unwrap_or(&Network::Mainnet).to_string())
+            .join(repo_name)
+            .into_os_string();
 
         macro_rules! ostr {
             ($arg:expr) => {
@@ -230,11 +272,7 @@ pub async fn clone_repositories(repos: Vec<&RepositorySource>, dir: &Path) -> an
     Ok(())
 }
 
-pub async fn initialize(
-    context: &WalletContext,
-    config: &Config,
-    dir: &Path,
-) -> anyhow::Result<SourceLookup> {
+pub async fn initialize(config: &Config, dir: &Path) -> anyhow::Result<NetworkLookup> {
     let mut repos = vec![];
     for s in &config.packages {
         match s {
@@ -243,52 +281,62 @@ pub async fn initialize(
         }
     }
     clone_repositories(repos, dir).await?;
-    verify_packages(context, config, dir).await
+    verify_packages(config, dir).await
 }
 
-pub async fn verify_packages(
-    context: &WalletContext,
-    config: &Config,
-    dir: &Path,
-) -> anyhow::Result<SourceLookup> {
+pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<NetworkLookup> {
     let mut tasks = vec![];
     for p in &config.packages {
         match p {
-            PackageSources::Repository(p) => {
-                let repo_name = repo_name_from_url(&p.repository)?;
-                let packages_dir = dir.join(repo_name);
-                for p in &p.paths {
+            PackageSources::Repository(r) => {
+                let repo_name = repo_name_from_url(&r.repository)?;
+                let network_name = r.network.clone().unwrap_or(Network::Mainnet).to_string();
+                let packages_dir = dir.join(network_name).join(repo_name);
+                for p in &r.paths {
                     let package_path = packages_dir.join(p).clone();
-                    let client = context.get_client().await?;
+                    let network = r.network.clone().unwrap_or(Network::Mainnet);
                     info!("verifying {p}");
                     let t =
-                        tokio::spawn(async move { verify_package(&client, package_path).await });
+                        tokio::spawn(async move { verify_package(&network, package_path).await });
                     tasks.push(t)
                 }
             }
             PackageSources::Directory(packages_dir) => {
                 for p in &packages_dir.paths {
                     let package_path = PathBuf::from(p);
-                    let client = context.get_client().await?;
+                    let network = packages_dir.network.clone().unwrap_or(Network::Mainnet);
                     info!("verifying {p}");
                     let t =
-                        tokio::spawn(async move { verify_package(&client, package_path).await });
+                        tokio::spawn(async move { verify_package(&network, package_path).await });
                     tasks.push(t)
                 }
             }
         }
     }
 
-    let mut lookup = BTreeMap::new();
+    let mut mainnet_lookup = SourceLookup::new();
+    let mut testnet_lookup = SourceLookup::new();
+    let mut devnet_lookup = SourceLookup::new();
+    let mut localnet_lookup = SourceLookup::new();
     for t in tasks {
-        let new_lookup = t.await.unwrap()?;
-        lookup.extend(new_lookup);
+        let (network, new_lookup) = t.await.unwrap()?;
+        match network {
+            Network::Mainnet => mainnet_lookup.extend(new_lookup),
+            Network::Testnet => testnet_lookup.extend(new_lookup),
+            Network::Devnet => devnet_lookup.extend(new_lookup),
+            Network::Localnet => localnet_lookup.extend(new_lookup),
+        }
     }
+    let mut lookup = NetworkLookup::new();
+    lookup.insert(Network::Mainnet, mainnet_lookup);
+    lookup.insert(Network::Testnet, testnet_lookup);
+    lookup.insert(Network::Devnet, devnet_lookup);
+    lookup.insert(Network::Localnet, localnet_lookup);
     Ok(lookup)
 }
 
 pub struct AppState {
-    pub sources: SourceLookup,
+    pub sources: NetworkLookup,
 }
 
 pub fn serve(app_state: AppState) -> anyhow::Result<Server<AddrIncoming, IntoMakeService<Router>>> {
@@ -309,6 +357,7 @@ pub fn serve(app_state: AppState) -> anyhow::Result<Server<AddrIncoming, IntoMak
 pub struct Request {
     address: String,
     module: String,
+    network: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -324,7 +373,11 @@ pub struct ErrorResponse {
 async fn api_route(
     headers: HeaderMap,
     State(app_state): State<Arc<AppState>>,
-    Query(Request { address, module }): Query<Request>,
+    Query(Request {
+        address,
+        module,
+        network,
+    }): Query<Request>,
 ) -> impl IntoResponse {
     let version = headers
         .get(SUI_SOURCE_VALIDATION_VERSION_HEADER)
@@ -354,13 +407,21 @@ async fn api_route(
         None => info!("No version set, using {SUI_SOURCE_VALIDATION_VERSION}"),
     };
 
+    let network = match network.as_deref() {
+        Some("mainnet") => Network::Mainnet,
+        Some("testnet") => Network::Testnet,
+        Some("devnet") => Network::Devnet,
+        Some("localnet") => Network::Localnet,
+        _ => Network::Mainnet,
+    };
+
     let symbol = Symbol::from(module);
     let Ok(address) = AccountAddress::from_hex_literal(&address) else {
 	let error = format!("Invalid hex address {address}");
 	return (StatusCode::BAD_REQUEST, headers, Json(ErrorResponse { error }).into_response())
     };
-    let Some(SourceInfo {source : Some(source), ..}) = app_state.sources.get(&(address, symbol)) else {
-	let error = format!("No source found for {symbol} at address {address}" );
+    let Some(SourceInfo {source : Some(source), ..}) = app_state.sources.get(&network).and_then(|l| l.get(&(address, symbol))) else {
+	let error = format!("No source found for {symbol} at address {address} on network {network}");
 	return (StatusCode::NOT_FOUND, headers, Json(ErrorResponse { error }).into_response())
     };
     (

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -358,9 +358,10 @@ pub fn serve(app_state: AppState) -> anyhow::Result<Server<AddrIncoming, IntoMak
 
 #[derive(Deserialize)]
 pub struct Request {
+    #[serde(default)]
+    network: Network,
     address: String,
     module: String,
-    network: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -408,14 +409,6 @@ async fn api_route(
         }
         Some(_) => (),
         None => info!("No version set, using {SUI_SOURCE_VALIDATION_VERSION}"),
-    };
-
-    let network = match network.as_deref() {
-        Some("mainnet") => Network::Mainnet,
-        Some("testnet") => Network::Testnet,
-        Some("devnet") => Network::Devnet,
-        Some("localnet") => Network::Localnet,
-        _ => Network::Mainnet,
     };
 
     let symbol = Symbol::from(module);

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -6,8 +6,6 @@ use tracing::info;
 
 use clap::Parser;
 
-use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
-use sui_sdk::wallet_context::WalletContext;
 use telemetry_subscribers::TelemetryConfig;
 
 use sui_source_validation_service::{host_port, initialize, parse_config, serve, AppState};
@@ -22,10 +20,8 @@ pub async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let _logging_guard = TelemetryConfig::new().with_env().init();
     let package_config = parse_config(args.config_path)?;
-    let sui_config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
-    let context = WalletContext::new(&sui_config, None, None).await?;
     let tmp_dir = tempfile::tempdir()?;
-    let sources = initialize(&context, &package_config, tmp_dir.path()).await?;
+    let sources = initialize(&package_config, tmp_dir.path()).await?;
     info!("verification complete");
     info!("serving on {}", host_port());
     serve(AppState { sources })?

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -3,39 +3,45 @@
 
 use expect_test::expect;
 use reqwest::Client;
+use std::fs;
 use std::{collections::BTreeMap, path::PathBuf};
 
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use sui_source_validation_service::{
     host_port, initialize, serve, verify_packages, AppState, CloneCommand, Config, ErrorResponse,
-    PackageSources, RepositorySource, SourceInfo, SourceResponse,
+    Network, NetworkLookup, PackageSources, RepositorySource, SourceInfo, SourceResponse,
     SUI_SOURCE_VALIDATION_VERSION_HEADER,
 };
 use test_cluster::TestClusterBuilder;
 
+const LOCALNET_PORT: u16 = 9000;
 const TEST_FIXTURES_DIR: &str = "tests/fixture";
 
 #[tokio::test]
 async fn test_verify_packages() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await;
-    let context = &mut cluster.wallet;
+    let _cluster = TestClusterBuilder::new()
+        .with_fullnode_rpc_port(LOCALNET_PORT)
+        .build()
+        .await;
 
     let config = Config {
         packages: vec![PackageSources::Repository(RepositorySource {
             repository: "https://github.com/mystenlabs/sui".into(),
             branch: "main".into(),
             paths: vec!["move-stdlib".into()],
+            network: Some(Network::Localnet),
         })],
     };
 
     let fixtures = tempfile::tempdir()?;
+    fs::create_dir(fixtures.path().join("localnet"))?;
     fs_extra::dir::copy(
         PathBuf::from(TEST_FIXTURES_DIR).join("sui"),
-        fixtures.path(),
+        fixtures.path().join("localnet"),
         &fs_extra::dir::CopyOptions::default(),
     )?;
-    let result = verify_packages(context, &config, fixtures.path()).await;
+    let result = verify_packages(&config, fixtures.path()).await;
     let truncated_error_message = &result
         .unwrap_err()
         .to_string()
@@ -56,11 +62,9 @@ Multiple source verification errors found:
 
 #[tokio::test]
 async fn test_api_route() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await;
-    let context = &mut cluster.wallet;
     let config = Config { packages: vec![] };
     let tmp_dir = tempfile::tempdir()?;
-    initialize(context, &config, tmp_dir.path()).await?;
+    initialize(&config, tmp_dir.path()).await?;
 
     // set up sample lookup to serve
     let fixtures = tempfile::tempdir()?;
@@ -76,8 +80,8 @@ async fn test_api_route() -> anyhow::Result<()> {
         .into_path()
         .join("sui/move-stdlib/sources/address.move");
 
-    let mut sources = BTreeMap::new();
-    sources.insert(
+    let mut test_lookup = BTreeMap::new();
+    test_lookup.insert(
         (
             AccountAddress::from_hex_literal(address).unwrap(),
             Symbol::from(module),
@@ -87,6 +91,8 @@ async fn test_api_route() -> anyhow::Result<()> {
             source: Some("module address {...}".to_owned()),
         },
     );
+    let mut sources = NetworkLookup::new();
+    sources.insert(Network::Localnet, test_lookup);
     tokio::spawn(serve(AppState { sources }).expect("Cannot start service."));
 
     let client = Client::new();
@@ -94,7 +100,7 @@ async fn test_api_route() -> anyhow::Result<()> {
     // check that serve returns expected sample code
     let json = client
         .get(format!(
-            "http://{}/api?address={address}&module={module}",
+            "http://{}/api?address={address}&module={module}&network=localnet",
             host_port()
         ))
         .send()
@@ -109,7 +115,7 @@ async fn test_api_route() -> anyhow::Result<()> {
     // check server rejects bad version header
     let json = client
         .get(format!(
-            "http://{}/api?address={address}&module={module}",
+            "http://{}/api?address={address}&module={module}&network=localnet",
             host_port()
         ))
         .header(SUI_SOURCE_VALIDATION_VERSION_HEADER, "bogus")
@@ -161,6 +167,7 @@ fn test_parse_package_config() -> anyhow::Result<()> {
                     "crates/sui-framework/packages/sui-framework",
                     "crates/sui-framework/packages/sui-system",
                 ],
+                network: None,
             },
         ),
         Directory(
@@ -168,6 +175,7 @@ fn test_parse_package_config() -> anyhow::Result<()> {
                 paths: [
                     "home/user/some/package",
                 ],
+                network: None,
             },
         ),
     ],
@@ -183,6 +191,7 @@ fn test_clone_command() -> anyhow::Result<()> {
         repository: "https://github.com/user/repo".into(),
         branch: "main".into(),
         paths: vec!["a".into(), "b".into()],
+        network: Some(Network::Localnet),
     };
 
     let command = CloneCommand::new(&source, PathBuf::from("/tmp").as_path())?;
@@ -196,11 +205,11 @@ fn test_clone_command() -> anyhow::Result<()> {
             "--filter=tree:0",
             "--branch=main",
             "https://github.com/user/repo",
-            "/tmp/repo",
+            "/tmp/localnet/repo",
         ],
         [
             "-C",
-            "/tmp/repo",
+            "/tmp/localnet/repo",
             "sparse-checkout",
             "set",
             "--no-cone",
@@ -209,7 +218,7 @@ fn test_clone_command() -> anyhow::Result<()> {
         ],
         [
             "-C",
-            "/tmp/repo",
+            "/tmp/localnet/repo",
             "checkout",
         ],
     ],


### PR DESCRIPTION
## Description 

Adds support for multiple networks (`mainnet`, `testnet`, `devnet`, `localnet`) with a top-level lookup to case out on sources. Some notes:


- RPC clients for networks are constructed during verification, we no longer use `sui-config` or local wallet context (yay!).

- Schema change to `config.toml`: a `network` field is optional and defaults to `mainnet`. If multiple network packages need to be served from a single repository, the config needs a separate entry that fully qualifies the repository, branch, and network. This is for simplicity of spec and implementation--basically, we just duplicate a previous entry for any additional networks and change the `network` field (and/or change corresponding package paths for flexibility if these differ across networks). I anticipate it is going to be rare for most packages to specify more than one or two networks.
  - Subnote***: With automated address management the need for `network` in `config.toml` will hopefully largely disappear (we'll ideally resolve the network from `Move.lock`).





## Test Plan 

Added / updated tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
