### PR TITLE
indexer: split obj and tx ingestion

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -43,7 +43,9 @@ impl<S: IndexerStore> ExtendedApi<S> {
         {
             cp
         } else {
-            self.state.get_latest_checkpoint_sequence_number().await? as u64
+            self.state
+                .get_latest_tx_checkpoint_sequence_number()
+                .await? as u64
         };
 
         let object_cursor = cursor.as_ref().map(|c| c.object_id);

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -116,7 +116,7 @@ impl<S: IndexerStore> ReadApi<S> {
 
     async fn get_latest_checkpoint_sequence_number_internal(&self) -> Result<u64, IndexerError> {
         self.state
-            .get_latest_checkpoint_sequence_number()
+            .get_latest_tx_checkpoint_sequence_number()
             .await
             .map(|n| n as u64)
     }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -517,7 +517,11 @@ where
                     self.metrics.checkpoint_db_commit_latency.start_timer();
                 let mut checkpoint_tx_commit_res = self
                     .state
-                    .persist_checkpoint_transactions(&checkpoint, &transactions)
+                    .persist_checkpoint_transactions(
+                        &checkpoint,
+                        &transactions,
+                        self.metrics.total_transaction_chunk_committed.clone(),
+                    )
                     .await;
                 while let Err(e) = checkpoint_tx_commit_res {
                     warn!(
@@ -530,7 +534,11 @@ where
                     .await;
                     checkpoint_tx_commit_res = self
                         .state
-                        .persist_checkpoint_transactions(&checkpoint, &transactions)
+                        .persist_checkpoint_transactions(
+                            &checkpoint,
+                            &transactions,
+                            self.metrics.total_transaction_chunk_committed.clone(),
+                        )
                         .await;
                 }
                 checkpoint_tx_db_guard.stop_and_record();
@@ -590,6 +598,7 @@ where
                     .state
                     .persist_object_changes(
                         &object_changes,
+                        self.metrics.total_object_change_chunk_committed.clone(),
                         self.metrics.object_mutation_db_commit_latency.clone(),
                         self.metrics.object_deletion_db_commit_latency.clone(),
                     )
@@ -607,6 +616,7 @@ where
                         .state
                         .persist_object_changes(
                             &object_changes,
+                            self.metrics.total_object_change_chunk_committed.clone(),
                             self.metrics.object_mutation_db_commit_latency.clone(),
                             self.metrics.object_deletion_db_commit_latency.clone(),
                         )

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -29,7 +29,6 @@ use sui_types::committee::EpochId;
 use sui_types::messages_checkpoint::{CheckpointCommitment, CheckpointSequenceNumber};
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemStateTrait};
-use sui_types::transaction::SenderSignedData;
 use sui_types::SUI_SYSTEM_ADDRESS;
 
 use crate::errors::IndexerError;
@@ -58,11 +57,15 @@ const EPOCH_QUEUE_LIMIT: usize = 2;
 pub struct CheckpointHandler<S> {
     state: S,
     http_client: HttpClient,
-    subscription_handler: Arc<SubscriptionHandler>,
+    // MUSTFIX(gegaowp): remove subscription_handler from checkpoint_handler;
+    // b/c subscription_handler should be on indexer reader, while checkpoint_handler is on indexer writer.
+    // subscription_handler: Arc<SubscriptionHandler>,
     metrics: IndexerMetrics,
     config: IndexerConfig,
-    checkpoint_sender: Arc<Mutex<Sender<TemporaryCheckpointStore>>>,
-    checkpoint_receiver: Arc<Mutex<Receiver<TemporaryCheckpointStore>>>,
+    tx_checkpoint_sender: Arc<Mutex<Sender<TemporaryCheckpointStore>>>,
+    tx_checkpoint_receiver: Arc<Mutex<Receiver<TemporaryCheckpointStore>>>,
+    object_checkpoint_sender: Arc<Mutex<Sender<TemporaryCheckpointStore>>>,
+    object_checkpoint_receiver: Arc<Mutex<Receiver<TemporaryCheckpointStore>>>,
     epoch_sender: Arc<Mutex<Sender<TemporaryEpochStore>>>,
     epoch_receiver: Arc<Mutex<Receiver<TemporaryEpochStore>>>,
 }
@@ -74,20 +77,24 @@ where
     pub fn new(
         state: S,
         http_client: HttpClient,
-        subscription_handler: Arc<SubscriptionHandler>,
+        _subscription_handler: Arc<SubscriptionHandler>,
         metrics: IndexerMetrics,
         config: &IndexerConfig,
     ) -> Self {
-        let (checkpoint_sender, checkpoint_receiver) = mpsc::channel(CHECKPOINT_QUEUE_LIMIT);
+        let (tx_checkpoint_sender, tx_checkpoint_receiver) = mpsc::channel(CHECKPOINT_QUEUE_LIMIT);
+        let (object_checkpoint_sender, object_checkpoint_receiver) =
+            mpsc::channel(CHECKPOINT_QUEUE_LIMIT);
         let (epoch_sender, epoch_receiver) = mpsc::channel(EPOCH_QUEUE_LIMIT);
         Self {
             state,
             http_client,
-            subscription_handler,
+            // subscription_handler,
             metrics,
             config: config.clone(),
-            checkpoint_sender: Arc::new(Mutex::new(checkpoint_sender)),
-            checkpoint_receiver: Arc::new(Mutex::new(checkpoint_receiver)),
+            tx_checkpoint_sender: Arc::new(Mutex::new(tx_checkpoint_sender)),
+            tx_checkpoint_receiver: Arc::new(Mutex::new(tx_checkpoint_receiver)),
+            object_checkpoint_sender: Arc::new(Mutex::new(object_checkpoint_sender)),
+            object_checkpoint_receiver: Arc::new(Mutex::new(object_checkpoint_receiver)),
             epoch_sender: Arc::new(Mutex::new(epoch_sender)),
             epoch_receiver: Arc::new(Mutex::new(epoch_receiver)),
         }
@@ -95,10 +102,11 @@ where
 
     pub fn spawn(self) -> JoinHandle<()> {
         info!("Indexer checkpoint handler started...");
-        let download_handler = self.clone();
+        let tx_download_handler = self.clone();
         spawn_monitored_task!(async move {
-            let mut checkpoint_download_index_res =
-                download_handler.start_download_and_index().await;
+            let mut checkpoint_download_index_res = tx_download_handler
+                .start_download_and_index_tx_checkpoint()
+                .await;
             while let Err(e) = &checkpoint_download_index_res {
                 warn!(
                     "Indexer checkpoint download & index failed with error: {:?}, retrying after {:?} secs...",
@@ -108,14 +116,37 @@ where
                     DOWNLOAD_RETRY_INTERVAL_IN_SECS,
                 ))
                 .await;
-                checkpoint_download_index_res = download_handler.start_download_and_index().await;
+                checkpoint_download_index_res = tx_download_handler
+                    .start_download_and_index_tx_checkpoint()
+                    .await;
             }
         });
 
-        let checkpoint_commit_handler = self.clone();
+        let object_download_handler = self.clone();
         spawn_monitored_task!(async move {
-            let mut checkpoint_commit_res =
-                checkpoint_commit_handler.start_checkpoint_commit().await;
+            let mut object_download_index_res = object_download_handler
+                .start_download_and_index_object_checkpoint()
+                .await;
+            while let Err(e) = &object_download_index_res {
+                warn!(
+                    "Indexer object download & index failed with error: {:?}, retrying after {:?} secs...",
+                    e, DOWNLOAD_RETRY_INTERVAL_IN_SECS
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    DOWNLOAD_RETRY_INTERVAL_IN_SECS,
+                ))
+                .await;
+                object_download_index_res = object_download_handler
+                    .start_download_and_index_object_checkpoint()
+                    .await;
+            }
+        });
+
+        let tx_checkpoint_commit_handler = self.clone();
+        spawn_monitored_task!(async move {
+            let mut checkpoint_commit_res = tx_checkpoint_commit_handler
+                .start_tx_checkpoint_commit()
+                .await;
             while let Err(e) = &checkpoint_commit_res {
                 warn!(
                     "Indexer checkpoint commit failed with error: {:?}, retrying after {:?} secs...",
@@ -125,7 +156,29 @@ where
                     DOWNLOAD_RETRY_INTERVAL_IN_SECS,
                 ))
                 .await;
-                checkpoint_commit_res = checkpoint_commit_handler.start_checkpoint_commit().await;
+                checkpoint_commit_res = tx_checkpoint_commit_handler
+                    .start_tx_checkpoint_commit()
+                    .await;
+            }
+        });
+
+        let object_checkpoint_commit_handler = self.clone();
+        spawn_monitored_task!(async move {
+            let mut object_checkpoint_commit_res = object_checkpoint_commit_handler
+                .start_object_checkpoint_commit()
+                .await;
+            while let Err(e) = &object_checkpoint_commit_res {
+                warn!(
+                    "Indexer object checkpoint commit failed with error: {:?}, retrying after {:?} secs...",
+                    e, DOWNLOAD_RETRY_INTERVAL_IN_SECS
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    DOWNLOAD_RETRY_INTERVAL_IN_SECS,
+                ))
+                .await;
+                object_checkpoint_commit_res = object_checkpoint_commit_handler
+                    .start_object_checkpoint_commit()
+                    .await;
             }
         });
 
@@ -145,19 +198,23 @@ where
         })
     }
 
-    async fn start_download_and_index(&self) -> Result<(), IndexerError> {
+    async fn start_download_and_index_tx_checkpoint(&self) -> Result<(), IndexerError> {
         info!("Indexer checkpoint download & index task started...");
         // NOTE: important not to cast i64 to u64 here,
         // because -1 will be returned when checkpoints table is empty.
-        let last_seq_from_db = self.state.get_latest_checkpoint_sequence_number().await?;
+        let last_seq_from_db = self
+            .state
+            .get_latest_tx_checkpoint_sequence_number()
+            .await?;
         if last_seq_from_db > 0 {
-            info!("Resuming from checkpoint {last_seq_from_db}");
+            info!("Resuming tx handler from checkpoint {last_seq_from_db}");
         }
         let mut next_cursor_sequence_number = last_seq_from_db + 1;
         // NOTE: we will download checkpoints in parallel, but we will commit them sequentially.
         // We will start with MAX_PARALLEL_DOWNLOADS, and adjust if no more checkpoints are available.
         let mut current_parallel_downloads = MAX_PARALLEL_DOWNLOADS;
         loop {
+            // Step 1: download tx checkpoint data for checkpoints in the current batch
             let download_futures = (next_cursor_sequence_number
                 ..next_cursor_sequence_number + current_parallel_downloads as i64)
                 .map(|seq_num| self.download_checkpoint_data(seq_num as u64));
@@ -184,7 +241,6 @@ where
                     break;
                 }
             }
-
             next_cursor_sequence_number += downloaded_checkpoints.len() as i64;
             // NOTE: with this line, we can make sure that:
             // - when indexer is way behind and catching up, we download MAX_PARALLEL_DOWNLOADS checkpoints in parallel;
@@ -199,7 +255,7 @@ where
                 continue;
             }
 
-            // Index checkpoint data
+            // Step 2: Transform tx checkpoint data to indexed_checkpoints
             let index_timer = self.metrics.checkpoint_index_latency.start_timer();
             let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
                 |downloaded_checkpoint| async {
@@ -221,6 +277,22 @@ where
                 indexed_checkpoint_epoch_vec.into_iter().unzip();
             index_timer.stop_and_record();
 
+            // Step 3: send indexed_checkpoints to channel to be committed later.
+            let tx_checkpoint_sender_guard = self.tx_checkpoint_sender.lock().await;
+            // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
+            // Checkpoints are sent sequentially to stick to the order of checkpoint sequence numbers.
+            for indexed_checkpoint in indexed_checkpoints {
+                tx_checkpoint_sender_guard
+                .send(indexed_checkpoint)
+                .await
+                .map_err(|e| {
+                    error!("Failed to send indexed checkpoint to checkpoint commit handler with error: {}", e.to_string());
+                    IndexerError::MpscChannelError(e.to_string())
+                })?;
+            }
+            drop(tx_checkpoint_sender_guard);
+
+            // Step 4: handle indexed_epochs, which depends on downloaded object changes.
             for epoch in indexed_epochs.into_iter().flatten() {
                 // commit first epoch immediately, send other epochs to channel to be committed later.
                 if epoch.last_epoch.is_none() {
@@ -247,12 +319,92 @@ where
                     drop(epoch_sender_guard);
                 }
             }
+        }
+    }
 
-            let checkpoint_sender_guard = self.checkpoint_sender.lock().await;
+    async fn start_download_and_index_object_checkpoint(&self) -> Result<(), IndexerError> {
+        info!("Indexer object checkpoint download & index task started...");
+        let last_seq_from_db = self
+            .state
+            .get_latest_object_checkpoint_sequence_number()
+            .await?;
+        if last_seq_from_db > 0 {
+            info!("Resuming obj handler from checkpoint {last_seq_from_db}");
+        }
+        let mut next_cursor_sequence_number = last_seq_from_db + 1;
+        // NOTE: we will download checkpoints in parallel, but we will commit them sequentially.
+        // We will start with MAX_PARALLEL_DOWNLOADS, and adjust if no more checkpoints are available.
+        let mut current_parallel_downloads = MAX_PARALLEL_DOWNLOADS;
+        loop {
+            // Step 1: download tx checkpoint data for checkpoints in the current batch
+            let download_futures = (next_cursor_sequence_number
+                ..next_cursor_sequence_number + current_parallel_downloads as i64)
+                .map(|seq_num| self.download_checkpoint_data(seq_num as u64));
+            let download_results = join_all(download_futures).await;
+            let mut downloaded_checkpoints = vec![];
+            // NOTE: Push sequentially and if one of the downloads failed,
+            // we will discard all following checkpoints and retry, to avoid messing up the DB commit order.
+            for download_result in download_results {
+                if let Ok(checkpoint) = download_result {
+                    downloaded_checkpoints.push(checkpoint);
+                } else {
+                    if let Err(IndexerError::UnexpectedFullnodeResponseError(fn_e)) =
+                        download_result
+                    {
+                        warn!(
+                            "Unexpected response from fullnode for checkpoints: {}",
+                            fn_e
+                        );
+                    } else if let Err(IndexerError::FullNodeReadingError(fn_e)) = download_result {
+                        warn!("Fullnode reading error for checkpoints {}: {}. It can be transient or due to rate limiting.", next_cursor_sequence_number, fn_e);
+                    } else {
+                        warn!("Error downloading checkpoints: {:?}", download_result);
+                    }
+                    break;
+                }
+            }
+            next_cursor_sequence_number += downloaded_checkpoints.len() as i64;
+            // NOTE: with this line, we can make sure that:
+            // - when indexer is way behind and catching up, we download MAX_PARALLEL_DOWNLOADS checkpoints in parallel;
+            // - when indexer is up to date, we download at least one checkpoint at a time.
+            current_parallel_downloads =
+                std::cmp::min(downloaded_checkpoints.len() + 1, MAX_PARALLEL_DOWNLOADS);
+            if downloaded_checkpoints.is_empty() {
+                warn!(
+                    "No checkpoints were downloaded for sequence number {}, retrying...",
+                    next_cursor_sequence_number
+                );
+                continue;
+            }
+
+            // Step 2: Transform tx checkpoint data to indexed_checkpoints and indexed_epochs
+            let index_timer = self.metrics.checkpoint_index_latency.start_timer();
+            let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
+                |downloaded_checkpoint| async {
+                    self.index_checkpoint_and_epoch(downloaded_checkpoint).await
+                },
+            ))
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, IndexerError>>()
+            .map_err(|e| {
+                error!(
+                    "Failed to index checkpoints {:?} with error: {}",
+                    downloaded_checkpoints,
+                    e.to_string()
+                );
+                e
+            })?;
+            let (indexed_checkpoints, _indexed_epochs): (Vec<_>, Vec<_>) =
+                indexed_checkpoint_epoch_vec.into_iter().unzip();
+            index_timer.stop_and_record();
+
+            // Step 3: send indexed_checkpoints to object channel to be committed later.
+            let object_checkpoint_sender_guard = self.object_checkpoint_sender.lock().await;
             // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
             // Checkpoints are sent sequentially to stick to the order of checkpoint sequence numbers.
             for indexed_checkpoint in indexed_checkpoints {
-                checkpoint_sender_guard
+                object_checkpoint_sender_guard
                 .send(indexed_checkpoint)
                 .await
                 .map_err(|e| {
@@ -260,34 +412,21 @@ where
                     IndexerError::MpscChannelError(e.to_string())
                 })?;
             }
-            drop(checkpoint_sender_guard);
-
-            // NOTE(gegaowp): today ws processing actually will block next checkpoint download,
-            // we can pipeline this as well in the future if needed
-            for checkpoint in &downloaded_checkpoints {
-                let ws_guard = self.metrics.subscription_process_latency.start_timer();
-                for tx in &checkpoint.transactions {
-                    let data: SenderSignedData = bcs::from_bytes(&tx.raw_transaction)?;
-                    self.subscription_handler
-                        .process_tx(data.transaction_data(), &tx.effects, &tx.events)
-                        .await?;
-                }
-                ws_guard.stop_and_record();
-            }
+            drop(object_checkpoint_sender_guard);
         }
     }
 
-    async fn start_checkpoint_commit(&self) -> Result<(), IndexerError> {
-        info!("Indexer checkpoint commit task started...");
+    async fn start_tx_checkpoint_commit(&self) -> Result<(), IndexerError> {
+        info!("Indexer tx checkpoint commit task started...");
         loop {
-            let mut checkpoint_receiver_guard = self.checkpoint_receiver.lock().await;
-            let indexed_checkpoint = checkpoint_receiver_guard.recv().await;
-            drop(checkpoint_receiver_guard);
+            let mut tx_checkpoint_receiver_guard = self.tx_checkpoint_receiver.lock().await;
+            let indexed_checkpoint = tx_checkpoint_receiver_guard.recv().await;
+            drop(tx_checkpoint_receiver_guard);
 
             if let Some(indexed_checkpoint) = indexed_checkpoint {
                 if self.config.skip_db_commit {
                     info!(
-                        "Downloaded and indexed checkpoint {} successfully, skipping DB commit...",
+                        "Downloaded and indexed tx checkpoint {} successfully, skipping DB commit...",
                         indexed_checkpoint.checkpoint.sequence_number,
                     );
                     continue;
@@ -298,7 +437,7 @@ where
                     checkpoint,
                     transactions,
                     events,
-                    object_changes,
+                    object_changes: _,
                     packages,
                     input_objects,
                     changed_objects,
@@ -396,21 +535,53 @@ where
                 }
                 checkpoint_tx_db_guard.stop_and_record();
                 self.metrics
-                    .latest_indexer_checkpoint_sequence_number
+                    .latest_tx_checkpoint_sequence_number
                     .set(checkpoint_seq);
-
-                self.metrics.total_checkpoint_committed.inc();
+                self.metrics.total_tx_checkpoint_committed.inc();
                 let tx_count = transactions.len();
                 self.metrics
                     .total_transaction_committed
                     .inc_by(tx_count as u64);
                 info!(
-                    "Checkpoint {} committed with {} transactions.",
+                    "Tx checkpoint {} committed with {} transactions.",
                     checkpoint_seq, tx_count,
                 );
                 self.metrics
                     .transaction_per_checkpoint
                     .observe(tx_count as f64);
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    }
+
+    async fn start_object_checkpoint_commit(&self) -> Result<(), IndexerError> {
+        info!("Indexer object checkpoint commit task started...");
+        loop {
+            let mut object_checkpoint_receiver_guard = self.object_checkpoint_receiver.lock().await;
+            let indexed_checkpoint = object_checkpoint_receiver_guard.recv().await;
+            drop(object_checkpoint_receiver_guard);
+
+            if let Some(indexed_checkpoint) = indexed_checkpoint {
+                if self.config.skip_db_commit {
+                    info!(
+                        "Downloaded and indexed object checkpoint {} successfully, skipping DB commit...",
+                        indexed_checkpoint.checkpoint.sequence_number,
+                    );
+                    continue;
+                }
+                let TemporaryCheckpointStore {
+                    checkpoint,
+                    transactions: _,
+                    events: _,
+                    object_changes,
+                    packages: _,
+                    input_objects: _,
+                    changed_objects: _,
+                    move_calls: _,
+                    recipients: _,
+                } = indexed_checkpoint;
+                let checkpoint_seq = checkpoint.sequence_number;
 
                 // NOTE: commit object changes in the current task to stick to the original order,
                 // spawned tasks are possible to be executed in a different order.
@@ -449,6 +620,11 @@ where
                 self.metrics
                     .latest_indexer_object_checkpoint_sequence_number
                     .set(checkpoint_seq);
+                info!(
+                    "Object checkpoint {} committed with {} object changes.",
+                    checkpoint_seq,
+                    object_changes.len(),
+                );
             } else {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -20,6 +20,9 @@ pub struct IndexerMetrics {
     pub total_object_checkpoint_committed: IntCounter,
     pub total_transaction_committed: IntCounter,
     pub total_object_change_committed: IntCounter,
+    // NOTE: *_chunk_commited counts number of DB commits
+    pub total_transaction_chunk_committed: IntCounter,
+    pub total_object_change_chunk_committed: IntCounter,
     pub total_epoch_committed: IntCounter,
     pub latest_fullnode_checkpoint_sequence_number: IntGauge,
     pub latest_tx_checkpoint_sequence_number: IntGauge,
@@ -92,6 +95,18 @@ impl IndexerMetrics {
             total_object_change_committed: register_int_counter_with_registry!(
                 "total_object_change_committed",
                 "Total number of object change committed",
+                registry,
+            )
+            .unwrap(),
+            total_transaction_chunk_committed: register_int_counter_with_registry!(
+                "total_transaction_chunk_commited",
+                "Total number of transaction chunk committed",
+                registry,
+            )
+            .unwrap(),
+            total_object_change_chunk_committed: register_int_counter_with_registry!(
+                "total_object_change_chunk_committed",
+                "Total number of object change chunk committed",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -16,13 +16,13 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
 #[derive(Clone)]
 pub struct IndexerMetrics {
     pub total_checkpoint_received: IntCounter,
-    pub total_checkpoint_committed: IntCounter,
+    pub total_tx_checkpoint_committed: IntCounter,
     pub total_object_checkpoint_committed: IntCounter,
     pub total_transaction_committed: IntCounter,
     pub total_object_change_committed: IntCounter,
     pub total_epoch_committed: IntCounter,
     pub latest_fullnode_checkpoint_sequence_number: IntGauge,
-    pub latest_indexer_checkpoint_sequence_number: IntGauge,
+    pub latest_tx_checkpoint_sequence_number: IntGauge,
     pub latest_indexer_object_checkpoint_sequence_number: IntGauge,
     // checkpoint E2E latency is:
     // fullnode_download_latency + checkpoint_index_latency + db_commit_latency
@@ -71,7 +71,7 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
-            total_checkpoint_committed: register_int_counter_with_registry!(
+            total_tx_checkpoint_committed: register_int_counter_with_registry!(
                 "total_checkpoint_committed",
                 "Total number of checkpoint committed",
                 registry,
@@ -107,7 +107,7 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
-            latest_indexer_checkpoint_sequence_number: register_int_gauge_with_registry!(
+            latest_tx_checkpoint_sequence_number: register_int_gauge_with_registry!(
                 "latest_indexer_checkpoint_sequence_number",
                 "Latest checkpoint sequence number from the Indexer",
                 registry,

--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -34,7 +34,10 @@ where
             self.store.get_last_address_processed_checkpoint().await?;
         // process another batch of events, 100 checkpoints at a time, otherwise sleep for 3 seconds
         loop {
-            let latest_checkpoint = self.store.get_latest_checkpoint_sequence_number().await?;
+            let latest_checkpoint = self
+                .store
+                .get_latest_tx_checkpoint_sequence_number()
+                .await?;
             if latest_checkpoint >= last_processed_addr_checkpoint + ADDRESS_STATS_BATCH_SIZE as i64
             {
                 let cursor = match last_processed_addr_checkpoint {

--- a/crates/sui-indexer/src/processors/checkpoint_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors/checkpoint_metrics_processor.rs
@@ -31,7 +31,10 @@ where
         let mut last_processed_cp = last_cp_metrics.checkpoint;
         // process another batch of events, 100 checkpoints at a time, otherwise sleep for 3 seconds
         loop {
-            let latest_checkpoint = self.store.get_latest_checkpoint_sequence_number().await?;
+            let latest_checkpoint = self
+                .store
+                .get_latest_tx_checkpoint_sequence_number()
+                .await?;
             if latest_checkpoint >= last_processed_cp + CHECKPOINT_METRICS_BATCH_SIZE as i64 {
                 let checkpoints = self
                     .store

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use prometheus::Histogram;
+use prometheus::{Histogram, IntCounter};
 
 use move_core_types::identifier::Identifier;
 use sui_json_rpc_types::{
@@ -220,10 +220,12 @@ pub trait IndexerStore {
         &self,
         checkpoint: &Checkpoint,
         transactions: &[Transaction],
+        total_transaction_chunk_committed_counter: IntCounter,
     ) -> Result<usize, IndexerError>;
     async fn persist_object_changes(
         &self,
         tx_object_changes: &[TransactionObjectChanges],
+        total_object_change_chunk_committed_counter: IntCounter,
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
     ) -> Result<(), IndexerError>;

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -36,7 +36,8 @@ use crate::types::CheckpointTransactionBlockResponse;
 pub trait IndexerStore {
     type ModuleCache;
 
-    async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
+    async fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
+    async fn get_latest_object_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
     async fn get_checkpoints(
         &self,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -19,7 +19,7 @@ use fastcrypto::hash::Digest;
 use fastcrypto::traits::ToFromBytes;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::identifier::Identifier;
-use prometheus::Histogram;
+use prometheus::{Histogram, IntCounter};
 use tracing::info;
 
 use sui_json_rpc_types::{
@@ -1253,6 +1253,7 @@ impl PgIndexerStore {
                 deleted_objects,
                 None,
                 None,
+                None,
             )
         })
     }
@@ -1261,6 +1262,7 @@ impl PgIndexerStore {
         &self,
         checkpoint: &Checkpoint,
         transactions: &[Transaction],
+        total_transaction_chunk_committed_counter: IntCounter,
     ) -> Result<usize, IndexerError> {
         transactional_blocking!(&self.blocking_cp, |conn| {
             // Commit indexed transactions
@@ -1278,6 +1280,9 @@ impl PgIndexerStore {
                     .map_err(IndexerError::from)
                     .context("Failed writing transactions to PostgresDB")?;
             }
+            // chunks.counter() will consume the iterator, so we need to calculate the number of chunks separately.
+            let num_chunks = (transactions.len() + PG_COMMIT_CHUNK_SIZE - 1) / PG_COMMIT_CHUNK_SIZE;
+            total_transaction_chunk_committed_counter.inc_by(num_chunks as u64);
 
             // Commit indexed checkpoint last, so that if the checkpoint is committed,
             // all related data have been committed as well.
@@ -1293,6 +1298,7 @@ impl PgIndexerStore {
     fn persist_object_changes(
         &self,
         tx_object_changes: &[TransactionObjectChanges],
+        total_object_change_chunk_committed_counter: IntCounter,
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
     ) -> Result<(), IndexerError> {
@@ -1313,6 +1319,7 @@ impl PgIndexerStore {
                 conn,
                 mutated_objects,
                 deleted_objects,
+                Some(total_object_change_chunk_committed_counter),
                 Some(object_mutation_latency),
                 Some(object_deletion_latency),
             )?;
@@ -2273,11 +2280,16 @@ impl IndexerStore for PgIndexerStore {
         &self,
         checkpoint: &Checkpoint,
         transactions: &[Transaction],
+        total_transaction_chunk_committed_counter: IntCounter,
     ) -> Result<usize, IndexerError> {
         let checkpoint = checkpoint.to_owned();
         let transactions = transactions.to_owned();
         self.spawn_blocking(move |this| {
-            this.persist_checkpoint_transactions(&checkpoint, &transactions)
+            this.persist_checkpoint_transactions(
+                &checkpoint,
+                &transactions,
+                total_transaction_chunk_committed_counter,
+            )
         })
         .await
     }
@@ -2285,6 +2297,7 @@ impl IndexerStore for PgIndexerStore {
     async fn persist_object_changes(
         &self,
         tx_object_changes: &[TransactionObjectChanges],
+        total_object_change_chunk_committed_counter: IntCounter,
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
     ) -> Result<(), IndexerError> {
@@ -2292,6 +2305,7 @@ impl IndexerStore for PgIndexerStore {
         self.spawn_blocking(move |this| {
             this.persist_object_changes(
                 &tx_object_changes,
+                total_object_change_chunk_committed_counter,
                 object_mutation_latency,
                 object_deletion_latency,
             )
@@ -2471,6 +2485,7 @@ fn persist_transaction_object_changes(
     conn: &mut PgConnection,
     mutated_objects: Vec<Object>,
     deleted_objects: Vec<Object>,
+    total_object_change_chunk_committed_counter: Option<IntCounter>,
     object_mutation_latency: Option<Histogram>,
     object_deletion_latency: Option<Histogram>,
 ) -> Result<usize, IndexerError> {
@@ -2479,9 +2494,13 @@ fn persist_transaction_object_changes(
     // we have to limit update of one object once in a query.
 
     // MUSTFIX(gegaowp): clean up the metrics codes after experiment
-    if let Some(object_mutation_latency) = object_mutation_latency {
+    if let (Some(object_mutation_latency), Some(object_change_chunk_counter)) = (
+        object_mutation_latency,
+        total_object_change_chunk_committed_counter.clone(),
+    ) {
         let object_mutation_guard = object_mutation_latency.start_timer();
         let mut mutated_object_groups = group_and_sort_objects(mutated_objects);
+        let mut db_commit_counter = 0;
         loop {
             let mutated_object_group = mutated_object_groups
                 .iter_mut()
@@ -2501,8 +2520,10 @@ fn persist_transaction_object_changes(
                         e
                     ))
                 })?;
+            db_commit_counter += 1;
         }
         object_mutation_guard.stop_and_record();
+        object_change_chunk_counter.inc_by(db_commit_counter);
     } else {
         let mut mutated_object_groups = group_and_sort_objects(mutated_objects);
         loop {
@@ -2528,7 +2549,11 @@ fn persist_transaction_object_changes(
     }
 
     // MUSTFIX(gegaowp): clean up the metrics codes after experiment
-    if let Some(object_deletion_latency) = object_deletion_latency {
+    if let (Some(object_deletion_latency), Some(object_deletion_chunk_counter)) = (
+        object_deletion_latency,
+        total_object_change_chunk_committed_counter,
+    ) {
+        let mut db_commit_counter = 0;
         let object_deletion_guard = object_deletion_latency.start_timer();
         for deleted_object_change_chunk in deleted_objects.chunks(PG_COMMIT_CHUNK_SIZE) {
             diesel::insert_into(objects::table)
@@ -2549,8 +2574,10 @@ fn persist_transaction_object_changes(
                         e
                     ))
                 })?;
+            db_commit_counter += 1;
         }
         object_deletion_guard.stop_and_record();
+        object_deletion_chunk_counter.inc_by(db_commit_counter);
     } else {
         for deleted_object_change_chunk in deleted_objects.chunks(PG_COMMIT_CHUNK_SIZE) {
             diesel::insert_into(objects::table)

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -1175,9 +1175,9 @@ pub mod pg_integration_test {
             start_test_cluster(Some(20000)).await;
         // Allow indexer to sync
         wait_until_next_checkpoint(&store).await;
-        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        let mut cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         while cp_res.is_err() {
-            cp_res = store.get_latest_checkpoint_sequence_number().await;
+            cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         }
         let cp = cp_res.unwrap() as u64;
         let first_checkpoint = indexer_rpc_client
@@ -1292,9 +1292,9 @@ pub mod pg_integration_test {
 
     async fn wait_until_next_checkpoint(store: &PgIndexerStore) {
         let since = std::time::Instant::now();
-        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        let mut cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         while cp_res.is_err() {
-            cp_res = store.get_latest_checkpoint_sequence_number().await;
+            cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         }
         let mut cp = cp_res.unwrap();
         let target = cp + 1;
@@ -1304,9 +1304,9 @@ pub mod pg_integration_test {
                 panic!("wait_until_next_checkpoint timed out!");
             }
             tokio::task::yield_now().await;
-            let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+            let mut cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
             while cp_res.is_err() {
-                cp_res = store.get_latest_checkpoint_sequence_number().await;
+                cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
             }
             cp = cp_res.unwrap();
         }
@@ -1314,9 +1314,9 @@ pub mod pg_integration_test {
 
     async fn wait_for_checkpoint(store: &PgIndexerStore, target: i64) {
         let since = std::time::Instant::now();
-        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        let mut cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         while cp_res.is_err() {
-            cp_res = store.get_latest_checkpoint_sequence_number().await;
+            cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
         }
         let mut cp = cp_res.unwrap();
         while cp < target {
@@ -1325,9 +1325,9 @@ pub mod pg_integration_test {
                 panic!("wait_for_checkpoint timed out!");
             }
             tokio::task::yield_now().await;
-            let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+            let mut cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
             while cp_res.is_err() {
-                cp_res = store.get_latest_checkpoint_sequence_number().await;
+                cp_res = store.get_latest_tx_checkpoint_sequence_number().await;
             }
             cp = cp_res.unwrap();
         }


### PR DESCRIPTION
## Description 

- Split object ingestion and tx ingestion b/c object ingestion is getting much slower with grown TPS.
- also added counters for DB commits of tx and objects tables.

## Test Plan 

local run and test writer on indexer branch

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
