### PR TITLE
[EffectsV2] created, mutated and etc all return Vec

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -100,7 +100,7 @@ impl ExecutionEffects {
     pub fn created(&self) -> Vec<(ObjectRef, Owner)> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
-                certified_effects.data().created().to_vec()
+                certified_effects.data().created()
             }
             ExecutionEffects::SuiTransactionBlockEffects(sui_tx_effects) => sui_tx_effects
                 .created()

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1444,23 +1444,21 @@ impl AuthorityStore {
 
         let tombstones = effects
             .deleted()
-            .iter()
-            .chain(effects.wrapped().iter())
+            .into_iter()
+            .chain(effects.wrapped())
             .map(|obj_ref| ObjectKey(obj_ref.0, obj_ref.1));
         write_batch.delete_batch(&self.perpetual_tables.objects, tombstones)?;
 
         let all_new_object_keys = effects
-            .mutated()
-            .iter()
-            .chain(effects.created().iter())
-            .chain(effects.unwrapped().iter())
-            .map(|((id, version, _), _)| ObjectKey(*id, *version));
+            .all_changed_objects()
+            .into_iter()
+            .map(|((id, version, _), _, _)| ObjectKey(id, version));
         write_batch.delete_batch(&self.perpetual_tables.objects, all_new_object_keys.clone())?;
 
         let modified_object_keys = effects
             .modified_at_versions()
-            .iter()
-            .map(|(id, version)| ObjectKey(*id, *version));
+            .into_iter()
+            .map(|(id, version)| ObjectKey(id, version));
 
         macro_rules! get_objects_and_locks {
             ($object_keys: expr) => {

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -136,11 +136,9 @@ where
         effects
             .iter()
             .flat_map(|fx| {
-                fx.created()
-                    .iter()
-                    .map(|(oref, _)| oref.2)
-                    .chain(fx.unwrapped().iter().map(|(oref, _)| oref.2))
-                    .chain(fx.mutated().iter().map(|(oref, _)| oref.2))
+                fx.all_changed_objects()
+                    .into_iter()
+                    .map(|(oref, _, _)| oref.2)
             })
             .collect::<Vec<ObjectDigest>>(),
     );
@@ -167,12 +165,12 @@ where
         .iter()
         .flat_map(|fx| {
             fx.unwrapped()
-                .iter()
+                .into_iter()
                 .map(|(oref, _owner)| (*fx.transaction_digest(), oref.0, oref.1))
         })
         .chain(effects.iter().flat_map(|fx| {
             fx.unwrapped_then_deleted()
-                .iter()
+                .into_iter()
                 .map(|oref| (*fx.transaction_digest(), oref.0, oref.1))
         }))
         .collect::<Vec<(TransactionDigest, ObjectID, SequenceNumber)>>();
@@ -193,8 +191,8 @@ where
         .iter()
         .flat_map(|fx| {
             fx.modified_at_versions()
-                .iter()
-                .map(|(id, seq_num)| (*fx.transaction_digest(), *id, *seq_num))
+                .into_iter()
+                .map(|(id, seq_num)| (*fx.transaction_digest(), id, seq_num))
         })
         .filter_map(|(tx_digest, id, seq_num)| {
             // unwrapped tx
@@ -268,11 +266,9 @@ where
         effects
             .iter()
             .flat_map(|fx| {
-                fx.created()
-                    .iter()
-                    .map(|(oref, _)| oref.2)
-                    .chain(fx.unwrapped().iter().map(|(oref, _)| oref.2))
-                    .chain(fx.mutated().iter().map(|(oref, _)| oref.2))
+                fx.all_changed_objects()
+                    .into_iter()
+                    .map(|(oref, _, _)| oref.2)
             })
             .collect::<Vec<ObjectDigest>>(),
     );
@@ -282,8 +278,8 @@ where
         .iter()
         .flat_map(|fx| {
             fx.modified_at_versions()
-                .iter()
-                .map(|(id, version)| ObjectKey(*id, *version))
+                .into_iter()
+                .map(|(id, version)| ObjectKey(id, version))
         })
         .collect();
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3689,8 +3689,8 @@ async fn test_store_revert_add_ofield() {
     assert_eq!(add_effects.created().len(), 1);
 
     let field_v0 = add_effects.created()[0].0;
-    let outer_v1 = find_by_id(add_effects.mutated(), outer_v0.0).unwrap();
-    let inner_v1 = find_by_id(add_effects.mutated(), inner_v0.0).unwrap();
+    let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
+    let inner_v1 = find_by_id(&add_effects.mutated(), inner_v0.0).unwrap();
 
     let db = &authority_state.database;
 
@@ -3770,8 +3770,8 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(add_effects.created().len(), 1);
 
     let field_v0 = add_effects.created()[0].0;
-    let outer_v1 = find_by_id(add_effects.mutated(), outer_v0.0).unwrap();
-    let inner_v1 = find_by_id(add_effects.mutated(), inner_v0.0).unwrap();
+    let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
+    let inner_v1 = find_by_id(&add_effects.mutated(), inner_v0.0).unwrap();
 
     let remove_ofield_txn = to_sender_signed_transaction(
         TransactionData::new_move_call(
@@ -3802,8 +3802,8 @@ async fn test_store_revert_remove_ofield() {
         .into_message();
 
     assert!(remove_effects.status().is_ok());
-    let outer_v2 = find_by_id(remove_effects.mutated(), outer_v0.0).unwrap();
-    let inner_v2 = find_by_id(remove_effects.mutated(), inner_v0.0).unwrap();
+    let outer_v2 = find_by_id(&remove_effects.mutated(), outer_v0.0).unwrap();
+    let inner_v2 = find_by_id(&remove_effects.mutated(), inner_v0.0).unwrap();
 
     let db = &authority_state.database;
 
@@ -5219,7 +5219,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .unwrap()
         .1
         .into_data();
-    let ((package_c_id, _, _), _) = txn_effects.created().first().unwrap();
+    let ((package_c_id, _, _), _) = txn_effects.created()[0];
     let gas_ref = txn_effects.gas_object().0;
 
     // Publish `package B`
@@ -5229,7 +5229,7 @@ async fn test_publish_transitive_dependencies_ok() {
     let mut build_config = BuildConfig::new_for_testing();
     build_config.config.additional_named_addresses.extend([
         ("b".to_string(), AccountAddress::ZERO),
-        ("c".to_string(), (*package_c_id).into()),
+        ("c".to_string(), (package_c_id).into()),
     ]);
 
     let modules = build_config
@@ -5239,7 +5239,7 @@ async fn test_publish_transitive_dependencies_ok() {
 
     let mut builder = ProgrammableTransactionBuilder::new();
 
-    builder.publish_immutable(modules, vec![*package_c_id]); // Note: B depends on C
+    builder.publish_immutable(modules, vec![package_c_id]); // Note: B depends on C
 
     let kind = TransactionKind::programmable(builder.finish());
     let txn_data = TransactionData::new_with_gas_coins(
@@ -5255,7 +5255,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .unwrap()
         .1
         .into_data();
-    let ((package_b_id, _, _), _) = txn_effects.created().first().unwrap();
+    let ((package_b_id, _, _), _) = txn_effects.created()[0];
     let gas_ref = txn_effects.gas_object().0;
 
     // Publish `package A`
@@ -5265,8 +5265,8 @@ async fn test_publish_transitive_dependencies_ok() {
     let mut build_config = BuildConfig::new_for_testing();
     build_config.config.additional_named_addresses.extend([
         ("a".to_string(), AccountAddress::ZERO),
-        ("b".to_string(), (*package_b_id).into()),
-        ("c".to_string(), (*package_c_id).into()),
+        ("b".to_string(), (package_b_id).into()),
+        ("c".to_string(), (package_c_id).into()),
     ]);
 
     let modules = build_config
@@ -5276,7 +5276,7 @@ async fn test_publish_transitive_dependencies_ok() {
 
     let mut builder = ProgrammableTransactionBuilder::new();
 
-    builder.publish_immutable(modules, vec![*package_b_id, *package_c_id]); // Note: A depends on B and C.
+    builder.publish_immutable(modules, vec![package_b_id, package_c_id]); // Note: A depends on B and C.
 
     let kind = TransactionKind::programmable(builder.finish());
     let txn_data = TransactionData::new_with_gas_coins(
@@ -5292,7 +5292,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .unwrap()
         .1
         .into_data();
-    let ((package_a_id, _, _), _) = txn_effects.created().first().unwrap();
+    let ((package_a_id, _, _), _) = txn_effects.created()[0];
     let gas_ref = txn_effects.gas_object().0;
 
     // Publish `package root`
@@ -5308,9 +5308,9 @@ async fn test_publish_transitive_dependencies_ok() {
     let mut build_config = BuildConfig::new_for_testing();
     build_config.config.additional_named_addresses.extend([
         ("examples".to_string(), AccountAddress::ZERO),
-        ("a".to_string(), (*package_a_id).into()),
-        ("b".to_string(), (*package_b_id).into()),
-        ("c".to_string(), (*package_c_id).into()),
+        ("a".to_string(), (package_a_id).into()),
+        ("b".to_string(), (package_b_id).into()),
+        ("c".to_string(), (package_c_id).into()),
     ]);
 
     let modules = build_config
@@ -5321,7 +5321,7 @@ async fn test_publish_transitive_dependencies_ok() {
     let mut builder = ProgrammableTransactionBuilder::new();
     let mut deps = BuiltInFramework::all_package_ids();
     // Note: root depends on A, B, C.
-    deps.extend([*package_a_id, *package_b_id, *package_c_id]);
+    deps.extend([package_a_id, package_b_id, package_c_id]);
     builder.publish_immutable(modules, deps);
 
     let kind = TransactionKind::programmable(builder.finish());

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -714,9 +714,9 @@ async fn test_native_transfer_insufficient_gas_execution() {
     assert_eq!(gas_coin.value(), 0);
     // After a failed transfer, the version should have been incremented,
     // but the owner of the object should remain the same, unchanged.
-    let ((_, version, _), owner) = effects.mutated_excluding_gas().first().unwrap();
-    assert_eq!(version, &gas_object.version());
-    assert_eq!(owner, &gas_object.owner);
+    let ((_, version, _), owner) = effects.mutated_excluding_gas()[0];
+    assert_eq!(version, gas_object.version());
+    assert_eq!(owner, gas_object.owner);
 
     assert_eq!(
         effects.into_status().unwrap_err().0,

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -327,7 +327,7 @@ async fn test_object_owning_another_object() {
     effects.status().unwrap();
     let child_effect = effects
         .mutated()
-        .iter()
+        .into_iter()
         .find(|((id, _, _), _)| id == &child.0)
         .unwrap();
     // Check that the child is now owned by the parent.
@@ -566,8 +566,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     assert_eq!(
         effects
             .modified_at_versions()
-            .iter()
-            .cloned()
+            .into_iter()
             .collect::<HashSet<_>>(),
         HashSet::from([
             (gas_ref.0, gas_ref.1),
@@ -661,8 +660,7 @@ async fn test_remove_child_when_no_prior_version_exists() {
     assert_eq!(
         effects
             .modified_at_versions()
-            .iter()
-            .cloned()
+            .into_iter()
             .collect::<HashSet<_>>(),
         HashSet::from([
             (gas_ref.0, gas_ref.1),
@@ -2881,12 +2879,12 @@ pub async fn build_and_publish_test_package_with_upgrade_cap(
 
     let package = effects
         .created()
-        .iter()
+        .into_iter()
         .find(|(_, owner)| matches!(owner, Owner::Immutable))
         .unwrap();
     let upgrade_cap = effects
         .created()
-        .iter()
+        .into_iter()
         .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
         .unwrap();
 

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -155,7 +155,7 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
 pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     sender: SuiAddress,
-    modified_at_versions: &[(ObjectID, SequenceNumber)],
+    modified_at_versions: Vec<(ObjectID, SequenceNumber)>,
     all_changed_objects: Vec<(&OwnedObjectRef, WriteKind)>,
     all_deleted: Vec<(&SuiObjectRef, DeleteKind)>,
 ) -> Result<Vec<ObjectChange>, E> {
@@ -174,11 +174,11 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
         })
         .collect();
     let all_changed_objects = all_changed
-        .iter()
-        .map(|(obj_ref, owner, write_kind)| (obj_ref, owner, *write_kind))
+        .into_iter()
+        .map(|(obj_ref, owner, write_kind)| (obj_ref, owner, write_kind))
         .collect();
 
-    let all_deleted: Vec<(ObjectRef, DeleteKind)> = all_deleted
+    let all_deleted_objects: Vec<(ObjectRef, DeleteKind)> = all_deleted
         .into_iter()
         .map(|(obj_ref, delete_kind)| {
             (
@@ -186,10 +186,6 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                 delete_kind,
             )
         })
-        .collect();
-    let all_deleted_objects = all_deleted
-        .iter()
-        .map(|(obj_ref, delete_kind)| (obj_ref, *delete_kind))
         .collect();
 
     sui_json_rpc::get_object_changes(

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -597,8 +597,7 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                     executed_epoch: effect.executed_epoch(),
                     modified_at_versions: effect
                         .modified_at_versions()
-                        .iter()
-                        .copied()
+                        .into_iter()
                         .map(|(object_id, sequence_number)| {
                             SuiTransactionBlockEffectsModifiedAtVersions {
                                 object_id,
@@ -615,7 +614,7 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                             .collect(),
                     ),
                     transaction_digest: *effect.transaction_digest(),
-                    created: to_owned_ref(effect.created().to_vec()),
+                    created: to_owned_ref(effect.created()),
                     mutated: to_owned_ref(effect.mutated().to_vec()),
                     unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
                     deleted: to_sui_object_ref(effect.deleted().to_vec()),

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -40,14 +40,14 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
         }]);
     }
 
-    let all_mutated: Vec<(&ObjectRef, &Owner, WriteKind)> = effects.all_changed_objects();
-    let all_mutated = all_mutated
-        .iter()
+    let all_mutated = effects
+        .all_changed_objects()
+        .into_iter()
         .filter_map(|((id, version, digest), _, _)| {
-            if matches!(mocked_coin, Some(coin) if *id == coin) {
+            if matches!(mocked_coin, Some(coin) if id == coin) {
                 return None;
             }
-            Some((*id, *version, Some(*digest)))
+            Some((id, version, Some(digest)))
         })
         .collect::<Vec<_>>();
 
@@ -67,16 +67,16 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
         object_provider,
         &effects
             .modified_at_versions()
-            .iter()
+            .into_iter()
             .filter_map(|(id, version)| {
-                if matches!(mocked_coin, Some(coin) if *id == coin) {
+                if matches!(mocked_coin, Some(coin) if id == coin) {
                     return None;
                 }
                 // We won't be able to get dynamic object from object provider today
-                if unwrapped_then_deleted.contains(id) {
+                if unwrapped_then_deleted.contains(&id) {
                     return None;
                 }
-                Some((*id, *version, input_objs_to_digest.get(id).cloned()))
+                Some((id, version, input_objs_to_digest.get(&id).cloned()))
             })
             .collect::<Vec<_>>(),
         &all_mutated,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -341,10 +341,10 @@ async fn find_package_object_id(
             .await?;
 
         for ((id, _, _), _) in effect.created() {
-            if let Ok(object_read) = state.get_object_read(id) {
+            if let Ok(object_read) = state.get_object_read(&id) {
                 if let Ok(object) = object_read.into_object() {
                     if matches!(object.type_(), Some(type_) if type_.is(&object_struct_tag)) {
-                        return Ok(*id);
+                        return Ok(id);
                     }
                 }
             }

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -13,40 +13,40 @@ use crate::ObjectProvider;
 pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     sender: SuiAddress,
-    modified_at_versions: &[(ObjectID, SequenceNumber)],
-    all_changed_objects: Vec<(&ObjectRef, &Owner, WriteKind)>,
-    all_deleted: Vec<(&ObjectRef, DeleteKind)>,
+    modified_at_versions: Vec<(ObjectID, SequenceNumber)>,
+    all_changed_objects: Vec<(ObjectRef, Owner, WriteKind)>,
+    all_deleted: Vec<(ObjectRef, DeleteKind)>,
 ) -> Result<Vec<ObjectChange>, E> {
     let mut object_changes = vec![];
 
-    let modify_at_version = modified_at_versions
-        .iter()
-        .cloned()
-        .collect::<BTreeMap<_, _>>();
+    let modify_at_version = modified_at_versions.into_iter().collect::<BTreeMap<_, _>>();
 
-    for ((id, version, digest), owner, kind) in all_changed_objects {
-        let o = object_provider.get_object(id, version).await?;
+    for ((object_id, version, digest), owner, kind) in all_changed_objects {
+        let o = object_provider.get_object(&object_id, &version).await?;
         if let Some(type_) = o.type_() {
             let object_type = type_.clone().into();
 
             match kind {
                 WriteKind::Mutate => object_changes.push(ObjectChange::Mutated {
                     sender,
-                    owner: *owner,
+                    owner,
                     object_type,
-                    object_id: *id,
-                    version: *version,
+                    object_id,
+                    version,
                     // modify_at_version should always be available for mutated object
-                    previous_version: modify_at_version.get(id).cloned().unwrap_or_default(),
-                    digest: *digest,
+                    previous_version: modify_at_version
+                        .get(&object_id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    digest,
                 }),
                 WriteKind::Create => object_changes.push(ObjectChange::Created {
                     sender,
-                    owner: *owner,
+                    owner,
                     object_type,
-                    object_id: *id,
-                    version: *version,
-                    digest: *digest,
+                    object_id,
+                    version,
+                    digest,
                 }),
                 _ => {}
             }
@@ -55,7 +55,7 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                 object_changes.push(ObjectChange::Published {
                     package_id: p.id(),
                     version: p.version(),
-                    digest: *digest,
+                    digest,
                     modules: p.serialized_module_map().keys().cloned().collect(),
                 })
             }
@@ -64,7 +64,7 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
 
     for ((id, version, _), kind) in all_deleted {
         let o = object_provider
-            .find_object_lt_or_eq_version(id, version)
+            .find_object_lt_or_eq_version(&id, &version)
             .await?;
         if let Some(o) = o {
             if let Some(type_) = o.type_() {
@@ -73,14 +73,14 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                     DeleteKind::Normal => object_changes.push(ObjectChange::Deleted {
                         sender,
                         object_type,
-                        object_id: *id,
-                        version: *version,
+                        object_id: id,
+                        version,
                     }),
                     DeleteKind::Wrap => object_changes.push(ObjectChange::Wrapped {
                         sender,
                         object_type,
-                        object_id: *id,
-                        version: *version,
+                        object_id: id,
+                        version,
                     }),
                     _ => {}
                 }

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -332,7 +332,7 @@ pub fn remove_transaction(path: &Path, opt: RemoveTransactionOptions) -> anyhow:
     };
     let mut objects_to_remove = vec![];
     for mutated_obj in effects.modified_at_versions() {
-        let new_objs = perpetual_db.get_newer_object_keys(mutated_obj)?;
+        let new_objs = perpetual_db.get_newer_object_keys(&mutated_obj)?;
         if new_objs.len() > 1 {
             bail!(
                 "Dependents of transaction {:?} have already executed! Mutated object: {:?}, new objects: {:?}",

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -200,31 +200,31 @@ pub trait TransactionEffectsAPI {
     fn status(&self) -> &ExecutionStatus;
     fn into_status(self) -> ExecutionStatus;
     fn executed_epoch(&self) -> EpochId;
-    fn modified_at_versions(&self) -> &[(ObjectID, SequenceNumber)];
+    fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)>;
     /// Returns the list of shared objects used in the input, with full object reference
     /// and use kind. This is needed in effects because in transaction we only have object ID
     /// for shared objects. Their version and digest can only be figured out after sequencing.
     /// Also provides the use kind to indicate whether the object was mutated or read-only.
     /// Down the road it could also indicate use-of-deleted.
     fn input_shared_objects(&self) -> Vec<(ObjectRef, InputSharedObjectKind)>;
-    fn created(&self) -> &[(ObjectRef, Owner)];
-    fn mutated(&self) -> &[(ObjectRef, Owner)];
-    fn unwrapped(&self) -> &[(ObjectRef, Owner)];
-    fn deleted(&self) -> &[ObjectRef];
-    fn unwrapped_then_deleted(&self) -> &[ObjectRef];
-    fn wrapped(&self) -> &[ObjectRef];
+    fn created(&self) -> Vec<(ObjectRef, Owner)>;
+    fn mutated(&self) -> Vec<(ObjectRef, Owner)>;
+    fn unwrapped(&self) -> Vec<(ObjectRef, Owner)>;
+    fn deleted(&self) -> Vec<ObjectRef>;
+    fn unwrapped_then_deleted(&self) -> Vec<ObjectRef>;
+    fn wrapped(&self) -> Vec<ObjectRef>;
     fn gas_object(&self) -> (ObjectRef, Owner);
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
     fn dependencies(&self) -> &[TransactionDigest];
     // All changed objects include created, mutated and unwrapped objects,
     // they do NOT include wrapped and deleted.
-    fn all_changed_objects(&self) -> Vec<(&ObjectRef, &Owner, WriteKind)>;
+    fn all_changed_objects(&self) -> Vec<(ObjectRef, Owner, WriteKind)>;
 
-    fn all_deleted(&self) -> Vec<(&ObjectRef, DeleteKind)>;
+    fn all_deleted(&self) -> Vec<(ObjectRef, DeleteKind)>;
 
     fn transaction_digest(&self) -> &TransactionDigest;
 
-    fn mutated_excluding_gas(&self) -> Vec<&(ObjectRef, Owner)>;
+    fn mutated_excluding_gas(&self) -> Vec<(ObjectRef, Owner)>;
 
     fn gas_cost_summary(&self) -> &GasCostSummary;
 
@@ -241,7 +241,7 @@ pub trait TransactionEffectsAPI {
         obj_ref: ObjectRef,
         kind: InputSharedObjectKind,
     );
-    fn modified_at_versions_mut_for_testing(&mut self) -> &mut Vec<(ObjectID, SequenceNumber)>;
+    fn unsafe_add_deleted_object_for_testing(&mut self, object: ObjectRef);
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Default)]

--- a/crates/transaction-fuzzer/tests/pt_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/pt_fuzz.rs
@@ -42,12 +42,12 @@ fn publish_coin_factory(
     );
     let package = effects
         .created()
-        .iter()
+        .into_iter()
         .find(|(_, owner)| matches!(owner, Owner::Immutable))
         .unwrap();
     let cap = effects
         .created()
-        .iter()
+        .into_iter()
         .find(|(obj_ref, _)| {
             if let Some(stag) = exec
                 .rt
@@ -104,7 +104,7 @@ pub fn run_pt_success(
     );
     let new_cap = effects
         .mutated()
-        .iter()
+        .into_iter()
         .find(|(obj_ref, _)| {
             if let Some(stag) = exec
                 .rt

--- a/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
@@ -22,7 +22,7 @@ fn publish_type_factory(exec: &mut Executor, account: &mut AccountCurrent) -> Ob
     let effects = exec.publish("type_factory", vec![], account);
     let package = effects
         .created()
-        .iter()
+        .into_iter()
         .find(|(_, owner)| matches!(owner, Owner::Immutable))
         .unwrap();
     package.0


### PR DESCRIPTION
## Description 

Make all of created, mutated, unwrapped, wrapped, deleted, unwrapped_and_deleted return Vec instead of list ref, since effects V2 won't be able to return list ref.
This is a non-functional change.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
