### PR TITLE
[EffectsV2] effects gas_object() return value instead of ref

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -135,7 +135,7 @@ impl ExecutionEffects {
     pub fn gas_object(&self) -> (ObjectRef, Owner) {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
-                *certified_effects.data().gas_object()
+                certified_effects.data().gas_object()
             }
             ExecutionEffects::SuiTransactionBlockEffects(sui_tx_effects) => {
                 let refe = &sui_tx_effects.gas_object();

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -34,7 +34,7 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
     // Only charge gas when tx fails, skip all object parsing
     if effects.status() != &ExecutionStatus::Success {
         return Ok(vec![BalanceChange {
-            owner: *gas_owner,
+            owner: gas_owner,
             coin_type: GAS::type_tag(),
             amount: effects.gas_cost_summary().net_gas_usage().neg() as i128,
         }]);

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -86,8 +86,8 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     fn wrapped(&self) -> &[ObjectRef] {
         &self.wrapped
     }
-    fn gas_object(&self) -> &(ObjectRef, Owner) {
-        &self.gas_object
+    fn gas_object(&self) -> (ObjectRef, Owner) {
+        self.gas_object
     }
     fn events_digest(&self) -> Option<&TransactionEventsDigest> {
         self.events_digest.as_ref()

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -203,7 +203,7 @@ pub trait TransactionEffectsAPI {
     fn deleted(&self) -> &[ObjectRef];
     fn unwrapped_then_deleted(&self) -> &[ObjectRef];
     fn wrapped(&self) -> &[ObjectRef];
-    fn gas_object(&self) -> &(ObjectRef, Owner);
+    fn gas_object(&self) -> (ObjectRef, Owner);
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
     fn dependencies(&self) -> &[TransactionDigest];
     // All changed objects include created, mutated and unwrapped objects,


### PR DESCRIPTION
## Description 

In effects v2 we may use index offset to reference gas object, and we also store lamport sequence number separately. 
Hence we won't be able to return a reference to gas object. Return value instead.
This is a non-functional change.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
