### PR TITLE
[rpc] logging macro logs original error instead of RpcError

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -220,23 +220,22 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> RpcResult<Vec<DelegatedStake>> {
-        with_tracing!(async move { Ok(self.get_stakes_by_ids(staked_sui_ids).await?) })
+        with_tracing!(async move { self.get_stakes_by_ids(staked_sui_ids).await })
     }
 
     #[instrument(skip(self))]
     async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
-        with_tracing!(async move { Ok(self.get_stakes(owner).await?) })
+        with_tracing!(async move { self.get_stakes(owner).await })
     }
 
     #[instrument(skip(self))]
     async fn get_committee_info(&self, epoch: Option<BigInt<u64>>) -> RpcResult<SuiCommittee> {
         with_tracing!(async move {
-            Ok(self
-                .state
+            self.state
                 .committee_store()
                 .get_or_latest_committee(epoch.map(|e| *e))
                 .map(|committee| committee.into())
-                .map_err(Error::from)?)
+                .map_err(Error::from)
         })
     }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -323,6 +323,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 self.read_api
                     .get_object(id, Some(SuiObjectDataOptions::full_content()))
                     .await
+                    .map_err(Error::from)
             } else {
                 Ok(SuiObjectResponse::new_with_error(
                     SuiObjectResponseError::DynamicFieldNotFound { parent_object_id },

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -149,12 +149,12 @@ impl MoveUtilsServer for MoveUtils {
             let identifier = Identifier::new(struct_name.as_str()).map_err(|e| {
                 Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
             })?;
-            Ok(match structs.get(&identifier) {
+            match structs.get(&identifier) {
                 Some(struct_) => Ok(struct_.clone().into()),
                 None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
                     format!("No struct was found with struct name {}", struct_name),
                 ))),
-            }?)
+            }
         })
     }
 
@@ -171,12 +171,12 @@ impl MoveUtilsServer for MoveUtils {
             let identifier = Identifier::new(function_name.as_str()).map_err(|e| {
                 Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
             })?;
-            Ok(match functions.get(&identifier) {
+            match functions.get(&identifier) {
                 Some(function) => Ok(function.clone().into()),
                 None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
                     format!("No function was found with function name {}", function_name),
                 ))),
-            }?)
+            }
         })
     }
 
@@ -218,7 +218,7 @@ impl MoveUtilsServer for MoveUtils {
                 .get(&module)
                 .and_then(|m| m.functions.get(&identifier).map(|f| f.parameters.clone()));
 
-            Ok(match parameters {
+            match parameters {
                 Some(parameters) => Ok(parameters
                     .iter()
                     .map(|p| match p {
@@ -240,7 +240,7 @@ impl MoveUtilsServer for MoveUtils {
                 None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
                     format!("No parameters found for function {}", function),
                 ))),
-            }?)
+            }
         })
     }
 }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -218,9 +218,8 @@ impl WriteApiServer for TransactionExecutionApi {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
         with_tracing!(Duration::from_secs(10), async move {
-            Ok(self
-                .execute_transaction_block(tx_bytes, signatures, opts, request_type)
-                .await?)
+            self.execute_transaction_block(tx_bytes, signatures, opts, request_type)
+                .await
         })
     }
 
@@ -235,11 +234,10 @@ impl WriteApiServer for TransactionExecutionApi {
         with_tracing!(async move {
             let tx_kind: TransactionKind =
                 bcs::from_bytes(&tx_bytes.to_vec().map_err(Error::from)?).map_err(Error::from)?;
-            Ok(self
-                .state
+            self.state
                 .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
                 .await
-                .map_err(Error::from)?)
+                .map_err(Error::from)
         })
     }
 
@@ -248,7 +246,7 @@ impl WriteApiServer for TransactionExecutionApi {
         &self,
         tx_bytes: Base64,
     ) -> RpcResult<DryRunTransactionBlockResponse> {
-        with_tracing!(async move { Ok(self.dry_run_transaction_block(tx_bytes).await?) })
+        with_tracing!(async move { self.dry_run_transaction_block(tx_bytes).await })
     }
 }
 


### PR DESCRIPTION
## Description 

Currently, when we hit the `with_tracing!` macro, the error is already an `RpcError`. Down the line, if/ when we want to replace internal errors with a generic error string, we'll lose the debug information in our error logs. This PR modifies the macro to log and map the original error instead.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
