### PR TITLE
[kiosk] Post-audit patches

### DIFF
--- a/kiosk/sources/extensions/personal_kiosk.move
+++ b/kiosk/sources/extensions/personal_kiosk.move
@@ -19,6 +19,8 @@ module kiosk::personal_kiosk {
     const EIncorrectOwnedObject: u64 = 1;
     /// Trying to get the owner of a non-personal Kiosk.
     const EKioskNotOwned: u64 = 2;
+    /// Trying to make a someone else's Kiosk "personal".
+    const EWrongKiosk: u64 = 3;
 
     /// A key-only wrapper for the KioskOwnerCap. Makes sure that the Kiosk can
     /// not be traded altogether with its contents.
@@ -45,6 +47,8 @@ module kiosk::personal_kiosk {
     public fun new(
         kiosk: &mut Kiosk, cap: KioskOwnerCap, ctx: &mut TxContext
     ): PersonalKioskCap {
+        assert!(kiosk::has_access(kiosk, &cap), EWrongKiosk);
+
         let owner = sender(ctx);
 
         // set the owner property of the Kiosk

--- a/kiosk/tests/extensions/personal_kiosk_tests.move
+++ b/kiosk/tests/extensions/personal_kiosk_tests.move
@@ -47,6 +47,18 @@ module kiosk::personal_kiosk_tests {
         share(kiosk)
     }
 
+    #[test, expected_failure(abort_code = kiosk::personal_kiosk::EWrongKiosk)]
+    fun try_not_owned_kiosk_fail() {
+        let ctx = &mut test::ctx();
+        let (kiosk_1, cap_1) = test::get_kiosk(ctx);
+        let (kiosk_2, cap_2) = test::get_kiosk(ctx);
+
+        let _p1 = personal_kiosk::new(&mut kiosk_2, cap_1, ctx);
+        let _p2 = personal_kiosk::new(&mut kiosk_1, cap_2, ctx);
+
+        abort 1337
+    }
+
     #[test, expected_failure(abort_code = kiosk::personal_kiosk::EIncorrectCapObject)]
     fun borrow_replace_cap_fail() {
         let ctx = &mut test::ctx();


### PR DESCRIPTION
## Description 

Adds a better error on not-owned Kiosk, not a serious issue.

## Test Plan 

Features the test for the new abort a code.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- personal_kiosk now emits a nicer local abort code