### PR TITLE
[Narwhal] cleanup more unused handlers

### DIFF
--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -41,8 +41,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -125,8 +123,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -209,8 +205,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -293,8 +287,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -377,8 +369,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -461,8 +451,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
@@ -545,8 +533,6 @@ validator_configs:
           worker_network_admin_server_base_port: 8765
         anemo:
           send_certificate_rate_limit: ~
-          get_payload_availability_rate_limit: ~
-          get_certificates_rate_limit: ~
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -517,22 +517,6 @@ pub(crate) fn make_anemo_config() -> anemo_cli::Config {
                     ),
                 )
                 .add_method(
-                    "GetPayloadAvailability",
-                    anemo_cli::ron_method!(
-                        PrimaryToPrimaryClient,
-                        get_payload_availability,
-                        PayloadAvailabilityRequest
-                    ),
-                )
-                .add_method(
-                    "GetCertificates",
-                    anemo_cli::ron_method!(
-                        PrimaryToPrimaryClient,
-                        get_certificates,
-                        GetCertificatesRequest
-                    ),
-                )
-                .add_method(
                     "FetchCertificates",
                     anemo_cli::ron_method!(
                         PrimaryToPrimaryClient,

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -64,7 +64,6 @@ They are defined as follows:
 - `range_synchronize_timeout`: The timeout configuration when synchronizing a range of certificates from peers.
 - `certificates_synchronize_timeout`: The timeout configuration when requesting certificates from peers.
 - `payload_synchronize_timeout`: Timeout when has requested the payload for a certificate and is waiting to receive them.
-- `payload_availability_timeout`: The timeout configuration when for when we ask the other peers to discover who has the payload available for the dictated certificates.
 - `socket_addr`: The socket address the consensus api gRPC server should be listening to.
 - `get_collections_timeout`: The timeout configuration when requesting batches from workers.
 - `remove_collections_timeout`: The timeout configuration when removing batches from workers.

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -246,8 +246,6 @@ impl NetworkAdminServerParameters {
 pub struct AnemoParameters {
     /// Per-peer rate-limits (in requests/sec) for the PrimaryToPrimary service.
     pub send_certificate_rate_limit: Option<NonZeroU32>,
-    pub get_payload_availability_rate_limit: Option<NonZeroU32>,
-    pub get_certificates_rate_limit: Option<NonZeroU32>,
 
     /// Per-peer rate-limits (in requests/sec) for the WorkerToWorker service.
     pub report_batch_rate_limit: Option<NonZeroU32>,

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -22,8 +22,6 @@ expression: parameters
   },
   "anemo": {
     "send_certificate_rate_limit": null,
-    "get_payload_availability_rate_limit": null,
-    "get_certificates_rate_limit": null,
     "report_batch_rate_limit": null,
     "request_batch_rate_limit": null
   }

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -22,8 +22,6 @@ expression: params
   },
   "anemo": {
     "send_certificate_rate_limit": null,
-    "get_payload_availability_rate_limit": null,
-    "get_certificates_rate_limit": null,
     "report_batch_rate_limit": null,
     "request_batch_rate_limit": null
   }

--- a/narwhal/network/src/p2p.rs
+++ b/narwhal/network/src/p2p.rs
@@ -11,8 +11,8 @@ use crypto::NetworkPublicKey;
 use std::time::Duration;
 use types::{
     Batch, BatchDigest, FetchCertificatesRequest, FetchCertificatesResponse,
-    GetCertificatesRequest, GetCertificatesResponse, PrimaryToPrimaryClient, RequestBatchRequest,
-    RequestBatchesRequest, RequestBatchesResponse, WorkerBatchMessage, WorkerToWorkerClient,
+    PrimaryToPrimaryClient, RequestBatchRequest, RequestBatchesRequest, RequestBatchesResponse,
+    WorkerBatchMessage, WorkerToWorkerClient,
 };
 
 fn send<F, R, Fut>(
@@ -63,22 +63,6 @@ where
 
 #[async_trait]
 impl PrimaryToPrimaryRpc for anemo::Network {
-    async fn get_certificates(
-        &self,
-        peer: &NetworkPublicKey,
-        request: impl anemo::types::request::IntoRequest<GetCertificatesRequest> + Send,
-    ) -> Result<GetCertificatesResponse> {
-        let peer_id = PeerId(peer.0.to_bytes());
-        let peer = self
-            .peer(peer_id)
-            .ok_or_else(|| format_err!("Network has no connection with peer {peer_id}"))?;
-        let response = PrimaryToPrimaryClient::new(peer)
-            .get_certificates(request)
-            .await
-            .map_err(|e| format_err!("Network error {:?}", e))?;
-        Ok(response.into_body())
-    }
-
     async fn fetch_certificates(
         &self,
         peer: &NetworkPublicKey,

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -6,9 +6,8 @@ use async_trait::async_trait;
 use crypto::NetworkPublicKey;
 use types::{
     error::LocalClientError, Batch, BatchDigest, FetchBatchesRequest, FetchBatchesResponse,
-    FetchCertificatesRequest, FetchCertificatesResponse, GetCertificatesRequest,
-    GetCertificatesResponse, RequestBatchesRequest, RequestBatchesResponse,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
+    FetchCertificatesRequest, FetchCertificatesResponse, RequestBatchesRequest,
+    RequestBatchesResponse, WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
     WorkerSynchronizeMessage,
 };
 
@@ -37,11 +36,6 @@ pub trait ReliableNetwork<Request: Clone + Send + Sync> {
 
 #[async_trait]
 pub trait PrimaryToPrimaryRpc {
-    async fn get_certificates(
-        &self,
-        peer: &NetworkPublicKey,
-        request: impl anemo::types::request::IntoRequest<GetCertificatesRequest> + Send,
-    ) -> Result<GetCertificatesResponse>;
     async fn fetch_certificates(
         &self,
         peer: &NetworkPublicKey,

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -60,12 +60,10 @@ use types::{
     ensure,
     error::{DagError, DagResult},
     now, Certificate, CertificateAPI, CertificateDigest, FetchCertificatesRequest,
-    FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse, Header, HeaderAPI,
-    MetadataAPI, PayloadAvailabilityRequest, PayloadAvailabilityResponse,
-    PreSubscribedBroadcastSender, PrimaryToPrimary, PrimaryToPrimaryServer, RequestVoteRequest,
-    RequestVoteResponse, Round, SendCertificateRequest, SendCertificateResponse, Vote, VoteInfoAPI,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage, WorkerToPrimary,
-    WorkerToPrimaryServer,
+    FetchCertificatesResponse, Header, HeaderAPI, MetadataAPI, PreSubscribedBroadcastSender,
+    PrimaryToPrimary, PrimaryToPrimaryServer, RequestVoteRequest, RequestVoteResponse, Round,
+    SendCertificateRequest, SendCertificateResponse, Vote, VoteInfoAPI, WorkerOthersBatchMessage,
+    WorkerOurBatchMessage, WorkerOwnBatchMessage, WorkerToPrimary, WorkerToPrimaryServer,
 };
 
 #[cfg(any(test))]
@@ -200,7 +198,6 @@ impl Primary {
             signature_service: signature_service.clone(),
             header_store: header_store.clone(),
             certificate_store: certificate_store.clone(),
-            payload_store: payload_store.clone(),
             vote_digest_store,
             rx_narwhal_round_updates,
             parent_digests: Default::default(),
@@ -220,22 +217,6 @@ impl Primary {
         // Apply other rate limits from configuration as needed.
         if let Some(limit) = parameters.anemo.send_certificate_rate_limit {
             primary_service = primary_service.add_layer_for_send_certificate(
-                InboundRequestLayer::new(rate_limit::RateLimitLayer::new(
-                    governor::Quota::per_second(limit),
-                    rate_limit::WaitMode::Block,
-                )),
-            );
-        }
-        if let Some(limit) = parameters.anemo.get_payload_availability_rate_limit {
-            primary_service = primary_service.add_layer_for_get_payload_availability(
-                InboundRequestLayer::new(rate_limit::RateLimitLayer::new(
-                    governor::Quota::per_second(limit),
-                    rate_limit::WaitMode::Block,
-                )),
-            );
-        }
-        if let Some(limit) = parameters.anemo.get_certificates_rate_limit {
-            primary_service = primary_service.add_layer_for_get_certificates(
                 InboundRequestLayer::new(rate_limit::RateLimitLayer::new(
                     governor::Quota::per_second(limit),
                     rate_limit::WaitMode::Block,
@@ -547,7 +528,6 @@ struct PrimaryReceiverHandler {
     signature_service: SignatureService<Signature, { crypto::INTENT_MESSAGE_LENGTH }>,
     header_store: HeaderStore,
     certificate_store: CertificateStore,
-    payload_store: PayloadStore,
     /// The store to persist the last voted round per authority, used to ensure idempotence.
     vote_digest_store: VoteDigestStore,
     /// Get a signal when the round changes.
@@ -924,26 +904,6 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
             })
     }
 
-    async fn get_certificates(
-        &self,
-        request: anemo::Request<GetCertificatesRequest>,
-    ) -> Result<anemo::Response<GetCertificatesResponse>, anemo::rpc::Status> {
-        let digests = request.into_body().digests;
-        if digests.is_empty() {
-            return Ok(anemo::Response::new(GetCertificatesResponse {
-                certificates: Vec::new(),
-            }));
-        }
-
-        // TODO [issue #195]: Do some accounting to prevent bad nodes from monopolizing our resources.
-        let certificates = self.certificate_store.read_all(digests).map_err(|e| {
-            anemo::rpc::Status::internal(format!("error while retrieving certificates: {e}"))
-        })?;
-        Ok(anemo::Response::new(GetCertificatesResponse {
-            certificates: certificates.into_iter().flatten().collect(),
-        }))
-    }
-
     #[instrument(level = "debug", skip_all, peer = ?request.peer_id())]
     async fn fetch_certificates(
         &self,
@@ -1037,50 +997,6 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
         // The requestor should be able to process certificates returned in this order without
         // any missing parents.
         Ok(anemo::Response::new(response))
-    }
-
-    async fn get_payload_availability(
-        &self,
-        request: anemo::Request<PayloadAvailabilityRequest>,
-    ) -> Result<anemo::Response<PayloadAvailabilityResponse>, anemo::rpc::Status> {
-        let digests = request.into_body().certificate_digests;
-        let certificates = self
-            .certificate_store
-            .read_all(digests.to_owned())
-            .map_err(|e| {
-                anemo::rpc::Status::internal(format!("error reading certificates: {e:?}"))
-            })?;
-
-        let mut result: Vec<(CertificateDigest, bool)> = Vec::new();
-        for (id, certificate_option) in digests.into_iter().zip(certificates) {
-            // Find batches only for certificates that exist.
-            if let Some(certificate) = certificate_option {
-                let payload_available = match self.payload_store.read_all(
-                    certificate
-                        .header()
-                        .payload()
-                        .iter()
-                        .map(|(batch, (worker_id, _))| (*batch, *worker_id)),
-                ) {
-                    Ok(payload_result) => payload_result.into_iter().all(|x| x.is_some()),
-                    Err(err) => {
-                        // Assume that we don't have the payloads available,
-                        // otherwise an error response should be sent back.
-                        error!("Error while retrieving payloads: {err}");
-                        false
-                    }
-                };
-                result.push((id, payload_available));
-            } else {
-                // We don't have the certificate available in first place,
-                // so we can't even look up the batches.
-                result.push((id, false));
-            }
-        }
-
-        Ok(anemo::Response::new(PayloadAvailabilityResponse {
-            payload_availability: result,
-        }))
     }
 }
 

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -252,8 +252,14 @@ impl Primary {
                 epoch_string.clone(),
             )));
 
+        let primary_peer_ids = committee
+            .authorities()
+            .map(|authority| PeerId(authority.network_key().0.to_bytes()));
         let routes = anemo::Router::new()
             .add_rpc_service(primary_service)
+            .route_layer(RequireAuthorizationLayer::new(AllowedPeers::new(
+                primary_peer_ids,
+            )))
             .route_layer(RequireAuthorizationLayer::new(AllowedEpoch::new(
                 epoch_string.clone(),
             )))

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -30,8 +30,7 @@ use tokio::{
 };
 use types::{
     BatchDigest, Certificate, CertificateAPI, CertificateDigest, FetchCertificatesRequest,
-    FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse, Header, HeaderAPI,
-    HeaderDigest, Metadata, PayloadAvailabilityRequest, PayloadAvailabilityResponse,
+    FetchCertificatesResponse, Header, HeaderAPI, HeaderDigest, Metadata,
     PreSubscribedBroadcastSender, PrimaryToPrimary, PrimaryToPrimaryServer, RequestVoteRequest,
     RequestVoteResponse, Round, SendCertificateRequest, SendCertificateResponse,
 };
@@ -52,18 +51,14 @@ impl PrimaryToPrimary for NetworkProxy {
             request
         );
     }
+
     async fn request_vote(
         &self,
         _request: anemo::Request<RequestVoteRequest>,
     ) -> Result<anemo::Response<RequestVoteResponse>, anemo::rpc::Status> {
         unimplemented!()
     }
-    async fn get_certificates(
-        &self,
-        _request: anemo::Request<GetCertificatesRequest>,
-    ) -> Result<anemo::Response<GetCertificatesResponse>, anemo::rpc::Status> {
-        unimplemented!()
-    }
+
     async fn fetch_certificates(
         &self,
         request: anemo::Request<FetchCertificatesRequest>,
@@ -75,13 +70,6 @@ impl PrimaryToPrimary for NetworkProxy {
         Ok(anemo::Response::new(
             self.response.lock().await.recv().await.unwrap(),
         ))
-    }
-
-    async fn get_payload_availability(
-        &self,
-        _request: anemo::Request<PayloadAvailabilityRequest>,
-    ) -> Result<anemo::Response<PayloadAvailabilityResponse>, anemo::rpc::Status> {
-        unimplemented!()
     }
 }
 

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -7,8 +7,7 @@ use crate::{
     synchronizer::Synchronizer,
     NUM_SHUTDOWN_RECEIVERS,
 };
-use bincode::Options;
-use config::{AuthorityIdentifier, Committee, Parameters, WorkerId};
+use config::{AuthorityIdentifier, Committee, Parameters};
 use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -20,16 +19,12 @@ use itertools::Itertools;
 use network::client::NetworkClient;
 use prometheus::Registry;
 use std::{
-    borrow::Borrow,
     collections::{BTreeSet, HashMap, HashSet},
     num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
-use storage::{CertificateStore, VoteDigestStore};
-use storage::{CertificateStoreCache, PayloadToken};
-use storage::{NodeStorage, PayloadStore};
-use store::rocks::{DBMap, MetricConf, ReadWriteOptions};
+use storage::{NodeStorage, VoteDigestStore};
 use test_utils::{make_optimal_signed_certificates, temp_dir, CommitteeFixture};
 use tokio::{
     sync::{oneshot, watch},
@@ -37,9 +32,8 @@ use tokio::{
 };
 
 use types::{
-    now, BatchDigest, Certificate, CertificateAPI, CertificateDigest, FetchCertificatesRequest,
-    Header, HeaderAPI, MockPrimaryToWorker, PayloadAvailabilityRequest,
-    PreSubscribedBroadcastSender, PrimaryToPrimary, RequestVoteRequest, Round,
+    now, Certificate, CertificateAPI, FetchCertificatesRequest, Header, HeaderAPI,
+    MockPrimaryToWorker, PreSubscribedBroadcastSender, PrimaryToPrimary, RequestVoteRequest,
 };
 use worker::{metrics::initialise_metrics, TrivialTransactionValidator, Worker};
 
@@ -323,7 +317,6 @@ async fn test_request_vote_has_missing_parents() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),
@@ -494,7 +487,6 @@ async fn test_request_vote_accept_missing_parents() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),
@@ -653,7 +645,6 @@ async fn test_request_vote_missing_batches() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),
@@ -803,7 +794,6 @@ async fn test_request_vote_already_voted() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),
@@ -994,7 +984,6 @@ async fn test_fetch_certificates_handler() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),
@@ -1120,281 +1109,6 @@ async fn test_fetch_certificates_handler() {
 }
 
 #[tokio::test]
-async fn test_process_payload_availability_success() {
-    let fixture = CommitteeFixture::builder()
-        .randomize_ports(true)
-        .committee_size(NonZeroUsize::new(4).unwrap())
-        .build();
-    let author = fixture.authorities().next().unwrap();
-    let id = author.id();
-    let worker_cache = fixture.worker_cache();
-    let primary = fixture.authorities().next().unwrap();
-    let signature_service = SignatureService::new(primary.keypair().copy());
-    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
-    let primary_channel_metrics = PrimaryChannelMetrics::new(&Registry::new());
-    let client = NetworkClient::new_from_keypair(&primary.network_keypair());
-
-    let (header_store, certificate_store, payload_store) = create_db_stores();
-    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
-    let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
-    let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(ConsensusRound::default());
-    let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
-
-    let synchronizer = Arc::new(Synchronizer::new(
-        id,
-        fixture.committee(),
-        worker_cache.clone(),
-        /* gc_depth */ 50,
-        client,
-        certificate_store.clone(),
-        payload_store.clone(),
-        tx_certificate_fetcher,
-        tx_new_certificates,
-        tx_parents,
-        rx_consensus_round_updates,
-        rx_synchronizer_network,
-        metrics.clone(),
-        &primary_channel_metrics,
-    ));
-    let handler = PrimaryReceiverHandler {
-        authority_id: id,
-        committee: fixture.committee(),
-        worker_cache: worker_cache.clone(),
-        synchronizer: synchronizer.clone(),
-        signature_service,
-        header_store: header_store.clone(),
-        certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
-        vote_digest_store: VoteDigestStore::new_for_tests(),
-        rx_narwhal_round_updates,
-        parent_digests: Default::default(),
-        metrics: metrics.clone(),
-    };
-
-    // GIVEN some mock certificates
-    let mut certificates = HashMap::new();
-    let mut missing_certificates = HashSet::new();
-
-    for i in 0..10 {
-        let header = Header::V1(
-            author
-                .header_builder(&fixture.committee())
-                .with_payload_batch(
-                    test_utils::fixture_batch_with_transactions(
-                        10,
-                        &test_utils::latest_protocol_version(),
-                    ),
-                    0,
-                    0,
-                )
-                .build()
-                .unwrap(),
-        );
-
-        let certificate = fixture.certificate(&header);
-        let digest = certificate.clone().digest();
-
-        certificates.insert(digest, certificate.clone());
-
-        // We want to simulate the scenario of both having some certificates
-        // found and some non found. Store only the half. The other half
-        // should be returned back as non found.
-        if i < 7 {
-            // write the certificate
-            certificate_store.write(certificate.clone()).unwrap();
-
-            for (digest, (worker_id, _)) in certificate.header().payload() {
-                payload_store.write(digest, worker_id).unwrap();
-            }
-        } else {
-            missing_certificates.insert(digest);
-        }
-    }
-
-    // WHEN requesting the payload availability for all the certificates
-    let request = anemo::Request::new(PayloadAvailabilityRequest {
-        certificate_digests: certificates.keys().copied().collect(),
-    });
-    let response = handler.get_payload_availability(request).await.unwrap();
-    let result_digests: HashSet<CertificateDigest> = response
-        .body()
-        .payload_availability
-        .iter()
-        .map(|(digest, _)| *digest)
-        .collect();
-
-    assert_eq!(
-        result_digests.len(),
-        certificates.len(),
-        "Returned unique number of certificates don't match the expected"
-    );
-
-    // ensure that we have no payload availability for some
-    let availability_map = response
-        .into_body()
-        .payload_availability
-        .into_iter()
-        .counts_by(|c| c.1);
-
-    for (available, found) in availability_map {
-        if available {
-            assert_eq!(found, 7, "Expected to have available payloads");
-        } else {
-            assert_eq!(found, 3, "Expected to have non available payloads");
-        }
-    }
-}
-
-#[tokio::test]
-async fn test_process_payload_availability_when_failures() {
-    // GIVEN
-    // We initialise the test stores manually to allow us
-    // inject some wrongly serialised values to cause data store errors.
-    let rocksdb = store::rocks::open_cf(
-        temp_dir(),
-        None,
-        MetricConf::default(),
-        &[
-            test_utils::CERTIFICATES_CF,
-            test_utils::CERTIFICATE_DIGEST_BY_ROUND_CF,
-            test_utils::CERTIFICATE_DIGEST_BY_ORIGIN_CF,
-            test_utils::PAYLOAD_CF,
-        ],
-    )
-    .expect("Failed creating database");
-
-    let (
-        certificate_map,
-        certificate_digest_by_round_map,
-        certificate_digest_by_origin_map,
-        payload_map,
-    ) = store::reopen!(&rocksdb,
-        test_utils::CERTIFICATES_CF;<CertificateDigest, Certificate>,
-        test_utils::CERTIFICATE_DIGEST_BY_ROUND_CF;<(Round, AuthorityIdentifier), CertificateDigest>,
-        test_utils::CERTIFICATE_DIGEST_BY_ORIGIN_CF;<(AuthorityIdentifier, Round), CertificateDigest>,
-        test_utils::PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
-
-    let certificate_store = CertificateStore::new(
-        certificate_map,
-        certificate_digest_by_round_map,
-        certificate_digest_by_origin_map,
-        CertificateStoreCache::new(NonZeroUsize::new(100).unwrap(), None),
-    );
-    let payload_store = PayloadStore::new(payload_map);
-
-    let fixture = CommitteeFixture::builder()
-        .randomize_ports(true)
-        .committee_size(NonZeroUsize::new(4).unwrap())
-        .build();
-    let committee = fixture.committee();
-    let author = fixture.authorities().next().unwrap();
-    let id = author.id();
-    let worker_cache = fixture.worker_cache();
-    let primary = fixture.authorities().next().unwrap();
-    let signature_service = SignatureService::new(primary.keypair().copy());
-    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
-    let primary_channel_metrics = PrimaryChannelMetrics::new(&Registry::new());
-    let client = NetworkClient::new_from_keypair(&primary.network_keypair());
-
-    let (header_store, _, _) = create_db_stores();
-    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
-    let (tx_new_certificates, _rx_new_certificates) = test_utils::test_channel!(100);
-    let (tx_parents, _rx_parents) = test_utils::test_channel!(100);
-    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
-        watch::channel(ConsensusRound::default());
-    let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
-
-    let synchronizer = Arc::new(Synchronizer::new(
-        id,
-        fixture.committee(),
-        worker_cache.clone(),
-        /* gc_depth */ 50,
-        client,
-        certificate_store.clone(),
-        payload_store.clone(),
-        tx_certificate_fetcher,
-        tx_new_certificates,
-        tx_parents,
-        rx_consensus_round_updates,
-        rx_synchronizer_network,
-        metrics.clone(),
-        &primary_channel_metrics,
-    ));
-    let handler = PrimaryReceiverHandler {
-        authority_id: id,
-        committee: fixture.committee(),
-        worker_cache: worker_cache.clone(),
-        synchronizer: synchronizer.clone(),
-        signature_service,
-        header_store: header_store.clone(),
-        certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
-        vote_digest_store: VoteDigestStore::new_for_tests(),
-        rx_narwhal_round_updates,
-        parent_digests: Default::default(),
-        metrics: metrics.clone(),
-    };
-
-    // AND some mock certificates
-    let mut certificate_digests = Vec::new();
-    for _ in 0..10 {
-        let header = Header::V1(
-            author
-                .header_builder(&committee)
-                .with_payload_batch(
-                    test_utils::fixture_batch_with_transactions(
-                        10,
-                        &test_utils::latest_protocol_version(),
-                    ),
-                    0,
-                    0,
-                )
-                .build()
-                .unwrap(),
-        );
-
-        let certificate = fixture.certificate(&header);
-        let digest = certificate.clone().digest();
-
-        // In order to test an error scenario that is coming from the data store,
-        // we are going to store for the provided certificate digests some unexpected
-        // payload in order to blow up the deserialisation.
-        let serialised_key = bincode::DefaultOptions::new()
-            .with_big_endian()
-            .with_fixint_encoding()
-            .serialize(&digest.borrow())
-            .expect("Couldn't serialise key");
-
-        // Just serialise the "false" value
-        let dummy_value = bcs::to_bytes(false.borrow()).expect("Couldn't serialise value");
-
-        rocksdb
-            .put_cf(
-                &rocksdb
-                    .cf_handle(test_utils::CERTIFICATES_CF)
-                    .expect("Couldn't find column family"),
-                serialised_key,
-                dummy_value,
-                &ReadWriteOptions::default().writeopts(),
-            )
-            .expect("Couldn't insert value");
-
-        certificate_digests.push(digest);
-    }
-
-    // WHEN requesting the payload availability for all the certificates
-    let request = anemo::Request::new(PayloadAvailabilityRequest {
-        certificate_digests,
-    });
-    let result = handler.get_payload_availability(request).await;
-    assert!(result.is_err(), "expected error reading certificates");
-}
-
-#[tokio::test]
 async fn test_request_vote_created_at_in_future() {
     telemetry_subscribers::init_for_testing();
     let fixture = CommitteeFixture::builder()
@@ -1444,7 +1158,6 @@ async fn test_request_vote_created_at_in_future() {
         signature_service,
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
-        payload_store: payload_store.clone(),
         vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         parent_digests: Default::default(),

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -37,14 +37,12 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
 use types::{
     Batch, BatchDigest, Certificate, CertificateAPI, CertificateDigest, FetchBatchesRequest,
-    FetchBatchesResponse, FetchCertificatesRequest, FetchCertificatesResponse,
-    GetCertificatesRequest, GetCertificatesResponse, Header, HeaderAPI, HeaderV1Builder,
-    PayloadAvailabilityRequest, PayloadAvailabilityResponse, PrimaryToPrimary,
-    PrimaryToPrimaryServer, PrimaryToWorker, PrimaryToWorkerServer, RequestBatchRequest,
-    RequestBatchResponse, RequestBatchesRequest, RequestBatchesResponse, RequestVoteRequest,
-    RequestVoteResponse, Round, SendCertificateRequest, SendCertificateResponse, TimestampMs,
-    Transaction, Vote, VoteAPI, WorkerBatchMessage, WorkerSynchronizeMessage, WorkerToWorker,
-    WorkerToWorkerServer,
+    FetchBatchesResponse, FetchCertificatesRequest, FetchCertificatesResponse, Header, HeaderAPI,
+    HeaderV1Builder, PrimaryToPrimary, PrimaryToPrimaryServer, PrimaryToWorker,
+    PrimaryToWorkerServer, RequestBatchRequest, RequestBatchResponse, RequestBatchesRequest,
+    RequestBatchesResponse, RequestVoteRequest, RequestVoteResponse, Round, SendCertificateRequest,
+    SendCertificateResponse, TimestampMs, Transaction, Vote, VoteAPI, WorkerBatchMessage,
+    WorkerSynchronizeMessage, WorkerToWorker, WorkerToWorkerServer,
 };
 
 pub mod cluster;
@@ -247,23 +245,11 @@ impl PrimaryToPrimary for PrimaryToPrimaryMockServer {
     ) -> Result<anemo::Response<RequestVoteResponse>, anemo::rpc::Status> {
         unimplemented!()
     }
-    async fn get_certificates(
-        &self,
-        _request: anemo::Request<GetCertificatesRequest>,
-    ) -> Result<anemo::Response<GetCertificatesResponse>, anemo::rpc::Status> {
-        unimplemented!()
-    }
+
     async fn fetch_certificates(
         &self,
         _request: anemo::Request<FetchCertificatesRequest>,
     ) -> Result<anemo::Response<FetchCertificatesResponse>, anemo::rpc::Status> {
-        unimplemented!()
-    }
-
-    async fn get_payload_availability(
-        &self,
-        _request: anemo::Request<PayloadAvailabilityRequest>,
-    ) -> Result<anemo::Response<PayloadAvailabilityResponse>, anemo::rpc::Status> {
         unimplemented!()
     }
 }

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -72,24 +72,6 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .method(
             anemo_build::manual::Method::builder()
-                .name("get_payload_availability")
-                .route_name("GetPayloadAvailability")
-                .request_type("crate::PayloadAvailabilityRequest")
-                .response_type("crate::PayloadAvailabilityResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
-                .name("get_certificates")
-                .route_name("GetCertificates")
-                .request_type("crate::GetCertificatesRequest")
-                .response_type("crate::GetCertificatesResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
                 .name("fetch_certificates")
                 .route_name("FetchCertificates")
                 .request_type("crate::FetchCertificatesRequest")

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -1304,18 +1304,6 @@ pub struct RequestVoteResponse {
     pub missing: Vec<CertificateDigest>,
 }
 
-/// Used by the primary to get specific certificates from other primaries.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetCertificatesRequest {
-    pub digests: Vec<CertificateDigest>,
-}
-
-/// Used by the primary to reply to GetCertificatesRequest.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetCertificatesResponse {
-    pub certificates: Vec<Certificate>,
-}
-
 /// Used by the primary to fetch certificates from other primaries.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchCertificatesRequest {
@@ -1390,25 +1378,6 @@ impl FetchCertificatesRequest {
 pub struct FetchCertificatesResponse {
     /// Certificates sorted from lower to higher rounds.
     pub certificates: Vec<Certificate>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PayloadAvailabilityRequest {
-    pub certificate_digests: Vec<CertificateDigest>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PayloadAvailabilityResponse {
-    pub payload_availability: Vec<(CertificateDigest, bool)>,
-}
-
-impl PayloadAvailabilityResponse {
-    pub fn available_certificates(&self) -> Vec<CertificateDigest> {
-        self.payload_availability
-            .iter()
-            .filter_map(|(digest, available)| available.then_some(*digest))
-            .collect()
-    }
 }
 
 /// Used by the primary to request that the worker sync the target missing batches.

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -95,7 +95,7 @@ impl Worker {
             keypair,
             id,
             committee: committee.clone(),
-            worker_cache,
+            worker_cache: worker_cache.clone(),
             protocol_config: protocol_config.clone(),
             parameters: parameters.clone(),
             store,
@@ -175,8 +175,15 @@ impl Worker {
                 epoch_string.clone(),
             )));
 
+        let worker_peer_ids = worker_cache
+            .all_workers()
+            .into_iter()
+            .map(|(worker_name, _)| PeerId(worker_name.0.to_bytes()));
         let routes = anemo::Router::new()
             .add_rpc_service(worker_service)
+            .route_layer(RequireAuthorizationLayer::new(AllowedPeers::new(
+                worker_peer_ids,
+            )))
             .route_layer(RequireAuthorizationLayer::new(AllowedEpoch::new(
                 epoch_string.clone(),
             )))


### PR DESCRIPTION
## Description 

After removal of external consensus, `GetCertificates` and `GetPayloadAvailability` handlers can be removed now.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
