### PR TITLE
cherry-pick: Improve readability of constants (#12998)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,6 +5165,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.23",
  "colored",
+ "hex",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -304,6 +304,7 @@ mod test {
         assert_eq!(expected_checkpoint, pruned);
     }
 
+    #[ignore("Disabled due to flakiness and timeouts - re-enable when timeouts are fixed")]
     #[sim_test(config = "test_config()")]
     async fn test_upgrade_compatibility() {
         // This test is intended to test the compatibility of the latest protocol version with

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.23",
  "colored",
+ "hex",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",

--- a/external-crates/move/tools/move-cli/tests/build_tests/disassemble_module/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/disassemble_module/args.exp
@@ -12,12 +12,17 @@ struct As {
 
 public zf(): u64 {
 B0:
-	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	0: LdConst[0](U64: 01000000..)
 	1: Ret
 }
-public af(): u64 {
+public af(): u32 {
 B0:
-	0: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdConst[1](U32: 00000000)
 	1: Ret
 }
+
+Constants [
+	0 => u64: 0100000000000000
+	1 => u32: 00000000
+]
 }

--- a/external-crates/move/tools/move-cli/tests/build_tests/disassemble_module/sources/m.move
+++ b/external-crates/move/tools/move-cli/tests/build_tests/disassemble_module/sources/m.move
@@ -4,9 +4,9 @@ struct Zs {}
 struct As {}
 
 const Zc: u64 = 1;
-const Ac: u64 = 0;
+const Ac: u32 = 0;
 
 public fun zf(): u64 { Zc }
-public fun af(): u64 { Ac }
+public fun af(): u32 { Ac }
 
 }

--- a/external-crates/move/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
+++ b/external-crates/move/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
@@ -61,7 +61,7 @@ B0:
 B1:
 [4]	4: Branch(7)
 B2:
-[2]	5: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+[2]	5: LdConst[0](U64: 00000000..)
 [2]	6: Abort
 B3:
 [4]	7: CopyLoc[0](x#0#0: u64)
@@ -69,6 +69,10 @@ B3:
 [4]	9: Mul
 [4]	10: Ret
 }
+
+Constants [
+	0 => u64: 0000000000000000
+]
 }
 Command `disassemble --package MoveStdlib --name signer`:
 // Move bytecode v6

--- a/external-crates/move/tools/move-disassembler/Cargo.toml
+++ b/external-crates/move/tools/move-disassembler/Cargo.toml
@@ -21,6 +21,7 @@ move-coverage = { path = "../move-coverage" }
 move-compiler = { path = "../../move-compiler" }
 
 clap = { version = "3.1.8", features = ["derive"] }
+hex = "0.4.3"
 
 [features]
 default = []


### PR DESCRIPTION
Cherry-pick of PR #12998

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

Improve readability of constants in the disassembled output of modules.
