### PR TITLE
multisig: Add multisig verify support in typescript

### DIFF
--- a/.changeset/lovely-plums-live.md
+++ b/.changeset/lovely-plums-live.md
@@ -2,4 +2,4 @@
 '@mysten/sui.js': minor
 ---
 
-Add verify multisig method
+Added a MultiSigPublicKey class for verifying multisig signatures

--- a/.changeset/lovely-plums-live.md
+++ b/.changeset/lovely-plums-live.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': minor
+---
+
+Add verify multisig method

--- a/.changeset/short-pugs-obey.md
+++ b/.changeset/short-pugs-obey.md
@@ -2,4 +2,4 @@
 '@mysten/sui.js': minor
 ---
 
-signMesssage uses BCS serialization for vector
+update signMessage to correctly wrap PersonalMessages before signing

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ packages:
     - '!sdk/typescript/transactions'
     - '!sdk/typescript/client'
     - '!sdk/typescript/verify'
+    - '!sdk/typescript/multisig'

--- a/sdk/typescript/multisig/package.json
+++ b/sdk/typescript/multisig/package.json
@@ -1,0 +1,5 @@
+{
+	"private": true,
+	"import": "../dist/esm/multisig/index.js",
+	"main": "../dist/cjs/multisig/index.js"
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -12,6 +12,7 @@
 		"dist",
 		"faucet",
 		"keypairs",
+		"multisig",
 		"src",
 		"transactions",
 		"verify"
@@ -34,10 +35,20 @@
 			"import": "./dist/esm/builder/index.js",
 			"require": "./dist/cjs/builder/index.js"
 		},
+		"./client": {
+			"source": "./src/client/index.ts",
+			"import": "./dist/esm/client/index.js",
+			"require": "./dist/cjs/client/index.js"
+		},
 		"./cryptography": {
 			"source": "./src/cryptography/index.ts",
 			"import": "./dist/esm/cryptography/index.js",
 			"require": "./dist/cjs/cryptography/index.js"
+		},
+		"./faucet": {
+			"source": "./src/faucet/index.ts",
+			"import": "./dist/esm/faucet/index.js",
+			"require": "./dist/cjs/faucet/index.js"
 		},
 		"./keypairs/ed25519": {
 			"source": "./src/keypairs/ed25519/index.ts",
@@ -54,15 +65,10 @@
 			"import": "./dist/esm/keypairs/secp256r1/index.js",
 			"require": "./dist/cjs/keypairs/secp256r1/index.js"
 		},
-		"./faucet": {
-			"source": "./src/faucet/index.ts",
-			"import": "./dist/esm/faucet/index.js",
-			"require": "./dist/cjs/faucet/index.js"
-		},
-		"./client": {
-			"source": "./src/client/index.ts",
-			"import": "./dist/esm/client/index.js",
-			"require": "./dist/cjs/client/index.js"
+		"./multisig": {
+			"source": "./src/multisig/index.ts",
+			"import": "./dist/esm/multisig/index.js",
+			"require": "./dist/cjs/multisig/index.js"
 		},
 		"./transactions": {
 			"source": "./src/builder/export.ts",

--- a/sdk/typescript/src/cryptography/multisig.ts
+++ b/sdk/typescript/src/cryptography/multisig.ts
@@ -67,9 +67,9 @@ export function toMultiSigAddress(pks: PubkeyWeightPair[], threshold: number): s
 	let i = 3;
 	for (const pk of pks) {
 		tmp.set([pk.pubKey.flag()], i);
-		tmp.set(pk.pubKey.toBytes(), i + 1);
-		tmp.set([pk.weight], i + 1 + pk.pubKey.toBytes().length);
-		i += pk.pubKey.toBytes().length + 2;
+		tmp.set(pk.pubKey.toRawBytes(), i + 1);
+		tmp.set([pk.weight], i + 1 + pk.pubKey.toRawBytes().length);
+		i += pk.pubKey.toRawBytes().length + 2;
 	}
 	return normalizeSuiAddress(bytesToHex(blake2b(tmp.slice(0, i), { dkLen: 32 })));
 }

--- a/sdk/typescript/src/cryptography/multisig.ts
+++ b/sdk/typescript/src/cryptography/multisig.ts
@@ -15,6 +15,7 @@ import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
 import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
 import { builder } from '../builder/bcs.js';
 import { normalizeSuiAddress } from '../utils/sui-types.js';
+import { IntentScope, messageWithIntent } from './intent.js';
 
 export type PubkeyWeightPair = {
 	pubKey: PublicKey;
@@ -121,16 +122,62 @@ export function combinePartialSigs(
 
 /// Decode a multisig signature into a list of signatures, public keys and flags.
 export function decodeMultiSig(signature: string): SignaturePubkeyPair[] {
+	const multisig = parseMultiSig(signature);
+	return toSignaturePubkeyPairs(multisig);
+}
+
+/// Verify a multisig signature against the message it commits to.
+export function verifyMultisig(multisig: MultiSig, tx_bytes: Uint8Array): boolean {
+	let digest = blake2b(messageWithIntent(IntentScope.TransactionData, tx_bytes), { dkLen: 32 });
+	let threhsold = multisig.multisig_pk.threshold;
+	let weight = 0;
+	let res;
+	for (const p of toSignaturePubkeyPairs(multisig)) {
+		switch (p.signatureScheme) {
+			case 'ED25519':
+				res = (p.pubKey as Ed25519PublicKey).verify(digest, p.signature);
+				break;
+			case 'Secp256k1':
+				res = (p.pubKey as Secp256k1PublicKey).verify(digest, p.signature);
+				break;
+			case 'Secp256r1':
+				res = (p.pubKey as Secp256r1PublicKey).verify(digest, p.signature);
+				break;
+			default:
+				throw new Error('Unsupported signature scheme');
+		}
+
+		if (!res) {
+			return false;
+		} else {
+			if (!p.weight) {
+				throw new Error('Invalid weight in multisig');
+			} else {
+				weight += p.weight;
+			}
+		}
+	}
+	return weight >= threhsold;
+}
+
+/// Parse a Base64 encoded multisig signature to its struct.
+export function parseMultiSig(signature: SerializedSignature): MultiSig {
 	const parsed = fromB64(signature);
 	if (parsed.length < 1 || parsed[0] !== SIGNATURE_SCHEME_TO_FLAG['MultiSig']) {
 		throw new Error('Invalid MultiSig flag');
 	}
 	const multisig: MultiSig = builder.de('MultiSig', parsed.slice(1));
+	return multisig;
+}
+
+/// Parse the list of signatures, public keys and their weights in a multisig signature.
+export function toSignaturePubkeyPairs(multisig: MultiSig): SignaturePubkeyPair[] {
 	let res: SignaturePubkeyPair[] = new Array(multisig.sigs.length);
 	for (let i = 0; i < multisig.sigs.length; i++) {
 		let s: CompressedSignature = multisig.sigs[i];
 		let pk_index = as_indices(multisig.bitmap).at(i);
-		let pk_bytes = Object.values(multisig.multisig_pk.pk_map[pk_index as number].pubKey)[0];
+		let pair = multisig.multisig_pk.pk_map[pk_index as number];
+		let pk_bytes = Object.values(pair.pubKey)[0];
 		const scheme = Object.keys(s)[0] as SignatureScheme;
 
 		if (scheme === 'MultiSig') {
@@ -149,6 +196,7 @@ export function decodeMultiSig(signature: string): SignaturePubkeyPair[] {
 			signatureScheme: scheme,
 			signature: Uint8Array.from(Object.values(s)[0]),
 			pubKey: new PublicKey(pk_bytes),
+			weight: pair.weight,
 		};
 	}
 	return res;

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -34,14 +34,14 @@ export abstract class PublicKey {
 	 * Checks if two public keys are equal
 	 */
 	equals(publicKey: PublicKey) {
-		return bytesEqual(this.toBytes(), publicKey.toBytes());
+		return bytesEqual(this.toRawBytes(), publicKey.toRawBytes());
 	}
 
 	/**
 	 * Return the base-64 representation of the public key
 	 */
 	toBase64() {
-		return toB64(this.toBytes());
+		return toB64(this.toRawBytes());
 	}
 
 	/**
@@ -96,9 +96,29 @@ export abstract class PublicKey {
 	}
 
 	/**
+	 * Returns the bytes representation of the public key
+	 * prefixed with the signature scheme flag
+	 */
+	toSuiBytes(): Uint8Array {
+		const rawBytes = this.toRawBytes();
+		const suiBytes = new Uint8Array(rawBytes.length + 1);
+		suiBytes.set([this.flag()]);
+		suiBytes.set(rawBytes, 1);
+
+		return suiBytes;
+	}
+
+	/**
+	 * @deprecated use `toRawBytes` instead.
+	 */
+	toBytes() {
+		return this.toRawBytes();
+	}
+
+	/**
 	 * Return the byte array representation of the public key
 	 */
-	abstract toBytes(): Uint8Array;
+	abstract toRawBytes(): Uint8Array;
 
 	/**
 	 * Return the Sui address associated with this public key

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -5,6 +5,7 @@ import { toB64 } from '@mysten/bcs';
 import { IntentScope, messageWithIntent } from './intent.js';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bcs } from '../types/sui-bcs.js';
+import type { SerializedSignature } from './index.js';
 
 /**
  * Value to be converted into public key.
@@ -68,7 +69,7 @@ export abstract class PublicKey {
 
 	verifyWithIntent(
 		bytes: Uint8Array,
-		signature: Uint8Array,
+		signature: Uint8Array | SerializedSignature,
 		intent: IntentScope,
 	): Promise<boolean> {
 		const intentMessage = messageWithIntent(intent, bytes);
@@ -80,7 +81,10 @@ export abstract class PublicKey {
 	/**
 	 * Verifies that the signature is valid for for the provided PersonalMessage
 	 */
-	verifyPersonalMessage(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+	verifyPersonalMessage(
+		message: Uint8Array,
+		signature: Uint8Array | SerializedSignature,
+	): Promise<boolean> {
 		return this.verifyWithIntent(
 			bcs.ser(['vector', 'u8'], message).toBytes(),
 			signature,
@@ -91,7 +95,10 @@ export abstract class PublicKey {
 	/**
 	 * Verifies that the signature is valid for for the provided TransactionBlock
 	 */
-	verifyTransactionBlock(transactionBlock: Uint8Array, signature: Uint8Array): Promise<boolean> {
+	verifyTransactionBlock(
+		transactionBlock: Uint8Array,
+		signature: Uint8Array | SerializedSignature,
+	): Promise<boolean> {
 		return this.verifyWithIntent(transactionBlock, signature, IntentScope.TransactionData);
 	}
 
@@ -133,5 +140,5 @@ export abstract class PublicKey {
 	/**
 	 * Verifies that the signature is valid for for the provided message
 	 */
-	abstract verify(data: Uint8Array, signature: Uint8Array): Promise<boolean>;
+	abstract verify(data: Uint8Array, signature: Uint8Array | SerializedSignature): Promise<boolean>;
 }

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -15,6 +15,7 @@ export type SignaturePubkeyPair = {
 	signature: Uint8Array;
 	/** Base64-encoded public key */
 	pubKey: PublicKey;
+	weight?: number;
 };
 
 /**

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -9,13 +9,14 @@ export type SignatureScheme = 'ED25519' | 'Secp256k1' | 'Secp256r1' | 'MultiSig'
 /**
  * Pair of signature and corresponding public key
  */
-export type SignaturePubkeyPair = {
+export type SerializeSignatureInput = {
 	signatureScheme: SignatureScheme;
 	/** Base64-encoded signature */
 	signature: Uint8Array;
+	/** @deprecated use publicKey instead */
+	pubKey?: PublicKey;
 	/** Base64-encoded public key */
-	pubKey: PublicKey;
-	weight?: number;
+	publicKey?: PublicKey;
 };
 
 /**
@@ -50,8 +51,13 @@ export function toSerializedSignature({
 	signature,
 	signatureScheme,
 	pubKey,
-}: SignaturePubkeyPair): SerializedSignature {
-	const pubKeyBytes = pubKey.toBytes();
+	publicKey = pubKey,
+}: SerializeSignatureInput): SerializedSignature {
+	if (!publicKey) {
+		throw new Error('`publicKey` is required');
+	}
+
+	const pubKeyBytes = publicKey.toBytes();
 	const serializedSignature = new Uint8Array(1 + signature.length + pubKeyBytes.length);
 	serializedSignature.set([SIGNATURE_SCHEME_TO_FLAG[signatureScheme]]);
 	serializedSignature.set(signature, 1);
@@ -64,6 +70,13 @@ export function parseSerializedSignature(serializedSignature: SerializedSignatur
 
 	const signatureScheme =
 		SIGNATURE_FLAG_TO_SCHEME[bytes[0] as keyof typeof SIGNATURE_FLAG_TO_SCHEME];
+
+	if (signatureScheme === 'MultiSig') {
+		return {
+			signatureScheme,
+			bytes,
+		};
+	}
 
 	if (!(signatureScheme in SIGNATURE_SCHEME_TO_SIZE)) {
 		throw new Error('Unsupported signature scheme');
@@ -78,5 +91,6 @@ export function parseSerializedSignature(serializedSignature: SerializedSignatur
 		signatureScheme,
 		signature,
 		publicKey,
+		bytes,
 	};
 }

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -76,6 +76,7 @@ export function parseSerializedSignature(serializedSignature: SerializedSignatur
 	if (signatureScheme === 'MultiSig') {
 		const multisig: MultiSigStruct = builder.de('MultiSig', bytes.slice(1));
 		return {
+			serializedSignature,
 			signatureScheme,
 			multisig,
 			bytes,
@@ -92,6 +93,7 @@ export function parseSerializedSignature(serializedSignature: SerializedSignatur
 	const publicKey = bytes.slice(1 + signature.length);
 
 	return {
+		serializedSignature,
 		signatureScheme,
 		signature,
 		publicKey,

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -3,6 +3,8 @@
 
 import { fromB64, toB64 } from '@mysten/bcs';
 import type { PublicKey } from './publickey.js';
+import type { MultiSigStruct } from '../multisig/publickey.js';
+import { builder } from '../builder/bcs.js';
 
 export type SignatureScheme = 'ED25519' | 'Secp256k1' | 'Secp256r1' | 'MultiSig';
 
@@ -72,8 +74,10 @@ export function parseSerializedSignature(serializedSignature: SerializedSignatur
 		SIGNATURE_FLAG_TO_SCHEME[bytes[0] as keyof typeof SIGNATURE_FLAG_TO_SCHEME];
 
 	if (signatureScheme === 'MultiSig') {
+		const multisig: MultiSigStruct = builder.de('MultiSig', bytes.slice(1));
 		return {
 			signatureScheme,
+			multisig,
 			bytes,
 		};
 	}

--- a/sdk/typescript/src/cryptography/utils.ts
+++ b/sdk/typescript/src/cryptography/utils.ts
@@ -3,7 +3,7 @@
 /* eslint-disable import/no-cycle */
 
 import { fromB64 } from '@mysten/bcs';
-import type { SerializedSignature, SignaturePubkeyPair, SignatureScheme } from './signature.js';
+import type { SerializedSignature, SignatureScheme } from './signature.js';
 import { SIGNATURE_FLAG_TO_SCHEME } from './signature.js';
 import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
 import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
@@ -14,6 +14,18 @@ import { Ed25519Keypair } from '../keypairs/ed25519/keypair.js';
 import { Secp256k1Keypair } from '../keypairs/secp256k1/keypair.js';
 import type { ExportedKeypair, Keypair } from './keypair.js';
 import { LEGACY_PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE } from './keypair.js';
+
+/**
+ * Pair of signature and corresponding public key
+ */
+export type SignaturePubkeyPair = {
+	signatureScheme: SignatureScheme;
+	/** Base64-encoded signature */
+	signature: Uint8Array;
+	/** Base64-encoded public key */
+	pubKey: PublicKey;
+	weight?: number;
+};
 
 /// Expects to parse a serialized signature by its signature scheme to a list of signature
 /// and public key pairs. The list is of length 1 if it is not multisig.

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { blake2b } from '@noble/hashes/blake2b';
 import { fromB64 } from '@mysten/bcs';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
 import { PublicKey, bytesEqual } from '../../cryptography/publickey.js';
@@ -10,8 +9,6 @@ import {
 	SIGNATURE_SCHEME_TO_FLAG,
 	parseSerializedSignature,
 } from '../../cryptography/signature.js';
-import { bytesToHex } from '@noble/hashes/utils';
-import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
 import nacl from 'tweetnacl';
 
 const PUBLIC_KEY_SIZE = 32;
@@ -57,16 +54,6 @@ export class Ed25519PublicKey extends PublicKey {
 	 */
 	toRawBytes(): Uint8Array {
 		return this.data;
-	}
-
-	/**
-	 * Return the Sui address associated with this Ed25519 public key
-	 */
-	toSuiAddress(): string {
-		// Each hex char represents half a byte, hence hex address doubles the length
-		return normalizeSuiAddress(
-			bytesToHex(blake2b(this.toSuiBytes(), { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
-		);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/ed25519/publickey.ts
+++ b/sdk/typescript/src/keypairs/ed25519/publickey.ts
@@ -51,7 +51,7 @@ export class Ed25519PublicKey extends PublicKey {
 	/**
 	 * Return the byte array representation of the Ed25519 public key
 	 */
-	toBytes(): Uint8Array {
+	toRawBytes(): Uint8Array {
 		return this.data;
 	}
 
@@ -59,12 +59,9 @@ export class Ed25519PublicKey extends PublicKey {
 	 * Return the Sui address associated with this Ed25519 public key
 	 */
 	toSuiAddress(): string {
-		let tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['ED25519']]);
-		tmp.set(this.toBytes(), 1);
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(this.toSuiBytes(), { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -52,7 +52,7 @@ export class Secp256k1PublicKey extends PublicKey {
 	/**
 	 * Return the byte array representation of the Secp256k1 public key
 	 */
-	toBytes(): Uint8Array {
+	toRawBytes(): Uint8Array {
 		return this.data;
 	}
 
@@ -60,12 +60,9 @@ export class Secp256k1PublicKey extends PublicKey {
 	 * Return the Sui address associated with this Secp256k1 public key
 	 */
 	toSuiAddress(): string {
-		let tmp = new Uint8Array(SECP256K1_PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256k1']]);
-		tmp.set(this.toBytes(), 1);
 		// Each hex char represents half a byte, hence hex address doubles the length
 		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
+			bytesToHex(blake2b(this.toSuiBytes(), { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
 		);
 	}
 
@@ -83,7 +80,7 @@ export class Secp256k1PublicKey extends PublicKey {
 		return secp256k1.verify(
 			secp256k1.Signature.fromCompact(signature),
 			sha256(message),
-			this.toBytes(),
+			this.toRawBytes(),
 		);
 	}
 }

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -4,9 +4,13 @@
 import { fromB64 } from '@mysten/bcs';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bytesToHex } from '@noble/hashes/utils';
-import { PublicKey } from '../../cryptography/publickey.js';
+import { PublicKey, bytesEqual } from '../../cryptography/publickey.js';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
-import { SIGNATURE_SCHEME_TO_FLAG } from '../../cryptography/signature.js';
+import type { SerializedSignature } from '../../cryptography/signature.js';
+import {
+	SIGNATURE_SCHEME_TO_FLAG,
+	parseSerializedSignature,
+} from '../../cryptography/signature.js';
 import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
@@ -76,9 +80,25 @@ export class Secp256k1PublicKey extends PublicKey {
 	/**
 	 * Verifies that the signature is valid for for the provided message
 	 */
-	async verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+	async verify(message: Uint8Array, signature: Uint8Array | SerializedSignature): Promise<boolean> {
+		let bytes;
+		if (typeof signature === 'string') {
+			const parsed = parseSerializedSignature(signature);
+			if (parsed.signatureScheme !== 'Secp256k1') {
+				throw new Error('Invalid signature scheme');
+			}
+
+			if (!bytesEqual(this.toRawBytes(), parsed.publicKey)) {
+				throw new Error('Signature does not match public key');
+			}
+
+			bytes = parsed.signature;
+		} else {
+			bytes = signature;
+		}
+
 		return secp256k1.verify(
-			secp256k1.Signature.fromCompact(signature),
+			secp256k1.Signature.fromCompact(bytes),
 			sha256(message),
 			this.toRawBytes(),
 		);

--- a/sdk/typescript/src/keypairs/secp256k1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256k1/publickey.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromB64 } from '@mysten/bcs';
-import { blake2b } from '@noble/hashes/blake2b';
-import { bytesToHex } from '@noble/hashes/utils';
 import { PublicKey, bytesEqual } from '../../cryptography/publickey.js';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
 import type { SerializedSignature } from '../../cryptography/signature.js';
@@ -11,7 +9,6 @@ import {
 	SIGNATURE_SCHEME_TO_FLAG,
 	parseSerializedSignature,
 } from '../../cryptography/signature.js';
-import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 
@@ -58,16 +55,6 @@ export class Secp256k1PublicKey extends PublicKey {
 	 */
 	toRawBytes(): Uint8Array {
 		return this.data;
-	}
-
-	/**
-	 * Return the Sui address associated with this Secp256k1 public key
-	 */
-	toSuiAddress(): string {
-		// Each hex char represents half a byte, hence hex address doubles the length
-		return normalizeSuiAddress(
-			bytesToHex(blake2b(this.toSuiBytes(), { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
-		);
 	}
 
 	/**

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -52,7 +52,7 @@ export class Secp256r1PublicKey extends PublicKey {
 	/**
 	 * Return the byte array representation of the Secp256r1 public key
 	 */
-	toBytes(): Uint8Array {
+	toRawBytes(): Uint8Array {
 		return this.data;
 	}
 
@@ -83,7 +83,7 @@ export class Secp256r1PublicKey extends PublicKey {
 		return secp256r1.verify(
 			secp256r1.Signature.fromCompact(signature),
 			sha256(message),
-			this.toBytes(),
+			this.toRawBytes(),
 		);
 	}
 }

--- a/sdk/typescript/src/keypairs/secp256r1/publickey.ts
+++ b/sdk/typescript/src/keypairs/secp256r1/publickey.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromB64 } from '@mysten/bcs';
-import { blake2b } from '@noble/hashes/blake2b';
-import { bytesToHex } from '@noble/hashes/utils';
 import { PublicKey, bytesEqual } from '../../cryptography/publickey.js';
 import type { PublicKeyInitData } from '../../cryptography/publickey.js';
 import type { SerializedSignature } from '../../cryptography/signature.js';
@@ -11,7 +9,6 @@ import {
 	SIGNATURE_SCHEME_TO_FLAG,
 	parseSerializedSignature,
 } from '../../cryptography/signature.js';
-import { SUI_ADDRESS_LENGTH, normalizeSuiAddress } from '../../utils/sui-types.js';
 import { sha256 } from '@noble/hashes/sha256';
 import { secp256r1 } from '@noble/curves/p256';
 
@@ -58,19 +55,6 @@ export class Secp256r1PublicKey extends PublicKey {
 	 */
 	toRawBytes(): Uint8Array {
 		return this.data;
-	}
-
-	/**
-	 * Return the Sui address associated with this Secp256r1 public key
-	 */
-	toSuiAddress(): string {
-		let tmp = new Uint8Array(SECP256R1_PUBLIC_KEY_SIZE + 1);
-		tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256r1']]);
-		tmp.set(this.toBytes(), 1);
-		// Each hex char represents half a byte, hence hex address doubles the length
-		return normalizeSuiAddress(
-			bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
-		);
 	}
 
 	/**

--- a/sdk/typescript/src/multisig/index.ts
+++ b/sdk/typescript/src/multisig/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './publickey.js';

--- a/sdk/typescript/src/multisig/publickey.ts
+++ b/sdk/typescript/src/multisig/publickey.ts
@@ -215,16 +215,23 @@ export class MultiSigPublicKey extends PublicKey {
 				compressedSignatures[i] = { Secp256r1: bytes };
 			}
 
+			let publicKeyIndex;
 			for (let j = 0; j < this.publicKeys.length; j++) {
 				if (bytesEqual(parsed.publicKey, this.publicKeys[j].publicKey.toRawBytes())) {
 					if (bitmap & (1 << j)) {
 						throw new Error('Received multiple signatures from the same public key');
 					}
 
-					bitmap |= 1 << j;
+					publicKeyIndex = j;
 					break;
 				}
 			}
+
+			if (publicKeyIndex === undefined) {
+				throw new Error('Received signature from unknown public key');
+			}
+
+			bitmap |= 1 << publicKeyIndex;
 		}
 
 		let multisig: MultiSigStruct = {

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -15,7 +15,7 @@ export async function verifySignature(
 ): Promise<PublicKey> {
 	const parsedSignature = parseSignature(signature);
 
-	if (!(await parsedSignature.publicKey.verify(bytes, parsedSignature.signature))) {
+	if (!(await parsedSignature.publicKey.verify(bytes, parsedSignature.serializedSignature))) {
 		throw new Error(`Signature is not valid for the provided data`);
 	}
 
@@ -29,7 +29,10 @@ export async function verifyPersonalMessage(
 	const parsedSignature = parseSignature(signature);
 
 	if (
-		!(await parsedSignature.publicKey.verifyPersonalMessage(message, parsedSignature.signature))
+		!(await parsedSignature.publicKey.verifyPersonalMessage(
+			message,
+			parsedSignature.serializedSignature,
+		))
 	) {
 		throw new Error(`Signature is not valid for the provided message`);
 	}
@@ -46,7 +49,7 @@ export async function verifyTransactionBlock(
 	if (
 		!(await parsedSignature.publicKey.verifyTransactionBlock(
 			transactionBlock,
-			parsedSignature.signature,
+			parsedSignature.serializedSignature,
 		))
 	) {
 		throw new Error(`Signature is not valid for the provided TransactionBlock`);
@@ -55,15 +58,13 @@ export async function verifyTransactionBlock(
 	return parsedSignature.publicKey;
 }
 
-export function parseSignature(signature: SerializedSignature) {
+function parseSignature(signature: SerializedSignature) {
 	const parsedSignature = parseSerializedSignature(signature);
 
 	if (parsedSignature.signatureScheme === 'MultiSig') {
-		const signatureBytes = parsedSignature.bytes.slice(1);
 		return {
 			...parsedSignature,
 			publicKey: new MultiSigPublicKey(parsedSignature.multisig.multisig_pk),
-			signature: signatureBytes,
 		};
 	}
 

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -1,13 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { builder } from '../builder/bcs.js';
 import type { PublicKey, SerializedSignature, SignatureScheme } from '../cryptography/index.js';
 import { parseSerializedSignature } from '../cryptography/index.js';
 import { Ed25519PublicKey } from '../keypairs/ed25519/publickey.js';
 import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
 import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
-import type { MultiSigStruct } from '../multisig/publickey.js';
 // eslint-disable-next-line import/no-cycle
 import { MultiSigPublicKey } from '../multisig/publickey.js';
 
@@ -62,11 +60,9 @@ export function parseSignature(signature: SerializedSignature) {
 
 	if (parsedSignature.signatureScheme === 'MultiSig') {
 		const signatureBytes = parsedSignature.bytes.slice(1);
-		const multisig: MultiSigStruct = builder.de('MultiSig', signatureBytes);
 		return {
 			...parsedSignature,
-			multisig,
-			publicKey: new MultiSigPublicKey(multisig.multisig_pk),
+			publicKey: new MultiSigPublicKey(parsedSignature.multisig.multisig_pk),
 			signature: signatureBytes,
 		};
 	}

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PublicKey, SerializedSignature } from '../cryptography/index.js';
+import { builder } from '../builder/bcs.js';
+import type { PublicKey, SerializedSignature, SignatureScheme } from '../cryptography/index.js';
 import { parseSerializedSignature } from '../cryptography/index.js';
 import { Ed25519PublicKey } from '../keypairs/ed25519/publickey.js';
 import { Secp256k1PublicKey } from '../keypairs/secp256k1/publickey.js';
 import { Secp256r1PublicKey } from '../keypairs/secp256r1/publickey.js';
+import type { MultiSigStruct } from '../multisig/publickey.js';
+// eslint-disable-next-line import/no-cycle
+import { MultiSigPublicKey } from '../multisig/publickey.js';
 
 export async function verifySignature(
 	bytes: Uint8Array,
@@ -53,26 +57,38 @@ export async function verifyTransactionBlock(
 	return parsedSignature.publicKey;
 }
 
-function parseSignature(signature: SerializedSignature) {
+export function parseSignature(signature: SerializedSignature) {
 	const parsedSignature = parseSerializedSignature(signature);
-	let publicKey: PublicKey;
 
-	switch (parsedSignature.signatureScheme) {
-		case 'ED25519':
-			publicKey = new Ed25519PublicKey(parsedSignature.publicKey);
-			break;
-		case 'Secp256k1':
-			publicKey = new Secp256k1PublicKey(parsedSignature.publicKey);
-			break;
-		case 'Secp256r1':
-			publicKey = new Secp256r1PublicKey(parsedSignature.publicKey);
-			break;
-		default:
-			throw new Error(`Unsupported signature scheme ${parsedSignature.signatureScheme}`);
+	if (parsedSignature.signatureScheme === 'MultiSig') {
+		const signatureBytes = parsedSignature.bytes.slice(1);
+		const multisig: MultiSigStruct = builder.de('MultiSig', signatureBytes);
+		return {
+			...parsedSignature,
+			multisig,
+			publicKey: new MultiSigPublicKey(multisig.multisig_pk),
+			signature: signatureBytes,
+		};
 	}
 
+	const publicKey = publicKeyFromBytes(parsedSignature.signatureScheme, parsedSignature.publicKey);
 	return {
 		...parsedSignature,
 		publicKey,
 	};
+}
+
+export function publicKeyFromBytes(signatureScheme: SignatureScheme, bytes: Uint8Array): PublicKey {
+	switch (signatureScheme) {
+		case 'ED25519':
+			return new Ed25519PublicKey(bytes);
+		case 'Secp256k1':
+			return new Secp256k1PublicKey(bytes);
+		case 'Secp256r1':
+			return new Secp256r1PublicKey(bytes);
+		case 'MultiSig':
+			return new MultiSigPublicKey(bytes);
+		default:
+			throw new Error(`Unsupported signature scheme ${signatureScheme}`);
+	}
 }

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -11,7 +11,7 @@ import {
 	TransactionBlock,
 	verifyMessage,
 } from '../../../src';
-import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECRET_KEY = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCg=';
 
@@ -140,9 +140,8 @@ describe('ed25519-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSignature(serializedSignature);
 
-		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, serializedSignature)).toEqual(
 			true,
 		);
 		expect(await verifyMessage(bytes, serializedSignature, IntentScope.TransactionData)).toEqual(
@@ -156,10 +155,9 @@ describe('ed25519-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSignature(serializedSignature);
 
 		expect(
-			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+			await keypair.getPublicKey().verifyPersonalMessage(message, serializedSignature),
 		).toEqual(true);
 		expect(await verifyMessage(message, serializedSignature, IntentScope.PersonalMessage)).toEqual(
 			true,

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -40,7 +40,7 @@ const TEST_MNEMONIC =
 describe('ed25519-keypair', () => {
 	it('new keypair', () => {
 		const keypair = new Ed25519Keypair();
-		expect(keypair.getPublicKey().toBytes().length).toBe(32);
+		expect(keypair.getPublicKey().toRawBytes().length).toBe(32);
 		expect(2).toEqual(2);
 	});
 
@@ -86,7 +86,7 @@ describe('ed25519-keypair', () => {
 		const isValid = nacl.sign.detached.verify(
 			signData,
 			signature,
-			keypair.getPublicKey().toBytes(),
+			keypair.getPublicKey().toRawBytes(),
 		);
 		expect(isValid).toBeTruthy();
 		expect(keypair.getPublicKey().verify(signData, signature));
@@ -100,7 +100,7 @@ describe('ed25519-keypair', () => {
 		const isValid = nacl.sign.detached.verify(
 			signData,
 			signature,
-			keypair.getPublicKey().toBytes(),
+			keypair.getPublicKey().toRawBytes(),
 		);
 		expect(isValid).toBeTruthy();
 	});

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -9,10 +9,9 @@ import {
 	IntentScope,
 	PRIVATE_KEY_SIZE,
 	TransactionBlock,
-	parseSerializedSignature,
 	verifyMessage,
 } from '../../../src';
-import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECRET_KEY = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCg=';
 
@@ -141,7 +140,7 @@ describe('ed25519-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
 			true,
@@ -157,7 +156,7 @@ describe('ed25519-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(
 			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),

--- a/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
@@ -67,8 +67,8 @@ describe('Ed25519PublicKey', () => {
 
 	it('toBuffer', () => {
 		const key = new Ed25519PublicKey(VALID_KEY_BASE64);
-		expect(key.toBytes().length).toBe(32);
-		expect(new Ed25519PublicKey(key.toBytes()).equals(key)).toBe(true);
+		expect(key.toRawBytes().length).toBe(32);
+		expect(new Ed25519PublicKey(key.toRawBytes()).equals(key)).toBe(true);
 	});
 
 	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {

--- a/sdk/typescript/test/unit/cryptography/multisig.test.ts
+++ b/sdk/typescript/test/unit/cryptography/multisig.test.ts
@@ -23,14 +23,17 @@ describe('multisig address and combine sigs', () => {
 		let k3 = Ed25519Keypair.fromSecretKey(new Uint8Array(32).fill(0));
 		let pk3 = k3.getPublicKey();
 
-		const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys(3, [
-			{ publicKey: pk1, weight: 1 },
-			{
-				publicKey: pk2,
-				weight: 2,
-			},
-			{ publicKey: pk3, weight: 3 },
-		]);
+		const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys({
+			threshold: 3,
+			publicKeys: [
+				{ publicKey: pk1, weight: 1 },
+				{
+					publicKey: pk2,
+					weight: 2,
+				},
+				{ publicKey: pk3, weight: 3 },
+			],
+		});
 
 		const data = new Uint8Array([0, 0, 0, 5, 72, 101, 108, 108, 111]);
 

--- a/sdk/typescript/test/unit/cryptography/multisig.test.ts
+++ b/sdk/typescript/test/unit/cryptography/multisig.test.ts
@@ -2,19 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import {
-	combinePartialSigs,
-	decodeMultiSig,
-	parseMultiSig,
-	toMultiSigAddress,
-	verifyMultisig,
-} from '../../../src/cryptography/multisig';
-import { Ed25519Keypair, Secp256k1Keypair, toSerializedSignature } from '../../../src';
-import { blake2b } from '@noble/hashes/blake2b';
+import { Ed25519Keypair, Secp256k1Keypair, decodeMultiSig } from '../../../src';
+import { parseSignature } from '../../../src/verify';
+import { MultiSigPublicKey } from '../../../src/multisig';
 
 describe('multisig address and combine sigs', () => {
 	// Address and combined multisig matches rust impl: fn multisig_serde_test()
-	it('combines signature to multisig', () => {
+	it('combines signature to multisig', async () => {
 		const VALID_SECP256K1_SECRET_KEY = [
 			59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203, 174, 253, 102,
 			39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
@@ -29,87 +23,60 @@ describe('multisig address and combine sigs', () => {
 		let k3 = Ed25519Keypair.fromSecretKey(new Uint8Array(32).fill(0));
 		let pk3 = k3.getPublicKey();
 
+		const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys(3, [
+			{ publicKey: pk1, weight: 1 },
+			{
+				publicKey: pk2,
+				weight: 2,
+			},
+			{ publicKey: pk3, weight: 3 },
+		]);
+
 		const data = new Uint8Array([0, 0, 0, 5, 72, 101, 108, 108, 111]);
-		const digest = blake2b(data, { dkLen: 32 });
 
-		const sig1 = {
-			signature: k1.signData(digest),
-			signatureScheme: k1.getKeyScheme(),
-			pubKey: pk1,
-			weight: 1,
-		};
+		const sig1 = await k1.signPersonalMessage(data);
+		const sig2 = await k2.signPersonalMessage(data);
+		const sig3 = await k3.signPersonalMessage(data);
 
-		const ser_sig1 = toSerializedSignature(sig1);
-
-		const sig2 = {
-			signature: k2.signData(digest),
-			signatureScheme: k2.getKeyScheme(),
-			pubKey: pk2,
-			weight: 2,
-		};
-
-		const ser_sig2 = toSerializedSignature(sig2);
-
-		const sig3 = {
-			signature: k3.signData(digest),
-			signatureScheme: k3.getKeyScheme(),
-			pubKey: pk3,
-			weight: 3,
-		};
-		const ser_sig3 = toSerializedSignature(sig3);
-
-		expect(
-			toMultiSigAddress(
-				[
-					{ pubKey: pk1, weight: 1 },
-					{ pubKey: pk2, weight: 2 },
-					{ pubKey: pk3, weight: 3 },
-				],
-				3,
-			),
-		).toEqual('0x37b048598ca569756146f4e8ea41666c657406db154a31f11bb5c1cbaf0b98d7');
-
-		let multisig = combinePartialSigs(
-			[ser_sig1, ser_sig2],
-			[
-				{ pubKey: pk1, weight: 1 },
-				{ pubKey: pk2, weight: 2 },
-				{ pubKey: pk3, weight: 3 },
-			],
-			3,
+		expect(multiSigPublicKey.toSuiAddress()).toEqual(
+			'0x37b048598ca569756146f4e8ea41666c657406db154a31f11bb5c1cbaf0b98d7',
 		);
+
+		let multisig = multiSigPublicKey.combinePartialSignatures([sig1.signature, sig2.signature]);
 		expect(multisig).toEqual(
-			'AwIAvlJnUP0iJFZL+QTxkKC9FHZGwCa5I4TITHS/QDQ12q1sYW6SMt2Yp3PSNzsAay0Fp2MPVohqyyA02UtdQ2RNAQGH0eLk4ifl9h1I8Uc+4QlRYfJC21dUbP8aFaaRqiM/f32TKKg/4PSsGf9lFTGwKsHJYIMkDoqKwI8Xqr+3apQzAwADAFriILSy9l6XfBLt5hV5/1FwtsIsAGFow3tefGGvAYCDAQECHRUjB8a3Kw7QQYsOcM2A5/UpW42G9XItP1IT+9I5TzYCADtqJ7zOtqQtYqOo0CpvDXNlMhV3HeJDpjrASKGLWdopAwMA',
+			'AwIANe9gJJmT5m1UvpV8Hj7nOyif76rS5Zgg1bi7VApts+KwtSc2Bg8WJ6LBfGnZKugrOqtQsk5d2Q+IMRLD4hYmBQFYlrlXc01/ZSdgwSD3eGEdm6kxwtOwAvTWdb2wNZP2Hnkgrh+indYN4s2Qd99iYCz+xsY6aT5lpOBsDZb2x9LyAwADAFriILSy9l6XfBLt5hV5/1FwtsIsAGFow3tefGGvAYCDAQECHRUjB8a3Kw7QQYsOcM2A5/UpW42G9XItP1IT+9I5TzYCADtqJ7zOtqQtYqOo0CpvDXNlMhV3HeJDpjrASKGLWdopAwMA',
 		);
 
 		let decoded = decodeMultiSig(multisig);
-		expect(decoded).toEqual([sig1, sig2]);
+		expect(decoded).toEqual([
+			{
+				signature: parseSignature((await k1.signPersonalMessage(data)).signature).signature,
+				signatureScheme: k1.getKeyScheme(),
+				pubKey: pk1,
+				weight: 1,
+			},
+			{
+				signature: parseSignature((await k2.signPersonalMessage(data)).signature).signature,
+				signatureScheme: k2.getKeyScheme(),
+				pubKey: pk2,
+				weight: 2,
+			},
+		]);
 
+		const parsed = parseSignature(multisig);
 		// multisig (sig1 + sig2 weight 1+2 >= threshold ) verifies ok
-		expect(verifyMultisig(parseMultiSig(multisig), data)).toEqual(true);
+		expect(await parsed.publicKey.verifyPersonalMessage(data, parsed.signature)).toEqual(true);
 
-		let multisig_2 = combinePartialSigs(
-			[ser_sig3],
-			[
-				{ pubKey: pk1, weight: 1 },
-				{ pubKey: pk2, weight: 2 },
-				{ pubKey: pk3, weight: 3 },
-			],
-			3,
-		);
+		let multisig2 = parseSignature(multiSigPublicKey.combinePartialSignatures([sig3.signature]));
+
 		// multisig (sig3 only weight = 3 >= threshold) verifies ok
-		expect(verifyMultisig(parseMultiSig(multisig_2), data)).toEqual(true);
+		expect(await multiSigPublicKey.verifyPersonalMessage(data, multisig2.signature)).toEqual(true);
 
-		let multisig_3 = combinePartialSigs(
-			[ser_sig2],
-			[
-				{ pubKey: pk1, weight: 1 },
-				{ pubKey: pk2, weight: 2 },
-				{ pubKey: pk3, weight: 3 },
-			],
-			3,
-		);
+		let multisig3 = parseSignature(multiSigPublicKey.combinePartialSignatures([sig2.signature]));
+
 		// multisig (sig2 only weight = 2 < threshold) verify fails
-		expect(verifyMultisig(parseMultiSig(multisig_3), data)).toEqual(false);
+		expect(await multisig3.publicKey.verifyPersonalMessage(data, multisig3.signature)).toEqual(
+			false,
+		);
 	});
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -58,7 +58,7 @@ const TEST_MNEMONIC =
 describe('secp256k1-keypair', () => {
 	it('new keypair', () => {
 		const keypair = new Secp256k1Keypair();
-		expect(keypair.getPublicKey().toBytes().length).toBe(33);
+		expect(keypair.getPublicKey().toRawBytes().length).toBe(33);
 		expect(2).toEqual(2);
 	});
 
@@ -67,7 +67,7 @@ describe('secp256k1-keypair', () => {
 		const pub_key = new Uint8Array(VALID_SECP256K1_PUBLIC_KEY);
 		let pub_key_base64 = toB64(pub_key);
 		const keypair = Secp256k1Keypair.fromSecretKey(secret_key);
-		expect(keypair.getPublicKey().toBytes()).toEqual(new Uint8Array(pub_key));
+		expect(keypair.getPublicKey().toRawBytes()).toEqual(new Uint8Array(pub_key));
 		expect(keypair.getPublicKey().toBase64()).toEqual(pub_key_base64);
 	});
 
@@ -97,7 +97,7 @@ describe('secp256k1-keypair', () => {
 			secp256k1.verify(
 				secp256k1.Signature.fromCompact(sig),
 				msgHash,
-				keypair.getPublicKey().toBytes(),
+				keypair.getPublicKey().toRawBytes(),
 			),
 		).toBeTruthy();
 	});
@@ -118,7 +118,7 @@ describe('secp256k1-keypair', () => {
 			secp256k1.verify(
 				secp256k1.Signature.fromCompact(sig),
 				msgHash,
-				keypair.getPublicKey().toBytes(),
+				keypair.getPublicKey().toRawBytes(),
 			),
 		).toBeTruthy();
 	});

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -7,14 +7,13 @@ import {
 	PRIVATE_KEY_SIZE,
 	Secp256k1Keypair,
 	TransactionBlock,
-	parseSerializedSignature,
 	verifyMessage,
 } from '../../../src';
 import { describe, it, expect } from 'vitest';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
-import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 // Test case from https://github.com/rust-bitcoin/rust-secp256k1/blob/master/examples/sign_verify.rs#L26
 const VALID_SECP256K1_SECRET_KEY = [
@@ -180,7 +179,7 @@ describe('secp256k1-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
 			true,
@@ -196,7 +195,7 @@ describe('secp256k1-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(
 			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect } from 'vitest';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
-import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 // Test case from https://github.com/rust-bitcoin/rust-secp256k1/blob/master/examples/sign_verify.rs#L26
 const VALID_SECP256K1_SECRET_KEY = [
@@ -179,9 +179,8 @@ describe('secp256k1-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSignature(serializedSignature);
 
-		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, serializedSignature)).toEqual(
 			true,
 		);
 		expect(await verifyMessage(bytes, serializedSignature, IntentScope.TransactionData)).toEqual(
@@ -195,10 +194,9 @@ describe('secp256k1-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSignature(serializedSignature);
 
 		expect(
-			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+			await keypair.getPublicKey().verifyPersonalMessage(message, serializedSignature),
 		).toEqual(true);
 		expect(await verifyMessage(message, serializedSignature, IntentScope.PersonalMessage)).toEqual(
 			true,

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -68,8 +68,8 @@ describe('Secp256k1PublicKey', () => {
 		const pub_key = new Uint8Array(VALID_SECP256K1_PUBLIC_KEY);
 		let pub_key_base64 = toB64(pub_key);
 		const key = new Secp256k1PublicKey(pub_key_base64);
-		expect(key.toBytes().length).toBe(33);
-		expect(new Secp256k1PublicKey(key.toBytes()).equals(key)).toBe(true);
+		expect(key.toRawBytes().length).toBe(33);
+		expect(new Secp256k1PublicKey(key.toRawBytes()).equals(key)).toBe(true);
 	});
 
 	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {

--- a/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
@@ -6,13 +6,12 @@ import {
 	PRIVATE_KEY_SIZE,
 	Secp256r1Keypair,
 	TransactionBlock,
-	parseSerializedSignature,
 } from '../../../src';
 import { describe, it, expect } from 'vitest';
 import { secp256r1 } from '@noble/curves/p256';
 import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
-import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECP256R1_SECRET_KEY = [
 	66, 37, 141, 205, 161, 76, 241, 17, 198, 2, 184, 151, 27, 140, 200, 67, 233, 30, 70, 202, 144, 81,
@@ -183,7 +182,7 @@ describe('secp256r1-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
 			true,
@@ -196,7 +195,7 @@ describe('secp256r1-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSerializedSignature(serializedSignature);
+		const signature = parseSignature(serializedSignature);
 
 		expect(
 			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),

--- a/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
@@ -57,7 +57,7 @@ const TEST_MNEMONIC = 'open genre century trouble allow pioneer love task chat s
 describe('secp256r1-keypair', () => {
 	it('new keypair', () => {
 		const keypair = new Secp256r1Keypair();
-		expect(keypair.getPublicKey().toBytes().length).toBe(33);
+		expect(keypair.getPublicKey().toRawBytes().length).toBe(33);
 		expect(2).toEqual(2);
 	});
 
@@ -66,7 +66,7 @@ describe('secp256r1-keypair', () => {
 		const pub_key = new Uint8Array(VALID_SECP256R1_PUBLIC_KEY);
 		let pub_key_base64 = toB64(pub_key);
 		const keypair = Secp256r1Keypair.fromSecretKey(secret_key);
-		expect(keypair.getPublicKey().toBytes()).toEqual(new Uint8Array(pub_key));
+		expect(keypair.getPublicKey().toRawBytes()).toEqual(new Uint8Array(pub_key));
 		expect(keypair.getPublicKey().toBase64()).toEqual(pub_key_base64);
 	});
 
@@ -96,7 +96,7 @@ describe('secp256r1-keypair', () => {
 			secp256r1.verify(
 				secp256r1.Signature.fromCompact(sig),
 				msgHash,
-				keypair.getPublicKey().toBytes(),
+				keypair.getPublicKey().toRawBytes(),
 			),
 		).toBeTruthy();
 	});
@@ -117,7 +117,7 @@ describe('secp256r1-keypair', () => {
 			secp256r1.verify(
 				secp256r1.Signature.fromCompact(sig),
 				msgHash,
-				keypair.getPublicKey().toBytes(),
+				keypair.getPublicKey().toRawBytes(),
 			),
 		).toBeTruthy();
 	});

--- a/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-keypair.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { secp256r1 } from '@noble/curves/p256';
 import { fromB64, toB58, toB64 } from '@mysten/bcs';
 import { sha256 } from '@noble/hashes/sha256';
-import { parseSignature, verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
+import { verifyPersonalMessage, verifyTransactionBlock } from '../../../src/verify';
 
 const VALID_SECP256R1_SECRET_KEY = [
 	66, 37, 141, 205, 161, 76, 241, 17, 198, 2, 184, 151, 27, 140, 200, 67, 233, 30, 70, 202, 144, 81,
@@ -182,9 +182,8 @@ describe('secp256r1-keypair', () => {
 		const bytes = await txb.build();
 
 		const serializedSignature = (await keypair.signTransactionBlock(bytes)).signature;
-		const signature = parseSignature(serializedSignature);
 
-		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, signature.signature)).toEqual(
+		expect(await keypair.getPublicKey().verifyTransactionBlock(bytes, serializedSignature)).toEqual(
 			true,
 		);
 		expect(!!(await verifyTransactionBlock(bytes, serializedSignature))).toEqual(true);
@@ -195,10 +194,9 @@ describe('secp256r1-keypair', () => {
 		const message = new TextEncoder().encode('hello world');
 
 		const serializedSignature = (await keypair.signPersonalMessage(message)).signature;
-		const signature = parseSignature(serializedSignature);
 
 		expect(
-			await keypair.getPublicKey().verifyPersonalMessage(message, signature.signature),
+			await keypair.getPublicKey().verifyPersonalMessage(message, serializedSignature),
 		).toEqual(true);
 		expect(!!(await verifyPersonalMessage(message, serializedSignature))).toEqual(true);
 	});

--- a/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256r1-publickey.test.ts
@@ -53,8 +53,8 @@ describe('Secp256r1PublicKey', () => {
 		const pub_key = new Uint8Array(VALID_SECP256R1_PUBLIC_KEY);
 		let pub_key_base64 = toB64(pub_key);
 		const key = new Secp256r1PublicKey(pub_key_base64);
-		expect(key.toBytes().length).toBe(33);
-		expect(new Secp256r1PublicKey(key.toBytes()).equals(key)).toBe(true);
+		expect(key.toRawBytes().length).toBe(33);
+		expect(new Secp256r1PublicKey(key.toRawBytes()).equals(key)).toBe(true);
 	});
 
 	TEST_CASES.forEach(({ rawPublicKey, suiPublicKey, suiAddress }) => {


### PR DESCRIPTION
## Description 

Closes https://github.com/MystenLabs/sui/issues/12931. Add feature to verify a multisig in typescript. depends on https://github.com/MystenLabs/sui/pull/12997
## Test Plan 

unit tests. 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
