### PR TITLE
[CI] fix doc build

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -22,7 +22,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          # Upgrade below after the workspace upgrades to Rust 1.72 or later.
+          # https://substrate.stackexchange.com/a/9069
+          toolchain: nightly-2023-06-15
           override: true
 
       - name: Generate documentation


### PR DESCRIPTION
## Description 

There seems to be a build issue with a dependency not supporting Rust 1.72 or nightly.
According to https://substrate.stackexchange.com/a/9069, we can pin the nightly toolchain version for now until the main repo has upgraded.

## Test Plan 

https://github.com/MystenLabs/sui/actions/runs/5602870164

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
