### PR TITLE
[chore/nit] improve command and var name

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4393,10 +4393,13 @@ impl NodeStateDump {
             }
         }
 
-        // Objects and packages read at runtime
+        // Packages read at runtime, which were not previously loaded into the temoorary store
         // Some packages may be fetched at runtime and wont show up in input objects
         let mut runtime_reads = Vec::new();
-        for obj in inner_temporary_store.runtime_read_objects.values() {
+        for obj in inner_temporary_store
+            .runtime_packages_loaded_from_db
+            .values()
+        {
             runtime_reads.push(obj.clone());
         }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1039,7 +1039,7 @@ impl AuthorityStore {
             max_binary_format_version: _,
             loaded_child_objects: _,
             no_extraneous_module_bytes: _,
-            runtime_read_objects: _,
+            runtime_packages_loaded_from_db: _,
         } = inner_temporary_store;
         trace!(written =? written.values().map(|((obj_id, ver, _), _, _)| (obj_id, ver)).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");


### PR DESCRIPTION
## Description 

Renames variable `runtime_read_objects` to `runtime_packages_loaded_from_db` which better describes the variable functionality.
Also improves comments.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
