### PR TITLE
sdk: fix personal message to use bcs

### DIFF
--- a/.changeset/short-pugs-obey.md
+++ b/.changeset/short-pugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': minor
+---
+
+signMesssage uses BCS serialization for vector

--- a/dapps/kiosk-cli/README.md
+++ b/dapps/kiosk-cli/README.md
@@ -11,21 +11,25 @@ A simple CLI application written in NodeJS to showcase Kiosk usage and basic app
 ## Install and use
 
 Export a mnemonic phrase
+
 ```
 export MNEMONIC="..."
 ```
 
 Create a Kiosk
+
 ```
 pnpm cli new
 ```
 
 Mint a TestItem
+
 ```
 pnpm cli mint-to-kiosk
 ```
 
 View Kiosk contents
+
 ```
 pnpm cli contents
 
@@ -37,6 +41,7 @@ pnpm cli contents
 ```
 
 List an item in the Kiosk
+
 ```
 # list an item in the Kiosk
 pnpm list <item_id> <price>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ packages:
     - '!sdk/typescript/faucet'
     - '!sdk/typescript/transactions'
     - '!sdk/typescript/client'
+    - '!sdk/typescript/verify'

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -13,7 +13,8 @@
 		"faucet",
 		"keypairs",
 		"src",
-		"transactions"
+		"transactions",
+		"verify"
 	],
 	"engines": {
 		"node": ">=16"
@@ -67,6 +68,11 @@
 			"source": "./src/builder/export.ts",
 			"import": "./dist/esm/builder/export.js",
 			"require": "./dist/cjs/builder/export.js"
+		},
+		"./verify": {
+			"source": "./src/verify/index.ts",
+			"import": "./dist/esm/verify/index.js",
+			"require": "./dist/cjs/verify/index.js"
 		}
 	},
 	"scripts": {

--- a/sdk/typescript/src/cryptography/intent.ts
+++ b/sdk/typescript/src/cryptography/intent.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { bcs } from '../types/sui-bcs.js';
-
 // See: sui/crates/sui-types/src/intent.rs
 export enum AppId {
 	Sui = 0,
@@ -26,15 +24,9 @@ function intentWithScope(scope: IntentScope): Intent {
 }
 
 export function messageWithIntent(scope: IntentScope, message: Uint8Array) {
-	let serialized_msg = message;
-	// Serialize the personal message with BCS vector to match with rust
-	// See: `struct PersonalMessage` in sui/crates/sui-types/src/intent.rs
-	if (scope === IntentScope.PersonalMessage) {
-		serialized_msg = bcs.ser(['vector', 'u8'], message).toBytes();
-	}
 	const intent = intentWithScope(scope);
-	const intentMessage = new Uint8Array(intent.length + serialized_msg.length);
+	const intentMessage = new Uint8Array(intent.length + message.length);
 	intentMessage.set(intent);
-	intentMessage.set(serialized_msg, intent.length);
+	intentMessage.set(message, intent.length);
 	return intentMessage;
 }

--- a/sdk/typescript/src/cryptography/intent.ts
+++ b/sdk/typescript/src/cryptography/intent.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { bcs } from '../types/sui-bcs.js';
+
 // See: sui/crates/sui-types/src/intent.rs
 export enum AppId {
 	Sui = 0,
@@ -24,9 +26,15 @@ function intentWithScope(scope: IntentScope): Intent {
 }
 
 export function messageWithIntent(scope: IntentScope, message: Uint8Array) {
+	let serialized_msg = message;
+	// Serialize the personal message with BCS vector to match with rust
+	// See: `struct PersonalMessage` in sui/crates/sui-types/src/intent.rs
+	if (scope === IntentScope.PersonalMessage) {
+		serialized_msg = bcs.ser(['vector', 'u8'], message).toBytes();
+	}
 	const intent = intentWithScope(scope);
-	const intentMessage = new Uint8Array(intent.length + message.length);
+	const intentMessage = new Uint8Array(intent.length + serialized_msg.length);
 	intentMessage.set(intent);
-	intentMessage.set(message, intent.length);
+	intentMessage.set(serialized_msg, intent.length);
 	return intentMessage;
 }

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -7,6 +7,7 @@ import { toSerializedSignature } from './signature.js';
 import type { SignatureScheme } from './signature.js';
 import { IntentScope, messageWithIntent } from './intent.js';
 import { blake2b } from '@noble/hashes/blake2b';
+import { bcs } from '../types/sui-bcs.js';
 
 export const PRIVATE_KEY_SIZE = 32;
 export const LEGACY_PRIVATE_KEY_SIZE = 64;
@@ -47,8 +48,18 @@ export abstract class BaseSigner {
 		return this.signWithIntent(bytes, IntentScope.TransactionData);
 	}
 
+	async signPersonalMessage(bytes: Uint8Array) {
+		return this.signWithIntent(
+			bcs.ser(['vector', 'u8'], bytes).toBytes(),
+			IntentScope.PersonalMessage,
+		);
+	}
+
+	/**
+	 * @deprecated use `signPersonalMessage` instead
+	 */
 	async signMessage(bytes: Uint8Array) {
-		return this.signWithIntent(bytes, IntentScope.PersonalMessage);
+		return this.signPersonalMessage(bytes);
 	}
 
 	toSuiAddress(): string {
@@ -57,7 +68,7 @@ export abstract class BaseSigner {
 
 	/**
 	 * Return the signature for the data.
-	 * Prefer the async verion {@link sign}, as this method will be deprecated in a future release.
+	 * Prefer the async version {@link sign}, as this method will be deprecated in a future release.
 	 */
 	abstract signData(data: Uint8Array): Uint8Array;
 

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -8,6 +8,7 @@ import { PublicKey } from '../../cryptography/publickey.js';
 import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
 import { bytesToHex } from '@noble/hashes/utils';
 import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
+import nacl from 'tweetnacl';
 
 const PUBLIC_KEY_SIZE = 32;
 
@@ -72,5 +73,16 @@ export class Ed25519PublicKey extends PublicKey {
 	 */
 	flag(): number {
 		return SIGNATURE_SCHEME_TO_FLAG['ED25519'];
+	}
+
+	/**
+	 * Verifies that the signature is valid for for the provided message
+	 */
+	async verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+		return nacl.sign.detached.verify(message, signature, this.toBytes());
+	}
+
+	static fromBytes(bytes: Uint8Array): Ed25519PublicKey {
+		return new Ed25519PublicKey(bytes);
 	}
 }

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -81,8 +81,4 @@ export class Ed25519PublicKey extends PublicKey {
 	async verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
 		return nacl.sign.detached.verify(message, signature, this.toBytes());
 	}
-
-	static fromBytes(bytes: Uint8Array): Ed25519PublicKey {
-		return new Ed25519PublicKey(bytes);
-	}
 }

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -8,6 +8,8 @@ import { PublicKey } from '../../cryptography/publickey.js';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
 import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
 import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
 
 const SECP256K1_PUBLIC_KEY_SIZE = 33;
 
@@ -72,5 +74,20 @@ export class Secp256k1PublicKey extends PublicKey {
 	 */
 	flag(): number {
 		return SIGNATURE_SCHEME_TO_FLAG['Secp256k1'];
+	}
+
+	/**
+	 * Verifies that the signature is valid for for the provided message
+	 */
+	async verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+		return secp256k1.verify(
+			secp256k1.Signature.fromCompact(signature),
+			sha256(message),
+			this.toBytes(),
+		);
+	}
+
+	static fromBytes(bytes: Uint8Array): Secp256k1PublicKey {
+		return new Secp256k1PublicKey(bytes);
 	}
 }

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -86,8 +86,4 @@ export class Secp256k1PublicKey extends PublicKey {
 			this.toBytes(),
 		);
 	}
-
-	static fromBytes(bytes: Uint8Array): Secp256k1PublicKey {
-		return new Secp256k1PublicKey(bytes);
-	}
 }

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -86,8 +86,4 @@ export class Secp256r1PublicKey extends PublicKey {
 			this.toBytes(),
 		);
 	}
-
-	static fromBytes(bytes: Uint8Array): Secp256r1PublicKey {
-		return new Secp256r1PublicKey(bytes);
-	}
 }

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -8,6 +8,8 @@ import { PublicKey } from '../../cryptography/publickey.js';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
 import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
 import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
+import { sha256 } from '@noble/hashes/sha256';
+import { secp256r1 } from '@noble/curves/p256';
 
 const SECP256R1_PUBLIC_KEY_SIZE = 33;
 
@@ -72,5 +74,20 @@ export class Secp256r1PublicKey extends PublicKey {
 	 */
 	flag(): number {
 		return SIGNATURE_SCHEME_TO_FLAG['Secp256r1'];
+	}
+
+	/**
+	 * Verifies that the signature is valid for for the provided message
+	 */
+	async verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+		return secp256r1.verify(
+			secp256r1.Signature.fromCompact(signature),
+			sha256(message),
+			this.toBytes(),
+		);
+	}
+
+	static fromBytes(bytes: Uint8Array): Secp256r1PublicKey {
+		return new Secp256r1PublicKey(bytes);
 	}
 }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -20,6 +20,7 @@ import { IntentScope, messageWithIntent } from '../cryptography/intent.js';
 import type { Signer } from './signer.js';
 import type { SignedTransaction, SignedMessage } from './types.js';
 import type { SuiClient } from '../client/index.js';
+import { bcs } from '../types/sui-bcs.js';
 
 ///////////////////////////////
 // Exported Abstracts
@@ -74,7 +75,10 @@ export abstract class SignerWithProvider implements Signer {
 	 */
 	async signMessage(input: { message: Uint8Array }): Promise<SignedMessage> {
 		const signature = await this.signData(
-			messageWithIntent(IntentScope.PersonalMessage, input.message),
+			messageWithIntent(
+				IntentScope.PersonalMessage,
+				bcs.ser(['vector', 'u8'], input.message).toBytes(),
+			),
 		);
 
 		return {

--- a/sdk/typescript/src/utils/verify.ts
+++ b/sdk/typescript/src/utils/verify.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromB64 } from '@mysten/bcs';
-import nacl from 'tweetnacl';
 import { IntentScope } from '../cryptography/intent.js';
 import { messageWithIntent } from '../cryptography/intent.js';
-import { secp256k1 } from '@noble/curves/secp256k1';
-import { sha256 } from '@noble/hashes/sha256';
-import type { SerializedSignature, SignatureScheme } from '../cryptography/signature.js';
+import type { SerializedSignature } from '../cryptography/signature.js';
 import { blake2b } from '@noble/hashes/blake2b';
 import { toSingleSignaturePubkeyPair } from '../cryptography/utils.js';
 import { bcs } from '../types/sui-bcs.js';
@@ -30,14 +27,7 @@ export async function verifyMessage(
 			bcs.ser(['vector', 'u8'], typeof message === 'string' ? fromB64(message) : message).toBytes(),
 		);
 
-		if (
-			verifySignature(
-				blake2b(messageBytes, { dkLen: 32 }),
-				signature.signature,
-				signature.pubKey.toBytes(),
-				signature.signatureScheme,
-			)
-		) {
+		if (await signature.pubKey.verify(blake2b(messageBytes, { dkLen: 32 }), signature.signature)) {
 			return true;
 		}
 
@@ -48,11 +38,9 @@ export async function verifyMessage(
 			typeof message === 'string' ? fromB64(message) : message,
 		);
 
-		return verifySignature(
+		return signature.pubKey.verify(
 			blake2b(unwrappedMessageBytes, { dkLen: 32 }),
 			signature.signature,
-			signature.pubKey.toBytes(),
-			signature.signatureScheme,
 		);
 	}
 
@@ -61,26 +49,5 @@ export async function verifyMessage(
 		typeof message === 'string' ? fromB64(message) : message,
 	);
 
-	return verifySignature(
-		blake2b(messageBytes, { dkLen: 32 }),
-		signature.signature,
-		signature.pubKey.toBytes(),
-		signature.signatureScheme,
-	);
-}
-
-function verifySignature(
-	bytes: Uint8Array,
-	signature: Uint8Array,
-	publicKey: Uint8Array,
-	signatureScheme: SignatureScheme,
-) {
-	switch (signatureScheme) {
-		case 'ED25519':
-			return nacl.sign.detached.verify(bytes, signature, publicKey);
-		case 'Secp256k1':
-			return secp256k1.verify(secp256k1.Signature.fromCompact(signature), sha256(bytes), publicKey);
-		default:
-			throw new Error(`Unknown signature scheme: "${signatureScheme}"`);
-	}
+	return signature.pubKey.verify(blake2b(messageBytes, { dkLen: 32 }), signature.signature);
 }

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -10,45 +10,47 @@ import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
 export async function verifySignature(
 	bytes: Uint8Array,
 	signature: SerializedSignature,
-): Promise<false | PublicKey> {
+): Promise<PublicKey> {
 	const parsedSignature = parseSignature(signature);
 
-	if (await parsedSignature.publicKey.verify(bytes, parsedSignature.signature)) {
-		return parsedSignature.publicKey;
+	if (!(await parsedSignature.publicKey.verify(bytes, parsedSignature.signature))) {
+		throw new Error(`Signature is not valid for the provided data`);
 	}
 
-	return false;
+	return parsedSignature.publicKey;
 }
 
 export async function verifyPersonalMessage(
 	message: Uint8Array,
 	signature: SerializedSignature,
-): Promise<false | PublicKey> {
+): Promise<PublicKey> {
 	const parsedSignature = parseSignature(signature);
 
-	if (await parsedSignature.publicKey.verifyPersonalMessage(message, parsedSignature.signature)) {
-		return parsedSignature.publicKey;
+	if (
+		!(await parsedSignature.publicKey.verifyPersonalMessage(message, parsedSignature.signature))
+	) {
+		throw new Error(`Signature is not valid for the provided message`);
 	}
 
-	return false;
+	return parsedSignature.publicKey;
 }
 
 export async function verifyTransactionBlock(
 	transactionBlock: Uint8Array,
 	signature: SerializedSignature,
-): Promise<false | PublicKey> {
+): Promise<PublicKey> {
 	const parsedSignature = parseSignature(signature);
 
 	if (
-		await parsedSignature.publicKey.verifyTransactionBlock(
+		!(await parsedSignature.publicKey.verifyTransactionBlock(
 			transactionBlock,
 			parsedSignature.signature,
-		)
+		))
 	) {
-		return parsedSignature.publicKey;
+		throw new Error(`Signature is not valid for the provided TransactionBlock`);
 	}
 
-	return false;
+	return parsedSignature.publicKey;
 }
 
 function parseSignature(signature: SerializedSignature) {
@@ -57,13 +59,13 @@ function parseSignature(signature: SerializedSignature) {
 
 	switch (parsedSignature.signatureScheme) {
 		case 'ED25519':
-			publicKey = Ed25519PublicKey.fromBytes(parsedSignature.publicKey);
+			publicKey = new Ed25519PublicKey(parsedSignature.publicKey);
 			break;
 		case 'Secp256k1':
-			publicKey = Secp256k1PublicKey.fromBytes(parsedSignature.publicKey);
+			publicKey = new Secp256k1PublicKey(parsedSignature.publicKey);
 			break;
 		case 'Secp256r1':
-			publicKey = Secp256r1PublicKey.fromBytes(parsedSignature.publicKey);
+			publicKey = new Secp256r1PublicKey(parsedSignature.publicKey);
 			break;
 		default:
 			throw new Error(`Unsupported signature scheme ${parsedSignature.signatureScheme}`);

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PublicKey, SerializedSignature } from '../cryptography/index.js';
+import { parseSerializedSignature } from '../cryptography/index.js';
+import { Ed25519PublicKey } from '../keypairs/ed25519/publickey.js';
+import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
+import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
+
+export async function verifySignature(
+	bytes: Uint8Array,
+	signature: SerializedSignature,
+): Promise<false | PublicKey> {
+	const parsedSignature = parseSignature(signature);
+
+	if (await parsedSignature.publicKey.verify(bytes, parsedSignature.signature)) {
+		return parsedSignature.publicKey;
+	}
+
+	return false;
+}
+
+export async function verifyPersonalMessage(
+	message: Uint8Array,
+	signature: SerializedSignature,
+): Promise<false | PublicKey> {
+	const parsedSignature = parseSignature(signature);
+
+	if (await parsedSignature.publicKey.verifyPersonalMessage(message, parsedSignature.signature)) {
+		return parsedSignature.publicKey;
+	}
+
+	return false;
+}
+
+export async function verifyTransactionBlock(
+	transactionBlock: Uint8Array,
+	signature: SerializedSignature,
+): Promise<false | PublicKey> {
+	const parsedSignature = parseSignature(signature);
+
+	if (
+		await parsedSignature.publicKey.verifyTransactionBlock(
+			transactionBlock,
+			parsedSignature.signature,
+		)
+	) {
+		return parsedSignature.publicKey;
+	}
+
+	return false;
+}
+
+function parseSignature(signature: SerializedSignature) {
+	const parsedSignature = parseSerializedSignature(signature);
+	let publicKey: PublicKey;
+
+	switch (parsedSignature.signatureScheme) {
+		case 'ED25519':
+			publicKey = Ed25519PublicKey.fromBytes(parsedSignature.publicKey);
+			break;
+		case 'Secp256k1':
+			publicKey = Secp256k1PublicKey.fromBytes(parsedSignature.publicKey);
+			break;
+		case 'Secp256r1':
+			publicKey = Secp256r1PublicKey.fromBytes(parsedSignature.publicKey);
+			break;
+		default:
+			throw new Error(`Unsupported signature scheme ${parsedSignature.signatureScheme}`);
+	}
+
+	return {
+		...parsedSignature,
+		publicKey,
+	};
+}

--- a/sdk/typescript/test/e2e/keypairs.test.ts
+++ b/sdk/typescript/test/e2e/keypairs.test.ts
@@ -102,7 +102,7 @@ describe('Keypairs', () => {
 		const keypair = new Ed25519Keypair();
 		const signData = new TextEncoder().encode('hello world');
 
-		const { signature } = await keypair.signMessage(signData);
+		const { signature } = await keypair.signPersonalMessage(signData);
 		const isValid = await verifyMessage(signData, signature, IntentScope.PersonalMessage);
 		expect(isValid).toBe(true);
 	});
@@ -111,7 +111,7 @@ describe('Keypairs', () => {
 		const keypair = new Ed25519Keypair();
 		const signData = new TextEncoder().encode('hello world');
 
-		const { signature } = await keypair.signMessage(signData);
+		const { signature } = await keypair.signPersonalMessage(signData);
 		const isValid = await verifyMessage(
 			new TextEncoder().encode('hello worlds'),
 			signature,
@@ -148,7 +148,7 @@ describe('Keypairs', () => {
 		const keypair = new Secp256k1Keypair();
 		const signData = new TextEncoder().encode('hello world');
 
-		const { signature } = await keypair.signMessage(signData);
+		const { signature } = await keypair.signPersonalMessage(signData);
 
 		const isValid = await verifyMessage(signData, signature, IntentScope.PersonalMessage);
 		expect(isValid).toBe(true);

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -1,10 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromB64, toB64 } from '@mysten/bcs';
+import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import nacl from 'tweetnacl';
 import { describe, it, expect } from 'vitest';
-import { Ed25519Keypair, PRIVATE_KEY_SIZE } from '../../../src';
+import {
+	Ed25519Keypair,
+	IntentScope,
+	PRIVATE_KEY_SIZE,
+	TransactionBlock,
+	parseSerializedSignature,
+	verifyMessage,
+} from '../../../src';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECRET_KEY = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCg=';
 
@@ -82,6 +90,7 @@ describe('ed25519-keypair', () => {
 			keypair.getPublicKey().toBytes(),
 		);
 		expect(isValid).toBeTruthy();
+		expect(keypair.getPublicKey().verify(signData, signature));
 	});
 
 	it('incorrect coin type node for ed25519 derivation path', () => {
@@ -113,5 +122,49 @@ describe('ed25519-keypair', () => {
 		expect(() => {
 			Ed25519Keypair.deriveKeypair('aaa');
 		}).toThrow('Invalid mnemonic');
+	});
+
+	it('signs TransactionBlocks', async () => {
+		const keypair = new Ed25519Keypair();
+		const txb = new TransactionBlock();
+		txb.setSender(keypair.getPublicKey().toSuiAddress());
+		txb.setGasPrice(5);
+		txb.setGasBudget(100);
+		txb.setGasPayment([
+			{
+				objectId: (Math.random() * 100000).toFixed(0).padEnd(64, '0'),
+				version: String((Math.random() * 10000).toFixed(0)),
+				digest: toB58(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),
+			},
+		]);
+
+		const bytes = await txb.build();
+
+		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+			true,
+		);
+		expect(await verifyMessage(bytes, serializedSignature, IntentScope.TransactionData)).toEqual(
+			true,
+		);
+		expect(!!(await verifyTransactionBlock(bytes, serializedSignature))).toEqual(true);
+	});
+
+	it('signs PersonalMessages', async () => {
+		const keypair = new Ed25519Keypair();
+		const message = new TextEncoder().encode('hello world');
+
+		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(
+			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+		).toEqual(true);
+		expect(await verifyMessage(message, serializedSignature, IntentScope.PersonalMessage)).toEqual(
+			true,
+		);
+		expect(!!(await verifyPersonalMessage(message, serializedSignature))).toEqual(true);
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -3,13 +3,18 @@
 
 import {
 	DEFAULT_SECP256K1_DERIVATION_PATH,
+	IntentScope,
 	PRIVATE_KEY_SIZE,
 	Secp256k1Keypair,
+	TransactionBlock,
+	parseSerializedSignature,
+	verifyMessage,
 } from '../../../src';
 import { describe, it, expect } from 'vitest';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { fromB64, toB64 } from '@mysten/bcs';
+import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 // Test case from https://github.com/rust-bitcoin/rust-secp256k1/blob/master/examples/sign_verify.rs#L26
 const VALID_SECP256K1_SECRET_KEY = [
@@ -156,5 +161,49 @@ describe('secp256k1-keypair', () => {
 		expect(() => {
 			Secp256k1Keypair.deriveKeypair(TEST_MNEMONIC, `m/54'/784'/0'/0'/0'`);
 		}).toThrow('Invalid derivation path');
+	});
+
+	it('signs TransactionBlocks', async () => {
+		const keypair = new Secp256k1Keypair();
+		const txb = new TransactionBlock();
+		txb.setSender(keypair.getPublicKey().toSuiAddress());
+		txb.setGasPrice(5);
+		txb.setGasBudget(100);
+		txb.setGasPayment([
+			{
+				objectId: (Math.random() * 100000).toFixed(0).padEnd(64, '0'),
+				version: String((Math.random() * 10000).toFixed(0)),
+				digest: toB58(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),
+			},
+		]);
+
+		const bytes = await txb.build();
+
+		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+			true,
+		);
+		expect(await verifyMessage(bytes, serializedSignature, IntentScope.TransactionData)).toEqual(
+			true,
+		);
+		expect(!!(await verifyTransactionBlock(bytes, serializedSignature))).toEqual(true);
+	});
+
+	it('signs PersonalMessages', async () => {
+		const keypair = new Secp256k1Keypair();
+		const message = new TextEncoder().encode('hello world');
+
+		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(
+			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+		).toEqual(true);
+		expect(await verifyMessage(message, serializedSignature, IntentScope.PersonalMessage)).toEqual(
+			true,
+		);
+		expect(!!(await verifyPersonalMessage(message, serializedSignature))).toEqual(true);
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
@@ -5,11 +5,14 @@ import {
 	DEFAULT_SECP256R1_DERIVATION_PATH,
 	PRIVATE_KEY_SIZE,
 	Secp256r1Keypair,
+	TransactionBlock,
+	parseSerializedSignature,
 } from '../../../src';
 import { describe, it, expect } from 'vitest';
 import { secp256r1 } from '@noble/curves/p256';
-import { fromB64, toB64 } from '@mysten/bcs';
+import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECP256R1_SECRET_KEY = [
 	66, 37, 141, 205, 161, 76, 241, 17, 198, 2, 184, 151, 27, 140, 200, 67, 233, 30, 70, 202, 144, 81,
@@ -161,5 +164,43 @@ describe('secp256r1-keypair', () => {
 		expect(() => {
 			Secp256r1Keypair.deriveKeypair(TEST_MNEMONIC, `m/44'/784'/0'/0'/0'`);
 		}).toThrow('Invalid derivation path');
+	});
+
+	it('signs TransactionBlocks', async () => {
+		const keypair = new Secp256r1Keypair();
+		const txb = new TransactionBlock();
+		txb.setSender(keypair.getPublicKey().toSuiAddress());
+		txb.setGasPrice(5);
+		txb.setGasBudget(100);
+		txb.setGasPayment([
+			{
+				objectId: (Math.random() * 100000).toFixed(0).padEnd(64, '0'),
+				version: String((Math.random() * 10000).toFixed(0)),
+				digest: toB58(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),
+			},
+		]);
+
+		const bytes = await txb.build();
+
+		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+			true,
+		);
+		expect(!!(await verifyTransactionBlock(bytes, serializedSignature))).toEqual(true);
+	});
+
+	it('signs PersonalMessages', async () => {
+		const keypair = new Secp256r1Keypair();
+		const message = new TextEncoder().encode('hello world');
+
+		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
+		const signature = parseSerializedSignature(serializedSignature);
+
+		expect(
+			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+		).toEqual(true);
+		expect(!!(await verifyPersonalMessage(message, serializedSignature))).toEqual(true);
 	});
 });

--- a/sdk/typescript/verify/package.json
+++ b/sdk/typescript/verify/package.json
@@ -1,0 +1,5 @@
+{
+	"private": true,
+	"import": "../dist/esm/verify/index.js",
+	"main": "../dist/cjs/verify/index.js"
+}


### PR DESCRIPTION
## Description 

fix a bug that the signMessage in rust vs typescript has a discrepancy. this is make typescript use bcs serialization for a vector instead of just a plain vector. 

```
PersonalMessage {
  message: Vec<u8>
}
```
## Test Plan 

existing tests in ts still passes (bc verify and sign are both changed to the new format). 
tested against rust that a ts produced sig now verifies in rust. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
