### PR TITLE
[rpc][structured-error-handling][1/n] Group rpc-level client errors

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -37,13 +37,12 @@ use crate::{with_tracing, SuiRpcModule};
 #[cfg(test)]
 use mockall::automock;
 
-fn parse_to_struct_tag(coin_type: &str) -> Result<StructTag, Error> {
-    parse_sui_struct_tag(coin_type).map_err(|e| {
-        Error::SuiRpcInputError(SuiRpcInputError::CannotParseSuiStructTag(format!("{e}")))
-    })
+fn parse_to_struct_tag(coin_type: &str) -> Result<StructTag, SuiRpcInputError> {
+    parse_sui_struct_tag(coin_type)
+        .map_err(|e| SuiRpcInputError::CannotParseSuiStructTag(format!("{e}")))
 }
 
-fn parse_to_type_tag(coin_type: Option<String>) -> Result<TypeTag, Error> {
+fn parse_to_type_tag(coin_type: Option<String>) -> Result<TypeTag, SuiRpcInputError> {
     Ok(TypeTag::Struct(Box::new(match coin_type {
         Some(c) => parse_to_struct_tag(&c)?,
         None => GAS::type_(),
@@ -120,16 +119,16 @@ impl CoinReadApiServer for CoinReadApi {
                         Some(obj) => {
                             let coin_type = obj.coin_type_maybe();
                             if coin_type.is_none() {
-                                Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
+                                Err(SuiRpcInputError::GenericInvalid(
                                     "cursor is not a coin".to_string(),
-                                )))
+                                ))
                             } else {
                                 Ok((coin_type.unwrap().to_string(), object_id))
                             }
                         }
-                        None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
+                        None => Err(SuiRpcInputError::GenericInvalid(
                             "cursor not found".to_string(),
-                        ))),
+                        )),
                     }
                 }
                 None => {
@@ -471,23 +470,26 @@ mod tests {
     use expect_test::expect;
     use jsonrpsee::types::ErrorObjectOwned;
     use mockall::predicate;
+    use move_core_types::account_address::AccountAddress;
     use move_core_types::language_storage::StructTag;
     use sui_json_rpc_types::Coin;
     use sui_types::balance::Supply;
     use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
     use sui_types::coin::TreasuryCap;
     use sui_types::digests::{ObjectDigest, TransactionDigest};
+    use sui_types::effects::TransactionEffectsV1;
     use sui_types::gas_coin::GAS;
     use sui_types::id::UID;
     use sui_types::object::Object;
+    use sui_types::utils::create_fake_transaction;
     use sui_types::{parse_sui_struct_tag, TypeTag};
 
     fn get_test_owner() -> SuiAddress {
-        SuiAddress::random_for_testing_only()
+        AccountAddress::ONE.into()
     }
 
     fn get_test_package_id() -> ObjectID {
-        ObjectID::random()
+        ObjectID::from_hex_literal("0xf").unwrap()
     }
 
     fn get_test_coin_type(package_id: ObjectID) -> String {
@@ -537,7 +539,7 @@ mod tests {
         let input_coin_struct = parse_sui_struct_tag(&coin_name).expect("should not fail");
         let treasury_cap_struct = TreasuryCap::type_(input_coin_struct.clone());
         let treasury_cap = TreasuryCap {
-            id: UID::new(ObjectID::random()),
+            id: UID::new(get_test_package_id()),
             total_supply: Supply { value: 420 },
         };
         let treasury_cap_object =
@@ -963,7 +965,7 @@ mod tests {
         #[tokio::test]
         async fn test_object_not_found() {
             let owner = get_test_owner();
-            let object_id = ObjectID::random();
+            let object_id = get_test_package_id();
             let mut mock_state = MockState::new();
             mock_state.expect_get_object().returning(move |_| Ok(None));
 
@@ -1280,7 +1282,7 @@ mod tests {
             let input_coin_struct = parse_sui_struct_tag(&coin_name).expect("should not fail");
             let coin_metadata_struct = CoinMetadata::type_(input_coin_struct.clone());
             let coin_metadata = CoinMetadata {
-                id: UID::new(ObjectID::random()),
+                id: UID::new(get_test_package_id()),
                 decimals: 2,
                 name: "test_coin".to_string(),
                 symbol: "TEST".to_string(),
@@ -1313,13 +1315,46 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_object_not_found() {
+            let transaction_digest = TransactionDigest::from([0; 32]);
+            let verified_transaction =
+                VerifiedTransaction::new_unchecked(create_fake_transaction());
+            let transaction_effects: TransactionEffects =
+                TransactionEffects::V1(TransactionEffectsV1::default());
+
+            let mut mock_state = MockState::new();
+            mock_state
+                .expect_find_publish_txn_digest()
+                .return_once(move |_| Ok(transaction_digest));
+            mock_state
+                .expect_get_executed_transaction_and_effects()
+                .return_once(move |_| Ok((verified_transaction, transaction_effects)));
+
+            let internal = CoinReadInternalImpl {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Box::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_coin_metadata("0x2::sui::SUI".to_string())
+                .await;
+
+            assert!(response.is_ok());
+            let result = response.unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[tokio::test]
         async fn test_find_package_object_not_sui_coin_metadata() {
             let package_id = get_test_package_id();
             let coin_name = get_test_coin_type(package_id);
             let input_coin_struct = parse_sui_struct_tag(&coin_name).expect("should not fail");
             let coin_metadata_struct = CoinMetadata::type_(input_coin_struct.clone());
             let treasury_cap = TreasuryCap {
-                id: UID::new(ObjectID::random()),
+                id: UID::new(get_test_package_id()),
                 total_supply: Supply { value: 420 },
             };
             let treasury_cap_object =
@@ -1397,12 +1432,49 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_object_not_found() {
+            let package_id = get_test_package_id();
+            let (coin_name, _, _, _, _) = get_test_treasury_cap_peripherals(package_id);
+            let transaction_digest = TransactionDigest::from([0; 32]);
+            let verified_transaction =
+                VerifiedTransaction::new_unchecked(create_fake_transaction());
+            let transaction_effects: TransactionEffects =
+                TransactionEffects::V1(TransactionEffectsV1::default());
+
+            let mut mock_state = MockState::new();
+            mock_state
+                .expect_find_publish_txn_digest()
+                .return_once(move |_| Ok(transaction_digest));
+            mock_state
+                .expect_get_executed_transaction_and_effects()
+                .return_once(move |_| Ok((verified_transaction, transaction_effects)));
+
+            let internal = CoinReadInternalImpl {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Box::new(internal),
+            };
+
+            let response = coin_read_api.get_total_supply(coin_name.clone()).await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            let expected = expect!["-32602"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Cannot find object [0x2::coin::TreasuryCap<0xf::test_coin::TEST_COIN>] from [0x000000000000000000000000000000000000000000000000000000000000000f] package event."];
+            expected.assert_eq(error_object.message());
+        }
+
+        #[tokio::test]
         async fn test_find_package_object_not_treasury_cap() {
             let package_id = get_test_package_id();
             let (coin_name, input_coin_struct, treasury_cap_struct, _, _) =
                 get_test_treasury_cap_peripherals(package_id);
             let coin_metadata = CoinMetadata {
-                id: UID::new(ObjectID::random()),
+                id: UID::new(get_test_package_id()),
                 decimals: 2,
                 name: "test_coin".to_string(),
                 symbol: "TEST".to_string(),

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -92,14 +92,11 @@ impl CoinReadApiServer for CoinReadApi {
                 None => (coin_type_tag.to_string(), ObjectID::ZERO),
             };
 
-            let coins = self
-                .internal
+            self.internal
                 .get_coins_iterator(
                     owner, cursor, limit, true, // only care about one type of coin
                 )
-                .await?;
-
-            Ok(coins)
+                .await
         })
     }
 

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -78,7 +78,8 @@ impl Error {
             Error::SuiObjectResponseError(err) => match err {
                 SuiObjectResponseError::NotExists { .. }
                 | SuiObjectResponseError::DynamicFieldNotFound { .. }
-                | SuiObjectResponseError::Deleted { .. } => {
+                | SuiObjectResponseError::Deleted { .. }
+                | SuiObjectResponseError::DisplayError { .. } => {
                     RpcError::Call(CallError::InvalidParams(err.into()))
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -91,20 +91,20 @@ impl GovernanceReadApi {
                         .await?
                     {
                         Some(o) => stakes.push((StakedSui::try_from(&o)?, false)),
-                        None => {
-                            return Err(Error::UserInputError(UserInputError::ObjectNotFound {
+                        None => Err(SuiRpcInputError::UserInputError(
+                            UserInputError::ObjectNotFound {
                                 object_id: oref.0,
                                 version: None,
-                            }));
-                        }
+                            },
+                        ))?,
                     }
                 }
-                ObjectRead::NotExists(id) => {
-                    return Err(Error::UserInputError(UserInputError::ObjectNotFound {
+                ObjectRead::NotExists(id) => Err(SuiRpcInputError::UserInputError(
+                    UserInputError::ObjectNotFound {
                         object_id: id,
                         version: None,
-                    }));
-                }
+                    },
+                ))?,
             }
         }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -103,6 +103,20 @@ impl<R: ReadApiServer> IndexerApi<R> {
             metrics,
         }
     }
+
+    fn extract_values_from_dynamic_field_name(
+        &self,
+        name: DynamicFieldName,
+    ) -> Result<(TypeTag, Vec<u8>), SuiRpcInputError> {
+        let DynamicFieldName {
+            type_: name_type,
+            value,
+        } = name;
+        let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.database)?;
+        let sui_json_value = SuiJsonValue::new(value)?;
+        let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
+        Ok((name_type, name_bcs_value))
+    }
 }
 
 #[async_trait]
@@ -116,7 +130,8 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         limit: Option<usize>,
     ) -> RpcResult<ObjectsPage> {
         with_tracing!(async move {
-            let limit = validate_limit(limit, *QUERY_MAX_RESULT_LIMIT)?;
+            let limit =
+                validate_limit(limit, *QUERY_MAX_RESULT_LIMIT).map_err(SuiRpcInputError::from)?;
             self.metrics.get_owned_objects_limit.report(limit as u64);
             let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
             let options = options.unwrap_or_default();
@@ -307,13 +322,8 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         name: DynamicFieldName,
     ) -> RpcResult<SuiObjectResponse> {
         with_tracing!(async move {
-            let DynamicFieldName {
-                type_: name_type,
-                value,
-            } = name.clone();
-            let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.database)?;
-            let sui_json_value = SuiJsonValue::new(value)?;
-            let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
+            let (name_type, name_bcs_value) = self.extract_values_from_dynamic_field_name(name)?;
+
             let id = self
                 .state
                 .get_dynamic_field_object_id(parent_object_id, name_type, &name_bcs_value)
@@ -362,19 +372,19 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 ))
             })?;
             let domain_bcs_value = bcs::to_bytes(&domain).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
+                SuiRpcInputError::GenericInvalid(format!(
                     "Unable to serialize name: {:?} with error: {:?}",
                     domain, e
-                )))
+                ))
             })?;
             let record_object_id_option = self
                 .state
                 .get_dynamic_field_object_id(registry_id, name_type_tag, &domain_bcs_value)
                 .map_err(|e| {
-                    Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
+                    SuiRpcInputError::GenericInvalid(format!(
                         "Unable to lookup name in name service registry with error: {:?}",
                         e
-                    )))
+                    ))
                 })?;
             if let Some(record_object_id) = record_object_id_option {
                 let record_object_read =
@@ -445,10 +455,10 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
 
             let name_type_tag = TypeTag::Address;
             let addr_bcs_value = bcs::to_bytes(&address).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
+                SuiRpcInputError::GenericInvalid(format!(
                     "Unable to serialize address: {:?} with error: {:?}",
                     address, e
-                )))
+                ))
             })?;
 
             let addr_object_id_opt = self

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -182,7 +182,7 @@ impl MoveUtilsServer for MoveUtils {
     ) -> RpcResult<SuiMoveNormalizedStruct> {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
-            let structs = module.structs;            
+            let structs = module.structs;
             let identifier = Identifier::new(struct_name.as_str())
                 .map_err(|e| SuiRpcInputError::GenericInvalid(format!("{e}")))?;
             match structs.get(&identifier) {
@@ -190,7 +190,7 @@ impl MoveUtilsServer for MoveUtils {
                 None => Err(SuiRpcInputError::GenericNotFound(format!(
                     "No struct was found with struct name {}",
                     struct_name
-                )))
+                )))?,
             }
         })
     }
@@ -204,7 +204,7 @@ impl MoveUtilsServer for MoveUtils {
     ) -> RpcResult<SuiMoveNormalizedFunction> {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
-            let functions = module.functions;           
+            let functions = module.functions;
             let identifier = Identifier::new(function_name.as_str())
                 .map_err(|e| SuiRpcInputError::GenericInvalid(format!("{e}")))?;
             match functions.get(&identifier) {
@@ -212,7 +212,7 @@ impl MoveUtilsServer for MoveUtils {
                 None => Err(SuiRpcInputError::GenericNotFound(format!(
                     "No function was found with function name {}",
                     function_name
-                ))),
+                )))?,
             }
         })
     }
@@ -278,7 +278,7 @@ impl MoveUtilsServer for MoveUtils {
                 None => Err(SuiRpcInputError::GenericNotFound(format!(
                     "No parameters found for function {}",
                     function
-                ))),
+                )))?,
             }
         })
     }

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -3,7 +3,6 @@
 
 use crate::api::MoveUtilsServer;
 use crate::error::{Error, SuiRpcInputError};
-use crate::read_api::{get_move_module, get_move_modules_by_package};
 use crate::{with_tracing, SuiRpcModule};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -26,7 +25,8 @@ use sui_open_rpc::Module;
 use sui_types::base_types::ObjectID;
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, ObjectRead};
-use tracing::instrument;
+use tap::TapFallible;
+use tracing::{error, instrument, warn};
 
 #[cfg_attr(test, automock)]
 #[async_trait]
@@ -68,14 +68,51 @@ impl MoveUtilsInternalTrait for MoveUtilsInternal {
         package: ObjectID,
         module_name: String,
     ) -> Result<NormalizedModule, Error> {
-        get_move_module(self.get_state(), package, module_name).await
+        let normalized = self.get_move_modules_by_package(package).await?;
+        Ok(match normalized.get(&module_name) {
+            Some(module) => Ok(module.clone()),
+            None => Err(SuiRpcInputError::GenericNotFound(format!(
+                "No module found with module name {}",
+                module_name
+            ))),
+        }?)
     }
 
     async fn get_move_modules_by_package(
         &self,
         package: ObjectID,
     ) -> Result<BTreeMap<String, NormalizedModule>, Error> {
-        get_move_modules_by_package(self.get_state(), package).await
+        let object_read = self.get_state().get_object_read(&package).tap_err(|_| {
+            warn!("Failed to call get_move_modules_by_package for package: {package:?}");
+        })?;
+
+        match object_read {
+            ObjectRead::Exists(_obj_ref, object, _layout) => {
+                match object.data {
+                    Data::Package(p) => {
+                        // we are on the read path - it's OK to use VERSION_MAX of the supported Move
+                        // binary format
+                        normalize_modules(
+                        p.serialized_module_map().values(),
+                        /* max_binary_format_version */ VERSION_MAX,
+                        /* no_extraneous_module_bytes */ false,
+                    )
+                    .map_err(|e| {
+                        error!("Failed to call get_move_modules_by_package for package: {package:?}");
+                        Error::from(e)
+                    })
+                    }
+                    _ => Err(SuiRpcInputError::GenericInvalid(format!(
+                        "Object is not a package with ID {}",
+                        package
+                    )))?,
+                }
+            }
+            _ => Err(SuiRpcInputError::GenericNotFound(format!(
+                "Package object does not exist with ID {}",
+                package
+            )))?,
+        }
     }
 
     fn get_object_read(&self, package: ObjectID) -> Result<ObjectRead, Error> {
@@ -145,15 +182,15 @@ impl MoveUtilsServer for MoveUtils {
     ) -> RpcResult<SuiMoveNormalizedStruct> {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
-            let structs = module.structs;
-            let identifier = Identifier::new(struct_name.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let structs = module.structs;            
+            let identifier = Identifier::new(struct_name.as_str())
+                .map_err(|e| SuiRpcInputError::GenericInvalid(format!("{e}")))?;
             match structs.get(&identifier) {
                 Some(struct_) => Ok(struct_.clone().into()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No struct was found with struct name {}", struct_name),
-                ))),
+                None => Err(SuiRpcInputError::GenericNotFound(format!(
+                    "No struct was found with struct name {}",
+                    struct_name
+                )))
             }
         })
     }
@@ -167,14 +204,14 @@ impl MoveUtilsServer for MoveUtils {
     ) -> RpcResult<SuiMoveNormalizedFunction> {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
-            let functions = module.functions;
-            let identifier = Identifier::new(function_name.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let functions = module.functions;           
+            let identifier = Identifier::new(function_name.as_str())
+                .map_err(|e| SuiRpcInputError::GenericInvalid(format!("{e}")))?;
             match functions.get(&identifier) {
                 Some(function) => Ok(function.clone().into()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No function was found with function name {}", function_name),
+                None => Err(SuiRpcInputError::GenericNotFound(format!(
+                    "No function was found with function name {}",
+                    function_name
                 ))),
             }
         })
@@ -202,18 +239,19 @@ impl MoveUtilsServer for MoveUtils {
                         )
                         .map_err(Error::from)
                     }
-                    _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
-                        format!("Object is not a package with ID {}", package),
-                    ))),
+                    _ => Err(SuiRpcInputError::GenericInvalid(format!(
+                        "Object is not a package with ID {}",
+                        package
+                    )))?,
                 },
-                _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("Package object does not exist with ID {}", package),
-                ))),
+                _ => Err(SuiRpcInputError::GenericNotFound(format!(
+                    "Package object does not exist with ID {}",
+                    package
+                )))?,
             }?;
 
-            let identifier = Identifier::new(function.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let identifier = Identifier::new(function.as_str())
+                .map_err(|e| SuiRpcInputError::GenericInvalid(format!("{e}")))?;
             let parameters = normalized
                 .get(&module)
                 .and_then(|m| m.functions.get(&identifier).map(|f| f.parameters.clone()));
@@ -237,8 +275,9 @@ impl MoveUtilsServer for MoveUtils {
                         _ => MoveFunctionArgType::Pure,
                     })
                     .collect::<Vec<MoveFunctionArgType>>()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No parameters found for function {}", function),
+                None => Err(SuiRpcInputError::GenericNotFound(format!(
+                    "No parameters found for function {}",
+                    function
                 ))),
             }
         })

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -1,18 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use fastcrypto::encoding::Base64;
 use futures::future::join_all;
 use itertools::Itertools;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use linked_hash_map::LinkedHashMap;
-use move_binary_format::{file_format_common::VERSION_MAX, normalized::Module as NormalizedModule};
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::StructTag;
 use move_core_types::value::{MoveStruct, MoveStructLayout, MoveValue};
@@ -20,7 +18,6 @@ use tap::TapFallible;
 use tracing::{debug, error, info, instrument, warn};
 
 use mysten_metrics::spawn_monitored_task;
-use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
     BalanceChange, Checkpoint, CheckpointId, CheckpointPage, DisplayFieldsResponse, EventFilter,
@@ -34,17 +31,15 @@ use sui_open_rpc::Module;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::collection_types::VecMap;
-use sui_types::crypto::default_hash;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::SuiObjectResponseError;
+use sui_types::error::{SuiError, SuiObjectResponseError};
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointTimestamp};
-use sui_types::move_package::normalize_modules;
-use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
+use sui_types::object::{Object, ObjectRead, PastObjectRead};
 use sui_types::sui_serde::BigInt;
 use sui_types::transaction::TransactionDataAPI;
-use sui_types::transaction::{TransactionData, VerifiedTransaction};
+use sui_types::transaction::VerifiedTransaction;
 
 use crate::api::JsonRpcMetrics;
 use crate::api::{validate_limit, ReadApiServer};
@@ -140,9 +135,9 @@ impl ReadApi {
     ) -> Result<Vec<SuiTransactionBlockResponse>, Error> {
         let num_digests = digests.len();
         if num_digests > *QUERY_MAX_RESULT_LIMIT {
-            return Err(Error::SuiRpcInputError(
-                SuiRpcInputError::SizeLimitExceeded(QUERY_MAX_RESULT_LIMIT.to_string()),
-            ));
+            Err(SuiRpcInputError::SizeLimitExceeded(
+                QUERY_MAX_RESULT_LIMIT.to_string(),
+            ))?
         }
         self.metrics
             .get_tx_blocks_limit
@@ -158,9 +153,7 @@ impl ReadApi {
                     .map(|k| (k, IntermediateTransactionResponse::new(*k))),
             );
         if temp_response.len() < num_digests {
-            return Err(Error::SuiRpcInputError(
-                SuiRpcInputError::ContainsDuplicates,
-            ));
+            Err(SuiRpcInputError::ContainsDuplicates)?
         }
 
         if opts.require_input() {
@@ -328,9 +321,9 @@ impl ReadApi {
                 results.push(get_balance_changes_from_effect(
                     &object_cache,
                     resp.effects.as_ref().ok_or_else(|| {
-                        Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                        SuiRpcInputError::GenericNotFound(
                             "unable to derive balance changes because effect is empty".to_string(),
-                        ))
+                        )
                     })?,
                     input_objects,
                     None,
@@ -352,9 +345,9 @@ impl ReadApi {
             let mut results = vec![];
             for resp in temp_response.values() {
                 let effects = resp.effects.as_ref().ok_or_else(|| {
-                    Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                    SuiRpcInputError::GenericNotFound(
                         "unable to derive object changes because effect is empty".to_string(),
-                    ))
+                    )
                 })?;
 
                 results.push(get_object_changes(
@@ -362,10 +355,10 @@ impl ReadApi {
                     resp.transaction
                         .as_ref()
                         .ok_or_else(|| {
-                            Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                            SuiRpcInputError::GenericNotFound(
                                 "unable to derive object changes because transaction is empty"
                                     .to_string(),
-                            ))
+                            )
                         })?
                         .data()
                         .intent_message()
@@ -498,8 +491,8 @@ impl ReadApiServer for ReadApi {
                     .inc_by(objects.len() as u64);
                 Ok(objects)
             } else {
-                Err(Error::SuiRpcInputError(
-                    SuiRpcInputError::SizeLimitExceeded(QUERY_MAX_RESULT_LIMIT.to_string()),
+                Err(SuiRpcInputError::SizeLimitExceeded(
+                    QUERY_MAX_RESULT_LIMIT.to_string(),
                 ))
             }
         })
@@ -528,7 +521,11 @@ impl ReadApiServer for ReadApi {
                 PastObjectRead::VersionFound(object_ref, o, layout) => {
                     let display_fields = if options.show_display {
                         // TODO (jian): api breaking change to also modify past objects.
-                        Some(get_display_fields(self, &o, &layout)?)
+                        Some(get_display_fields(self, &o, &layout).map_err(|e| {
+                            Error::UnexpectedError(format!(
+                                "Unable to render object at version {version}: {e}"
+                            ))
+                        })?)
                     } else {
                         None
                     };
@@ -587,8 +584,8 @@ impl ReadApiServer for ReadApi {
                     Ok(success)
                 }
             } else {
-                Err(Error::SuiRpcInputError(
-                    SuiRpcInputError::SizeLimitExceeded(QUERY_MAX_RESULT_LIMIT.to_string()),
+                Err(SuiRpcInputError::SizeLimitExceeded(
+                    QUERY_MAX_RESULT_LIMIT.to_string(),
                 ))
             }
         })
@@ -822,9 +819,9 @@ impl ReadApiServer for ReadApi {
                 .state
                 .get_latest_checkpoint_sequence_number()
                 .map_err(|e| {
-                    Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(format!(
+                    SuiRpcInputError::GenericNotFound(format!(
                         "Latest checkpoint sequence number was not found with error :{e}"
-                    )))
+                    ))
                 })?
                 .into())
         })
@@ -844,7 +841,8 @@ impl ReadApiServer for ReadApi {
         descending_order: bool,
     ) -> RpcResult<CheckpointPage> {
         with_tracing!(async move {
-            let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
+            let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)
+                .map_err(SuiRpcInputError::from)?;
 
             let state = self.state.clone();
 
@@ -936,11 +934,9 @@ impl ReadApiServer for ReadApi {
                             .ok_or(anyhow!("Chain identifier not found"))?
                             .chain(),
                     )
-                    .ok_or(Error::SuiRpcInputError(
-                        SuiRpcInputError::ProtocolVersionUnsupported(
-                            ProtocolVersion::MIN.as_u64(),
-                            ProtocolVersion::MAX.as_u64(),
-                        ),
+                    .ok_or(SuiRpcInputError::ProtocolVersionUnsupported(
+                        ProtocolVersion::MIN.as_u64(),
+                        ProtocolVersion::MAX.as_u64(),
                     ))
                 })
                 .unwrap_or(Ok(self
@@ -996,11 +992,29 @@ fn to_sui_transaction_events(
     )?)
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ObjectDisplayError {
+    #[error("Not a move struct")]
+    NotMoveStruct,
+
+    #[error("Failed to extract layout")]
+    Layout,
+
+    #[error("Failed to extract Move object")]
+    MoveObject,
+
+    #[error(transparent)]
+    Deserialization(#[from] SuiError),
+
+    #[error("Failed to deserialize 'VersionUpdatedEvent': {0}")]
+    Bcs(#[from] bcs::Error),
+}
+
 fn get_display_fields(
     fullnode_api: &ReadApi,
     original_object: &Object,
     original_layout: &Option<MoveStructLayout>,
-) -> Result<DisplayFieldsResponse, Error> {
+) -> Result<DisplayFieldsResponse, ObjectDisplayError> {
     let Some((object_type, layout)) = get_object_type_and_struct(original_object, original_layout)? else {
         return Ok(DisplayFieldsResponse { data: None, error: None });
     };
@@ -1017,7 +1031,7 @@ fn get_display_object_by_type(
     fullnode_api: &ReadApi,
     object_type: &StructTag,
     // TODO: add query version support
-) -> Result<Option<DisplayVersionUpdatedEvent>, Error> {
+) -> Result<Option<DisplayVersionUpdatedEvent>, ObjectDisplayError> {
     let mut events = fullnode_api.state.query_events(
         EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
         None,
@@ -1028,9 +1042,7 @@ fn get_display_object_by_type(
     // If there's any recent version of Display, give it to the client.
     // TODO: add support for version query.
     if let Some(event) = events.pop() {
-        let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs[..])
-            .map_err(|e| anyhow!("Failed to deserialize 'VersionUpdatedEvent': {e}"))?; // TODO: currently, this is called on a value returned from state. Is this a client or server error?
-
+        let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs[..])?;
         Ok(Some(display))
     } else {
         Ok(None)
@@ -1040,7 +1052,7 @@ fn get_display_object_by_type(
 fn get_object_type_and_struct(
     o: &Object,
     layout: &Option<MoveStructLayout>,
-) -> Result<Option<(StructTag, MoveStruct)>, Error> {
+) -> Result<Option<(StructTag, MoveStruct)>, ObjectDisplayError> {
     if let Some(object_type) = o.type_() {
         let move_struct = get_move_struct(o, layout)?;
         Ok(Some((object_type.clone().into(), move_struct)))
@@ -1049,91 +1061,21 @@ fn get_object_type_and_struct(
     }
 }
 
-fn get_move_struct(o: &Object, layout: &Option<MoveStructLayout>) -> Result<MoveStruct, Error> {
-    let layout = layout.as_ref().ok_or_else(|| {
-        Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-            "Failed to extract layout".to_string(),
-        ))
-    })?;
+fn get_move_struct(
+    o: &Object,
+    layout: &Option<MoveStructLayout>,
+) -> Result<MoveStruct, ObjectDisplayError> {
+    let layout = layout.as_ref().ok_or_else(|| ObjectDisplayError::Layout)?;
     Ok(o.data
         .try_as_move()
-        .ok_or_else(|| {
-            Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                "Failed to extract Move object".to_string(),
-            ))
-        })?
+        .ok_or_else(|| ObjectDisplayError::MoveObject)?
         .to_move_struct(layout)?)
-}
-
-pub async fn get_move_module(
-    state: &AuthorityState,
-    package: ObjectID,
-    module_name: String,
-) -> Result<NormalizedModule, Error> {
-    let normalized = get_move_modules_by_package(state, package).await?;
-    Ok(match normalized.get(&module_name) {
-        Some(module) => Ok(module.clone()),
-        None => Err(SuiRpcInputError::GenericNotFound(format!(
-            "No module found with module name {}",
-            module_name
-        ))),
-    }?)
-}
-
-pub async fn get_move_modules_by_package(
-    state: &AuthorityState,
-    package: ObjectID,
-) -> Result<BTreeMap<String, NormalizedModule>, Error> {
-    let object_read = state.get_object_read(&package).tap_err(|_| {
-        warn!("Failed to call get_move_modules_by_package for package: {package:?}");
-    })?;
-
-    match object_read {
-        ObjectRead::Exists(_obj_ref, object, _layout) => match object.data {
-            Data::Package(p) => {
-                // we are on the read path - it's OK to use VERSION_MAX of the supported Move
-                // binary format
-                normalize_modules(
-                    p.serialized_module_map().values(),
-                    /* max_binary_format_version */ VERSION_MAX,
-                    /* no_extraneous_module_bytes */ false,
-                )
-                .map_err(|e| {
-                    error!("Failed to call get_move_modules_by_package for package: {package:?}");
-                    Error::from(e)
-                })
-            }
-            _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
-                format!("Object is not a package with ID {}", package),
-            ))),
-        },
-        _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-            format!("Package object does not exist with ID {}", package),
-        ))),
-    }
-}
-
-pub fn get_transaction_data_and_digest(
-    tx_bytes: Base64,
-) -> Result<(TransactionData, TransactionDigest), Error> {
-    let tx_data =
-        bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(Error::from)?; // TODO: is this a client or server error? Only used by dry_run_transaction_block
-    let intent_msg = IntentMessage::new(
-        Intent {
-            version: IntentVersion::V0,
-            scope: IntentScope::TransactionData,
-            app_id: AppId::Sui,
-        },
-        tx_data,
-    );
-    let txn_digest = TransactionDigest::new(default_hash(&intent_msg.value));
-    Ok((intent_msg.value, txn_digest))
 }
 
 pub fn get_rendered_fields(
     fields: VecMap<String, String>,
     move_struct: &MoveStruct,
-) -> Result<DisplayFieldsResponse, Error> {
+) -> Result<DisplayFieldsResponse, ObjectDisplayError> {
     let sui_move_value: SuiMoveValue = MoveValue::Struct(move_struct.clone()).into();
     if let SuiMoveValue::Struct(move_struct) = sui_move_value {
         let fields =
@@ -1165,9 +1107,7 @@ pub fn get_rendered_fields(
             error,
         });
     }
-    Err(SuiRpcInputError::GenericInvalid(
-        "Failed to parse move struct".to_string(),
-    ))?
+    Err(ObjectDisplayError::NotMoveStruct)?
 }
 
 fn parse_template(template: &str, move_struct: &SuiMoveStruct) -> Result<String, Error> {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -493,7 +493,7 @@ impl ReadApiServer for ReadApi {
             } else {
                 Err(SuiRpcInputError::SizeLimitExceeded(
                     QUERY_MAX_RESULT_LIMIT.to_string(),
-                ))
+                ))?
             }
         })
     }
@@ -586,7 +586,7 @@ impl ReadApiServer for ReadApi {
             } else {
                 Err(SuiRpcInputError::SizeLimitExceeded(
                     QUERY_MAX_RESULT_LIMIT.to_string(),
-                ))
+                ))?
             }
         })
     }
@@ -938,6 +938,7 @@ impl ReadApiServer for ReadApi {
                         ProtocolVersion::MIN.as_u64(),
                         ProtocolVersion::MAX.as_u64(),
                     ))
+                    .map_err(Error::from)
                 })
                 .unwrap_or(Ok(self
                     .state

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -11,7 +11,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 
 use mysten_metrics::spawn_monitored_task;
-use shared_crypto::intent::Intent;
+use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_core::authority::AuthorityState;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
@@ -21,19 +21,22 @@ use sui_json_rpc_types::{
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::SuiAddress;
+use sui_types::crypto::default_hash;
+use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::quorum_driver_types::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
 };
 use sui_types::signature::GenericSignature;
 use sui_types::sui_serde::BigInt;
-use sui_types::transaction::{Transaction, TransactionData, TransactionDataAPI, TransactionKind};
+use sui_types::transaction::{
+    InputObjectKind, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+};
 use tracing::instrument;
 
 use crate::api::JsonRpcMetrics;
 use crate::api::WriteApiServer;
 use crate::error::{Error, SuiRpcInputError};
-use crate::read_api::get_transaction_data_and_digest;
 use crate::{
     get_balance_changes_from_effect, get_object_changes, with_tracing, ObjectProviderCache,
     SuiRpcModule,
@@ -58,24 +61,41 @@ impl TransactionExecutionApi {
         }
     }
 
-    async fn execute_transaction_block(
+    pub fn convert_bytes<T: serde::de::DeserializeOwned>(
+        &self,
+        tx_bytes: Base64,
+    ) -> Result<T, SuiRpcInputError> {
+        let data: T = bcs::from_bytes(&tx_bytes.to_vec()?)?;
+        Ok(data)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn prepare_execute_transaction_block(
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
         opts: Option<SuiTransactionBlockResponseOptions>,
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> Result<SuiTransactionBlockResponse, Error> {
+    ) -> Result<
+        (
+            SuiTransactionBlockResponseOptions,
+            ExecuteTransactionRequestType,
+            SuiAddress,
+            Vec<InputObjectKind>,
+            Transaction,
+            Option<SuiTransactionBlock>,
+            Vec<u8>,
+        ),
+        SuiRpcInputError,
+    > {
         let opts = opts.unwrap_or_default();
-
         let request_type = match (request_type, opts.require_local_execution()) {
             (Some(ExecuteTransactionRequestType::WaitForEffectsCert), true) => {
-                return Err(Error::SuiRpcInputError(
-                    SuiRpcInputError::InvalidExecuteTransactionRequestType,
-                ));
+                Err(SuiRpcInputError::InvalidExecuteTransactionRequestType)?
             }
             (t, _) => t.unwrap_or_else(|| opts.default_execution_request_type()),
         };
-        let tx_data: TransactionData = bcs::from_bytes(&tx_bytes.to_vec()?)?;
+        let tx_data: TransactionData = self.convert_bytes(tx_bytes)?;
         let sender = tx_data.sender();
         let input_objs = tx_data.input_objects().unwrap_or_default();
 
@@ -84,7 +104,6 @@ impl TransactionExecutionApi {
             sigs.push(GenericSignature::from_bytes(&sig.to_vec()?)?);
         }
         let txn = Transaction::from_generic_sig_data(tx_data, Intent::sui_transaction(), sigs);
-        let digest = *txn.digest();
         let raw_transaction = if opts.show_raw_input {
             bcs::to_bytes(txn.data())?
         } else {
@@ -99,6 +118,27 @@ impl TransactionExecutionApi {
         } else {
             None
         };
+        Ok((
+            opts,
+            request_type,
+            sender,
+            input_objs,
+            txn,
+            transaction,
+            raw_transaction,
+        ))
+    }
+
+    async fn execute_transaction_block(
+        &self,
+        tx_bytes: Base64,
+        signatures: Vec<Base64>,
+        opts: Option<SuiTransactionBlockResponseOptions>,
+        request_type: Option<ExecuteTransactionRequestType>,
+    ) -> Result<SuiTransactionBlockResponse, Error> {
+        let (opts, request_type, sender, input_objs, txn, transaction, raw_transaction) =
+            self.prepare_execute_transaction_block(tx_bytes, signatures, opts, request_type)?;
+        let digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let orch_timer = self.metrics.orchestrator_latency_ms.start_timer();
@@ -169,12 +209,30 @@ impl TransactionExecutionApi {
         })
     }
 
+    pub fn prepare_dry_run_transaction_block(
+        &self,
+        tx_bytes: Base64,
+    ) -> Result<(TransactionData, TransactionDigest, Vec<InputObjectKind>), SuiRpcInputError> {
+        let tx_data: TransactionData = self.convert_bytes(tx_bytes)?;
+        let input_objs = tx_data.input_objects()?;
+        let intent_msg = IntentMessage::new(
+            Intent {
+                version: IntentVersion::V0,
+                scope: IntentScope::TransactionData,
+                app_id: AppId::Sui,
+            },
+            tx_data,
+        );
+        let txn_digest = TransactionDigest::new(default_hash(&intent_msg.value));
+        Ok((intent_msg.value, txn_digest, input_objs))
+    }
+
     async fn dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
     ) -> Result<DryRunTransactionBlockResponse, Error> {
-        let (txn_data, txn_digest) = get_transaction_data_and_digest(tx_bytes)?;
-        let input_objs = txn_data.input_objects()?;
+        let (txn_data, txn_digest, input_objs) =
+            self.prepare_dry_run_transaction_block(tx_bytes)?;
         let sender = txn_data.sender();
         let (resp, written_objects, transaction_effects, mock_gas) = self
             .state
@@ -232,9 +290,9 @@ impl WriteApiServer for TransactionExecutionApi {
         _epoch: Option<BigInt<u64>>,
     ) -> RpcResult<DevInspectResults> {
         with_tracing!(async move {
-            let tx_kind: TransactionKind =
-                bcs::from_bytes(&tx_bytes.to_vec().map_err(Error::from)?).map_err(Error::from)?;
-            self.state
+            let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
+            self
+                .state
                 .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
                 .await
                 .map_err(Error::from)

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -291,8 +291,7 @@ impl WriteApiServer for TransactionExecutionApi {
     ) -> RpcResult<DevInspectResults> {
         with_tracing!(async move {
             let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
-            self
-                .state
+            self.state
                 .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
                 .await
                 .map_err(Error::from)


### PR DESCRIPTION
## Description 

Transparently group RPC-level client errors together without modifying existing error response text. This will help us later w/ standardizing error strings as we now have an overview of possible errors, and can quickly jump to locations with `SuiRpcInputError`.

1. Gather client-fault errors under `SuiRpcInputError`
2. In `transaction_execution_api`, split out client input validation logic/ preparation into its own function to capture various client errors under one method.
3. Implement `From<SuiRpcInputError> to RpcError` so we can reduce scenarios where we need to convert into `Error` then into `RpcError`. This makes it clearer when a client error occurs on the rpc
4. Add some more `coin_api` tests to make sure we hit all `SuiRpcInputError` scenarios

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
