### PR TITLE
[FIX] swap arguments in mint function for trusted_coin module

### DIFF
--- a/crates/sui-core/src/unit_tests/data/hero/sources/trusted_coin.move
+++ b/crates/sui-core/src/unit_tests/data/hero/sources/trusted_coin.move
@@ -23,7 +23,7 @@ module examples::trusted_coin {
     }
 
     public entry fun mint(treasury_cap: &mut TreasuryCap<EXAMPLE>, amount: u64, ctx: &mut TxContext) {
-        let coin = coin::mint<EXAMPLE>(amount, treasury_cap, ctx);
+        let coin = coin::mint<EXAMPLE>(treasury_cap, amount, ctx);
         transfer::public_transfer(coin, tx_context::sender(ctx));
     }
 


### PR DESCRIPTION
## Description 

This PR fixes an issue where the arguments in the mint function for the trusted_coin module were swapped. 

## Test Plan 

No test required. Already covered.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

This PR fixes a bug in the trusted_coin module where the arguments in the mint function were swapped. This change should not have any impact on existing functionality.