### PR TITLE
[Narwhal] wait to cancel header proposal after higher round certificates have been created

### DIFF
--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -822,7 +822,7 @@ impl PrimaryReceiverHandler {
         // certificates to still have a chance to be included in the DAG while not wasting
         // resources on very old vote requests. This value affects performance but not correctness
         // of the algorithm.
-        const HEADER_AGE_LIMIT: Round = 3;
+        const HEADER_AGE_LIMIT: Round = 5;
 
         // Lock to ensure consistency between limit_round and where parent_digests are gc'ed.
         let mut parent_digests = self.parent_digests.lock();

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -90,13 +90,6 @@ async fn accept_certificates() {
     }
 
     // Ensure the Synchronizer sends the parents of the certificates to the proposer.
-    //
-    // The first messages are the Synchronizer letting us know about the round of parent certificates
-    for _i in 0..3 {
-        let received = rx_parents.recv().await.unwrap();
-        assert_eq!(received, (vec![], 0, 0));
-    }
-    // the next message actually contains the parents
     let received = rx_parents.recv().await.unwrap();
     assert_eq!(received, (certificates.clone(), 1, 0));
 
@@ -451,11 +444,6 @@ async fn synchronizer_recover_partial_certs() {
         synchronizer.try_accept_certificate(cert).await.unwrap();
     }
     tokio::time::sleep(Duration::from_secs(5)).await;
-
-    for _ in 0..2 {
-        let received = rx_parents.recv().await.unwrap();
-        assert_eq!(received, (vec![], 0, 0));
-    }
 
     // the recovery flow sends message that contains the parents
     let received = rx_parents.recv().await.unwrap();

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -507,7 +507,7 @@ async fn synchronizer_recover_previous_round() {
         .unwrap();
     let _ = tx_synchronizer_network.send(network.clone());
 
-    // Send 3 certificates from round 1, and 2 certificates from round 2 to Synchronizer.
+    // Create 3 certificates per round.
     let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
@@ -525,6 +525,7 @@ async fn synchronizer_recover_previous_round() {
         &latest_protocol_version(),
         &keys,
     );
+    // Send 3 certificates from round 1, and 2 certificates from round 2 to Synchronizer.
     let all_certificates: Vec<_> = all_certificates.into_iter().collect();
     let round_1_certificates = all_certificates[0..3].to_vec();
     let round_2_certificates = all_certificates[3..5].to_vec();


### PR DESCRIPTION
## Description 

Cancel header proposal less eagerly, by waiting until a higher round certificate has been created locally, instead of immediately observing a higher round certificate. Orphaned certificates can still be useful as votes on previous leaders. Transactions in the orphaned certificates will be retried, same as those in cancelled headers.

The main goal is to make the system behavior more intuitive. Also this change may help keeping latency consistent when headers are proposed more frequently for any reason.

## Test Plan 

CI
Deployed to private test and observed no change in p50 latency, p95 jitter and validator scores.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
