### PR TITLE
Two miscellaneous fixes

### DIFF
--- a/crates/sui-config/src/local_ip_utils.rs
+++ b/crates/sui-config/src/local_ip_utils.rs
@@ -84,7 +84,11 @@ pub fn get_available_port(host: &str) -> u16 {
         }
     }
 
-    panic!("Error: could not find an available port");
+    panic!(
+        "Error: could not find an available port on {}: {:?}",
+        host,
+        get_ephemeral_port(host)
+    );
 }
 
 #[cfg(not(msim))]

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -9,6 +9,7 @@ use fastcrypto::hash::{Digest, Hash, HashFunction};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -403,7 +404,7 @@ impl CommittedSubDagShell {
 pub type ShutdownToken = mpsc::Sender<()>;
 
 // Digest of ConsususOutput and CommittedSubDag
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ConsensusOutputDigest([u8; crypto::DIGEST_LENGTH]);
 
 impl AsRef<[u8]> for ConsensusOutputDigest {
@@ -415,6 +416,22 @@ impl AsRef<[u8]> for ConsensusOutputDigest {
 impl From<ConsensusOutputDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
     fn from(d: ConsensusOutputDigest) -> Self {
         Digest::new(d.0)
+    }
+}
+
+impl fmt::Debug for ConsensusOutputDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", base64::encode(self.0))
+    }
+}
+
+impl fmt::Display for ConsensusOutputDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{}",
+            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+        )
     }
 }
 


### PR DESCRIPTION
## Description 

1. Print `ConsensusOutputDigest` properly.
2. Include error when `get_available_port()` panics.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
