### PR TITLE
Fix and reenable test_upgrade_compatibility

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -304,7 +304,6 @@ mod test {
         assert_eq!(expected_checkpoint, pruned);
     }
 
-    #[ignore("Disabled due to flakiness and timeouts - re-enable when timeouts are fixed")]
     #[sim_test(config = "test_config()")]
     async fn test_upgrade_compatibility() {
         // This test is intended to test the compatibility of the latest protocol version with
@@ -354,7 +353,7 @@ mod test {
                 info!("Targeting protocol version: {}", version);
                 test_cluster.wait_for_all_nodes_upgrade_to(version).await;
                 info!("All nodes are at protocol version: {}", version);
-                // Let all nodes run for a bit at this version.
+                // Let all nodes run for a few epochs at this version.
                 tokio::time::sleep(Duration::from_secs(50)).await;
                 if version == max_ver {
                     let stake_subsidy_start_epoch = test_cluster
@@ -393,12 +392,14 @@ mod test {
         });
 
         test_simulated_load(test_init_data_clone, 120).await;
-        loop {
+        for _ in 0..30 {
             if finished.load(Ordering::Relaxed) {
                 break;
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
+
+        assert!(finished.load(Ordering::SeqCst));
     }
 
     async fn build_test_cluster(

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -68,7 +68,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_reconfig() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = build_test_cluster(4, 1000).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 60).await;
     }
 
@@ -97,7 +97,7 @@ mod test {
         // TODO added to invalidate a failing test seed in CI. Remove me
         tokio::time::sleep(Duration::from_secs(1)).await;
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = Arc::new(build_test_cluster(4, 5000).await);
+        let test_cluster = Arc::new(build_test_cluster(4, 1000).await);
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -185,7 +185,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_with_crashes_and_delays() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = build_test_cluster(4, 1000).await;
 
         let dead_validator_orig: Arc<Mutex<Option<DeadValidator>>> = Default::default();
 
@@ -243,7 +243,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_crashes_during_epoch_change() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = build_test_cluster(4, 10000).await;
 
         let dead_validator: Arc<Mutex<Option<DeadValidator>>> = Default::default();
         let keep_alive_nodes = get_keep_alive_nodes(&test_cluster);
@@ -255,7 +255,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_checkpoint_pruning() {
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = build_test_cluster(4, 1000).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 30).await;
 
         let swarm_dir = test_cluster.swarm.dir().join(AUTHORITIES_DB_NAME);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -964,28 +964,22 @@ impl AuthorityPerEpochStore {
     /// and verify that it allows new user certificates
     pub fn insert_pending_consensus_transactions(
         &self,
-        transactions: &[ConsensusTransaction],
+        transaction: &ConsensusTransaction,
         lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> SuiResult {
-        let mut batch = self.tables.pending_consensus_transactions.batch();
-        batch.insert_batch(
-            &self.tables.pending_consensus_transactions,
-            transactions.iter().map(|t| (t.key(), t)),
-        )?;
-        batch.write()?;
-
-        for transaction in transactions {
-            if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
-                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
-                // Caller is responsible for performing graceful check
-                assert!(
-                    state.should_accept_user_certs(),
-                    "Reconfiguration state should allow accepting user transactions"
-                );
-                self.pending_consensus_certificates
-                    .lock()
-                    .insert(*cert.digest());
-            }
+        self.tables
+            .pending_consensus_transactions
+            .insert(&transaction.key(), transaction)?;
+        if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
+            let state = lock.expect("Must pass reconfiguration lock when storing certificate");
+            // Caller is responsible for performing graceful check
+            assert!(
+                state.should_accept_user_certs(),
+                "Reconfiguration state should allow accepting user transactions"
+            );
+            self.pending_consensus_certificates
+                .lock()
+                .insert(*cert.digest());
         }
         Ok(())
     }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -550,7 +550,7 @@ impl ConsensusAdapter {
         lock: Option<&RwLockReadGuard<ReconfigState>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<JoinHandle<()>> {
-        epoch_store.insert_pending_consensus_transactions(&[transaction.clone()], lock)?;
+        epoch_store.insert_pending_consensus_transactions(&transaction, lock)?;
         Ok(self.submit_unchecked(transaction, epoch_store))
     }
 

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -13,9 +13,7 @@ use crate::transaction_manager::TransactionManager;
 use async_trait::async_trait;
 use narwhal_types::{validate_batch_version, BatchAPI};
 use narwhal_worker::TransactionValidator;
-use sui_types::base_types::AuthorityName;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
-use sui_types::transaction::VerifiedCertificate;
 use tap::TapFallible;
 use tokio::runtime::Handle;
 use tracing::{info, warn};
@@ -23,16 +21,14 @@ use tracing::{info, warn};
 /// Allows verifying the validity of transactions
 #[derive(Clone)]
 pub struct SuiTxValidator {
-    name: AuthorityName,
     epoch_store: Arc<AuthorityPerEpochStore>,
     checkpoint_service: Arc<dyn CheckpointServiceNotify + Send + Sync>,
-    transaction_manager: Arc<TransactionManager>,
+    _transaction_manager: Arc<TransactionManager>,
     metrics: Arc<SuiTxValidatorMetrics>,
 }
 
 impl SuiTxValidator {
     pub fn new(
-        name: AuthorityName,
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<dyn CheckpointServiceNotify + Send + Sync>,
         transaction_manager: Arc<TransactionManager>,
@@ -43,10 +39,9 @@ impl SuiTxValidator {
             epoch_store.epoch()
         );
         Self {
-            name,
             epoch_store,
             checkpoint_service,
-            transaction_manager,
+            _transaction_manager: transaction_manager,
             metrics,
         }
     }
@@ -83,25 +78,19 @@ impl TransactionValidator for SuiTxValidator {
             .map(|tx| tx_from_bytes(tx))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let epoch_store = self.epoch_store.clone();
-
-        let mut owned_tx_certs = Vec::new();
         let mut cert_batch = Vec::new();
         let mut ckpt_messages = Vec::new();
         let mut ckpt_batch = Vec::new();
         for tx in txs.into_iter() {
             match tx.kind {
                 ConsensusTransactionKind::UserTransaction(certificate) => {
-                    cert_batch.push(*certificate.clone());
+                    cert_batch.push(*certificate);
 
-                    if !certificate.contains_shared_object()
-                        && !epoch_store.is_tx_cert_consensus_message_processed(&certificate)?
-                    {
-                        // new_unchecked safety: we do not use the certs in this list until all
-                        // have had their signatures verified. All certs in cert_batch must be
-                        // verified by signature_verifier, or the entire batch will be rejected.
-                        owned_tx_certs.push(VerifiedCertificate::new_unchecked(*certificate));
-                    }
+                    // if !certificate.contains_shared_object() {
+                    //     // new_unchecked safety: we do not use the certs in this list until all
+                    //     // have had their signatures verified.
+                    //     owned_tx_certs.push(VerifiedCertificate::new_unchecked(*certificate));
+                    // }
                 }
                 ConsensusTransactionKind::CheckpointSignature(signature) => {
                     ckpt_messages.push(signature.clone());
@@ -115,10 +104,10 @@ impl TransactionValidator for SuiTxValidator {
         // verify the certificate signatures as a batch
         let cert_count = cert_batch.len();
         let ckpt_count = ckpt_batch.len();
-        let epoch_store_clone = epoch_store.clone();
+        let epoch_store = self.epoch_store.clone();
         Handle::current()
             .spawn_blocking(move || {
-                epoch_store_clone
+                epoch_store
                     .signature_verifier
                     .verify_certs_and_checkpoints(cert_batch, ckpt_batch)
                     .tap_err(|e| warn!("batch verification error: {}", e))
@@ -138,25 +127,16 @@ impl TransactionValidator for SuiTxValidator {
         self.metrics
             .checkpoint_signatures_verified
             .inc_by(ckpt_count as u64);
-
-        let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
-        if reconfiguration_lock.should_accept_user_certs() {
-            let consensus_transactions: Vec<_> = owned_tx_certs
-                .iter()
-                .map(|cert| {
-                    ConsensusTransaction::new_certificate_message(&self.name, cert.clone().into())
-                })
-                .collect();
-            epoch_store.insert_pending_consensus_transactions(
-                &consensus_transactions,
-                Some(&reconfiguration_lock),
-            )?;
-            self.transaction_manager
-                .enqueue_certificates(owned_tx_certs, &epoch_store)
-                .wrap_err("Failed to schedule certificates for execution")?;
-        }
-
         Ok(())
+
+        // todo - we should un-comment line below once we have a way to revert those transactions at the end of epoch
+        // all certificates had valid signatures, schedule them for execution prior to sequencing
+        // which is unnecessary for owned object transactions.
+        // It is unnecessary to write to pending_certificates table because the certs will be written
+        // via Narwhal output.
+        // self.transaction_manager
+        //     .enqueue_certificates(owned_tx_certs, &self.epoch_store)
+        //     .wrap_err("Failed to schedule certificates for execution")
     }
 }
 
@@ -233,7 +213,6 @@ mod tests {
 
         let metrics = SuiTxValidatorMetrics::new(&Default::default());
         let validator = SuiTxValidator::new(
-            state.name,
             state.epoch_store_for_testing().clone(),
             Arc::new(CheckpointServiceNoop {}),
             state.transaction_manager().clone(),

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -272,10 +272,7 @@ async fn access_clock_object_test() {
 
 #[sim_test]
 async fn shared_object_sync() {
-    let test_cluster = TestClusterBuilder::new()
-        .with_num_validators(7)
-        .build()
-        .await;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let package_id = publish_basics_package(&test_cluster.wallet).await.0;
 
     // Since we use submit_transaction_to_validators in this test, which does not go through fullnode,
@@ -292,21 +289,7 @@ async fn shared_object_sync() {
     let validators = test_cluster.get_validator_pubkeys();
     let (slow_validators, fast_validators): (Vec<_>, Vec<_>) =
         validators.iter().partition(|name| {
-            let position =
-                position_submit_certificate(&committee, name, create_counter_transaction.digest());
-            tracing::info!(?name, tx_digest = ?create_counter_transaction.digest(), ?position, "position");
-            position > 1
-        });
-
-    slow_validators
-        .iter()
-        .for_each(|n: &sui_types::base_types::AuthorityName| {
-            tracing::info!("slow validator: {:?}", n.concise())
-        });
-    fast_validators
-        .iter()
-        .for_each(|n: &sui_types::base_types::AuthorityName| {
-            tracing::info!("fast validator: {:?}", n.concise())
+            position_submit_certificate(&committee, name, create_counter_transaction.digest()) > 0
         });
 
     let (effects, _, _) = test_cluster
@@ -352,7 +335,7 @@ async fn shared_object_sync() {
 
     // Let's submit the transaction to the original set of validators, except the first.
     let (effects, _, _) = test_cluster
-        .submit_transaction_to_validators(increment_counter_transaction.clone(), &slow_validators)
+        .submit_transaction_to_validators(increment_counter_transaction.clone(), &validators[1..])
         .await
         .unwrap();
     assert!(effects.status().is_ok());
@@ -360,7 +343,7 @@ async fn shared_object_sync() {
     // Submit transactions to the out-of-date authority.
     // It will succeed because we share owned object certificates through narwhal
     let (effects, _, _) = test_cluster
-        .submit_transaction_to_validators(increment_counter_transaction, &fast_validators)
+        .submit_transaction_to_validators(increment_counter_transaction, &validators[0..1])
         .await
         .unwrap();
     assert!(effects.status().is_ok());

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -921,7 +921,6 @@ impl SuiNode {
                 worker_cache,
                 consensus_handler,
                 SuiTxValidator::new(
-                    state.name,
                     epoch_store,
                     checkpoint_service.clone(),
                     state.transaction_manager().clone(),


### PR DESCRIPTION
## Description 

It seems 57099fc1bc7fcd5c4adacb1eb9e9127d38024c09 unexpectedly broke epoch change, which resulted in `test_upgrade_compatibility` timing out.

## Test Plan 

CI
`MSIM_TEST_NUM=10 cargo simtest test_upgrade_compatibility`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
