### PR TITLE
[EffectsV2] Add unwrapped_then_deleted_v2

### DIFF
--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -171,7 +171,7 @@ where
                 .map(|(oref, _owner)| (*fx.transaction_digest(), oref.0, oref.1))
         })
         .chain(effects.iter().flat_map(|fx| {
-            fx.unwrapped_then_deleted()
+            fx.unwrapped_then_deleted_v1_deprecated()
                 .iter()
                 .map(|oref| (*fx.transaction_digest(), oref.0, oref.1))
         }))

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -423,7 +423,7 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.created().is_empty());
     assert_eq!(effects.mutated().len(), 2);
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     // compare the bytes
     let updated_object = validator

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -103,7 +103,7 @@ async fn test_object_wrapping_unwrapping() {
         (
             effects.created().len(),
             effects.deleted().len(),
-            effects.unwrapped_then_deleted().len(),
+            effects.unwrapped_then_deleted_v2().len(),
             effects.wrapped().len()
         ),
         (1, 0, 0, 1)
@@ -222,7 +222,7 @@ async fn test_object_wrapping_unwrapping() {
         effects.status()
     );
     assert_eq!(effects.deleted().len(), 1);
-    assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+    assert_eq!(effects.unwrapped_then_deleted_v2().len(), 1);
     // Check that both objects are marked as deleted in the authority.
     let expected_child_object_ref = (
         child_object_ref.0,
@@ -230,8 +230,8 @@ async fn test_object_wrapping_unwrapping() {
         ObjectDigest::OBJECT_DIGEST_DELETED,
     );
     assert!(effects
-        .unwrapped_then_deleted()
-        .contains(&expected_child_object_ref));
+        .unwrapped_then_deleted_v2()
+        .contains(&expected_child_object_ref.0));
     check_latest_object_ref(&authority, &expected_child_object_ref, true).await;
     let expected_parent_object_ref = (
         parent_object_ref.0,
@@ -561,7 +561,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     // considered created in the first place.
     assert_eq!(effects.deleted().len(), 2);
     // The child is considered as unwrapped and deleted, even though it was wrapped since creation.
-    assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+    assert_eq!(effects.unwrapped_then_deleted_v2().len(), 1);
 
     assert_eq!(
         effects
@@ -656,7 +656,7 @@ async fn test_remove_child_when_no_prior_version_exists() {
     // considered created in the first place.
     assert_eq!(effects.deleted().len(), 1);
     // The child was never created so it is not unwrapped.
-    assert_eq!(effects.unwrapped_then_deleted().len(), 0);
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     assert_eq!(
         effects
@@ -763,7 +763,7 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     // Check that parent object was deleted.
     assert_eq!(effects.deleted().len(), 2);
     // Check that child object was unwrapped and deleted.
-    assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+    assert_eq!(effects.unwrapped_then_deleted_v2().len(), 1);
 }
 
 #[tokio::test]
@@ -2302,7 +2302,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.unwrapped().is_empty());
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     // single
     let mut builder = ProgrammableTransactionBuilder::new();
@@ -2324,7 +2324,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.unwrapped().is_empty());
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     // two
     let mut builder = ProgrammableTransactionBuilder::new();
@@ -2349,7 +2349,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.unwrapped().is_empty());
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     // with move call value
     let mut builder = ProgrammableTransactionBuilder::new();
@@ -2379,7 +2379,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.unwrapped().is_empty());
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 
     // nested
     let mut builder = ProgrammableTransactionBuilder::new();
@@ -2416,7 +2416,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.unwrapped().is_empty());
     assert!(effects.deleted().is_empty());
-    assert!(effects.unwrapped_then_deleted().is_empty());
+    assert!(effects.unwrapped_then_deleted_v2().is_empty());
 }
 
 macro_rules! make_vec_tests_for_type {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -619,8 +619,9 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                     mutated: to_owned_ref(effect.mutated().to_vec()),
                     unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
                     deleted: to_sui_object_ref(effect.deleted().to_vec()),
+                    // TODO: Figure out how to not use deprecated method.
                     unwrapped_then_deleted: to_sui_object_ref(
-                        effect.unwrapped_then_deleted().to_vec(),
+                        effect.unwrapped_then_deleted_v1_deprecated().to_vec(),
                     ),
                     wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
                     gas_object: OwnedObjectRef {

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -59,9 +59,8 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
         })
         .collect::<HashMap<ObjectID, ObjectDigest>>();
     let unwrapped_then_deleted = effects
-        .unwrapped_then_deleted()
-        .iter()
-        .map(|e| e.0)
+        .unwrapped_then_deleted_v2()
+        .into_iter()
         .collect::<HashSet<_>>();
     get_balance_changes(
         object_provider,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1114,11 +1114,7 @@ impl<'a> SuiTestAdapter<'a> {
             .map(|((id, _, _), _)| *id)
             .collect();
         let mut deleted_ids: Vec<_> = effects.deleted().iter().map(|(id, _, _)| *id).collect();
-        let mut unwrapped_then_deleted_ids: Vec<_> = effects
-            .unwrapped_then_deleted()
-            .iter()
-            .map(|(id, _, _)| *id)
-            .collect();
+        let mut unwrapped_then_deleted_ids = effects.unwrapped_then_deleted_v2();
         let mut wrapped_ids: Vec<_> = effects.wrapped().iter().map(|(id, _, _)| *id).collect();
         let gas_summary = effects.gas_cost_summary();
 

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -96,8 +96,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     fn deleted(&self) -> &[ObjectRef] {
         &self.deleted
     }
-    fn unwrapped_then_deleted(&self) -> &[ObjectRef] {
+    fn unwrapped_then_deleted_v1_deprecated(&self) -> &[ObjectRef] {
         &self.unwrapped_then_deleted
+    }
+    fn unwrapped_then_deleted_v2(&self) -> Vec<ObjectID> {
+        self.unwrapped_then_deleted.iter().map(|r| r.0).collect()
     }
     fn wrapped(&self) -> &[ObjectRef] {
         &self.wrapped

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -211,7 +211,8 @@ pub trait TransactionEffectsAPI {
     fn mutated(&self) -> &[(ObjectRef, Owner)];
     fn unwrapped(&self) -> &[(ObjectRef, Owner)];
     fn deleted(&self) -> &[ObjectRef];
-    fn unwrapped_then_deleted(&self) -> &[ObjectRef];
+    fn unwrapped_then_deleted_v1_deprecated(&self) -> &[ObjectRef];
+    fn unwrapped_then_deleted_v2(&self) -> Vec<ObjectID>;
     fn wrapped(&self) -> &[ObjectRef];
     fn gas_object(&self) -> (ObjectRef, Owner);
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;


### PR DESCRIPTION
## Description 

In effects V2, we will no longer have the initial version and digest for unwrapped_then_deleted objects. Stop depending on that and return a list of ID instead. Make the old function v1_deprecated.
There are two remaining uses of the v1 method, one is in state accumulator which is expected since we used to depend on it; the other is when we convert effects to json rpc types. It's unclear to me how we should handle this yet. Maybe @amnn could advice.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
