### PR TITLE
[Protocol Config] Mark get_for_max_version as unsafe

### DIFF
--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
     // TODO: query the network for the current protocol version.
     let protocol_config = match opts.protocol_version {
         Some(v) => ProtocolConfig::get_for_version(ProtocolVersion::new(v), Chain::Unknown),
-        None => ProtocolConfig::get_for_max_version(),
+        None => ProtocolConfig::get_for_max_version_UNSAFE(),
     };
 
     let max_num_new_move_object_ids = protocol_config.max_num_new_move_object_ids();

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -214,7 +214,7 @@ async fn init_genesis(
     let pkg = Object::new_package(
         &modules,
         TransactionDigest::genesis(),
-        ProtocolConfig::get_for_max_version().max_move_package_size(),
+        ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
         &genesis_move_packages,
     )
     .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -276,7 +276,7 @@ async fn test_dry_run_no_gas_big_transfer() {
         sender,
         vec![],
         pt,
-        ProtocolConfig::get_for_max_version().max_tx_gas(),
+        ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas(),
         fullnode.reference_gas_price_for_testing().unwrap(),
     );
 
@@ -4752,7 +4752,7 @@ fn test_choose_next_system_packages() {
 
     let committee = Committee::new_simple_test_committee().0;
     let v = &committee.voting_rights;
-    let mut protocol_config = ProtocolConfig::get_for_max_version();
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
     protocol_config.set_advance_to_highest_supported_protocol_version_for_testing(false);
     protocol_config.set_buffer_stake_for_protocol_upgrade_bps_for_testing(7500);
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -22,10 +22,11 @@ use sui_types::{base_types::dbg_addr, crypto::get_key_pair};
 
 // The cost table is used only to get the max budget available which is not dependent on
 // the gas price
-static MAX_GAS_BUDGET: Lazy<u64> = Lazy::new(|| ProtocolConfig::get_for_max_version().max_tx_gas());
+static MAX_GAS_BUDGET: Lazy<u64> =
+    Lazy::new(|| ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas());
 // MIN_GAS_BUDGET_PRE_RGP has to be multiplied by the RGP to get the proper minimum
 static MIN_GAS_BUDGET_PRE_RGP: Lazy<u64> =
-    Lazy::new(|| ProtocolConfig::get_for_max_version().base_tx_cost_fixed());
+    Lazy::new(|| ProtocolConfig::get_for_max_version_UNSAFE().base_tx_cost_fixed());
 
 #[tokio::test]
 async fn test_tx_less_than_minimum_gas_budget() {
@@ -756,7 +757,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
 
     // Create a transaction with budget DELTA less than the gas cost required.
     let total_gas_used = gas_cost.net_gas_usage() as u64;
-    let config = ProtocolConfig::get_for_max_version();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let delta: u64 =
         gas_size as u64 * config.obj_data_cost_refundable() * config.storage_gas_price() + 1000;
     let budget = if delta < total_gas_used {

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -104,7 +104,7 @@ fn test_upgraded() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -132,7 +132,7 @@ fn test_depending_on_upgrade() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -157,7 +157,7 @@ fn test_upgrade_upgrades_linkage() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -169,7 +169,7 @@ fn test_upgrade_upgrades_linkage() {
         .new_upgraded(
             b_id2,
             &build_test_modules("B"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [&c_new],
         )
         .unwrap();
@@ -199,7 +199,7 @@ fn test_upgrade_linkage_digest_to_new_dep() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -211,7 +211,7 @@ fn test_upgrade_linkage_digest_to_new_dep() {
         .new_upgraded(
             b_id2,
             &build_test_modules("B"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [&c_new],
         )
         .unwrap();
@@ -253,7 +253,7 @@ fn test_upgrade_downngrades_linkage() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -265,7 +265,7 @@ fn test_upgrade_downngrades_linkage() {
         .new_upgraded(
             b_id2,
             &build_test_modules("B"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [&c_pkg],
         )
         .unwrap();
@@ -295,7 +295,7 @@ fn test_transitively_depending_on_upgrade() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -324,7 +324,7 @@ fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -384,7 +384,7 @@ fn test_fail_on_transitive_dependency_downgrade() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv2"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap();
@@ -409,7 +409,7 @@ fn test_fail_on_upgrade_missing_type() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv1"),
-            &ProtocolConfig::get_for_max_version(),
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
             [],
         )
         .unwrap_err();

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -270,7 +270,7 @@ async fn test_upgrade_package_happy_path() {
         .get_package(&runner.package.0)
         .unwrap()
         .unwrap();
-    let config = ProtocolConfig::get_for_max_version();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let normalized_modules = package
         .normalize(
             config.move_binary_format_version(),

--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -29,13 +29,13 @@ fn test_protocol_overrides() {
     });
 
     assert_eq!(
-        ProtocolConfig::get_for_max_version().max_function_definitions(),
+        ProtocolConfig::get_for_max_version_UNSAFE().max_function_definitions(),
         42
     );
 }
 
 // Same as the previous test, to ensure we have test isolation with all the caching that
-// happens in get_for_min_version/get_for_max_version.
+// happens in get_for_min_version/get_for_max_version_UNSAFE.
 #[test]
 fn test_protocol_overrides_2() {
     telemetry_subscribers::init_for_testing();
@@ -46,7 +46,7 @@ fn test_protocol_overrides_2() {
     });
 
     assert_eq!(
-        ProtocolConfig::get_for_max_version().max_function_definitions(),
+        ProtocolConfig::get_for_max_version_UNSAFE().max_function_definitions(),
         43
     );
 }

--- a/crates/sui-framework-tests/src/metered_verifier.rs
+++ b/crates/sui-framework-tests/src/metered_verifier.rs
@@ -21,7 +21,7 @@ fn test_metered_move_bytecode_verifier() {
     let compiled_modules: Vec<_> = compiled_package.get_modules().cloned().collect();
 
     let mut metered_verifier_config = default_verifier_config(
-        &ProtocolConfig::get_for_max_version(),
+        &ProtocolConfig::get_for_max_version_UNSAFE(),
         true, /* enable metering */
     );
     let registry = &Registry::new();
@@ -213,7 +213,7 @@ fn test_metered_move_bytecode_verifier() {
     packages.push(package.get_dependency_sorted_modules(with_unpublished_deps));
 
     let is_metered = true;
-    let protocol_config = ProtocolConfig::get_for_max_version();
+    let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
     let metered_verifier_config = default_verifier_config(&protocol_config, is_metered);
 
     // Check if the same meter is indeed used multiple invocations of the verifier
@@ -241,7 +241,7 @@ fn test_meter_system_packages() {
 
     let is_metered = true;
     let metered_verifier_config =
-        default_verifier_config(&ProtocolConfig::get_for_max_version(), is_metered);
+        default_verifier_config(&ProtocolConfig::get_for_max_version_UNSAFE(), is_metered);
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
@@ -305,7 +305,7 @@ fn test_build_and_verify_programmability_examples() {
 
     let is_metered = true;
     let metered_verifier_config =
-        default_verifier_config(&ProtocolConfig::get_for_max_version(), is_metered);
+        default_verifier_config(&ProtocolConfig::get_for_max_version_UNSAFE(), is_metered);
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let examples =

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -45,7 +45,7 @@ struct Args {
 }
 
 fn main() {
-    // Ensure that a validator never calls get_for_min_version/get_for_max_version.
+    // Ensure that a validator never calls get_for_min_version/get_for_max_version_UNSAFE.
     // TODO: re-enable after we figure out how to eliminate crashes in prod because of this.
     // ProtocolConfig::poison_get_for_min_version();
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -899,11 +899,19 @@ impl ProtocolConfig {
         ProtocolConfig::get_for_version(ProtocolVersion::MIN, Chain::Unknown)
     }
 
+    /// CAREFUL! - You probably want to use `get_for_version` instead.
+    ///
     /// Convenience to get the constants at the current maximum supported version.
-    /// Mainly used by genesis.
-    pub fn get_for_max_version() -> Self {
+    /// Mainly used by genesis. Note well that this function uses the max version
+    /// supported locally by the node, which is not necessarily the current version
+    /// of the network. ALSO, this function disregards chain specific config (by
+    /// using Chain::Unknown), thereby potentially returning a protocol config that
+    /// is incorrect for some feature flags. Definitely safe for testing and for
+    /// protocol version 11 and prior.
+    #[allow(non_snake_case)]
+    pub fn get_for_max_version_UNSAFE() -> Self {
         if Self::load_poison_get_for_min_version() {
-            panic!("get_for_max_version called on validator");
+            panic!("get_for_max_version_UNSAFE called on validator");
         }
         ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown)
     }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1888,7 +1888,7 @@ pub fn get_executor(
     let protocol_config = executor_version_override
         .map(|q| {
             let ver = if q < 0 {
-                ProtocolConfig::get_for_max_version().execution_version()
+                ProtocolConfig::get_for_max_version_UNSAFE().execution_version()
             } else {
                 q as u64
             };

--- a/crates/sui-snapshot/src/tests.rs
+++ b/crates/sui-snapshot/src/tests.rs
@@ -67,6 +67,7 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
         directory: Some(remote),
         ..Default::default()
     };
+
     let snapshot_writer = StateSnapshotWriterV1::new(
         &local_store_config,
         &remote_store_config,
@@ -119,7 +120,7 @@ async fn test_snapshot_empty_db() -> Result<(), anyhow::Error> {
         ..Default::default()
     };
     let include_wrapped_tombstone =
-        !ProtocolConfig::get_for_max_version().simplified_unwrap_then_delete();
+        !ProtocolConfig::get_for_max_version_UNSAFE().simplified_unwrap_then_delete();
     let snapshot_writer = StateSnapshotWriterV1::new(
         &local_store_config,
         &remote_store_config,

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -261,7 +261,7 @@ impl SurferState {
     async fn discover_entry_functions(&self, package: Object) {
         let package_id = package.id();
         let move_package = package.data.try_into_package().unwrap();
-        let config = ProtocolConfig::get_for_max_version();
+        let config = ProtocolConfig::get_for_max_version_UNSAFE();
         let entry_functions: Vec<_> = move_package
             .normalize(
                 config.move_binary_format_version(),

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -261,7 +261,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let mut protocol_config = if let Some(protocol_version) = protocol_version {
                     ProtocolConfig::get_for_version(protocol_version.into(), Chain::Unknown)
                 } else {
-                    ProtocolConfig::get_for_max_version()
+                    ProtocolConfig::get_for_max_version_UNSAFE()
                 };
                 if let Some(mx_tx_gas_override) = max_gas {
                     protocol_config.set_max_tx_gas_for_testing(mx_tx_gas_override)
@@ -271,7 +271,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             None => (
                 BTreeMap::new(),
                 BTreeSet::new(),
-                ProtocolConfig::get_for_max_version(),
+                ProtocolConfig::get_for_max_version_UNSAFE(),
             ),
         };
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -724,7 +724,7 @@ impl Object {
         Self::new_package(
             modules,
             previous_transaction,
-            ProtocolConfig::get_for_max_version().max_move_package_size(),
+            ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
             &dependencies,
         )
     }

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -346,7 +346,7 @@ fn test_move_package_size_for_gas_metering() {
     let package = Object::new_package(
         &[module],
         TransactionDigest::genesis(),
-        ProtocolConfig::get_for_max_version().max_move_package_size(),
+        ProtocolConfig::get_for_max_version_UNSAFE().max_move_package_size(),
         &[], // empty dependencies for empty package (no modules)
     )
     .unwrap();

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -811,7 +811,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     let pt = {
@@ -831,7 +831,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     let pt = {
@@ -841,7 +841,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     // Pay
@@ -858,7 +858,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     // TransferSui
@@ -869,7 +869,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     // PaySui
@@ -880,7 +880,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data.clone())
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 
     // PayAllSui
@@ -891,7 +891,7 @@ fn test_sponsored_transaction_validity_check() {
     };
     let kind = TransactionKind::programmable(pt);
     TransactionData::new_with_gas_data(kind, sender, gas_data)
-        .validity_check(&ProtocolConfig::get_for_max_version())
+        .validity_check(&ProtocolConfig::get_for_max_version_UNSAFE())
         .unwrap();
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -770,7 +770,7 @@ impl SuiClientCommands {
                 package_path,
                 build_config,
             } => {
-                let protocol_config = ProtocolConfig::get_for_max_version();
+                let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
                 let registry = &Registry::new();
                 let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
 

--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -32,7 +32,8 @@ const P2P_SUCCESS_STORAGE_USAGE: u64 = 1976000;
 const P2P_FAILURE_STORAGE_USAGE: u64 = 988000;
 const INSUFFICIENT_GAS_UNITS_THRESHOLD: u64 = 2;
 
-static PROTOCOL_CONFIG: Lazy<ProtocolConfig> = Lazy::new(ProtocolConfig::get_for_max_version);
+static PROTOCOL_CONFIG: Lazy<ProtocolConfig> =
+    Lazy::new(ProtocolConfig::get_for_max_version_UNSAFE);
 
 /// Represents a peer-to-peer transaction performed in the account universe.
 ///

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -85,8 +85,8 @@ fn generate_random_gas_data(
         gas_data: GasData {
             payment: object_refs,
             owner: sender,
-            price: rng.gen_range(0..=ProtocolConfig::get_for_max_version().max_gas_price()),
-            budget: rng.gen_range(0..=ProtocolConfig::get_for_max_version().max_tx_gas()),
+            price: rng.gen_range(0..=ProtocolConfig::get_for_max_version_UNSAFE().max_gas_price()),
+            budget: rng.gen_range(0..=ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas()),
         },
         objects: gas_objects,
         sender_key,
@@ -110,16 +110,16 @@ pub struct GasDataGenConfig {
 impl GasDataGenConfig {
     pub fn owned_by_sender_or_immut() -> Self {
         Self {
-            max_num_gas_objects: ProtocolConfig::get_for_max_version().max_gas_payment_objects()
-                as usize,
+            max_num_gas_objects: ProtocolConfig::get_for_max_version_UNSAFE()
+                .max_gas_payment_objects() as usize,
             owned_by_sender: true,
         }
     }
 
     pub fn any_owner() -> Self {
         Self {
-            max_num_gas_objects: ProtocolConfig::get_for_max_version().max_gas_payment_objects()
-                as usize,
+            max_num_gas_objects: ProtocolConfig::get_for_max_version_UNSAFE()
+                .max_gas_payment_objects() as usize,
             owned_by_sender: false,
         }
     }

--- a/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
+++ b/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
@@ -12,7 +12,8 @@ use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{Argument, CallArg, Command, ProgrammableTransaction};
 
-static PROTOCOL_CONFIG: Lazy<ProtocolConfig> = Lazy::new(ProtocolConfig::get_for_max_version);
+static PROTOCOL_CONFIG: Lazy<ProtocolConfig> =
+    Lazy::new(ProtocolConfig::get_for_max_version_UNSAFE);
 
 prop_compose! {
     pub fn gen_transfer()


### PR DESCRIPTION
## Description 

See main comment in `crates/sui-protocol-config/src/lib.rs` for reasons. This is currently in use in places that it shouldn't be. Migration will take more work, but for now, this should stop new incorrect usage.

## Test Plan 

`cargo build`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
