### PR TITLE
Remove BatchV1 and related code gating BatchV2

### DIFF
--- a/narwhal/network/src/client.rs
+++ b/narwhal/network/src/client.rs
@@ -11,8 +11,7 @@ use parking_lot::RwLock;
 use tokio::{select, time::sleep};
 use types::{
     error::LocalClientError, FetchBatchesRequest, FetchBatchesResponse, PrimaryToWorker,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
-    WorkerSynchronizeMessage, WorkerToPrimary,
+    WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerSynchronizeMessage, WorkerToPrimary,
 };
 
 use crate::traits::{PrimaryToWorkerClient, WorkerToPrimaryClient};
@@ -172,22 +171,6 @@ impl PrimaryToWorkerClient for NetworkClient {
 
 #[async_trait]
 impl WorkerToPrimaryClient for NetworkClient {
-    // TODO: Remove once we have upgraded to protocol version 12.
-    async fn report_our_batch(
-        &self,
-        request: WorkerOurBatchMessage,
-    ) -> Result<(), LocalClientError> {
-        let c = self.get_worker_to_primary_handler().await?;
-        select! {
-            resp = c.report_our_batch(Request::new(request)) => {
-                resp.map_err(|e| LocalClientError::Internal(format!("{e:?}")))?;
-                Ok(())
-            },
-            () = self.shutdown_notify.wait() => {
-                Err(LocalClientError::ShuttingDown)
-            },
-        }
-    }
     async fn report_own_batch(
         &self,
         request: WorkerOwnBatchMessage,

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -7,8 +7,7 @@ use crypto::NetworkPublicKey;
 use types::{
     error::LocalClientError, FetchBatchesRequest, FetchBatchesResponse, FetchCertificatesRequest,
     FetchCertificatesResponse, RequestBatchesRequest, RequestBatchesResponse,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
-    WorkerSynchronizeMessage,
+    WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerSynchronizeMessage,
 };
 
 pub trait ReliableNetwork<Request: Clone + Send + Sync> {
@@ -60,12 +59,6 @@ pub trait PrimaryToWorkerClient {
 
 #[async_trait]
 pub trait WorkerToPrimaryClient {
-    // TODO: Remove once we have upgraded to protocol version 12.
-    async fn report_our_batch(
-        &self,
-        request: WorkerOurBatchMessage,
-    ) -> Result<(), LocalClientError>;
-
     async fn report_own_batch(
         &self,
         request: WorkerOwnBatchMessage,

--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -13,8 +13,8 @@ use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, HeaderV1Builder,
-    Metadata, MetadataV1, VersionedMetadata, WorkerOthersBatchMessage, WorkerOurBatchMessage,
-    WorkerOwnBatchMessage, WorkerSynchronizeMessage,
+    MetadataV1, VersionedMetadata, WorkerOthersBatchMessage, WorkerOwnBatchMessage,
+    WorkerSynchronizeMessage,
 };
 
 #[allow(clippy::mutable_key_type)]
@@ -112,12 +112,7 @@ fn get_registry() -> Result<Registry> {
     );
     tracer.trace_value(&mut samples, &worker_index)?;
 
-    let our_batch = WorkerOurBatchMessage {
-        digest: BatchDigest([0u8; 32]),
-        worker_id: 0,
-        metadata: Metadata { created_at: 0 },
-    };
-    let our_batch_v2 = WorkerOwnBatchMessage {
+    let own_batch = WorkerOwnBatchMessage {
         digest: BatchDigest([0u8; 32]),
         worker_id: 0,
         metadata: VersionedMetadata::V1(MetadataV1 {
@@ -135,8 +130,7 @@ fn get_registry() -> Result<Registry> {
         is_certified: true,
     };
 
-    tracer.trace_value(&mut samples, &our_batch)?;
-    tracer.trace_value(&mut samples, &our_batch_v2)?;
+    tracer.trace_value(&mut samples, &own_batch)?;
     tracer.trace_value(&mut samples, &others_batch)?;
     tracer.trace_value(&mut samples, &sync)?;
 

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -4,10 +4,6 @@ AuthorityIdentifier:
 Batch:
   ENUM:
     0:
-      V1:
-        NEWTYPE:
-          TYPENAME: BatchV1
-    1:
       V2:
         NEWTYPE:
           TYPENAME: BatchV2
@@ -16,13 +12,6 @@ BatchDigest:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
-BatchV1:
-  STRUCT:
-    - transactions:
-        SEQ:
-          SEQ: U8
-    - metadata:
-        TYPENAME: Metadata
 BatchV2:
   STRUCT:
     - transactions:
@@ -113,13 +102,6 @@ WorkerOthersBatchMessage:
     - digest:
         TYPENAME: BatchDigest
     - worker_id: U32
-WorkerOurBatchMessage:
-  STRUCT:
-    - digest:
-        TYPENAME: BatchDigest
-    - worker_id: U32
-    - metadata:
-        TYPENAME: Metadata
 WorkerOwnBatchMessage:
   STRUCT:
     - digest:

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -109,16 +109,6 @@ fn build_anemo_services(out_dir: &Path) {
         .name("WorkerToPrimary")
         .package("narwhal")
         .attributes(automock_attribute.clone())
-        // TODO: Remove once we have upgraded to protocol version 12.
-        .method(
-            anemo_build::manual::Method::builder()
-                .name("report_our_batch")
-                .route_name("ReportOurBatch")
-                .request_type("crate::WorkerOurBatchMessage")
-                .response_type("()")
-                .codec_path(codec_path)
-                .build(),
-        )
         .method(
             anemo_build::manual::Method::builder()
                 .name("report_own_batch")

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -169,8 +169,6 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Batch {
 pub trait BatchAPI {
     fn transactions(&self) -> &Vec<Transaction>;
     fn transactions_mut(&mut self) -> &mut Vec<Transaction>;
-
-    // BatchV2 APIs
     fn versioned_metadata(&self) -> &VersionedMetadata;
     fn versioned_metadata_mut(&mut self) -> &mut VersionedMetadata;
 }

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -140,23 +140,16 @@ impl MetadataAPI for MetadataV1 {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Arbitrary)]
 #[enum_dispatch(BatchAPI)]
 pub enum Batch {
-    V1(BatchV1),
     V2(BatchV2),
 }
 
 impl Batch {
     pub fn new(transactions: Vec<Transaction>, protocol_config: &ProtocolConfig) -> Self {
-        // TODO: Remove once we have upgraded to protocol version 12.
-        if protocol_config.narwhal_versioned_metadata() {
-            Self::V2(BatchV2::new(transactions, protocol_config))
-        } else {
-            Self::V1(BatchV1::new(transactions))
-        }
+        Self::V2(BatchV2::new(transactions, protocol_config))
     }
 
     pub fn size(&self) -> usize {
         match self {
-            Batch::V1(data) => data.size(),
             Batch::V2(data) => data.size(),
         }
     }
@@ -167,7 +160,6 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Batch {
 
     fn digest(&self) -> BatchDigest {
         match self {
-            Batch::V1(data) => data.digest(),
             Batch::V2(data) => data.digest(),
         }
     }
@@ -177,8 +169,6 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Batch {
 pub trait BatchAPI {
     fn transactions(&self) -> &Vec<Transaction>;
     fn transactions_mut(&mut self) -> &mut Vec<Transaction>;
-    fn metadata(&self) -> &Metadata;
-    fn metadata_mut(&mut self) -> &mut Metadata;
 
     // BatchV2 APIs
     fn versioned_metadata(&self) -> &VersionedMetadata;
@@ -186,50 +176,6 @@ pub trait BatchAPI {
 }
 
 pub type Transaction = Vec<u8>;
-#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Arbitrary)]
-pub struct BatchV1 {
-    pub transactions: Vec<Transaction>,
-    pub metadata: Metadata,
-}
-
-impl BatchAPI for BatchV1 {
-    fn transactions(&self) -> &Vec<Transaction> {
-        &self.transactions
-    }
-
-    fn transactions_mut(&mut self) -> &mut Vec<Transaction> {
-        &mut self.transactions
-    }
-
-    fn metadata(&self) -> &Metadata {
-        &self.metadata
-    }
-
-    fn metadata_mut(&mut self) -> &mut Metadata {
-        &mut self.metadata
-    }
-
-    fn versioned_metadata(&self) -> &VersionedMetadata {
-        unimplemented!("BatchV1 does not have a VersionedMetadata field");
-    }
-
-    fn versioned_metadata_mut(&mut self) -> &mut VersionedMetadata {
-        unimplemented!("BatchV1 does not have a VersionedMetadata field");
-    }
-}
-
-impl BatchV1 {
-    pub fn new(transactions: Vec<Transaction>) -> Self {
-        Self {
-            transactions,
-            metadata: Metadata::default(),
-        }
-    }
-
-    pub fn size(&self) -> usize {
-        self.transactions.iter().map(|t| t.len()).sum()
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Arbitrary)]
 pub struct BatchV2 {
@@ -245,14 +191,6 @@ impl BatchAPI for BatchV2 {
 
     fn transactions_mut(&mut self) -> &mut Vec<Transaction> {
         &mut self.transactions
-    }
-
-    fn metadata(&self) -> &Metadata {
-        unimplemented!("BatchV2 does not have a Metadata field");
-    }
-
-    fn metadata_mut(&mut self) -> &mut Metadata {
-        unimplemented!("BatchV2 does not have a Metadata field");
     }
 
     fn versioned_metadata(&self) -> &VersionedMetadata {
@@ -275,35 +213,6 @@ impl BatchV2 {
     pub fn size(&self) -> usize {
         self.transactions.iter().map(|t| t.len()).sum()
     }
-}
-
-// TODO: Remove once we have upgraded to protocol version 12.
-pub fn validate_batch_version(
-    batch: &Batch,
-    protocol_config: &ProtocolConfig,
-) -> anyhow::Result<()> {
-    // If network has advanced to using version 12, which sets narwhal_versioned_metadata
-    // to true, we will start using BatchV2 locally and so we will only accept
-    // BatchV2 from the network. Otherwise BatchV1 is used.
-    match batch {
-        Batch::V1(_) => {
-            if protocol_config.narwhal_versioned_metadata() {
-                return Err(anyhow::anyhow!(format!(
-                    "Received {batch:?} but network is at {:?} and this batch version is no longer supported",
-                    protocol_config.version
-                )));
-            }
-        }
-        Batch::V2(_) => {
-            if !protocol_config.narwhal_versioned_metadata() {
-                return Err(anyhow::anyhow!(format!(
-                    "Received {batch:?} but network is at {:?} and this batch version is not supported yet",
-                    protocol_config.version
-                )));
-            }
-        }
-    };
-    Ok(())
 }
 
 #[derive(
@@ -353,16 +262,6 @@ impl AsRef<[u8]> for BatchDigest {
 impl BatchDigest {
     pub fn new(val: [u8; crypto::DIGEST_LENGTH]) -> BatchDigest {
         BatchDigest(val)
-    }
-}
-
-impl Hash<{ crypto::DIGEST_LENGTH }> for BatchV1 {
-    type TypedDigest = BatchDigest;
-
-    fn digest(&self) -> Self::TypedDigest {
-        BatchDigest::new(
-            crypto::DefaultHashFunction::digest_iterator(self.transactions.iter()).into(),
-        )
     }
 }
 
@@ -1449,15 +1348,6 @@ impl fmt::Display for BlockErrorKind {
     }
 }
 
-// TODO: Remove once we have upgraded to protocol version 12.
-/// Used by worker to inform primary it sealed a new batch.
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
-pub struct WorkerOurBatchMessage {
-    pub digest: BatchDigest,
-    pub worker_id: WorkerId,
-    pub metadata: Metadata,
-}
-
 /// Used by worker to inform primary it sealed a new batch.
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct WorkerOwnBatchMessage {
@@ -1536,30 +1426,13 @@ impl From<&Vote> for VoteInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        Batch, BatchAPI, BatchV1, BatchV2, Metadata, MetadataAPI, MetadataV1, Timestamp,
-        VersionedMetadata,
-    };
+    use crate::{Batch, BatchAPI, BatchV2, MetadataAPI, MetadataV1, Timestamp, VersionedMetadata};
     use std::time::Duration;
-    use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use test_utils::latest_protocol_version;
     use tokio::time::sleep;
 
     #[tokio::test]
     async fn test_elapsed() {
-        // TODO: Remove once we have upgraded to protocol version 12.
-        // BatchV1
-        let batch = Batch::new(
-            vec![],
-            &ProtocolConfig::get_for_version(ProtocolVersion::new(11), Chain::Unknown),
-        );
-        assert!(batch.metadata().created_at > 0);
-
-        sleep(Duration::from_secs(2)).await;
-
-        assert!(batch.metadata().created_at.elapsed().as_secs_f64() >= 2.0);
-
-        // BatchV2
         let batch = Batch::new(vec![], &latest_protocol_version());
 
         assert!(*batch.versioned_metadata().created_at() > 0);
@@ -1580,17 +1453,6 @@ mod tests {
 
     #[test]
     fn test_elapsed_when_newer_than_now() {
-        // TODO: Remove once we have upgraded to protocol version 12.
-        // BatchV1
-        let batch = Batch::V1(BatchV1 {
-            transactions: vec![],
-            metadata: Metadata {
-                created_at: 2999309726980, // something in the future - Fri Jan 16 2065 05:35:26
-            },
-        });
-
-        assert_eq!(batch.metadata().created_at.elapsed().as_secs_f64(), 0.0);
-
         // BatchV2
         let batch = Batch::V2(BatchV2 {
             transactions: vec![],

--- a/narwhal/types/src/tests/batch_serde.rs
+++ b/narwhal/types/src/tests/batch_serde.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::worker::batch_serde::Token::NewtypeVariant;
-use crate::{Batch, BatchV1, Metadata};
+use crate::{Batch, BatchV2, MetadataV1, VersionedMetadata};
 use serde_test::{assert_tokens, Token};
 #[test]
 fn test_serde_batch() {
     let tx = || vec![1; 5];
 
-    let batch = Batch::V1(BatchV1 {
+    let batch = Batch::V2(BatchV2 {
         transactions: (0..2).map(|_| tx()).collect(),
-        metadata: Metadata {
-            created_at: 1666205365890,
-        },
+        versioned_metadata: VersionedMetadata::V1(MetadataV1 {
+            created_at: 2999309726980,
+            received_at: None,
+        }),
     });
 
     assert_tokens(
@@ -20,10 +21,10 @@ fn test_serde_batch() {
         &[
             NewtypeVariant {
                 name: "Batch",
-                variant: "V1",
+                variant: "V2",
             },
             Token::Struct {
-                name: "BatchV1",
+                name: "BatchV2",
                 len: 2,
             },
             Token::Str("transactions"),
@@ -43,13 +44,19 @@ fn test_serde_batch() {
             Token::U8(1),
             Token::SeqEnd,
             Token::SeqEnd,
-            Token::Str("metadata"),
+            Token::Str("versioned_metadata"),
+            Token::NewtypeVariant {
+                name: "VersionedMetadata",
+                variant: "V1",
+            },
             Token::Struct {
-                name: "Metadata",
-                len: 1,
+                name: "MetadataV1",
+                len: 2,
             },
             Token::Str("created_at"),
-            Token::U64(1666205365890),
+            Token::U64(2999309726980),
+            Token::Str("received_at"),
+            Token::None,
             Token::StructEnd,
             Token::StructEnd,
         ],

--- a/narwhal/worker/src/batch_fetcher.rs
+++ b/narwhal/worker/src/batch_fetcher.rs
@@ -25,8 +25,7 @@ use tokio::{
 };
 use tracing::debug;
 use types::{
-    now, validate_batch_version, Batch, BatchAPI, BatchDigest, MetadataAPI, RequestBatchesRequest,
-    RequestBatchesResponse,
+    now, Batch, BatchAPI, BatchDigest, MetadataAPI, RequestBatchesRequest, RequestBatchesResponse,
 };
 
 use crate::metrics::WorkerMetrics;
@@ -39,7 +38,7 @@ pub struct BatchFetcher {
     network: Arc<dyn RequestBatchesNetwork>,
     batch_store: DBMap<BatchDigest, Batch>,
     metrics: Arc<WorkerMetrics>,
-    protocol_config: ProtocolConfig,
+    _protocol_config: ProtocolConfig,
 }
 
 impl BatchFetcher {
@@ -48,14 +47,14 @@ impl BatchFetcher {
         network: Network,
         batch_store: DBMap<BatchDigest, Batch>,
         metrics: Arc<WorkerMetrics>,
-        protocol_config: ProtocolConfig,
+        _protocol_config: ProtocolConfig,
     ) -> Self {
         Self {
             name,
             network: Arc::new(RequestBatchesNetworkImpl { network }),
             batch_store,
             metrics,
-            protocol_config,
+            _protocol_config,
         }
     }
 
@@ -122,21 +121,15 @@ impl BatchFetcher {
                             // Also persist the batches, so they are available after restarts.
                             let mut write_batch = self.batch_store.batch();
 
-                            // TODO: Remove once we have upgraded to protocol version 12.
-                            if self.protocol_config.narwhal_versioned_metadata() {
-                                // Set received_at timestamp for remote batches.
-                                let mut updated_new_batches = HashMap::new();
-                                for (digest, batch) in new_batches {
-                                    let mut batch = (*batch).clone();
-                                    batch.versioned_metadata_mut().set_received_at(now());
-                                    updated_new_batches.insert(*digest, batch.clone());
-                                }
-                                fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
-                                write_batch.insert_batch(&self.batch_store, updated_new_batches).unwrap();
-                            } else {
-                                fetched_batches.extend(new_batches.iter().map(|(d, b)| (**d, (*b).clone())));
-                                write_batch.insert_batch(&self.batch_store, new_batches).unwrap();
+                            // Set received_at timestamp for remote batches.
+                            let mut updated_new_batches = HashMap::new();
+                            for (digest, batch) in new_batches {
+                                let mut batch = (*batch).clone();
+                                batch.versioned_metadata_mut().set_received_at(now());
+                                updated_new_batches.insert(*digest, batch.clone());
                             }
+                            fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
+                            write_batch.insert_batch(&self.batch_store, updated_new_batches).unwrap();
 
                             write_batch.write().unwrap();
                             if remaining_digests.is_empty() {
@@ -275,10 +268,6 @@ impl BatchFetcher {
             )
             .await?;
         for batch in batches {
-            // TODO: Remove once we have upgraded to protocol version 12.
-            validate_batch_version(&batch, &self.protocol_config)
-                .map_err(|err| anyhow::anyhow!("[Protocol violation] Invalid batch: {err}"))?;
-
             let batch_digest = batch.digest();
             if !digests_to_fetch.contains(&batch_digest) {
                 bail!(
@@ -351,173 +340,7 @@ mod tests {
     use itertools::Itertools;
     use rand::rngs::StdRng;
     use std::collections::HashMap;
-    use test_utils::{get_protocol_config, latest_protocol_version};
-    use tokio::time::timeout;
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #1: Receive BatchV1 and network has not upgraded to 12 so we are okay
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v1_and_network_v11() {
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let v11_protocol_config = get_protocol_config(11);
-        let batchv1_1 = Batch::new(vec![vec![1]], &v11_protocol_config);
-        let batchv1_2 = Batch::new(vec![vec![2]], &v11_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv1_1.digest(), batchv1_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv1_1.clone());
-        network.put(&[2, 3], batchv1_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: v11_protocol_config,
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batchv1_1.digest(), batchv1_1.clone()),
-            (batchv1_2.digest(), batchv1_2.clone()),
-        ]);
-        let fetched_batches = fetcher.fetch(digests, known_workers).await;
-        assert_eq!(fetched_batches, expected_batches);
-        assert_eq!(
-            batch_store
-                .get(&batchv1_1.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv1_1.digest()
-        );
-        assert_eq!(
-            batch_store
-                .get(&batchv1_2.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv1_2.digest()
-        );
-    }
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #2: Receive BatchV1 but network has upgraded to 12 so we fail because we expect BatchV2
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v1_and_network_v12() {
-        telemetry_subscribers::init_for_testing();
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let latest_protocol_config = latest_protocol_version();
-        let v11_protocol_config = &get_protocol_config(11);
-        let batchv1_1 = Batch::new(vec![vec![1]], v11_protocol_config);
-        let batchv1_2 = Batch::new(vec![vec![2]], v11_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv1_1.digest(), batchv1_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv1_1.clone());
-        network.put(&[2, 3], batchv1_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_config,
-        };
-        let fetch_result = timeout(
-            Duration::from_secs(1),
-            fetcher.fetch(digests, known_workers),
-        )
-        .await;
-        assert!(fetch_result.is_err());
-    }
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #3: Receive BatchV2 but network is still in v11 so we fail because we expect BatchV1
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v2_and_network_v11() {
-        telemetry_subscribers::init_for_testing();
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let latest_protocol_config = &latest_protocol_version();
-        let v11_protocol_config = get_protocol_config(11);
-        let batchv2_1 = Batch::new(vec![vec![1]], latest_protocol_config);
-        let batchv2_2 = Batch::new(vec![vec![2]], latest_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv2_1.digest(), batchv2_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv2_1.clone());
-        network.put(&[2, 3], batchv2_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: v11_protocol_config,
-        };
-        let fetch_result = timeout(
-            Duration::from_secs(1),
-            fetcher.fetch(digests, known_workers),
-        )
-        .await;
-        assert!(fetch_result.is_err());
-    }
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #4: Receive BatchV2 and network is upgraded to 12 so we are okay
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v2_and_network_v12() {
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let latest_protocol_config = &latest_protocol_version();
-        let batchv2_1 = Batch::new(vec![vec![1]], latest_protocol_config);
-        let batchv2_2 = Batch::new(vec![vec![2]], latest_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv2_1.digest(), batchv2_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv2_1.clone());
-        network.put(&[2, 3], batchv2_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
-        };
-        let mut expected_batches = HashMap::from_iter(vec![
-            (batchv2_1.digest(), batchv2_1.clone()),
-            (batchv2_2.digest(), batchv2_2.clone()),
-        ]);
-        let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
-        // Reset metadata from the fetched and expected batches
-        for batch in fetched_batches.values_mut() {
-            // assert received_at was set to some value before resetting.
-            assert!(batch.versioned_metadata().received_at().is_some());
-            batch.versioned_metadata_mut().set_received_at(0);
-        }
-        for batch in expected_batches.values_mut() {
-            batch.versioned_metadata_mut().set_received_at(0);
-        }
-        assert_eq!(fetched_batches, expected_batches);
-        assert_eq!(
-            batch_store
-                .get(&batchv2_1.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv2_1.digest()
-        );
-        assert_eq!(
-            batch_store
-                .get(&batchv2_2.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv2_2.digest()
-        );
-    }
+    use test_utils::latest_protocol_version;
 
     #[tokio::test]
     pub async fn test_fetcher() {
@@ -536,7 +359,7 @@ mod tests {
             network: Arc::new(network.clone()),
             batch_store: batch_store.clone(),
             metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
+            _protocol_config: latest_protocol_version(),
         };
         let mut expected_batches = HashMap::from_iter(vec![
             (batch1.digest(), batch1.clone()),
@@ -587,7 +410,7 @@ mod tests {
             network: Arc::new(network.clone()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
+            _protocol_config: latest_protocol_version(),
         };
         let expected_batches = HashMap::from_iter(vec![
             (batch1.digest(), batch1.clone()),
@@ -619,7 +442,7 @@ mod tests {
             network: Arc::new(network.clone()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
+            _protocol_config: latest_protocol_version(),
         };
         let mut expected_batches = HashMap::from_iter(vec![
             (batch1.digest(), batch1.clone()),
@@ -661,7 +484,7 @@ mod tests {
             network: Arc::new(network.clone()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
+            _protocol_config: latest_protocol_version(),
         };
         let mut expected_batches = HashMap::from_iter(vec![
             (batch1.digest(), batch1.clone()),
@@ -723,7 +546,7 @@ mod tests {
             network: Arc::new(network.clone()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: latest_protocol_version(),
+            _protocol_config: latest_protocol_version(),
         };
         let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
 

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tracing::{error, warn};
 use types::{
     error::DagError, now, Batch, BatchAPI, BatchDigest, ConditionalBroadcastReceiver, MetadataAPI,
-    Transaction, TxResponse, WorkerOurBatchMessage, WorkerOwnBatchMessage,
+    Transaction, TxResponse, WorkerOwnBatchMessage,
 };
 
 #[cfg(feature = "trace_transaction")]
@@ -268,95 +268,48 @@ impl BatchMaker {
         let store = self.store.clone();
         let worker_id = self.id;
 
-        // TODO: Remove once we have upgraded to protocol version 12.
-        if self.protocol_config.narwhal_versioned_metadata() {
-            // The batch has been sealed so we can officially set its creation time
-            // for latency calculations.
-            batch.versioned_metadata_mut().set_created_at(now());
-            let metadata = batch.versioned_metadata().clone();
+        // The batch has been sealed so we can officially set its creation time
+        // for latency calculations.
+        batch.versioned_metadata_mut().set_created_at(now());
+        let metadata = batch.versioned_metadata().clone();
 
-            Some(Box::pin(async move {
-                // Now save it to disk
-                let digest = batch.digest();
+        Some(Box::pin(async move {
+            // Now save it to disk
+            let digest = batch.digest();
 
-                if let Err(e) = store.insert(&digest, &batch) {
-                    error!("Store failed with error: {:?}", e);
-                    return;
-                }
+            if let Err(e) = store.insert(&digest, &batch) {
+                error!("Store failed with error: {:?}", e);
+                return;
+            }
 
-                // Also wait for sending to be done here
-                //
-                // TODO: Here if we get back Err it means that potentially this was not send
-                //       to a quorum. However, if that happens we can still proceed on the basis
-                //       that an other authority will request the batch from us, and we will deliver
-                //       it since it is now stored. So ignore the error for the moment.
-                let _ = done_sending.await;
+            // Also wait for sending to be done here
+            //
+            // TODO: Here if we get back Err it means that potentially this was not send
+            //       to a quorum. However, if that happens we can still proceed on the basis
+            //       that an other authority will request the batch from us, and we will deliver
+            //       it since it is now stored. So ignore the error for the moment.
+            let _ = done_sending.await;
 
-                // Send the batch to the primary.
-                let message = WorkerOwnBatchMessage {
-                    digest,
-                    worker_id,
-                    metadata,
-                };
-                if let Err(e) = client.report_own_batch(message).await {
-                    warn!("Failed to report our batch: {}", e);
-                    // Drop all response handers to signal error, since we
-                    // cannot ensure the primary has actually signaled the
-                    // batch will eventually be sent.
-                    // The transaction submitter will see the error and retry.
-                    return;
-                }
+            // Send the batch to the primary.
+            let message = WorkerOwnBatchMessage {
+                digest,
+                worker_id,
+                metadata,
+            };
+            if let Err(e) = client.report_own_batch(message).await {
+                warn!("Failed to report our batch: {}", e);
+                // Drop all response handers to signal error, since we
+                // cannot ensure the primary has actually signaled the
+                // batch will eventually be sent.
+                // The transaction submitter will see the error and retry.
+                return;
+            }
 
-                // We now signal back to the transaction sender that the transaction is in a
-                // batch and also the digest of the batch.
-                for response in responses {
-                    let _ = response.send(digest);
-                }
-            }))
-        } else {
-            // The batch has been sealed so we can officially set its creation time
-            // for latency calculations.
-            batch.metadata_mut().created_at = now();
-            let metadata = batch.metadata().clone();
-
-            Some(Box::pin(async move {
-                // Now save it to disk
-                let digest = batch.digest();
-
-                if let Err(e) = store.insert(&digest, &batch) {
-                    error!("Store failed with error: {:?}", e);
-                    return;
-                }
-
-                // Also wait for sending to be done here
-                //
-                // TODO: Here if we get back Err it means that potentially this was not send
-                //       to a quorum. However, if that happens we can still proceed on the basis
-                //       that an other authority will request the batch from us, and we will deliver
-                //       it since it is now stored. So ignore the error for the moment.
-                let _ = done_sending.await;
-
-                // Send the batch to the primary.
-                let message = WorkerOurBatchMessage {
-                    digest,
-                    worker_id,
-                    metadata,
-                };
-                if let Err(e) = client.report_our_batch(message).await {
-                    warn!("Failed to report our batch: {}", e);
-                    // Drop all response handers to signal error, since we
-                    // cannot ensure the primary has actually signaled the
-                    // batch will eventually be sent.
-                    // The transaction submitter will see the error and retry.
-                    return;
-                }
-
-                // We now signal back to the transaction sender that the transaction is in a
-                // batch and also the digest of the batch.
-                for response in responses {
-                    let _ = response.send(digest);
-                }
-            }))
-        }
+            // We now signal back to the transaction sender that the transaction is in a
+            // batch and also the digest of the batch.
+            for response in responses {
+                let _ = response.send(digest);
+            }
+        }))
     }
 }

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -14,10 +14,9 @@ use store::{rocks::DBMap, Map};
 use sui_protocol_config::ProtocolConfig;
 use tracing::{debug, trace};
 use types::{
-    now, validate_batch_version, Batch, BatchAPI, BatchDigest, FetchBatchesRequest,
-    FetchBatchesResponse, MetadataAPI, PrimaryToWorker, RequestBatchesRequest,
-    RequestBatchesResponse, WorkerBatchMessage, WorkerOthersBatchMessage, WorkerSynchronizeMessage,
-    WorkerToWorker, WorkerToWorkerClient,
+    now, Batch, BatchAPI, BatchDigest, FetchBatchesRequest, FetchBatchesResponse, MetadataAPI,
+    PrimaryToWorker, RequestBatchesRequest, RequestBatchesResponse, WorkerBatchMessage,
+    WorkerOthersBatchMessage, WorkerSynchronizeMessage, WorkerToWorker, WorkerToWorkerClient,
 };
 
 use crate::{batch_fetcher::BatchFetcher, TransactionValidator};
@@ -43,11 +42,7 @@ impl<V: TransactionValidator> WorkerToWorker for WorkerReceiverHandler<V> {
         request: anemo::Request<WorkerBatchMessage>,
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
         let message = request.into_body();
-        if let Err(err) = self
-            .validator
-            .validate_batch(&message.batch, &self.protocol_config)
-            .await
-        {
+        if let Err(err) = self.validator.validate_batch(&message.batch).await {
             return Err(anemo::rpc::Status::new_with_message(
                 StatusCode::BadRequest,
                 format!("Invalid batch: {err}"),
@@ -212,11 +207,7 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
         for batch in response.batches.iter_mut() {
             if !message.is_certified {
                 // This batch is not part of a certificate, so we need to validate it.
-                if let Err(err) = self
-                    .validator
-                    .validate_batch(batch, &self.protocol_config)
-                    .await
-                {
+                if let Err(err) = self.validator.validate_batch(batch).await {
                     return Err(anemo::rpc::Status::new_with_message(
                         StatusCode::BadRequest,
                         format!("Invalid batch: {err}"),
@@ -224,21 +215,10 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                 }
             }
 
-            // TODO: Remove once we have upgraded to protocol version 12.
-            validate_batch_version(batch, &self.protocol_config).map_err(|err| {
-                anemo::rpc::Status::new_with_message(
-                    StatusCode::BadRequest,
-                    format!("Invalid batch: {err}"),
-                )
-            })?;
-
             let digest = batch.digest();
             if missing.remove(&digest) {
-                // TODO: Remove once we have upgraded to protocol version 12.
-                if self.protocol_config.narwhal_versioned_metadata() {
-                    // Set received_at timestamp for remote batch.
-                    batch.versioned_metadata_mut().set_received_at(now());
-                }
+                // Set received_at timestamp for remote batch.
+                batch.versioned_metadata_mut().set_received_at(now());
                 self.store.insert(&digest, batch).map_err(|e| {
                     anemo::rpc::Status::internal(format!("failed to write to batch store: {e:?}"))
                 })?;

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -4,7 +4,7 @@
 
 use fastcrypto::hash::Hash;
 use std::vec;
-use test_utils::{get_protocol_config, latest_protocol_version, CommitteeFixture};
+use test_utils::{latest_protocol_version, CommitteeFixture};
 use types::{MockWorkerToWorker, WorkerToWorkerServer};
 
 use super::*;
@@ -84,134 +84,6 @@ async fn synchronize() {
 
     // Verify it is now stored
     assert!(store.get(&digest).unwrap().is_some());
-}
-
-// TODO: Remove once we have upgraded to protocol version 12.
-#[tokio::test]
-async fn synchronize_versioned_batches() {
-    telemetry_subscribers::init_for_testing();
-
-    let latest_protocol_config = &latest_protocol_version();
-    // protocol version 11 should only support BatchV1
-    let protocol_config_v11 = &get_protocol_config(11);
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let committee = fixture.committee();
-    let worker_cache = fixture.worker_cache();
-    let authority_id = fixture.authorities().next().unwrap().id();
-    let id = 0;
-
-    // Create a new test store.
-    let store = test_utils::create_batch_store();
-
-    // Create network with mock behavior to respond to RequestBatches request.
-    let target_primary = fixture.authorities().nth(1).unwrap();
-    let batch_v1 = test_utils::batch(protocol_config_v11);
-    let digest_v1 = batch_v1.digest();
-    let message_v1 = WorkerSynchronizeMessage {
-        digests: vec![digest_v1],
-        target: target_primary.id(),
-        is_certified: false,
-    };
-
-    let batch_v2 = test_utils::batch(latest_protocol_config);
-    let digest_v2 = batch_v2.digest();
-    let message_v2 = WorkerSynchronizeMessage {
-        digests: vec![digest_v2],
-        target: target_primary.id(),
-        is_certified: false,
-    };
-
-    let mut mock_server = MockWorkerToWorker::new();
-    let mock_batch_response_v1 = batch_v1.clone();
-    mock_server
-        .expect_request_batches()
-        .withf(move |request| request.body().batch_digests == vec![digest_v1])
-        .times(2)
-        .returning(move |_| {
-            Ok(anemo::Response::new(RequestBatchesResponse {
-                batches: vec![mock_batch_response_v1.clone()],
-                is_size_limit_reached: false,
-            }))
-        });
-    let mock_batch_response_v2 = batch_v2.clone();
-    mock_server
-        .expect_request_batches()
-        .withf(move |request| request.body().batch_digests == vec![digest_v2])
-        .times(2)
-        .returning(move |_| {
-            Ok(anemo::Response::new(RequestBatchesResponse {
-                batches: vec![mock_batch_response_v2.clone()],
-                is_size_limit_reached: false,
-            }))
-        });
-    let routes = anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(mock_server));
-    let target_worker = target_primary.worker(id);
-    let _recv_network = target_worker.new_network(routes);
-    let send_network = test_utils::random_network();
-    send_network
-        .connect_with_peer_id(
-            target_worker
-                .info()
-                .worker_address
-                .to_anemo_address()
-                .unwrap(),
-            anemo::PeerId(target_worker.info().name.0.to_bytes()),
-        )
-        .await
-        .unwrap();
-
-    let handler_v11 = PrimaryReceiverHandler {
-        authority_id,
-        id,
-        committee: committee.clone(),
-        protocol_config: protocol_config_v11.clone(),
-        worker_cache: worker_cache.clone(),
-        store: store.clone(),
-        request_batches_timeout: Duration::from_secs(999),
-        request_batches_retry_nodes: 3, // Not used in this test.
-        network: Some(send_network.clone()),
-        batch_fetcher: None,
-        validator: TrivialTransactionValidator,
-    };
-
-    let handler_latest_version = PrimaryReceiverHandler {
-        authority_id,
-        id,
-        committee,
-        protocol_config: latest_protocol_config.clone(),
-        worker_cache,
-        store: store.clone(),
-        request_batches_timeout: Duration::from_secs(999),
-        request_batches_retry_nodes: 3, // Not used in this test.
-        network: Some(send_network),
-        batch_fetcher: None,
-        validator: TrivialTransactionValidator,
-    };
-
-    // Case #1: Receive BatchV1 and network has not upgraded to 12 so we are okay
-    assert!(store.get(&digest_v1).unwrap().is_none());
-    let request = anemo::Request::new(message_v1.clone());
-    handler_v11.synchronize(request).await.unwrap();
-    assert!(store.get(&digest_v1).unwrap().is_some());
-
-    // Remove the batch from the store so we can test the other cases.
-    store.remove(&digest_v1).unwrap();
-
-    // Case #2: Receive BatchV1 but network has upgraded to 12 so we fail because we expect BatchV2
-    let request = anemo::Request::new(message_v1);
-    let response = handler_latest_version.synchronize(request).await;
-    assert!(response.is_err());
-
-    // Case #3: Receive BatchV2 but network is still in v11 so we fail because we expect BatchV1
-    let request = anemo::Request::new(message_v2.clone());
-    let response = handler_v11.synchronize(request).await;
-    assert!(response.is_err());
-
-    // Case #4: Receive BatchV2 and network is upgraded to 12 so we are okay
-    assert!(store.get(&digest_v2).unwrap().is_none());
-    let request = anemo::Request::new(message_v2.clone());
-    handler_latest_version.synchronize(request).await.unwrap();
-    assert!(store.get(&digest_v2).unwrap().is_some());
 }
 
 #[tokio::test]

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -39,11 +39,7 @@ impl TransactionValidator for NilTxValidator {
     fn validate(&self, _tx: &[u8]) -> Result<(), Self::Error> {
         eyre::bail!("Invalid transaction");
     }
-    async fn validate_batch(
-        &self,
-        _txs: &Batch,
-        _protocol_config: &ProtocolConfig,
-    ) -> Result<(), Self::Error> {
+    async fn validate_batch(&self, _txs: &Batch) -> Result<(), Self::Error> {
         eyre::bail!("Invalid batch");
     }
 }

--- a/narwhal/worker/src/tx_validator.rs
+++ b/narwhal/worker/src/tx_validator.rs
@@ -3,7 +3,6 @@ use std::fmt::{Debug, Display};
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use async_trait::async_trait;
-use sui_protocol_config::ProtocolConfig;
 use types::Batch;
 
 /// Defines the validation procedure for receiving either a new single transaction (from a client)
@@ -15,11 +14,7 @@ pub trait TransactionValidator: Clone + Send + Sync + 'static {
     /// Determines if a transaction valid for the worker to consider putting in a batch
     fn validate(&self, t: &[u8]) -> Result<(), Self::Error>;
     /// Determines if this batch can be voted on
-    async fn validate_batch(
-        &self,
-        b: &Batch,
-        protocol_config: &ProtocolConfig,
-    ) -> Result<(), Self::Error>;
+    async fn validate_batch(&self, b: &Batch) -> Result<(), Self::Error>;
 }
 
 /// Simple validator that accepts all transactions and batches.
@@ -33,11 +28,7 @@ impl TransactionValidator for TrivialTransactionValidator {
         Ok(())
     }
 
-    async fn validate_batch(
-        &self,
-        _b: &Batch,
-        _protocol_config: &ProtocolConfig,
-    ) -> Result<(), Self::Error> {
+    async fn validate_batch(&self, _b: &Batch) -> Result<(), Self::Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Description 

We have moved past protocol version 12 so we can remove this old code.

## Test Plan 

Unit Tests + Deploy to private-testnet