### PR TITLE
[EffectsV2] Lift up a few effects APIs

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1445,10 +1445,9 @@ impl AuthorityStore {
         }
 
         let tombstones = effects
-            .deleted()
+            .all_removed_objects()
             .into_iter()
-            .chain(effects.wrapped())
-            .map(|obj_ref| ObjectKey(obj_ref.0, obj_ref.1));
+            .map(|(obj_ref, _)| ObjectKey(obj_ref.0, obj_ref.1));
         write_batch.delete_batch(&self.perpetual_tables.objects, tombstones)?;
 
         let all_new_object_keys = effects

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -373,7 +373,7 @@ impl ReadApi {
                         .sender(),
                     effects.modified_at_versions(),
                     effects.all_changed_objects(),
-                    effects.all_deleted(),
+                    effects.all_removed_objects(),
                 ));
             }
             let results = join_all(results).await;
@@ -741,7 +741,7 @@ impl ReadApiServer for ReadApi {
                         sender,
                         effects.modified_at_versions(),
                         effects.all_changed_objects(),
-                        effects.all_deleted(),
+                        effects.all_removed_objects(),
                     )
                     .await;
 

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -146,7 +146,7 @@ impl TransactionExecutionApi {
                     sender,
                     effects.effects.modified_at_versions(),
                     effects.effects.all_changed_objects(),
-                    effects.effects.all_deleted(),
+                    effects.effects.all_removed_objects(),
                 )
                 .await?,
             )
@@ -193,7 +193,7 @@ impl TransactionExecutionApi {
             sender,
             transaction_effects.modified_at_versions(),
             transaction_effects.all_changed_objects(),
-            transaction_effects.all_deleted(),
+            transaction_effects.all_removed_objects(),
         )
         .await?;
 


### PR DESCRIPTION
## Description 

There are a few API functions in TransactionEffects that can be derived from other functions. They don't need to be defined per-effect type, but can be defined at top level. This will reduce code duplication when we introduce new effects variants.
Also change the semantics of all_deleted to exclude unwrapped_then_deleted objects and rename it, because unwrapped_then_deleted are never needed with this API call.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
