### PR TITLE
Remove usage of Session from adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9311,6 +9311,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "leb128",
+ "linked-hash-map",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -16,6 +16,7 @@ use move_binary_format::access::ModuleAccess;
 use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::file_format::CompiledModule;
 use move_binary_format::normalized;
+use move_core_types::language_storage::ModuleId;
 use move_core_types::{
     account_address::AccountAddress,
     ident_str,
@@ -380,6 +381,19 @@ impl MovePackage {
             type_origin_table,
             linkage_table,
         )
+    }
+
+    // Retrieve the module with `ModuleId` in the given package.
+    // The module must be the `storage_id` or the call will return `None`.
+    // Check if the address of the module is the same of the package
+    // and return `None` if that is not the case.
+    // All modules in a package share the address with the package.
+    pub fn get_module(&self, storage_id: &ModuleId) -> Option<&Vec<u8>> {
+        if self.id != ObjectID::from(*storage_id.address()) {
+            None
+        } else {
+            self.module_map.get(&storage_id.name().to_string())
+        }
     }
 
     /// Return the size of the package in bytes

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -680,6 +680,10 @@ impl Object {
     }
 
     // Note: this will panic if `modules` is empty
+    pub fn new_from_package(package: MovePackage, previous_transaction: TransactionDigest) -> Self {
+        Self::new_package_from_data(Data::Package(package), previous_transaction)
+    }
+
     pub fn new_package<'p>(
         modules: &[CompiledModule],
         previous_transaction: TransactionDigest,

--- a/external-crates/move/move-vm/runtime/src/lib.rs
+++ b/external-crates/move/move-vm/runtime/src/lib.rs
@@ -17,7 +17,7 @@ pub mod logging;
 pub mod move_vm;
 pub mod native_extensions;
 pub mod native_functions;
-mod runtime;
+pub mod runtime;
 pub mod session;
 #[macro_use]
 mod tracing;

--- a/external-crates/move/move-vm/runtime/src/move_vm.rs
+++ b/external-crates/move/move-vm/runtime/src/move_vm.rs
@@ -101,4 +101,8 @@ impl MoveVM {
     pub fn get_module_metadata(&self, module: ModuleId, key: &[u8]) -> Option<Metadata> {
         self.runtime.loader().get_metadata(module, key)
     }
+
+    pub fn get_runtime(&self) -> &VMRuntime {
+        &self.runtime
+    }
 }

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 anyhow = { workspace = true, features = ["backtrace"] }
 bcs.workspace = true
 leb128.workspace = true
+linked-hash-map.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -6,27 +6,41 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
     use std::{
+        borrow::Borrow,
         collections::{BTreeMap, BTreeSet, HashMap},
         sync::Arc,
     };
 
     use crate::adapter::new_native_extensions;
     use crate::error::convert_vm_error;
+    use linked_hash_map::LinkedHashMap;
+    use move_binary_format::errors::{PartialVMError, PartialVMResult};
     use move_binary_format::{
         errors::{Location, VMError, VMResult},
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
         CompiledModule,
     };
+    use move_core_types::gas_algebra::NumBytes;
+    use move_core_types::resolver::ModuleResolver;
+    use move_core_types::value::MoveTypeLayout;
+    use move_core_types::vm_status::StatusCode;
     use move_core_types::{
         account_address::AccountAddress,
+        identifier::IdentStr,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
     #[cfg(debug_assertions)]
     use move_vm_profiler::GasProfiler;
-    use move_vm_runtime::{move_vm::MoveVM, session::Session};
+    use move_vm_runtime::native_extensions::NativeContextExtensions;
+    use move_vm_runtime::{
+        move_vm::MoveVM,
+        session::{LoadedFunctionInstantiation, SerializedReturnValues},
+    };
+    use move_vm_types::data_store::DataStore;
     #[cfg(debug_assertions)]
     use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
+    use move_vm_types::values::{GlobalValue, Value as VMValue};
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
     };
@@ -45,8 +59,7 @@ mod checked {
         move_package::MovePackage,
         object::{Data, MoveObject, Object, Owner},
         storage::{
-            BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
-            ObjectChange, WriteKind,
+            BackingPackageStore, DeleteKind, DeleteKindWithOldVersion, ObjectChange, WriteKind,
         },
         transaction::{Argument, CallArg, ObjectArg},
         type_resolver::TypeTagResolver,
@@ -58,7 +71,7 @@ mod checked {
         execution_status::CommandArgumentError,
     };
 
-    use crate::programmable_transactions::linkage_view::{LinkageView, SavedLinkage};
+    use crate::programmable_transactions::linkage_view::LinkageView;
 
     /// Maintains all runtime state specific to programmable transactions
     pub struct ExecutionContext<'vm, 'state, 'a> {
@@ -68,6 +81,9 @@ mod checked {
         pub metrics: Arc<LimitsMetrics>,
         /// The MoveVM
         pub vm: &'vm MoveVM,
+        /// The LinkageView for this session
+        pub linkage_view: LinkageView<'state>,
+        pub native_extensions: NativeContextExtensions<'state>,
         /// The global state, used for resolving packages
         pub state_view: &'state dyn ExecutionState,
         /// A shared transaction context, contains transaction digest information and manages the
@@ -75,12 +91,10 @@ mod checked {
         pub tx_context: &'a mut TxContext,
         /// The gas charger used for metering
         pub gas_charger: &'a mut GasCharger,
-        /// The session used for interacting with Move types and calls
-        pub session: Session<'state, 'vm, LinkageView<'state>>,
         /// Additional transfers not from the Move runtime
         additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
         /// Newly published packages
-        new_packages: Vec<Object>,
+        new_packages: LinkedHashMap<ObjectID, MovePackage>,
         /// User events are claimed after each Move call
         user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
         // runtime data
@@ -119,18 +133,7 @@ mod checked {
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
         ) -> Result<Self, ExecutionError> {
-            // we need a new session just for loading types, which is sad
-            // TODO remove this
-            let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
-            let mut tmp_session = new_session(
-                vm,
-                linkage,
-                state_view.as_child_resolver(),
-                BTreeMap::new(),
-                !gas_charger.is_unmetered(),
-                protocol_config,
-                metrics.clone(),
-            );
+            let mut linkage_view = LinkageView::new(Box::new(state_view.as_sui_resolver()));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()
@@ -138,7 +141,8 @@ mod checked {
                     load_call_arg(
                         vm,
                         state_view,
-                        &mut tmp_session,
+                        &mut linkage_view,
+                        &LinkedHashMap::new(),
                         &mut input_object_map,
                         call_arg,
                     )
@@ -148,7 +152,8 @@ mod checked {
                 let mut gas = load_object(
                     vm,
                     state_view,
-                    &mut tmp_session,
+                    &mut linkage_view,
+                    &LinkedHashMap::new(),
                     &mut input_object_map,
                     /* imm override */ false,
                     gas_coin,
@@ -180,17 +185,7 @@ mod checked {
                     },
                 }
             };
-            // the session was just used for ability and layout metadata fetching, no changes should
-            // exist. Plus, Sui Move does not use these changes or events
-            let (res, linkage) = tmp_session.finish();
-            let (change_set, move_events) =
-                res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
-            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-            assert_invariant!(move_events.is_empty(), "Events must be empty");
-            // make the real session
-            let session = new_session(
-                vm,
-                linkage,
+            let native_extensions = new_native_extensions(
                 state_view.as_child_resolver(),
                 input_object_map,
                 !gas_charger.is_unmetered(),
@@ -218,24 +213,29 @@ mod checked {
                 protocol_config,
                 metrics,
                 vm,
+                linkage_view,
+                native_extensions,
                 state_view,
                 tx_context,
                 gas_charger,
-                session,
                 gas,
                 inputs,
                 results: vec![],
                 additional_transfers: vec![],
-                new_packages: vec![],
+                new_packages: LinkedHashMap::new(),
                 user_events: vec![],
                 borrowed: HashMap::new(),
             })
         }
 
+        pub fn object_runtime(&mut self) -> &ObjectRuntime {
+            self.native_extensions.get()
+        }
+
         /// Create a new ID and update the state
         pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
             let object_id = self.tx_context.fresh_id();
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             object_runtime
                 .new_id(object_id)
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
@@ -244,7 +244,7 @@ mod checked {
 
         /// Delete an ID and update the state
         pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             object_runtime
                 .delete_id(object_id)
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
@@ -256,49 +256,38 @@ mod checked {
             &mut self,
             package_id: ObjectID,
         ) -> Result<AccountAddress, ExecutionError> {
-            let resolver = self.session.get_resolver();
-            if resolver.has_linkage(package_id) {
+            if self.linkage_view.has_linkage(package_id) {
                 // Setting same context again, can skip.
-                return Ok(resolver.original_package_id().unwrap_or(*package_id));
+                return Ok(self
+                    .linkage_view
+                    .original_package_id()
+                    .unwrap_or(*package_id));
             }
 
-            let package = package_for_linkage(&self.session, package_id)
+            let package = package_for_linkage(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            set_linkage(&mut self.session, &package)
-        }
-
-        /// Set the link context for the session from the linkage information in the `package`.  Returns
-        /// the runtime ID of the link context package on success.
-        pub fn set_linkage(
-            &mut self,
-            package: &MovePackage,
-        ) -> Result<AccountAddress, ExecutionError> {
-            set_linkage(&mut self.session, package)
-        }
-
-        /// Turn off linkage information, so that the next use of the session will need to set linkage
-        /// information to succeed.
-        pub fn reset_linkage(&mut self) {
-            reset_linkage(&mut self.session);
-        }
-
-        /// Reset the linkage context, and save it (if one exists)
-        pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
-            steal_linkage(&mut self.session)
-        }
-
-        /// Restore a previously stolen/saved link context.
-        pub fn restore_linkage(
-            &mut self,
-            saved: Option<SavedLinkage>,
-        ) -> Result<(), ExecutionError> {
-            restore_linkage(&mut self.session, saved)
+            self.linkage_view.set_linkage(&package)
         }
 
         /// Load a type using the context's current session.
         pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
-            load_type(&mut self.session, type_tag)
+            load_type(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                type_tag,
+            )
+        }
+
+        /// Load a type using the context's current session.
+        pub fn load_type_from_struct(&mut self, struct_tag: &StructTag) -> VMResult<Type> {
+            load_type_from_struct(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                struct_tag,
+            )
         }
 
         /// Takes the user events from the runtime and tags them with the Move module of the function
@@ -309,7 +298,7 @@ mod checked {
             function: FunctionDefinitionIndex,
             last_offset: CodeOffset,
         ) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             let events = object_runtime.take_user_events();
             let num_events = self.user_events.len() + events.len();
             let max_events = self.protocol_config.max_num_event_emit();
@@ -323,7 +312,8 @@ mod checked {
                 .into_iter()
                 .map(|(ty, tag, value)| {
                     let layout = self
-                        .session
+                        .vm
+                        .get_runtime()
                         .type_to_type_layout(&ty)
                         .map_err(|e| self.convert_vm_error(e))?;
                     let Some(bytes) = value.simple_serialize(&layout) else {
@@ -476,7 +466,7 @@ mod checked {
             assert_invariant!(
                 was_mut_opt.is_some() && was_mut_opt.unwrap(),
                 "Should never restore a non-mut borrowed value. \
-            The take+restore is an implementation detail of mutable references"
+                The take+restore is an implementation detail of mutable references"
             );
             // restore is exclusively used for mut
             let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
@@ -486,7 +476,7 @@ mod checked {
             assert_invariant!(
                 old_value.is_none() || old_value.unwrap().is_copyable(),
                 "Should never restore a non-taken value, unless it is copyable. \
-            The take+restore is an implementation detail of mutable references"
+                The take+restore is an implementation detail of mutable references"
             );
             Ok(())
         }
@@ -506,10 +496,9 @@ mod checked {
             &self,
             modules: &[CompiledModule],
             dependencies: impl IntoIterator<Item = &'p MovePackage>,
-        ) -> Result<Object, ExecutionError> {
-            Object::new_package(
+        ) -> Result<MovePackage, ExecutionError> {
+            MovePackage::new_initial(
                 modules,
-                self.tx_context.digest(),
                 self.protocol_config.max_move_package_size(),
                 dependencies,
             )
@@ -522,22 +511,26 @@ mod checked {
             previous_package: &MovePackage,
             new_modules: &[CompiledModule],
             dependencies: impl IntoIterator<Item = &'p MovePackage>,
-        ) -> Result<Object, ExecutionError> {
-            Object::new_upgraded_package(
-                previous_package,
+        ) -> Result<MovePackage, ExecutionError> {
+            previous_package.new_upgraded(
                 storage_id,
                 new_modules,
-                self.tx_context.digest(),
                 self.protocol_config,
                 dependencies,
             )
         }
 
         /// Add a newly created package to write as an effect of the transaction
-        pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
-            assert_invariant!(package.is_package(), "Must be a package");
-            self.new_packages.push(package);
-            Ok(())
+        pub fn write_package(&mut self, package: MovePackage) {
+            self.new_packages.insert(package.id(), package);
+        }
+
+        /// Return the last pacakge pushed in `write_package`.
+        /// This function should be used in block of codes that push a pacakge, verify
+        /// it, run the init and in case of error will remove the package.
+        /// The package has to be pushed for the init to run correctly.
+        pub fn remove_package(&mut self, id: ObjectID) -> Option<MovePackage> {
+            self.new_packages.remove(&id)
         }
 
         /// Finish a command: clearing the borrows and adding the results to the result vector
@@ -557,12 +550,11 @@ mod checked {
         pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
             let Self {
                 protocol_config,
-                metrics,
                 vm,
-                state_view,
+                linkage_view,
+                mut native_extensions,
                 tx_context,
                 gas_charger,
-                session,
                 additional_transfers,
                 new_packages,
                 gas,
@@ -634,7 +626,7 @@ mod checked {
                                 } else {
                                     let msg = if abilities.has_copy() {
                                         "The value has copy, but not drop. \
-                                    Its last usage must be by-value so it can be taken."
+                                        Its last usage must be by-value so it can be taken."
                                     } else {
                                         "Unused value without drop"
                                     };
@@ -661,17 +653,7 @@ mod checked {
                 refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
             }
 
-            let (res, linkage) = session.finish_with_extensions();
-            let (change_set, events, mut native_context_extensions) =
-                res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-            // Sui Move programs should never touch global state, so resources should be empty
-            assert_invariant!(
-                change_set.resources().next().is_none(),
-                "Change set must be empty"
-            );
-            // Sui Move no longer uses Move's internal event system
-            assert_invariant!(events.is_empty(), "Events must be empty");
-            let object_runtime: ObjectRuntime = native_context_extensions.remove();
+            let object_runtime: ObjectRuntime = native_extensions.remove();
             let new_ids = object_runtime.new_ids().clone();
             // tell the object runtime what input objects were taken and which were transferred
             let external_transfers = additional_writes.keys().copied().collect();
@@ -686,22 +668,12 @@ mod checked {
                 "Events should be taken after every Move call"
             );
             let mut object_changes = BTreeMap::new();
-            for package in new_packages {
-                let id = package.id();
-                let change = ObjectChange::Write(package, WriteKind::Create);
+            for (_, package) in new_packages {
+                let package_obj = Object::new_from_package(package, tx_digest);
+                let id = package_obj.id();
+                let change = ObjectChange::Write(package_obj, WriteKind::Create);
                 object_changes.insert(id, change);
             }
-            // we need a new session just for deserializing and fetching abilities. Which is sad
-            // TODO remove this
-            let tmp_session = new_session(
-                vm,
-                linkage,
-                state_view.as_child_resolver(),
-                BTreeMap::new(),
-                !gas_charger.is_unmetered(),
-                protocol_config,
-                metrics,
-            );
             for (id, additional_write) in additional_writes {
                 let AdditionalWrite {
                     recipient,
@@ -726,7 +698,7 @@ mod checked {
                 let move_object = unsafe {
                     create_written_object(
                         vm,
-                        &tmp_session,
+                        &linkage_view,
                         protocol_config,
                         &input_object_metadata,
                         &loaded_child_objects,
@@ -743,13 +715,15 @@ mod checked {
             }
 
             for (id, (write_kind, recipient, ty, value)) in writes {
-                let abilities = tmp_session
+                let abilities = vm
+                    .get_runtime()
                     .get_type_abilities(&ty)
-                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                    .map_err(|e| convert_vm_error(e, vm, &linkage_view))?;
                 let has_public_transfer = abilities.has_store();
-                let layout = tmp_session
+                let layout = vm
+                    .get_runtime()
                     .type_to_type_layout(&ty)
-                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                    .map_err(|e| convert_vm_error(e, vm, &linkage_view))?;
                 let Some(bytes) = value.simple_serialize(&layout) else {
                     invariant_violation!("Failed to deserialize already serialized Move value");
                 };
@@ -757,7 +731,7 @@ mod checked {
                 let move_object = unsafe {
                     create_written_object(
                         vm,
-                        &tmp_session,
+                        &linkage_view,
                         protocol_config,
                         &input_object_metadata,
                         &loaded_child_objects,
@@ -804,14 +778,6 @@ mod checked {
                 object_changes.insert(id, ObjectChange::Delete(delete_kind_with_seq));
             }
 
-            let (res, linkage) = tmp_session.finish();
-            let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-
-            // the session was just used for ability and layout metadata fetching, no changes should
-            // exist. Plus, Sui Move does not use these changes or events
-            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-            assert_invariant!(move_events.is_empty(), "Events must be empty");
-
             Ok(ExecutionResults {
                 object_changes,
                 user_events,
@@ -820,7 +786,7 @@ mod checked {
 
         /// Convert a VM Error to an execution one
         pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-            crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
+            crate::error::convert_vm_error(error, self.vm, &self.linkage_view)
         }
 
         /// Special case errors for type arguments to Move functions
@@ -877,8 +843,8 @@ mod checked {
                 Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
                 Argument::Input(i) => {
                     let Some(input_value) = self.inputs.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
+                        return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                    };
                     (input_value.object_metadata.as_ref(), &mut input_value.inner)
                 }
                 Argument::Result(i) => {
@@ -908,80 +874,96 @@ mod checked {
             }
             Ok((metadata, &mut result_value.value))
         }
+
+        pub(crate) fn execute_function_bypass_visibility(
+            &mut self,
+            module: &ModuleId,
+            function_name: &IdentStr,
+            ty_args: Vec<Type>,
+            args: Vec<impl Borrow<[u8]>>,
+        ) -> VMResult<SerializedReturnValues> {
+            let gas_status = self.gas_charger.move_gas_status_mut();
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().execute_function_bypass_visibility(
+                module,
+                function_name,
+                ty_args,
+                args,
+                &mut data_store,
+                gas_status,
+                &mut self.native_extensions,
+            )
+        }
+
+        pub(crate) fn load_function(
+            &mut self,
+            module_id: &ModuleId,
+            function_name: &IdentStr,
+            type_arguments: &[Type],
+        ) -> VMResult<LoadedFunctionInstantiation> {
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().load_function(
+                module_id,
+                function_name,
+                type_arguments,
+                &mut data_store,
+            )
+        }
+
+        pub(crate) fn make_object_value(
+            &mut self,
+            type_: MoveObjectType,
+            has_public_transfer: bool,
+            used_in_non_entry_move_call: bool,
+            contents: &[u8],
+        ) -> Result<ObjectValue, ExecutionError> {
+            make_object_value(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                type_,
+                has_public_transfer,
+                used_in_non_entry_move_call,
+                contents,
+            )
+        }
+
+        pub fn publish_module_bundle(
+            &mut self,
+            modules: Vec<Vec<u8>>,
+            sender: AccountAddress,
+        ) -> VMResult<()> {
+            // TODO: publish_module_bundle() currently doesn't charge gas.
+            // Do we want to charge there?
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().publish_module_bundle(
+                modules,
+                sender,
+                &mut data_store,
+                self.gas_charger.move_gas_status_mut(),
+            )
+        }
     }
 
     impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
         fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
-            self.session
+            self.vm
+                .get_runtime()
                 .get_type_tag(type_)
                 .map_err(|e| self.convert_vm_error(e))
         }
     }
 
-    pub(crate) fn new_session<'state, 'vm>(
-        vm: &'vm MoveVM,
-        linkage: LinkageView<'state>,
-        child_resolver: &'state dyn ChildObjectResolver,
-        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-        is_metered: bool,
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-    ) -> Session<'state, 'vm, LinkageView<'state>> {
-        vm.new_session_with_extensions(
-            linkage,
-            new_native_extensions(
-                child_resolver,
-                input_objects,
-                is_metered,
-                protocol_config,
-                metrics,
-            ),
-        )
-    }
-
-    // Create a new Session suitable for resolving type and type operations rather than execution
-    pub(crate) fn new_session_for_linkage<'vm, 'state>(
-        vm: &'vm MoveVM,
-        linkage: LinkageView<'state>,
-    ) -> Session<'state, 'vm, LinkageView<'state>> {
-        vm.new_session(linkage)
-    }
-
-    /// Set the link context for the session from the linkage information in the `package`.
-    pub fn set_linkage(
-        session: &mut Session<LinkageView>,
-        linkage: &MovePackage,
-    ) -> Result<AccountAddress, ExecutionError> {
-        session.get_resolver_mut().set_linkage(linkage)
-    }
-
-    /// Turn off linkage information, so that the next use of the session will need to set linkage
-    /// information to succeed.
-    pub fn reset_linkage(session: &mut Session<LinkageView>) {
-        session.get_resolver_mut().reset_linkage();
-    }
-
-    pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
-        session.get_resolver_mut().steal_linkage()
-    }
-
-    pub fn restore_linkage(
-        session: &mut Session<LinkageView>,
-        saved: Option<SavedLinkage>,
-    ) -> Result<(), ExecutionError> {
-        session.get_resolver_mut().restore_linkage(saved)
-    }
-
     /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
     /// if the object at that ID does not exist, or is not a package.
     fn package_for_linkage(
-        session: &Session<LinkageView>,
+        linkage_view: &LinkageView,
         package_id: ObjectID,
     ) -> VMResult<MovePackage> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
-        match session.get_resolver().get_package(&package_id) {
+        match linkage_view.get_package(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
@@ -994,16 +976,75 @@ mod checked {
         }
     }
 
-    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
-    /// reset after this operation, because during the operation, it may change when loading a struct.
-    pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
-        use move_binary_format::errors::PartialVMError;
-        use move_core_types::vm_status::StatusCode;
-
+    pub fn load_type_from_struct(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
+        struct_tag: &StructTag,
+    ) -> VMResult<Type> {
         fn verification_error<T>(code: StatusCode) -> VMResult<T> {
             Err(PartialVMError::new(code).finish(Location::Undefined))
         }
 
+        let StructTag {
+            address,
+            module,
+            name,
+            type_params,
+        } = struct_tag;
+
+        // Load the package that the struct is defined in, in storage
+        let defining_id = ObjectID::from_address(*address);
+        let package = package_for_linkage(linkage_view, defining_id)?;
+
+        // Set the defining package as the link context while loading the
+        // struct
+        let original_address = linkage_view.set_linkage(&package).map_err(|e| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message(e.to_string())
+                .finish(Location::Undefined)
+        })?;
+
+        let runtime_id = ModuleId::new(original_address, module.clone());
+        let data_store = SuiDataStore::new(linkage_view, new_packages);
+        let res = vm.get_runtime().load_struct(&runtime_id, name, &data_store);
+        linkage_view.reset_linkage();
+        let (idx, struct_type) = res?;
+
+        // Recursively load type parameters, if necessary
+        let type_param_constraints = struct_type.type_param_constraints();
+        if type_param_constraints.len() != type_params.len() {
+            return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
+        }
+
+        if type_params.is_empty() {
+            Ok(Type::Struct(idx))
+        } else {
+            let loaded_type_params = type_params
+                .iter()
+                .map(|type_param| load_type(vm, linkage_view, new_packages, type_param))
+                .collect::<VMResult<Vec<_>>>()?;
+
+            // Verify that the type parameter constraints on the struct are met
+            for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
+                let abilities = vm.get_runtime().get_type_abilities(param)?;
+                if !constraint.is_subset(abilities) {
+                    return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
+                }
+            }
+
+            Ok(Type::StructInstantiation(idx, loaded_type_params))
+        }
+    }
+
+    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
+    /// reset after this operation, because during the operation, it may change when loading a struct.
+    pub fn load_type(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
+        type_tag: &TypeTag,
+    ) -> VMResult<Type> {
         Ok(match type_tag {
             TypeTag::Bool => Type::Bool,
             TypeTag::U8 => Type::U8,
@@ -1015,63 +1056,19 @@ mod checked {
             TypeTag::Address => Type::Address,
             TypeTag::Signer => Type::Signer,
 
-            TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
+            TypeTag::Vector(inner) => {
+                Type::Vector(Box::new(load_type(vm, linkage_view, new_packages, inner)?))
+            }
             TypeTag::Struct(struct_tag) => {
-                let StructTag {
-                    address,
-                    module,
-                    name,
-                    type_params,
-                } = struct_tag.as_ref();
-
-                // Load the package that the struct is defined in, in storage
-                let defining_id = ObjectID::from_address(*address);
-                let package = package_for_linkage(session, defining_id)?;
-
-                // Set the defining package as the link context on the session while loading the
-                // struct
-                let original_address = set_linkage(session, &package).map_err(|e| {
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(e.to_string())
-                        .finish(Location::Undefined)
-                })?;
-
-                let runtime_id = ModuleId::new(original_address, module.clone());
-                let res = session.load_struct(&runtime_id, name);
-                reset_linkage(session);
-                let (idx, struct_type) = res?;
-
-                // Recursively load type parameters, if necessary
-                let type_param_constraints = struct_type.type_param_constraints();
-                if type_param_constraints.len() != type_params.len() {
-                    return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
-                }
-
-                if type_params.is_empty() {
-                    Type::Struct(idx)
-                } else {
-                    let loaded_type_params = type_params
-                        .iter()
-                        .map(|type_param| load_type(session, type_param))
-                        .collect::<VMResult<Vec<_>>>()?;
-
-                    // Verify that the type parameter constraints on the struct are met
-                    for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
-                        let abilities = session.get_type_abilities(param)?;
-                        if !constraint.is_subset(abilities) {
-                            return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
-                        }
-                    }
-
-                    Type::StructInstantiation(idx, loaded_type_params)
-                }
+                return load_type_from_struct(vm, linkage_view, new_packages, struct_tag)
             }
         })
     }
 
-    pub(crate) fn make_object_value<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    pub(crate) fn make_object_value(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
         type_: MoveObjectType,
         has_public_transfer: bool,
         used_in_non_entry_move_call: bool,
@@ -1079,16 +1076,16 @@ mod checked {
     ) -> Result<ObjectValue, ExecutionError> {
         let contents = if type_.is_coin() {
             let Ok(coin) = Coin::from_bcs_bytes(contents) else {
-            invariant_violation!("Could not deserialize a coin")
-        };
+                invariant_violation!("Could not deserialize a coin")
+            };
             ObjectContents::Coin(coin)
         } else {
             ObjectContents::Raw(contents.to_vec())
         };
 
         let tag: StructTag = type_.into();
-        let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
-            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        let type_ = load_type_from_struct(vm, linkage_view, new_packages, &tag)
+            .map_err(|e| crate::error::convert_vm_error(e, vm, linkage_view))?;
         Ok(ObjectValue {
             type_,
             has_public_transfer,
@@ -1097,19 +1094,21 @@ mod checked {
         })
     }
 
-    pub(crate) fn value_from_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    pub(crate) fn value_from_object(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
         object: &Object,
     ) -> Result<ObjectValue, ExecutionError> {
         let Object { data: Data::Move(object), .. } = object else {
-        invariant_violation!("Expected a Move object");
-    };
+            invariant_violation!("Expected a Move object");
+        };
 
         let used_in_non_entry_move_call = false;
         make_object_value(
             vm,
-            session,
+            linkage_view,
+            new_packages,
             object.type_().clone(),
             object.has_public_transfer(),
             used_in_non_entry_move_call,
@@ -1118,18 +1117,19 @@ mod checked {
     }
 
     /// Load an input object from the state_view
-    fn load_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_object(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         override_as_immutable: bool,
         id: ObjectID,
     ) -> Result<InputValue, ExecutionError> {
         let Some(obj) = state_view.read_object(&id) else {
-        // protected by transaction input checker
-        invariant_violation!("Object {} does not exist yet", id);
-    };
+            // protected by transaction input checker
+            invariant_violation!("Object {} does not exist yet", id);
+        };
         // override_as_immutable ==> Owner::Shared
         assert_invariant!(
             !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
@@ -1152,12 +1152,12 @@ mod checked {
             owner,
             version,
         };
-        let obj_value = value_from_object(vm, session, obj)?;
+        let obj_value = value_from_object(vm, linkage_view, new_packages, obj)?;
         let contained_uids = {
-            let fully_annotated_layout =
-                session
-                    .type_to_fully_annotated_layout(&obj_value.type_)
-                    .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+            let fully_annotated_layout = vm
+                .get_runtime()
+                .type_to_fully_annotated_layout(&obj_value.type_)
+                .map_err(|e| convert_vm_error(e, vm, linkage_view))?;
             let mut bytes = vec![];
             obj_value.write_bcs_bytes(&mut bytes);
             match get_all_uids(&fully_annotated_layout, &bytes) {
@@ -1179,26 +1179,33 @@ mod checked {
     }
 
     /// Load an a CallArg, either an object or a raw set of BCS bytes
-    fn load_call_arg<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_call_arg(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         call_arg: CallArg,
     ) -> Result<InputValue, ExecutionError> {
         Ok(match call_arg {
             CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
-            CallArg::Object(obj_arg) => {
-                load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
-            }
+            CallArg::Object(obj_arg) => load_object_arg(
+                vm,
+                state_view,
+                linkage_view,
+                new_packages,
+                input_object_map,
+                obj_arg,
+            )?,
         })
     }
 
     /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-    fn load_object_arg<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_object_arg(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &LinkedHashMap<ObjectID, MovePackage>,
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         obj_arg: ObjectArg,
     ) -> Result<InputValue, ExecutionError> {
@@ -1206,7 +1213,8 @@ mod checked {
             ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
                 vm,
                 state_view,
-                session,
+                linkage_view,
+                new_packages,
                 input_object_map,
                 /* imm override */ false,
                 id,
@@ -1214,7 +1222,8 @@ mod checked {
             ObjectArg::SharedObject { id, mutable, .. } => load_object(
                 vm,
                 state_view,
-                session,
+                linkage_view,
+                new_packages,
                 input_object_map,
                 /* imm override */ !mutable,
                 id,
@@ -1283,9 +1292,9 @@ mod checked {
     ///
     /// This function assumes proper generation of has_public_transfer, either from the abilities of
     /// the StructTag, or from the runtime correctly propagating from the inputs
-    unsafe fn create_written_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &Session<'state, 'vm, LinkageView<'state>>,
+    unsafe fn create_written_object(
+        vm: &MoveVM,
+        linkage_view: &LinkageView,
         protocol_config: &ProtocolConfig,
         input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
         loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
@@ -1310,14 +1319,15 @@ mod checked {
             .map(|metadata| metadata.version)
             .or_else(|| loaded_child_version_opt.copied());
 
+        let type_tag = vm
+            .get_runtime()
+            .get_type_tag(&type_)
+            .map_err(|e| crate::error::convert_vm_error(e, vm, linkage_view))?;
+
         debug_assert!(
             (write_kind == WriteKind::Mutate) == old_obj_ver.is_some(),
-            "Inconsistent state: write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
+            "Inconsistent state for [{type_tag:?}]({id:?}): write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
         );
-
-        let type_tag = session
-            .get_type_tag(&type_)
-            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
 
         let struct_tag = match type_tag {
             TypeTag::Struct(inner) => *inner,
@@ -1330,5 +1340,116 @@ mod checked {
             contents,
             protocol_config,
         )
+    }
+
+    // Implementation of the `DataStore` trait for the Move VM.
+    // When used during execution it may have a list of new packages that have
+    // just been published in the current context. Thos are used for module/type
+    // resolution when executing module init.
+    // It may be created with an empty slice of packages either when no publish/upgrade
+    // are performed or when a type is requested not during execution.
+    pub(crate) struct SuiDataStore<'state, 'a> {
+        linkage_view: &'a LinkageView<'state>,
+        new_packages: &'a LinkedHashMap<ObjectID, MovePackage>,
+    }
+
+    impl<'state, 'a> SuiDataStore<'state, 'a> {
+        pub(crate) fn new(
+            linkage_view: &'a LinkageView<'state>,
+            new_packages: &'a LinkedHashMap<ObjectID, MovePackage>,
+        ) -> Self {
+            Self {
+                linkage_view,
+                new_packages,
+            }
+        }
+
+        fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
+            self.new_packages
+                .get(&ObjectID::from(*module_id.address()))
+                .and_then(|package| package.get_module(module_id))
+        }
+    }
+
+    // TODO: `DataStore` wil be reworked and this is likely to disappear.
+    //       Leaving this comment around until then as testament to better days to come...
+    impl<'state, 'a> DataStore for SuiDataStore<'state, 'a> {
+        fn link_context(&self) -> AccountAddress {
+            self.linkage_view.link_context()
+        }
+
+        fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
+            self.linkage_view.relocate(module_id).map_err(|err| {
+                PartialVMError::new(StatusCode::LINKER_ERROR)
+                    .with_message(format!("Error relocating {module_id}: {err:?}"))
+            })
+        }
+
+        fn defining_module(
+            &self,
+            runtime_id: &ModuleId,
+            struct_: &IdentStr,
+        ) -> PartialVMResult<ModuleId> {
+            self.linkage_view
+                .defining_module(runtime_id, struct_)
+                .map_err(|err| {
+                    PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
+                        "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
+                    ))
+                })
+        }
+
+        fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
+            if let Some(bytes) = self.get_module(module_id) {
+                return Ok(bytes.clone());
+            }
+            match self.linkage_view.get_module(module_id) {
+                Ok(Some(bytes)) => Ok(bytes),
+                Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                    .with_message(format!("Cannot find {:?} in data cache", module_id))
+                    .finish(Location::Undefined)),
+                Err(err) => {
+                    let msg = format!("Unexpected storage error: {:?}", err);
+                    Err(
+                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                            .with_message(msg)
+                            .finish(Location::Undefined),
+                    )
+                }
+            }
+        }
+
+        //
+        // TODO: later we will clean up the interface with the runtime and the functions below
+        //       will likely be exposed via extensions
+        //
+
+        fn load_resource(
+            &mut self,
+            _addr: AccountAddress,
+            _ty: &Type,
+        ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
+            panic!("load_resource should never be called for LinkageView")
+        }
+
+        fn emit_event(
+            &mut self,
+            _guid: Vec<u8>,
+            _seq_num: u64,
+            _ty: Type,
+            _val: VMValue,
+        ) -> PartialVMResult<()> {
+            panic!("emit_event should never be called for LinkageView")
+        }
+
+        fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, VMValue)> {
+            panic!("events should never be called for LinkageView")
+        }
+
+        fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
+            // we cannot panic here because during executon and publishing this is
+            // currently called from the publish flow in the Move runtime
+            Ok(())
+        }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use checked::*;
+
 #[sui_macros::with_checked_arithmetic]
 mod checked {
+    use linked_hash_map::LinkedHashMap;
     use std::{
         collections::{BTreeMap, BTreeSet},
         fmt,
@@ -89,7 +91,7 @@ mod checked {
         let mut mode_results = Mode::empty_results();
         for (idx, command) in commands.into_iter().enumerate() {
             if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
-                let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+                let object_runtime: &ObjectRuntime = context.object_runtime();
                 // We still need to record the loaded child objects for replay
                 let loaded_child_objects = object_runtime.loaded_child_objects();
                 drop(context);
@@ -99,7 +101,7 @@ mod checked {
         }
 
         // Save loaded objects table in case we fail in post execution
-        let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+        let object_runtime: &ObjectRuntime = context.object_runtime();
         // We still need to record the loaded child objects for replay
         let loaded_child_objects = object_runtime.loaded_child_objects();
 
@@ -135,16 +137,17 @@ mod checked {
         let results = match command {
             Command::MakeMoveVec(tag_opt, args) if args.is_empty() => {
                 let Some(tag) = tag_opt else {
-                invariant_violation!(
-                    "input checker ensures if args are empty, there is a type specified"
-                );
-            };
+                    invariant_violation!(
+                        "input checker ensures if args are empty, there is a type specified"
+                    );
+                };
                 let elem_ty = context
                     .load_type(&tag)
                     .map_err(|e| context.convert_vm_error(e))?;
                 let ty = Type::Vector(Box::new(elem_ty));
                 let abilities = context
-                    .session
+                    .vm
+                    .get_runtime()
                     .get_type_abilities(&ty)
                     .map_err(|e| context.convert_vm_error(e))?;
                 // BCS layout for any empty vector should be the same
@@ -188,7 +191,8 @@ mod checked {
                 }
                 let ty = Type::Vector(Box::new(elem_ty));
                 let abilities = context
-                    .session
+                    .vm
+                    .get_runtime()
                     .get_type_abilities(&ty)
                     .map_err(|e| context.convert_vm_error(e))?;
                 vec![Value::Raw(
@@ -217,13 +221,13 @@ mod checked {
             Command::SplitCoins(coin_arg, amount_args) => {
                 let mut obj: ObjectValue = context.borrow_arg_mut(0, coin_arg)?;
                 let ObjectContents::Coin(coin) = &mut obj.contents else {
-                let e = ExecutionErrorKind::command_argument_error(
-                    CommandArgumentError::TypeMismatch,
-                    0,
-                );
-                let msg = "Expected a coin but got an non coin object".to_owned();
-                return Err(ExecutionError::new_with_source(e, msg));
-            };
+                    let e = ExecutionErrorKind::command_argument_error(
+                        CommandArgumentError::TypeMismatch,
+                        0,
+                    );
+                    let msg = "Expected a coin but got an non coin object".to_owned();
+                    return Err(ExecutionError::new_with_source(e, msg));
+                };
                 let split_coins = amount_args
                     .into_iter()
                     .map(|amount_arg| {
@@ -244,13 +248,13 @@ mod checked {
             Command::MergeCoins(target_arg, coin_args) => {
                 let mut target: ObjectValue = context.borrow_arg_mut(0, target_arg)?;
                 let ObjectContents::Coin(target_coin) = &mut target.contents else {
-                let e = ExecutionErrorKind::command_argument_error(
-                    CommandArgumentError::TypeMismatch,
-                    0,
-                );
-                let msg = "Expected a coin but got an non coin object".to_owned();
-                return Err(ExecutionError::new_with_source(e, msg));
-            };
+                    let e = ExecutionErrorKind::command_argument_error(
+                        CommandArgumentError::TypeMismatch,
+                        0,
+                    );
+                    let msg = "Expected a coin but got an non coin object".to_owned();
+                    return Err(ExecutionError::new_with_source(e, msg));
+                };
                 let coins: Vec<ObjectValue> = coin_args
                     .into_iter()
                     .enumerate()
@@ -266,11 +270,11 @@ mod checked {
                         return Err(ExecutionError::new_with_source(e, msg));
                     }
                     let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
-                    invariant_violation!(
-                        "Target coin was a coin, and we already checked for the same type. \
-                        This should be a coin"
-                    );
-                };
+                        invariant_violation!(
+                            "Target coin was a coin, and we already checked for the same type. \
+                            This should be a coin"
+                        );
+                    };
                     context.delete_id(*id.object_id())?;
                     target_coin.add(balance)?;
                 }
@@ -311,7 +315,7 @@ mod checked {
                     /* is_init */ false,
                 );
 
-                context.reset_linkage();
+                context.linkage_view.reset_linkage();
                 return_values?
             }
             Command::Publish(modules, dep_ids) => {
@@ -381,7 +385,7 @@ mod checked {
 
         // save the link context because calls to `make_value` below can set new ones, and we don't want
         // it to be clobbered.
-        let saved_linkage = context.steal_linkage();
+        let saved_linkage = context.linkage_view.steal_linkage();
         // write back mutable inputs. We also update if they were used in non entry Move calls
         // though we do not care for immutable usages of objects or other values
         let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
@@ -398,7 +402,7 @@ mod checked {
             return_value_kinds,
         );
 
-        context.restore_linkage(saved_linkage)?;
+        context.linkage_view.restore_linkage(saved_linkage)?;
         res
     }
 
@@ -441,9 +445,7 @@ mod checked {
             ValueKind::Object {
                 type_,
                 has_public_transfer,
-            } => Value::Object(make_object_value(
-                context.vm,
-                &mut context.session,
+            } => Value::Object(context.make_object_value(
                 type_,
                 has_public_transfer,
                 used_in_non_entry_move_call,
@@ -493,27 +495,30 @@ mod checked {
         // For newly published packages, runtime ID matches storage ID.
         let storage_id = runtime_id;
         let dependencies = fetch_packages(context, &dep_ids)?;
-        let package_obj = context.new_package(&modules, &dependencies)?;
+        let package = context.new_package(&modules, &dependencies)?;
 
-        let Some(package) = package_obj.data.try_as_package() else {
-        invariant_violation!("Newly created package object is not a package");
-    };
-
-        context.set_linkage(package)?;
+        // Here we optimistacally push the package that is being published/upgraded
+        // and if there is an error of any kind (verification or module init) we
+        // remove it.
+        // The call to `pop_last_package` later is fine because we cannot re-enter and
+        // the last package we pushed is the one we are verifying and running the init from
+        context.linkage_view.set_linkage(&package)?;
+        let id = package.id();
+        context.write_package(package);
         let res = publish_and_verify_modules(context, runtime_id, &modules)
             .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
-        context.reset_linkage();
+        context.linkage_view.reset_linkage();
+        if res.is_err() {
+            context.remove_package(id);
+        }
         res?;
 
-        context.write_package(package_obj)?;
         let values = if Mode::packages_are_predefined() {
             // no upgrade cap for genesis modules
             vec![]
         } else {
             let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
-            vec![Value::Object(make_object_value(
-                context.vm,
-                &mut context.session,
+            vec![Value::Object(context.make_object_value(
                 UpgradeCap::type_().into(),
                 /* has_public_transfer */ true,
                 /* used_in_non_entry_move_call */ false,
@@ -537,10 +542,10 @@ mod checked {
         );
 
         let upgrade_ticket_type = context
-            .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
+            .load_type_from_struct(&UpgradeTicket::type_())
             .map_err(|e| context.convert_vm_error(e))?;
         let upgrade_receipt_type = context
-            .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
+            .load_type_from_struct(&UpgradeReceipt::type_())
             .map_err(|e| context.convert_vm_error(e))?;
 
         let upgrade_ticket: UpgradeTicket = {
@@ -595,21 +600,17 @@ mod checked {
         let storage_id = context.tx_context.fresh_id();
 
         let dependencies = fetch_packages(context, &dep_ids)?;
-        let package_obj =
+        let package =
             context.upgrade_package(storage_id, &current_package, &modules, &dependencies)?;
 
-        let Some(package) = package_obj.data.try_as_package() else {
-        invariant_violation!("Newly created package object is not a package");
-    };
-
-        context.set_linkage(package)?;
+        context.linkage_view.set_linkage(&package)?;
         let res = publish_and_verify_modules(context, runtime_id, &modules);
-        context.reset_linkage();
+        context.linkage_view.reset_linkage();
         res?;
 
         check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
 
-        context.write_package(package_obj)?;
+        context.write_package(package);
         Ok(vec![Value::Raw(
             RawValueType::Loaded {
                 ty: upgrade_receipt_type,
@@ -628,32 +629,32 @@ mod checked {
     ) -> Result<(), ExecutionError> {
         // Make sure this is a known upgrade policy.
         let Ok(policy) = UpgradePolicy::try_from(policy) else {
-        return Err(ExecutionError::from_kind(
-            ExecutionErrorKind::PackageUpgradeError {
-                upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy },
-            },
-        ));
-    };
+            return Err(ExecutionError::from_kind(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy },
+                },
+            ));
+        };
 
         let Ok(current_normalized) = existing_package
-        .normalize(
-            context.protocol_config.move_binary_format_version(),
-            context.protocol_config.no_extraneous_module_bytes(),
-        )
-    else {
-        invariant_violation!("Tried to normalize modules in existing package but failed")
-    };
+            .normalize(
+                context.protocol_config.move_binary_format_version(),
+                context.protocol_config.no_extraneous_module_bytes(),
+            )
+        else {
+            invariant_violation!("Tried to normalize modules in existing package but failed")
+        };
 
         let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
         for (name, cur_module) in current_normalized {
             let Some(new_module) = new_normalized.remove(&name) else {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PackageUpgradeError {
-                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
-                },
-                format!("Existing module {name} not found in next version of package"),
-            ));
-        };
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::PackageUpgradeError {
+                        upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+                    },
+                    format!("Existing module {name} not found in next version of package"),
+                ));
+            };
 
             check_module_compatibility(&policy, &cur_module, &new_module)?;
         }
@@ -757,13 +758,11 @@ mod checked {
         }
         // script visibility checked manually for entry points
         let mut result = context
-            .session
             .execute_function_bypass_visibility(
                 module_id,
                 function,
                 type_arguments,
                 serialized_arguments,
-                context.gas_charger.move_gas_status_mut(),
             )
             .map_err(|e| context.convert_vm_error(e))?;
 
@@ -776,8 +775,8 @@ mod checked {
         // objects).
         if tx_context_kind == TxContextKind::Mutable {
             let Some((_, ctx_bytes, _)) = result.mutable_reference_outputs.pop() else {
-            invariant_violation!("Missing TxContext in reference outputs");
-        };
+                invariant_violation!("Missing TxContext in reference outputs");
+            };
             let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).map_err(|e| {
                 ExecutionError::invariant_violation(format!(
                     "Unable to deserialize TxContext bytes. {e}"
@@ -829,14 +828,7 @@ mod checked {
             })
             .collect();
         context
-            .session
-            .publish_module_bundle(
-                new_module_bytes,
-                AccountAddress::from(package_id),
-                // TODO: publish_module_bundle() currently doesn't charge gas.
-                // Do we want to charge there?
-                context.gas_charger.move_gas_status_mut(),
-            )
+            .publish_module_bundle(new_module_bytes, AccountAddress::from(package_id))
             .map_err(|e| context.convert_vm_error(e))?;
 
         // run the Sui verifier
@@ -932,32 +924,30 @@ mod checked {
         from_init: bool,
     ) -> Result<LoadedFunctionInfo, ExecutionError> {
         if from_init {
-            // the session is weird and does not load the module on publishing. This is a temporary
-            // work around, since loading the function through the session will cause the module
-            // to be loaded through the sessions data store.
-            let result = context
-                .session
-                .load_function(module_id, function, type_arguments);
+            let result = context.load_function(module_id, function, type_arguments);
             assert_invariant!(
                 result.is_ok(),
                 "The modules init should be able to be loaded"
             );
         }
+        let no_new_packages = LinkedHashMap::new();
+        let data_store = SuiDataStore::new(&context.linkage_view, &no_new_packages);
         let module = context
             .vm
-            .load_module(module_id, context.session.get_resolver())
+            .get_runtime()
+            .load_module(module_id, &data_store)
             .map_err(|e| context.convert_vm_error(e))?;
         let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
-        module.identifier_at(module.function_handle_at(fdef.function).name) == function
-    }) else {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::FunctionNotFound,
-            format!(
-                "Could not resolve function '{}' in module {}",
-                function, &module_id,
-            ),
-        ));
-    };
+            module.identifier_at(module.function_handle_at(fdef.function).name) == function
+        }) else {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::FunctionNotFound,
+                format!(
+                    "Could not resolve function '{}' in module {}",
+                    function, &module_id,
+                ),
+            ));
+        };
 
         // entry on init is now banned, so ban invoking it
         if !from_init && function == INIT_FN_NAME && context.protocol_config.ban_entry_init() {
@@ -996,7 +986,6 @@ mod checked {
             }
         };
         let signature = context
-            .session
             .load_function(module_id, function, type_arguments)
             .map_err(|e| context.convert_vm_error(e))?;
         let signature =
@@ -1076,7 +1065,8 @@ mod checked {
                     t => t,
                 };
                 let abilities = context
-                    .session
+                    .vm
+                    .get_runtime()
                     .get_type_abilities(return_type)
                     .map_err(|e| context.convert_vm_error(e))?;
                 Ok(match return_type {
@@ -1086,12 +1076,13 @@ mod checked {
                     }
                     Type::Struct(_) | Type::StructInstantiation(_, _) if abilities.has_key() => {
                         let type_tag = context
-                            .session
+                            .vm
+                            .get_runtime()
                             .get_type_tag(return_type)
                             .map_err(|e| context.convert_vm_error(e))?;
                         let TypeTag::Struct(struct_tag) = type_tag else {
-                        invariant_violation!("Struct type make a non struct type tag")
-                    };
+                            invariant_violation!("Struct type make a non struct type tag")
+                        };
                         ValueKind::Object {
                             type_: MoveObjectType::from(*struct_tag),
                             has_public_transfer: abilities.has_store(),
@@ -1133,7 +1124,7 @@ mod checked {
         {
             let msg = format!(
                 "Cannot directly call sui::{m}::{f}. \
-            Use the public variant instead, sui::{m}::public_{f}",
+                Use the public variant instead, sui::{m}::public_{f}",
                 m = TRANSFER_MODULE,
                 f = function
             );
@@ -1216,12 +1207,13 @@ mod checked {
                     }) = &value
                     {
                         let type_tag = context
-                            .session
+                            .vm
+                            .get_runtime()
                             .get_type_tag(type_)
                             .map_err(|e| context.convert_vm_error(e))?;
                         let TypeTag::Struct(struct_tag) = type_tag else {
-                        invariant_violation!("Struct type make a non struct type tag")
-                    };
+                            invariant_violation!("Struct type make a non struct type tag")
+                        };
                         let type_ = (*struct_tag).into();
                         ValueKind::Object {
                             type_,
@@ -1229,7 +1221,8 @@ mod checked {
                         }
                     } else {
                         let abilities = context
-                            .session
+                            .vm
+                            .get_runtime()
                             .get_type_abilities(inner)
                             .map_err(|e| context.convert_vm_error(e))?;
                         ValueKind::Raw((**inner).clone(), abilities)
@@ -1280,19 +1273,19 @@ mod checked {
             // and might need to run validation in addition to the BCS layout
             Value::Raw(RawValueType::Any, bytes) => {
                 let Some(layout) = primitive_serialization_layout(context, param_ty)? else {
-                let msg = format!(
-                    "Non-primitive argument at index {}. If it is an object, it must be \
-                    populated by an object",
-                    idx,
-                );
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::command_argument_error(
-                        CommandArgumentError::InvalidUsageOfPureArg,
-                        idx as u16,
-                    ),
-                    msg,
-                ));
-            };
+                    let msg = format!(
+                        "Non-primitive argument at index {}. If it is an object, it must be \
+                        populated by an object",
+                        idx,
+                    );
+                    return Err(ExecutionError::new_with_source(
+                        ExecutionErrorKind::command_argument_error(
+                            CommandArgumentError::InvalidUsageOfPureArg,
+                            idx as u16,
+                        ),
+                        msg,
+                    ));
+                };
                 bcs_argument_validate(bytes, idx as u16, layout)?;
                 return Ok(());
             }
@@ -1338,9 +1331,9 @@ mod checked {
             _ => return Ok(TxContextKind::None),
         };
         let Type::Struct(idx) = &**inner else { return Ok(TxContextKind::None) };
-        let Some(s) = context.session.get_struct_type(*idx) else {
-        invariant_violation!("Loaded struct not found")
-    };
+        let Some(s) = context.vm.get_runtime().get_struct_type(*idx) else {
+            invariant_violation!("Loaded struct not found")
+        };
         let (module_addr, module_name, struct_name) = get_struct_ident(&s);
         let is_tx_context_type = module_addr == &SUI_FRAMEWORK_ADDRESS
             && module_name == TX_CONTEXT_MODULE_NAME
@@ -1380,9 +1373,9 @@ mod checked {
                 info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
             }
             Type::StructInstantiation(idx, targs) => {
-                let Some(s) = context.session.get_struct_type(*idx) else {
-                invariant_violation!("Loaded struct not found")
-            };
+                let Some(s) = context.vm.get_runtime().get_struct_type(*idx) else {
+                    invariant_violation!("Loaded struct not found")
+                };
                 let resolved_struct = get_struct_ident(&s);
                 // is option of a string
                 if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
@@ -1393,9 +1386,9 @@ mod checked {
                 }
             }
             Type::Struct(idx) => {
-                let Some(s) = context.session.get_struct_type(*idx) else {
-                invariant_violation!("Loaded struct not found")
-            };
+                let Some(s) = context.vm.get_runtime().get_struct_type(*idx) else {
+                    invariant_violation!("Loaded struct not found")
+                };
                 let resolved_struct = get_struct_ident(&s);
                 if resolved_struct == RESOLVED_SUI_ID {
                     Some(PrimitiveArgumentLayout::Address)

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::programmable_transactions::context::new_session_for_linkage;
-use crate::programmable_transactions::{context::load_type, linkage_view::LinkageView};
+use crate::programmable_transactions::context::load_type_from_struct;
+use crate::programmable_transactions::linkage_view::LinkageView;
+use linked_hash_map::LinkedHashMap;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
+use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
-use move_vm_runtime::{move_vm::MoveVM, session::Session};
+use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
@@ -23,7 +24,8 @@ use sui_types::{
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
 /// common to the runtime.
 pub struct TypeLayoutResolver<'state, 'vm> {
-    session: Session<'state, 'vm, LinkageView<'state>>,
+    vm: &'vm MoveVM,
+    linkage_view: LinkageView<'state>,
 }
 
 /// Implements SuiResolver traits by providing null implementations for module and resource
@@ -32,9 +34,8 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let session =
-            new_session_for_linkage(vm, LinkageView::new(Box::new(NullSuiResolver(state_view))));
-        Self { session }
+        let linkage_view = LinkageView::new(Box::new(NullSuiResolver(state_view)));
+        Self { vm, linkage_view }
     }
 }
 
@@ -45,16 +46,15 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
         format: ObjectFormatOptions,
     ) -> Result<MoveStructLayout, SuiError> {
         let struct_tag: StructTag = object.type_().clone().into();
-        let type_tag: TypeTag = TypeTag::from(struct_tag.clone());
-        let Ok(ty) = load_type(&mut self.session, &type_tag) else {
+        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &LinkedHashMap::new(), &struct_tag) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),
             });
         };
         let layout = if format.include_types() {
-            self.session.type_to_fully_annotated_layout(&ty)
+            self.vm.get_runtime().type_to_fully_annotated_layout(&ty)
         } else {
-            self.session.type_to_type_layout(&ty)
+            self.vm.get_runtime().type_to_type_layout(&ty)
         };
         let Ok(MoveTypeLayout::Struct(layout)) = layout else {
             return Err(SuiError::FailObjectLayout {


### PR DESCRIPTION
## Description 

This is the first step in removing `Session` from the execution layer/adapter.
It actually gets rid of `Session` entirely, however more clean up is needed.
I am looking for feedback if anybody has strong feelings and have thought about how to refactor the VM component. What I mean is that we have few "objects" that contribute to Move execution: `MoveVM`, `NativeContextExtensions`, `LinkageView`, `ExecutionState`, and they are currently all splashed as single fields in `ExecutionContext`. I feel that they may benefit from being abstracted as a single component/struct with a cohesive API (that again, maybe not).
I will work in that direction but I would welcome ideas if anybody has thought about this already

## Test Plan 

Existing tests, this is not a new feature and it is not intended to introduce any new behavior

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
