### PR TITLE
[move-compiler] Added support for linter warning suppression

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -53,7 +53,9 @@ use sui_types::{
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
 
-use crate::linters::{self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier};
+use crate::linters::{
+    known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
+};
 
 #[cfg(test)]
 #[path = "unit_tests/build_tests.rs"]
@@ -134,7 +136,11 @@ impl BuildConfig {
             let (files, units_res) = if lint {
                 let lint_visitors =
                     vec![ShareOwnedVerifier.visitor(), SelfTransferVerifier.visitor()];
-                compiler.add_visitors(lint_visitors).build()?
+                let (filter_attr_name, filters) = known_filters();
+                compiler
+                    .add_visitors(lint_visitors)
+                    .add_custom_known_filters(filters, filter_attr_name)
+                    .build()?
             } else {
                 compiler.build()?
             };

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,5 +1,41 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use move_compiler::{
+    diagnostics::codes::{DiagnosticsID, WarningFilter},
+    expansion::ast as E,
+};
+
 pub mod self_transfer;
 pub mod share_owned;
+
+pub const SHARE_OWNED_DIAG_CATEGORY: u8 = 1;
+pub const SELF_TRANSFER_DIAG_CATEGORY: u8 = 2;
+
+pub const ALLOW_ATTR_NAME: &str = "linter_allow";
+
+pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
+pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
+
+pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
+    (
+        E::AttributeName_::Unknown(ALLOW_ATTR_NAME.into()),
+        vec![
+            WarningFilter::All,
+            WarningFilter::Code(
+                DiagnosticsID {
+                    category: SHARE_OWNED_DIAG_CATEGORY,
+                    code: 1,
+                },
+                Some(SHARE_OWNED_FILTER_NAME),
+            ),
+            WarningFilter::Code(
+                DiagnosticsID {
+                    category: SELF_TRANSFER_DIAG_CATEGORY,
+                    code: 1,
+                },
+                Some(SELF_TRANSFER_FILTER_NAME),
+            ),
+        ],
+    )
+}

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,13 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_compiler::{diagnostics::codes::WarningFilter, expansion::ast as E};
+use move_compiler::{
+    diagnostics::codes::{DiagnosticsID, WarningFilter},
+    expansion::ast as E,
+};
 
 pub mod self_transfer;
 pub mod share_owned;
 
 pub const SHARE_OWNED_DIAG_CATEGORY: u8 = 1;
+pub const SHARE_OWNED_DIAG_CODE: u8 = 1;
 pub const SELF_TRANSFER_DIAG_CATEGORY: u8 = 2;
+pub const SELF_TRANSFER_DIAG_CODE: u8 = 1;
 
 pub const ALLOW_ATTR_NAME: &str = "linter_allow";
 
@@ -19,8 +24,20 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
         E::AttributeName_::Unknown(ALLOW_ATTR_NAME.into()),
         vec![
             WarningFilter::All,
-            WarningFilter::Category(SHARE_OWNED_DIAG_CATEGORY, Some(SHARE_OWNED_FILTER_NAME)),
-            WarningFilter::Category(SELF_TRANSFER_DIAG_CATEGORY, Some(SELF_TRANSFER_FILTER_NAME)),
+            WarningFilter::Code(
+                DiagnosticsID {
+                    category: SHARE_OWNED_DIAG_CATEGORY,
+                    code: SHARE_OWNED_DIAG_CODE,
+                },
+                Some(SHARE_OWNED_FILTER_NAME),
+            ),
+            WarningFilter::Code(
+                DiagnosticsID {
+                    category: SELF_TRANSFER_DIAG_CATEGORY,
+                    code: SELF_TRANSFER_DIAG_CODE,
+                },
+                Some(SELF_TRANSFER_FILTER_NAME),
+            ),
         ],
     )
 }

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -14,7 +14,7 @@ pub const SHARE_OWNED_DIAG_CODE: u8 = 1;
 pub const SELF_TRANSFER_DIAG_CATEGORY: u8 = 2;
 pub const SELF_TRANSFER_DIAG_CODE: u8 = 1;
 
-pub const ALLOW_ATTR_NAME: &str = "linter_allow";
+pub const ALLOW_ATTR_NAME: &str = "lint_allow";
 pub const LINT_WARNING_PREFIX: &str = "Lint ";
 
 pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_compiler::{
-    diagnostics::codes::{DiagnosticsID, WarningFilter},
-    expansion::ast as E,
-};
+use move_compiler::{diagnostics::codes::WarningFilter, expansion::ast as E};
 
 pub mod self_transfer;
 pub mod share_owned;
@@ -22,20 +19,8 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
         E::AttributeName_::Unknown(ALLOW_ATTR_NAME.into()),
         vec![
             WarningFilter::All,
-            WarningFilter::Code(
-                DiagnosticsID {
-                    category: SHARE_OWNED_DIAG_CATEGORY,
-                    code: 1,
-                },
-                Some(SHARE_OWNED_FILTER_NAME),
-            ),
-            WarningFilter::Code(
-                DiagnosticsID {
-                    category: SELF_TRANSFER_DIAG_CATEGORY,
-                    code: 1,
-                },
-                Some(SELF_TRANSFER_FILTER_NAME),
-            ),
+            WarningFilter::Category(SHARE_OWNED_DIAG_CATEGORY, Some(SHARE_OWNED_FILTER_NAME)),
+            WarningFilter::Category(SELF_TRANSFER_DIAG_CATEGORY, Some(SELF_TRANSFER_FILTER_NAME)),
         ],
     )
 }

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -15,6 +15,7 @@ pub const SELF_TRANSFER_DIAG_CATEGORY: u8 = 2;
 pub const SELF_TRANSFER_DIAG_CODE: u8 = 1;
 
 pub const ALLOW_ATTR_NAME: &str = "linter_allow";
+pub const LINT_WARNING_PREFIX: &str = "Lint ";
 
 pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
 pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
@@ -23,19 +24,21 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
     (
         E::AttributeName_::Unknown(ALLOW_ATTR_NAME.into()),
         vec![
-            WarningFilter::All,
+            WarningFilter::All(Some(LINT_WARNING_PREFIX)),
             WarningFilter::Code(
-                DiagnosticsID {
-                    category: SHARE_OWNED_DIAG_CATEGORY,
-                    code: SHARE_OWNED_DIAG_CODE,
-                },
+                DiagnosticsID::new(
+                    SHARE_OWNED_DIAG_CATEGORY,
+                    SHARE_OWNED_DIAG_CODE,
+                    Some(LINT_WARNING_PREFIX),
+                ),
                 Some(SHARE_OWNED_FILTER_NAME),
             ),
             WarningFilter::Code(
-                DiagnosticsID {
-                    category: SELF_TRANSFER_DIAG_CATEGORY,
-                    code: SELF_TRANSFER_DIAG_CODE,
-                },
+                DiagnosticsID::new(
+                    SELF_TRANSFER_DIAG_CATEGORY,
+                    SELF_TRANSFER_DIAG_CODE,
+                    Some(LINT_WARNING_PREFIX),
+                ),
                 Some(SELF_TRANSFER_FILTER_NAME),
             ),
         ],

--- a/crates/sui-move-build/src/linters/self_transfer.rs
+++ b/crates/sui-move-build/src/linters/self_transfer.rs
@@ -26,7 +26,7 @@ use move_compiler::{
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
-use super::SELF_TRANSFER_DIAG_CATEGORY;
+use super::{SELF_TRANSFER_DIAG_CATEGORY, SELF_TRANSFER_DIAG_CODE};
 
 const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("sui", "transfer", "public_transfer"),
@@ -39,7 +39,7 @@ const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
     "Lint ",
     Severity::Warning,
     SELF_TRANSFER_DIAG_CATEGORY,
-    /* code */ 1,
+    SELF_TRANSFER_DIAG_CODE,
     "non-composable transfer to sender",
 );
 

--- a/crates/sui-move-build/src/linters/self_transfer.rs
+++ b/crates/sui-move-build/src/linters/self_transfer.rs
@@ -26,6 +26,8 @@ use move_compiler::{
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
+use super::SELF_TRANSFER_DIAG_CATEGORY;
+
 const TRANSFER_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("sui", "transfer", "public_transfer"),
     ("sui", "transfer", "transfer"),
@@ -36,7 +38,7 @@ const INVALID_LOC: Loc = Loc::invalid();
 const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
     "Lint ",
     Severity::Warning,
-    /* category */ 1,
+    SELF_TRANSFER_DIAG_CATEGORY,
     /* code */ 1,
     "non-composable transfer to sender",
 );

--- a/crates/sui-move-build/src/linters/share_owned.rs
+++ b/crates/sui-move-build/src/linters/share_owned.rs
@@ -30,6 +30,8 @@ use move_compiler::{
 };
 use std::collections::BTreeMap;
 
+use super::SHARE_OWNED_DIAG_CATEGORY;
+
 const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("sui", "transfer", "public_share_object"),
     ("sui", "transfer", "share_object"),
@@ -38,7 +40,7 @@ const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
 const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
     "Lint ",
     Severity::Warning,
-    /* category */ 1,
+    SHARE_OWNED_DIAG_CATEGORY,
     /* code */ 1,
     "possible owned object share",
 );

--- a/crates/sui-move-build/src/linters/share_owned.rs
+++ b/crates/sui-move-build/src/linters/share_owned.rs
@@ -30,7 +30,7 @@ use move_compiler::{
 };
 use std::collections::BTreeMap;
 
-use super::SHARE_OWNED_DIAG_CATEGORY;
+use super::{SHARE_OWNED_DIAG_CATEGORY, SHARE_OWNED_DIAG_CODE};
 
 const SHARE_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("sui", "transfer", "public_share_object"),
@@ -41,7 +41,7 @@ const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
     "Lint ",
     Severity::Warning,
     SHARE_OWNED_DIAG_CATEGORY,
-    /* code */ 1,
+    SHARE_OWNED_DIAG_CODE,
     "possible owned object share",
 );
 

--- a/crates/sui-move-build/tests/linter/self_transfer.exp
+++ b/crates/sui-move-build/tests/linter/self_transfer.exp
@@ -9,7 +9,7 @@ warning[Lint W02001]: non-composable transfer to sender
    │         │                                                       Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function public_transfer_bad
    │
-   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:27:9
@@ -22,7 +22,7 @@ warning[Lint W02001]: non-composable transfer to sender
    │         │                                                Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function private_transfer_bad
    │
-   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:31:9
@@ -35,7 +35,7 @@ warning[Lint W02001]: non-composable transfer to sender
    │         │                                                Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function private_transfer_no_store_bad
    │
-   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:39:9
@@ -48,5 +48,5 @@ warning[Lint W02001]: non-composable transfer to sender
 39 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to transaction sender address in function transfer_through_assigns_bad
    │
-   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/crates/sui-move-build/tests/linter/self_transfer.exp
+++ b/crates/sui-move-build/tests/linter/self_transfer.exp
@@ -1,4 +1,4 @@
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:23:9
    │
 22 │     public fun public_transfer_bad(ctx: &mut TxContext) {
@@ -8,8 +8,10 @@ warning[Lint W01001]: non-composable transfer to sender
    │         │                                                       │
    │         │                                                       Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function public_transfer_bad
+   │
+   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:27:9
    │
 26 │     public fun private_transfer_bad(ctx: &mut TxContext) {
@@ -19,8 +21,10 @@ warning[Lint W01001]: non-composable transfer to sender
    │         │                                                │
    │         │                                                Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function private_transfer_bad
+   │
+   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:31:9
    │
 30 │     public fun private_transfer_no_store_bad(ctx: &mut TxContext) {
@@ -30,8 +34,10 @@ warning[Lint W01001]: non-composable transfer to sender
    │         │                                                │
    │         │                                                Transaction sender address coming from here
    │         Transfer of an object to transaction sender address in function private_transfer_no_store_bad
+   │
+   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01001]: non-composable transfer to sender
+warning[Lint W02001]: non-composable transfer to sender
    ┌─ tests/linter/self_transfer.move:37:9
    │
 34 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
@@ -41,4 +47,6 @@ warning[Lint W01001]: non-composable transfer to sender
 36 │         let another_sender = sender;
 37 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to transaction sender address in function transfer_through_assigns_bad
+   │
+   = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/crates/sui-move-build/tests/linter/self_transfer.exp
+++ b/crates/sui-move-build/tests/linter/self_transfer.exp
@@ -38,14 +38,14 @@ warning[Lint W02001]: non-composable transfer to sender
    = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02001]: non-composable transfer to sender
-   ┌─ tests/linter/self_transfer.move:37:9
+   ┌─ tests/linter/self_transfer.move:39:9
    │
-34 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
+36 │     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
    │                ---------------------------- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
-35 │         let sender = tx_context::sender(ctx);
+37 │         let sender = tx_context::sender(ctx);
    │                      ----------------------- Transaction sender address coming from here
-36 │         let another_sender = sender;
-37 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
+38 │         let another_sender = sender;
+39 │         transfer::public_transfer(S1 { id: object::new(ctx), }, another_sender)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to transaction sender address in function transfer_through_assigns_bad
    │
    = This warning can be suppressed with '#[allow(self_transfer)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/crates/sui-move-build/tests/linter/self_transfer.move
+++ b/crates/sui-move-build/tests/linter/self_transfer.move
@@ -31,6 +31,8 @@ module 0x42::test {
         transfer::transfer(S2 { id: object::new(ctx), }, tx_context::sender(ctx))
     }
 
+    // non-linter suppression annotation should not suppress linter warnings
+    #[allow(all)]
     public fun transfer_through_assigns_bad(ctx: &mut TxContext) {
         let sender = tx_context::sender(ctx);
         let another_sender = sender;

--- a/crates/sui-move-build/tests/linter/self_transfer.move
+++ b/crates/sui-move-build/tests/linter/self_transfer.move
@@ -50,7 +50,7 @@ module 0x42::test {
         transfer::transfer(S1 { id: object::new(ctx), }, xfer_address);
     }
 
-    #[linter_allow(self_transfer)]
+    #[lint_allow(self_transfer)]
     public fun public_transfer_bad_suppressed(ctx: &mut TxContext) {
         transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
     }

--- a/crates/sui-move-build/tests/linter/self_transfer.move
+++ b/crates/sui-move-build/tests/linter/self_transfer.move
@@ -47,4 +47,9 @@ module 0x42::test {
         transfer::public_transfer(S1 { id: object::new(ctx), }, xfer_address);
         transfer::transfer(S1 { id: object::new(ctx), }, xfer_address);
     }
+
+    #[linter_allow(self_transfer)]
+    public fun public_transfer_bad_suppressed(ctx: &mut TxContext) {
+        transfer::public_transfer(S1 { id: object::new(ctx), }, tx_context::sender(ctx))
+    }
 }

--- a/crates/sui-move-build/tests/linter/share_owned.exp
+++ b/crates/sui-move-build/tests/linter/share_owned.exp
@@ -25,3 +25,19 @@ warning[Lint W01001]: possible owned object share
    │
    = This warning can be suppressed with '#[allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[W09008]: unused function
+   ┌─ tests/linter/share_owned.move:48:9
+   │
+48 │     fun private_fun_should_not_be_suppressed() {}
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The non-'public', non-'entry' function 'private_fun_should_not_be_suppressed' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09008]: unused function
+   ┌─ tests/linter/share_owned.move:52:9
+   │
+52 │     fun another_private_fun_should_not_be_suppressed() {}
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The non-'public', non-'entry' function 'another_private_fun_should_not_be_suppressed' is never called. Consider removing it.
+   │
+   = This warning can be suppressed with '#[allow(unused_function)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/crates/sui-move-build/tests/linter/share_owned.exp
+++ b/crates/sui-move-build/tests/linter/share_owned.exp
@@ -10,7 +10,7 @@ warning[Lint W01001]: possible owned object share
    │         │                             Creating a fresh object and sharing it within the same function will ensure this does not abort.
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
-   = This warning can be suppressed with '#[allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W01001]: possible owned object share
    ┌─ tests/linter/share_owned.move:35:9
@@ -23,7 +23,7 @@ warning[Lint W01001]: possible owned object share
    │         │                             Creating a fresh object and sharing it within the same function will ensure this does not abort.
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
-   = This warning can be suppressed with '#[allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[lint_allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09008]: unused function
    ┌─ tests/linter/share_owned.move:48:9

--- a/crates/sui-move-build/tests/linter/share_owned.exp
+++ b/crates/sui-move-build/tests/linter/share_owned.exp
@@ -9,6 +9,8 @@ warning[Lint W01001]: possible owned object share
    │         │                             │
    │         │                             Creating a fresh object and sharing it within the same function will ensure this does not abort.
    │         Potential abort from a (potentially) owned object created by a different transaction.
+   │
+   = This warning can be suppressed with '#[allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W01001]: possible owned object share
    ┌─ tests/linter/share_owned.move:35:9
@@ -20,4 +22,6 @@ warning[Lint W01001]: possible owned object share
    │         │                             │
    │         │                             Creating a fresh object and sharing it within the same function will ensure this does not abort.
    │         Potential abort from a (potentially) owned object created by a different transaction.
+   │
+   = This warning can be suppressed with '#[allow(share_owned)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/crates/sui-move-build/tests/linter/share_owned.move
+++ b/crates/sui-move-build/tests/linter/share_owned.move
@@ -42,4 +42,14 @@ module 0x42::test2 {
         transfer::public_share_object(o);
         object::delete(id);
     }
+
+    // a linter suppression should not work for regular compiler warnings
+    #[linter_allow(code_suppression_should_not_work)]
+    fun private_fun_should_not_be_suppressed() {}
+
+    // a linter suppression should not work for regular compiler warnings
+    #[linter_allow(category_suppression_should_not_work)]
+    fun another_private_fun_should_not_be_suppressed() {}
+
+
 }

--- a/crates/sui-move-build/tests/linter/share_owned.move
+++ b/crates/sui-move-build/tests/linter/share_owned.move
@@ -35,4 +35,11 @@ module 0x42::test2 {
         transfer::public_share_object(o);
         object::delete(id);
     }
+
+    #[linter_allow(share_owned)]
+    public entry fun unpack_obj_suppressed(w: Wrapper) {
+        let Wrapper { id, i: _, o } = w;
+        transfer::public_share_object(o);
+        object::delete(id);
+    }
 }

--- a/crates/sui-move-build/tests/linter/share_owned.move
+++ b/crates/sui-move-build/tests/linter/share_owned.move
@@ -36,7 +36,7 @@ module 0x42::test2 {
         object::delete(id);
     }
 
-    #[linter_allow(share_owned)]
+    #[lint_allow(share_owned)]
     public entry fun unpack_obj_suppressed(w: Wrapper) {
         let Wrapper { id, i: _, o } = w;
         transfer::public_share_object(o);

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -8,15 +8,17 @@ use move_command_line_common::{
     testing::{add_update_baseline_fix, format_diff, read_env_update_baseline},
 };
 use move_compiler::{
-    cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::move_check_for_errors,
+    diagnostics::codes::{self, CategoryID, DiagnosticsID, WarningFilter},
     editions::Flavor,
+    expansion::ast as E,
     shared::{NumericalAddress, PackageConfig},
     Compiler, PASS_PARSER,
 };
 
 use sui_move_build::linters::{
     known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
+    LINT_WARNING_PREFIX,
 };
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
@@ -35,12 +37,32 @@ fn linter_tests(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
+pub fn known_filters_for_test() -> (E::AttributeName_, Vec<WarningFilter>) {
+    let (filter_attr_name, mut filters) = known_filters();
+
+    let unused_function_code_filter = WarningFilter::Code(
+        DiagnosticsID::new(
+            codes::Category::UnusedItem as u8,
+            codes::UnusedItem::Function as u8,
+            Some(LINT_WARNING_PREFIX),
+        ),
+        Some("code_suppression_should_not_work"),
+    );
+    let unused_function_category_filter = WarningFilter::Category(
+        CategoryID::new(codes::Category::UnusedItem as u8, Some(LINT_WARNING_PREFIX)),
+        Some("category_suppression_should_not_work"),
+    );
+    filters.push(unused_function_code_filter);
+    filters.push(unused_function_category_filter);
+    (filter_attr_name, filters)
+}
+
 fn run_tests(path: &Path) -> anyhow::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
 
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
     let lint_visitors = vec![ShareOwnedVerifier.visitor(), SelfTransferVerifier.visitor()];
-    let (filter_attr_name, filters) = known_filters();
+    let (filter_attr_name, filters) = known_filters_for_test();
     let (files, comments_and_compiler_res) = Compiler::from_files(
         targets,
         vec![MOVE_STDLIB_PATH.to_string(), SUI_FRAMEWORK_PATH.to_string()],

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -16,7 +16,7 @@ use move_compiler::{
 };
 
 use sui_move_build::linters::{
-    self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
+    known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
 };
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
@@ -40,6 +40,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
 
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
     let lint_visitors = vec![ShareOwnedVerifier.visitor(), SelfTransferVerifier.visitor()];
+    let (filter_attr_name, filters) = known_filters();
     let (files, comments_and_compiler_res) = Compiler::from_files(
         targets,
         vec![MOVE_STDLIB_PATH.to_string(), SUI_FRAMEWORK_PATH.to_string()],
@@ -50,6 +51,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         flavor: Flavor::Sui,
         ..PackageConfig::default()
     })
+    .add_custom_known_filters(filters, filter_attr_name)
     .run::<PASS_PARSER>()?;
 
     let diags = move_check_for_errors(comments_and_compiler_res);

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -8,6 +8,7 @@ use move_command_line_common::{
     testing::{add_update_baseline_fix, format_diff, read_env_update_baseline},
 };
 use move_compiler::{
+    cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::move_check_for_errors,
     diagnostics::codes::{self, CategoryID, DiagnosticsID, WarningFilter},
     editions::Flavor,

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -14,12 +14,16 @@ pub enum Severity {
     Bug = 3,
 }
 
-/// Identifies a warning category. Includes an option external prefix to distinguish warnings from
+/// A an optional prefix to distinguish between different types of warnings (internal vs. possibly
+/// multiple externally provided ones).
+type ExternalPrefix = Option<&'static str>;
+
+/// Identifies a warning category. Includes an external prefix to distinguish warnings from
 /// different sources.
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub struct CategoryID {
     category: u8,
-    external_prefix: Option<&'static str>,
+    external_prefix: ExternalPrefix,
 }
 
 /// Identifies a warning diagnostic through a warning category ID and a warning code.
@@ -59,7 +63,7 @@ pub(crate) trait DiagnosticCode: Copy {
 /// Represents a single annotation for a diagnostic filter
 pub enum WarningFilter {
     /// Filters all warnings
-    All(/* external_prefix */ Option<&'static str>),
+    All(ExternalPrefix),
     /// Filters all warnings of a specific category. Only known filters have names.
     Category(CategoryID, /* name */ Option<&'static str>),
     /// Filters a single warning, as defined by codes below. Only known filters have names.
@@ -326,7 +330,7 @@ impl WarningFilter {
 //**************************************************************************************************
 
 impl CategoryID {
-    pub fn new(category: u8, external_prefix: Option<&'static str>) -> Self {
+    pub fn new(category: u8, external_prefix: ExternalPrefix) -> Self {
         CategoryID {
             category,
             external_prefix,
@@ -343,7 +347,7 @@ impl CategoryID {
 }
 
 impl DiagnosticsID {
-    pub fn new(category: u8, code: u8, external_prefix: Option<&'static str>) -> Self {
+    pub fn new(category: u8, code: u8, external_prefix: ExternalPrefix) -> Self {
         let category_id = CategoryID {
             category,
             external_prefix,
@@ -359,7 +363,7 @@ impl DiagnosticsID {
         self.code
     }
 
-    pub fn external_prefix(&self) -> Option<&'static str> {
+    pub fn external_prefix(&self) -> ExternalPrefix {
         self.category_id.external_prefix
     }
 

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -54,7 +54,7 @@ pub enum WarningFilter {
     /// Filters all warnings
     All,
     /// Filters all warnings of a specific category. Only known filters have names.
-    Category(Category, /* name */ Option<&'static str>),
+    Category(/* category */ u8, /* name */ Option<&'static str>),
     /// Filters a single warning, as defined by codes below. Only known filters have names.
     Code(DiagnosticsID, /* name */ Option<&'static str>),
 }

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -53,8 +53,8 @@ pub(crate) trait DiagnosticCode: Copy {
 pub enum WarningFilter {
     /// Filters all warnings
     All,
-    /// Filters all warnings of a specific category
-    Category(Category),
+    /// Filters all warnings of a specific category. Only known filters have names.
+    Category(Category, /* name */ Option<&'static str>),
     /// Filters a single warning, as defined by codes below. Only known filters have names.
     Code(DiagnosticsID, /* name */ Option<&'static str>),
 }
@@ -303,9 +303,8 @@ impl WarningFilter {
     pub fn to_str(self) -> Option<&'static str> {
         match self {
             Self::All => Some("all"),
-            Self::Category(Category::UnusedItem) => Some("unused"),
+            Self::Category(_, n) => n,
             Self::Code(_, n) => n,
-            _ => None,
         }
     }
 }

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -14,11 +14,16 @@ pub enum Severity {
     Bug = 3,
 }
 
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
+pub struct DiagnosticsID {
+    pub category: u8,
+    pub code: u8,
+}
+
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct DiagnosticInfo {
     severity: Severity,
-    category: u8,
-    code: u8,
+    id: DiagnosticsID,
     message: &'static str,
     external_prefix: Option<&'static str>,
 }
@@ -36,8 +41,7 @@ pub(crate) trait DiagnosticCode: Copy {
         let (code, message) = self.code_and_message();
         DiagnosticInfo {
             severity,
-            category,
-            code,
+            id: DiagnosticsID { category, code },
             message,
             external_prefix: None,
         }
@@ -76,8 +80,7 @@ pub const fn custom(
     assert!(category <= 99);
     DiagnosticInfo {
         severity,
-        category,
-        code,
+        id: DiagnosticsID { category, code },
         message,
         external_prefix: Some(external_prefix),
     }
@@ -349,8 +352,7 @@ impl DiagnosticInfo {
     pub fn render(self) -> (/* code */ String, /* message */ &'static str) {
         let Self {
             severity,
-            category,
-            code,
+            id: DiagnosticsID { category, code },
             message,
             external_prefix,
         } = self;
@@ -373,11 +375,11 @@ impl DiagnosticInfo {
     }
 
     pub fn category(&self) -> u8 {
-        self.category
+        self.id.category
     }
 
     pub fn code(&self) -> u8 {
-        self.code
+        self.id.code
     }
 
     pub fn message(&self) -> &'static str {
@@ -386,6 +388,10 @@ impl DiagnosticInfo {
 
     pub fn is_external(&self) -> bool {
         self.external_prefix.is_some()
+    }
+
+    pub fn id(&self) -> DiagnosticsID {
+        self.id
     }
 }
 

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -6,9 +6,7 @@ pub mod codes;
 
 use crate::{
     command_line::COLOR_MODE_ENV_VAR,
-    diagnostics::codes::{
-        Category, DiagnosticCode, DiagnosticInfo, DiagnosticsID, Severity, WarningFilter,
-    },
+    diagnostics::codes::{DiagnosticCode, DiagnosticInfo, DiagnosticsID, Severity, WarningFilter},
     shared::{ast_debug::AstDebug, FILTER_UNUSED_FUNCTION},
 };
 use codespan_reporting::{
@@ -508,7 +506,7 @@ impl AstDebug for WarningFilters {
                 w.write(&format!("#[{}(", WARNING_FILTER_ATTR,));
                 let items = category
                     .iter()
-                    .map(|(cat, n)| WarningFilter::Category(Category::try_from(*cat).unwrap(), *n))
+                    .map(|(cat, n)| WarningFilter::Category(*cat, *n))
                     .chain(
                         codes
                             .iter()

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -430,13 +430,7 @@ impl WarningFilters {
                     let cat = cat as u8;
                     category.insert(cat, n);
                     // remove any codes now covered by this category
-                    codes.retain(
-                        |DiagnosticsID {
-                             category: codes_cat,
-                             code: _,
-                         },
-                         _| codes_cat != &cat,
-                    );
+                    codes.retain(|diag_id, _| diag_id.category != cat);
                 }
                 WarningFilter::Code(diag_id, n) => {
                     // no need to add the filter if already covered by the category

--- a/external-crates/move/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/move-compiler/src/expansion/ast.rs
@@ -67,6 +67,16 @@ pub enum AttributeName_ {
     Unknown(Symbol),
     Known(KnownAttribute),
 }
+
+impl AttributeName_ {
+    pub fn name(&self) -> Symbol {
+        match self {
+            Self::Unknown(s) => *s,
+            Self::Known(a) => a.name().into(),
+        }
+    }
+}
+
 pub type AttributeName = Spanned<AttributeName_>;
 
 pub type Attributes = UniqueMap<AttributeName, Attribute>;

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -739,7 +739,7 @@ fn warning_filter(
                 let msg = format!(
                     "Expected list of warnings, e.g. '{}({})'",
                     DiagnosticAttribute::ALLOW,
-                    WarningFilter::Category(Category::UnusedItem, Some(FILTER_UNUSED))
+                    WarningFilter::Category(Category::UnusedItem as u8, Some(FILTER_UNUSED))
                         .to_str()
                         .unwrap(),
                 );

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -763,7 +763,7 @@ fn warning_filter(
                 n
             }
         };
-        let Some(filter) = WarningFilter::from_str(name_.as_str()) else {
+        let Some(filter) = context.env.filter_from_str(name_.as_str()) else {
             let msg = format!("Unknown warning filter '{name_}'");
             context
                 .env

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -4,7 +4,10 @@
 
 use crate::{
     diag,
-    diagnostics::{codes::WarningFilter, Diagnostic, WarningFilters},
+    diagnostics::{
+        codes::{CategoryID, WarningFilter},
+        Diagnostic, WarningFilters,
+    },
     expansion::{
         aliases::{AliasMap, AliasSet},
         ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_, SpecId},
@@ -739,9 +742,12 @@ fn warning_filter(
                 let msg = format!(
                     "Expected list of warnings, e.g. '{}({})'",
                     DiagnosticAttribute::ALLOW,
-                    WarningFilter::Category(Category::UnusedItem as u8, Some(FILTER_UNUSED))
-                        .to_str()
-                        .unwrap(),
+                    WarningFilter::Category(
+                        CategoryID::new(Category::UnusedItem as u8, None),
+                        Some(FILTER_UNUSED)
+                    )
+                    .to_str()
+                    .unwrap(),
                 );
                 context
                     .env

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -739,7 +739,7 @@ fn warning_filter(
                 let msg = format!(
                     "Expected list of warnings, e.g. '{}({})'",
                     DiagnosticAttribute::ALLOW,
-                    WarningFilter::Category(Category::UnusedItem)
+                    WarningFilter::Category(Category::UnusedItem, Some(FILTER_UNUSED))
                         .to_str()
                         .unwrap(),
                 );

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -230,6 +230,18 @@ pub struct CompilationEnv {
     // pub counter: u64,
 }
 
+macro_rules! known_code_filter {
+    ($name:ident, $category:ident::$code:ident, $attr_name:ident) => {
+        (
+            KnownFilterKey::new($name, $attr_name),
+            WarningFilter::Code(
+                DiagnosticsID::new(Category::$category as u8, $category::$code as u8, None),
+                Some($name),
+            ),
+        )
+    };
+}
+
 impl CompilationEnv {
     pub fn new(
         flags: Flags,
@@ -258,101 +270,43 @@ impl CompilationEnv {
                     Some(FILTER_UNUSED),
                 ),
             ),
-            (
-                KnownFilterKey::new(FILTER_MISSING_PHANTOM, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::Declarations as u8,
-                        Declarations::InvalidNonPhantomUse as u8,
-                        None,
-                    ),
-                    Some(FILTER_MISSING_PHANTOM),
-                ),
+            known_code_filter!(
+                FILTER_MISSING_PHANTOM,
+                Declarations::InvalidNonPhantomUse,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_USE, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(Category::UnusedItem as u8, UnusedItem::Alias as u8, None),
-                    Some(FILTER_UNUSED_USE),
-                ),
+            known_code_filter!(FILTER_UNUSED_USE, UnusedItem::Alias, filter_attr_name),
+            known_code_filter!(
+                FILTER_UNUSED_VARIABLE,
+                UnusedItem::Variable,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_VARIABLE, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::Variable as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_VARIABLE),
-                ),
+            known_code_filter!(
+                FILTER_UNUSED_ASSIGNMENT,
+                UnusedItem::Assignment,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_ASSIGNMENT, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::Assignment as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_ASSIGNMENT),
-                ),
+            known_code_filter!(
+                FILTER_UNUSED_TRAILING_SEMI,
+                UnusedItem::TrailingSemi,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_TRAILING_SEMI, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::TrailingSemi as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_TRAILING_SEMI),
-                ),
+            known_code_filter!(
+                FILTER_UNUSED_ATTRIBUTE,
+                UnusedItem::Attribute,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_ATTRIBUTE, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::Attribute as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_ATTRIBUTE),
-                ),
+            known_code_filter!(
+                FILTER_UNUSED_TYPE_PARAMETER,
+                UnusedItem::StructTypeParam,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_TYPE_PARAMETER, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::StructTypeParam as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_TYPE_PARAMETER),
-                ),
+            known_code_filter!(
+                FILTER_UNUSED_FUNCTION,
+                UnusedItem::Function,
+                filter_attr_name
             ),
-            (
-                KnownFilterKey::new(FILTER_UNUSED_FUNCTION, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::Function as u8,
-                        None,
-                    ),
-                    Some(FILTER_UNUSED_FUNCTION),
-                ),
-            ),
-            (
-                KnownFilterKey::new(FILTER_DEAD_CODE, filter_attr_name),
-                WarningFilter::Code(
-                    DiagnosticsID::new(
-                        Category::UnusedItem as u8,
-                        UnusedItem::DeadCode as u8,
-                        None,
-                    ),
-                    Some(FILTER_DEAD_CODE),
-                ),
-            ),
+            known_code_filter!(FILTER_DEAD_CODE, UnusedItem::DeadCode, filter_attr_name),
         ]);
 
         let known_filter_names: BTreeMap<DiagnosticsID, Symbol> = known_filters

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -252,7 +252,7 @@ impl CompilationEnv {
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED.to_string(), filter_attr_name.clone()),
-                WarningFilter::Category(Category::UnusedItem, Some(FILTER_UNUSED)),
+                WarningFilter::Category(Category::UnusedItem as u8, Some(FILTER_UNUSED)),
             ),
             (
                 KnownFilterKey::new(FILTER_MISSING_PHANTOM.to_string(), filter_attr_name.clone()),

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -399,7 +399,7 @@ impl CompilationEnv {
         if !is_filtered {
             // add help to suppress warning, if applicable
             // TODO do we want a centralized place for tips like this?
-            if diag.info().severity() == Severity::Warning && !diag.info().is_external() {
+            if diag.info().severity() == Severity::Warning {
                 if let Some(filter_name) = self.known_filter_names.get(&diag.info().id()) {
                     let help = format!(
                         "This warning can be suppressed with '#[{}({})]' \

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     command_line as cli,
     diagnostics::{
         codes::{
-            Category, Declarations, DiagnosticsID, Severity, UnusedItem, WarningFilter,
+            Category, CategoryID, Declarations, DiagnosticsID, Severity, UnusedItem, WarningFilter,
             WARNING_FILTER_ATTR,
         },
         Diagnostic, Diagnostics, WarningFilters,
@@ -249,99 +249,107 @@ impl CompilationEnv {
         let known_filters = BTreeMap::from([
             (
                 KnownFilterKey::new(FILTER_ALL, filter_attr_name),
-                WarningFilter::All,
+                WarningFilter::All(None),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED, filter_attr_name),
-                WarningFilter::Category(Category::UnusedItem as u8, Some(FILTER_UNUSED)),
+                WarningFilter::Category(
+                    CategoryID::new(Category::UnusedItem as u8, None),
+                    Some(FILTER_UNUSED),
+                ),
             ),
             (
                 KnownFilterKey::new(FILTER_MISSING_PHANTOM, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::Declarations as u8,
-                        code: Declarations::InvalidNonPhantomUse as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::Declarations as u8,
+                        Declarations::InvalidNonPhantomUse as u8,
+                        None,
+                    ),
                     Some(FILTER_MISSING_PHANTOM),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_USE, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::Alias as u8,
-                    },
+                    DiagnosticsID::new(Category::UnusedItem as u8, UnusedItem::Alias as u8, None),
                     Some(FILTER_UNUSED_USE),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_VARIABLE, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::Variable as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::Variable as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_VARIABLE),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_ASSIGNMENT, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::Assignment as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::Assignment as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_ASSIGNMENT),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_TRAILING_SEMI, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::TrailingSemi as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::TrailingSemi as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_TRAILING_SEMI),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_ATTRIBUTE, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::Attribute as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::Attribute as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_ATTRIBUTE),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_TYPE_PARAMETER, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::StructTypeParam as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::StructTypeParam as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_TYPE_PARAMETER),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED_FUNCTION, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::Function as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::Function as u8,
+                        None,
+                    ),
                     Some(FILTER_UNUSED_FUNCTION),
                 ),
             ),
             (
                 KnownFilterKey::new(FILTER_DEAD_CODE, filter_attr_name),
                 WarningFilter::Code(
-                    DiagnosticsID {
-                        category: Category::UnusedItem as u8,
-                        code: UnusedItem::DeadCode as u8,
-                    },
+                    DiagnosticsID::new(
+                        Category::UnusedItem as u8,
+                        UnusedItem::DeadCode as u8,
+                        None,
+                    ),
                     Some(FILTER_DEAD_CODE),
                 ),
             ),
@@ -491,7 +499,7 @@ impl CompilationEnv {
         self.known_filter_attributes.insert(filter_attr_name);
         for filter in filters {
             match filter {
-                WarningFilter::All => {
+                WarningFilter::All(_) => {
                     self.known_filters
                         .insert(KnownFilterKey::new(FILTER_ALL, filter_attr_name), filter);
                 }

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -252,7 +252,7 @@ impl CompilationEnv {
             ),
             (
                 KnownFilterKey::new(FILTER_UNUSED.to_string(), filter_attr_name.clone()),
-                WarningFilter::Category(Category::UnusedItem),
+                WarningFilter::Category(Category::UnusedItem, Some(FILTER_UNUSED)),
             ),
             (
                 KnownFilterKey::new(FILTER_MISSING_PHANTOM.to_string(), filter_attr_name.clone()),


### PR DESCRIPTION
## Description 

This implements the ability to add suppression of external warnings, particularly warnings coming from Sui linters.

## Test Plan 

Must pass all existing tests plus updated linter tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Developers can now selectively suppress linter warnings. Linter warnings now also feature an additional message describing how they can be suppressed.