### PR TITLE
Add an inexpensive archive consistency check mode

### DIFF
--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -85,6 +85,12 @@ impl FileCompression {
     }
 }
 
+pub fn compute_sha3_checksum_for_bytes(bytes: Bytes) -> Result<[u8; 32]> {
+    let mut hasher = Sha3_256::default();
+    io::copy(&mut bytes.reader(), &mut hasher)?;
+    Ok(hasher.finalize().digest)
+}
+
 pub fn compute_sha3_checksum_for_file(file: &mut File) -> Result<[u8; 32]> {
     let mut hasher = Sha3_256::default();
     io::copy(file, &mut hasher)?;

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -29,7 +29,7 @@ use eyre::ContextCompat;
 use indicatif::{ProgressBar, ProgressStyle};
 use prometheus::Registry;
 use sui_archival::reader::{ArchiveReader, ArchiveReaderMetrics};
-use sui_archival::verify_archive_with_genesis_config;
+use sui_archival::{verify_archive_with_checksums, verify_archive_with_genesis_config};
 use sui_config::node::ArchiveReaderConfig;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::authority::AuthorityStore;
@@ -641,6 +641,13 @@ pub async fn verify_archive(
     interactive: bool,
 ) -> Result<()> {
     verify_archive_with_genesis_config(genesis, remote_store_config, concurrency, interactive).await
+}
+
+pub async fn verify_archive_by_checksum(
+    remote_store_config: ObjectStoreConfig,
+    concurrency: usize,
+) -> Result<()> {
+    verify_archive_with_checksums(remote_store_config, concurrency).await
 }
 
 pub async fn state_sync_from_archive(


### PR DESCRIPTION
## Description 

The current archive consistency check downloads and iterates over every single checkpoint and transaction from genesis. This is really slow for daily runs and over time this will get even worse. Adding an inexpensive consistency check mode where we verify consistency using stored sha3 checksums in manifest for every file.

## Test Plan 

Existing tests and running in testnet
