### PR TITLE
Deprecate un-needed statics

### DIFF
--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -179,12 +179,18 @@ export class TransactionBlock {
 		return tx;
 	}
 
-	/** A helper to retrieve the Transaction builder `Transactions` */
+	/**
+	 * A helper to retrieve the Transaction builder `Transactions`
+	 * @deprecated Either use the helper methods on the `TransactionBlock` class, or import `Transactions` from `@mysten/sui.js/transactions`.
+	 */
 	static get Transactions() {
 		return Transactions;
 	}
 
-	/** A helper to retrieve the Transaction builder `Inputs` */
+	/**
+	 * A helper to retrieve the Transaction builder `Inputs`
+	 * * @deprecated Either use the helper methods on the `TransactionBlock` class, or import `Inputs` from `@mysten/sui.js/transactions`.
+	 */
 	static get Inputs() {
 		return Inputs;
 	}


### PR DESCRIPTION
## Description 

Just noticed these statics were floating here and not really needed. I originally added these to avoid needing more imports but:
1. That's dumb.
2. We added aliases on the transaction block builder itself so it's not really useful to have the alias.
3. Just import it.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
