### PR TITLE
[Feat] Add tests for pay module

### DIFF
--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -14,6 +14,30 @@ module sui::pay_tests {
     const TEST_SENDER_ADDR: address = @0xA11CE;
 
     #[test]
+    fun test_split() {
+        let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
+        let scenario = &mut scenario_val;
+        let ctx = test_scenario::ctx(scenario);
+        let coin = coin::mint_for_testing<SUI>(10, ctx);
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        pay::split(&mut coin, 3, test_scenario::ctx(scenario));
+
+        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        
+        assert!(coin::value(&coin1) == 3, 0);
+        assert!(coin::value(&coin) == 7, 0);
+        // Hence, total value is 10.
+
+        // Now, destroy all the objects
+        test_utils::destroy(coin);
+        test_utils::destroy(coin1);
+        
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
     public entry fun test_coin_split_n() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;


### PR DESCRIPTION
## Description 

This PR adds test cases for the pay module. The tests cover the join, join_vec, and join_vec_and_transfer functions. The tests ensure that the functions correctly combine and transfer coins, and that the resulting coin has the expected value.

## Test Plan 

I tested the new test cases by running the `pay_tests.move` file in the VSCode with Sui Move Analyzer, CLI and verifying that all tests passed successfully.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A (not a user-facing or breaking change)