### PR TITLE
[EffectsV2] shared_objects return vec instead of ref

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -951,9 +951,9 @@ impl AuthorityPerEpochStore {
         self.set_assigned_shared_object_versions(
             certificate,
             &effects
-                .shared_objects()
-                .iter()
-                .map(|(id, version, _)| (*id, *version))
+                .input_shared_objects()
+                .into_iter()
+                .map(|(obj_ref, _)| (obj_ref.0, obj_ref.1))
                 .collect(),
             parent_sync_store,
         )

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1427,7 +1427,7 @@ impl AuthorityStore {
         info!(?tx_digest, ?effects, "reverting transaction");
 
         // We should never be reverting shared object transactions.
-        assert!(effects.shared_objects().is_empty());
+        assert!(effects.input_shared_objects().is_empty());
 
         let mut write_batch = self.perpetual_tables.transactions.batch();
         write_batch.delete_batch(

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -383,8 +383,9 @@ where
         // For now, validators only pass back input shared object.
         let fastpath_input_objects = if !response.fastpath_input_objects.is_empty() {
             let input_shared_objects = signed_effects
-                .shared_objects()
-                .iter()
+                .input_shared_objects()
+                .into_iter()
+                .map(|(obj_ref, _kind)| obj_ref)
                 .collect::<HashSet<_>>();
             for object in &response.fastpath_input_objects {
                 let obj_ref = object.compute_object_reference();

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -215,11 +215,11 @@ async fn access_clock_object_test() {
     assert_eq!(
         objects.first().unwrap().compute_object_reference(),
         effects
-            .shared_objects()
-            .iter()
-            .find(|(id, _, _)| *id == SUI_CLOCK_OBJECT_ID)
+            .input_shared_objects()
+            .into_iter()
+            .find(|((id, _, _), _)| id == &SUI_CLOCK_OBJECT_ID)
+            .map(|(obj_ref, _)| obj_ref)
             .unwrap()
-            .clone()
     );
 
     let finish = SystemTime::now()

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -607,7 +607,13 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                         })
                         .collect(),
                     gas_used: effect.gas_cost_summary().clone(),
-                    shared_objects: to_sui_object_ref(effect.shared_objects().to_vec()),
+                    shared_objects: to_sui_object_ref(
+                        effect
+                            .input_shared_objects()
+                            .into_iter()
+                            .map(|(obj_ref, _)| obj_ref)
+                            .collect(),
+                    ),
                     transaction_digest: *effect.transaction_digest(),
                     created: to_owned_ref(effect.created().to_vec()),
                     mutated: to_owned_ref(effect.mutated().to_vec()),


### PR DESCRIPTION
## Description 

In effects V2 we won't have a field called shared_objects anymore, hence we cannot return a list reference.
Unfortunately enum_dispatch doesn't work with trait methods that return trait (impl Iterator) types. Here we must return a vector instead.
This is a non-functional-change.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
