### PR TITLE
source service (easy): clean up pass

### DIFF
--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -194,7 +194,7 @@ fn test_clone_command() -> anyhow::Result<()> {
         network: Some(Network::Localnet),
     };
 
-    let command = CloneCommand::new(&source, PathBuf::from("/tmp").as_path())?;
+    let command = CloneCommand::new(&source, PathBuf::from("/foo").as_path())?;
     let expect = expect![
         r#"CloneCommand {
     args: [
@@ -205,11 +205,11 @@ fn test_clone_command() -> anyhow::Result<()> {
             "--filter=tree:0",
             "--branch=main",
             "https://github.com/user/repo",
-            "/tmp/localnet/repo",
+            "/foo/localnet/repo",
         ],
         [
             "-C",
-            "/tmp/localnet/repo",
+            "/foo/localnet/repo",
             "sparse-checkout",
             "set",
             "--no-cone",
@@ -218,7 +218,7 @@ fn test_clone_command() -> anyhow::Result<()> {
         ],
         [
             "-C",
-            "/tmp/localnet/repo",
+            "/foo/localnet/repo",
             "checkout",
         ],
     ],


### PR DESCRIPTION
## Description 

Various cleanups to source service bundled together, see inline comments.

## Test Plan 

Semantics-preserving / tests pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
