### PR TITLE
[macros] Update `with_checked_arithmetic` macro, and convert usage of `checked_arithmetic` macro to attribute macro

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -1,292 +1,304 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::authority::AuthorityStore;
-use crate::transaction_signing_filter;
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
-use sui_config::transaction_deny_config::TransactionDenyConfig;
-use sui_macros::checked_arithmetic;
-use sui_protocol_config::ProtocolConfig;
-use sui_types::base_types::ObjectRef;
-use sui_types::error::{UserInputError, UserInputResult};
-use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::metrics::BytecodeVerifierMetrics;
-use sui_types::transaction::{
-    InputObjectKind, InputObjects, TransactionData, TransactionDataAPI, TransactionKind,
-    VersionedProtocolMessage,
-};
-use sui_types::{
-    base_types::{SequenceNumber, SuiAddress},
-    error::SuiResult,
-    fp_ensure,
-    gas::SuiGasStatus,
-    object::{Object, Owner},
-};
-use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
-use tracing::instrument;
+pub use checked::*;
 
-checked_arithmetic! {
-
-// Entry point for all checks related to gas.
-// Called on both signing and execution.
-// On success the gas part of the transaction (gas data and gas coins)
-// is verified and good to go
-async fn get_gas_status(
-    objects: &[Object],
-    gas: &[ObjectRef],
-    epoch_store: &AuthorityPerEpochStore,
-    transaction: &TransactionData,
-) -> SuiResult<SuiGasStatus> {
-    check_gas(
-        objects,
-        epoch_store,
-        gas,
-        transaction.gas_budget(),
-        transaction.gas_price(),
-        transaction.kind(),
-    )
-    .await
-}
-
-#[instrument(level = "trace", skip_all)]
-pub async fn check_transaction_input(
-    store: &AuthorityStore,
-    epoch_store: &AuthorityPerEpochStore,
-    transaction: &TransactionData,
-    transaction_deny_config: &TransactionDenyConfig,
-    metrics: &Arc<BytecodeVerifierMetrics>,
-) -> SuiResult<(SuiGasStatus, InputObjects)> {
-    transaction.check_version_supported(epoch_store.protocol_config())?;
-    transaction.validity_check(epoch_store.protocol_config())?;
-    let input_objects = transaction.input_objects()?;
-    transaction_signing_filter::check_transaction_for_signing(
-        transaction,
-        &input_objects,
-        transaction_deny_config,
-        store,
-    )?;
-
-    // Runs verifier, which could be expensive.
-    check_non_system_packages_to_be_published(transaction, epoch_store.protocol_config(), metrics)?;
-
-    let objects = store.check_input_objects(&input_objects, epoch_store.protocol_config())?;
-    let gas_status = get_gas_status(&objects, transaction.gas(), epoch_store, transaction).await?;
-    let input_objects = check_objects(transaction, input_objects, objects)?;
-    Ok((gas_status, input_objects))
-}
-
-pub async fn check_transaction_input_with_given_gas(
-    store: &AuthorityStore,
-    epoch_store: &AuthorityPerEpochStore,
-    transaction: &TransactionData,
-    gas_object: Object,
-    metrics: &Arc<BytecodeVerifierMetrics>,
-) -> SuiResult<(SuiGasStatus, InputObjects)> {
-    transaction.check_version_supported(epoch_store.protocol_config())?;
-    transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-    check_non_system_packages_to_be_published(transaction, epoch_store.protocol_config(), metrics)?;
-    let mut input_objects = transaction.input_objects()?;
-    let mut objects = store.check_input_objects(&input_objects, epoch_store.protocol_config())?;
-
-    let gas_object_ref = gas_object.compute_object_reference();
-    input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
-    objects.push(gas_object);
-
-    let gas_status = get_gas_status(&objects, &[gas_object_ref], epoch_store, transaction).await?;
-    let input_objects = check_objects(transaction, input_objects, objects)?;
-    Ok((gas_status, input_objects))
-}
-
-/// WARNING! This should only be used for the dev-inspect transaction. This transaction type
-/// bypasses many of the normal object checks
-pub(crate) async fn check_dev_inspect_input(
-    store: &AuthorityStore,
-    config: &ProtocolConfig,
-    kind: &TransactionKind,
-    gas_object: Object,
-) -> SuiResult<(ObjectRef, InputObjects)> {
-    let gas_object_ref = gas_object.compute_object_reference();
-    kind.validity_check(config)?;
-    match kind {
-        TransactionKind::ProgrammableTransaction(_) => (),
-        TransactionKind::ChangeEpoch(_)
-        | TransactionKind::Genesis(_)
-        | TransactionKind::ConsensusCommitPrologue(_) => {
-            return Err(UserInputError::Unsupported(format!(
-                "Transaction kind {} is not supported in dev-inspect",
-                kind
-            ))
-            .into())
-        }
-    }
-    let mut input_objects = kind.input_objects()?;
-    let mut objects = store.check_input_objects(&input_objects, config)?;
-    let mut used_objects: HashSet<SuiAddress> = HashSet::new();
-    for object in &objects {
-        if !object.is_immutable() {
-            fp_ensure!(
-                used_objects.insert(object.id().into()),
-                UserInputError::MutableObjectUsedMoreThanOnce {
-                    object_id: object.id()
-                }
-                .into()
-            );
-        }
-    }
-    input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
-    objects.push(gas_object);
-    let input_objects = InputObjects::new(input_objects.into_iter().zip(objects).collect());
-    Ok((gas_object_ref, input_objects))
-}
-
-pub async fn check_certificate_input(
-    store: &AuthorityStore,
-    epoch_store: &AuthorityPerEpochStore,
-    cert: &VerifiedExecutableTransaction,
-) -> SuiResult<(SuiGasStatus, InputObjects)> {
-    let protocol_version = epoch_store.protocol_version();
-
-    // This should not happen - validators should not have signed the txn in the first place.
-    assert!(
-        cert.data()
-            .transaction_data()
-            .check_version_supported(epoch_store.protocol_config())
-            .is_ok(),
-        "Certificate formed with unsupported message version {:?} for protocol version {:?}",
-        cert.message_version(),
-        protocol_version
-    );
-
-    let tx_data = &cert.data().intent_message().value;
-    let input_object_kinds = tx_data.input_objects()?;
-    let input_object_data = if tx_data.is_change_epoch_tx() {
-        // When changing the epoch, we update a the system object, which is shared, without going
-        // through sequencing, so we must bypass the sequence checks here.
-        store.check_input_objects(&input_object_kinds, epoch_store.protocol_config())?
-    } else {
-        store.check_sequenced_input_objects(cert.digest(), &input_object_kinds, epoch_store)?
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+    use crate::authority::AuthorityStore;
+    use crate::transaction_signing_filter;
+    use std::collections::{BTreeMap, HashSet};
+    use std::sync::Arc;
+    use sui_config::transaction_deny_config::TransactionDenyConfig;
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::base_types::ObjectRef;
+    use sui_types::error::{UserInputError, UserInputResult};
+    use sui_types::executable_transaction::VerifiedExecutableTransaction;
+    use sui_types::metrics::BytecodeVerifierMetrics;
+    use sui_types::transaction::{
+        InputObjectKind, InputObjects, TransactionData, TransactionDataAPI, TransactionKind,
+        VersionedProtocolMessage,
     };
-    let gas_status =
-        get_gas_status(&input_object_data, tx_data.gas(), epoch_store, tx_data).await?;
-    let input_objects = check_objects(tx_data, input_object_kinds, input_object_data)?;
-    Ok((gas_status, input_objects))
-}
+    use sui_types::{
+        base_types::{SequenceNumber, SuiAddress},
+        error::SuiResult,
+        fp_ensure,
+        gas::SuiGasStatus,
+        object::{Object, Owner},
+    };
+    use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
+    use tracing::instrument;
 
-/// Check transaction gas data/info and gas coins consistency.
-/// Return the gas status to be used for the lifecycle of the transaction.
-#[instrument(level = "trace", skip_all)]
-async fn check_gas(
-    objects: &[Object],
-    epoch_store: &AuthorityPerEpochStore,
-    gas: &[ObjectRef],
-    gas_budget: u64,
-    gas_price: u64,
-    tx_kind: &TransactionKind,
-) -> SuiResult<SuiGasStatus> {
-    if tx_kind.is_system_tx() {
-        Ok(SuiGasStatus::new_unmetered())
-    } else {
-        let protocol_config = epoch_store.protocol_config();
-        let reference_gas_price = epoch_store.reference_gas_price();
+    // Entry point for all checks related to gas.
+    // Called on both signing and execution.
+    // On success the gas part of the transaction (gas data and gas coins)
+    // is verified and good to go
+    async fn get_gas_status(
+        objects: &[Object],
+        gas: &[ObjectRef],
+        epoch_store: &AuthorityPerEpochStore,
+        transaction: &TransactionData,
+    ) -> SuiResult<SuiGasStatus> {
+        check_gas(
+            objects,
+            epoch_store,
+            gas,
+            transaction.gas_budget(),
+            transaction.gas_price(),
+            transaction.kind(),
+        )
+        .await
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub async fn check_transaction_input(
+        store: &AuthorityStore,
+        epoch_store: &AuthorityPerEpochStore,
+        transaction: &TransactionData,
+        transaction_deny_config: &TransactionDenyConfig,
+        metrics: &Arc<BytecodeVerifierMetrics>,
+    ) -> SuiResult<(SuiGasStatus, InputObjects)> {
+        transaction.check_version_supported(epoch_store.protocol_config())?;
+        transaction.validity_check(epoch_store.protocol_config())?;
+        let input_objects = transaction.input_objects()?;
+        transaction_signing_filter::check_transaction_for_signing(
+            transaction,
+            &input_objects,
+            transaction_deny_config,
+            store,
+        )?;
+
+        // Runs verifier, which could be expensive.
+        check_non_system_packages_to_be_published(
+            transaction,
+            epoch_store.protocol_config(),
+            metrics,
+        )?;
+
+        let objects = store.check_input_objects(&input_objects, epoch_store.protocol_config())?;
         let gas_status =
-            SuiGasStatus::new(gas_budget, gas_price, reference_gas_price, protocol_config)?;
-
-        // check balance and coins consistency
-        // load all gas coins
-        let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
-        let mut gas_objects = vec![];
-        for obj_ref in gas {
-            let obj = objects.get(&obj_ref.0);
-            let obj = *obj.ok_or(UserInputError::ObjectNotFound {
-                object_id: obj_ref.0,
-                version: Some(obj_ref.1),
-            })?;
-            gas_objects.push(obj);
-        }
-        gas_status.check_gas_balance(&gas_objects, gas_budget)?;
-        Ok(gas_status)
-    }
-}
-
-/// Check all the objects used in the transaction against the database, and ensure
-/// that they are all the correct version and number.
-#[instrument(level = "trace", skip_all)]
-pub fn check_objects(
-    transaction: &TransactionData,
-    input_objects: Vec<InputObjectKind>,
-    objects: Vec<Object>,
-) -> UserInputResult<InputObjects> {
-    // We require that mutable objects cannot show up more than once.
-    let mut used_objects: HashSet<SuiAddress> = HashSet::new();
-    for object in objects.iter() {
-        if !object.is_immutable() {
-            fp_ensure!(
-                used_objects.insert(object.id().into()),
-                UserInputError::MutableObjectUsedMoreThanOnce {
-                    object_id: object.id()
-                }
-            );
-        }
+            get_gas_status(&objects, transaction.gas(), epoch_store, transaction).await?;
+        let input_objects = check_objects(transaction, input_objects, objects)?;
+        Ok((gas_status, input_objects))
     }
 
-    // Gather all objects and errors.
-    let mut all_objects = Vec::with_capacity(input_objects.len());
+    pub async fn check_transaction_input_with_given_gas(
+        store: &AuthorityStore,
+        epoch_store: &AuthorityPerEpochStore,
+        transaction: &TransactionData,
+        gas_object: Object,
+        metrics: &Arc<BytecodeVerifierMetrics>,
+    ) -> SuiResult<(SuiGasStatus, InputObjects)> {
+        transaction.check_version_supported(epoch_store.protocol_config())?;
+        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
+        check_non_system_packages_to_be_published(
+            transaction,
+            epoch_store.protocol_config(),
+            metrics,
+        )?;
+        let mut input_objects = transaction.input_objects()?;
+        let mut objects =
+            store.check_input_objects(&input_objects, epoch_store.protocol_config())?;
 
-    for (object_kind, object) in input_objects.into_iter().zip(objects) {
-        // For Gas Object, we check the object is owned by gas owner
-        // TODO: this is a quadratic check and though limits are low we should do it differently
-        let owner_address = if transaction
-            .gas()
-            .iter()
-            .any(|obj_ref| *obj_ref.0 == *object.id())
-        {
-            transaction.gas_owner()
+        let gas_object_ref = gas_object.compute_object_reference();
+        input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
+        objects.push(gas_object);
+
+        let gas_status =
+            get_gas_status(&objects, &[gas_object_ref], epoch_store, transaction).await?;
+        let input_objects = check_objects(transaction, input_objects, objects)?;
+        Ok((gas_status, input_objects))
+    }
+
+    /// WARNING! This should only be used for the dev-inspect transaction. This transaction type
+    /// bypasses many of the normal object checks
+    pub(crate) async fn check_dev_inspect_input(
+        store: &AuthorityStore,
+        config: &ProtocolConfig,
+        kind: &TransactionKind,
+        gas_object: Object,
+    ) -> SuiResult<(ObjectRef, InputObjects)> {
+        let gas_object_ref = gas_object.compute_object_reference();
+        kind.validity_check(config)?;
+        match kind {
+            TransactionKind::ProgrammableTransaction(_) => (),
+            TransactionKind::ChangeEpoch(_)
+            | TransactionKind::Genesis(_)
+            | TransactionKind::ConsensusCommitPrologue(_) => {
+                return Err(UserInputError::Unsupported(format!(
+                    "Transaction kind {} is not supported in dev-inspect",
+                    kind
+                ))
+                .into())
+            }
+        }
+        let mut input_objects = kind.input_objects()?;
+        let mut objects = store.check_input_objects(&input_objects, config)?;
+        let mut used_objects: HashSet<SuiAddress> = HashSet::new();
+        for object in &objects {
+            if !object.is_immutable() {
+                fp_ensure!(
+                    used_objects.insert(object.id().into()),
+                    UserInputError::MutableObjectUsedMoreThanOnce {
+                        object_id: object.id()
+                    }
+                    .into()
+                );
+            }
+        }
+        input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
+        objects.push(gas_object);
+        let input_objects = InputObjects::new(input_objects.into_iter().zip(objects).collect());
+        Ok((gas_object_ref, input_objects))
+    }
+
+    pub async fn check_certificate_input(
+        store: &AuthorityStore,
+        epoch_store: &AuthorityPerEpochStore,
+        cert: &VerifiedExecutableTransaction,
+    ) -> SuiResult<(SuiGasStatus, InputObjects)> {
+        let protocol_version = epoch_store.protocol_version();
+
+        // This should not happen - validators should not have signed the txn in the first place.
+        assert!(
+            cert.data()
+                .transaction_data()
+                .check_version_supported(epoch_store.protocol_config())
+                .is_ok(),
+            "Certificate formed with unsupported message version {:?} for protocol version {:?}",
+            cert.message_version(),
+            protocol_version
+        );
+
+        let tx_data = &cert.data().intent_message().value;
+        let input_object_kinds = tx_data.input_objects()?;
+        let input_object_data = if tx_data.is_change_epoch_tx() {
+            // When changing the epoch, we update a the system object, which is shared, without going
+            // through sequencing, so we must bypass the sequence checks here.
+            store.check_input_objects(&input_object_kinds, epoch_store.protocol_config())?
         } else {
-            transaction.sender()
+            store.check_sequenced_input_objects(cert.digest(), &input_object_kinds, epoch_store)?
         };
-        // Check if the object contents match the type of lock we need for
-        // this object.
-        let system_transaction = transaction.is_system_tx();
-        check_one_object(&owner_address, object_kind, &object, system_transaction)?;
-        all_objects.push((object_kind, object));
-    }
-    if !transaction.is_genesis_tx() && all_objects.is_empty() {
-        return Err(UserInputError::ObjectInputArityViolation);
+        let gas_status =
+            get_gas_status(&input_object_data, tx_data.gas(), epoch_store, tx_data).await?;
+        let input_objects = check_objects(tx_data, input_object_kinds, input_object_data)?;
+        Ok((gas_status, input_objects))
     }
 
-    Ok(InputObjects::new(all_objects))
-}
+    /// Check transaction gas data/info and gas coins consistency.
+    /// Return the gas status to be used for the lifecycle of the transaction.
+    #[instrument(level = "trace", skip_all)]
+    async fn check_gas(
+        objects: &[Object],
+        epoch_store: &AuthorityPerEpochStore,
+        gas: &[ObjectRef],
+        gas_budget: u64,
+        gas_price: u64,
+        tx_kind: &TransactionKind,
+    ) -> SuiResult<SuiGasStatus> {
+        if tx_kind.is_system_tx() {
+            Ok(SuiGasStatus::new_unmetered())
+        } else {
+            let protocol_config = epoch_store.protocol_config();
+            let reference_gas_price = epoch_store.reference_gas_price();
+            let gas_status =
+                SuiGasStatus::new(gas_budget, gas_price, reference_gas_price, protocol_config)?;
 
-/// Check one object against a reference
-fn check_one_object(
-    owner: &SuiAddress,
-    object_kind: InputObjectKind,
-    object: &Object,
-    system_transaction: bool,
-) -> UserInputResult {
-    match object_kind {
-        InputObjectKind::MovePackage(package_id) => {
-            fp_ensure!(
-                object.data.try_as_package().is_some(),
-                UserInputError::MoveObjectAsPackage {
-                    object_id: package_id
-                }
-            );
+            // check balance and coins consistency
+            // load all gas coins
+            let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
+            let mut gas_objects = vec![];
+            for obj_ref in gas {
+                let obj = objects.get(&obj_ref.0);
+                let obj = *obj.ok_or(UserInputError::ObjectNotFound {
+                    object_id: obj_ref.0,
+                    version: Some(obj_ref.1),
+                })?;
+                gas_objects.push(obj);
+            }
+            gas_status.check_gas_balance(&gas_objects, gas_budget)?;
+            Ok(gas_status)
         }
-        InputObjectKind::ImmOrOwnedMoveObject((object_id, sequence_number, object_digest)) => {
-            fp_ensure!(
-                !object.is_package(),
-                UserInputError::MovePackageAsObject { object_id }
-            );
-            fp_ensure!(
-                sequence_number < SequenceNumber::MAX,
-                UserInputError::InvalidSequenceNumber
-            );
+    }
 
-            // This is an invariant - we just load the object with the given ID and version.
-            assert_eq!(
+    /// Check all the objects used in the transaction against the database, and ensure
+    /// that they are all the correct version and number.
+    #[instrument(level = "trace", skip_all)]
+    pub fn check_objects(
+        transaction: &TransactionData,
+        input_objects: Vec<InputObjectKind>,
+        objects: Vec<Object>,
+    ) -> UserInputResult<InputObjects> {
+        // We require that mutable objects cannot show up more than once.
+        let mut used_objects: HashSet<SuiAddress> = HashSet::new();
+        for object in objects.iter() {
+            if !object.is_immutable() {
+                fp_ensure!(
+                    used_objects.insert(object.id().into()),
+                    UserInputError::MutableObjectUsedMoreThanOnce {
+                        object_id: object.id()
+                    }
+                );
+            }
+        }
+
+        // Gather all objects and errors.
+        let mut all_objects = Vec::with_capacity(input_objects.len());
+
+        for (object_kind, object) in input_objects.into_iter().zip(objects) {
+            // For Gas Object, we check the object is owned by gas owner
+            // TODO: this is a quadratic check and though limits are low we should do it differently
+            let owner_address = if transaction
+                .gas()
+                .iter()
+                .any(|obj_ref| *obj_ref.0 == *object.id())
+            {
+                transaction.gas_owner()
+            } else {
+                transaction.sender()
+            };
+            // Check if the object contents match the type of lock we need for
+            // this object.
+            let system_transaction = transaction.is_system_tx();
+            check_one_object(&owner_address, object_kind, &object, system_transaction)?;
+            all_objects.push((object_kind, object));
+        }
+        if !transaction.is_genesis_tx() && all_objects.is_empty() {
+            return Err(UserInputError::ObjectInputArityViolation);
+        }
+
+        Ok(InputObjects::new(all_objects))
+    }
+
+    /// Check one object against a reference
+    fn check_one_object(
+        owner: &SuiAddress,
+        object_kind: InputObjectKind,
+        object: &Object,
+        system_transaction: bool,
+    ) -> UserInputResult {
+        match object_kind {
+            InputObjectKind::MovePackage(package_id) => {
+                fp_ensure!(
+                    object.data.try_as_package().is_some(),
+                    UserInputError::MoveObjectAsPackage {
+                        object_id: package_id
+                    }
+                );
+            }
+            InputObjectKind::ImmOrOwnedMoveObject((object_id, sequence_number, object_digest)) => {
+                fp_ensure!(
+                    !object.is_package(),
+                    UserInputError::MovePackageAsObject { object_id }
+                );
+                fp_ensure!(
+                    sequence_number < SequenceNumber::MAX,
+                    UserInputError::InvalidSequenceNumber
+                );
+
+                // This is an invariant - we just load the object with the given ID and version.
+                assert_eq!(
                 object.version(),
                 sequence_number,
                 "The fetched object version {} does not match the requested version {}, object id: {}",
@@ -295,132 +307,131 @@ fn check_one_object(
                 object.id(),
             );
 
-            // Check the digest matches - user could give a mismatched ObjectDigest
-            let expected_digest = object.digest();
-            fp_ensure!(
-                expected_digest == object_digest,
-                UserInputError::InvalidObjectDigest {
-                    object_id,
-                    expected_digest
-                }
-            );
+                // Check the digest matches - user could give a mismatched ObjectDigest
+                let expected_digest = object.digest();
+                fp_ensure!(
+                    expected_digest == object_digest,
+                    UserInputError::InvalidObjectDigest {
+                        object_id,
+                        expected_digest
+                    }
+                );
 
-            match object.owner {
-                Owner::Immutable => {
-                    // Nothing else to check for Immutable.
-                }
-                Owner::AddressOwner(actual_owner) => {
-                    // Check the owner is correct.
-                    fp_ensure!(
+                match object.owner {
+                    Owner::Immutable => {
+                        // Nothing else to check for Immutable.
+                    }
+                    Owner::AddressOwner(actual_owner) => {
+                        // Check the owner is correct.
+                        fp_ensure!(
                         owner == &actual_owner,
                         UserInputError::IncorrectUserSignature {
                             error: format!("Object {:?} is owned by account address {:?}, but given owner/signer address is {:?}", object_id, actual_owner, owner),
                         }
                     );
-                }
-                Owner::ObjectOwner(owner) => {
-                    return Err(UserInputError::InvalidChildObjectArgument {
-                        child_id: object.id(),
-                        parent_id: owner.into(),
+                    }
+                    Owner::ObjectOwner(owner) => {
+                        return Err(UserInputError::InvalidChildObjectArgument {
+                            child_id: object.id(),
+                            parent_id: owner.into(),
+                        });
+                    }
+                    Owner::Shared { .. } => {
+                        // This object is a mutable shared object. However the transaction
+                        // specifies it as an owned object. This is inconsistent.
+                        return Err(UserInputError::NotSharedObjectError);
+                    }
+                };
+            }
+            InputObjectKind::SharedMoveObject {
+                id: SUI_CLOCK_OBJECT_ID,
+                initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+                mutable: true,
+            } => {
+                // Only system transactions can accept the Clock
+                // object as a mutable parameter.
+                if system_transaction {
+                    return Ok(());
+                } else {
+                    return Err(UserInputError::ImmutableParameterExpectedError {
+                        object_id: SUI_CLOCK_OBJECT_ID,
                     });
                 }
-                Owner::Shared { .. } => {
-                    // This object is a mutable shared object. However the transaction
-                    // specifies it as an owned object. This is inconsistent.
-                    return Err(UserInputError::NotSharedObjectError);
-                }
-            };
-        }
-        InputObjectKind::SharedMoveObject {
-            id: SUI_CLOCK_OBJECT_ID,
-            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
-            mutable: true,
-        } => {
-            // Only system transactions can accept the Clock
-            // object as a mutable parameter.
-            if system_transaction {
-                return Ok(());
-            } else {
-                return Err(UserInputError::ImmutableParameterExpectedError {
-                    object_id: SUI_CLOCK_OBJECT_ID,
-                });
             }
-        }
-        InputObjectKind::SharedMoveObject {
-            initial_shared_version: input_initial_shared_version,
-            ..
-        } => {
-            fp_ensure!(
-                object.version() < SequenceNumber::MAX,
-                UserInputError::InvalidSequenceNumber
-            );
+            InputObjectKind::SharedMoveObject {
+                initial_shared_version: input_initial_shared_version,
+                ..
+            } => {
+                fp_ensure!(
+                    object.version() < SequenceNumber::MAX,
+                    UserInputError::InvalidSequenceNumber
+                );
 
-            match object.owner {
-                Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
-                    // When someone locks an object as shared it must be shared already.
-                    return Err(UserInputError::NotSharedObjectError);
-                }
-                Owner::Shared {
-                    initial_shared_version: actual_initial_shared_version,
-                } => {
-                    fp_ensure!(
-                        input_initial_shared_version == actual_initial_shared_version,
-                        UserInputError::SharedObjectStartingVersionMismatch
-                    )
+                match object.owner {
+                    Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+                        // When someone locks an object as shared it must be shared already.
+                        return Err(UserInputError::NotSharedObjectError);
+                    }
+                    Owner::Shared {
+                        initial_shared_version: actual_initial_shared_version,
+                    } => {
+                        fp_ensure!(
+                            input_initial_shared_version == actual_initial_shared_version,
+                            UserInputError::SharedObjectStartingVersionMismatch
+                        )
+                    }
                 }
             }
-        }
-    };
-    Ok(())
-}
-
-/// Check package verification timeout
-#[instrument(level = "trace", skip_all)]
-pub fn check_non_system_packages_to_be_published(
-    transaction: &TransactionData,
-    protocol_config: &ProtocolConfig,
-    metrics: &Arc<BytecodeVerifierMetrics>,
-) -> UserInputResult<()> {
-    // Only meter non-system programmable transaction blocks
-    if transaction.is_system_tx() {
-        return Ok(());
+        };
+        Ok(())
     }
 
-    let TransactionKind::ProgrammableTransaction(pt) = transaction.kind() else {
+    /// Check package verification timeout
+    #[instrument(level = "trace", skip_all)]
+    pub fn check_non_system_packages_to_be_published(
+        transaction: &TransactionData,
+        protocol_config: &ProtocolConfig,
+        metrics: &Arc<BytecodeVerifierMetrics>,
+    ) -> UserInputResult<()> {
+        // Only meter non-system programmable transaction blocks
+        if transaction.is_system_tx() {
+            return Ok(());
+        }
+
+        let TransactionKind::ProgrammableTransaction(pt) = transaction.kind() else {
         return Ok(());
     };
 
-    // We use a custom config with metering enabled
-    let is_metered = true;
-    // Use the same verifier and meter for all packages
-    let mut verifier = sui_execution::verifier(protocol_config, is_metered, metrics);
+        // We use a custom config with metering enabled
+        let is_metered = true;
+        // Use the same verifier and meter for all packages
+        let mut verifier = sui_execution::verifier(protocol_config, is_metered, metrics);
 
-    // Measure time for verifying all packages in the PTB
-    let shared_meter_verifier_timer = metrics
-        .verifier_runtime_per_ptb_success_latency
-        .start_timer();
+        // Measure time for verifying all packages in the PTB
+        let shared_meter_verifier_timer = metrics
+            .verifier_runtime_per_ptb_success_latency
+            .start_timer();
 
-    let verifier_status = pt
-        .non_system_packages_to_be_published()
-        .try_for_each(|module_bytes| verifier.meter_module_bytes(protocol_config, module_bytes))
-        .map_err(|e| UserInputError::PackageVerificationTimedout { err: e.to_string() });
+        let verifier_status = pt
+            .non_system_packages_to_be_published()
+            .try_for_each(|module_bytes| verifier.meter_module_bytes(protocol_config, module_bytes))
+            .map_err(|e| UserInputError::PackageVerificationTimedout { err: e.to_string() });
 
-    match verifier_status {
-        Ok(_) => {
-            // Success: stop and record the success timer
-            shared_meter_verifier_timer.stop_and_record();
-        }
-        Err(err) => {
-            // Failure: redirect the success timers output to the failure timer and
-            // discard the success timer
-            metrics
-                .verifier_runtime_per_ptb_timeout_latency
-                .observe(shared_meter_verifier_timer.stop_and_discard());
-            return Err(err);
-        }
-    };
+        match verifier_status {
+            Ok(_) => {
+                // Success: stop and record the success timer
+                shared_meter_verifier_timer.stop_and_record();
+            }
+            Err(err) => {
+                // Failure: redirect the success timers output to the failure timer and
+                // discard the success timer
+                metrics
+                    .verifier_runtime_per_ptb_timeout_latency
+                    .observe(shared_meter_verifier_timer.stop_and_discard());
+                return Err(err);
+            }
+        };
 
-    Ok(())
-}
-
+        Ok(())
+    }
 }

--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -362,4 +362,195 @@ mod test {
     }
 
     }
+
+    #[with_checked_arithmetic]
+    mod with_checked_arithmetic_tests {
+
+        struct Test {
+            a: i32,
+            b: i32,
+        }
+
+        fn unchecked_add(a: i32, b: i32) -> i32 {
+            a + b
+        }
+
+        #[test]
+        fn test_checked_arithmetic_macro() {
+            unchecked_add(1, 2);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_checked_arithmetic_macro_panic() {
+            unchecked_add(i32::MAX, 1);
+        }
+
+        fn unchecked_add_hidden(a: i32, b: i32) -> i32 {
+            let inner = |a: i32, b: i32| a + b;
+            inner(a, b)
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_checked_arithmetic_macro_panic_hidden() {
+            unchecked_add_hidden(i32::MAX, 1);
+        }
+
+        fn unchecked_add_hidden_2(a: i32, b: i32) -> i32 {
+            fn inner(a: i32, b: i32) -> i32 {
+                a + b
+            }
+            inner(a, b)
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_checked_arithmetic_macro_panic_hidden_2() {
+            unchecked_add_hidden_2(i32::MAX, 1);
+        }
+
+        impl Test {
+            fn add(&self) -> i32 {
+                self.a + self.b
+            }
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_checked_arithmetic_impl() {
+            let t = Test { a: 1, b: i32::MAX };
+            t.add();
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_macro_overflow() {
+            #[allow(arithmetic_overflow)]
+            fn f() {
+                println!("{}", i32::MAX + 1);
+            }
+
+            f()
+        }
+
+        // Make sure that we still do addition correctly!
+        #[test]
+        fn test_non_overflow() {
+            fn f() {
+                assert_eq!(1i32 + 2i32, 3i32);
+                assert_eq!(3i32 - 1i32, 2i32);
+                assert_eq!(4i32 * 3i32, 12i32);
+                assert_eq!(12i32 / 3i32, 4i32);
+                assert_eq!(12i32 % 5i32, 2i32);
+
+                let mut a = 1i32;
+                a += 2i32;
+                assert_eq!(a, 3i32);
+
+                let mut a = 3i32;
+                a -= 1i32;
+                assert_eq!(a, 2i32);
+
+                let mut a = 4i32;
+                a *= 3i32;
+                assert_eq!(a, 12i32);
+
+                let mut a = 12i32;
+                a /= 3i32;
+                assert_eq!(a, 4i32);
+
+                let mut a = 12i32;
+                a %= 5i32;
+                assert_eq!(a, 2i32);
+            }
+
+            f();
+        }
+
+        #[test]
+        fn test_exprs_evaluated_once_right() {
+            let mut called = false;
+            let mut f = || {
+                if called {
+                    panic!("called twice");
+                }
+                called = true;
+                1i32
+            };
+
+            assert_eq!(2i32 + f(), 3);
+        }
+
+        #[test]
+        fn test_exprs_evaluated_once_left() {
+            let mut called = false;
+            let mut f = || {
+                if called {
+                    panic!("called twice");
+                }
+                called = true;
+                1i32
+            };
+
+            assert_eq!(f() + 2i32, 3);
+        }
+
+        #[test]
+        fn test_assign_op_evals_once() {
+            struct Foo {
+                a: i32,
+                called: bool,
+            }
+
+            impl Foo {
+                fn get_a_mut(&mut self) -> &mut i32 {
+                    if self.called {
+                        panic!("called twice");
+                    }
+                    let ret = &mut self.a;
+                    self.called = true;
+                    ret
+                }
+            }
+
+            let mut foo = Foo {
+                a: 1,
+                called: false,
+            };
+
+            *foo.get_a_mut() += 2;
+            assert_eq!(foo.a, 3);
+        }
+
+        #[test]
+        fn test_more_macro_syntax() {
+            struct Foo {
+                a: i32,
+                b: i32,
+            }
+
+            impl Foo {
+                const BAR: i32 = 1;
+
+                fn new(a: i32, b: i32) -> Foo {
+                    Foo { a, b }
+                }
+            }
+
+            fn new_foo(a: i32) -> Foo {
+                Foo { a, b: 0 }
+            }
+
+            // verify that we translate the contents of macros correctly
+            assert_eq!(Foo::BAR + 1, 2);
+            assert_eq!(Foo::new(1, 2).b, 2);
+            assert_eq!(new_foo(1).a, 1);
+
+            let v = vec![Foo::new(1, 2), Foo::new(3, 2)];
+
+            assert_eq!(v[0].a, 1);
+            assert_eq!(v[1].b, 2);
+        }
+    }
 }

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -286,12 +286,9 @@ pub fn with_checked_arithmetic(_attr: TokenStream, item: TokenStream) -> TokenSt
             let transformed_impl = CheckArithmetic.fold_item_impl(input_impl);
             TokenStream::from(quote! { #transformed_impl })
         }
-        _ => {
-            let err = syn::Error::new_spanned(
-                input_item,
-                "The with_checked_arithmetic attribute can only be applied to functions and impl blocks",
-            );
-            err.to_compile_error().into()
+        item => {
+            let transformed_impl = CheckArithmetic.fold_item(item);
+            TokenStream::from(quote! { #transformed_impl })
         }
     }
 }

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -2,330 +2,310 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::gas_model::gas_predicates::{dont_charge_budget_on_storage_oog, gas_price_too_high};
-use crate::{
-    base_types::{ObjectID, ObjectRef},
-    digests::TransactionDigest,
-    effects::{TransactionEffects, TransactionEffectsAPI},
-    error::{ExecutionError, SuiResult, UserInputError, UserInputResult},
-    gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
-    is_system_package,
-    object::{Data, Object},
-    storage::{DeleteKindWithOldVersion, WriteKind},
-    sui_serde::{BigInt, Readable},
-    temporary_store::TemporaryStore,
-};
-use enum_dispatch::enum_dispatch;
-use itertools::MultiUnzip;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use sui_protocol_config::ProtocolConfig;
-use tracing::trace;
+pub use checked::*;
 
-sui_macros::checked_arithmetic! {
+#[sui_macros::with_checked_arithmetic]
+pub mod checked {
 
-/// Tracks all gas operations for a single transaction.
-/// This is the main entry point for gas accounting.
-/// All the information about gas is stored in this object.
-/// The objective here is two-fold:
-/// 1- Isolate al version info into a single entry point. This file and the other gas
-///    related files are the only one that check for gas version.
-/// 2- Isolate all gas accounting into a single implementation. Gas objects are not
-///    passed around, and they are retrieved from this instance.
-#[derive(Debug)]
-pub struct GasCharger {
-    tx_digest: TransactionDigest,
-    gas_model_version: u64,
-    gas_coins: Vec<ObjectRef>,
-    // this is the the first gas coin in `gas_coins` and the one that all others will
-    // be smashed into. It can be None for system transactions when `gas_coins` is empty.
-    smashed_gas_coin: Option<ObjectID>,
-    gas_status: SuiGasStatus,
-}
+    use crate::gas_model::gas_predicates::{dont_charge_budget_on_storage_oog, gas_price_too_high};
+    use crate::{
+        base_types::{ObjectID, ObjectRef},
+        digests::TransactionDigest,
+        effects::{TransactionEffects, TransactionEffectsAPI},
+        error::{ExecutionError, SuiResult, UserInputError, UserInputResult},
+        gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
+        is_system_package,
+        object::{Data, Object},
+        storage::{DeleteKindWithOldVersion, WriteKind},
+        sui_serde::{BigInt, Readable},
+        temporary_store::TemporaryStore,
+    };
+    use enum_dispatch::enum_dispatch;
+    use itertools::MultiUnzip;
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+    use sui_protocol_config::ProtocolConfig;
+    use tracing::trace;
 
-impl GasCharger {
-    pub fn new(
+    /// Tracks all gas operations for a single transaction.
+    /// This is the main entry point for gas accounting.
+    /// All the information about gas is stored in this object.
+    /// The objective here is two-fold:
+    /// 1- Isolate al version info into a single entry point. This file and the other gas
+    ///    related files are the only one that check for gas version.
+    /// 2- Isolate all gas accounting into a single implementation. Gas objects are not
+    ///    passed around, and they are retrieved from this instance.
+    #[derive(Debug)]
+    pub struct GasCharger {
         tx_digest: TransactionDigest,
+        gas_model_version: u64,
         gas_coins: Vec<ObjectRef>,
+        // this is the the first gas coin in `gas_coins` and the one that all others will
+        // be smashed into. It can be None for system transactions when `gas_coins` is empty.
+        smashed_gas_coin: Option<ObjectID>,
         gas_status: SuiGasStatus,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        let gas_model_version = protocol_config.gas_model_version();
-        Self {
-            tx_digest,
-            gas_model_version,
-            gas_coins,
-            smashed_gas_coin: None,
-            gas_status,
+    }
+
+    impl GasCharger {
+        pub fn new(
+            tx_digest: TransactionDigest,
+            gas_coins: Vec<ObjectRef>,
+            gas_status: SuiGasStatus,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
+            let gas_model_version = protocol_config.gas_model_version();
+            Self {
+                tx_digest,
+                gas_model_version,
+                gas_coins,
+                smashed_gas_coin: None,
+                gas_status,
+            }
         }
-    }
 
-    pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
-        Self {
-            tx_digest,
-            gas_model_version: 6, // pick any of the latest, it should not matter
-            gas_coins: vec![],
-            smashed_gas_coin: None,
-            gas_status: SuiGasStatus::new_unmetered(),
+        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+            Self {
+                tx_digest,
+                gas_model_version: 6, // pick any of the latest, it should not matter
+                gas_coins: vec![],
+                smashed_gas_coin: None,
+                gas_status: SuiGasStatus::new_unmetered(),
+            }
         }
-    }
 
-    // TODO: there is only one caller to this function that should not exist otherwise.
-    //       Explore way to remove it.
-    pub(crate) fn gas_coins(&self) -> &[ObjectRef] {
-        &self.gas_coins
-    }
-
-    // Return the logical gas coin for this transactions or None if no gas coin was present
-    // (system transactions).
-    pub fn gas_coin(&self) -> Option<ObjectID> {
-        self.smashed_gas_coin
-    }
-
-    pub fn gas_budget(&self) -> u64 {
-        self.gas_status.gas_budget()
-    }
-
-    pub fn unmetered_storage_rebate(&self) -> u64 {
-        self.gas_status.unmetered_storage_rebate()
-    }
-
-    pub fn no_charges(&self) -> bool {
-        self.gas_status.gas_used() == 0
-            && self.gas_status.storage_rebate() == 0
-            && self.gas_status.storage_gas_units() == 0
-    }
-
-    pub fn is_unmetered(&self) -> bool {
-        self.gas_status.is_unmetered()
-    }
-
-    pub fn move_gas_status(&self) -> &GasStatus {
-        self.gas_status.move_gas_status()
-    }
-
-    pub fn move_gas_status_mut(&mut self) -> &mut GasStatus {
-        self.gas_status.move_gas_status_mut()
-    }
-
-    pub fn summary(&self) -> GasCostSummary {
-        self.gas_status.summary()
-    }
-
-    // This function is called when the transaction is about to be executed.
-    // It will smash all gas coins into a single one and set the logical gas coin
-    // to be the first one in the list.
-    // After this call, `gas_coin` will return it id of the gas coin.
-    // This function panics if errors are found while operation on the gas coins.
-    // Transaction and certificate input checks must have insured that all gas coins
-    // are correct.
-    pub fn smash_gas(&mut self, temporary_store: &mut TemporaryStore<'_>) {
-        let gas_coin_count = self.gas_coins.len();
-        if gas_coin_count == 0 || (gas_coin_count == 1 && self.gas_coins[0].0 == ObjectID::ZERO) {
-            return; // self.smashed_gas_coin is None
+        // TODO: there is only one caller to this function that should not exist otherwise.
+        //       Explore way to remove it.
+        pub(crate) fn gas_coins(&self) -> &[ObjectRef] {
+            &self.gas_coins
         }
-        // set the first coin to be the transaction only gas coin.
-        // All others will be smashed into this one.
-        let gas_coin_id = self.gas_coins[0].0;
-        self.smashed_gas_coin = Some(gas_coin_id);
-        if gas_coin_count == 1 {
-            return;
+
+        // Return the logical gas coin for this transactions or None if no gas coin was present
+        // (system transactions).
+        pub fn gas_coin(&self) -> Option<ObjectID> {
+            self.smashed_gas_coin
         }
-        // sum the value of all gas coins
-        let new_balance = self
-            .gas_coins
-            .iter()
-            .map(|obj_ref| {
-                let obj = temporary_store.objects().get(&obj_ref.0).unwrap();
-                let Data::Move(move_obj) = &obj.data else {
+
+        pub fn gas_budget(&self) -> u64 {
+            self.gas_status.gas_budget()
+        }
+
+        pub fn unmetered_storage_rebate(&self) -> u64 {
+            self.gas_status.unmetered_storage_rebate()
+        }
+
+        pub fn no_charges(&self) -> bool {
+            self.gas_status.gas_used() == 0
+                && self.gas_status.storage_rebate() == 0
+                && self.gas_status.storage_gas_units() == 0
+        }
+
+        pub fn is_unmetered(&self) -> bool {
+            self.gas_status.is_unmetered()
+        }
+
+        pub fn move_gas_status(&self) -> &GasStatus {
+            self.gas_status.move_gas_status()
+        }
+
+        pub fn move_gas_status_mut(&mut self) -> &mut GasStatus {
+            self.gas_status.move_gas_status_mut()
+        }
+
+        pub fn summary(&self) -> GasCostSummary {
+            self.gas_status.summary()
+        }
+
+        // This function is called when the transaction is about to be executed.
+        // It will smash all gas coins into a single one and set the logical gas coin
+        // to be the first one in the list.
+        // After this call, `gas_coin` will return it id of the gas coin.
+        // This function panics if errors are found while operation on the gas coins.
+        // Transaction and certificate input checks must have insured that all gas coins
+        // are correct.
+        pub fn smash_gas(&mut self, temporary_store: &mut TemporaryStore<'_>) {
+            let gas_coin_count = self.gas_coins.len();
+            if gas_coin_count == 0 || (gas_coin_count == 1 && self.gas_coins[0].0 == ObjectID::ZERO)
+            {
+                return; // self.smashed_gas_coin is None
+            }
+            // set the first coin to be the transaction only gas coin.
+            // All others will be smashed into this one.
+            let gas_coin_id = self.gas_coins[0].0;
+            self.smashed_gas_coin = Some(gas_coin_id);
+            if gas_coin_count == 1 {
+                return;
+            }
+            // sum the value of all gas coins
+            let new_balance = self
+                .gas_coins
+                .iter()
+                .map(|obj_ref| {
+                    let obj = temporary_store.objects().get(&obj_ref.0).unwrap();
+                    let Data::Move(move_obj) = &obj.data else {
                     return Err(ExecutionError::invariant_violation(
                         "Provided non-gas coin object as input for gas!"
                     ));
                 };
-                if !move_obj.type_().is_gas_coin() {
-                    return Err(ExecutionError::invariant_violation(
-                        "Provided non-gas coin object as input for gas!",
-                    ));
+                    if !move_obj.type_().is_gas_coin() {
+                        return Err(ExecutionError::invariant_violation(
+                            "Provided non-gas coin object as input for gas!",
+                        ));
+                    }
+                    Ok(move_obj.get_coin_value_unsafe())
+                })
+                .collect::<Result<Vec<u64>, ExecutionError>>()
+                // transaction and certificate input checks must have insured that all gas coins
+                // are valid
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Invariant violation: non-gas coin object as input for gas in txn {}",
+                        self.tx_digest
+                    )
+                })
+                .iter()
+                .sum();
+            let mut primary_gas_object = temporary_store
+                .objects()
+                .get(&gas_coin_id)
+                // unwrap should be safe because we checked that this exists in `self.objects()` above
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Invariant violation: gas coin not found in store in txn {}",
+                        self.tx_digest
+                    )
+                })
+                .clone();
+            // delete all gas objects except the primary_gas_object
+            for (id, version, _digest) in &self.gas_coins[1..] {
+                debug_assert_ne!(*id, primary_gas_object.id());
+                temporary_store.delete_object(id, DeleteKindWithOldVersion::Normal(*version));
+            }
+            primary_gas_object
+                .data
+                .try_as_move_mut()
+                // unwrap should be safe because we checked that the primary gas object was a coin object above.
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Invariant violation: invalid coin object in txn {}",
+                        self.tx_digest
+                    )
+                })
+                .set_coin_value_unsafe(new_balance);
+            temporary_store.write_object(primary_gas_object, WriteKind::Mutate);
+        }
+
+        //
+        // Gas charging operations
+        //
+
+        pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+            self.gas_status
+                .track_storage_mutation(new_size, storage_rebate)
+        }
+
+        pub fn reset_storage_cost_and_rebate(&mut self) {
+            self.gas_status.reset_storage_cost_and_rebate();
+        }
+
+        pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+            self.gas_status.charge_publish_package(size)
+        }
+
+        pub fn charge_input_objects(
+            &mut self,
+            temporary_store: &TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            let objects = temporary_store.objects();
+            // TODO: Charge input object count.
+            let _object_count = objects.len();
+            // Charge bytes read
+            let total_size = temporary_store
+                .objects()
+                .iter()
+                // don't charge for loading Sui Framework or Move stdlib
+                .filter(|(id, _)| !is_system_package(**id))
+                .map(|(_, obj)| obj.object_size_for_gas_metering())
+                .sum();
+            self.gas_status.charge_storage_read(total_size)
+        }
+
+        /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
+        /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+        pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
+            temporary_store.drop_writes();
+            self.gas_status.reset_storage_cost_and_rebate();
+            self.smash_gas(temporary_store);
+        }
+
+        /// Entry point for gas charging.
+        /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of
+        /// mutated objects
+        /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
+        /// The happy path of this function follows (1) + (2) and is fairly simple.
+        /// Most of the complexity is in the unhappy paths:
+        /// - if execution aborted before calling this function, we have to dump all writes +
+        ///   re-smash gas, then charge for storage
+        /// - if we run out of gas while charging for storage, we have to dump all writes +
+        ///   re-smash gas, then charge for storage again
+        pub fn charge_gas<T>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &mut Result<T, ExecutionError>,
+        ) -> GasCostSummary {
+            // at this point, we have done *all* charging for computation,
+            // but have not yet set the storage rebate or storage gas units
+            debug_assert!(self.gas_status.storage_rebate() == 0);
+            debug_assert!(self.gas_status.storage_gas_units() == 0);
+
+            if self.smashed_gas_coin.is_some() {
+                // bucketize computation cost
+                if let Err(err) = self.gas_status.bucketize_computation() {
+                    if execution_result.is_ok() {
+                        *execution_result = Err(err);
+                    }
                 }
-                Ok(move_obj.get_coin_value_unsafe())
-            })
-            .collect::<Result<Vec<u64>, ExecutionError>>()
-            // transaction and certificate input checks must have insured that all gas coins
-            // are valid
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Invariant violation: non-gas coin object as input for gas in txn {}",
-                    self.tx_digest
-                )
-            })
-            .iter()
-            .sum();
-        let mut primary_gas_object = temporary_store
-            .objects()
-            .get(&gas_coin_id)
-            // unwrap should be safe because we checked that this exists in `self.objects()` above
-            .unwrap_or_else(|| {
-                panic!(
-                    "Invariant violation: gas coin not found in store in txn {}",
-                    self.tx_digest
-                )
-            })
-            .clone();
-        // delete all gas objects except the primary_gas_object
-        for (id, version, _digest) in &self.gas_coins[1..] {
-            debug_assert_ne!(*id, primary_gas_object.id());
-            temporary_store.delete_object(id, DeleteKindWithOldVersion::Normal(*version));
-        }
-        primary_gas_object
-            .data
-            .try_as_move_mut()
-            // unwrap should be safe because we checked that the primary gas object was a coin object above.
-            .unwrap_or_else(|| {
-                panic!(
-                    "Invariant violation: invalid coin object in txn {}",
-                    self.tx_digest
-                )
-            })
-            .set_coin_value_unsafe(new_balance);
-        temporary_store.write_object(primary_gas_object, WriteKind::Mutate);
-    }
 
-    //
-    // Gas charging operations
-    //
-
-    pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
-        self.gas_status
-            .track_storage_mutation(new_size, storage_rebate)
-    }
-
-    pub fn reset_storage_cost_and_rebate(&mut self) {
-        self.gas_status.reset_storage_cost_and_rebate();
-    }
-
-    pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-        self.gas_status.charge_publish_package(size)
-    }
-
-    pub fn charge_input_objects(
-        &mut self,
-        temporary_store: &TemporaryStore<'_>,
-    ) -> Result<(), ExecutionError> {
-        let objects = temporary_store.objects();
-        // TODO: Charge input object count.
-        let _object_count = objects.len();
-        // Charge bytes read
-        let total_size = temporary_store
-            .objects()
-            .iter()
-            // don't charge for loading Sui Framework or Move stdlib
-            .filter(|(id, _)| !is_system_package(**id))
-            .map(|(_, obj)| obj.object_size_for_gas_metering())
-            .sum();
-        self.gas_status.charge_storage_read(total_size)
-    }
-
-    /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
-    /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
-    pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
-        temporary_store.drop_writes();
-        self.gas_status.reset_storage_cost_and_rebate();
-        self.smash_gas(temporary_store);
-    }
-
-    /// Entry point for gas charging.
-    /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of
-    /// mutated objects
-    /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
-    /// The happy path of this function follows (1) + (2) and is fairly simple.
-    /// Most of the complexity is in the unhappy paths:
-    /// - if execution aborted before calling this function, we have to dump all writes +
-    ///   re-smash gas, then charge for storage
-    /// - if we run out of gas while charging for storage, we have to dump all writes +
-    ///   re-smash gas, then charge for storage again
-    pub fn charge_gas<T>(
-        &mut self,
-        temporary_store: &mut TemporaryStore<'_>,
-        execution_result: &mut Result<T, ExecutionError>,
-    ) -> GasCostSummary {
-        // at this point, we have done *all* charging for computation,
-        // but have not yet set the storage rebate or storage gas units
-        debug_assert!(self.gas_status.storage_rebate() == 0);
-        debug_assert!(self.gas_status.storage_gas_units() == 0);
-
-        if self.smashed_gas_coin.is_some() {
-            // bucketize computation cost
-            if let Err(err) = self.gas_status.bucketize_computation() {
-                if execution_result.is_ok() {
-                    *execution_result = Err(err);
+                // On error we need to dump writes, deletes, etc before charging storage gas
+                if execution_result.is_err() {
+                    self.reset(temporary_store);
                 }
             }
 
-            // On error we need to dump writes, deletes, etc before charging storage gas
-            if execution_result.is_err() {
-                self.reset(temporary_store);
-            }
-        }
-
-        // compute and collect storage charges
-        temporary_store.ensure_gas_and_input_mutated(self);
-        temporary_store.collect_storage_and_rebate(self);
-
-        // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
-        // for storage, however they track storage values to check for conservation rules
-        if let Some(gas_object_id) = self.smashed_gas_coin {
-            if dont_charge_budget_on_storage_oog(self.gas_model_version) {
-                self.handle_storage_and_rebate_v2(temporary_store, execution_result)
-            } else {
-                self.handle_storage_and_rebate_v1(temporary_store, execution_result)
-            }
-
-            let cost_summary = self.gas_status.summary();
-            let gas_used = cost_summary.net_gas_usage();
-
-            let mut gas_object = temporary_store.read_object(&gas_object_id).unwrap().clone();
-            deduct_gas(&mut gas_object, gas_used);
-            #[skip_checked_arithmetic]
-            trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
-
-            temporary_store.write_object(gas_object, WriteKind::Mutate);
-            cost_summary
-        } else {
-            GasCostSummary::default()
-        }
-    }
-
-    fn handle_storage_and_rebate_v1<T>(
-        &mut self,
-        temporary_store: &mut TemporaryStore<'_>,
-        execution_result: &mut Result<T, ExecutionError>,
-    ) {
-        if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-            self.reset(temporary_store);
-            self.gas_status.adjust_computation_on_out_of_gas();
-            temporary_store.ensure_gas_and_input_mutated(self);
-            temporary_store.collect_rebate(self);
-            if execution_result.is_ok() {
-                *execution_result = Err(err);
-            }
-        }
-    }
-
-    fn handle_storage_and_rebate_v2<T>(
-        &mut self,
-        temporary_store: &mut TemporaryStore<'_>,
-        execution_result: &mut Result<T, ExecutionError>,
-    ) {
-        if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-            // we run out of gas charging storage, reset and try charging for storage again.
-            // Input objects are touched and so they have a storage cost
-            self.reset(temporary_store);
+            // compute and collect storage charges
             temporary_store.ensure_gas_and_input_mutated(self);
             temporary_store.collect_storage_and_rebate(self);
+
+            // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
+            // for storage, however they track storage values to check for conservation rules
+            if let Some(gas_object_id) = self.smashed_gas_coin {
+                if dont_charge_budget_on_storage_oog(self.gas_model_version) {
+                    self.handle_storage_and_rebate_v2(temporary_store, execution_result)
+                } else {
+                    self.handle_storage_and_rebate_v1(temporary_store, execution_result)
+                }
+
+                let cost_summary = self.gas_status.summary();
+                let gas_used = cost_summary.net_gas_usage();
+
+                let mut gas_object = temporary_store.read_object(&gas_object_id).unwrap().clone();
+                deduct_gas(&mut gas_object, gas_used);
+                #[skip_checked_arithmetic]
+                trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+
+                temporary_store.write_object(gas_object, WriteKind::Mutate);
+                cost_summary
+            } else {
+                GasCostSummary::default()
+            }
+        }
+
+        fn handle_storage_and_rebate_v1<T>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &mut Result<T, ExecutionError>,
+        ) {
             if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                // we run out of gas attempting to charge for the input objects exclusively,
-                // deal with this edge case by not charging for storage
                 self.reset(temporary_store);
                 self.gas_status.adjust_computation_on_out_of_gas();
                 temporary_store.ensure_gas_and_input_mutated(self);
@@ -333,240 +313,262 @@ impl GasCharger {
                 if execution_result.is_ok() {
                     *execution_result = Err(err);
                 }
-            } else if execution_result.is_ok() {
-                *execution_result = Err(err);
+            }
+        }
+
+        fn handle_storage_and_rebate_v2<T>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &mut Result<T, ExecutionError>,
+        ) {
+            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
+                // we run out of gas charging storage, reset and try charging for storage again.
+                // Input objects are touched and so they have a storage cost
+                self.reset(temporary_store);
+                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.collect_storage_and_rebate(self);
+                if let Err(err) = self.gas_status.charge_storage_and_rebate() {
+                    // we run out of gas attempting to charge for the input objects exclusively,
+                    // deal with this edge case by not charging for storage
+                    self.reset(temporary_store);
+                    self.gas_status.adjust_computation_on_out_of_gas();
+                    temporary_store.ensure_gas_and_input_mutated(self);
+                    temporary_store.collect_rebate(self);
+                    if execution_result.is_ok() {
+                        *execution_result = Err(err);
+                    }
+                } else if execution_result.is_ok() {
+                    *execution_result = Err(err);
+                }
             }
         }
     }
-}
 
-#[enum_dispatch]
-pub(crate) trait SuiGasStatusAPI {
-    fn is_unmetered(&self) -> bool;
-    fn move_gas_status(&self) -> &GasStatus;
-    fn move_gas_status_mut(&mut self) -> &mut GasStatus;
-    fn bucketize_computation(&mut self) -> Result<(), ExecutionError>;
-    fn summary(&self) -> GasCostSummary;
-    fn gas_budget(&self) -> u64;
-    fn storage_gas_units(&self) -> u64;
-    fn storage_rebate(&self) -> u64;
-    fn unmetered_storage_rebate(&self) -> u64;
-    fn gas_used(&self) -> u64;
-    fn reset_storage_cost_and_rebate(&mut self);
-    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError>;
-    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError>;
-    fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64;
-    fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
-    fn adjust_computation_on_out_of_gas(&mut self);
-}
+    #[enum_dispatch]
+    pub(crate) trait SuiGasStatusAPI {
+        fn is_unmetered(&self) -> bool;
+        fn move_gas_status(&self) -> &GasStatus;
+        fn move_gas_status_mut(&mut self) -> &mut GasStatus;
+        fn bucketize_computation(&mut self) -> Result<(), ExecutionError>;
+        fn summary(&self) -> GasCostSummary;
+        fn gas_budget(&self) -> u64;
+        fn storage_gas_units(&self) -> u64;
+        fn storage_rebate(&self) -> u64;
+        fn unmetered_storage_rebate(&self) -> u64;
+        fn gas_used(&self) -> u64;
+        fn reset_storage_cost_and_rebate(&mut self);
+        fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError>;
+        fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError>;
+        fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64;
+        fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
+        fn adjust_computation_on_out_of_gas(&mut self);
+    }
 
-/// Version aware enum for gas status.
-#[enum_dispatch(SuiGasStatusAPI)]
-#[derive(Debug)]
-pub enum SuiGasStatus {
-    // V1 does not exists any longer as it was a pre mainnet version.
-    // So we start the enum from V2
-    V2(SuiGasStatusV2),
-}
+    /// Version aware enum for gas status.
+    #[enum_dispatch(SuiGasStatusAPI)]
+    #[derive(Debug)]
+    pub enum SuiGasStatus {
+        // V1 does not exists any longer as it was a pre mainnet version.
+        // So we start the enum from V2
+        V2(SuiGasStatusV2),
+    }
 
-impl SuiGasStatus {
-    pub fn new(
-        gas_budget: u64,
-        gas_price: u64,
-        reference_gas_price: u64,
-        config: &ProtocolConfig,
-    ) -> SuiResult<Self> {
-        // Common checks. We may pull them into version specific status as needed, but they
-        // are unlikely to change.
+    impl SuiGasStatus {
+        pub fn new(
+            gas_budget: u64,
+            gas_price: u64,
+            reference_gas_price: u64,
+            config: &ProtocolConfig,
+        ) -> SuiResult<Self> {
+            // Common checks. We may pull them into version specific status as needed, but they
+            // are unlikely to change.
 
-        // gas price must be bigger or equal to reference gas price
-        if gas_price < reference_gas_price {
-            return Err(UserInputError::GasPriceUnderRGP {
+            // gas price must be bigger or equal to reference gas price
+            if gas_price < reference_gas_price {
+                return Err(UserInputError::GasPriceUnderRGP {
+                    gas_price,
+                    reference_gas_price,
+                }
+                .into());
+            }
+            if gas_price_too_high(config.gas_model_version()) && gas_price >= config.max_gas_price()
+            {
+                return Err(UserInputError::GasPriceTooHigh {
+                    max_gas_price: config.max_gas_price(),
+                }
+                .into());
+            }
+
+            Ok(Self::V2(SuiGasStatusV2::new_with_budget(
+                gas_budget,
                 gas_price,
                 reference_gas_price,
+                config,
+            )))
+        }
+
+        pub fn new_unmetered() -> Self {
+            Self::V2(SuiGasStatusV2::new_unmetered())
+        }
+
+        // This is the only public API on SuiGasStatus, all other gas related operations should
+        // go through `GasCharger`
+        pub fn check_gas_balance(&self, gas_objs: &[&Object], gas_budget: u64) -> UserInputResult {
+            match self {
+                Self::V2(status) => status.check_gas_balance(gas_objs, gas_budget),
             }
-            .into());
         }
-        if gas_price_too_high(config.gas_model_version())
-            && gas_price >= config.max_gas_price()
-        {
-            return Err(UserInputError::GasPriceTooHigh {
-                max_gas_price: config.max_gas_price(),
+    }
+
+    /// Summary of the charges in a transaction.
+    /// Storage is charged independently of computation.
+    /// There are 3 parts to the storage charges:
+    /// `storage_cost`: it is the charge of storage at the time the transaction is executed.
+    ///                 The cost of storage is the number of bytes of the objects being mutated
+    ///                 multiplied by a variable storage cost per byte
+    /// `storage_rebate`: this is the amount a user gets back when manipulating an object.
+    ///                   The `storage_rebate` is the `storage_cost` for an object minus fees.
+    /// `non_refundable_storage_fee`: not all the value of the object storage cost is
+    ///                               given back to user and there is a small fraction that
+    ///                               is kept by the system. This value tracks that charge.
+    ///
+    /// When looking at a gas cost summary the amount charged to the user is
+    /// `computation_cost + storage_cost - storage_rebate`
+    /// and that is the amount that is deducted from the gas coins.
+    /// `non_refundable_storage_fee` is collected from the objects being mutated/deleted
+    /// and it is tracked by the system in storage funds.
+    ///
+    /// Objects deleted, including the older versions of objects mutated, have the storage field
+    /// on the objects added up to a pool of "potential rebate". This rebate then is reduced
+    /// by the "nonrefundable rate" such that:
+    /// `potential_rebate(storage cost of deleted/mutated objects) =
+    /// storage_rebate + non_refundable_storage_fee`
+
+    #[serde_as]
+    #[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GasCostSummary {
+        /// Cost of computation/execution
+        #[schemars(with = "BigInt<u64>")]
+        #[serde_as(as = "Readable<BigInt<u64>, _>")]
+        pub computation_cost: u64,
+        /// Storage cost, it's the sum of all storage cost for all objects created or mutated.
+        #[schemars(with = "BigInt<u64>")]
+        #[serde_as(as = "Readable<BigInt<u64>, _>")]
+        pub storage_cost: u64,
+        /// The amount of storage cost refunded to the user for all objects deleted or mutated in the
+        /// transaction.
+        #[schemars(with = "BigInt<u64>")]
+        #[serde_as(as = "Readable<BigInt<u64>, _>")]
+        pub storage_rebate: u64,
+        /// The fee for the rebate. The portion of the storage rebate kept by the system.
+        #[schemars(with = "BigInt<u64>")]
+        #[serde_as(as = "Readable<BigInt<u64>, _>")]
+        pub non_refundable_storage_fee: u64,
+    }
+
+    impl GasCostSummary {
+        pub fn new(
+            computation_cost: u64,
+            storage_cost: u64,
+            storage_rebate: u64,
+            non_refundable_storage_fee: u64,
+        ) -> GasCostSummary {
+            GasCostSummary {
+                computation_cost,
+                storage_cost,
+                storage_rebate,
+                non_refundable_storage_fee,
             }
-            .into());
         }
 
-        Ok(Self::V2(SuiGasStatusV2::new_with_budget(
-            gas_budget,
-            gas_price,
-            reference_gas_price,
-            config,
-        )))
-    }
-
-    pub fn new_unmetered() -> Self {
-        Self::V2(SuiGasStatusV2::new_unmetered())
-    }
-
-    // This is the only public API on SuiGasStatus, all other gas related operations should
-    // go through `GasCharger`
-    pub fn check_gas_balance(&self, gas_objs: &[&Object], gas_budget: u64) -> UserInputResult {
-        match self {
-            Self::V2(status) => status.check_gas_balance(gas_objs, gas_budget),
+        pub fn gas_used(&self) -> u64 {
+            self.computation_cost + self.storage_cost
         }
-    }
-}
 
-/// Summary of the charges in a transaction.
-/// Storage is charged independently of computation.
-/// There are 3 parts to the storage charges:
-/// `storage_cost`: it is the charge of storage at the time the transaction is executed.
-///                 The cost of storage is the number of bytes of the objects being mutated
-///                 multiplied by a variable storage cost per byte
-/// `storage_rebate`: this is the amount a user gets back when manipulating an object.
-///                   The `storage_rebate` is the `storage_cost` for an object minus fees.
-/// `non_refundable_storage_fee`: not all the value of the object storage cost is
-///                               given back to user and there is a small fraction that
-///                               is kept by the system. This value tracks that charge.
-///
-/// When looking at a gas cost summary the amount charged to the user is
-/// `computation_cost + storage_cost - storage_rebate`
-/// and that is the amount that is deducted from the gas coins.
-/// `non_refundable_storage_fee` is collected from the objects being mutated/deleted
-/// and it is tracked by the system in storage funds.
-///
-/// Objects deleted, including the older versions of objects mutated, have the storage field
-/// on the objects added up to a pool of "potential rebate". This rebate then is reduced
-/// by the "nonrefundable rate" such that:
-/// `potential_rebate(storage cost of deleted/mutated objects) =
-/// storage_rebate + non_refundable_storage_fee`
-
-#[serde_as]
-#[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct GasCostSummary {
-    /// Cost of computation/execution
-    #[schemars(with = "BigInt<u64>")]
-    #[serde_as(as = "Readable<BigInt<u64>, _>")]
-    pub computation_cost: u64,
-    /// Storage cost, it's the sum of all storage cost for all objects created or mutated.
-    #[schemars(with = "BigInt<u64>")]
-    #[serde_as(as = "Readable<BigInt<u64>, _>")]
-    pub storage_cost: u64,
-    /// The amount of storage cost refunded to the user for all objects deleted or mutated in the
-    /// transaction.
-    #[schemars(with = "BigInt<u64>")]
-    #[serde_as(as = "Readable<BigInt<u64>, _>")]
-    pub storage_rebate: u64,
-    /// The fee for the rebate. The portion of the storage rebate kept by the system.
-    #[schemars(with = "BigInt<u64>")]
-    #[serde_as(as = "Readable<BigInt<u64>, _>")]
-    pub non_refundable_storage_fee: u64,
-}
-
-impl GasCostSummary {
-    pub fn new(
-        computation_cost: u64,
-        storage_cost: u64,
-        storage_rebate: u64,
-        non_refundable_storage_fee: u64,
-    ) -> GasCostSummary {
-        GasCostSummary {
-            computation_cost,
-            storage_cost,
-            storage_rebate,
-            non_refundable_storage_fee,
-        }
-    }
-
-    pub fn gas_used(&self) -> u64 {
-        self.computation_cost + self.storage_cost
-    }
-
-    /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
-    /// will be burned, then re-minted + added to the storage fund at the next epoch change
-    pub fn sender_rebate(&self, storage_rebate_rate: u64) -> u64 {
-        // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
-        // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
-        const BASIS_POINTS: u128 = 10000;
-        (((self.storage_rebate as u128 * storage_rebate_rate as u128)
+        /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+        /// will be burned, then re-minted + added to the storage fund at the next epoch change
+        pub fn sender_rebate(&self, storage_rebate_rate: u64) -> u64 {
+            // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+            // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+            const BASIS_POINTS: u128 = 10000;
+            (((self.storage_rebate as u128 * storage_rebate_rate as u128)
             + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
             / BASIS_POINTS) as u64
-    }
+        }
 
-    /// Get net gas usage, positive number means used gas; negative number means refund.
-    pub fn net_gas_usage(&self) -> i64 {
-        self.gas_used() as i64 - self.storage_rebate as i64
-    }
+        /// Get net gas usage, positive number means used gas; negative number means refund.
+        pub fn net_gas_usage(&self) -> i64 {
+            self.gas_used() as i64 - self.storage_rebate as i64
+        }
 
-    pub fn new_from_txn_effects<'a>(
-        transactions: impl Iterator<Item = &'a TransactionEffects>,
-    ) -> GasCostSummary {
-        let (storage_costs, computation_costs, storage_rebates, non_refundable_storage_fee): (
-            Vec<u64>,
-            Vec<u64>,
-            Vec<u64>,
-            Vec<u64>,
-        ) = transactions
-            .map(|e| {
-                (
-                    e.gas_cost_summary().storage_cost,
-                    e.gas_cost_summary().computation_cost,
-                    e.gas_cost_summary().storage_rebate,
-                    e.gas_cost_summary().non_refundable_storage_fee,
-                )
-            })
-            .multiunzip();
+        pub fn new_from_txn_effects<'a>(
+            transactions: impl Iterator<Item = &'a TransactionEffects>,
+        ) -> GasCostSummary {
+            let (storage_costs, computation_costs, storage_rebates, non_refundable_storage_fee): (
+                Vec<u64>,
+                Vec<u64>,
+                Vec<u64>,
+                Vec<u64>,
+            ) = transactions
+                .map(|e| {
+                    (
+                        e.gas_cost_summary().storage_cost,
+                        e.gas_cost_summary().computation_cost,
+                        e.gas_cost_summary().storage_rebate,
+                        e.gas_cost_summary().non_refundable_storage_fee,
+                    )
+                })
+                .multiunzip();
 
-        GasCostSummary {
-            storage_cost: storage_costs.iter().sum(),
-            computation_cost: computation_costs.iter().sum(),
-            storage_rebate: storage_rebates.iter().sum(),
-            non_refundable_storage_fee: non_refundable_storage_fee.iter().sum(),
+            GasCostSummary {
+                storage_cost: storage_costs.iter().sum(),
+                computation_cost: computation_costs.iter().sum(),
+                storage_rebate: storage_rebates.iter().sum(),
+                non_refundable_storage_fee: non_refundable_storage_fee.iter().sum(),
+            }
         }
     }
-}
 
-impl std::fmt::Display for GasCostSummary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
+    impl std::fmt::Display for GasCostSummary {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
             f,
             "computation_cost: {}, storage_cost: {},  storage_rebate: {}, non_refundable_storage_fee: {}",
             self.computation_cost, self.storage_cost, self.storage_rebate, self.non_refundable_storage_fee,
         )
-    }
-}
-
-//
-// Helper functions to deal with gas coins operations.
-//
-
-pub fn deduct_gas(gas_object: &mut Object, charge_or_rebate: i64) {
-    // The object must be a gas coin as we have checked in transaction handle phase.
-    let gas_coin = gas_object.data.try_as_move_mut().unwrap();
-    let balance = gas_coin.get_coin_value_unsafe();
-    let new_balance = if charge_or_rebate < 0 {
-        balance + (-charge_or_rebate as u64)
-    } else {
-        assert!(balance >= charge_or_rebate as u64);
-        balance - charge_or_rebate as u64
-    };
-    gas_coin.set_coin_value_unsafe(new_balance)
-}
-
-pub fn get_gas_balance(gas_object: &Object) -> UserInputResult<u64> {
-    if let Some(move_obj) = gas_object.data.try_as_move() {
-        if !move_obj.type_().is_gas_coin() {
-            return Err(UserInputError::InvalidGasObject {
-                object_id: gas_object.id(),
-            });
         }
-        Ok(move_obj.get_coin_value_unsafe())
-    } else {
-        Err(UserInputError::InvalidGasObject {
-            object_id: gas_object.id(),
-        })
     }
-}
 
+    //
+    // Helper functions to deal with gas coins operations.
+    //
+
+    pub fn deduct_gas(gas_object: &mut Object, charge_or_rebate: i64) {
+        // The object must be a gas coin as we have checked in transaction handle phase.
+        let gas_coin = gas_object.data.try_as_move_mut().unwrap();
+        let balance = gas_coin.get_coin_value_unsafe();
+        let new_balance = if charge_or_rebate < 0 {
+            balance + (-charge_or_rebate as u64)
+        } else {
+            assert!(balance >= charge_or_rebate as u64);
+            balance - charge_or_rebate as u64
+        };
+        gas_coin.set_coin_value_unsafe(new_balance)
+    }
+
+    pub fn get_gas_balance(gas_object: &Object) -> UserInputResult<u64> {
+        if let Some(move_obj) = gas_object.data.try_as_move() {
+            if !move_obj.type_().is_gas_coin() {
+                return Err(UserInputError::InvalidGasObject {
+                    object_id: gas_object.id(),
+                });
+            }
+            Ok(move_obj.get_coin_value_unsafe())
+        } else {
+            Err(UserInputError::InvalidGasObject {
+                object_id: gas_object.id(),
+            })
+        }
+    }
 }

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -27,128 +27,134 @@ pub const MIST_PER_SUI: u64 = 1_000_000_000;
 /// Total supply denominated in Sui
 pub const TOTAL_SUPPLY_SUI: u64 = 10_000_000_000;
 
+// Note: cannot use checked arithmetic here since `const unwrap` is still unstable.
 /// Total supply denominated in Mist
 pub const TOTAL_SUPPLY_MIST: u64 = TOTAL_SUPPLY_SUI * MIST_PER_SUI;
 
 pub const GAS_MODULE_NAME: &IdentStr = ident_str!("sui");
 pub const GAS_STRUCT_NAME: &IdentStr = ident_str!("SUI");
 
-sui_macros::checked_arithmetic! {
+pub use checked::*;
 
-pub struct GAS {}
-impl GAS {
-    pub fn type_() -> StructTag {
-        StructTag {
-            address: SUI_FRAMEWORK_ADDRESS,
-            name: GAS_STRUCT_NAME.to_owned(),
-            module: GAS_MODULE_NAME.to_owned(),
-            type_params: Vec::new(),
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use super::*;
+
+    pub struct GAS {}
+    impl GAS {
+        pub fn type_() -> StructTag {
+            StructTag {
+                address: SUI_FRAMEWORK_ADDRESS,
+                name: GAS_STRUCT_NAME.to_owned(),
+                module: GAS_MODULE_NAME.to_owned(),
+                type_params: Vec::new(),
+            }
+        }
+
+        pub fn type_tag() -> TypeTag {
+            TypeTag::Struct(Box::new(Self::type_()))
+        }
+
+        pub fn is_gas(other: &StructTag) -> bool {
+            &Self::type_() == other
+        }
+
+        pub fn is_gas_type(other: &TypeTag) -> bool {
+            match other {
+                TypeTag::Struct(s) => Self::is_gas(s),
+                _ => false,
+            }
         }
     }
 
-    pub fn type_tag() -> TypeTag {
-        TypeTag::Struct(Box::new(Self::type_()))
-    }
+    /// Rust version of the Move sui::coin::Coin<Sui::sui::SUI> type
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GasCoin(pub Coin);
 
-    pub fn is_gas(other: &StructTag) -> bool {
-        &Self::type_() == other
-    }
+    impl GasCoin {
+        pub fn new(id: ObjectID, value: u64) -> Self {
+            Self(Coin::new(UID::new(id), value))
+        }
 
-    pub fn is_gas_type(other: &TypeTag) -> bool {
-        match other {
-            TypeTag::Struct(s) => Self::is_gas(s),
-            _ => false,
+        pub fn value(&self) -> u64 {
+            self.0.value()
+        }
+
+        pub fn type_() -> StructTag {
+            Coin::type_(TypeTag::Struct(Box::new(GAS::type_())))
+        }
+
+        /// Return `true` if `s` is the type of a gas coin (i.e., 0x2::coin::Coin<0x2::sui::SUI>)
+        pub fn is_gas_coin(s: &StructTag) -> bool {
+            Coin::is_coin(s) && s.type_params.len() == 1 && GAS::is_gas_type(&s.type_params[0])
+        }
+
+        /// Return `true` if `s` is the type of a gas balance (i.e., 0x2::balance::Balance<0x2::sui::SUI>)
+        pub fn is_gas_balance(s: &StructTag) -> bool {
+            Balance::is_balance(s)
+                && s.type_params.len() == 1
+                && GAS::is_gas_type(&s.type_params[0])
+        }
+
+        pub fn id(&self) -> &ObjectID {
+            self.0.id()
+        }
+
+        pub fn to_bcs_bytes(&self) -> Vec<u8> {
+            bcs::to_bytes(&self).unwrap()
+        }
+
+        pub fn to_object(&self, version: SequenceNumber) -> MoveObject {
+            MoveObject::new_gas_coin(version, *self.id(), self.value())
+        }
+
+        pub fn layout() -> MoveStructLayout {
+            Coin::layout(TypeTag::Struct(Box::new(GAS::type_())))
+        }
+
+        #[cfg(test)]
+        pub fn new_for_testing(value: u64) -> Self {
+            Self::new(ObjectID::random(), value)
         }
     }
-}
 
-/// Rust version of the Move sui::coin::Coin<Sui::sui::SUI> type
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GasCoin(pub Coin);
+    impl TryFrom<&MoveObject> for GasCoin {
+        type Error = ExecutionError;
 
-impl GasCoin {
-    pub fn new(id: ObjectID, value: u64) -> Self {
-        Self(Coin::new(UID::new(id), value))
-    }
-
-    pub fn value(&self) -> u64 {
-        self.0.value()
-    }
-
-    pub fn type_() -> StructTag {
-        Coin::type_(TypeTag::Struct(Box::new(GAS::type_())))
-    }
-
-    /// Return `true` if `s` is the type of a gas coin (i.e., 0x2::coin::Coin<0x2::sui::SUI>)
-    pub fn is_gas_coin(s: &StructTag) -> bool {
-        Coin::is_coin(s) && s.type_params.len() == 1 && GAS::is_gas_type(&s.type_params[0])
-    }
-
-    /// Return `true` if `s` is the type of a gas balance (i.e., 0x2::balance::Balance<0x2::sui::SUI>)
-    pub fn is_gas_balance(s: &StructTag) -> bool {
-        Balance::is_balance(s) && s.type_params.len() == 1 && GAS::is_gas_type(&s.type_params[0])
-    }
-
-    pub fn id(&self) -> &ObjectID {
-        self.0.id()
-    }
-
-    pub fn to_bcs_bytes(&self) -> Vec<u8> {
-        bcs::to_bytes(&self).unwrap()
-    }
-
-    pub fn to_object(&self, version: SequenceNumber) -> MoveObject {
-        MoveObject::new_gas_coin(version, *self.id(), self.value())
-    }
-
-    pub fn layout() -> MoveStructLayout {
-        Coin::layout(TypeTag::Struct(Box::new(GAS::type_())))
-    }
-
-    #[cfg(test)]
-    pub fn new_for_testing(value: u64) -> Self {
-        Self::new(ObjectID::random(), value)
-    }
-}
-
-impl TryFrom<&MoveObject> for GasCoin {
-    type Error = ExecutionError;
-
-    fn try_from(value: &MoveObject) -> Result<GasCoin, ExecutionError> {
-        if !value.type_().is_gas_coin() {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::InvalidGasObject,
-                format!("Gas object type is not a gas coin: {}", value.type_()),
-            ));
-        }
-        let gas_coin: GasCoin = bcs::from_bytes(value.contents()).map_err(|err| {
-            ExecutionError::new_with_source(
-                ExecutionErrorKind::InvalidGasObject,
-                format!("Unable to deserialize gas object: {:?}", err),
-            )
-        })?;
-        Ok(gas_coin)
-    }
-}
-
-impl TryFrom<&Object> for GasCoin {
-    type Error = ExecutionError;
-
-    fn try_from(value: &Object) -> Result<GasCoin, ExecutionError> {
-        match &value.data {
-            Data::Move(obj) => obj.try_into(),
-            Data::Package(_) => Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::InvalidGasObject,
-                format!("Gas object type is not a gas coin: {:?}", value),
-            )),
+        fn try_from(value: &MoveObject) -> Result<GasCoin, ExecutionError> {
+            if !value.type_().is_gas_coin() {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::InvalidGasObject,
+                    format!("Gas object type is not a gas coin: {}", value.type_()),
+                ));
+            }
+            let gas_coin: GasCoin = bcs::from_bytes(value.contents()).map_err(|err| {
+                ExecutionError::new_with_source(
+                    ExecutionErrorKind::InvalidGasObject,
+                    format!("Unable to deserialize gas object: {:?}", err),
+                )
+            })?;
+            Ok(gas_coin)
         }
     }
-}
 
-impl Display for GasCoin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Coin {{ id: {}, value: {} }}", self.id(), self.value())
+    impl TryFrom<&Object> for GasCoin {
+        type Error = ExecutionError;
+
+        fn try_from(value: &Object) -> Result<GasCoin, ExecutionError> {
+            match &value.data {
+                Data::Move(obj) => obj.try_into(),
+                Data::Package(_) => Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::InvalidGasObject,
+                    format!("Gas object type is not a gas coin: {:?}", value),
+                )),
+            }
+        }
     }
-}
 
+    impl Display for GasCoin {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Coin {{ id: {}, value: {} }}", self.id(), self.value())
+        }
+    }
 }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -2,464 +2,465 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{UserInputError, UserInputResult};
-use crate::gas::{self, GasCostSummary, SuiGasStatusAPI};
-use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
-use crate::gas_model::units_types::CostTable;
-use crate::{
-    error::{ExecutionError, ExecutionErrorKind},
-    gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
-    object::{Object, Owner},
-};
-use move_core_types::vm_status::StatusCode;
-use sui_protocol_config::*;
+pub use checked::*;
 
-sui_macros::checked_arithmetic! {
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use crate::error::{UserInputError, UserInputResult};
+    use crate::gas::{self, GasCostSummary, SuiGasStatusAPI};
+    use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
+    use crate::gas_model::units_types::CostTable;
+    use crate::{
+        error::{ExecutionError, ExecutionErrorKind},
+        gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
+        object::{Object, Owner},
+    };
+    use move_core_types::vm_status::StatusCode;
+    use sui_protocol_config::*;
 
-/// A bucket defines a range of units that will be priced the same.
-/// After execution a call to `GasStatus::bucketize` will round the computation
-/// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
-#[allow(dead_code)]
-pub(crate) struct ComputationBucket {
-    min: u64,
-    max: u64,
-    cost: u64,
-}
-
-impl ComputationBucket {
-    fn new(min: u64, max: u64, cost: u64) -> Self {
-        ComputationBucket { min, max, cost }
+    /// A bucket defines a range of units that will be priced the same.
+    /// After execution a call to `GasStatus::bucketize` will round the computation
+    /// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
+    #[allow(dead_code)]
+    pub(crate) struct ComputationBucket {
+        min: u64,
+        max: u64,
+        cost: u64,
     }
 
-    fn simple(min: u64, max: u64) -> Self {
-        Self::new(min, max, max)
-    }
-}
+    impl ComputationBucket {
+        fn new(min: u64, max: u64, cost: u64) -> Self {
+            ComputationBucket { min, max, cost }
+        }
 
-fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
-    for bucket in table {
-        if bucket.max >= computation_cost {
-            return bucket.cost;
+        fn simple(min: u64, max: u64) -> Self {
+            Self::new(min, max, max)
         }
     }
-    match table.last() {
-        // maybe not a literal here could be better?
-        None => 5_000_000,
-        Some(bucket) => bucket.cost,
+
+    fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
+        for bucket in table {
+            if bucket.max >= computation_cost {
+                return bucket.cost;
+            }
+        }
+        match table.last() {
+            // maybe not a literal here could be better?
+            None => 5_000_000,
+            Some(bucket) => bucket.cost,
+        }
     }
-}
 
-// define the bucket table for computation charging
-// If versioning defines multiple functions and
-fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
-    assert!(max_bucket_cost >= 5_000_000);
-    vec![
-        ComputationBucket::simple(0, 1_000),
-        ComputationBucket::simple(1_000, 5_000),
-        ComputationBucket::simple(5_000, 10_000),
-        ComputationBucket::simple(10_000, 20_000),
-        ComputationBucket::simple(20_000, 50_000),
-        ComputationBucket::simple(50_000, 200_000),
-        ComputationBucket::simple(200_000, 1_000_000),
-        ComputationBucket::simple(1_000_000, max_bucket_cost),
-    ]
-}
+    // define the bucket table for computation charging
+    // If versioning defines multiple functions and
+    fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
+        assert!(max_bucket_cost >= 5_000_000);
+        vec![
+            ComputationBucket::simple(0, 1_000),
+            ComputationBucket::simple(1_000, 5_000),
+            ComputationBucket::simple(5_000, 10_000),
+            ComputationBucket::simple(10_000, 20_000),
+            ComputationBucket::simple(20_000, 50_000),
+            ComputationBucket::simple(50_000, 200_000),
+            ComputationBucket::simple(200_000, 1_000_000),
+            ComputationBucket::simple(1_000_000, max_bucket_cost),
+        ]
+    }
 
-/// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
-/// will be burned, then re-minted + added to the storage fund at the next epoch change
-fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
-    // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
-    // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
-    const BASIS_POINTS: u128 = 10000;
-    (((storage_rebate as u128 * storage_rebate_rate as u128)
+    /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+    /// will be burned, then re-minted + added to the storage fund at the next epoch change
+    fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
+        // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+        // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+        const BASIS_POINTS: u128 = 10000;
+        (((storage_rebate as u128 * storage_rebate_rate as u128)
         + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
         / BASIS_POINTS) as u64
-}
-
-/// A list of constant costs of various operations in Sui.
-pub struct SuiCostTable {
-    /// A flat fee charged for every transaction. This is also the minimum amount of
-    /// gas charged for a transaction.
-    pub(crate) min_transaction_cost: u64,
-    /// Maximum allowable budget for a transaction.
-    pub(crate) max_gas_budget: u64,
-    /// Computation cost per byte charged for package publish. This cost is primarily
-    /// determined by the cost to verify and link a package. Note that this does not
-    /// include the cost of writing the package to the store.
-    package_publish_per_byte_cost: u64,
-    /// Per byte cost to read objects from the store. This is computation cost instead of
-    /// storage cost because it does not change the amount of data stored on the db.
-    object_read_per_byte_cost: u64,
-    /// Unit cost of a byte in the storage. This will be used both for charging for
-    /// new storage as well as rebating for deleting storage. That is, we expect users to
-    /// get full refund on the object storage when it's deleted.
-    storage_per_byte_cost: u64,
-    /// Execution cost table to be used.
-    pub execution_cost_table: CostTable,
-    /// Computation buckets to cost transaction in price groups
-    computation_bucket: Vec<ComputationBucket>,
-}
-
-impl std::fmt::Debug for SuiCostTable {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: dump the fields.
-        write!(f, "SuiCostTable(...)")
     }
-}
 
-impl SuiCostTable {
-    pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
-        // gas_price here is the Reference Gas Price, however we may decide
-        // to change it to be the price passed in the transaction
-        let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
-            c.base_tx_cost_fixed() * gas_price
-        } else {
-            c.base_tx_cost_fixed()
-        };
-        Self {
-            min_transaction_cost,
-            max_gas_budget: c.max_tx_gas(),
-            package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
-            object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
-            storage_per_byte_cost: c.obj_data_cost_refundable(),
-            execution_cost_table: cost_table_for_version(c.gas_model_version()),
-            computation_bucket: computation_bucket(c.max_gas_computation_bucket()),
+    /// A list of constant costs of various operations in Sui.
+    pub struct SuiCostTable {
+        /// A flat fee charged for every transaction. This is also the minimum amount of
+        /// gas charged for a transaction.
+        pub(crate) min_transaction_cost: u64,
+        /// Maximum allowable budget for a transaction.
+        pub(crate) max_gas_budget: u64,
+        /// Computation cost per byte charged for package publish. This cost is primarily
+        /// determined by the cost to verify and link a package. Note that this does not
+        /// include the cost of writing the package to the store.
+        package_publish_per_byte_cost: u64,
+        /// Per byte cost to read objects from the store. This is computation cost instead of
+        /// storage cost because it does not change the amount of data stored on the db.
+        object_read_per_byte_cost: u64,
+        /// Unit cost of a byte in the storage. This will be used both for charging for
+        /// new storage as well as rebating for deleting storage. That is, we expect users to
+        /// get full refund on the object storage when it's deleted.
+        storage_per_byte_cost: u64,
+        /// Execution cost table to be used.
+        pub execution_cost_table: CostTable,
+        /// Computation buckets to cost transaction in price groups
+        computation_bucket: Vec<ComputationBucket>,
+    }
+
+    impl std::fmt::Debug for SuiCostTable {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            // TODO: dump the fields.
+            write!(f, "SuiCostTable(...)")
         }
     }
 
-    pub(crate) fn unmetered() -> Self {
-        Self {
-            min_transaction_cost: 0,
-            max_gas_budget: u64::MAX,
-            package_publish_per_byte_cost: 0,
-            object_read_per_byte_cost: 0,
-            storage_per_byte_cost: 0,
-            execution_cost_table: ZERO_COST_SCHEDULE.clone(),
-            // should not matter
-            computation_bucket: computation_bucket(5_000_000),
+    impl SuiCostTable {
+        pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
+            // gas_price here is the Reference Gas Price, however we may decide
+            // to change it to be the price passed in the transaction
+            let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
+                c.base_tx_cost_fixed() * gas_price
+            } else {
+                c.base_tx_cost_fixed()
+            };
+            Self {
+                min_transaction_cost,
+                max_gas_budget: c.max_tx_gas(),
+                package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
+                object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
+                storage_per_byte_cost: c.obj_data_cost_refundable(),
+                execution_cost_table: cost_table_for_version(c.gas_model_version()),
+                computation_bucket: computation_bucket(c.max_gas_computation_bucket()),
+            }
+        }
+
+        pub(crate) fn unmetered() -> Self {
+            Self {
+                min_transaction_cost: 0,
+                max_gas_budget: u64::MAX,
+                package_publish_per_byte_cost: 0,
+                object_read_per_byte_cost: 0,
+                storage_per_byte_cost: 0,
+                execution_cost_table: ZERO_COST_SCHEDULE.clone(),
+                // should not matter
+                computation_bucket: computation_bucket(5_000_000),
+            }
         }
     }
-}
 
-#[allow(dead_code)]
-#[derive(Debug)]
-pub struct SuiGasStatus {
-    // GasStatus as used by the VM, that is all the VM sees
-    pub gas_status: GasStatus,
-    // Cost table contains a set of constant/config for the gas model/charging
-    cost_table: SuiCostTable,
-    // Gas budget for this gas status instance.
-    // Typically the gas budget as defined in the `TransactionData::GasData`
-    gas_budget: u64,
-    // Computation cost after execution. This is the result of the gas used by the `GasStatus`
-    // properly bucketized.
-    // Starts at 0 and it is assigned in `bucketize_computation`.
-    computation_cost: u64,
-    // Whether to charge or go unmetered
-    charge: bool,
-    // Gas price for computation.
-    // This is a multiplier on the final charge as related to the RGP (reference gas price).
-    // Checked at signing: `gas_price >= reference_gas_price`
-    // and then conceptually
-    // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
-    gas_price: u64,
-    // RGP as defined in the protocol config.
-    reference_gas_price: u64,
-    // Gas price for storage. This is a multiplier on the final charge
-    // as related to the storage gas price defined in the system
-    // (`ProtocolConfig::storage_gas_price`).
-    // Conceptually, given a constant `obj_data_cost_refundable`
-    // (defined in `ProtocolConfig::obj_data_cost_refundable`)
-    // `total_storage_cost = storage_bytes * obj_data_cost_refundable`
-    // `final_storage_cost = total_storage_cost * storage_gas_price`
-    storage_gas_price: u64,
-    /// storage_cost is the total storage gas to charge. This is an accumulator computed
-    /// at the end of execution while determining storage charges.
-    /// It tracks `total_storage_cost = storage_bytes * obj_data_cost_refundable` as
-    /// described in `storage_gas_price`
-    /// It will be multiplied by the storage gas price.
-    storage_cost: u64,
-    /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
-    /// This is an accumulator computed at the end of execution while determining storage charges.
-    /// It is the sum of all `storage_rebate` of all objects mutated or deleted during
-    /// execution. The value is in Sui.
-    storage_rebate: u64,
-    // storage rebate rate as defined in the ProtocolConfig
-    rebate_rate: u64,
-    /// Amount of storage rebate accumulated when we are running in unmetered mode (i.e. system transaction).
-    /// This allows us to track how much storage rebate we need to retain in system transactions.
-    unmetered_storage_rebate: u64,
-    /// Rounding value to round up gas charges.
-    gas_rounding_step: Option<u64>,
-}
-
-impl SuiGasStatus {
-    fn new(
-        move_gas_status: GasStatus,
-        gas_budget: u64,
-        charge: bool,
-        gas_price: u64,
-        reference_gas_price: u64,
-        storage_gas_price: u64,
-        rebate_rate: u64,
-        gas_rounding_step: Option<u64>,
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    pub struct SuiGasStatus {
+        // GasStatus as used by the VM, that is all the VM sees
+        pub gas_status: GasStatus,
+        // Cost table contains a set of constant/config for the gas model/charging
         cost_table: SuiCostTable,
-    ) -> SuiGasStatus {
-        let gas_rounding_step = gas_rounding_step.map(|val| val.max(1));
-        SuiGasStatus {
-            gas_status: move_gas_status,
-            gas_budget,
-            charge,
-            computation_cost: 0,
-            gas_price,
-            reference_gas_price,
-            storage_gas_price,
-            storage_cost: 0,
-            storage_rebate: 0,
-            rebate_rate,
-            unmetered_storage_rebate: 0,
-            gas_rounding_step,
-            cost_table,
-        }
-    }
-
-    pub(crate) fn new_with_budget(
+        // Gas budget for this gas status instance.
+        // Typically the gas budget as defined in the `TransactionData::GasData`
         gas_budget: u64,
+        // Computation cost after execution. This is the result of the gas used by the `GasStatus`
+        // properly bucketized.
+        // Starts at 0 and it is assigned in `bucketize_computation`.
+        computation_cost: u64,
+        // Whether to charge or go unmetered
+        charge: bool,
+        // Gas price for computation.
+        // This is a multiplier on the final charge as related to the RGP (reference gas price).
+        // Checked at signing: `gas_price >= reference_gas_price`
+        // and then conceptually
+        // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
         gas_price: u64,
+        // RGP as defined in the protocol config.
         reference_gas_price: u64,
-        config: &ProtocolConfig,
-    ) -> SuiGasStatus {
-        let storage_gas_price = config.storage_gas_price();
-        let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
-        let computation_budget = if gas_budget > max_computation_budget {
-            max_computation_budget
-        } else {
-            gas_budget
-        };
-        let sui_cost_table = SuiCostTable::new(config, gas_price);
-        let gas_rounding_step = config.gas_rounding_step_as_option();
-        Self::new(
-            GasStatus::new(
-                sui_cost_table.execution_cost_table.clone(),
-                computation_budget,
+        // Gas price for storage. This is a multiplier on the final charge
+        // as related to the storage gas price defined in the system
+        // (`ProtocolConfig::storage_gas_price`).
+        // Conceptually, given a constant `obj_data_cost_refundable`
+        // (defined in `ProtocolConfig::obj_data_cost_refundable`)
+        // `total_storage_cost = storage_bytes * obj_data_cost_refundable`
+        // `final_storage_cost = total_storage_cost * storage_gas_price`
+        storage_gas_price: u64,
+        /// storage_cost is the total storage gas to charge. This is an accumulator computed
+        /// at the end of execution while determining storage charges.
+        /// It tracks `total_storage_cost = storage_bytes * obj_data_cost_refundable` as
+        /// described in `storage_gas_price`
+        /// It will be multiplied by the storage gas price.
+        storage_cost: u64,
+        /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
+        /// This is an accumulator computed at the end of execution while determining storage charges.
+        /// It is the sum of all `storage_rebate` of all objects mutated or deleted during
+        /// execution. The value is in Sui.
+        storage_rebate: u64,
+        // storage rebate rate as defined in the ProtocolConfig
+        rebate_rate: u64,
+        /// Amount of storage rebate accumulated when we are running in unmetered mode (i.e. system transaction).
+        /// This allows us to track how much storage rebate we need to retain in system transactions.
+        unmetered_storage_rebate: u64,
+        /// Rounding value to round up gas charges.
+        gas_rounding_step: Option<u64>,
+    }
+
+    impl SuiGasStatus {
+        fn new(
+            move_gas_status: GasStatus,
+            gas_budget: u64,
+            charge: bool,
+            gas_price: u64,
+            reference_gas_price: u64,
+            storage_gas_price: u64,
+            rebate_rate: u64,
+            gas_rounding_step: Option<u64>,
+            cost_table: SuiCostTable,
+        ) -> SuiGasStatus {
+            let gas_rounding_step = gas_rounding_step.map(|val| val.max(1));
+            SuiGasStatus {
+                gas_status: move_gas_status,
+                gas_budget,
+                charge,
+                computation_cost: 0,
                 gas_price,
-                config.gas_model_version(),
-            ),
-            gas_budget,
-            true,
-            gas_price,
-            reference_gas_price,
-            storage_gas_price,
-            config.storage_rebate_rate(),
-            gas_rounding_step,
-            sui_cost_table,
-        )
-    }
+                reference_gas_price,
+                storage_gas_price,
+                storage_cost: 0,
+                storage_rebate: 0,
+                rebate_rate,
+                unmetered_storage_rebate: 0,
+                gas_rounding_step,
+                cost_table,
+            }
+        }
 
-    pub fn new_unmetered() -> SuiGasStatus {
-        Self::new(
-            GasStatus::new_unmetered(),
-            0,
-            false,
-            0,
-            0,
-            0,
-            0,
-            None,
-            SuiCostTable::unmetered(),
-        )
-    }
+        pub(crate) fn new_with_budget(
+            gas_budget: u64,
+            gas_price: u64,
+            reference_gas_price: u64,
+            config: &ProtocolConfig,
+        ) -> SuiGasStatus {
+            let storage_gas_price = config.storage_gas_price();
+            let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
+            let computation_budget = if gas_budget > max_computation_budget {
+                max_computation_budget
+            } else {
+                gas_budget
+            };
+            let sui_cost_table = SuiCostTable::new(config, gas_price);
+            let gas_rounding_step = config.gas_rounding_step_as_option();
+            Self::new(
+                GasStatus::new(
+                    sui_cost_table.execution_cost_table.clone(),
+                    computation_budget,
+                    gas_price,
+                    config.gas_model_version(),
+                ),
+                gas_budget,
+                true,
+                gas_price,
+                reference_gas_price,
+                storage_gas_price,
+                config.storage_rebate_rate(),
+                gas_rounding_step,
+                sui_cost_table,
+            )
+        }
 
-    // Check whether gas arguments are legit:
-    // 1. Gas object has an address owner.
-    // 2. Gas budget is between min and max budget allowed
-    // 3. Gas balance (all gas coins together) is bigger or equal to budget
-    pub(crate) fn check_gas_balance(
-        &self,
-        gas_objs: &[&Object],
-        gas_budget: u64,
-    ) -> UserInputResult {
-        // 1. All gas objects have an address owner
-        for gas_object in gas_objs {
-            if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
-                return Err(UserInputError::GasObjectNotOwnedObject {
-                    owner: gas_object.owner,
+        pub fn new_unmetered() -> SuiGasStatus {
+            Self::new(
+                GasStatus::new_unmetered(),
+                0,
+                false,
+                0,
+                0,
+                0,
+                0,
+                None,
+                SuiCostTable::unmetered(),
+            )
+        }
+
+        // Check whether gas arguments are legit:
+        // 1. Gas object has an address owner.
+        // 2. Gas budget is between min and max budget allowed
+        // 3. Gas balance (all gas coins together) is bigger or equal to budget
+        pub(crate) fn check_gas_balance(
+            &self,
+            gas_objs: &[&Object],
+            gas_budget: u64,
+        ) -> UserInputResult {
+            // 1. All gas objects have an address owner
+            for gas_object in gas_objs {
+                if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
+                    return Err(UserInputError::GasObjectNotOwnedObject {
+                        owner: gas_object.owner,
+                    });
+                }
+            }
+
+            // 2. Gas budget is between min and max budget allowed
+            if gas_budget > self.cost_table.max_gas_budget {
+                return Err(UserInputError::GasBudgetTooHigh {
+                    gas_budget,
+                    max_budget: self.cost_table.max_gas_budget,
                 });
             }
-        }
-
-        // 2. Gas budget is between min and max budget allowed
-        if gas_budget > self.cost_table.max_gas_budget {
-            return Err(UserInputError::GasBudgetTooHigh {
-                gas_budget,
-                max_budget: self.cost_table.max_gas_budget,
-            });
-        }
-        if gas_budget < self.cost_table.min_transaction_cost {
-            return Err(UserInputError::GasBudgetTooLow {
-                gas_budget,
-                min_budget: self.cost_table.min_transaction_cost,
-            });
-        }
-
-        // 3. Gas balance (all gas coins together) is bigger or equal to budget
-        let mut gas_balance = 0u128;
-        for gas_obj in gas_objs {
-            gas_balance += gas::get_gas_balance(gas_obj)? as u128;
-        }
-        if gas_balance < gas_budget as u128 {
-            Err(UserInputError::GasBalanceTooLow {
-                gas_balance,
-                needed_gas_amount: gas_budget as u128,
-            })
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl SuiGasStatusAPI for SuiGasStatus {
-    fn is_unmetered(&self) -> bool {
-        !self.charge
-    }
-
-    fn move_gas_status(&self) -> &GasStatus {
-        &self.gas_status
-    }
-
-    fn move_gas_status_mut(&mut self) -> &mut GasStatus {
-        &mut self.gas_status
-    }
-
-    fn bucketize_computation(&mut self) -> Result<(), ExecutionError> {
-        let gas_used = self.gas_status.gas_used_pre_gas_price();
-        let gas_used = if let Some(gas_rounding) = self.gas_rounding_step {
-            if gas_used > 0 && gas_used % gas_rounding == 0 {
-                gas_used * self.gas_price
-            } else {
-                ((gas_used / gas_rounding) + 1) * gas_rounding * self.gas_price
+            if gas_budget < self.cost_table.min_transaction_cost {
+                return Err(UserInputError::GasBudgetTooLow {
+                    gas_budget,
+                    min_budget: self.cost_table.min_transaction_cost,
+                });
             }
-        } else {
-            let bucket_cost = get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
-            // charge extra on top of `computation_cost` to make the total computation
-            // cost a bucket value
-            bucket_cost * self.gas_price
-        };
-        if self.gas_budget <= gas_used {
-            self.computation_cost = self.gas_budget;
-            Err(ExecutionErrorKind::InsufficientGas.into())
-        } else {
-            self.computation_cost = gas_used;
-            Ok(())
-        }
-    }
 
-    /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
-    /// We use initial budget, combined with remaining gas and storage cost to derive
-    /// computation cost.
-    fn summary(&self) -> GasCostSummary {
-        // compute storage rebate, both rebate and non refundable fee
-        let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
-        assert!(sender_rebate <= self.storage_rebate);
-        let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
-        GasCostSummary {
-            computation_cost: self.computation_cost,
-            storage_cost: self.storage_cost,
-            storage_rebate: sender_rebate,
-            non_refundable_storage_fee,
-        }
-    }
-
-    fn gas_budget(&self) -> u64 {
-        self.gas_budget
-    }
-
-    fn storage_gas_units(&self) -> u64 {
-        self.storage_cost
-    }
-
-    fn storage_rebate(&self) -> u64 {
-        self.storage_rebate
-    }
-
-    fn unmetered_storage_rebate(&self) -> u64 {
-        self.unmetered_storage_rebate
-    }
-
-    fn gas_used(&self) -> u64 {
-        self.gas_status.gas_used_pre_gas_price()
-    }
-
-    fn reset_storage_cost_and_rebate(&mut self) {
-        self.storage_cost = 0;
-        self.storage_rebate = 0;
-        self.unmetered_storage_rebate = 0;
-    }
-
-    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
-        self.gas_status
-            .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
-            .map_err(|e| {
-                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                ExecutionErrorKind::InsufficientGas.into()
-            })
-    }
-
-    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-        self.gas_status
-            .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
-            .map_err(|e| {
-                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                ExecutionErrorKind::InsufficientGas.into()
-            })
-    }
-
-    /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
-    /// There is no charge in this function. Charges will all be applied together at the end
-    /// (`track_storage_mutation`).
-    /// Return the new storage rebate (cost of object storage) according to `new_size`.
-    fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
-        if self.is_unmetered() {
-            self.unmetered_storage_rebate += storage_rebate;
-            return 0;
-        }
-        self.storage_rebate += storage_rebate;
-        // compute and track cost (based on size)
-        let new_size = new_size as u64;
-        let storage_cost =
-            new_size * self.cost_table.storage_per_byte_cost * self.storage_gas_price;
-        // track rebate
-        self.storage_cost += storage_cost;
-        // return the new object rebate (object storage cost)
-        storage_cost
-    }
-
-    fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
-        let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
-        assert!(sender_rebate <= self.storage_rebate);
-        if sender_rebate >= self.storage_cost {
-            // there is more rebate than cost, when deducting gas we are adding
-            // to whatever is the current amount charged so we are `Ok`
-            Ok(())
-        } else {
-            let gas_left = self.gas_budget - self.computation_cost;
-            // we have to charge for storage and may go out of gas, check
-            if gas_left < self.storage_cost - sender_rebate {
-                // Running out of gas would cause the temporary store to reset
-                // and zero storage and rebate.
-                // The remaining_gas will be 0 and we will charge all in computation
-                Err(ExecutionErrorKind::InsufficientGas.into())
+            // 3. Gas balance (all gas coins together) is bigger or equal to budget
+            let mut gas_balance = 0u128;
+            for gas_obj in gas_objs {
+                gas_balance += gas::get_gas_balance(gas_obj)? as u128;
+            }
+            if gas_balance < gas_budget as u128 {
+                Err(UserInputError::GasBalanceTooLow {
+                    gas_balance,
+                    needed_gas_amount: gas_budget as u128,
+                })
             } else {
                 Ok(())
             }
         }
     }
 
-    fn adjust_computation_on_out_of_gas(&mut self) {
-        self.storage_rebate = 0;
-        self.storage_cost = 0;
-        self.computation_cost = self.gas_budget;
-    }
-}
+    impl SuiGasStatusAPI for SuiGasStatus {
+        fn is_unmetered(&self) -> bool {
+            !self.charge
+        }
 
+        fn move_gas_status(&self) -> &GasStatus {
+            &self.gas_status
+        }
+
+        fn move_gas_status_mut(&mut self) -> &mut GasStatus {
+            &mut self.gas_status
+        }
+
+        fn bucketize_computation(&mut self) -> Result<(), ExecutionError> {
+            let gas_used = self.gas_status.gas_used_pre_gas_price();
+            let gas_used = if let Some(gas_rounding) = self.gas_rounding_step {
+                if gas_used > 0 && gas_used % gas_rounding == 0 {
+                    gas_used * self.gas_price
+                } else {
+                    ((gas_used / gas_rounding) + 1) * gas_rounding * self.gas_price
+                }
+            } else {
+                let bucket_cost = get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
+                // charge extra on top of `computation_cost` to make the total computation
+                // cost a bucket value
+                bucket_cost * self.gas_price
+            };
+            if self.gas_budget <= gas_used {
+                self.computation_cost = self.gas_budget;
+                Err(ExecutionErrorKind::InsufficientGas.into())
+            } else {
+                self.computation_cost = gas_used;
+                Ok(())
+            }
+        }
+
+        /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
+        /// We use initial budget, combined with remaining gas and storage cost to derive
+        /// computation cost.
+        fn summary(&self) -> GasCostSummary {
+            // compute storage rebate, both rebate and non refundable fee
+            let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
+            assert!(sender_rebate <= self.storage_rebate);
+            let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
+            GasCostSummary {
+                computation_cost: self.computation_cost,
+                storage_cost: self.storage_cost,
+                storage_rebate: sender_rebate,
+                non_refundable_storage_fee,
+            }
+        }
+
+        fn gas_budget(&self) -> u64 {
+            self.gas_budget
+        }
+
+        fn storage_gas_units(&self) -> u64 {
+            self.storage_cost
+        }
+
+        fn storage_rebate(&self) -> u64 {
+            self.storage_rebate
+        }
+
+        fn unmetered_storage_rebate(&self) -> u64 {
+            self.unmetered_storage_rebate
+        }
+
+        fn gas_used(&self) -> u64 {
+            self.gas_status.gas_used_pre_gas_price()
+        }
+
+        fn reset_storage_cost_and_rebate(&mut self) {
+            self.storage_cost = 0;
+            self.storage_rebate = 0;
+            self.unmetered_storage_rebate = 0;
+        }
+
+        fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
+            self.gas_status
+                .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
+                .map_err(|e| {
+                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                    ExecutionErrorKind::InsufficientGas.into()
+                })
+        }
+
+        fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+            self.gas_status
+                .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
+                .map_err(|e| {
+                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                    ExecutionErrorKind::InsufficientGas.into()
+                })
+        }
+
+        /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
+        /// There is no charge in this function. Charges will all be applied together at the end
+        /// (`track_storage_mutation`).
+        /// Return the new storage rebate (cost of object storage) according to `new_size`.
+        fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+            if self.is_unmetered() {
+                self.unmetered_storage_rebate += storage_rebate;
+                return 0;
+            }
+            self.storage_rebate += storage_rebate;
+            // compute and track cost (based on size)
+            let new_size = new_size as u64;
+            let storage_cost =
+                new_size * self.cost_table.storage_per_byte_cost * self.storage_gas_price;
+            // track rebate
+            self.storage_cost += storage_cost;
+            // return the new object rebate (object storage cost)
+            storage_cost
+        }
+
+        fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
+            let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
+            assert!(sender_rebate <= self.storage_rebate);
+            if sender_rebate >= self.storage_cost {
+                // there is more rebate than cost, when deducting gas we are adding
+                // to whatever is the current amount charged so we are `Ok`
+                Ok(())
+            } else {
+                let gas_left = self.gas_budget - self.computation_cost;
+                // we have to charge for storage and may go out of gas, check
+                if gas_left < self.storage_cost - sender_rebate {
+                    // Running out of gas would cause the temporary store to reset
+                    // and zero storage and rebate.
+                    // The remaining_gas will be 0 and we will charge all in computation
+                    Err(ExecutionErrorKind::InsufficientGas.into())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        fn adjust_computation_on_out_of_gas(&mut self) {
+            self.storage_rebate = 0;
+            self.storage_cost = 0;
+            self.computation_cost = self.gas_budget;
+        }
+    }
 }

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -1,146 +1,149 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+pub use checked::*;
 
-use anyhow::Result;
-use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
-use move_bytecode_verifier::meter::Meter;
-use move_bytecode_verifier::verify_module_with_config_metered;
-use move_core_types::account_address::AccountAddress;
-use move_vm_config::{
-    runtime::{VMConfig, VMRuntimeLimitsConfig},
-    verifier::VerifierConfig,
-};
-use move_vm_runtime::{
-    move_vm::MoveVM, native_extensions::NativeContextExtensions,
-    native_functions::NativeFunctionTable,
-};
-use sui_move_natives::object_runtime;
-use sui_types::metrics::BytecodeVerifierMetrics;
-use sui_verifier::check_for_verifier_timeout;
-use tracing::instrument;
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use std::{collections::BTreeMap, sync::Arc};
 
-use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
-use sui_protocol_config::ProtocolConfig;
-use sui_types::{
-    base_types::*,
-    error::ExecutionError,
-    error::{ExecutionErrorKind, SuiError},
-    metrics::LimitsMetrics,
-    storage::ChildObjectResolver,
-};
-use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
-
-sui_macros::checked_arithmetic! {
-
-pub fn default_verifier_config(
-    protocol_config: &ProtocolConfig,
-    is_metered: bool,
-) -> VerifierConfig {
-    let (
-        max_back_edges_per_function,
-        max_back_edges_per_module,
-        max_per_fun_meter_units,
-        max_per_mod_meter_units,
-    ) = if is_metered {
-        (
-            Some(protocol_config.max_back_edges_per_function() as usize),
-            Some(protocol_config.max_back_edges_per_module() as usize),
-            Some(protocol_config.max_verifier_meter_ticks_per_function() as u128),
-            Some(protocol_config.max_meter_ticks_per_module() as u128),
-        )
-    } else {
-        (None, None, None, None)
+    use anyhow::Result;
+    use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
+    use move_bytecode_verifier::meter::Meter;
+    use move_bytecode_verifier::verify_module_with_config_metered;
+    use move_core_types::account_address::AccountAddress;
+    use move_vm_config::{
+        runtime::{VMConfig, VMRuntimeLimitsConfig},
+        verifier::VerifierConfig,
     };
+    use move_vm_runtime::{
+        move_vm::MoveVM, native_extensions::NativeContextExtensions,
+        native_functions::NativeFunctionTable,
+    };
+    use sui_move_natives::object_runtime;
+    use sui_types::metrics::BytecodeVerifierMetrics;
+    use sui_verifier::check_for_verifier_timeout;
+    use tracing::instrument;
 
-    VerifierConfig {
-        max_loop_depth: Some(protocol_config.max_loop_depth() as usize),
-        max_generic_instantiation_length: Some(
-            protocol_config.max_generic_instantiation_length() as usize
-        ),
-        max_function_parameters: Some(protocol_config.max_function_parameters() as usize),
-        max_basic_blocks: Some(protocol_config.max_basic_blocks() as usize),
-        max_value_stack_size: protocol_config.max_value_stack_size() as usize,
-        max_type_nodes: Some(protocol_config.max_type_nodes() as usize),
-        max_push_size: Some(protocol_config.max_push_size() as usize),
-        max_dependency_depth: Some(protocol_config.max_dependency_depth() as usize),
-        max_fields_in_struct: Some(protocol_config.max_fields_in_struct() as usize),
-        max_function_definitions: Some(protocol_config.max_function_definitions() as usize),
-        max_struct_definitions: Some(protocol_config.max_struct_definitions() as usize),
-        max_constant_vector_len: Some(protocol_config.max_move_vector_len()),
-        max_back_edges_per_function,
-        max_back_edges_per_module,
-        max_basic_blocks_in_script: None,
-        max_per_fun_meter_units,
-        max_per_mod_meter_units,
-        max_idenfitier_len: protocol_config.max_move_identifier_len_as_option(), // Before protocol version 9, there was no limit
-    }
-}
+    use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::{
+        base_types::*,
+        error::ExecutionError,
+        error::{ExecutionErrorKind, SuiError},
+        metrics::LimitsMetrics,
+        storage::ChildObjectResolver,
+    };
+    use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
-pub fn new_move_vm(
-    natives: NativeFunctionTable,
-    protocol_config: &ProtocolConfig,
-    paranoid_type_checks: bool,
-) -> Result<MoveVM, SuiError> {
-    MoveVM::new_with_config(
-        natives,
-        VMConfig {
-            verifier: default_verifier_config(
-                protocol_config,
-                false, /* we do not enable metering in execution*/
+    pub fn default_verifier_config(
+        protocol_config: &ProtocolConfig,
+        is_metered: bool,
+    ) -> VerifierConfig {
+        let (
+            max_back_edges_per_function,
+            max_back_edges_per_module,
+            max_per_fun_meter_units,
+            max_per_mod_meter_units,
+        ) = if is_metered {
+            (
+                Some(protocol_config.max_back_edges_per_function() as usize),
+                Some(protocol_config.max_back_edges_per_module() as usize),
+                Some(protocol_config.max_verifier_meter_ticks_per_function() as u128),
+                Some(protocol_config.max_meter_ticks_per_module() as u128),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+        VerifierConfig {
+            max_loop_depth: Some(protocol_config.max_loop_depth() as usize),
+            max_generic_instantiation_length: Some(
+                protocol_config.max_generic_instantiation_length() as usize,
             ),
-            max_binary_format_version: protocol_config.move_binary_format_version(),
-            paranoid_type_checks,
-            runtime_limits_config: VMRuntimeLimitsConfig {
-                vector_len_max: protocol_config.max_move_vector_len(),
-                max_value_nest_depth: protocol_config.max_move_value_depth_as_option(),
+            max_function_parameters: Some(protocol_config.max_function_parameters() as usize),
+            max_basic_blocks: Some(protocol_config.max_basic_blocks() as usize),
+            max_value_stack_size: protocol_config.max_value_stack_size() as usize,
+            max_type_nodes: Some(protocol_config.max_type_nodes() as usize),
+            max_push_size: Some(protocol_config.max_push_size() as usize),
+            max_dependency_depth: Some(protocol_config.max_dependency_depth() as usize),
+            max_fields_in_struct: Some(protocol_config.max_fields_in_struct() as usize),
+            max_function_definitions: Some(protocol_config.max_function_definitions() as usize),
+            max_struct_definitions: Some(protocol_config.max_struct_definitions() as usize),
+            max_constant_vector_len: Some(protocol_config.max_move_vector_len()),
+            max_back_edges_per_function,
+            max_back_edges_per_module,
+            max_basic_blocks_in_script: None,
+            max_per_fun_meter_units,
+            max_per_mod_meter_units,
+            max_idenfitier_len: protocol_config.max_move_identifier_len_as_option(), // Before protocol version 9, there was no limit
+        }
+    }
+
+    pub fn new_move_vm(
+        natives: NativeFunctionTable,
+        protocol_config: &ProtocolConfig,
+        paranoid_type_checks: bool,
+    ) -> Result<MoveVM, SuiError> {
+        MoveVM::new_with_config(
+            natives,
+            VMConfig {
+                verifier: default_verifier_config(
+                    protocol_config,
+                    false, /* we do not enable metering in execution*/
+                ),
+                max_binary_format_version: protocol_config.move_binary_format_version(),
+                paranoid_type_checks,
+                runtime_limits_config: VMRuntimeLimitsConfig {
+                    vector_len_max: protocol_config.max_move_vector_len(),
+                    max_value_nest_depth: protocol_config.max_move_value_depth_as_option(),
+                },
+                enable_invariant_violation_check_in_swap_loc: !protocol_config
+                    .disable_invariant_violation_check_in_swap_loc(),
+                check_no_extraneous_bytes_during_deserialization: protocol_config
+                    .no_extraneous_module_bytes(),
+                #[cfg(debug_assertions)]
+                profiler_config: std::default::Default::default(),
+                // Don't augment errors with execution state on-chain
+                error_execution_state: false,
             },
-            enable_invariant_violation_check_in_swap_loc: !protocol_config
-                .disable_invariant_violation_check_in_swap_loc(),
-            check_no_extraneous_bytes_during_deserialization: protocol_config
-                .no_extraneous_module_bytes(),
-            #[cfg(debug_assertions)] profiler_config: std::default::Default::default(),
-            // Don't augment errors with execution state on-chain
-            error_execution_state: false,
-        },
-    )
-    .map_err(|_| SuiError::ExecutionInvariantViolation)
-}
+        )
+        .map_err(|_| SuiError::ExecutionInvariantViolation)
+    }
 
-pub fn new_native_extensions<'r>(
-    child_resolver: &'r dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-    is_metered: bool,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> NativeContextExtensions<'r> {
-    let mut extensions = NativeContextExtensions::default();
-    extensions.add(ObjectRuntime::new(
-        child_resolver,
-        input_objects,
-        is_metered,
-        protocol_config,
-        metrics,
-    ));
-    extensions.add(NativesCostTable::from_protocol_config(protocol_config));
-    extensions
-}
+    pub fn new_native_extensions<'r>(
+        child_resolver: &'r dyn ChildObjectResolver,
+        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
+        is_metered: bool,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> NativeContextExtensions<'r> {
+        let mut extensions = NativeContextExtensions::default();
+        extensions.add(ObjectRuntime::new(
+            child_resolver,
+            input_objects,
+            is_metered,
+            protocol_config,
+            metrics,
+        ));
+        extensions.add(NativesCostTable::from_protocol_config(protocol_config));
+        extensions
+    }
 
-/// Given a list of `modules` and an `object_id`, mutate each module's self ID (which must be
-/// 0x0) to be `object_id`.
-pub fn substitute_package_id(
-    modules: &mut [CompiledModule],
-    object_id: ObjectID,
-) -> Result<(), ExecutionError> {
-    let new_address = AccountAddress::from(object_id);
+    /// Given a list of `modules` and an `object_id`, mutate each module's self ID (which must be
+    /// 0x0) to be `object_id`.
+    pub fn substitute_package_id(
+        modules: &mut [CompiledModule],
+        object_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        let new_address = AccountAddress::from(object_id);
 
-    for module in modules.iter_mut() {
-        let self_handle = module.self_handle().clone();
-        let self_address_idx = self_handle.address;
+        for module in modules.iter_mut() {
+            let self_handle = module.self_handle().clone();
+            let self_address_idx = self_handle.address;
 
-        let addrs = &mut module.address_identifiers;
-        let Some(address_mut) = addrs.get_mut(self_address_idx.0 as usize) else {
+            let addrs = &mut module.address_identifiers;
+            let Some(address_mut) = addrs.get_mut(self_address_idx.0 as usize) else {
             let name = module.identifier_at(self_handle.name);
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PublishErrorNonZeroAddress,
@@ -148,48 +151,67 @@ pub fn substitute_package_id(
             ));
         };
 
-        if *address_mut != AccountAddress::ZERO {
-            let name = module.identifier_at(self_handle.name);
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PublishErrorNonZeroAddress,
-                format!("Publishing module {name} with non-zero address is not allowed"),
-            ));
-        };
+            if *address_mut != AccountAddress::ZERO {
+                let name = module.identifier_at(self_handle.name);
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::PublishErrorNonZeroAddress,
+                    format!("Publishing module {name} with non-zero address is not allowed"),
+                ));
+            };
 
-        *address_mut = new_address;
+            *address_mut = new_address;
+        }
+
+        Ok(())
     }
 
-    Ok(())
-}
-
-pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
-    format!(
+    pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
+        format!(
         "Unable to unwrap object {}. Was unable to retrieve last known version in the parent sync",
         id
     )
-}
+    }
 
-/// Run the bytecode verifier with a meter limit
-///
-/// This function only fails if the verification does not complete within the limit.  If the
-/// modules fail to verify but verification completes within the meter limit, the function
-/// succeeds.
-#[instrument(level = "trace", skip_all)]
-pub fn run_metered_move_bytecode_verifier(
-    modules: &[CompiledModule],
-    verifier_config: &VerifierConfig,
-    meter: &mut impl Meter,
-    metrics: &Arc<BytecodeVerifierMetrics>,
-) -> Result<(), SuiError> {
-    // run the Move verifier
-    for module in modules.iter() {
-        let per_module_meter_verifier_timer = metrics
-            .verifier_runtime_per_module_success_latency
-            .start_timer();
+    /// Run the bytecode verifier with a meter limit
+    ///
+    /// This function only fails if the verification does not complete within the limit.  If the
+    /// modules fail to verify but verification completes within the meter limit, the function
+    /// succeeds.
+    #[instrument(level = "trace", skip_all)]
+    pub fn run_metered_move_bytecode_verifier(
+        modules: &[CompiledModule],
+        verifier_config: &VerifierConfig,
+        meter: &mut impl Meter,
+        metrics: &Arc<BytecodeVerifierMetrics>,
+    ) -> Result<(), SuiError> {
+        // run the Move verifier
+        for module in modules.iter() {
+            let per_module_meter_verifier_timer = metrics
+                .verifier_runtime_per_module_success_latency
+                .start_timer();
 
-        if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
-            // Check that the status indicates mtering timeout
-            if check_for_verifier_timeout(&e.major_status()) {
+            if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
+                // Check that the status indicates mtering timeout
+                if check_for_verifier_timeout(&e.major_status()) {
+                    // Discard success timer, but record timeout/failure timer
+                    metrics
+                        .verifier_runtime_per_module_timeout_latency
+                        .observe(per_module_meter_verifier_timer.stop_and_discard());
+                    metrics
+                        .verifier_timeout_metrics
+                        .with_label_values(&[
+                            BytecodeVerifierMetrics::MOVE_VERIFIER_TAG,
+                            BytecodeVerifierMetrics::TIMEOUT_TAG,
+                        ])
+                        .inc();
+                    return Err(SuiError::ModuleVerificationFailure {
+                        error: format!("Verification timedout: {}", e),
+                    });
+                };
+            } else if let Err(err) =
+                sui_verify_module_metered_check_timeout_only(module, &BTreeMap::new(), meter)
+            {
+                // We only checked that the failure was due to timeout
                 // Discard success timer, but record timeout/failure timer
                 metrics
                     .verifier_runtime_per_module_timeout_latency
@@ -197,44 +219,22 @@ pub fn run_metered_move_bytecode_verifier(
                 metrics
                     .verifier_timeout_metrics
                     .with_label_values(&[
-                        BytecodeVerifierMetrics::MOVE_VERIFIER_TAG,
+                        BytecodeVerifierMetrics::SUI_VERIFIER_TAG,
                         BytecodeVerifierMetrics::TIMEOUT_TAG,
                     ])
                     .inc();
-                return Err(SuiError::ModuleVerificationFailure {
-                    error: format!("Verification timedout: {}", e),
-                });
-            };
-        } else if let Err(err) = sui_verify_module_metered_check_timeout_only(
-            module,
-            &BTreeMap::new(),
-            meter,
-        ) {
-            // We only checked that the failure was due to timeout
-            // Discard success timer, but record timeout/failure timer
-            metrics
-                .verifier_runtime_per_module_timeout_latency
-                .observe(per_module_meter_verifier_timer.stop_and_discard());
+                return Err(err.into());
+            }
+            // Save the success timer
+            per_module_meter_verifier_timer.stop_and_record();
             metrics
                 .verifier_timeout_metrics
                 .with_label_values(&[
-                    BytecodeVerifierMetrics::SUI_VERIFIER_TAG,
-                    BytecodeVerifierMetrics::TIMEOUT_TAG,
+                    BytecodeVerifierMetrics::OVERALL_TAG,
+                    BytecodeVerifierMetrics::SUCCESS_TAG,
                 ])
                 .inc();
-            return Err(err.into());
         }
-        // Save the success timer
-        per_module_meter_verifier_timer.stop_and_record();
-        metrics
-            .verifier_timeout_metrics
-            .with_label_values(&[
-                BytecodeVerifierMetrics::OVERALL_TAG,
-                BytecodeVerifierMetrics::SUCCESS_TAG,
-            ])
-            .inc();
+        Ok(())
     }
-    Ok(())
-}
-
 }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -1,808 +1,811 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::CompiledModule;
-use move_vm_runtime::move_vm::MoveVM;
-use once_cell::sync::Lazy;
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
-use sui_types::balance::{
-    BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
-    BALANCE_MODULE_NAME,
-};
-use sui_types::execution_mode::{self, ExecutionMode};
-use sui_types::gas_coin::GAS;
-use sui_types::metrics::LimitsMetrics;
-use sui_types::object::OBJECT_START_VERSION;
-use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use tracing::{info, instrument, trace, warn};
+pub use checked::*;
 
-use crate::programmable_transactions;
-use crate::type_layout_resolver::TypeLayoutResolver;
-use move_binary_format::access::ModuleAccess;
-use sui_macros::checked_arithmetic;
-use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
-use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
-use sui_types::committee::EpochId;
-use sui_types::effects::TransactionEffects;
-use sui_types::error::{ExecutionError, ExecutionErrorKind};
-use sui_types::execution_status::ExecutionStatus;
-use sui_types::gas::{GasCharger, GasCostSummary};
-use sui_types::messages_consensus::ConsensusCommitPrologue;
-use sui_types::storage::WriteKind;
-#[cfg(msim)]
-use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
-use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
-use sui_types::temporary_store::InnerTemporaryStore;
-use sui_types::temporary_store::TemporaryStore;
-use sui_types::transaction::{
-    Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
-    TransactionKind,
-};
-use sui_types::{
-    base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
-    object::Object,
-    sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
-    SUI_FRAMEWORK_ADDRESS,
-};
-use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID};
+#[sui_macros::with_checked_arithmetic]
+mod checked {
 
-/// If a transaction digest shows up in this list, when executing such transaction,
-/// we will always return `ExecutionError::CertificateDenied` without executing it (but still do
-/// gas smashing). Because this list is not gated by protocol version, there are a few important
-/// criteria for adding a digest to this list:
-/// 1. The certificate must be causing all validators to either panic or hang forever deterministically.
-/// 2. If we ever ship a fix to make it no longer panic or hang when executing such transaction,
-/// we must make sure the transaction is already in this list. Otherwise nodes running the newer version
-/// without these transactions in the list will generate forked result.
-/// Below is a scenario of when we need to use this list:
-/// 1. We detect that a specific transaction is causing all validators to either panic or hang forever deterministically.
-/// 2. We push a CertificateDenyConfig to deny such transaction to all validators asap.
-/// 3. To make sure that all fullnodes are able to sync to the latest version, we need to add the transaction digest
-/// to this list as well asap, and ship this binary to all fullnodes, so that they can sync past this transaction.
-/// 4. We then can start fixing the issue, and ship the fix to all nodes.
-/// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
-/// node that sync from genesis will fork on this transaction. We may be able to remove it once
-/// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
-pub fn get_denied_certificates() -> &'static HashSet<TransactionDigest> {
-    static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> = Lazy::new(|| HashSet::from([]));
-    Lazy::force(&DENIED_CERTIFICATES)
-}
+    use move_binary_format::CompiledModule;
+    use move_vm_runtime::move_vm::MoveVM;
+    use once_cell::sync::Lazy;
+    use std::{
+        collections::{BTreeSet, HashSet},
+        sync::Arc,
+    };
+    use sui_types::balance::{
+        BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
+        BALANCE_MODULE_NAME,
+    };
+    use sui_types::execution_mode::{self, ExecutionMode};
+    use sui_types::gas_coin::GAS;
+    use sui_types::metrics::LimitsMetrics;
+    use sui_types::object::OBJECT_START_VERSION;
+    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+    use tracing::{info, instrument, trace, warn};
 
-fn is_certificate_denied(
-    transaction_digest: &TransactionDigest,
-    certificate_deny_set: &HashSet<TransactionDigest>,
-) -> bool {
-    certificate_deny_set.contains(transaction_digest)
-        || get_denied_certificates().contains(transaction_digest)
-}
+    use crate::programmable_transactions;
+    use crate::type_layout_resolver::TypeLayoutResolver;
+    use move_binary_format::access::ModuleAccess;
+    use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
+    use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
+    use sui_types::committee::EpochId;
+    use sui_types::effects::TransactionEffects;
+    use sui_types::error::{ExecutionError, ExecutionErrorKind};
+    use sui_types::execution_status::ExecutionStatus;
+    use sui_types::gas::{GasCharger, GasCostSummary};
+    use sui_types::messages_consensus::ConsensusCommitPrologue;
+    use sui_types::storage::WriteKind;
+    #[cfg(msim)]
+    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
+    use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
+    use sui_types::temporary_store::InnerTemporaryStore;
+    use sui_types::temporary_store::TemporaryStore;
+    use sui_types::transaction::{
+        Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
+        TransactionKind,
+    };
+    use sui_types::{
+        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        object::Object,
+        sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
+        SUI_FRAMEWORK_ADDRESS,
+    };
+    use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID};
 
-checked_arithmetic! {
+    /// If a transaction digest shows up in this list, when executing such transaction,
+    /// we will always return `ExecutionError::CertificateDenied` without executing it (but still do
+    /// gas smashing). Because this list is not gated by protocol version, there are a few important
+    /// criteria for adding a digest to this list:
+    /// 1. The certificate must be causing all validators to either panic or hang forever deterministically.
+    /// 2. If we ever ship a fix to make it no longer panic or hang when executing such transaction,
+    /// we must make sure the transaction is already in this list. Otherwise nodes running the newer version
+    /// without these transactions in the list will generate forked result.
+    /// Below is a scenario of when we need to use this list:
+    /// 1. We detect that a specific transaction is causing all validators to either panic or hang forever deterministically.
+    /// 2. We push a CertificateDenyConfig to deny such transaction to all validators asap.
+    /// 3. To make sure that all fullnodes are able to sync to the latest version, we need to add the transaction digest
+    /// to this list as well asap, and ship this binary to all fullnodes, so that they can sync past this transaction.
+    /// 4. We then can start fixing the issue, and ship the fix to all nodes.
+    /// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
+    /// node that sync from genesis will fork on this transaction. We may be able to remove it once
+    /// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
+    pub fn get_denied_certificates() -> &'static HashSet<TransactionDigest> {
+        static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> =
+            Lazy::new(|| HashSet::from([]));
+        Lazy::force(&DENIED_CERTIFICATES)
+    }
 
-#[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
-    shared_object_refs: Vec<ObjectRef>,
-    mut temporary_store: TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    transaction_signer: SuiAddress,
-    gas_charger: &mut GasCharger,
-    transaction_digest: TransactionDigest,
-    mut transaction_dependencies: BTreeSet<TransactionDigest>,
-    move_vm: &Arc<MoveVM>,
-    epoch_id: &EpochId,
-    epoch_timestamp_ms: u64,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool,
-    certificate_deny_set: &HashSet<TransactionDigest>,
-) -> (
-    InnerTemporaryStore,
-    TransactionEffects,
-    Result<Mode::ExecutionResults, ExecutionError>,
-) {
-    let mut tx_ctx = TxContext::new_from_components(
-        &transaction_signer,
-        &transaction_digest,
-        epoch_id,
-        epoch_timestamp_ms,
-    );
+    fn is_certificate_denied(
+        transaction_digest: &TransactionDigest,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+    ) -> bool {
+        certificate_deny_set.contains(transaction_digest)
+            || get_denied_certificates().contains(transaction_digest)
+    }
 
-    let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));
+    #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
+        shared_object_refs: Vec<ObjectRef>,
+        mut temporary_store: TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        gas_charger: &mut GasCharger,
+        transaction_digest: TransactionDigest,
+        mut transaction_dependencies: BTreeSet<TransactionDigest>,
+        move_vm: &Arc<MoveVM>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        let mut tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+        );
 
-    let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
-    let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
-        &mut temporary_store,
-        transaction_kind,
-        gas_charger,
-        &mut tx_ctx,
-        move_vm,
-        protocol_config,
-        metrics,
-        enable_expensive_checks,
-        deny_cert,
-    );
+        let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));
 
-    let status = if let Err(error) = &execution_result {
-        // Elaborate errors in logs if they are unexpected or their status is terse.
-        use ExecutionErrorKind as K;
-        match error.kind() {
-            K::InvariantViolation | K::VMInvariantViolation => {
-                #[skip_checked_arithmetic]
-                tracing::error!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "INVARIANT VIOLATION! Source: {:?}",
-                    error.source(),
-                );
-            }
+        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
+        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
+            &mut temporary_store,
+            transaction_kind,
+            gas_charger,
+            &mut tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            deny_cert,
+        );
 
-            K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                #[skip_checked_arithmetic]
-                tracing::debug!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "Verification Error. Source: {:?}",
-                    error.source(),
-                );
-            }
+        let status = if let Err(error) = &execution_result {
+            // Elaborate errors in logs if they are unexpected or their status is terse.
+            use ExecutionErrorKind as K;
+            match error.kind() {
+                K::InvariantViolation | K::VMInvariantViolation => {
+                    #[skip_checked_arithmetic]
+                    tracing::error!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "INVARIANT VIOLATION! Source: {:?}",
+                        error.source(),
+                    );
+                }
 
-            K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                #[skip_checked_arithmetic]
-                tracing::debug!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "Publish/Upgrade Error. Source: {:?}",
-                    error.source(),
-                )
-            }
+                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+                    #[skip_checked_arithmetic]
+                    tracing::debug!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "Verification Error. Source: {:?}",
+                        error.source(),
+                    );
+                }
 
-            _ => (),
+                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+                    #[skip_checked_arithmetic]
+                    tracing::debug!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "Publish/Upgrade Error. Source: {:?}",
+                        error.source(),
+                    )
+                }
+
+                _ => (),
+            };
+
+            let (status, command) = error.to_execution_status();
+            ExecutionStatus::new_failure(status, command)
+        } else {
+            ExecutionStatus::Success
         };
 
-        let (status, command) = error.to_execution_status();
-        ExecutionStatus::new_failure(status, command)
-    } else {
-        ExecutionStatus::Success
-    };
+        #[skip_checked_arithmetic]
+        trace!(
+            tx_digest = ?transaction_digest,
+            computation_gas_cost = gas_cost_summary.computation_cost,
+            storage_gas_cost = gas_cost_summary.storage_cost,
+            storage_gas_rebate = gas_cost_summary.storage_rebate,
+            "Finished execution of transaction with status {:?}",
+            status
+        );
 
-    #[skip_checked_arithmetic]
-    trace!(
-        tx_digest = ?transaction_digest,
-        computation_gas_cost = gas_cost_summary.computation_cost,
-        storage_gas_cost = gas_cost_summary.storage_cost,
-        storage_gas_rebate = gas_cost_summary.storage_rebate,
-        "Finished execution of transaction with status {:?}",
-        status
-    );
+        // Remove from dependencies the generic hash
+        transaction_dependencies.remove(&TransactionDigest::genesis());
 
-    // Remove from dependencies the generic hash
-    transaction_dependencies.remove(&TransactionDigest::genesis());
+        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
+            temporary_store
+                .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
+                .unwrap()
+        } // else, in dev inspect mode and anything goes--don't check
 
-    if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
-        temporary_store
-            .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
-            .unwrap()
-    } // else, in dev inspect mode and anything goes--don't check
+        let (inner, effects) = temporary_store.to_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies.into_iter().collect(),
+            gas_cost_summary,
+            status,
+            gas_charger,
+            *epoch_id,
+        );
+        (inner, effects, execution_result)
+    }
 
-    let (inner, effects) = temporary_store.to_effects(
-        shared_object_refs,
-        &transaction_digest,
-        transaction_dependencies.into_iter().collect(),
-        gas_cost_summary,
-        status,
-        gas_charger,
-        *epoch_id,
-    );
-    (inner, effects, execution_result)
-}
+    #[instrument(name = "tx_execute", level = "debug", skip_all)]
+    fn execute_transaction<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        gas_charger: &mut GasCharger,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        deny_cert: bool,
+    ) -> (
+        GasCostSummary,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        gas_charger.smash_gas(temporary_store);
 
-#[instrument(name = "tx_execute", level = "debug", skip_all)]
-fn execute_transaction<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    gas_charger: &mut GasCharger,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool,
-    deny_cert: bool,
-) -> (
-    GasCostSummary,
-    Result<Mode::ExecutionResults, ExecutionError>,
-) {
-    gas_charger.smash_gas(temporary_store);
+        // At this point no charges have been applied yet
+        debug_assert!(
+            gas_charger.no_charges(),
+            "No gas charges must be applied yet"
+        );
 
-    // At this point no charges have been applied yet
-    debug_assert!(
-        gas_charger.no_charges(),
-        "No gas charges must be applied yet"
-    );
+        let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
+        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
 
-    let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
-    let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+        // We must charge object read here during transaction execution, because if this fails
+        // we must still ensure an effect is committed and all objects versions incremented
+        let result = gas_charger.charge_input_objects(temporary_store);
+        let mut result = result.and_then(|()| {
+            let mut execution_result = if deny_cert {
+                Err(ExecutionError::new(
+                    ExecutionErrorKind::CertificateDenied,
+                    None,
+                ))
+            } else {
+                execution_loop::<Mode>(
+                    temporary_store,
+                    transaction_kind,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                )
+            };
 
-    // We must charge object read here during transaction execution, because if this fails
-    // we must still ensure an effect is committed and all objects versions incremented
-    let result = gas_charger.charge_input_objects(temporary_store);
-    let mut result = result.and_then(|()| {
-        let mut execution_result = if deny_cert {
-            Err(ExecutionError::new(
-                ExecutionErrorKind::CertificateDenied,
-                None,
-            ))
-        } else {
-            execution_loop::<Mode>(
+            let meter_check = check_meter_limit(
                 temporary_store,
-                transaction_kind,
-                tx_ctx,
-                move_vm,
                 gas_charger,
                 protocol_config,
                 metrics.clone(),
-            )
-        };
-
-        let meter_check = check_meter_limit(
-            temporary_store,
-            gas_charger,
-            protocol_config,
-            metrics.clone(),
-        );
-        if let Err(e) = meter_check {
-            execution_result = Err(e);
-        }
-
-        if execution_result.is_ok() {
-            let gas_check = check_written_objects_limit::<Mode>(
-                temporary_store,
-                gas_charger,
-                protocol_config,
-                metrics,
             );
-            if let Err(e) = gas_check {
+            if let Err(e) = meter_check {
                 execution_result = Err(e);
             }
-        }
 
-        execution_result
-    });
-
-    let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
-
-    if let Err(e) = run_conservation_checks::<Mode>(
-        temporary_store,
-        gas_charger,
-        tx_ctx,
-        move_vm,
-        enable_expensive_checks,
-        &cost_summary,
-        is_genesis_tx,
-        advance_epoch_gas_summary,
-    ) {
-        result = Err(e);
-    }
-
-    (cost_summary, result)
-}
-
-#[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
-fn run_conservation_checks<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    gas_charger: &mut GasCharger,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    enable_expensive_checks: bool,
-    cost_summary: &GasCostSummary,
-    is_genesis_tx: bool,
-    advance_epoch_gas_summary: Option<(u64, u64)>,
-) -> Result<(), ExecutionError> {
-    // === begin SUI conservation checks ===
-    // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-    // information provided to check_sui_conserved, because we mint rewards, and burn
-    // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-    // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-    // We could probably clean up the code a bit.
-    // Put all the storage rebate accumulated in the system transaction
-    // to the 0x5 object so that it's not lost.
-    let mut result: std::result::Result<(), sui_types::error::ExecutionError> = Ok(());
-    temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
-    if !is_genesis_tx && !Mode::allow_arbitrary_values() {
-        // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-        let conservation_result = {
-            let mut layout_resolver = TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-            temporary_store.check_sui_conserved(
-                cost_summary,
-                advance_epoch_gas_summary,
-                &mut layout_resolver,
-                enable_expensive_checks,
-            )
-        };
-        if let Err(conservation_err) = conservation_result {
-            // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
-            // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
-            result = Err(conservation_err);
-            gas_charger.reset(temporary_store);
-            gas_charger.charge_gas(temporary_store, &mut result);
-            // check conservation once more more
-            let mut layout_resolver = TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-            if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                cost_summary,
-                advance_epoch_gas_summary,
-                &mut layout_resolver,
-                enable_expensive_checks,
-            ) {
-                // if we still fail, it's a problem with gas
-                // charging that happens even in the "aborted" case--no other option but panic.
-                // we will create or destroy SUI otherwise
-                panic!(
-                    "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                    tx_ctx.digest(),
-                    recovery_err,
-                    gas_charger.summary()
-                )
-            }
-        }
-    } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
-      // we're in the non-production dev inspect mode which allows us to violate conservation
-      // === end SUI conservation checks ===
-    result
-}
-
-#[instrument(name = "check_meter_limit", level = "debug", skip_all)]
-fn check_meter_limit(
-    temporary_store: &mut TemporaryStore<'_>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    let effects_estimated_size = temporary_store.estimate_effects_size_upperbound();
-
-    // Check if a limit threshold was crossed.
-    // For metered transactions, there is not soft limit.
-    // For system transactions, we allow a soft limit with alerting, and a hard limit where we terminate
-    match check_limit_by_meter!(
-        !gas_charger.is_unmetered(),
-        effects_estimated_size,
-        protocol_config.max_serialized_tx_effects_size_bytes(),
-        protocol_config.max_serialized_tx_effects_size_bytes_system_tx(),
-        metrics.excessive_estimated_effects_size
-    ) {
-        LimitThresholdCrossed::None => Ok(()),
-        LimitThresholdCrossed::Soft(_, limit) => {
-            warn!(
-                effects_estimated_size = effects_estimated_size,
-                soft_limit = limit,
-                "Estimated transaction effects size crossed soft limit",
-            );
-            Ok(())
-        }
-        LimitThresholdCrossed::Hard(_, lim) => Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::EffectsTooLarge {
-                current_size: effects_estimated_size as u64,
-                max_size: lim as u64,
-            },
-            "Transaction effects are too large",
-        )),
-    }
-
-}
-
-#[instrument(name = "check_written_objects_limit", level = "debug", skip_all)]
-fn check_written_objects_limit<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    if let (Some(normal_lim), Some(system_lim)) = (
-        protocol_config.max_size_written_objects_as_option(),
-        protocol_config.max_size_written_objects_system_tx_as_option(),
-    ) {
-        let written_objects_size = temporary_store.written_objects_size();
-
-        match check_limit_by_meter!(
-            !gas_charger.is_unmetered(),
-            written_objects_size,
-            normal_lim,
-            system_lim,
-            metrics.excessive_written_objects_size
-        ) {
-            LimitThresholdCrossed::None => (),
-            LimitThresholdCrossed::Soft(_, limit) => {
-                warn!(
-                    written_objects_size = written_objects_size,
-                    soft_limit = limit,
-                    "Written objects size crossed soft limit",
-                )
-            }
-            LimitThresholdCrossed::Hard(_, lim) => {
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::WrittenObjectsTooLarge {
-                        current_size: written_objects_size as u64,
-                        max_size: lim as u64,
-                    },
-                    "Written objects size crossed hard limit",
-                ))
-            }
-        };
-    }
-
-    Ok(())
-}
-
-fn execution_loop<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<Mode::ExecutionResults, ExecutionError> {
-    match transaction_kind {
-        TransactionKind::ChangeEpoch(change_epoch) => {
-            advance_epoch(
-                change_epoch,
-                temporary_store,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics,
-            )?;
-            Ok(Mode::empty_results())
-        }
-        TransactionKind::Genesis(GenesisTransaction { objects }) => {
-            if tx_ctx.epoch() != 0 {
-                panic!("BUG: Genesis Transactions can only be executed in epoch 0");
-            }
-
-            for genesis_object in objects {
-                match genesis_object {
-                    sui_types::transaction::GenesisObject::RawObject { data, owner } => {
-                        let object = Object {
-                            data,
-                            owner,
-                            previous_transaction: tx_ctx.digest(),
-                            storage_rebate: 0,
-                        };
-                        temporary_store.write_object(object, WriteKind::Create);
-                    }
+            if execution_result.is_ok() {
+                let gas_check = check_written_objects_limit::<Mode>(
+                    temporary_store,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                );
+                if let Err(e) = gas_check {
+                    execution_result = Err(e);
                 }
             }
-            Ok(Mode::empty_results())
+
+            execution_result
+        });
+
+        let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
+
+        if let Err(e) = run_conservation_checks::<Mode>(
+            temporary_store,
+            gas_charger,
+            tx_ctx,
+            move_vm,
+            enable_expensive_checks,
+            &cost_summary,
+            is_genesis_tx,
+            advance_epoch_gas_summary,
+        ) {
+            result = Err(e);
         }
-        TransactionKind::ConsensusCommitPrologue(prologue) => {
-            setup_consensus_commit(
-                prologue,
-                temporary_store,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics,
-            )
-            .expect("ConsensusCommitPrologue cannot fail");
-            Ok(Mode::empty_results())
-        }
-        TransactionKind::ProgrammableTransaction(pt) => {
-            programmable_transactions::execution::execute::<Mode>(
-                protocol_config,
-                metrics,
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                pt,
-            )
-        }
-    }
-}
 
-fn mint_epoch_rewards_in_pt(
-    builder: &mut ProgrammableTransactionBuilder,
-    params: &AdvanceEpochParams,
-) -> (Argument, Argument) {
-    // Create storage rewards.
-    let storage_charge_arg = builder
-        .input(CallArg::Pure(
-            bcs::to_bytes(&params.storage_charge).unwrap(),
-        ))
-        .unwrap();
-    let storage_rewards = builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![storage_charge_arg],
-    );
-
-    // Create computation rewards.
-    let computation_charge_arg = builder
-        .input(CallArg::Pure(
-            bcs::to_bytes(&params.computation_charge).unwrap(),
-        ))
-        .unwrap();
-    let computation_rewards = builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![computation_charge_arg],
-    );
-    (storage_rewards, computation_rewards)
-}
-
-pub fn construct_advance_epoch_pt(
-    params: &AdvanceEpochParams,
-) -> Result<ProgrammableTransaction, ExecutionError> {
-    let mut builder = ProgrammableTransactionBuilder::new();
-    // Step 1: Create storage and computation rewards.
-    let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
-
-    // Step 2: Advance the epoch.
-    let mut arguments = vec![storage_rewards, computation_rewards];
-    let call_arg_arguments = vec![
-        CallArg::SUI_SYSTEM_MUT,
-        CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_fund_reinvest_rate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.reward_slashing_rate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap()),
-    ]
-    .into_iter()
-    .map(|a| builder.input(a))
-    .collect::<Result<_, _>>();
-
-    assert_invariant!(
-        call_arg_arguments.is_ok(),
-        "Unable to generate args for advance_epoch transaction!"
-    );
-
-    arguments.append(&mut call_arg_arguments.unwrap());
-
-    info!("Call arguments to advance_epoch transaction: {:?}", params);
-
-    let storage_rebates = builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
-        SUI_SYSTEM_MODULE_NAME.to_owned(),
-        ADVANCE_EPOCH_FUNCTION_NAME.to_owned(),
-        vec![],
-        arguments,
-    );
-
-    // Step 3: Destroy the storage rebates.
-    builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_DESTROY_REBATES_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![storage_rebates],
-    );
-    Ok(builder.finish())
-}
-
-pub fn construct_advance_epoch_safe_mode_pt(
-    params: &AdvanceEpochParams,
-    protocol_config: &ProtocolConfig,
-) -> Result<ProgrammableTransaction, ExecutionError> {
-    let mut builder = ProgrammableTransactionBuilder::new();
-    // Step 1: Create storage and computation rewards.
-    let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
-
-    // Step 2: Advance the epoch.
-    let mut arguments = vec![storage_rewards, computation_rewards];
-
-    let mut args = vec![
-        CallArg::SUI_SYSTEM_MUT,
-        CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
-    ];
-
-    if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
-        args.push(CallArg::Pure(
-            bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap(),
-        ));
+        (cost_summary, result)
     }
 
-    let call_arg_arguments = args
+    #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
+    fn run_conservation_checks<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        enable_expensive_checks: bool,
+        cost_summary: &GasCostSummary,
+        is_genesis_tx: bool,
+        advance_epoch_gas_summary: Option<(u64, u64)>,
+    ) -> Result<(), ExecutionError> {
+        // === begin SUI conservation checks ===
+        // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
+        // information provided to check_sui_conserved, because we mint rewards, and burn
+        // the rebates. We also need to pass in the unmetered_storage_rebate because storage
+        // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
+        // We could probably clean up the code a bit.
+        // Put all the storage rebate accumulated in the system transaction
+        // to the 0x5 object so that it's not lost.
+        let mut result: std::result::Result<(), sui_types::error::ExecutionError> = Ok(());
+        temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
+        if !is_genesis_tx && !Mode::allow_arbitrary_values() {
+            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+            let conservation_result = {
+                let mut layout_resolver =
+                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                temporary_store.check_sui_conserved(
+                    cost_summary,
+                    advance_epoch_gas_summary,
+                    &mut layout_resolver,
+                    enable_expensive_checks,
+                )
+            };
+            if let Err(conservation_err) = conservation_result {
+                // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
+                // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
+                result = Err(conservation_err);
+                gas_charger.reset(temporary_store);
+                gas_charger.charge_gas(temporary_store, &mut result);
+                // check conservation once more more
+                let mut layout_resolver =
+                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                if let Err(recovery_err) = temporary_store.check_sui_conserved(
+                    cost_summary,
+                    advance_epoch_gas_summary,
+                    &mut layout_resolver,
+                    enable_expensive_checks,
+                ) {
+                    // if we still fail, it's a problem with gas
+                    // charging that happens even in the "aborted" case--no other option but panic.
+                    // we will create or destroy SUI otherwise
+                    panic!(
+                        "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
+                        tx_ctx.digest(),
+                        recovery_err,
+                        gas_charger.summary()
+                    )
+                }
+            }
+        } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
+          // we're in the non-production dev inspect mode which allows us to violate conservation
+          // === end SUI conservation checks ===
+        result
+    }
+
+    #[instrument(name = "check_meter_limit", level = "debug", skip_all)]
+    fn check_meter_limit(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        let effects_estimated_size = temporary_store.estimate_effects_size_upperbound();
+
+        // Check if a limit threshold was crossed.
+        // For metered transactions, there is not soft limit.
+        // For system transactions, we allow a soft limit with alerting, and a hard limit where we terminate
+        match check_limit_by_meter!(
+            !gas_charger.is_unmetered(),
+            effects_estimated_size,
+            protocol_config.max_serialized_tx_effects_size_bytes(),
+            protocol_config.max_serialized_tx_effects_size_bytes_system_tx(),
+            metrics.excessive_estimated_effects_size
+        ) {
+            LimitThresholdCrossed::None => Ok(()),
+            LimitThresholdCrossed::Soft(_, limit) => {
+                warn!(
+                    effects_estimated_size = effects_estimated_size,
+                    soft_limit = limit,
+                    "Estimated transaction effects size crossed soft limit",
+                );
+                Ok(())
+            }
+            LimitThresholdCrossed::Hard(_, lim) => Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::EffectsTooLarge {
+                    current_size: effects_estimated_size as u64,
+                    max_size: lim as u64,
+                },
+                "Transaction effects are too large",
+            )),
+        }
+    }
+
+    #[instrument(name = "check_written_objects_limit", level = "debug", skip_all)]
+    fn check_written_objects_limit<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        if let (Some(normal_lim), Some(system_lim)) = (
+            protocol_config.max_size_written_objects_as_option(),
+            protocol_config.max_size_written_objects_system_tx_as_option(),
+        ) {
+            let written_objects_size = temporary_store.written_objects_size();
+
+            match check_limit_by_meter!(
+                !gas_charger.is_unmetered(),
+                written_objects_size,
+                normal_lim,
+                system_lim,
+                metrics.excessive_written_objects_size
+            ) {
+                LimitThresholdCrossed::None => (),
+                LimitThresholdCrossed::Soft(_, limit) => {
+                    warn!(
+                        written_objects_size = written_objects_size,
+                        soft_limit = limit,
+                        "Written objects size crossed soft limit",
+                    )
+                }
+                LimitThresholdCrossed::Hard(_, lim) => {
+                    return Err(ExecutionError::new_with_source(
+                        ExecutionErrorKind::WrittenObjectsTooLarge {
+                            current_size: written_objects_size as u64,
+                            max_size: lim as u64,
+                        },
+                        "Written objects size crossed hard limit",
+                    ))
+                }
+            };
+        }
+
+        Ok(())
+    }
+
+    fn execution_loop<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+        match transaction_kind {
+            TransactionKind::ChangeEpoch(change_epoch) => {
+                advance_epoch(
+                    change_epoch,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )?;
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::Genesis(GenesisTransaction { objects }) => {
+                if tx_ctx.epoch() != 0 {
+                    panic!("BUG: Genesis Transactions can only be executed in epoch 0");
+                }
+
+                for genesis_object in objects {
+                    match genesis_object {
+                        sui_types::transaction::GenesisObject::RawObject { data, owner } => {
+                            let object = Object {
+                                data,
+                                owner,
+                                previous_transaction: tx_ctx.digest(),
+                                storage_rebate: 0,
+                            };
+                            temporary_store.write_object(object, WriteKind::Create);
+                        }
+                    }
+                }
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ConsensusCommitPrologue(prologue) => {
+                setup_consensus_commit(
+                    prologue,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ProgrammableTransaction(pt) => {
+                programmable_transactions::execution::execute::<Mode>(
+                    protocol_config,
+                    metrics,
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    pt,
+                )
+            }
+        }
+    }
+
+    fn mint_epoch_rewards_in_pt(
+        builder: &mut ProgrammableTransactionBuilder,
+        params: &AdvanceEpochParams,
+    ) -> (Argument, Argument) {
+        // Create storage rewards.
+        let storage_charge_arg = builder
+            .input(CallArg::Pure(
+                bcs::to_bytes(&params.storage_charge).unwrap(),
+            ))
+            .unwrap();
+        let storage_rewards = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![storage_charge_arg],
+        );
+
+        // Create computation rewards.
+        let computation_charge_arg = builder
+            .input(CallArg::Pure(
+                bcs::to_bytes(&params.computation_charge).unwrap(),
+            ))
+            .unwrap();
+        let computation_rewards = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![computation_charge_arg],
+        );
+        (storage_rewards, computation_rewards)
+    }
+
+    pub fn construct_advance_epoch_pt(
+        params: &AdvanceEpochParams,
+    ) -> Result<ProgrammableTransaction, ExecutionError> {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Step 1: Create storage and computation rewards.
+        let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
+
+        // Step 2: Advance the epoch.
+        let mut arguments = vec![storage_rewards, computation_rewards];
+        let call_arg_arguments = vec![
+            CallArg::SUI_SYSTEM_MUT,
+            CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_fund_reinvest_rate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.reward_slashing_rate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap()),
+        ]
         .into_iter()
         .map(|a| builder.input(a))
         .collect::<Result<_, _>>();
 
-    assert_invariant!(
-        call_arg_arguments.is_ok(),
-        "Unable to generate args for advance_epoch transaction!"
-    );
+        assert_invariant!(
+            call_arg_arguments.is_ok(),
+            "Unable to generate args for advance_epoch transaction!"
+        );
 
-    arguments.append(&mut call_arg_arguments.unwrap());
+        arguments.append(&mut call_arg_arguments.unwrap());
 
-    info!("Call arguments to advance_epoch transaction: {:?}", params);
+        info!("Call arguments to advance_epoch transaction: {:?}", params);
 
-    builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
-        SUI_SYSTEM_MODULE_NAME.to_owned(),
-        ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned(),
-        vec![],
-        arguments,
-    );
+        let storage_rebates = builder.programmable_move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            ADVANCE_EPOCH_FUNCTION_NAME.to_owned(),
+            vec![],
+            arguments,
+        );
 
-    Ok(builder.finish())
-}
+        // Step 3: Destroy the storage rebates.
+        builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_DESTROY_REBATES_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![storage_rebates],
+        );
+        Ok(builder.finish())
+    }
 
-fn advance_epoch(
-    change_epoch: ChangeEpoch,
-    temporary_store: &mut TemporaryStore<'_>,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    let params = AdvanceEpochParams {
-        epoch: change_epoch.epoch,
-        next_protocol_version: change_epoch.protocol_version,
-        storage_charge: change_epoch.storage_charge,
-        computation_charge: change_epoch.computation_charge,
-        storage_rebate: change_epoch.storage_rebate,
-        non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
-        storage_fund_reinvest_rate: protocol_config.storage_fund_reinvest_rate(),
-        reward_slashing_rate: protocol_config.reward_slashing_rate(),
-        epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
-    };
-    let advance_epoch_pt = construct_advance_epoch_pt(&params)?;
-    let result = programmable_transactions::execution::execute::<execution_mode::System>(
-        protocol_config,
-        metrics.clone(),
-        move_vm,
-        temporary_store,
-        tx_ctx,
-        gas_charger,
-        advance_epoch_pt,
-    );
+    pub fn construct_advance_epoch_safe_mode_pt(
+        params: &AdvanceEpochParams,
+        protocol_config: &ProtocolConfig,
+    ) -> Result<ProgrammableTransaction, ExecutionError> {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Step 1: Create storage and computation rewards.
+        let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
 
-    #[cfg(msim)]
-    let result = maybe_modify_result(result, change_epoch.epoch);
+        // Step 2: Advance the epoch.
+        let mut arguments = vec![storage_rewards, computation_rewards];
 
-    if result.is_err() {
-        tracing::error!(
+        let mut args = vec![
+            CallArg::SUI_SYSTEM_MUT,
+            CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
+        ];
+
+        if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
+            args.push(CallArg::Pure(
+                bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap(),
+            ));
+        }
+
+        let call_arg_arguments = args
+            .into_iter()
+            .map(|a| builder.input(a))
+            .collect::<Result<_, _>>();
+
+        assert_invariant!(
+            call_arg_arguments.is_ok(),
+            "Unable to generate args for advance_epoch transaction!"
+        );
+
+        arguments.append(&mut call_arg_arguments.unwrap());
+
+        info!("Call arguments to advance_epoch transaction: {:?}", params);
+
+        builder.programmable_move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned(),
+            vec![],
+            arguments,
+        );
+
+        Ok(builder.finish())
+    }
+
+    fn advance_epoch(
+        change_epoch: ChangeEpoch,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        let params = AdvanceEpochParams {
+            epoch: change_epoch.epoch,
+            next_protocol_version: change_epoch.protocol_version,
+            storage_charge: change_epoch.storage_charge,
+            computation_charge: change_epoch.computation_charge,
+            storage_rebate: change_epoch.storage_rebate,
+            non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
+            storage_fund_reinvest_rate: protocol_config.storage_fund_reinvest_rate(),
+            reward_slashing_rate: protocol_config.reward_slashing_rate(),
+            epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
+        };
+        let advance_epoch_pt = construct_advance_epoch_pt(&params)?;
+        let result = programmable_transactions::execution::execute::<execution_mode::System>(
+            protocol_config,
+            metrics.clone(),
+            move_vm,
+            temporary_store,
+            tx_ctx,
+            gas_charger,
+            advance_epoch_pt,
+        );
+
+        #[cfg(msim)]
+        let result = maybe_modify_result(result, change_epoch.epoch);
+
+        if result.is_err() {
+            tracing::error!(
             "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx data: {:?}",
             result.as_ref().err(),
             temporary_store.objects(),
             change_epoch,
         );
-        temporary_store.drop_writes();
-        // Must reset the storage rebate since we are re-executing.
-        gas_charger.reset_storage_cost_and_rebate();
+            temporary_store.drop_writes();
+            // Must reset the storage rebate since we are re-executing.
+            gas_charger.reset_storage_cost_and_rebate();
 
-        if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
-            temporary_store.advance_epoch_safe_mode(&params, protocol_config);
-        } else {
-            let advance_epoch_safe_mode_pt =
-                construct_advance_epoch_safe_mode_pt(&params, protocol_config)?;
-            programmable_transactions::execution::execute::<execution_mode::System>(
-                protocol_config,
-                metrics.clone(),
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                advance_epoch_safe_mode_pt,
-            )
-            .expect("Advance epoch with safe mode must succeed");
-        }
-    }
-
-    for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
-        let max_format_version = protocol_config.move_binary_format_version();
-        let deserialized_modules: Vec<_> = modules
-            .iter()
-            .map(|m| {
-                CompiledModule::deserialize_with_config(
-                    m,
-                    max_format_version,
-                    protocol_config.no_extraneous_module_bytes(),
+            if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
+                temporary_store.advance_epoch_safe_mode(&params, protocol_config);
+            } else {
+                let advance_epoch_safe_mode_pt =
+                    construct_advance_epoch_safe_mode_pt(&params, protocol_config)?;
+                programmable_transactions::execution::execute::<execution_mode::System>(
+                    protocol_config,
+                    metrics.clone(),
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    advance_epoch_safe_mode_pt,
                 )
-                .unwrap()
-            })
-            .collect();
-
-        if version == OBJECT_START_VERSION {
-            let package_id = deserialized_modules.first().unwrap().address();
-            info!("adding new system package {package_id}");
-
-            let publish_pt = {
-                let mut b = ProgrammableTransactionBuilder::new();
-                b.command(Command::Publish(modules, dependencies));
-                b.finish()
-            };
-
-            programmable_transactions::execution::execute::<execution_mode::System>(
-                protocol_config,
-                metrics.clone(),
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                publish_pt,
-            )
-            .expect("System Package Publish must succeed");
-        } else {
-            let mut new_package = Object::new_system_package(
-                &deserialized_modules,
-                version,
-                dependencies,
-                tx_ctx.digest(),
-            );
-
-            info!(
-                "upgraded system package {:?}",
-                new_package.compute_object_reference()
-            );
-
-            // Decrement the version before writing the package so that the store can record the
-            // version growing by one in the effects.
-            new_package
-                .data
-                .try_as_package_mut()
-                .unwrap()
-                .decrement_version();
-
-            // upgrade of a previously existing framework module
-            temporary_store.write_object(new_package, WriteKind::Mutate);
+                .expect("Advance epoch with safe mode must succeed");
+            }
         }
+
+        for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
+            let max_format_version = protocol_config.move_binary_format_version();
+            let deserialized_modules: Vec<_> = modules
+                .iter()
+                .map(|m| {
+                    CompiledModule::deserialize_with_config(
+                        m,
+                        max_format_version,
+                        protocol_config.no_extraneous_module_bytes(),
+                    )
+                    .unwrap()
+                })
+                .collect();
+
+            if version == OBJECT_START_VERSION {
+                let package_id = deserialized_modules.first().unwrap().address();
+                info!("adding new system package {package_id}");
+
+                let publish_pt = {
+                    let mut b = ProgrammableTransactionBuilder::new();
+                    b.command(Command::Publish(modules, dependencies));
+                    b.finish()
+                };
+
+                programmable_transactions::execution::execute::<execution_mode::System>(
+                    protocol_config,
+                    metrics.clone(),
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    publish_pt,
+                )
+                .expect("System Package Publish must succeed");
+            } else {
+                let mut new_package = Object::new_system_package(
+                    &deserialized_modules,
+                    version,
+                    dependencies,
+                    tx_ctx.digest(),
+                );
+
+                info!(
+                    "upgraded system package {:?}",
+                    new_package.compute_object_reference()
+                );
+
+                // Decrement the version before writing the package so that the store can record the
+                // version growing by one in the effects.
+                new_package
+                    .data
+                    .try_as_package_mut()
+                    .unwrap()
+                    .decrement_version();
+
+                // upgrade of a previously existing framework module
+                temporary_store.write_object(new_package, WriteKind::Mutate);
+            }
+        }
+
+        Ok(())
     }
 
-    Ok(())
-}
-
-/// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:
-///
-/// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
-///   consensus.
-fn setup_consensus_commit(
-    prologue: ConsensusCommitPrologue,
-    temporary_store: &mut TemporaryStore<'_>,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let res = builder.move_call(
-            SUI_FRAMEWORK_ADDRESS.into(),
-            CLOCK_MODULE_NAME.to_owned(),
-            CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME.to_owned(),
-            vec![],
-            vec![
-                CallArg::CLOCK_MUT,
-                CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
-            ],
-        );
-        assert_invariant!(
-            res.is_ok(),
-            "Unable to generate consensus_commit_prologue transaction!"
-        );
-        builder.finish()
-    };
-    programmable_transactions::execution::execute::<execution_mode::System>(
-        protocol_config,
-        metrics,
-        move_vm,
-        temporary_store,
-        tx_ctx,
-        gas_charger,
-        pt,
-    )
-
+    /// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:
+    ///
+    /// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
+    ///   consensus.
+    fn setup_consensus_commit(
+        prologue: ConsensusCommitPrologue,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let res = builder.move_call(
+                SUI_FRAMEWORK_ADDRESS.into(),
+                CLOCK_MODULE_NAME.to_owned(),
+                CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME.to_owned(),
+                vec![],
+                vec![
+                    CallArg::CLOCK_MUT,
+                    CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
+                ],
+            );
+            assert_invariant!(
+                res.is_ok(),
+                "Unable to generate consensus_commit_prologue transaction!"
+            );
+            builder.finish()
+        };
+        programmable_transactions::execution::execute::<execution_mode::System>(
+            protocol_config,
+            metrics,
+            move_vm,
+            temporary_store,
+            tx_ctx,
+            gas_charger,
+            pt,
+        )
     }
 }

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -1,765 +1,785 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
-};
+pub use checked::*;
 
-use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
-use crate::error::convert_vm_error;
-use move_binary_format::{
-    errors::{Location, VMError, VMResult},
-    file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
-    CompiledModule,
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{ModuleId, StructTag, TypeTag},
-};
-#[cfg(debug_assertions)]
-use move_vm_profiler::GasProfiler;
-use move_vm_runtime::{move_vm::MoveVM, session::Session};
-#[cfg(debug_assertions)]
-use move_vm_types::gas::GasMeter;
-use move_vm_types::loaded_data::runtime_types::Type;
-use sui_move_natives::object_runtime::{
-    self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
-};
-use sui_protocol_config::ProtocolConfig;
-use sui_types::gas::GasCharger;
-use sui_types::{
-    balance::Balance,
-    base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
-    coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind},
-    execution::{
-        ExecutionResults, ExecutionState, InputObjectMetadata, InputValue, ObjectValue,
-        RawValueType, ResultValue, UsageKind,
-    },
-    metrics::LimitsMetrics,
-    move_package::MovePackage,
-    object::{Data, MoveObject, Object, Owner},
-    storage::{
-        BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
-        ObjectChange, WriteKind,
-    },
-    transaction::{Argument, CallArg, ObjectArg},
-    type_resolver::TypeTagResolver,
-};
-use sui_types::{
-    error::command_argument_error,
-    execution::{CommandKind, ObjectContents, TryFromValue, Value},
-    execution_mode::ExecutionMode,
-    execution_status::CommandArgumentError,
-};
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use std::{
+        collections::{BTreeMap, BTreeSet, HashMap},
+        sync::Arc,
+    };
 
-use super::linkage_view::{LinkageView, SavedLinkage};
+    use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
+    use crate::error::convert_vm_error;
+    use move_binary_format::{
+        errors::{Location, VMError, VMResult},
+        file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
+        CompiledModule,
+    };
+    use move_core_types::{
+        account_address::AccountAddress,
+        language_storage::{ModuleId, StructTag, TypeTag},
+    };
+    #[cfg(debug_assertions)]
+    use move_vm_profiler::GasProfiler;
+    use move_vm_runtime::{move_vm::MoveVM, session::Session};
+    #[cfg(debug_assertions)]
+    use move_vm_types::gas::GasMeter;
+    use move_vm_types::loaded_data::runtime_types::Type;
+    use sui_move_natives::object_runtime::{
+        self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
+    };
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::gas::GasCharger;
+    use sui_types::{
+        balance::Balance,
+        base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
+        coin::Coin,
+        error::{ExecutionError, ExecutionErrorKind},
+        execution::{
+            ExecutionResults, ExecutionState, InputObjectMetadata, InputValue, ObjectValue,
+            RawValueType, ResultValue, UsageKind,
+        },
+        metrics::LimitsMetrics,
+        move_package::MovePackage,
+        object::{Data, MoveObject, Object, Owner},
+        storage::{
+            BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
+            ObjectChange, WriteKind,
+        },
+        transaction::{Argument, CallArg, ObjectArg},
+        type_resolver::TypeTagResolver,
+    };
+    use sui_types::{
+        error::command_argument_error,
+        execution::{CommandKind, ObjectContents, TryFromValue, Value},
+        execution_mode::ExecutionMode,
+        execution_status::CommandArgumentError,
+    };
 
-sui_macros::checked_arithmetic! {
+    use crate::programmable_transactions::linkage_view::{LinkageView, SavedLinkage};
 
-/// Maintains all runtime state specific to programmable transactions
-pub struct ExecutionContext<'vm, 'state, 'a> {
-    /// The protocol config
-    pub protocol_config: &'a ProtocolConfig,
-    /// Metrics for reporting exceeded limits
-    pub metrics: Arc<LimitsMetrics>,
-    /// The MoveVM
-    pub vm: &'vm MoveVM,
-    /// The global state, used for resolving packages
-    pub state_view: &'state dyn ExecutionState,
-    /// A shared transaction context, contains transaction digest information and manages the
-    /// creation of new object IDs
-    pub tx_context: &'a mut TxContext,
-    /// The gas charger used for metering
-    pub gas_charger: &'a mut GasCharger,
-    /// The session used for interacting with Move types and calls
-    pub session: Session<'state, 'vm, LinkageView<'state>>,
-    /// Additional transfers not from the Move runtime
-    additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
-    /// Newly published packages
-    new_packages: Vec<Object>,
-    /// User events are claimed after each Move call
-    user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
-    // runtime data
-    /// The runtime value for the Gas coin, None if it has been taken/moved
-    gas: InputValue,
-    /// The runtime value for the inputs/call args, None if it has been taken/moved
-    inputs: Vec<InputValue>,
-    /// The results of a given command. For most commands, the inner vector will have length 1.
-    /// It will only not be 1 for Move calls with multiple return values.
-    /// Inner values are None if taken/moved by-value
-    results: Vec<Vec<ResultValue>>,
-    /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
-    /// This gets cleared out when new results are pushed, i.e. the end of a command
-    borrowed: HashMap<Argument, /* mut */ bool>,
-}
+    /// Maintains all runtime state specific to programmable transactions
+    pub struct ExecutionContext<'vm, 'state, 'a> {
+        /// The protocol config
+        pub protocol_config: &'a ProtocolConfig,
+        /// Metrics for reporting exceeded limits
+        pub metrics: Arc<LimitsMetrics>,
+        /// The MoveVM
+        pub vm: &'vm MoveVM,
+        /// The global state, used for resolving packages
+        pub state_view: &'state dyn ExecutionState,
+        /// A shared transaction context, contains transaction digest information and manages the
+        /// creation of new object IDs
+        pub tx_context: &'a mut TxContext,
+        /// The gas charger used for metering
+        pub gas_charger: &'a mut GasCharger,
+        /// The session used for interacting with Move types and calls
+        pub session: Session<'state, 'vm, LinkageView<'state>>,
+        /// Additional transfers not from the Move runtime
+        additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
+        /// Newly published packages
+        new_packages: Vec<Object>,
+        /// User events are claimed after each Move call
+        user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
+        // runtime data
+        /// The runtime value for the Gas coin, None if it has been taken/moved
+        gas: InputValue,
+        /// The runtime value for the inputs/call args, None if it has been taken/moved
+        inputs: Vec<InputValue>,
+        /// The results of a given command. For most commands, the inner vector will have length 1.
+        /// It will only not be 1 for Move calls with multiple return values.
+        /// Inner values are None if taken/moved by-value
+        results: Vec<Vec<ResultValue>>,
+        /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
+        /// This gets cleared out when new results are pushed, i.e. the end of a command
+        borrowed: HashMap<Argument, /* mut */ bool>,
+    }
 
-/// A write for an object that was generated outside of the Move ObjectRuntime
-struct AdditionalWrite {
-    /// The new owner of the object
-    recipient: Owner,
-    /// the type of the object,
-    type_: Type,
-    /// if the object has public transfer or not, i.e. if it has store
-    has_public_transfer: bool,
-    /// contents of the object
-    bytes: Vec<u8>,
-}
+    /// A write for an object that was generated outside of the Move ObjectRuntime
+    struct AdditionalWrite {
+        /// The new owner of the object
+        recipient: Owner,
+        /// the type of the object,
+        type_: Type,
+        /// if the object has public transfer or not, i.e. if it has store
+        has_public_transfer: bool,
+        /// contents of the object
+        bytes: Vec<u8>,
+    }
 
-impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
-    pub fn new(
-        protocol_config: &'a ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        tx_context: &'a mut TxContext,
-        gas_charger: &'a mut GasCharger,
-        inputs: Vec<CallArg>,
-    ) -> Result<Self, ExecutionError> {
-        // we need a new session just for loading types, which is sad
-        // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
-        let mut tmp_session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            BTreeMap::new(),
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics.clone(),
-        );
-        let mut input_object_map = BTreeMap::new();
-        let inputs = inputs
-            .into_iter()
-            .map(|call_arg| {
-                load_call_arg(
+    impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
+        pub fn new(
+            protocol_config: &'a ProtocolConfig,
+            metrics: Arc<LimitsMetrics>,
+            vm: &'vm MoveVM,
+            state_view: &'state dyn ExecutionState,
+            tx_context: &'a mut TxContext,
+            gas_charger: &'a mut GasCharger,
+            inputs: Vec<CallArg>,
+        ) -> Result<Self, ExecutionError> {
+            // we need a new session just for loading types, which is sad
+            // TODO remove this
+            let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
+            let mut tmp_session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                BTreeMap::new(),
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics.clone(),
+            );
+            let mut input_object_map = BTreeMap::new();
+            let inputs = inputs
+                .into_iter()
+                .map(|call_arg| {
+                    load_call_arg(
+                        vm,
+                        state_view,
+                        &mut tmp_session,
+                        &mut input_object_map,
+                        call_arg,
+                    )
+                })
+                .collect::<Result<_, ExecutionError>>()?;
+            let gas = if let Some(gas_coin) = gas_charger.gas_coin() {
+                let mut gas = load_object(
                     vm,
                     state_view,
                     &mut tmp_session,
                     &mut input_object_map,
-                    call_arg,
-                )
-            })
-            .collect::<Result<_, ExecutionError>>()?;
-        let gas = if let Some(gas_coin) = gas_charger.gas_coin() {
-            let mut gas = load_object(
-                vm,
-                state_view,
-                &mut tmp_session,
-                &mut input_object_map,
-                /* imm override */ false,
-                gas_coin,
-            )?;
-            // subtract the max gas budget. This amount is off limits in the programmable transaction,
-            // so to mimic this "off limits" behavior, we act as if the coin has less balance than
-            // it really does
-            let Some(Value::Object(ObjectValue {
+                    /* imm override */ false,
+                    gas_coin,
+                )?;
+                // subtract the max gas budget. This amount is off limits in the programmable transaction,
+                // so to mimic this "off limits" behavior, we act as if the coin has less balance than
+                // it really does
+                let Some(Value::Object(ObjectValue {
                 contents: ObjectContents::Coin(coin),
                 ..
             })) = &mut gas.inner.value else {
                 invariant_violation!("Gas object should be a populated coin")
             };
-            let max_gas_in_balance = gas_charger.gas_budget();
-            let Some(new_balance) = coin.balance.value().checked_sub(max_gas_in_balance) else {
+                let max_gas_in_balance = gas_charger.gas_budget();
+                let Some(new_balance) = coin.balance.value().checked_sub(max_gas_in_balance) else {
                 invariant_violation!(
                     "Transaction input checker should check that there is enough gas"
                 );
             };
-            coin.balance = Balance::new(new_balance);
-            gas
-        } else {
-            InputValue {
-                object_metadata: None,
-                inner: ResultValue {
-                    last_usage_kind: None,
-                    value: None,
-                },
+                coin.balance = Balance::new(new_balance);
+                gas
+            } else {
+                InputValue {
+                    object_metadata: None,
+                    inner: ResultValue {
+                        last_usage_kind: None,
+                        value: None,
+                    },
+                }
+            };
+            // the session was just used for ability and layout metadata fetching, no changes should
+            // exist. Plus, Sui Move does not use these changes or events
+            let (res, linkage) = tmp_session.finish();
+            let (change_set, move_events) =
+                res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
+            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+            assert_invariant!(move_events.is_empty(), "Events must be empty");
+            // make the real session
+            let session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                input_object_map,
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics.clone(),
+            );
+
+            // Set the profiler if in debug mode
+            #[cfg(debug_assertions)]
+            {
+                let tx_digest = tx_context.digest();
+                let remaining_gas: u64 =
+                    move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())
+                        .into();
+                gas_charger
+                    .move_gas_status_mut()
+                    .set_profiler(GasProfiler::init(
+                        &vm.config().profiler_config,
+                        format!("{}", tx_digest),
+                        remaining_gas,
+                    ));
             }
-        };
-        // the session was just used for ability and layout metadata fetching, no changes should
-        // exist. Plus, Sui Move does not use these changes or events
-        let (res, linkage) = tmp_session.finish();
-        let (change_set, move_events) =
-            res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
-        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-        assert_invariant!(move_events.is_empty(), "Events must be empty");
-        // make the real session
-        let session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            input_object_map,
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics.clone(),
-        );
 
-        // Set the profiler if in debug mode
-        #[cfg(debug_assertions)]
-        {
-            let tx_digest = tx_context.digest();
-            let remaining_gas: u64 =  move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status()).into();
-            gas_charger.move_gas_status_mut().set_profiler(GasProfiler::init(&vm.config().profiler_config, format!("{}", tx_digest), remaining_gas));
+            Ok(Self {
+                protocol_config,
+                metrics,
+                vm,
+                state_view,
+                tx_context,
+                gas_charger,
+                session,
+                gas,
+                inputs,
+                results: vec![],
+                additional_transfers: vec![],
+                new_packages: vec![],
+                user_events: vec![],
+                borrowed: HashMap::new(),
+            })
         }
 
-        Ok(Self {
-            protocol_config,
-            metrics,
-            vm,
-            state_view,
-            tx_context,
-            gas_charger,
-            session,
-            gas,
-            inputs,
-            results: vec![],
-            additional_transfers: vec![],
-            new_packages: vec![],
-            user_events: vec![],
-            borrowed: HashMap::new(),
-        })
-    }
-
-    /// Create a new ID and update the state
-    pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
-        let object_id = self.tx_context.fresh_id();
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        object_runtime
-            .new_id(object_id)
-            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
-        Ok(object_id)
-    }
-
-    /// Delete an ID and update the state
-    pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        object_runtime
-            .delete_id(object_id)
-            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
-    }
-
-    /// Set the link context for the session from the linkage information in the MovePackage found
-    /// at `package_id`.  Returns the runtime ID of the link context package on success.
-    pub fn set_link_context(
-        &mut self,
-        package_id: ObjectID,
-    ) -> Result<AccountAddress, ExecutionError> {
-        let resolver = self.session.get_resolver();
-        if resolver.has_linkage(package_id) {
-            // Setting same context again, can skip.
-            return Ok(resolver.original_package_id().unwrap_or(*package_id));
+        /// Create a new ID and update the state
+        pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
+            let object_id = self.tx_context.fresh_id();
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            object_runtime
+                .new_id(object_id)
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
+            Ok(object_id)
         }
 
-        let package =
-            package_for_linkage(&self.session, package_id).map_err(|e| self.convert_vm_error(e))?;
-
-        set_linkage(&mut self.session, &package)
-    }
-
-    /// Set the link context for the session from the linkage information in the `package`.  Returns
-    /// the runtime ID of the link context package on success.
-    pub fn set_linkage(&mut self, package: &MovePackage) -> Result<AccountAddress, ExecutionError> {
-        set_linkage(&mut self.session, package)
-    }
-
-    /// Turn off linkage information, so that the next use of the session will need to set linkage
-    /// information to succeed.
-    pub fn reset_linkage(&mut self) {
-        reset_linkage(&mut self.session);
-    }
-
-    /// Reset the linkage context, and save it (if one exists)
-    pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
-        steal_linkage(&mut self.session)
-    }
-
-    /// Restore a previously stolen/saved link context.
-    pub fn restore_linkage(&mut self, saved: Option<SavedLinkage>) -> Result<(), ExecutionError> {
-        restore_linkage(&mut self.session, saved)
-    }
-
-    /// Load a type using the context's current session.
-    pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
-        load_type(&mut self.session, type_tag)
-    }
-
-    /// Takes the user events from the runtime and tags them with the Move module of the function
-    /// that was invoked for the command
-    pub fn take_user_events(
-        &mut self,
-        module_id: &ModuleId,
-        function: FunctionDefinitionIndex,
-        last_offset: CodeOffset,
-    ) -> Result<(), ExecutionError> {
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        let events = object_runtime.take_user_events();
-        let num_events = self.user_events.len() + events.len();
-        let max_events = self.protocol_config.max_num_event_emit();
-        if num_events as u64 > max_events {
-            let err = max_event_error(max_events)
-                .at_code_offset(function, last_offset)
-                .finish(Location::Module(module_id.clone()));
-            return Err(self.convert_vm_error(err));
+        /// Delete an ID and update the state
+        pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            object_runtime
+                .delete_id(object_id)
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
         }
-        let new_events = events
-            .into_iter()
-            .map(|(ty, tag, value)| {
-                let layout = self
-                    .session
-                    .type_to_type_layout(&ty)
-                    .map_err(|e| self.convert_vm_error(e))?;
-                let Some(bytes) = value.simple_serialize(&layout) else {
+
+        /// Set the link context for the session from the linkage information in the MovePackage found
+        /// at `package_id`.  Returns the runtime ID of the link context package on success.
+        pub fn set_link_context(
+            &mut self,
+            package_id: ObjectID,
+        ) -> Result<AccountAddress, ExecutionError> {
+            let resolver = self.session.get_resolver();
+            if resolver.has_linkage(package_id) {
+                // Setting same context again, can skip.
+                return Ok(resolver.original_package_id().unwrap_or(*package_id));
+            }
+
+            let package = package_for_linkage(&self.session, package_id)
+                .map_err(|e| self.convert_vm_error(e))?;
+
+            set_linkage(&mut self.session, &package)
+        }
+
+        /// Set the link context for the session from the linkage information in the `package`.  Returns
+        /// the runtime ID of the link context package on success.
+        pub fn set_linkage(
+            &mut self,
+            package: &MovePackage,
+        ) -> Result<AccountAddress, ExecutionError> {
+            set_linkage(&mut self.session, package)
+        }
+
+        /// Turn off linkage information, so that the next use of the session will need to set linkage
+        /// information to succeed.
+        pub fn reset_linkage(&mut self) {
+            reset_linkage(&mut self.session);
+        }
+
+        /// Reset the linkage context, and save it (if one exists)
+        pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
+            steal_linkage(&mut self.session)
+        }
+
+        /// Restore a previously stolen/saved link context.
+        pub fn restore_linkage(
+            &mut self,
+            saved: Option<SavedLinkage>,
+        ) -> Result<(), ExecutionError> {
+            restore_linkage(&mut self.session, saved)
+        }
+
+        /// Load a type using the context's current session.
+        pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
+            load_type(&mut self.session, type_tag)
+        }
+
+        /// Takes the user events from the runtime and tags them with the Move module of the function
+        /// that was invoked for the command
+        pub fn take_user_events(
+            &mut self,
+            module_id: &ModuleId,
+            function: FunctionDefinitionIndex,
+            last_offset: CodeOffset,
+        ) -> Result<(), ExecutionError> {
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let events = object_runtime.take_user_events();
+            let num_events = self.user_events.len() + events.len();
+            let max_events = self.protocol_config.max_num_event_emit();
+            if num_events as u64 > max_events {
+                let err = max_event_error(max_events)
+                    .at_code_offset(function, last_offset)
+                    .finish(Location::Module(module_id.clone()));
+                return Err(self.convert_vm_error(err));
+            }
+            let new_events = events
+                .into_iter()
+                .map(|(ty, tag, value)| {
+                    let layout = self
+                        .session
+                        .type_to_type_layout(&ty)
+                        .map_err(|e| self.convert_vm_error(e))?;
+                    let Some(bytes) = value.simple_serialize(&layout) else {
                     invariant_violation!("Failed to deserialize already serialized Move value");
                 };
-                Ok((module_id.clone(), tag, bytes))
-            })
-            .collect::<Result<Vec<_>, ExecutionError>>()?;
-        self.user_events.extend(new_events);
-        Ok(())
-    }
+                    Ok((module_id.clone(), tag, bytes))
+                })
+                .collect::<Result<Vec<_>, ExecutionError>>()?;
+            self.user_events.extend(new_events);
+            Ok(())
+        }
 
-    /// Get the argument value. Cloning the value if it is copyable, and setting its value to None
-    /// if it is not (making it unavailable).
-    /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
-    /// or if it is an object that cannot be taken by value (shared or immutable)
-    pub fn by_value_arg<V: TryFromValue>(
-        &mut self,
-        command_kind: CommandKind<'_>,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.by_value_arg_(command_kind, arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn by_value_arg_<V: TryFromValue>(
-        &mut self,
-        command_kind: CommandKind<'_>,
-        arg: Argument,
-    ) -> Result<V, CommandArgumentError> {
-        let is_borrowed = self.arg_is_borrowed(&arg);
-        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::ByValue)?;
-        let is_copyable = if let Some(val) = val_opt {
-            val.is_copyable()
-        } else {
-            return Err(CommandArgumentError::InvalidValueUsage);
-        };
-        // If it was taken, we catch this above.
-        // If it was not copyable and was borrowed, error as it creates a dangling reference in
-        // effect.
-        // We allow copyable values to be copied out even if borrowed, as we do not care about
-        // referential transparency at this level.
-        if !is_copyable && is_borrowed {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Get the argument value. Cloning the value if it is copyable, and setting its value to None
+        /// if it is not (making it unavailable).
+        /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
+        /// or if it is an object that cannot be taken by value (shared or immutable)
+        pub fn by_value_arg<V: TryFromValue>(
+            &mut self,
+            command_kind: CommandKind<'_>,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.by_value_arg_(command_kind, arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        // Gas coin cannot be taken by value, except in TransferObjects
-        if matches!(arg, Argument::GasCoin) && !matches!(command_kind, CommandKind::TransferObjects)
-        {
-            return Err(CommandArgumentError::InvalidGasCoinUsage);
+        fn by_value_arg_<V: TryFromValue>(
+            &mut self,
+            command_kind: CommandKind<'_>,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            let is_borrowed = self.arg_is_borrowed(&arg);
+            let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::ByValue)?;
+            let is_copyable = if let Some(val) = val_opt {
+                val.is_copyable()
+            } else {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            };
+            // If it was taken, we catch this above.
+            // If it was not copyable and was borrowed, error as it creates a dangling reference in
+            // effect.
+            // We allow copyable values to be copied out even if borrowed, as we do not care about
+            // referential transparency at this level.
+            if !is_copyable && is_borrowed {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            // Gas coin cannot be taken by value, except in TransferObjects
+            if matches!(arg, Argument::GasCoin)
+                && !matches!(command_kind, CommandKind::TransferObjects)
+            {
+                return Err(CommandArgumentError::InvalidGasCoinUsage);
+            }
+            // Immutable objects and shared objects cannot be taken by value
+            if matches!(
+                input_metadata_opt,
+                Some(InputObjectMetadata {
+                    owner: Owner::Immutable | Owner::Shared { .. },
+                    ..
+                })
+            ) {
+                return Err(CommandArgumentError::InvalidObjectByValue);
+            }
+            let val = if is_copyable {
+                val_opt.as_ref().unwrap().clone()
+            } else {
+                val_opt.take().unwrap()
+            };
+            V::try_from_value(val)
         }
-        // Immutable objects and shared objects cannot be taken by value
-        if matches!(
-            input_metadata_opt,
-            Some(InputObjectMetadata {
-                owner: Owner::Immutable | Owner::Shared { .. },
-                ..
-            })
-        ) {
-            return Err(CommandArgumentError::InvalidObjectByValue);
-        }
-        let val = if is_copyable {
-            val_opt.as_ref().unwrap().clone()
-        } else {
-            val_opt.take().unwrap()
-        };
-        V::try_from_value(val)
-    }
 
-    /// Mimic a mutable borrow by taking the argument value, setting its value to None,
-    /// making it unavailable. The value will be marked as borrowed and must be returned with
-    /// restore_arg
-    /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
-    /// or if it is an object that cannot be mutably borrowed (immutable)
-    pub fn borrow_arg_mut<V: TryFromValue>(
-        &mut self,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.borrow_arg_mut_(arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn borrow_arg_mut_<V: TryFromValue>(
-        &mut self,
-        arg: Argument,
-    ) -> Result<V, CommandArgumentError> {
-        // mutable borrowing requires unique usage
-        if self.arg_is_borrowed(&arg) {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Mimic a mutable borrow by taking the argument value, setting its value to None,
+        /// making it unavailable. The value will be marked as borrowed and must be returned with
+        /// restore_arg
+        /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
+        /// or if it is an object that cannot be mutably borrowed (immutable)
+        pub fn borrow_arg_mut<V: TryFromValue>(
+            &mut self,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.borrow_arg_mut_(arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        self.borrowed.insert(arg, /* is_mut */ true);
-        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
-        let is_copyable = if let Some(val) = val_opt {
-            val.is_copyable()
-        } else {
-            // error if taken
-            return Err(CommandArgumentError::InvalidValueUsage);
-        };
-        if input_metadata_opt.is_some() && !input_metadata_opt.unwrap().is_mutable_input {
-            return Err(CommandArgumentError::InvalidObjectByMutRef);
+        fn borrow_arg_mut_<V: TryFromValue>(
+            &mut self,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            // mutable borrowing requires unique usage
+            if self.arg_is_borrowed(&arg) {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            self.borrowed.insert(arg, /* is_mut */ true);
+            let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
+            let is_copyable = if let Some(val) = val_opt {
+                val.is_copyable()
+            } else {
+                // error if taken
+                return Err(CommandArgumentError::InvalidValueUsage);
+            };
+            if input_metadata_opt.is_some() && !input_metadata_opt.unwrap().is_mutable_input {
+                return Err(CommandArgumentError::InvalidObjectByMutRef);
+            }
+            // if it is copyable, don't take it as we allow for the value to be copied even if
+            // mutably borrowed
+            let val = if is_copyable {
+                val_opt.as_ref().unwrap().clone()
+            } else {
+                val_opt.take().unwrap()
+            };
+            V::try_from_value(val)
         }
-        // if it is copyable, don't take it as we allow for the value to be copied even if
-        // mutably borrowed
-        let val = if is_copyable {
-            val_opt.as_ref().unwrap().clone()
-        } else {
-            val_opt.take().unwrap()
-        };
-        V::try_from_value(val)
-    }
 
-    /// Mimics an immutable borrow by cloning the argument value without setting its value to None
-    /// Errors if out of bounds, if the argument is mutably borrowed,
-    /// or if it is unavailable (already taken)
-    pub fn borrow_arg<V: TryFromValue>(
-        &mut self,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.borrow_arg_(arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn borrow_arg_<V: TryFromValue>(&mut self, arg: Argument) -> Result<V, CommandArgumentError> {
-        // immutable borrowing requires the value was not mutably borrowed.
-        // If it was copied, that is okay.
-        // If it was taken/moved, we will find out below
-        if self.arg_is_mut_borrowed(&arg) {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Mimics an immutable borrow by cloning the argument value without setting its value to None
+        /// Errors if out of bounds, if the argument is mutably borrowed,
+        /// or if it is unavailable (already taken)
+        pub fn borrow_arg<V: TryFromValue>(
+            &mut self,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.borrow_arg_(arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        self.borrowed.insert(arg, /* is_mut */ false);
-        let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowImm)?;
-        if val_opt.is_none() {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        fn borrow_arg_<V: TryFromValue>(
+            &mut self,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            // immutable borrowing requires the value was not mutably borrowed.
+            // If it was copied, that is okay.
+            // If it was taken/moved, we will find out below
+            if self.arg_is_mut_borrowed(&arg) {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            self.borrowed.insert(arg, /* is_mut */ false);
+            let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowImm)?;
+            if val_opt.is_none() {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            V::try_from_value(val_opt.as_ref().unwrap().clone())
         }
-        V::try_from_value(val_opt.as_ref().unwrap().clone())
-    }
 
-    /// Restore an argument after being mutably borrowed
-    pub fn restore_arg<Mode: ExecutionMode>(
-        &mut self,
-        updates: &mut Mode::ArgumentUpdates,
-        arg: Argument,
-        value: Value,
-    ) -> Result<(), ExecutionError> {
-        Mode::add_argument_update(self, updates, arg, &value)?;
-        let was_mut_opt = self.borrowed.remove(&arg);
-        assert_invariant!(
-            was_mut_opt.is_some() && was_mut_opt.unwrap(),
-            "Should never restore a non-mut borrowed value. \
+        /// Restore an argument after being mutably borrowed
+        pub fn restore_arg<Mode: ExecutionMode>(
+            &mut self,
+            updates: &mut Mode::ArgumentUpdates,
+            arg: Argument,
+            value: Value,
+        ) -> Result<(), ExecutionError> {
+            Mode::add_argument_update(self, updates, arg, &value)?;
+            let was_mut_opt = self.borrowed.remove(&arg);
+            assert_invariant!(
+                was_mut_opt.is_some() && was_mut_opt.unwrap(),
+                "Should never restore a non-mut borrowed value. \
             The take+restore is an implementation detail of mutable references"
-        );
-        // restore is exclusively used for mut
-        let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
+            );
+            // restore is exclusively used for mut
+            let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
             invariant_violation!("Should be able to borrow argument to restore it")
         };
-        let old_value = value_opt.replace(value);
-        assert_invariant!(
-            old_value.is_none() || old_value.unwrap().is_copyable(),
-            "Should never restore a non-taken value, unless it is copyable. \
+            let old_value = value_opt.replace(value);
+            assert_invariant!(
+                old_value.is_none() || old_value.unwrap().is_copyable(),
+                "Should never restore a non-taken value, unless it is copyable. \
             The take+restore is an implementation detail of mutable references"
-        );
-        Ok(())
-    }
+            );
+            Ok(())
+        }
 
-    /// Transfer the object to a new owner
-    pub fn transfer_object(
-        &mut self,
-        obj: ObjectValue,
-        addr: SuiAddress,
-    ) -> Result<(), ExecutionError> {
-        self.additional_transfers.push((addr, obj));
-        Ok(())
-    }
+        /// Transfer the object to a new owner
+        pub fn transfer_object(
+            &mut self,
+            obj: ObjectValue,
+            addr: SuiAddress,
+        ) -> Result<(), ExecutionError> {
+            self.additional_transfers.push((addr, obj));
+            Ok(())
+        }
 
-    /// Create a new package
-    pub fn new_package<'p>(
-        &self,
-        modules: &[CompiledModule],
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<Object, ExecutionError> {
-        Object::new_package(
-            modules,
-            self.tx_context.digest(),
-            self.protocol_config.max_move_package_size(),
-            dependencies,
-        )
-    }
+        /// Create a new package
+        pub fn new_package<'p>(
+            &self,
+            modules: &[CompiledModule],
+            dependencies: impl IntoIterator<Item = &'p MovePackage>,
+        ) -> Result<Object, ExecutionError> {
+            Object::new_package(
+                modules,
+                self.tx_context.digest(),
+                self.protocol_config.max_move_package_size(),
+                dependencies,
+            )
+        }
 
-    /// Create a package upgrade from `previous_package` with `new_modules` and `dependencies`
-    pub fn upgrade_package<'p>(
-        &self,
-        storage_id: ObjectID,
-        previous_package: &MovePackage,
-        new_modules: &[CompiledModule],
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<Object, ExecutionError> {
-        Object::new_upgraded_package(
-            previous_package,
-            storage_id,
-            new_modules,
-            self.tx_context.digest(),
-            self.protocol_config,
-            dependencies,
-        )
-    }
+        /// Create a package upgrade from `previous_package` with `new_modules` and `dependencies`
+        pub fn upgrade_package<'p>(
+            &self,
+            storage_id: ObjectID,
+            previous_package: &MovePackage,
+            new_modules: &[CompiledModule],
+            dependencies: impl IntoIterator<Item = &'p MovePackage>,
+        ) -> Result<Object, ExecutionError> {
+            Object::new_upgraded_package(
+                previous_package,
+                storage_id,
+                new_modules,
+                self.tx_context.digest(),
+                self.protocol_config,
+                dependencies,
+            )
+        }
 
-    /// Add a newly created package to write as an effect of the transaction
-    pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
-        assert_invariant!(package.is_package(), "Must be a package");
-        self.new_packages.push(package);
-        Ok(())
-    }
+        /// Add a newly created package to write as an effect of the transaction
+        pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
+            assert_invariant!(package.is_package(), "Must be a package");
+            self.new_packages.push(package);
+            Ok(())
+        }
 
-    /// Finish a command: clearing the borrows and adding the results to the result vector
-    pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
-        assert_invariant!(
-            self.borrowed.values().all(|is_mut| !is_mut),
-            "all mut borrows should be restored"
-        );
-        // clear borrow state
-        self.borrowed = HashMap::new();
-        self.results
-            .push(results.into_iter().map(ResultValue::new).collect());
-        Ok(())
-    }
+        /// Finish a command: clearing the borrows and adding the results to the result vector
+        pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
+            assert_invariant!(
+                self.borrowed.values().all(|is_mut| !is_mut),
+                "all mut borrows should be restored"
+            );
+            // clear borrow state
+            self.borrowed = HashMap::new();
+            self.results
+                .push(results.into_iter().map(ResultValue::new).collect());
+            Ok(())
+        }
 
-    /// Determine the object changes and collect all user events
-    pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
-        let Self {
-            protocol_config,
-            metrics,
-            vm,
-            state_view,
-            tx_context,
-            gas_charger,
-            session,
-            additional_transfers,
-            new_packages,
-            gas,
-            inputs,
-            results,
-            user_events,
-            ..
-        } = self;
-        let tx_digest = tx_context.digest();
-        let mut additional_writes = BTreeMap::new();
-        let mut input_object_metadata = BTreeMap::new();
-        // Any object value that has not been taken (still has `Some` for it's value) needs to
-        // written as it's value might have changed (and eventually it's sequence number will need
-        // to increase)
-        let mut by_value_inputs = BTreeSet::new();
-        let mut add_input_object_write = |input| -> Result<(), ExecutionError> {
-            let InputValue {
-                object_metadata: object_metadata_opt,
-                inner: ResultValue { value, .. },
-            } = input;
-            let Some(object_metadata) = object_metadata_opt else { return Ok(()) };
-            let is_mutable_input = object_metadata.is_mutable_input;
-            let owner = object_metadata.owner;
-            let id = object_metadata.id;
-            input_object_metadata.insert(object_metadata.id, object_metadata);
-            let Some(Value::Object(object_value)) = value else {
+        /// Determine the object changes and collect all user events
+        pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
+            let Self {
+                protocol_config,
+                metrics,
+                vm,
+                state_view,
+                tx_context,
+                gas_charger,
+                session,
+                additional_transfers,
+                new_packages,
+                gas,
+                inputs,
+                results,
+                user_events,
+                ..
+            } = self;
+            let tx_digest = tx_context.digest();
+            let mut additional_writes = BTreeMap::new();
+            let mut input_object_metadata = BTreeMap::new();
+            // Any object value that has not been taken (still has `Some` for it's value) needs to
+            // written as it's value might have changed (and eventually it's sequence number will need
+            // to increase)
+            let mut by_value_inputs = BTreeSet::new();
+            let mut add_input_object_write = |input| -> Result<(), ExecutionError> {
+                let InputValue {
+                    object_metadata: object_metadata_opt,
+                    inner: ResultValue { value, .. },
+                } = input;
+                let Some(object_metadata) = object_metadata_opt else { return Ok(()) };
+                let is_mutable_input = object_metadata.is_mutable_input;
+                let owner = object_metadata.owner;
+                let id = object_metadata.id;
+                input_object_metadata.insert(object_metadata.id, object_metadata);
+                let Some(Value::Object(object_value)) = value else {
                 by_value_inputs.insert(id);
                 return Ok(())
             };
-            if is_mutable_input {
-                add_additional_write(&mut additional_writes, owner, object_value)?;
+                if is_mutable_input {
+                    add_additional_write(&mut additional_writes, owner, object_value)?;
+                }
+                Ok(())
+            };
+            let gas_id_opt = gas.object_metadata.as_ref().map(|info| info.id);
+            add_input_object_write(gas)?;
+            for input in inputs {
+                add_input_object_write(input)?
             }
-            Ok(())
-        };
-        let gas_id_opt = gas.object_metadata.as_ref().map(|info| info.id);
-        add_input_object_write(gas)?;
-        for input in inputs {
-            add_input_object_write(input)?
-        }
-        // check for unused values
-        // disable this check for dev inspect
-        if !Mode::allow_arbitrary_values() {
-            for (i, command_result) in results.iter().enumerate() {
-                for (j, result_value) in command_result.iter().enumerate() {
-                    let ResultValue {
-                        last_usage_kind,
-                        value,
-                    } = result_value;
-                    match value {
-                        None => (),
-                        Some(Value::Object(_)) => {
-                            return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
-                                result_idx: i as u16,
-                                secondary_idx: j as u16,
+            // check for unused values
+            // disable this check for dev inspect
+            if !Mode::allow_arbitrary_values() {
+                for (i, command_result) in results.iter().enumerate() {
+                    for (j, result_value) in command_result.iter().enumerate() {
+                        let ResultValue {
+                            last_usage_kind,
+                            value,
+                        } = result_value;
+                        match value {
+                            None => (),
+                            Some(Value::Object(_)) => {
+                                return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
+                                    result_idx: i as u16,
+                                    secondary_idx: j as u16,
+                                }
+                                .into())
                             }
-                            .into())
-                        }
-                        Some(Value::Raw(RawValueType::Any, _)) => (),
-                        Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
-                            // - nothing to check for drop
-                            // - if it does not have drop, but has copy,
-                            //   the last usage must be by value in order to "lie" and say that the
-                            //   last usage is actually a take instead of a clone
-                            // - Otherwise, an error
-                            if abilities.has_drop()
-                                || (abilities.has_copy()
-                                    && matches!(last_usage_kind, Some(UsageKind::ByValue)))
-                            {
-                            } else {
-                                let msg = if abilities.has_copy() {
-                                    "The value has copy, but not drop. \
-                                    Its last usage must be by-value so it can be taken."
+                            Some(Value::Raw(RawValueType::Any, _)) => (),
+                            Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
+                                // - nothing to check for drop
+                                // - if it does not have drop, but has copy,
+                                //   the last usage must be by value in order to "lie" and say that the
+                                //   last usage is actually a take instead of a clone
+                                // - Otherwise, an error
+                                if abilities.has_drop()
+                                    || (abilities.has_copy()
+                                        && matches!(last_usage_kind, Some(UsageKind::ByValue)))
+                                {
                                 } else {
-                                    "Unused value without drop"
-                                };
-                                return Err(ExecutionError::new_with_source(
-                                    ExecutionErrorKind::UnusedValueWithoutDrop {
-                                        result_idx: i as u16,
-                                        secondary_idx: j as u16,
-                                    },
-                                    msg,
-                                ));
+                                    let msg = if abilities.has_copy() {
+                                        "The value has copy, but not drop. \
+                                    Its last usage must be by-value so it can be taken."
+                                    } else {
+                                        "Unused value without drop"
+                                    };
+                                    return Err(ExecutionError::new_with_source(
+                                        ExecutionErrorKind::UnusedValueWithoutDrop {
+                                            result_idx: i as u16,
+                                            secondary_idx: j as u16,
+                                        },
+                                        msg,
+                                    ));
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-        // add transfers from TransferObjects command
-        for (recipient, object_value) in additional_transfers {
-            let owner = Owner::AddressOwner(recipient);
-            add_additional_write(&mut additional_writes, owner, object_value)?;
-        }
-        // Refund unused gas
-        if let Some(gas_id) = gas_id_opt {
-            refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
-        }
+            // add transfers from TransferObjects command
+            for (recipient, object_value) in additional_transfers {
+                let owner = Owner::AddressOwner(recipient);
+                add_additional_write(&mut additional_writes, owner, object_value)?;
+            }
+            // Refund unused gas
+            if let Some(gas_id) = gas_id_opt {
+                refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
+            }
 
-        let (res, linkage) = session.finish_with_extensions();
-        let (change_set, events, mut native_context_extensions) =
-            res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-        // Sui Move programs should never touch global state, so resources should be empty
-        assert_invariant!(
-            change_set.resources().next().is_none(),
-            "Change set must be empty"
-        );
-        // Sui Move no longer uses Move's internal event system
-        assert_invariant!(events.is_empty(), "Events must be empty");
-        let object_runtime: ObjectRuntime = native_context_extensions.remove();
-        let new_ids = object_runtime.new_ids().clone();
-        // tell the object runtime what input objects were taken and which were transferred
-        let external_transfers = additional_writes.keys().copied().collect();
-        let RuntimeResults {
-            writes,
-            deletions,
-            user_events: remaining_events,
-            loaded_child_objects,
-        } = object_runtime.finish(by_value_inputs, external_transfers)?;
-        assert_invariant!(
-            remaining_events.is_empty(),
-            "Events should be taken after every Move call"
-        );
-        let mut object_changes = BTreeMap::new();
-        for package in new_packages {
-            let id = package.id();
-            let change = ObjectChange::Write(package, WriteKind::Create);
-            object_changes.insert(id, change);
-        }
-        // we need a new session just for deserializing and fetching abilities. Which is sad
-        // TODO remove this
-        let tmp_session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            BTreeMap::new(),
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics,
-        );
-        for (id, additional_write) in additional_writes {
-            let AdditionalWrite {
-                recipient,
-                type_,
-                has_public_transfer,
-                bytes,
-            } = additional_write;
-            let write_kind = if input_object_metadata.contains_key(&id)
-                || loaded_child_objects.contains_key(&id)
-            {
-                assert_invariant!(
-                    !new_ids.contains_key(&id),
-                    "new id should not be in mutations"
-                );
-                WriteKind::Mutate
-            } else if new_ids.contains_key(&id) {
-                WriteKind::Create
-            } else {
-                WriteKind::Unwrap
-            };
-            // safe given the invariant that the runtime correctly propagates has_public_transfer
-            let move_object = unsafe {
-                create_written_object(
-                    vm,
-                    &tmp_session,
-                    protocol_config,
-                    &input_object_metadata,
-                    &loaded_child_objects,
-                    id,
+            let (res, linkage) = session.finish_with_extensions();
+            let (change_set, events, mut native_context_extensions) =
+                res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
+            // Sui Move programs should never touch global state, so resources should be empty
+            assert_invariant!(
+                change_set.resources().next().is_none(),
+                "Change set must be empty"
+            );
+            // Sui Move no longer uses Move's internal event system
+            assert_invariant!(events.is_empty(), "Events must be empty");
+            let object_runtime: ObjectRuntime = native_context_extensions.remove();
+            let new_ids = object_runtime.new_ids().clone();
+            // tell the object runtime what input objects were taken and which were transferred
+            let external_transfers = additional_writes.keys().copied().collect();
+            let RuntimeResults {
+                writes,
+                deletions,
+                user_events: remaining_events,
+                loaded_child_objects,
+            } = object_runtime.finish(by_value_inputs, external_transfers)?;
+            assert_invariant!(
+                remaining_events.is_empty(),
+                "Events should be taken after every Move call"
+            );
+            let mut object_changes = BTreeMap::new();
+            for package in new_packages {
+                let id = package.id();
+                let change = ObjectChange::Write(package, WriteKind::Create);
+                object_changes.insert(id, change);
+            }
+            // we need a new session just for deserializing and fetching abilities. Which is sad
+            // TODO remove this
+            let tmp_session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                BTreeMap::new(),
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics,
+            );
+            for (id, additional_write) in additional_writes {
+                let AdditionalWrite {
+                    recipient,
                     type_,
                     has_public_transfer,
                     bytes,
-                    write_kind,
-                )?
-            };
-            let object = Object::new_move(move_object, recipient, tx_digest);
-            let change = ObjectChange::Write(object, write_kind);
-            object_changes.insert(id, change);
-        }
+                } = additional_write;
+                let write_kind = if input_object_metadata.contains_key(&id)
+                    || loaded_child_objects.contains_key(&id)
+                {
+                    assert_invariant!(
+                        !new_ids.contains_key(&id),
+                        "new id should not be in mutations"
+                    );
+                    WriteKind::Mutate
+                } else if new_ids.contains_key(&id) {
+                    WriteKind::Create
+                } else {
+                    WriteKind::Unwrap
+                };
+                // safe given the invariant that the runtime correctly propagates has_public_transfer
+                let move_object = unsafe {
+                    create_written_object(
+                        vm,
+                        &tmp_session,
+                        protocol_config,
+                        &input_object_metadata,
+                        &loaded_child_objects,
+                        id,
+                        type_,
+                        has_public_transfer,
+                        bytes,
+                        write_kind,
+                    )?
+                };
+                let object = Object::new_move(move_object, recipient, tx_digest);
+                let change = ObjectChange::Write(object, write_kind);
+                object_changes.insert(id, change);
+            }
 
-        for (id, (write_kind, recipient, ty, value)) in writes {
-            let abilities = tmp_session
-                .get_type_abilities(&ty)
-                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
-            let has_public_transfer = abilities.has_store();
-            let layout = tmp_session
-                .type_to_type_layout(&ty)
-                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
-            let Some(bytes) = value.simple_serialize(&layout) else {
+            for (id, (write_kind, recipient, ty, value)) in writes {
+                let abilities = tmp_session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                let has_public_transfer = abilities.has_store();
+                let layout = tmp_session
+                    .type_to_type_layout(&ty)
+                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                let Some(bytes) = value.simple_serialize(&layout) else {
                 invariant_violation!("Failed to deserialize already serialized Move value");
             };
-            // safe because has_public_transfer has been determined by the abilities
-            let move_object = unsafe {
-                create_written_object(
-                    vm,
-                    &tmp_session,
-                    protocol_config,
-                    &input_object_metadata,
-                    &loaded_child_objects,
-                    id,
-                    ty,
-                    has_public_transfer,
-                    bytes,
-                    write_kind,
-                )?
-            };
-            let object = Object::new_move(move_object, recipient, tx_digest);
-            let change = ObjectChange::Write(object, write_kind);
-            object_changes.insert(id, change);
-        }
-        for (id, delete_kind) in deletions {
-            // For deleted and wrapped objects, the object must exist either in the input or was
-            // loaded as child object. We can read them to get the previous version.
-            // For unwrap_then_delete, in older protocol versions, we must consult the object store
-            // to see if there exists a tombstone, and if so we include it otherwise we skip it.
-            // In newer protocol versions, we can just skip it.
-            let delete_kind_with_seq = match delete_kind {
-                DeleteKind::Normal | DeleteKind::Wrap => {
-                    let old_version = match input_object_metadata.get(&id) {
+                // safe because has_public_transfer has been determined by the abilities
+                let move_object = unsafe {
+                    create_written_object(
+                        vm,
+                        &tmp_session,
+                        protocol_config,
+                        &input_object_metadata,
+                        &loaded_child_objects,
+                        id,
+                        ty,
+                        has_public_transfer,
+                        bytes,
+                        write_kind,
+                    )?
+                };
+                let object = Object::new_move(move_object, recipient, tx_digest);
+                let change = ObjectChange::Write(object, write_kind);
+                object_changes.insert(id, change);
+            }
+            for (id, delete_kind) in deletions {
+                // For deleted and wrapped objects, the object must exist either in the input or was
+                // loaded as child object. We can read them to get the previous version.
+                // For unwrap_then_delete, in older protocol versions, we must consult the object store
+                // to see if there exists a tombstone, and if so we include it otherwise we skip it.
+                // In newer protocol versions, we can just skip it.
+                let delete_kind_with_seq = match delete_kind {
+                    DeleteKind::Normal | DeleteKind::Wrap => {
+                        let old_version = match input_object_metadata.get(&id) {
                         Some(metadata) => {
                             assert_invariant!(
                                 !matches!(metadata.owner, Owner::Immutable),
@@ -774,488 +794,491 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
                             }
                         }
                     };
-                    if delete_kind == DeleteKind::Normal {
-                        DeleteKindWithOldVersion::Normal(old_version)
-                    } else {
-                        DeleteKindWithOldVersion::Wrap(old_version)
+                        if delete_kind == DeleteKind::Normal {
+                            DeleteKindWithOldVersion::Normal(old_version)
+                        } else {
+                            DeleteKindWithOldVersion::Wrap(old_version)
+                        }
                     }
-                }
-                DeleteKind::UnwrapThenDelete => {
-                    if protocol_config.simplified_unwrap_then_delete() {
-                        DeleteKindWithOldVersion::UnwrapThenDelete
-                    } else {
-                        let old_version = match state_view.get_latest_parent_entry_ref(id) {
-                            Ok(Some((_, previous_version, _))) => previous_version,
-                            // This object was not created this transaction but has never existed in
-                            // storage, skip it.
-                            Ok(None) => continue,
-                            Err(_) => invariant_violation!("{}", missing_unwrapped_msg(&id)),
-                        };
-                        DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(old_version)
+                    DeleteKind::UnwrapThenDelete => {
+                        if protocol_config.simplified_unwrap_then_delete() {
+                            DeleteKindWithOldVersion::UnwrapThenDelete
+                        } else {
+                            let old_version = match state_view.get_latest_parent_entry_ref(id) {
+                                Ok(Some((_, previous_version, _))) => previous_version,
+                                // This object was not created this transaction but has never existed in
+                                // storage, skip it.
+                                Ok(None) => continue,
+                                Err(_) => invariant_violation!("{}", missing_unwrapped_msg(&id)),
+                            };
+                            DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(old_version)
+                        }
                     }
-                }
-            };
-            object_changes.insert(id, ObjectChange::Delete(delete_kind_with_seq));
+                };
+                object_changes.insert(id, ObjectChange::Delete(delete_kind_with_seq));
+            }
+
+            let (res, linkage) = tmp_session.finish();
+            let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
+
+            // the session was just used for ability and layout metadata fetching, no changes should
+            // exist. Plus, Sui Move does not use these changes or events
+            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+            assert_invariant!(move_events.is_empty(), "Events must be empty");
+
+            Ok(ExecutionResults {
+                object_changes,
+                user_events,
+            })
         }
 
-        let (res, linkage) = tmp_session.finish();
-        let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-
-        // the session was just used for ability and layout metadata fetching, no changes should
-        // exist. Plus, Sui Move does not use these changes or events
-        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-        assert_invariant!(move_events.is_empty(), "Events must be empty");
-
-        Ok(ExecutionResults {
-            object_changes,
-            user_events,
-        })
-    }
-
-    /// Convert a VM Error to an execution one
-    pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-        crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
-    }
-
-    /// Special case errors for type arguments to Move functions
-    pub fn convert_type_argument_error(&self, idx: usize, error: VMError) -> ExecutionError {
-        use move_core_types::vm_status::StatusCode;
-        use sui_types::execution_status::TypeArgumentError;
-        match error.major_status() {
-            StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
-                ExecutionErrorKind::TypeArityMismatch.into()
-            }
-            StatusCode::TYPE_RESOLUTION_FAILURE => ExecutionErrorKind::TypeArgumentError {
-                argument_idx: idx as TypeParameterIndex,
-                kind: TypeArgumentError::TypeNotFound,
-            }
-            .into(),
-            StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
-                argument_idx: idx as TypeParameterIndex,
-                kind: TypeArgumentError::ConstraintNotSatisfied,
-            }
-            .into(),
-            _ => self.convert_vm_error(error),
+        /// Convert a VM Error to an execution one
+        pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
+            crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
         }
-    }
 
-    /// Returns true if the value at the argument's location is borrowed, mutably or immutably
-    fn arg_is_borrowed(&self, arg: &Argument) -> bool {
-        self.borrowed.contains_key(arg)
-    }
-
-    /// Returns true if the value at the argument's location is mutably borrowed
-    fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
-        matches!(self.borrowed.get(arg), Some(/* mut */ true))
-    }
-
-    /// Internal helper to borrow the value for an argument and update the most recent usage
-    fn borrow_mut(
-        &mut self,
-        arg: Argument,
-        usage: UsageKind,
-    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError> {
-        self.borrow_mut_impl(arg, Some(usage))
-    }
-
-    /// Internal helper to borrow the value for an argument
-    /// Updates the most recent usage if specified
-    fn borrow_mut_impl(
-        &mut self,
-        arg: Argument,
-        update_last_usage: Option<UsageKind>,
-    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError> {
-        let (metadata, result_value) = match arg {
-            Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
-            Argument::Input(i) => {
-                let Some(input_value) = self.inputs.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
-                (input_value.object_metadata.as_ref(), &mut input_value.inner)
-            }
-            Argument::Result(i) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
-                if command_result.len() != 1 {
-                    return Err(CommandArgumentError::InvalidResultArity { result_idx: i });
+        /// Special case errors for type arguments to Move functions
+        pub fn convert_type_argument_error(&self, idx: usize, error: VMError) -> ExecutionError {
+            use move_core_types::vm_status::StatusCode;
+            use sui_types::execution_status::TypeArgumentError;
+            match error.major_status() {
+                StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
+                    ExecutionErrorKind::TypeArityMismatch.into()
                 }
-                (None, &mut command_result[0])
+                StatusCode::TYPE_RESOLUTION_FAILURE => ExecutionErrorKind::TypeArgumentError {
+                    argument_idx: idx as TypeParameterIndex,
+                    kind: TypeArgumentError::TypeNotFound,
+                }
+                .into(),
+                StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
+                    argument_idx: idx as TypeParameterIndex,
+                    kind: TypeArgumentError::ConstraintNotSatisfied,
+                }
+                .into(),
+                _ => self.convert_vm_error(error),
             }
-            Argument::NestedResult(i, j) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
+        }
+
+        /// Returns true if the value at the argument's location is borrowed, mutably or immutably
+        fn arg_is_borrowed(&self, arg: &Argument) -> bool {
+            self.borrowed.contains_key(arg)
+        }
+
+        /// Returns true if the value at the argument's location is mutably borrowed
+        fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
+            matches!(self.borrowed.get(arg), Some(/* mut */ true))
+        }
+
+        /// Internal helper to borrow the value for an argument and update the most recent usage
+        fn borrow_mut(
+            &mut self,
+            arg: Argument,
+            usage: UsageKind,
+        ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError>
+        {
+            self.borrow_mut_impl(arg, Some(usage))
+        }
+
+        /// Internal helper to borrow the value for an argument
+        /// Updates the most recent usage if specified
+        fn borrow_mut_impl(
+            &mut self,
+            arg: Argument,
+            update_last_usage: Option<UsageKind>,
+        ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError>
+        {
+            let (metadata, result_value) = match arg {
+                Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
+                Argument::Input(i) => {
+                    let Some(input_value) = self.inputs.get_mut(i as usize) else {
                     return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
                 };
-                let Some(result_value) = command_result.get_mut(j as usize) else {
+                    (input_value.object_metadata.as_ref(), &mut input_value.inner)
+                }
+                Argument::Result(i) => {
+                    let Some(command_result) = self.results.get_mut(i as usize) else {
+                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                };
+                    if command_result.len() != 1 {
+                        return Err(CommandArgumentError::InvalidResultArity { result_idx: i });
+                    }
+                    (None, &mut command_result[0])
+                }
+                Argument::NestedResult(i, j) => {
+                    let Some(command_result) = self.results.get_mut(i as usize) else {
+                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                };
+                    let Some(result_value) = command_result.get_mut(j as usize) else {
                     return Err(CommandArgumentError::SecondaryIndexOutOfBounds {
                         result_idx: i,
                         secondary_idx: j,
                     });
                 };
-                (None, result_value)
+                    (None, result_value)
+                }
+            };
+            if let Some(usage) = update_last_usage {
+                result_value.last_usage_kind = Some(usage);
             }
-        };
-        if let Some(usage) = update_last_usage {
-            result_value.last_usage_kind = Some(usage);
+            Ok((metadata, &mut result_value.value))
         }
-        Ok((metadata, &mut result_value.value))
-    }
-}
-
-impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
-    fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
-        self.session
-            .get_type_tag(type_)
-            .map_err(|e| self.convert_vm_error(e))
-    }
-}
-
-pub(crate) fn new_session<'state, 'vm>(
-    vm: &'vm MoveVM,
-    linkage: LinkageView<'state>,
-    child_resolver: &'state dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-    is_metered: bool,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Session<'state, 'vm, LinkageView<'state>> {
-    vm.new_session_with_extensions(
-        linkage,
-        new_native_extensions(
-            child_resolver,
-            input_objects,
-            is_metered,
-            protocol_config,
-            metrics,
-        ),
-    )
-}
-
-// Create a new Session suitable for resolving type and type operations rather than execution
-pub(crate) fn new_session_for_linkage<'vm, 'state>(
-    vm: &'vm MoveVM,
-    linkage: LinkageView<'state>,
-) -> Session<'state, 'vm, LinkageView<'state>> {
-    vm.new_session(linkage)
-}
-
-/// Set the link context for the session from the linkage information in the `package`.
-pub fn set_linkage(
-    session: &mut Session<LinkageView>,
-    linkage: &MovePackage,
-) -> Result<AccountAddress, ExecutionError> {
-    session.get_resolver_mut().set_linkage(linkage)
-}
-
-/// Turn off linkage information, so that the next use of the session will need to set linkage
-/// information to succeed.
-pub fn reset_linkage(session: &mut Session<LinkageView>) {
-    session.get_resolver_mut().reset_linkage();
-}
-
-pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
-    session.get_resolver_mut().steal_linkage()
-}
-
-pub fn restore_linkage(
-    session: &mut Session<LinkageView>,
-    saved: Option<SavedLinkage>,
-) -> Result<(), ExecutionError> {
-    session.get_resolver_mut().restore_linkage(saved)
-}
-
-/// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
-/// if the object at that ID does not exist, or is not a package.
-fn package_for_linkage(
-    session: &Session<LinkageView>,
-    package_id: ObjectID,
-) -> VMResult<MovePackage> {
-    use move_binary_format::errors::PartialVMError;
-    use move_core_types::vm_status::StatusCode;
-
-    match session.get_resolver().get_package(&package_id) {
-        Ok(Some(package)) => Ok(package),
-        Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-            .with_message(format!("Cannot find link context {package_id} in store"))
-            .finish(Location::Undefined)),
-        Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-            .with_message(format!(
-                "Error loading link context {package_id} from store: {err}"
-            ))
-            .finish(Location::Undefined)),
-    }
-}
-
-/// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
-/// reset after this operation, because during the operation, it may change when loading a struct.
-pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
-    use move_binary_format::errors::PartialVMError;
-    use move_core_types::vm_status::StatusCode;
-
-    fn verification_error<T>(code: StatusCode) -> VMResult<T> {
-        Err(PartialVMError::new(code).finish(Location::Undefined))
     }
 
-    Ok(match type_tag {
-        TypeTag::Bool => Type::Bool,
-        TypeTag::U8 => Type::U8,
-        TypeTag::U16 => Type::U16,
-        TypeTag::U32 => Type::U32,
-        TypeTag::U64 => Type::U64,
-        TypeTag::U128 => Type::U128,
-        TypeTag::U256 => Type::U256,
-        TypeTag::Address => Type::Address,
-        TypeTag::Signer => Type::Signer,
+    impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
+        fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
+            self.session
+                .get_type_tag(type_)
+                .map_err(|e| self.convert_vm_error(e))
+        }
+    }
 
-        TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
-        TypeTag::Struct(struct_tag) => {
-            let StructTag {
-                address,
-                module,
-                name,
-                type_params,
-            } = struct_tag.as_ref();
+    pub(crate) fn new_session<'state, 'vm>(
+        vm: &'vm MoveVM,
+        linkage: LinkageView<'state>,
+        child_resolver: &'state dyn ChildObjectResolver,
+        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
+        is_metered: bool,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Session<'state, 'vm, LinkageView<'state>> {
+        vm.new_session_with_extensions(
+            linkage,
+            new_native_extensions(
+                child_resolver,
+                input_objects,
+                is_metered,
+                protocol_config,
+                metrics,
+            ),
+        )
+    }
 
-            // Load the package that the struct is defined in, in storage
-            let defining_id = ObjectID::from_address(*address);
-            let package = package_for_linkage(session, defining_id)?;
+    // Create a new Session suitable for resolving type and type operations rather than execution
+    pub(crate) fn new_session_for_linkage<'vm, 'state>(
+        vm: &'vm MoveVM,
+        linkage: LinkageView<'state>,
+    ) -> Session<'state, 'vm, LinkageView<'state>> {
+        vm.new_session(linkage)
+    }
 
-            // Set the defining package as the link context on the session while loading the
-            // struct
-            let original_address = set_linkage(session, &package).map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(e.to_string())
-                    .finish(Location::Undefined)
-            })?;
+    /// Set the link context for the session from the linkage information in the `package`.
+    pub fn set_linkage(
+        session: &mut Session<LinkageView>,
+        linkage: &MovePackage,
+    ) -> Result<AccountAddress, ExecutionError> {
+        session.get_resolver_mut().set_linkage(linkage)
+    }
 
-            let runtime_id = ModuleId::new(original_address, module.clone());
-            let res = session.load_struct(&runtime_id, name);
-            reset_linkage(session);
-            let (idx, struct_type) = res?;
+    /// Turn off linkage information, so that the next use of the session will need to set linkage
+    /// information to succeed.
+    pub fn reset_linkage(session: &mut Session<LinkageView>) {
+        session.get_resolver_mut().reset_linkage();
+    }
 
-            // Recursively load type parameters, if necessary
-            let type_param_constraints = struct_type.type_param_constraints();
-            if type_param_constraints.len() != type_params.len() {
-                return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
-            }
+    pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
+        session.get_resolver_mut().steal_linkage()
+    }
 
-            if type_params.is_empty() {
-                Type::Struct(idx)
-            } else {
-                let loaded_type_params = type_params
-                    .iter()
-                    .map(|type_param| load_type(session, type_param))
-                    .collect::<VMResult<Vec<_>>>()?;
+    pub fn restore_linkage(
+        session: &mut Session<LinkageView>,
+        saved: Option<SavedLinkage>,
+    ) -> Result<(), ExecutionError> {
+        session.get_resolver_mut().restore_linkage(saved)
+    }
 
-                // Verify that the type parameter constraints on the struct are met
-                for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
-                    let abilities = session.get_type_abilities(param)?;
-                    if !constraint.is_subset(abilities) {
-                        return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
-                    }
+    /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
+    /// if the object at that ID does not exist, or is not a package.
+    fn package_for_linkage(
+        session: &Session<LinkageView>,
+        package_id: ObjectID,
+    ) -> VMResult<MovePackage> {
+        use move_binary_format::errors::PartialVMError;
+        use move_core_types::vm_status::StatusCode;
+
+        match session.get_resolver().get_package(&package_id) {
+            Ok(Some(package)) => Ok(package),
+            Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Cannot find link context {package_id} in store"))
+                .finish(Location::Undefined)),
+            Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!(
+                    "Error loading link context {package_id} from store: {err}"
+                ))
+                .finish(Location::Undefined)),
+        }
+    }
+
+    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
+    /// reset after this operation, because during the operation, it may change when loading a struct.
+    pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
+        use move_binary_format::errors::PartialVMError;
+        use move_core_types::vm_status::StatusCode;
+
+        fn verification_error<T>(code: StatusCode) -> VMResult<T> {
+            Err(PartialVMError::new(code).finish(Location::Undefined))
+        }
+
+        Ok(match type_tag {
+            TypeTag::Bool => Type::Bool,
+            TypeTag::U8 => Type::U8,
+            TypeTag::U16 => Type::U16,
+            TypeTag::U32 => Type::U32,
+            TypeTag::U64 => Type::U64,
+            TypeTag::U128 => Type::U128,
+            TypeTag::U256 => Type::U256,
+            TypeTag::Address => Type::Address,
+            TypeTag::Signer => Type::Signer,
+
+            TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
+            TypeTag::Struct(struct_tag) => {
+                let StructTag {
+                    address,
+                    module,
+                    name,
+                    type_params,
+                } = struct_tag.as_ref();
+
+                // Load the package that the struct is defined in, in storage
+                let defining_id = ObjectID::from_address(*address);
+                let package = package_for_linkage(session, defining_id)?;
+
+                // Set the defining package as the link context on the session while loading the
+                // struct
+                let original_address = set_linkage(session, &package).map_err(|e| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(e.to_string())
+                        .finish(Location::Undefined)
+                })?;
+
+                let runtime_id = ModuleId::new(original_address, module.clone());
+                let res = session.load_struct(&runtime_id, name);
+                reset_linkage(session);
+                let (idx, struct_type) = res?;
+
+                // Recursively load type parameters, if necessary
+                let type_param_constraints = struct_type.type_param_constraints();
+                if type_param_constraints.len() != type_params.len() {
+                    return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
                 }
 
-                Type::StructInstantiation(idx, loaded_type_params)
-            }
-        }
-    })
-}
+                if type_params.is_empty() {
+                    Type::Struct(idx)
+                } else {
+                    let loaded_type_params = type_params
+                        .iter()
+                        .map(|type_param| load_type(session, type_param))
+                        .collect::<VMResult<Vec<_>>>()?;
 
-pub(crate) fn make_object_value<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    type_: MoveObjectType,
-    has_public_transfer: bool,
-    used_in_non_entry_move_call: bool,
-    contents: &[u8],
-) -> Result<ObjectValue, ExecutionError> {
-    let contents = if type_.is_coin() {
-        let Ok(coin) = Coin::from_bcs_bytes(contents) else {
+                    // Verify that the type parameter constraints on the struct are met
+                    for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
+                        let abilities = session.get_type_abilities(param)?;
+                        if !constraint.is_subset(abilities) {
+                            return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
+                        }
+                    }
+
+                    Type::StructInstantiation(idx, loaded_type_params)
+                }
+            }
+        })
+    }
+
+    pub(crate) fn make_object_value<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        type_: MoveObjectType,
+        has_public_transfer: bool,
+        used_in_non_entry_move_call: bool,
+        contents: &[u8],
+    ) -> Result<ObjectValue, ExecutionError> {
+        let contents = if type_.is_coin() {
+            let Ok(coin) = Coin::from_bcs_bytes(contents) else {
             invariant_violation!("Could not deserialize a coin")
         };
-        ObjectContents::Coin(coin)
-    } else {
-        ObjectContents::Raw(contents.to_vec())
-    };
+            ObjectContents::Coin(coin)
+        } else {
+            ObjectContents::Raw(contents.to_vec())
+        };
 
-    let tag: StructTag = type_.into();
-    let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
-        .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
-    Ok(ObjectValue {
-        type_,
-        has_public_transfer,
-        used_in_non_entry_move_call,
-        contents,
-    })
-}
+        let tag: StructTag = type_.into();
+        let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
+            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        Ok(ObjectValue {
+            type_,
+            has_public_transfer,
+            used_in_non_entry_move_call,
+            contents,
+        })
+    }
 
-pub(crate) fn value_from_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    object: &Object,
-) -> Result<ObjectValue, ExecutionError> {
-    let Object { data: Data::Move(object), .. } = object else {
+    pub(crate) fn value_from_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        object: &Object,
+    ) -> Result<ObjectValue, ExecutionError> {
+        let Object { data: Data::Move(object), .. } = object else {
         invariant_violation!("Expected a Move object");
     };
 
-    let used_in_non_entry_move_call = false;
-    make_object_value(
-        vm,
-        session,
-        object.type_().clone(),
-        object.has_public_transfer(),
-        used_in_non_entry_move_call,
-        object.contents(),
-    )
-}
+        let used_in_non_entry_move_call = false;
+        make_object_value(
+            vm,
+            session,
+            object.type_().clone(),
+            object.has_public_transfer(),
+            used_in_non_entry_move_call,
+            object.contents(),
+        )
+    }
 
-/// Load an input object from the state_view
-fn load_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    override_as_immutable: bool,
-    id: ObjectID,
-) -> Result<InputValue, ExecutionError> {
-    let Some(obj) = state_view.read_object(&id) else {
+    /// Load an input object from the state_view
+    fn load_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        override_as_immutable: bool,
+        id: ObjectID,
+    ) -> Result<InputValue, ExecutionError> {
+        let Some(obj) = state_view.read_object(&id) else {
         // protected by transaction input checker
         invariant_violation!("Object {} does not exist yet", id);
     };
-    // override_as_immutable ==> Owner::Shared
-    assert_invariant!(
-        !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
-        "override_as_immutable should only be set for shared objects"
-    );
-    let is_mutable_input = match obj.owner {
-        Owner::AddressOwner(_) => true,
-        Owner::Shared { .. } => !override_as_immutable,
-        Owner::Immutable => false,
-        Owner::ObjectOwner(_) => {
-            // protected by transaction input checker
-            invariant_violation!("ObjectOwner objects cannot be input")
-        }
-    };
-    let owner = obj.owner;
-    let version = obj.version();
-    let object_metadata = InputObjectMetadata {
-        id,
-        is_mutable_input,
-        owner,
-        version,
-    };
-    let obj_value = value_from_object(vm, session, obj)?;
-    let contained_uids = {
-        let fully_annotated_layout = session
-            .type_to_fully_annotated_layout(&obj_value.type_)
-            .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
-        let mut bytes = vec![];
-        obj_value.write_bcs_bytes(&mut bytes);
-        match get_all_uids(&fully_annotated_layout, &bytes) {
-            Err(e) => invariant_violation!(
-                "Unable to retrieve UIDs for object. Got error: {e}"
-            ),
-            Ok(uids) => uids,
-        }
-    };
-    let runtime_input = object_runtime::InputObject {
-        contained_uids,
-        owner,
-        version,
-    };
-    let prev = input_object_map.insert(id, runtime_input);
-    // protected by transaction input checker
-    assert_invariant!(prev.is_none(), "Duplicate input object {}", id);
-    Ok(InputValue::new_object(object_metadata, obj_value))
-}
-
-/// Load an a CallArg, either an object or a raw set of BCS bytes
-fn load_call_arg<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    call_arg: CallArg,
-) -> Result<InputValue, ExecutionError> {
-    Ok(match call_arg {
-        CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
-        CallArg::Object(obj_arg) => {
-            load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
-        }
-    })
-}
-
-/// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-fn load_object_arg<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    obj_arg: ObjectArg,
-) -> Result<InputValue, ExecutionError> {
-    match obj_arg {
-        ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
-            vm,
-            state_view,
-            session,
-            input_object_map,
-            /* imm override */ false,
+        // override_as_immutable ==> Owner::Shared
+        assert_invariant!(
+            !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
+            "override_as_immutable should only be set for shared objects"
+        );
+        let is_mutable_input = match obj.owner {
+            Owner::AddressOwner(_) => true,
+            Owner::Shared { .. } => !override_as_immutable,
+            Owner::Immutable => false,
+            Owner::ObjectOwner(_) => {
+                // protected by transaction input checker
+                invariant_violation!("ObjectOwner objects cannot be input")
+            }
+        };
+        let owner = obj.owner;
+        let version = obj.version();
+        let object_metadata = InputObjectMetadata {
             id,
-        ),
-        ObjectArg::SharedObject { id, mutable, .. } => load_object(
-            vm,
-            state_view,
-            session,
-            input_object_map,
-            /* imm override */ !mutable,
-            id,
-        ),
+            is_mutable_input,
+            owner,
+            version,
+        };
+        let obj_value = value_from_object(vm, session, obj)?;
+        let contained_uids = {
+            let fully_annotated_layout =
+                session
+                    .type_to_fully_annotated_layout(&obj_value.type_)
+                    .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+            let mut bytes = vec![];
+            obj_value.write_bcs_bytes(&mut bytes);
+            match get_all_uids(&fully_annotated_layout, &bytes) {
+                Err(e) => {
+                    invariant_violation!("Unable to retrieve UIDs for object. Got error: {e}")
+                }
+                Ok(uids) => uids,
+            }
+        };
+        let runtime_input = object_runtime::InputObject {
+            contained_uids,
+            owner,
+            version,
+        };
+        let prev = input_object_map.insert(id, runtime_input);
+        // protected by transaction input checker
+        assert_invariant!(prev.is_none(), "Duplicate input object {}", id);
+        Ok(InputValue::new_object(object_metadata, obj_value))
     }
-}
 
-/// Generate an additional write for an ObjectValue
-fn add_additional_write(
-    additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
-    owner: Owner,
-    object_value: ObjectValue,
-) -> Result<(), ExecutionError> {
-    let ObjectValue {
-        type_,
-        has_public_transfer,
-        contents,
-        ..
-    } = object_value;
-    let bytes = match contents {
-        ObjectContents::Coin(coin) => coin.to_bcs_bytes(),
-        ObjectContents::Raw(bytes) => bytes,
-    };
-    let object_id = MoveObject::id_opt(&bytes).map_err(|e| {
-        ExecutionError::invariant_violation(format!("No id for Raw object bytes. {e}"))
-    })?;
-    let additional_write = AdditionalWrite {
-        recipient: owner,
-        type_,
-        has_public_transfer,
-        bytes,
-    };
-    additional_writes.insert(object_id, additional_write);
-    Ok(())
-}
+    /// Load an a CallArg, either an object or a raw set of BCS bytes
+    fn load_call_arg<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        call_arg: CallArg,
+    ) -> Result<InputValue, ExecutionError> {
+        Ok(match call_arg {
+            CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
+            CallArg::Object(obj_arg) => {
+                load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
+            }
+        })
+    }
 
-/// The max budget was deducted from the gas coin at the beginning of the transaction,
-/// now we return exactly that amount. Gas will be charged by the execution engine
-fn refund_max_gas_budget(
-    additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
-    gas_charger: &mut GasCharger,
-    gas_id: ObjectID,
-) -> Result<(), ExecutionError> {
-    let Some(AdditionalWrite { bytes,.. }) = additional_writes.get_mut(&gas_id) else {
+    /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
+    fn load_object_arg<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        obj_arg: ObjectArg,
+    ) -> Result<InputValue, ExecutionError> {
+        match obj_arg {
+            ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
+                vm,
+                state_view,
+                session,
+                input_object_map,
+                /* imm override */ false,
+                id,
+            ),
+            ObjectArg::SharedObject { id, mutable, .. } => load_object(
+                vm,
+                state_view,
+                session,
+                input_object_map,
+                /* imm override */ !mutable,
+                id,
+            ),
+        }
+    }
+
+    /// Generate an additional write for an ObjectValue
+    fn add_additional_write(
+        additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
+        owner: Owner,
+        object_value: ObjectValue,
+    ) -> Result<(), ExecutionError> {
+        let ObjectValue {
+            type_,
+            has_public_transfer,
+            contents,
+            ..
+        } = object_value;
+        let bytes = match contents {
+            ObjectContents::Coin(coin) => coin.to_bcs_bytes(),
+            ObjectContents::Raw(bytes) => bytes,
+        };
+        let object_id = MoveObject::id_opt(&bytes).map_err(|e| {
+            ExecutionError::invariant_violation(format!("No id for Raw object bytes. {e}"))
+        })?;
+        let additional_write = AdditionalWrite {
+            recipient: owner,
+            type_,
+            has_public_transfer,
+            bytes,
+        };
+        additional_writes.insert(object_id, additional_write);
+        Ok(())
+    }
+
+    /// The max budget was deducted from the gas coin at the beginning of the transaction,
+    /// now we return exactly that amount. Gas will be charged by the execution engine
+    fn refund_max_gas_budget(
+        additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
+        gas_charger: &mut GasCharger,
+        gas_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        let Some(AdditionalWrite { bytes,.. }) = additional_writes.get_mut(&gas_id) else {
         invariant_violation!("Gas object cannot be wrapped or destroyed")
     };
-    let Ok(mut coin) = Coin::from_bcs_bytes(bytes) else {
+        let Ok(mut coin) = Coin::from_bcs_bytes(bytes) else {
         invariant_violation!("Gas object must be a coin")
     };
-    let Some(new_balance) = coin
+        let Some(new_balance) = coin
         .balance
         .value()
         .checked_add(gas_charger.gas_budget()) else {
@@ -1264,63 +1287,62 @@ fn refund_max_gas_budget(
                 "Gas coin too large after returning the max gas budget",
             ));
         };
-    coin.balance = Balance::new(new_balance);
-    *bytes = coin.to_bcs_bytes();
-    Ok(())
-}
+        coin.balance = Balance::new(new_balance);
+        *bytes = coin.to_bcs_bytes();
+        Ok(())
+    }
 
-/// Generate an MoveObject given an updated/written object
-/// # Safety
-///
-/// This function assumes proper generation of has_public_transfer, either from the abilities of
-/// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &Session<'state, 'vm, LinkageView<'state>>,
-    protocol_config: &ProtocolConfig,
-    input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
-    loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
-    id: ObjectID,
-    type_: Type,
-    has_public_transfer: bool,
-    contents: Vec<u8>,
-    write_kind: WriteKind,
-) -> Result<MoveObject, ExecutionError> {
-    debug_assert_eq!(
-        id,
-        MoveObject::id_opt(&contents).expect("object contents should start with an id")
-    );
-    let metadata_opt = input_object_metadata.get(&id);
-    let loaded_child_version_opt = loaded_child_objects.get(&id);
-    assert_invariant!(
-        metadata_opt.is_none() || loaded_child_version_opt.is_none(),
-        "Loaded {id} as a child, but that object was an input object",
-    );
+    /// Generate an MoveObject given an updated/written object
+    /// # Safety
+    ///
+    /// This function assumes proper generation of has_public_transfer, either from the abilities of
+    /// the StructTag, or from the runtime correctly propagating from the inputs
+    unsafe fn create_written_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &Session<'state, 'vm, LinkageView<'state>>,
+        protocol_config: &ProtocolConfig,
+        input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
+        loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
+        id: ObjectID,
+        type_: Type,
+        has_public_transfer: bool,
+        contents: Vec<u8>,
+        write_kind: WriteKind,
+    ) -> Result<MoveObject, ExecutionError> {
+        debug_assert_eq!(
+            id,
+            MoveObject::id_opt(&contents).expect("object contents should start with an id")
+        );
+        let metadata_opt = input_object_metadata.get(&id);
+        let loaded_child_version_opt = loaded_child_objects.get(&id);
+        assert_invariant!(
+            metadata_opt.is_none() || loaded_child_version_opt.is_none(),
+            "Loaded {id} as a child, but that object was an input object",
+        );
 
-    let old_obj_ver = metadata_opt
-        .map(|metadata| metadata.version)
-        .or_else(|| loaded_child_version_opt.copied());
+        let old_obj_ver = metadata_opt
+            .map(|metadata| metadata.version)
+            .or_else(|| loaded_child_version_opt.copied());
 
-    debug_assert!(
-        (write_kind == WriteKind::Mutate) == old_obj_ver.is_some(),
-        "Inconsistent state: write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
-    );
+        debug_assert!(
+            (write_kind == WriteKind::Mutate) == old_obj_ver.is_some(),
+            "Inconsistent state: write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
+        );
 
-    let type_tag = session
-        .get_type_tag(&type_)
-        .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        let type_tag = session
+            .get_type_tag(&type_)
+            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
 
-    let struct_tag = match type_tag {
-        TypeTag::Struct(inner) => *inner,
-        _ => invariant_violation!("Non struct type for object"),
-    };
-    MoveObject::new_from_execution(
-        struct_tag.into(),
-        has_public_transfer,
-        old_obj_ver.unwrap_or_else(SequenceNumber::new),
-        contents,
-        protocol_config,
-    )
-}
-
+        let struct_tag = match type_tag {
+            TypeTag::Struct(inner) => *inner,
+            _ => invariant_violation!("Non struct type for object"),
+        };
+        MoveObject::new_from_execution(
+            struct_tag.into(),
+            has_public_transfer,
+            old_obj_ver.unwrap_or_else(SequenceNumber::new),
+            contents,
+            protocol_config,
+        )
+    }
 }

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -1,221 +1,222 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    sync::Arc,
-};
+pub use checked::*;
+#[sui_macros::with_checked_arithmetic]
+mod checked {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fmt,
+        sync::Arc,
+    };
 
-use move_binary_format::{
-    access::ModuleAccess,
-    compatibility::{Compatibility, InclusionCheck},
-    errors::{Location, PartialVMResult, VMResult},
-    file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
-    normalized, CompiledModule,
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    identifier::IdentStr,
-    language_storage::{ModuleId, TypeTag},
-    u256::U256,
-};
-use move_vm_runtime::{
-    move_vm::MoveVM,
-    session::{LoadedFunctionInstantiation, SerializedReturnValues},
-};
-use move_vm_types::loaded_data::runtime_types::{StructType, Type};
-use serde::{de::DeserializeSeed, Deserialize};
-use sui_move_natives::object_runtime::ObjectRuntime;
-use sui_protocol_config::ProtocolConfig;
-use sui_types::{
-    base_types::{
-        MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
-        RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
-    },
-    coin::Coin,
-    error::{command_argument_error, ExecutionError, ExecutionErrorKind},
-    event::Event,
-    execution::{
-        CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue, RawValueType,
-        Value,
-    },
-    gas::GasCharger,
-    id::{RESOLVED_SUI_ID, UID},
-    metrics::LimitsMetrics,
-    move_package::{
-        normalize_deserialized_modules, MovePackage, UpgradeCap, UpgradePolicy, UpgradeReceipt,
-        UpgradeTicket,
-    },
-    storage::get_packages,
-    transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
-    SUI_FRAMEWORK_ADDRESS,
-};
-use sui_types::{
-    execution_mode::ExecutionMode,
-    execution_status::{CommandArgumentError, PackageUpgradeError},
-};
-use sui_verifier::{
-    private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
-    INIT_FN_NAME,
-};
+    use move_binary_format::{
+        access::ModuleAccess,
+        compatibility::{Compatibility, InclusionCheck},
+        errors::{Location, PartialVMResult, VMResult},
+        file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
+        normalized, CompiledModule,
+    };
+    use move_core_types::{
+        account_address::AccountAddress,
+        identifier::IdentStr,
+        language_storage::{ModuleId, TypeTag},
+        u256::U256,
+    };
+    use move_vm_runtime::{
+        move_vm::MoveVM,
+        session::{LoadedFunctionInstantiation, SerializedReturnValues},
+    };
+    use move_vm_types::loaded_data::runtime_types::{StructType, Type};
+    use serde::{de::DeserializeSeed, Deserialize};
+    use sui_move_natives::object_runtime::ObjectRuntime;
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::{
+        base_types::{
+            MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
+            RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
+        },
+        coin::Coin,
+        error::{command_argument_error, ExecutionError, ExecutionErrorKind},
+        event::Event,
+        execution::{
+            CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue,
+            RawValueType, Value,
+        },
+        gas::GasCharger,
+        id::{RESOLVED_SUI_ID, UID},
+        metrics::LimitsMetrics,
+        move_package::{
+            normalize_deserialized_modules, MovePackage, UpgradeCap, UpgradePolicy, UpgradeReceipt,
+            UpgradeTicket,
+        },
+        storage::get_packages,
+        transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
+        SUI_FRAMEWORK_ADDRESS,
+    };
+    use sui_types::{
+        execution_mode::ExecutionMode,
+        execution_status::{CommandArgumentError, PackageUpgradeError},
+    };
+    use sui_verifier::{
+        private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
+        INIT_FN_NAME,
+    };
 
-use super::context::*;
-use crate::adapter::substitute_package_id;
+    use crate::adapter::substitute_package_id;
+    use crate::programmable_transactions::context::*;
 
-sui_macros::checked_arithmetic! {
+    pub fn execute<Mode: ExecutionMode>(
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        vm: &MoveVM,
+        state_view: &mut dyn ExecutionState,
+        tx_context: &mut TxContext,
+        gas_charger: &mut GasCharger,
+        pt: ProgrammableTransaction,
+    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+        let ProgrammableTransaction { inputs, commands } = pt;
+        let mut context = ExecutionContext::new(
+            protocol_config,
+            metrics,
+            vm,
+            state_view,
+            tx_context,
+            gas_charger,
+            inputs,
+        )?;
+        // execute commands
+        let mut mode_results = Mode::empty_results();
+        for (idx, command) in commands.into_iter().enumerate() {
+            if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
+                let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+                // We still need to record the loaded child objects for replay
+                let loaded_child_objects = object_runtime.loaded_child_objects();
+                drop(context);
+                state_view.save_loaded_child_objects(loaded_child_objects);
+                return Err(err.with_command_index(idx));
+            };
+        }
 
-pub fn execute<Mode: ExecutionMode>(
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    vm: &MoveVM,
-    state_view: &mut dyn ExecutionState,
-    tx_context: &mut TxContext,
-    gas_charger: &mut GasCharger,
-    pt: ProgrammableTransaction,
-) -> Result<Mode::ExecutionResults, ExecutionError> {
-    let ProgrammableTransaction { inputs, commands } = pt;
-    let mut context = ExecutionContext::new(
-        protocol_config,
-        metrics,
-        vm,
-        state_view,
-        tx_context,
-        gas_charger,
-        inputs,
-    )?;
-    // execute commands
-    let mut mode_results = Mode::empty_results();
-    for (idx, command) in commands.into_iter().enumerate() {
-        if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
-            let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
-            // We still need to record the loaded child objects for replay
-            let loaded_child_objects = object_runtime.loaded_child_objects();
-            drop(context);
-            state_view.save_loaded_child_objects(loaded_child_objects);
-            return Err(err.with_command_index(idx));
-        };
+        // Save loaded objects table in case we fail in post execution
+        let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+        // We still need to record the loaded child objects for replay
+        let loaded_child_objects = object_runtime.loaded_child_objects();
+
+        // apply changes
+        let finished = context.finish::<Mode>();
+        // Save loaded objects for debug. We dont want to lose the info
+        state_view.save_loaded_child_objects(loaded_child_objects);
+
+        let ExecutionResults {
+            object_changes,
+            user_events,
+        } = finished?;
+        state_view.apply_object_changes(object_changes);
+        for (module_id, tag, contents) in user_events {
+            state_view.log_event(Event::new(
+                module_id.address(),
+                module_id.name(),
+                tx_context.sender(),
+                tag,
+                contents,
+            ))
+        }
+        Ok(mode_results)
     }
 
-    // Save loaded objects table in case we fail in post execution
-    let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
-    // We still need to record the loaded child objects for replay
-    let loaded_child_objects = object_runtime.loaded_child_objects();
-
-    // apply changes
-    let finished = context.finish::<Mode>();
-    // Save loaded objects for debug. We dont want to lose the info
-    state_view.save_loaded_child_objects(loaded_child_objects);
-
-    let ExecutionResults {
-        object_changes,
-        user_events,
-    } = finished?;
-    state_view.apply_object_changes(object_changes);
-    for (module_id, tag, contents) in user_events {
-        state_view.log_event(Event::new(
-            module_id.address(),
-            module_id.name(),
-            tx_context.sender(),
-            tag,
-            contents,
-        ))
-    }
-    Ok(mode_results)
-}
-
-/// Execute a single command
-fn execute_command<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    mode_results: &mut Mode::ExecutionResults,
-    command: Command,
-) -> Result<(), ExecutionError> {
-    let mut argument_updates = Mode::empty_arguments();
-    let results = match command {
-        Command::MakeMoveVec(tag_opt, args) if args.is_empty() => {
-            let Some(tag) = tag_opt else {
+    /// Execute a single command
+    fn execute_command<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        mode_results: &mut Mode::ExecutionResults,
+        command: Command,
+    ) -> Result<(), ExecutionError> {
+        let mut argument_updates = Mode::empty_arguments();
+        let results = match command {
+            Command::MakeMoveVec(tag_opt, args) if args.is_empty() => {
+                let Some(tag) = tag_opt else {
                 invariant_violation!(
                     "input checker ensures if args are empty, there is a type specified"
                 );
             };
-            let elem_ty = context
-                .load_type(&tag)
-                .map_err(|e| context.convert_vm_error(e))?;
-            let ty = Type::Vector(Box::new(elem_ty));
-            let abilities = context
-                .session
-                .get_type_abilities(&ty)
-                .map_err(|e| context.convert_vm_error(e))?;
-            // BCS layout for any empty vector should be the same
-            let bytes = bcs::to_bytes::<Vec<u8>>(&vec![]).unwrap();
-            vec![Value::Raw(
-                RawValueType::Loaded {
-                    ty,
-                    abilities,
-                    used_in_non_entry_move_call: false,
-                },
-                bytes,
-            )]
-        }
-        Command::MakeMoveVec(tag_opt, args) => {
-            let mut res = vec![];
-            leb128::write::unsigned(&mut res, args.len() as u64).unwrap();
-            let mut arg_iter = args.into_iter().enumerate();
-            let (mut used_in_non_entry_move_call, elem_ty) = match tag_opt {
-                Some(tag) => {
-                    let elem_ty = context
-                        .load_type(&tag)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    (false, elem_ty)
-                }
-                // If no tag specified, it _must_ be an object
-                None => {
-                    // empty args covered above
-                    let (idx, arg) = arg_iter.next().unwrap();
-                    let obj: ObjectValue =
-                        context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                    obj.write_bcs_bytes(&mut res);
-                    (obj.used_in_non_entry_move_call, obj.type_)
-                }
-            };
-            for (idx, arg) in arg_iter {
-                let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                check_param_type::<Mode>(context, idx, &value, &elem_ty)?;
-                used_in_non_entry_move_call =
-                    used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
-                value.write_bcs_bytes(&mut res);
+                let elem_ty = context
+                    .load_type(&tag)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                let ty = Type::Vector(Box::new(elem_ty));
+                let abilities = context
+                    .session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                // BCS layout for any empty vector should be the same
+                let bytes = bcs::to_bytes::<Vec<u8>>(&vec![]).unwrap();
+                vec![Value::Raw(
+                    RawValueType::Loaded {
+                        ty,
+                        abilities,
+                        used_in_non_entry_move_call: false,
+                    },
+                    bytes,
+                )]
             }
-            let ty = Type::Vector(Box::new(elem_ty));
-            let abilities = context
-                .session
-                .get_type_abilities(&ty)
-                .map_err(|e| context.convert_vm_error(e))?;
-            vec![Value::Raw(
-                RawValueType::Loaded {
-                    ty,
-                    abilities,
-                    used_in_non_entry_move_call,
-                },
-                res,
-            )]
-        }
-        Command::TransferObjects(objs, addr_arg) => {
-            let objs: Vec<ObjectValue> = objs
-                .into_iter()
-                .enumerate()
-                .map(|(idx, arg)| context.by_value_arg(CommandKind::TransferObjects, idx, arg))
-                .collect::<Result<_, _>>()?;
-            let addr: SuiAddress =
-                context.by_value_arg(CommandKind::TransferObjects, objs.len(), addr_arg)?;
-            for obj in objs {
-                obj.ensure_public_transfer_eligible()?;
-                context.transfer_object(obj, addr)?;
+            Command::MakeMoveVec(tag_opt, args) => {
+                let mut res = vec![];
+                leb128::write::unsigned(&mut res, args.len() as u64).unwrap();
+                let mut arg_iter = args.into_iter().enumerate();
+                let (mut used_in_non_entry_move_call, elem_ty) = match tag_opt {
+                    Some(tag) => {
+                        let elem_ty = context
+                            .load_type(&tag)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        (false, elem_ty)
+                    }
+                    // If no tag specified, it _must_ be an object
+                    None => {
+                        // empty args covered above
+                        let (idx, arg) = arg_iter.next().unwrap();
+                        let obj: ObjectValue =
+                            context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
+                        obj.write_bcs_bytes(&mut res);
+                        (obj.used_in_non_entry_move_call, obj.type_)
+                    }
+                };
+                for (idx, arg) in arg_iter {
+                    let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
+                    check_param_type::<Mode>(context, idx, &value, &elem_ty)?;
+                    used_in_non_entry_move_call =
+                        used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
+                    value.write_bcs_bytes(&mut res);
+                }
+                let ty = Type::Vector(Box::new(elem_ty));
+                let abilities = context
+                    .session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                vec![Value::Raw(
+                    RawValueType::Loaded {
+                        ty,
+                        abilities,
+                        used_in_non_entry_move_call,
+                    },
+                    res,
+                )]
             }
-            vec![]
-        }
-        Command::SplitCoins(coin_arg, amount_args) => {
-            let mut obj: ObjectValue = context.borrow_arg_mut(0, coin_arg)?;
-            let ObjectContents::Coin(coin) = &mut obj.contents else {
+            Command::TransferObjects(objs, addr_arg) => {
+                let objs: Vec<ObjectValue> = objs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, arg)| context.by_value_arg(CommandKind::TransferObjects, idx, arg))
+                    .collect::<Result<_, _>>()?;
+                let addr: SuiAddress =
+                    context.by_value_arg(CommandKind::TransferObjects, objs.len(), addr_arg)?;
+                for obj in objs {
+                    obj.ensure_public_transfer_eligible()?;
+                    context.transfer_object(obj, addr)?;
+                }
+                vec![]
+            }
+            Command::SplitCoins(coin_arg, amount_args) => {
+                let mut obj: ObjectValue = context.borrow_arg_mut(0, coin_arg)?;
+                let ObjectContents::Coin(coin) = &mut obj.contents else {
                 let e = ExecutionErrorKind::command_argument_error(
                     CommandArgumentError::TypeMismatch,
                     0,
@@ -223,26 +224,26 @@ fn execute_command<Mode: ExecutionMode>(
                 let msg = "Expected a coin but got an non coin object".to_owned();
                 return Err(ExecutionError::new_with_source(e, msg));
             };
-            let split_coins = amount_args
-                .into_iter()
-                .map(|amount_arg| {
-                    let amount: u64 =
-                        context.by_value_arg(CommandKind::SplitCoins, 1, amount_arg)?;
-                    let new_coin_id = context.fresh_id()?;
-                    let new_coin = coin.split(amount, UID::new(new_coin_id))?;
-                    let coin_type = obj.type_.clone();
-                    // safe because we are propagating the coin type, and relying on the internal
-                    // invariant that coin values have a coin type
-                    let new_coin = unsafe { ObjectValue::coin(coin_type, new_coin) };
-                    Ok(Value::Object(new_coin))
-                })
-                .collect::<Result<_, ExecutionError>>()?;
-            context.restore_arg::<Mode>(&mut argument_updates, coin_arg, Value::Object(obj))?;
-            split_coins
-        }
-        Command::MergeCoins(target_arg, coin_args) => {
-            let mut target: ObjectValue = context.borrow_arg_mut(0, target_arg)?;
-            let ObjectContents::Coin(target_coin) = &mut target.contents else {
+                let split_coins = amount_args
+                    .into_iter()
+                    .map(|amount_arg| {
+                        let amount: u64 =
+                            context.by_value_arg(CommandKind::SplitCoins, 1, amount_arg)?;
+                        let new_coin_id = context.fresh_id()?;
+                        let new_coin = coin.split(amount, UID::new(new_coin_id))?;
+                        let coin_type = obj.type_.clone();
+                        // safe because we are propagating the coin type, and relying on the internal
+                        // invariant that coin values have a coin type
+                        let new_coin = unsafe { ObjectValue::coin(coin_type, new_coin) };
+                        Ok(Value::Object(new_coin))
+                    })
+                    .collect::<Result<_, ExecutionError>>()?;
+                context.restore_arg::<Mode>(&mut argument_updates, coin_arg, Value::Object(obj))?;
+                split_coins
+            }
+            Command::MergeCoins(target_arg, coin_args) => {
+                let mut target: ObjectValue = context.borrow_arg_mut(0, target_arg)?;
+                let ObjectContents::Coin(target_coin) = &mut target.contents else {
                 let e = ExecutionErrorKind::command_argument_error(
                     CommandArgumentError::TypeMismatch,
                     0,
@@ -250,387 +251,383 @@ fn execute_command<Mode: ExecutionMode>(
                 let msg = "Expected a coin but got an non coin object".to_owned();
                 return Err(ExecutionError::new_with_source(e, msg));
             };
-            let coins: Vec<ObjectValue> = coin_args
-                .into_iter()
-                .enumerate()
-                .map(|(idx, arg)| context.by_value_arg(CommandKind::MergeCoins, idx + 1, arg))
-                .collect::<Result<_, _>>()?;
-            for (idx, coin) in coins.into_iter().enumerate() {
-                if target.type_ != coin.type_ {
-                    let e = ExecutionErrorKind::command_argument_error(
-                        CommandArgumentError::TypeMismatch,
-                        (idx + 1) as u16,
-                    );
-                    let msg = "Coins do not have the same type".to_owned();
-                    return Err(ExecutionError::new_with_source(e, msg));
-                }
-                let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
+                let coins: Vec<ObjectValue> = coin_args
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, arg)| context.by_value_arg(CommandKind::MergeCoins, idx + 1, arg))
+                    .collect::<Result<_, _>>()?;
+                for (idx, coin) in coins.into_iter().enumerate() {
+                    if target.type_ != coin.type_ {
+                        let e = ExecutionErrorKind::command_argument_error(
+                            CommandArgumentError::TypeMismatch,
+                            (idx + 1) as u16,
+                        );
+                        let msg = "Coins do not have the same type".to_owned();
+                        return Err(ExecutionError::new_with_source(e, msg));
+                    }
+                    let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
                     invariant_violation!(
                         "Target coin was a coin, and we already checked for the same type. \
                         This should be a coin"
                     );
                 };
-                context.delete_id(*id.object_id())?;
-                target_coin.add(balance)?;
+                    context.delete_id(*id.object_id())?;
+                    target_coin.add(balance)?;
+                }
+                context.restore_arg::<Mode>(
+                    &mut argument_updates,
+                    target_arg,
+                    Value::Object(target),
+                )?;
+                vec![]
             }
-            context.restore_arg::<Mode>(
-                &mut argument_updates,
-                target_arg,
-                Value::Object(target),
-            )?;
-            vec![]
-        }
-        Command::MoveCall(move_call) => {
-            let ProgrammableMoveCall {
-                package,
-                module,
-                function,
-                type_arguments,
-                arguments,
-            } = *move_call;
+            Command::MoveCall(move_call) => {
+                let ProgrammableMoveCall {
+                    package,
+                    module,
+                    function,
+                    type_arguments,
+                    arguments,
+                } = *move_call;
 
-            // Convert type arguments to `Type`s
-            let mut loaded_type_arguments = Vec::with_capacity(type_arguments.len());
-            for (ix, type_arg) in type_arguments.into_iter().enumerate() {
-                let ty = context
-                    .load_type(&type_arg)
-                    .map_err(|e| context.convert_type_argument_error(ix, e))?;
-                loaded_type_arguments.push(ty);
+                // Convert type arguments to `Type`s
+                let mut loaded_type_arguments = Vec::with_capacity(type_arguments.len());
+                for (ix, type_arg) in type_arguments.into_iter().enumerate() {
+                    let ty = context
+                        .load_type(&type_arg)
+                        .map_err(|e| context.convert_type_argument_error(ix, e))?;
+                    loaded_type_arguments.push(ty);
+                }
+
+                let original_address = context.set_link_context(package)?;
+                let runtime_id = ModuleId::new(original_address, module);
+                let return_values = execute_move_call::<Mode>(
+                    context,
+                    &mut argument_updates,
+                    &runtime_id,
+                    &function,
+                    loaded_type_arguments,
+                    arguments,
+                    /* is_init */ false,
+                );
+
+                context.reset_linkage();
+                return_values?
             }
+            Command::Publish(modules, dep_ids) => {
+                execute_move_publish::<Mode>(context, &mut argument_updates, modules, dep_ids)?
+            }
+            Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
+                execute_move_upgrade::<Mode>(
+                    context,
+                    modules,
+                    dep_ids,
+                    current_package_id,
+                    upgrade_ticket,
+                )?
+            }
+        };
 
-            let original_address = context.set_link_context(package)?;
-            let runtime_id = ModuleId::new(original_address, module);
-            let return_values = execute_move_call::<Mode>(
-                context,
-                &mut argument_updates,
-                &runtime_id,
-                &function,
-                loaded_type_arguments,
-                arguments,
-                /* is_init */ false,
-            );
-
-            context.reset_linkage();
-            return_values?
-        }
-        Command::Publish(modules, dep_ids) => {
-            execute_move_publish::<Mode>(context, &mut argument_updates, modules, dep_ids)?
-        }
-        Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
-            execute_move_upgrade::<Mode>(
-                context,
-                modules,
-                dep_ids,
-                current_package_id,
-                upgrade_ticket,
-            )?
-        }
-    };
-
-    Mode::finish_command(context, mode_results, argument_updates, &results)?;
-    context.push_command_results(results)?;
-    Ok(())
-}
-
-/// Execute a single Move call
-fn execute_move_call<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: Vec<Type>,
-    arguments: Vec<Argument>,
-    is_init: bool,
-) -> Result<Vec<Value>, ExecutionError> {
-    // check that the function is either an entry function or a valid public function
-    let LoadedFunctionInfo {
-        kind,
-        signature,
-        return_value_kinds,
-        index,
-        last_instr,
-    } = check_visibility_and_signature::<Mode>(
-        context,
-        module_id,
-        function,
-        &type_arguments,
-        is_init,
-    )?;
-    // build the arguments, storing meta data about by-mut-ref args
-    let (tx_context_kind, by_mut_ref, serialized_arguments) =
-        build_move_args::<Mode>(context, module_id, function, kind, &signature, &arguments)?;
-    // invoke the VM
-    let SerializedReturnValues {
-        mutable_reference_outputs,
-        return_values,
-    } = vm_move_call(
-        context,
-        module_id,
-        function,
-        type_arguments,
-        tx_context_kind,
-        serialized_arguments,
-    )?;
-    assert_invariant!(
-        by_mut_ref.len() == mutable_reference_outputs.len(),
-        "lost mutable input"
-    );
-
-    context.take_user_events(module_id, index, last_instr)?;
-
-    // save the link context because calls to `make_value` below can set new ones, and we don't want
-    // it to be clobbered.
-    let saved_linkage = context.steal_linkage();
-    // write back mutable inputs. We also update if they were used in non entry Move calls
-    // though we do not care for immutable usages of objects or other values
-    let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
-    let res = write_back_results::<Mode>(
-        context,
-        argument_updates,
-        &arguments,
-        used_in_non_entry_move_call,
-        mutable_reference_outputs
-            .into_iter()
-            .map(|(i, bytes, _layout)| (i, bytes)),
-        by_mut_ref,
-        return_values.into_iter().map(|(bytes, _layout)| bytes),
-        return_value_kinds,
-    );
-
-    context.restore_linkage(saved_linkage)?;
-    res
-}
-
-fn write_back_results<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    arguments: &[Argument],
-    non_entry_move_call: bool,
-    mut_ref_values: impl IntoIterator<Item = (u8, Vec<u8>)>,
-    mut_ref_kinds: impl IntoIterator<Item = (u8, ValueKind)>,
-    return_values: impl IntoIterator<Item = Vec<u8>>,
-    return_value_kinds: impl IntoIterator<Item = ValueKind>,
-) -> Result<Vec<Value>, ExecutionError> {
-    for ((i, bytes), (j, kind)) in mut_ref_values.into_iter().zip(mut_ref_kinds) {
-        assert_invariant!(i == j, "lost mutable input");
-        let arg_idx = i as usize;
-        let value = make_value(context, kind, bytes, non_entry_move_call)?;
-        context.restore_arg::<Mode>(argument_updates, arguments[arg_idx], value)?;
+        Mode::finish_command(context, mode_results, argument_updates, &results)?;
+        context.push_command_results(results)?;
+        Ok(())
     }
 
-    return_values
-        .into_iter()
-        .zip(return_value_kinds)
-        .map(|(bytes, kind)| {
-            // only non entry functions have return values
-            make_value(
-                context, kind, bytes, /* used_in_non_entry_move_call */ true,
-            )
-        })
-        .collect()
-}
+    /// Execute a single Move call
+    fn execute_move_call<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: Vec<Type>,
+        arguments: Vec<Argument>,
+        is_init: bool,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        // check that the function is either an entry function or a valid public function
+        let LoadedFunctionInfo {
+            kind,
+            signature,
+            return_value_kinds,
+            index,
+            last_instr,
+        } = check_visibility_and_signature::<Mode>(
+            context,
+            module_id,
+            function,
+            &type_arguments,
+            is_init,
+        )?;
+        // build the arguments, storing meta data about by-mut-ref args
+        let (tx_context_kind, by_mut_ref, serialized_arguments) =
+            build_move_args::<Mode>(context, module_id, function, kind, &signature, &arguments)?;
+        // invoke the VM
+        let SerializedReturnValues {
+            mutable_reference_outputs,
+            return_values,
+        } = vm_move_call(
+            context,
+            module_id,
+            function,
+            type_arguments,
+            tx_context_kind,
+            serialized_arguments,
+        )?;
+        assert_invariant!(
+            by_mut_ref.len() == mutable_reference_outputs.len(),
+            "lost mutable input"
+        );
 
-fn make_value(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    value_info: ValueKind,
-    bytes: Vec<u8>,
-    used_in_non_entry_move_call: bool,
-) -> Result<Value, ExecutionError> {
-    Ok(match value_info {
-        ValueKind::Object {
-            type_,
-            has_public_transfer,
-        } => Value::Object(make_object_value(
-            context.vm,
-            &mut context.session,
-            type_,
-            has_public_transfer,
+        context.take_user_events(module_id, index, last_instr)?;
+
+        // save the link context because calls to `make_value` below can set new ones, and we don't want
+        // it to be clobbered.
+        let saved_linkage = context.steal_linkage();
+        // write back mutable inputs. We also update if they were used in non entry Move calls
+        // though we do not care for immutable usages of objects or other values
+        let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
+        let res = write_back_results::<Mode>(
+            context,
+            argument_updates,
+            &arguments,
             used_in_non_entry_move_call,
-            &bytes,
-        )?),
-        ValueKind::Raw(ty, abilities) => Value::Raw(
-            RawValueType::Loaded {
-                ty,
-                abilities,
-                used_in_non_entry_move_call,
-            },
-            bytes,
-        ),
-    })
-}
+            mutable_reference_outputs
+                .into_iter()
+                .map(|(i, bytes, _layout)| (i, bytes)),
+            by_mut_ref,
+            return_values.into_iter().map(|(bytes, _layout)| bytes),
+            return_value_kinds,
+        );
 
-/// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
-/// published package on success.
-fn execute_move_publish<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    module_bytes: Vec<Vec<u8>>,
-    dep_ids: Vec<ObjectID>,
-) -> Result<Vec<Value>, ExecutionError> {
-    assert_invariant!(
-        !module_bytes.is_empty(),
-        "empty package is checked in transaction input checker"
-    );
-    context
-        .gas_charger
-        .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
+        context.restore_linkage(saved_linkage)?;
+        res
+    }
 
-    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
+    fn write_back_results<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        arguments: &[Argument],
+        non_entry_move_call: bool,
+        mut_ref_values: impl IntoIterator<Item = (u8, Vec<u8>)>,
+        mut_ref_kinds: impl IntoIterator<Item = (u8, ValueKind)>,
+        return_values: impl IntoIterator<Item = Vec<u8>>,
+        return_value_kinds: impl IntoIterator<Item = ValueKind>,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        for ((i, bytes), (j, kind)) in mut_ref_values.into_iter().zip(mut_ref_kinds) {
+            assert_invariant!(i == j, "lost mutable input");
+            let arg_idx = i as usize;
+            let value = make_value(context, kind, bytes, non_entry_move_call)?;
+            context.restore_arg::<Mode>(argument_updates, arguments[arg_idx], value)?;
+        }
 
-    // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
-    // runtime does not to know about new packages created, since Move objects and Move packages
-    // cannot interact
-    let runtime_id = if Mode::packages_are_predefined() {
-        // do not calculate or substitute id for predefined packages
-        (*modules[0].self_id().address()).into()
-    } else {
-        let id = context.tx_context.fresh_id();
-        substitute_package_id(&mut modules, id)?;
-        id
-    };
-
-    // For newly published packages, runtime ID matches storage ID.
-    let storage_id = runtime_id;
-    let dependencies = fetch_packages(context, &dep_ids)?;
-    let package_obj = context.new_package(&modules, &dependencies)?;
-
-    let Some(package) = package_obj.data.try_as_package() else {
-        invariant_violation!("Newly created package object is not a package");
-    };
-
-    context.set_linkage(package)?;
-    let res = publish_and_verify_modules(context, runtime_id, &modules)
-        .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
-    context.reset_linkage();
-    res?;
-
-    context.write_package(package_obj)?;
-    let values = if Mode::packages_are_predefined() {
-        // no upgrade cap for genesis modules
-        vec![]
-    } else {
-        let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
-        vec![Value::Object(make_object_value(
-            context.vm,
-            &mut context.session,
-            UpgradeCap::type_().into(),
-            /* has_public_transfer */ true,
-            /* used_in_non_entry_move_call */ false,
-            &bcs::to_bytes(cap).unwrap(),
-        )?)]
-    };
-    Ok(values)
-}
-
-/// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
-fn execute_move_upgrade<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_bytes: Vec<Vec<u8>>,
-    dep_ids: Vec<ObjectID>,
-    current_package_id: ObjectID,
-    upgrade_ticket_arg: Argument,
-) -> Result<Vec<Value>, ExecutionError>
-{
-    assert_invariant!(
-        !module_bytes.is_empty(),
-        "empty package is checked in transaction input checker"
-    );
-
-    let upgrade_ticket_type = context
-        .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
-        .map_err(|e| context.convert_vm_error(e))?;
-    let upgrade_receipt_type = context
-        .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    let upgrade_ticket: UpgradeTicket = {
-        let mut ticket_bytes = Vec::new();
-        let ticket_val: Value =
-            context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
-        check_param_type::<Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
-        ticket_val.write_bcs_bytes(&mut ticket_bytes);
-        bcs::from_bytes(&ticket_bytes).map_err(|_| {
-            ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
-                arg_idx: 0,
-                kind: CommandArgumentError::InvalidBCSBytes,
+        return_values
+            .into_iter()
+            .zip(return_value_kinds)
+            .map(|(bytes, kind)| {
+                // only non entry functions have return values
+                make_value(
+                    context, kind, bytes, /* used_in_non_entry_move_call */ true,
+                )
             })
-        })?
-    };
-
-    // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
-    if current_package_id != upgrade_ticket.package.bytes {
-        return Err(ExecutionError::from_kind(
-            ExecutionErrorKind::PackageUpgradeError {
-                upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
-                    package_id: current_package_id,
-                    ticket_id: upgrade_ticket.package.bytes,
-                },
-            },
-        ));
+            .collect()
     }
 
-    // Check digest.
-    let hash_modules = true;
-    let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
-        &module_bytes,
-        &dep_ids,
-        hash_modules,
-    )
-    .to_vec();
-    if computed_digest != upgrade_ticket.digest {
-        return Err(ExecutionError::from_kind(
-            ExecutionErrorKind::PackageUpgradeError {
-                upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
-                    digest: computed_digest,
+    fn make_value(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        value_info: ValueKind,
+        bytes: Vec<u8>,
+        used_in_non_entry_move_call: bool,
+    ) -> Result<Value, ExecutionError> {
+        Ok(match value_info {
+            ValueKind::Object {
+                type_,
+                has_public_transfer,
+            } => Value::Object(make_object_value(
+                context.vm,
+                &mut context.session,
+                type_,
+                has_public_transfer,
+                used_in_non_entry_move_call,
+                &bytes,
+            )?),
+            ValueKind::Raw(ty, abilities) => Value::Raw(
+                RawValueType::Loaded {
+                    ty,
+                    abilities,
+                    used_in_non_entry_move_call,
                 },
-            },
-        ));
+                bytes,
+            ),
+        })
     }
 
-    // Check that this package ID points to a package and get the package we're upgrading.
-    let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
+    /// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
+    /// published package on success.
+    fn execute_move_publish<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        module_bytes: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        assert_invariant!(
+            !module_bytes.is_empty(),
+            "empty package is checked in transaction input checker"
+        );
+        context
+            .gas_charger
+            .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
 
-    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
-    let runtime_id = current_package.original_package_id();
-    substitute_package_id(&mut modules, runtime_id)?;
+        let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
 
-    // Upgraded packages share their predecessor's runtime ID but get a new storage ID.
-    let storage_id = context.tx_context.fresh_id();
+        // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
+        // runtime does not to know about new packages created, since Move objects and Move packages
+        // cannot interact
+        let runtime_id = if Mode::packages_are_predefined() {
+            // do not calculate or substitute id for predefined packages
+            (*modules[0].self_id().address()).into()
+        } else {
+            let id = context.tx_context.fresh_id();
+            substitute_package_id(&mut modules, id)?;
+            id
+        };
 
-    let dependencies = fetch_packages(context, &dep_ids)?;
-    let package_obj =
-        context.upgrade_package(storage_id, &current_package, &modules, &dependencies)?;
+        // For newly published packages, runtime ID matches storage ID.
+        let storage_id = runtime_id;
+        let dependencies = fetch_packages(context, &dep_ids)?;
+        let package_obj = context.new_package(&modules, &dependencies)?;
 
-    let Some(package) = package_obj.data.try_as_package() else {
+        let Some(package) = package_obj.data.try_as_package() else {
         invariant_violation!("Newly created package object is not a package");
     };
 
-    context.set_linkage(package)?;
-    let res = publish_and_verify_modules(context, runtime_id, &modules);
-    context.reset_linkage();
-    res?;
+        context.set_linkage(package)?;
+        let res = publish_and_verify_modules(context, runtime_id, &modules)
+            .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
+        context.reset_linkage();
+        res?;
 
-    check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
+        context.write_package(package_obj)?;
+        let values = if Mode::packages_are_predefined() {
+            // no upgrade cap for genesis modules
+            vec![]
+        } else {
+            let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
+            vec![Value::Object(make_object_value(
+                context.vm,
+                &mut context.session,
+                UpgradeCap::type_().into(),
+                /* has_public_transfer */ true,
+                /* used_in_non_entry_move_call */ false,
+                &bcs::to_bytes(cap).unwrap(),
+            )?)]
+        };
+        Ok(values)
+    }
 
-    context.write_package(package_obj)?;
-    Ok(vec![Value::Raw(
-        RawValueType::Loaded {
-            ty: upgrade_receipt_type,
-            abilities: AbilitySet::EMPTY,
-            used_in_non_entry_move_call: false,
-        },
-        bcs::to_bytes(&UpgradeReceipt::new(upgrade_ticket, storage_id)).unwrap(),
-    )])
-}
+    /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
+    fn execute_move_upgrade<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_bytes: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+        current_package_id: ObjectID,
+        upgrade_ticket_arg: Argument,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        assert_invariant!(
+            !module_bytes.is_empty(),
+            "empty package is checked in transaction input checker"
+        );
 
-fn check_compatibility<'a>(
-    context: &ExecutionContext,
-    existing_package: &MovePackage,
-    upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
-    policy: u8,
-) -> Result<(), ExecutionError> {
-    // Make sure this is a known upgrade policy.
-    let Ok(policy) = UpgradePolicy::try_from(policy) else {
+        let upgrade_ticket_type = context
+            .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
+            .map_err(|e| context.convert_vm_error(e))?;
+        let upgrade_receipt_type = context
+            .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        let upgrade_ticket: UpgradeTicket = {
+            let mut ticket_bytes = Vec::new();
+            let ticket_val: Value =
+                context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
+            check_param_type::<Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
+            ticket_val.write_bcs_bytes(&mut ticket_bytes);
+            bcs::from_bytes(&ticket_bytes).map_err(|_| {
+                ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
+                    arg_idx: 0,
+                    kind: CommandArgumentError::InvalidBCSBytes,
+                })
+            })?
+        };
+
+        // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
+        if current_package_id != upgrade_ticket.package.bytes {
+            return Err(ExecutionError::from_kind(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
+                        package_id: current_package_id,
+                        ticket_id: upgrade_ticket.package.bytes,
+                    },
+                },
+            ));
+        }
+
+        // Check digest.
+        let hash_modules = true;
+        let computed_digest =
+            MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids, hash_modules)
+                .to_vec();
+        if computed_digest != upgrade_ticket.digest {
+            return Err(ExecutionError::from_kind(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
+                        digest: computed_digest,
+                    },
+                },
+            ));
+        }
+
+        // Check that this package ID points to a package and get the package we're upgrading.
+        let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
+
+        let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
+        let runtime_id = current_package.original_package_id();
+        substitute_package_id(&mut modules, runtime_id)?;
+
+        // Upgraded packages share their predecessor's runtime ID but get a new storage ID.
+        let storage_id = context.tx_context.fresh_id();
+
+        let dependencies = fetch_packages(context, &dep_ids)?;
+        let package_obj =
+            context.upgrade_package(storage_id, &current_package, &modules, &dependencies)?;
+
+        let Some(package) = package_obj.data.try_as_package() else {
+        invariant_violation!("Newly created package object is not a package");
+    };
+
+        context.set_linkage(package)?;
+        let res = publish_and_verify_modules(context, runtime_id, &modules);
+        context.reset_linkage();
+        res?;
+
+        check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
+
+        context.write_package(package_obj)?;
+        Ok(vec![Value::Raw(
+            RawValueType::Loaded {
+                ty: upgrade_receipt_type,
+                abilities: AbilitySet::EMPTY,
+                used_in_non_entry_move_call: false,
+            },
+            bcs::to_bytes(&UpgradeReceipt::new(upgrade_ticket, storage_id)).unwrap(),
+        )])
+    }
+
+    fn check_compatibility<'a>(
+        context: &ExecutionContext,
+        existing_package: &MovePackage,
+        upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
+        policy: u8,
+    ) -> Result<(), ExecutionError> {
+        // Make sure this is a known upgrade policy.
+        let Ok(policy) = UpgradePolicy::try_from(policy) else {
         return Err(ExecutionError::from_kind(
             ExecutionErrorKind::PackageUpgradeError {
                 upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy },
@@ -638,7 +635,7 @@ fn check_compatibility<'a>(
         ));
     };
 
-    let Ok(current_normalized) = existing_package
+        let Ok(current_normalized) = existing_package
         .normalize(
             context.protocol_config.move_binary_format_version(),
             context.protocol_config.no_extraneous_module_bytes(),
@@ -647,9 +644,9 @@ fn check_compatibility<'a>(
         invariant_violation!("Tried to normalize modules in existing package but failed")
     };
 
-    let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
-    for (name, cur_module) in current_normalized {
-        let Some(new_module) = new_normalized.remove(&name) else {
+        let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
+        for (name, cur_module) in current_normalized {
+            let Some(new_module) = new_normalized.remove(&name) else {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
@@ -658,304 +655,299 @@ fn check_compatibility<'a>(
             ));
         };
 
-        check_module_compatibility(
-            &policy,
-            &cur_module,
-            &new_module,
-        )?;
-    }
-
-    Ok(())
-}
-
-fn check_module_compatibility(
-    policy: &UpgradePolicy,
-    cur_module: &normalized::Module,
-    new_module: &normalized::Module,
-) -> Result<(), ExecutionError> {
-    match policy {
-        UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
-        UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
-        UpgradePolicy::Compatible => {
-            let compatibility = Compatibility {
-                check_struct_and_pub_function_linking: true,
-                check_struct_layout: true,
-                check_friend_linking: false,
-                check_private_entry_linking: false,
-                disallowed_new_abilities: AbilitySet::ALL,
-                disallow_change_struct_type_params: true,
-            };
-
-            compatibility.check(cur_module, new_module)
+            check_module_compatibility(&policy, &cur_module, &new_module)?;
         }
-    }
-    .map_err(|e| ExecutionError::new_with_source(
-        ExecutionErrorKind::PackageUpgradeError {
-            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
-        },
-        e,
-    ))
-}
 
-fn fetch_package(
-    context: &ExecutionContext<'_, '_, '_>,
-    package_id: &ObjectID,
-) -> Result<MovePackage, ExecutionError> {
-    let mut fetched_packages = fetch_packages(context, vec![package_id])?;
-    assert_invariant!(
-        fetched_packages.len() == 1,
-        "Number of fetched packages must match the number of package object IDs if successful."
-    );
-    match fetched_packages.pop() {
-        Some(pkg) => Ok(pkg),
-        None => invariant_violation!(
-            "We should always fetch a package for each object or return a dependency error."
-        ),
-    }
-}
-
-fn fetch_packages<'ctx, 'vm, 'state, 'a>(
-    context: &'ctx ExecutionContext<'vm, 'state, 'a>,
-    package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
-) -> Result<Vec<MovePackage>, ExecutionError> {
-    let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
-    match get_packages(&context.state_view, package_ids) {
-        Err(e) => Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::PublishUpgradeMissingDependency,
-            e,
-        )),
-        Ok(Err(missing_deps)) => {
-            let msg = format!(
-                "Missing dependencies: {}",
-                missing_deps
-                    .into_iter()
-                    .map(|dep| format!("{}", dep))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PublishUpgradeMissingDependency,
-                msg,
-            ))
-        }
-        Ok(Ok(pkgs)) => Ok(pkgs),
-    }
-}
-
-/***************************************************************************************************
- * Move execution
- **************************************************************************************************/
-
-fn vm_move_call(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: Vec<Type>,
-    tx_context_kind: TxContextKind,
-    mut serialized_arguments: Vec<Vec<u8>>,
-) -> Result<SerializedReturnValues, ExecutionError> {
-    match tx_context_kind {
-        TxContextKind::None => (),
-        TxContextKind::Mutable | TxContextKind::Immutable => {
-            serialized_arguments.push(context.tx_context.to_vec());
-        }
-    }
-    // script visibility checked manually for entry points
-    let mut result = context
-        .session
-        .execute_function_bypass_visibility(
-            module_id,
-            function,
-            type_arguments,
-            serialized_arguments,
-            context.gas_charger.move_gas_status_mut(),
-        )
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    // When this function is used during publishing, it
-    // may be executed several times, with objects being
-    // created in the Move VM in each Move call. In such
-    // case, we need to update TxContext value so that it
-    // reflects what happened each time we call into the
-    // Move VM (e.g. to account for the number of created
-    // objects).
-    if tx_context_kind == TxContextKind::Mutable {
-        let Some((_, ctx_bytes, _)) = result.mutable_reference_outputs.pop() else {
-            invariant_violation!("Missing TxContext in reference outputs");
-        };
-        let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).map_err(|e| {
-            ExecutionError::invariant_violation(format!(
-                "Unable to deserialize TxContext bytes. {e}"
-            ))
-        })?;
-        context.tx_context.update_state(updated_ctx)?;
-    }
-    Ok(result)
-}
-
-#[allow(clippy::extra_unused_type_parameters)]
-fn deserialize_modules<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_bytes: &[Vec<u8>],
-) -> Result<Vec<CompiledModule>, ExecutionError> {
-    let modules = module_bytes
-        .iter()
-        .map(|b| {
-            CompiledModule::deserialize_with_config(
-                b,
-                context.protocol_config.move_binary_format_version(),
-                context.protocol_config.no_extraneous_module_bytes(),
-            )
-            .map_err(|e| e.finish(Location::Undefined))
-        })
-        .collect::<VMResult<Vec<CompiledModule>>>()
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    assert_invariant!(
-        !modules.is_empty(),
-        "input checker ensures package is not empty"
-    );
-
-    Ok(modules)
-}
-
-fn publish_and_verify_modules(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    package_id: ObjectID,
-    modules: &[CompiledModule],
-) -> Result<(), ExecutionError> {
-    // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
-    let new_module_bytes: Vec<_> = modules
-        .iter()
-        .map(|m| {
-            let mut bytes = Vec::new();
-            m.serialize(&mut bytes).unwrap();
-            bytes
-        })
-        .collect();
-    context
-        .session
-        .publish_module_bundle(
-            new_module_bytes,
-            AccountAddress::from(package_id),
-            // TODO: publish_module_bundle() currently doesn't charge gas.
-            // Do we want to charge there?
-            context.gas_charger.move_gas_status_mut(),
-        )
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    // run the Sui verifier
-    for module in modules {
-        // Run Sui bytecode verifier, which runs some additional checks that assume the Move
-        // bytecode verifier has passed.
-        sui_verifier::verifier::sui_verify_module_unmetered(
-            module,
-            &BTreeMap::new(),
-        )?;
+        Ok(())
     }
 
-    Ok(())
-}
+    fn check_module_compatibility(
+        policy: &UpgradePolicy,
+        cur_module: &normalized::Module,
+        new_module: &normalized::Module,
+    ) -> Result<(), ExecutionError> {
+        match policy {
+            UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
+            UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
+            UpgradePolicy::Compatible => {
+                let compatibility = Compatibility {
+                    check_struct_and_pub_function_linking: true,
+                    check_struct_layout: true,
+                    check_friend_linking: false,
+                    check_private_entry_linking: false,
+                    disallowed_new_abilities: AbilitySet::ALL,
+                    disallow_change_struct_type_params: true,
+                };
 
-fn init_modules<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    modules: &[CompiledModule],
-) -> Result<(), ExecutionError> {
-    let modules_to_init = modules.iter().filter_map(|module| {
-        for fdef in &module.function_defs {
-            let fhandle = module.function_handle_at(fdef.function);
-            let fname = module.identifier_at(fhandle.name);
-            if fname == INIT_FN_NAME {
-                return Some(module.self_id());
+                compatibility.check(cur_module, new_module)
             }
         }
-        None
-    });
-
-    for module_id in modules_to_init {
-        let return_values = execute_move_call::<Mode>(
-            context,
-            argument_updates,
-            &module_id,
-            INIT_FN_NAME,
-            vec![],
-            vec![],
-            /* is_init */ true,
-        )?;
-
-        assert_invariant!(
-            return_values.is_empty(),
-            "init should not have return values"
-        )
+        .map_err(|e| {
+            ExecutionError::new_with_source(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+                },
+                e,
+            )
+        })
     }
 
-    Ok(())
-}
-
-/***************************************************************************************************
- * Move signatures
- **************************************************************************************************/
-
-/// Helper marking what function we are invoking
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum FunctionKind {
-    PrivateEntry,
-    PublicEntry,
-    NonEntry,
-    Init,
-}
-
-/// Used to remember type information about a type when resolving the signature
-enum ValueKind {
-    Object {
-        type_: MoveObjectType,
-        has_public_transfer: bool,
-    },
-    Raw(Type, AbilitySet),
-}
-
-struct LoadedFunctionInfo {
-    /// The kind of the function, e.g. public or private or init
-    kind: FunctionKind,
-    /// The signature information of the function
-    signature: LoadedFunctionInstantiation,
-    /// Object or type information for the return values
-    return_value_kinds: Vec<ValueKind>,
-    /// Definition index of the function
-    index: FunctionDefinitionIndex,
-    /// The length of the function used for setting error information, or 0 if native
-    last_instr: CodeOffset,
-}
-
-/// Checks that the function to be called is either
-/// - an entry function
-/// - a public function that does not return references
-/// - module init (only internal usage)
-fn check_visibility_and_signature<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: &[Type],
-    from_init: bool,
-) -> Result<LoadedFunctionInfo, ExecutionError> {
-    if from_init {
-        // the session is weird and does not load the module on publishing. This is a temporary
-        // work around, since loading the function through the session will cause the module
-        // to be loaded through the sessions data store.
-        let result = context
-            .session
-            .load_function(module_id, function, type_arguments);
+    fn fetch_package(
+        context: &ExecutionContext<'_, '_, '_>,
+        package_id: &ObjectID,
+    ) -> Result<MovePackage, ExecutionError> {
+        let mut fetched_packages = fetch_packages(context, vec![package_id])?;
         assert_invariant!(
-            result.is_ok(),
-            "The modules init should be able to be loaded"
+            fetched_packages.len() == 1,
+            "Number of fetched packages must match the number of package object IDs if successful."
         );
+        match fetched_packages.pop() {
+            Some(pkg) => Ok(pkg),
+            None => invariant_violation!(
+                "We should always fetch a package for each object or return a dependency error."
+            ),
+        }
     }
-    let module = context
-        .vm
-        .load_module(module_id, context.session.get_resolver())
-        .map_err(|e| context.convert_vm_error(e))?;
-    let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
+
+    fn fetch_packages<'ctx, 'vm, 'state, 'a>(
+        context: &'ctx ExecutionContext<'vm, 'state, 'a>,
+        package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
+    ) -> Result<Vec<MovePackage>, ExecutionError> {
+        let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
+        match get_packages(&context.state_view, package_ids) {
+            Err(e) => Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::PublishUpgradeMissingDependency,
+                e,
+            )),
+            Ok(Err(missing_deps)) => {
+                let msg = format!(
+                    "Missing dependencies: {}",
+                    missing_deps
+                        .into_iter()
+                        .map(|dep| format!("{}", dep))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::PublishUpgradeMissingDependency,
+                    msg,
+                ))
+            }
+            Ok(Ok(pkgs)) => Ok(pkgs),
+        }
+    }
+
+    /***************************************************************************************************
+     * Move execution
+     **************************************************************************************************/
+
+    fn vm_move_call(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: Vec<Type>,
+        tx_context_kind: TxContextKind,
+        mut serialized_arguments: Vec<Vec<u8>>,
+    ) -> Result<SerializedReturnValues, ExecutionError> {
+        match tx_context_kind {
+            TxContextKind::None => (),
+            TxContextKind::Mutable | TxContextKind::Immutable => {
+                serialized_arguments.push(context.tx_context.to_vec());
+            }
+        }
+        // script visibility checked manually for entry points
+        let mut result = context
+            .session
+            .execute_function_bypass_visibility(
+                module_id,
+                function,
+                type_arguments,
+                serialized_arguments,
+                context.gas_charger.move_gas_status_mut(),
+            )
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        // When this function is used during publishing, it
+        // may be executed several times, with objects being
+        // created in the Move VM in each Move call. In such
+        // case, we need to update TxContext value so that it
+        // reflects what happened each time we call into the
+        // Move VM (e.g. to account for the number of created
+        // objects).
+        if tx_context_kind == TxContextKind::Mutable {
+            let Some((_, ctx_bytes, _)) = result.mutable_reference_outputs.pop() else {
+            invariant_violation!("Missing TxContext in reference outputs");
+        };
+            let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).map_err(|e| {
+                ExecutionError::invariant_violation(format!(
+                    "Unable to deserialize TxContext bytes. {e}"
+                ))
+            })?;
+            context.tx_context.update_state(updated_ctx)?;
+        }
+        Ok(result)
+    }
+
+    #[allow(clippy::extra_unused_type_parameters)]
+    fn deserialize_modules<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_bytes: &[Vec<u8>],
+    ) -> Result<Vec<CompiledModule>, ExecutionError> {
+        let modules = module_bytes
+            .iter()
+            .map(|b| {
+                CompiledModule::deserialize_with_config(
+                    b,
+                    context.protocol_config.move_binary_format_version(),
+                    context.protocol_config.no_extraneous_module_bytes(),
+                )
+                .map_err(|e| e.finish(Location::Undefined))
+            })
+            .collect::<VMResult<Vec<CompiledModule>>>()
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        assert_invariant!(
+            !modules.is_empty(),
+            "input checker ensures package is not empty"
+        );
+
+        Ok(modules)
+    }
+
+    fn publish_and_verify_modules(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        package_id: ObjectID,
+        modules: &[CompiledModule],
+    ) -> Result<(), ExecutionError> {
+        // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
+        let new_module_bytes: Vec<_> = modules
+            .iter()
+            .map(|m| {
+                let mut bytes = Vec::new();
+                m.serialize(&mut bytes).unwrap();
+                bytes
+            })
+            .collect();
+        context
+            .session
+            .publish_module_bundle(
+                new_module_bytes,
+                AccountAddress::from(package_id),
+                // TODO: publish_module_bundle() currently doesn't charge gas.
+                // Do we want to charge there?
+                context.gas_charger.move_gas_status_mut(),
+            )
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        // run the Sui verifier
+        for module in modules {
+            // Run Sui bytecode verifier, which runs some additional checks that assume the Move
+            // bytecode verifier has passed.
+            sui_verifier::verifier::sui_verify_module_unmetered(module, &BTreeMap::new())?;
+        }
+
+        Ok(())
+    }
+
+    fn init_modules<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        modules: &[CompiledModule],
+    ) -> Result<(), ExecutionError> {
+        let modules_to_init = modules.iter().filter_map(|module| {
+            for fdef in &module.function_defs {
+                let fhandle = module.function_handle_at(fdef.function);
+                let fname = module.identifier_at(fhandle.name);
+                if fname == INIT_FN_NAME {
+                    return Some(module.self_id());
+                }
+            }
+            None
+        });
+
+        for module_id in modules_to_init {
+            let return_values = execute_move_call::<Mode>(
+                context,
+                argument_updates,
+                &module_id,
+                INIT_FN_NAME,
+                vec![],
+                vec![],
+                /* is_init */ true,
+            )?;
+
+            assert_invariant!(
+                return_values.is_empty(),
+                "init should not have return values"
+            )
+        }
+
+        Ok(())
+    }
+
+    /***************************************************************************************************
+     * Move signatures
+     **************************************************************************************************/
+
+    /// Helper marking what function we are invoking
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    enum FunctionKind {
+        PrivateEntry,
+        PublicEntry,
+        NonEntry,
+        Init,
+    }
+
+    /// Used to remember type information about a type when resolving the signature
+    enum ValueKind {
+        Object {
+            type_: MoveObjectType,
+            has_public_transfer: bool,
+        },
+        Raw(Type, AbilitySet),
+    }
+
+    struct LoadedFunctionInfo {
+        /// The kind of the function, e.g. public or private or init
+        kind: FunctionKind,
+        /// The signature information of the function
+        signature: LoadedFunctionInstantiation,
+        /// Object or type information for the return values
+        return_value_kinds: Vec<ValueKind>,
+        /// Definition index of the function
+        index: FunctionDefinitionIndex,
+        /// The length of the function used for setting error information, or 0 if native
+        last_instr: CodeOffset,
+    }
+
+    /// Checks that the function to be called is either
+    /// - an entry function
+    /// - a public function that does not return references
+    /// - module init (only internal usage)
+    fn check_visibility_and_signature<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: &[Type],
+        from_init: bool,
+    ) -> Result<LoadedFunctionInfo, ExecutionError> {
+        if from_init {
+            // the session is weird and does not load the module on publishing. This is a temporary
+            // work around, since loading the function through the session will cause the module
+            // to be loaded through the sessions data store.
+            let result = context
+                .session
+                .load_function(module_id, function, type_arguments);
+            assert_invariant!(
+                result.is_ok(),
+                "The modules init should be able to be loaded"
+            );
+        }
+        let module = context
+            .vm
+            .load_module(module_id, context.session.get_resolver())
+            .map_err(|e| context.convert_vm_error(e))?;
+        let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
         module.identifier_at(module.function_handle_at(fdef.function).name) == function
     }) else {
         return Err(ExecutionError::new_with_source(
@@ -967,325 +959,327 @@ fn check_visibility_and_signature<Mode: ExecutionMode>(
         ));
     };
 
-    // entry on init is now banned, so ban invoking it
-    if !from_init && function == INIT_FN_NAME && context.protocol_config.ban_entry_init() {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            "Cannot call 'init'",
-        ));
-    }
-
-    let last_instr: CodeOffset = fdef
-        .code
-        .as_ref()
-        .map(|code| code.code.len() - 1)
-        .unwrap_or(0) as CodeOffset;
-    let function_kind = match (fdef.visibility, fdef.is_entry) {
-        (Visibility::Private | Visibility::Friend, true) => FunctionKind::PrivateEntry,
-        (Visibility::Public, true) => FunctionKind::PublicEntry,
-        (Visibility::Public, false) => FunctionKind::NonEntry,
-        (Visibility::Private, false) if from_init => {
-            assert_invariant!(
-                function == INIT_FN_NAME,
-                "module init specified non-init function"
-            );
-            FunctionKind::Init
-        }
-        (Visibility::Private | Visibility::Friend, false)
-            if Mode::allow_arbitrary_function_calls() =>
-        {
-            FunctionKind::NonEntry
-        }
-        (Visibility::Private | Visibility::Friend, false) => {
+        // entry on init is now banned, so ban invoking it
+        if !from_init && function == INIT_FN_NAME && context.protocol_config.ban_entry_init() {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
-                "Can only call `entry` or `public` functions",
+                "Cannot call 'init'",
             ));
         }
-    };
-    let signature = context
-        .session
-        .load_function(module_id, function, type_arguments)
-        .map_err(|e| context.convert_vm_error(e))?;
-    let signature =
-        subst_signature(signature, type_arguments).map_err(|e| context.convert_vm_error(e))?;
-    let return_value_kinds = match function_kind {
-        FunctionKind::Init => {
-            assert_invariant!(
-                signature.return_.is_empty(),
-                "init functions must have no return values"
-            );
-            vec![]
-        }
-        FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
-            check_non_entry_signature::<Mode>(context, module_id, function, &signature)?
-        }
-    };
-    check_private_generics(context, module_id, function, type_arguments)?;
-    Ok(LoadedFunctionInfo {
-        kind: function_kind,
-        signature,
-        return_value_kinds,
-        index: FunctionDefinitionIndex(index as u16),
-        last_instr,
-    })
-}
 
-/// substitutes the type arguments into the parameter and return types
-fn subst_signature(
-    signature: LoadedFunctionInstantiation,
-    type_arguments: &[Type],
-) -> VMResult<LoadedFunctionInstantiation> {
-    let LoadedFunctionInstantiation {
-        parameters,
-        return_,
-    } = signature;
-    let parameters = parameters
-        .into_iter()
-        .map(|ty| ty.subst(type_arguments))
-        .collect::<PartialVMResult<Vec<_>>>()
-        .map_err(|err| err.finish(Location::Undefined))?;
-    let return_ = return_
-        .into_iter()
-        .map(|ty| ty.subst(type_arguments))
-        .collect::<PartialVMResult<Vec<_>>>()
-        .map_err(|err| err.finish(Location::Undefined))?;
-    Ok(LoadedFunctionInstantiation {
-        parameters,
-        return_,
-    })
-}
-
-/// Checks that the non-entry function does not return references. And marks the return values
-/// as object or non-object return values
-fn check_non_entry_signature<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    _module_id: &ModuleId,
-    _function: &IdentStr,
-    signature: &LoadedFunctionInstantiation,
-) -> Result<Vec<ValueKind>, ExecutionError> {
-    signature
-        .return_
-        .iter()
-        .enumerate()
-        .map(|(idx, return_type)| {
-            let return_type = match return_type {
-                // for dev-inspect, just dereference the value
-                Type::Reference(inner) | Type::MutableReference(inner)
-                    if Mode::allow_arbitrary_values() =>
-                {
-                    inner
-                }
-                Type::Reference(_) | Type::MutableReference(_) => {
-                    return Err(ExecutionError::from_kind(
-                        ExecutionErrorKind::InvalidPublicFunctionReturnType { idx: idx as u16 },
-                    ))
-                }
-                t => t,
-            };
-            let abilities = context
-                .session
-                .get_type_abilities(return_type)
-                .map_err(|e| context.convert_vm_error(e))?;
-            Ok(match return_type {
-                Type::MutableReference(_) | Type::Reference(_) => unreachable!(),
-                Type::TyParam(_) => invariant_violation!("TyParam should have been substituted"),
-                Type::Struct(_) | Type::StructInstantiation(_, _) if abilities.has_key() => {
-                    let type_tag = context
-                        .session
-                        .get_type_tag(return_type)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    let TypeTag::Struct(struct_tag) = type_tag else {
-                        invariant_violation!("Struct type make a non struct type tag")
-                    };
-                    ValueKind::Object {
-                        type_: MoveObjectType::from(*struct_tag),
-                        has_public_transfer: abilities.has_store(),
-                    }
-                }
-                Type::Struct(_)
-                | Type::StructInstantiation(_, _)
-                | Type::Bool
-                | Type::U8
-                | Type::U64
-                | Type::U128
-                | Type::Address
-                | Type::Signer
-                | Type::Vector(_)
-                | Type::U16
-                | Type::U32
-                | Type::U256 => ValueKind::Raw(return_type.clone(), abilities),
-            })
+        let last_instr: CodeOffset = fdef
+            .code
+            .as_ref()
+            .map(|code| code.code.len() - 1)
+            .unwrap_or(0) as CodeOffset;
+        let function_kind = match (fdef.visibility, fdef.is_entry) {
+            (Visibility::Private | Visibility::Friend, true) => FunctionKind::PrivateEntry,
+            (Visibility::Public, true) => FunctionKind::PublicEntry,
+            (Visibility::Public, false) => FunctionKind::NonEntry,
+            (Visibility::Private, false) if from_init => {
+                assert_invariant!(
+                    function == INIT_FN_NAME,
+                    "module init specified non-init function"
+                );
+                FunctionKind::Init
+            }
+            (Visibility::Private | Visibility::Friend, false)
+                if Mode::allow_arbitrary_function_calls() =>
+            {
+                FunctionKind::NonEntry
+            }
+            (Visibility::Private | Visibility::Friend, false) => {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::NonEntryFunctionInvoked,
+                    "Can only call `entry` or `public` functions",
+                ));
+            }
+        };
+        let signature = context
+            .session
+            .load_function(module_id, function, type_arguments)
+            .map_err(|e| context.convert_vm_error(e))?;
+        let signature =
+            subst_signature(signature, type_arguments).map_err(|e| context.convert_vm_error(e))?;
+        let return_value_kinds = match function_kind {
+            FunctionKind::Init => {
+                assert_invariant!(
+                    signature.return_.is_empty(),
+                    "init functions must have no return values"
+                );
+                vec![]
+            }
+            FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
+                check_non_entry_signature::<Mode>(context, module_id, function, &signature)?
+            }
+        };
+        check_private_generics(context, module_id, function, type_arguments)?;
+        Ok(LoadedFunctionInfo {
+            kind: function_kind,
+            signature,
+            return_value_kinds,
+            index: FunctionDefinitionIndex(index as u16),
+            last_instr,
         })
-        .collect()
-}
-
-fn check_private_generics(
-    _context: &mut ExecutionContext,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    _type_arguments: &[Type],
-) -> Result<(), ExecutionError> {
-    let module_ident = (module_id.address(), module_id.name());
-    if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE) {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            format!("Cannot directly call functions in sui::{}", EVENT_MODULE),
-        ));
     }
 
-    if module_ident == (&SUI_FRAMEWORK_ADDRESS, TRANSFER_MODULE)
-        && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
-    {
-        let msg = format!(
-            "Cannot directly call sui::{m}::{f}. \
-            Use the public variant instead, sui::{m}::public_{f}",
-            m = TRANSFER_MODULE,
-            f = function
-        );
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            msg,
-        ));
+    /// substitutes the type arguments into the parameter and return types
+    fn subst_signature(
+        signature: LoadedFunctionInstantiation,
+        type_arguments: &[Type],
+    ) -> VMResult<LoadedFunctionInstantiation> {
+        let LoadedFunctionInstantiation {
+            parameters,
+            return_,
+        } = signature;
+        let parameters = parameters
+            .into_iter()
+            .map(|ty| ty.subst(type_arguments))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        let return_ = return_
+            .into_iter()
+            .map(|ty| ty.subst(type_arguments))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        Ok(LoadedFunctionInstantiation {
+            parameters,
+            return_,
+        })
     }
 
-    Ok(())
-}
-
-type ArgInfo = (
-    TxContextKind,
-    /* mut ref */
-    Vec<(LocalIndex, ValueKind)>,
-    Vec<Vec<u8>>,
-);
-
-/// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
-/// each value
-fn build_move_args<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    function_kind: FunctionKind,
-    signature: &LoadedFunctionInstantiation,
-    args: &[Argument],
-) -> Result<ArgInfo, ExecutionError> {
-    // check the arity
-    let parameters = &signature.parameters;
-    let tx_ctx_kind = match parameters.last() {
-        Some(t) => is_tx_context(context, t)?,
-        None => TxContextKind::None,
-    };
-    // an init function can have one or two arguments, with the last one always being of type
-    // &mut TxContext and the additional (first) one representing a one time witness type (see
-    // one_time_witness verifier pass for additional explanation)
-    let has_one_time_witness = function_kind == FunctionKind::Init && parameters.len() == 2;
-    let has_tx_context = tx_ctx_kind != TxContextKind::None;
-    let num_args = args.len() + (has_one_time_witness as usize) + (has_tx_context as usize);
-    if num_args != parameters.len() {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::ArityMismatch,
-            format!(
-                "Expected {:?} argument{} calling function '{}', but found {:?}",
-                parameters.len(),
-                if parameters.len() == 1 { "" } else { "s" },
-                function,
-                num_args
-            ),
-        ));
-    }
-
-    // check the types and remember which are by mutable ref
-    let mut by_mut_ref = vec![];
-    let mut serialized_args = Vec::with_capacity(num_args);
-    let command_kind = CommandKind::MoveCall {
-        package: (*module_id.address()).into(),
-        module: module_id.name(),
-        function,
-    };
-    // an init function can have one or two arguments, with the last one always being of type
-    // &mut TxContext and the additional (first) one representing a one time witness type (see
-    // one_time_witness verifier pass for additional explanation)
-    if has_one_time_witness {
-        // one time witness type is a struct with a single bool filed which in bcs is encoded as
-        // 0x01
-        let bcs_true_value = bcs::to_bytes(&true).unwrap();
-        serialized_args.push(bcs_true_value)
-    }
-    for ((idx, arg), param_ty) in args.iter().copied().enumerate().zip(parameters) {
-        let (value, non_ref_param_ty): (Value, &Type) = match param_ty {
-            Type::MutableReference(inner) => {
-                let value = context.borrow_arg_mut(idx, arg)?;
-                let object_info = if let Value::Object(ObjectValue {
-                    type_,
-                    has_public_transfer,
-                    ..
-                }) = &value
-                {
-                    let type_tag = context
-                        .session
-                        .get_type_tag(type_)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    let TypeTag::Struct(struct_tag) = type_tag else {
+    /// Checks that the non-entry function does not return references. And marks the return values
+    /// as object or non-object return values
+    fn check_non_entry_signature<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        _module_id: &ModuleId,
+        _function: &IdentStr,
+        signature: &LoadedFunctionInstantiation,
+    ) -> Result<Vec<ValueKind>, ExecutionError> {
+        signature
+            .return_
+            .iter()
+            .enumerate()
+            .map(|(idx, return_type)| {
+                let return_type = match return_type {
+                    // for dev-inspect, just dereference the value
+                    Type::Reference(inner) | Type::MutableReference(inner)
+                        if Mode::allow_arbitrary_values() =>
+                    {
+                        inner
+                    }
+                    Type::Reference(_) | Type::MutableReference(_) => {
+                        return Err(ExecutionError::from_kind(
+                            ExecutionErrorKind::InvalidPublicFunctionReturnType { idx: idx as u16 },
+                        ))
+                    }
+                    t => t,
+                };
+                let abilities = context
+                    .session
+                    .get_type_abilities(return_type)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                Ok(match return_type {
+                    Type::MutableReference(_) | Type::Reference(_) => unreachable!(),
+                    Type::TyParam(_) => {
+                        invariant_violation!("TyParam should have been substituted")
+                    }
+                    Type::Struct(_) | Type::StructInstantiation(_, _) if abilities.has_key() => {
+                        let type_tag = context
+                            .session
+                            .get_type_tag(return_type)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        let TypeTag::Struct(struct_tag) = type_tag else {
                         invariant_violation!("Struct type make a non struct type tag")
                     };
-                    let type_ = (*struct_tag).into();
-                    ValueKind::Object {
-                        type_,
-                        has_public_transfer: *has_public_transfer,
+                        ValueKind::Object {
+                            type_: MoveObjectType::from(*struct_tag),
+                            has_public_transfer: abilities.has_store(),
+                        }
                     }
-                } else {
-                    let abilities = context
-                        .session
-                        .get_type_abilities(inner)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    ValueKind::Raw((**inner).clone(), abilities)
-                };
-                by_mut_ref.push((idx as LocalIndex, object_info));
-                (value, inner)
-            }
-            Type::Reference(inner) => (context.borrow_arg(idx, arg)?, inner),
-            t => {
-                let value = context.by_value_arg(command_kind, idx, arg)?;
-                (value, t)
-            }
-        };
-        if matches!(
-            function_kind,
-            FunctionKind::PrivateEntry | FunctionKind::Init
-        ) && value.was_used_in_non_entry_move_call()
-        {
-            return Err(command_argument_error(
-                CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
-                idx,
+                    Type::Struct(_)
+                    | Type::StructInstantiation(_, _)
+                    | Type::Bool
+                    | Type::U8
+                    | Type::U64
+                    | Type::U128
+                    | Type::Address
+                    | Type::Signer
+                    | Type::Vector(_)
+                    | Type::U16
+                    | Type::U32
+                    | Type::U256 => ValueKind::Raw(return_type.clone(), abilities),
+                })
+            })
+            .collect()
+    }
+
+    fn check_private_generics(
+        _context: &mut ExecutionContext,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        _type_arguments: &[Type],
+    ) -> Result<(), ExecutionError> {
+        let module_ident = (module_id.address(), module_id.name());
+        if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE) {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::NonEntryFunctionInvoked,
+                format!("Cannot directly call functions in sui::{}", EVENT_MODULE),
             ));
         }
-        check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
-        let bytes = {
-            let mut v = vec![];
-            value.write_bcs_bytes(&mut v);
-            v
-        };
-        serialized_args.push(bytes);
-    }
-    Ok((tx_ctx_kind, by_mut_ref, serialized_args))
-}
 
-/// checks that the value is compatible with the specified type
-fn check_param_type<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    idx: usize,
-    value: &Value,
-    param_ty: &Type,
-) -> Result<(), ExecutionError> {
-    let ty = match value {
-        // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
-        // be violated (like for string or Option)
-        Value::Raw(RawValueType::Any, _) if Mode::allow_arbitrary_values() => return Ok(()),
-        // Any means this was just some bytes passed in as an argument (as opposed to being
-        // generated from a Move function). Meaning we only allow "primitive" values
-        // and might need to run validation in addition to the BCS layout
-        Value::Raw(RawValueType::Any, bytes) => {
-            let Some(layout) = primitive_serialization_layout(context, param_ty)? else {
+        if module_ident == (&SUI_FRAMEWORK_ADDRESS, TRANSFER_MODULE)
+            && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
+        {
+            let msg = format!(
+                "Cannot directly call sui::{m}::{f}. \
+            Use the public variant instead, sui::{m}::public_{f}",
+                m = TRANSFER_MODULE,
+                f = function
+            );
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::NonEntryFunctionInvoked,
+                msg,
+            ));
+        }
+
+        Ok(())
+    }
+
+    type ArgInfo = (
+        TxContextKind,
+        /* mut ref */
+        Vec<(LocalIndex, ValueKind)>,
+        Vec<Vec<u8>>,
+    );
+
+    /// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
+    /// each value
+    fn build_move_args<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        function_kind: FunctionKind,
+        signature: &LoadedFunctionInstantiation,
+        args: &[Argument],
+    ) -> Result<ArgInfo, ExecutionError> {
+        // check the arity
+        let parameters = &signature.parameters;
+        let tx_ctx_kind = match parameters.last() {
+            Some(t) => is_tx_context(context, t)?,
+            None => TxContextKind::None,
+        };
+        // an init function can have one or two arguments, with the last one always being of type
+        // &mut TxContext and the additional (first) one representing a one time witness type (see
+        // one_time_witness verifier pass for additional explanation)
+        let has_one_time_witness = function_kind == FunctionKind::Init && parameters.len() == 2;
+        let has_tx_context = tx_ctx_kind != TxContextKind::None;
+        let num_args = args.len() + (has_one_time_witness as usize) + (has_tx_context as usize);
+        if num_args != parameters.len() {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::ArityMismatch,
+                format!(
+                    "Expected {:?} argument{} calling function '{}', but found {:?}",
+                    parameters.len(),
+                    if parameters.len() == 1 { "" } else { "s" },
+                    function,
+                    num_args
+                ),
+            ));
+        }
+
+        // check the types and remember which are by mutable ref
+        let mut by_mut_ref = vec![];
+        let mut serialized_args = Vec::with_capacity(num_args);
+        let command_kind = CommandKind::MoveCall {
+            package: (*module_id.address()).into(),
+            module: module_id.name(),
+            function,
+        };
+        // an init function can have one or two arguments, with the last one always being of type
+        // &mut TxContext and the additional (first) one representing a one time witness type (see
+        // one_time_witness verifier pass for additional explanation)
+        if has_one_time_witness {
+            // one time witness type is a struct with a single bool filed which in bcs is encoded as
+            // 0x01
+            let bcs_true_value = bcs::to_bytes(&true).unwrap();
+            serialized_args.push(bcs_true_value)
+        }
+        for ((idx, arg), param_ty) in args.iter().copied().enumerate().zip(parameters) {
+            let (value, non_ref_param_ty): (Value, &Type) = match param_ty {
+                Type::MutableReference(inner) => {
+                    let value = context.borrow_arg_mut(idx, arg)?;
+                    let object_info = if let Value::Object(ObjectValue {
+                        type_,
+                        has_public_transfer,
+                        ..
+                    }) = &value
+                    {
+                        let type_tag = context
+                            .session
+                            .get_type_tag(type_)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        let TypeTag::Struct(struct_tag) = type_tag else {
+                        invariant_violation!("Struct type make a non struct type tag")
+                    };
+                        let type_ = (*struct_tag).into();
+                        ValueKind::Object {
+                            type_,
+                            has_public_transfer: *has_public_transfer,
+                        }
+                    } else {
+                        let abilities = context
+                            .session
+                            .get_type_abilities(inner)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        ValueKind::Raw((**inner).clone(), abilities)
+                    };
+                    by_mut_ref.push((idx as LocalIndex, object_info));
+                    (value, inner)
+                }
+                Type::Reference(inner) => (context.borrow_arg(idx, arg)?, inner),
+                t => {
+                    let value = context.by_value_arg(command_kind, idx, arg)?;
+                    (value, t)
+                }
+            };
+            if matches!(
+                function_kind,
+                FunctionKind::PrivateEntry | FunctionKind::Init
+            ) && value.was_used_in_non_entry_move_call()
+            {
+                return Err(command_argument_error(
+                    CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
+                    idx,
+                ));
+            }
+            check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
+            let bytes = {
+                let mut v = vec![];
+                value.write_bcs_bytes(&mut v);
+                v
+            };
+            serialized_args.push(bytes);
+        }
+        Ok((tx_ctx_kind, by_mut_ref, serialized_args))
+    }
+
+    /// checks that the value is compatible with the specified type
+    fn check_param_type<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        idx: usize,
+        value: &Value,
+        param_ty: &Type,
+    ) -> Result<(), ExecutionError> {
+        let ty = match value {
+            // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
+            // be violated (like for string or Option)
+            Value::Raw(RawValueType::Any, _) if Mode::allow_arbitrary_values() => return Ok(()),
+            // Any means this was just some bytes passed in as an argument (as opposed to being
+            // generated from a Move function). Meaning we only allow "primitive" values
+            // and might need to run validation in addition to the BCS layout
+            Value::Raw(RawValueType::Any, bytes) => {
+                let Some(layout) = primitive_serialization_layout(context, param_ty)? else {
                 let msg = format!(
                     "Non-primitive argument at index {}. If it is an object, it must be \
                     populated by an object",
@@ -1299,323 +1293,325 @@ fn check_param_type<Mode: ExecutionMode>(
                     msg,
                 ));
             };
-            bcs_argument_validate(bytes, idx as u16, layout)?;
-            return Ok(());
+                bcs_argument_validate(bytes, idx as u16, layout)?;
+                return Ok(());
+            }
+            Value::Raw(RawValueType::Loaded { ty, abilities, .. }, _) => {
+                assert_invariant!(
+                    Mode::allow_arbitrary_values() || !abilities.has_key(),
+                    "Raw value should never be an object"
+                );
+                ty
+            }
+            Value::Object(obj) => &obj.type_,
+        };
+        if ty != param_ty {
+            Err(command_argument_error(
+                CommandArgumentError::TypeMismatch,
+                idx,
+            ))
+        } else {
+            Ok(())
         }
-        Value::Raw(RawValueType::Loaded { ty, abilities, .. }, _) => {
-            assert_invariant!(
-                Mode::allow_arbitrary_values() || !abilities.has_key(),
-                "Raw value should never be an object"
-            );
-            ty
-        }
-        Value::Object(obj) => &obj.type_,
-    };
-    if ty != param_ty {
-        Err(command_argument_error(
-            CommandArgumentError::TypeMismatch,
-            idx,
-        ))
-    } else {
-        Ok(())
     }
-}
 
-fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
-    let module_id = &s.defining_id;
-    let struct_name = &s.name;
-    (
-        module_id.address(),
-        module_id.name(),
-        struct_name.as_ident_str(),
-    )
-}
+    fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
+        let module_id = &s.defining_id;
+        let struct_name = &s.name;
+        (
+            module_id.address(),
+            module_id.name(),
+            struct_name.as_ident_str(),
+        )
+    }
 
-// Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
-// a MutableReference, and Immutable otherwise.
-// Returns None for all other types
-pub fn is_tx_context(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    t: &Type,
-) -> Result<TxContextKind, ExecutionError> {
-    let (is_mut, inner) = match t {
-        Type::MutableReference(inner) => (true, inner),
-        Type::Reference(inner) => (false, inner),
-        _ => return Ok(TxContextKind::None),
-    };
-    let Type::Struct(idx) = &**inner else { return Ok(TxContextKind::None) };
-    let Some(s) = context.session.get_struct_type(*idx) else {
+    // Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
+    // a MutableReference, and Immutable otherwise.
+    // Returns None for all other types
+    pub fn is_tx_context(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        t: &Type,
+    ) -> Result<TxContextKind, ExecutionError> {
+        let (is_mut, inner) = match t {
+            Type::MutableReference(inner) => (true, inner),
+            Type::Reference(inner) => (false, inner),
+            _ => return Ok(TxContextKind::None),
+        };
+        let Type::Struct(idx) = &**inner else { return Ok(TxContextKind::None) };
+        let Some(s) = context.session.get_struct_type(*idx) else {
         invariant_violation!("Loaded struct not found")
     };
-    let (module_addr, module_name, struct_name) = get_struct_ident(&s);
-    let is_tx_context_type = module_addr == &SUI_FRAMEWORK_ADDRESS
-        && module_name == TX_CONTEXT_MODULE_NAME
-        && struct_name == TX_CONTEXT_STRUCT_NAME;
-    Ok(if is_tx_context_type {
-        if is_mut {
-            TxContextKind::Mutable
+        let (module_addr, module_name, struct_name) = get_struct_ident(&s);
+        let is_tx_context_type = module_addr == &SUI_FRAMEWORK_ADDRESS
+            && module_name == TX_CONTEXT_MODULE_NAME
+            && struct_name == TX_CONTEXT_STRUCT_NAME;
+        Ok(if is_tx_context_type {
+            if is_mut {
+                TxContextKind::Mutable
+            } else {
+                TxContextKind::Immutable
+            }
         } else {
-            TxContextKind::Immutable
-        }
-    } else {
-        TxContextKind::None
-    })
-}
+            TxContextKind::None
+        })
+    }
 
-/// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
-fn primitive_serialization_layout(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    param_ty: &Type,
-) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
-    Ok(match param_ty {
-        Type::Signer => return Ok(None),
-        Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
-            invariant_violation!("references and type parameters should be checked elsewhere")
-        }
-        Type::Bool => Some(PrimitiveArgumentLayout::Bool),
-        Type::U8 => Some(PrimitiveArgumentLayout::U8),
-        Type::U16 => Some(PrimitiveArgumentLayout::U16),
-        Type::U32 => Some(PrimitiveArgumentLayout::U32),
-        Type::U64 => Some(PrimitiveArgumentLayout::U64),
-        Type::U128 => Some(PrimitiveArgumentLayout::U128),
-        Type::U256 => Some(PrimitiveArgumentLayout::U256),
-        Type::Address => Some(PrimitiveArgumentLayout::Address),
+    /// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
+    fn primitive_serialization_layout(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        param_ty: &Type,
+    ) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
+        Ok(match param_ty {
+            Type::Signer => return Ok(None),
+            Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
+                invariant_violation!("references and type parameters should be checked elsewhere")
+            }
+            Type::Bool => Some(PrimitiveArgumentLayout::Bool),
+            Type::U8 => Some(PrimitiveArgumentLayout::U8),
+            Type::U16 => Some(PrimitiveArgumentLayout::U16),
+            Type::U32 => Some(PrimitiveArgumentLayout::U32),
+            Type::U64 => Some(PrimitiveArgumentLayout::U64),
+            Type::U128 => Some(PrimitiveArgumentLayout::U128),
+            Type::U256 => Some(PrimitiveArgumentLayout::U256),
+            Type::Address => Some(PrimitiveArgumentLayout::Address),
 
-        Type::Vector(inner) => {
-            let info_opt = primitive_serialization_layout(context, inner)?;
-            info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
-        }
-        Type::StructInstantiation(idx, targs) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
+            Type::Vector(inner) => {
+                let info_opt = primitive_serialization_layout(context, inner)?;
+                info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
+            }
+            Type::StructInstantiation(idx, targs) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
                 invariant_violation!("Loaded struct not found")
             };
-            let resolved_struct = get_struct_ident(&s);
-            // is option of a string
-            if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
-                let info_opt = primitive_serialization_layout(context, &targs[0])?;
-                info_opt.map(|layout| PrimitiveArgumentLayout::Option(Box::new(layout)))
-            } else {
-                None
+                let resolved_struct = get_struct_ident(&s);
+                // is option of a string
+                if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
+                    let info_opt = primitive_serialization_layout(context, &targs[0])?;
+                    info_opt.map(|layout| PrimitiveArgumentLayout::Option(Box::new(layout)))
+                } else {
+                    None
+                }
             }
-        }
-        Type::Struct(idx) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
+            Type::Struct(idx) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
                 invariant_violation!("Loaded struct not found")
             };
-            let resolved_struct = get_struct_ident(&s);
-            if resolved_struct == RESOLVED_SUI_ID {
-                Some(PrimitiveArgumentLayout::Address)
-            } else if resolved_struct == RESOLVED_ASCII_STR {
-                Some(PrimitiveArgumentLayout::Ascii)
-            } else if resolved_struct == RESOLVED_UTF8_STR {
-                Some(PrimitiveArgumentLayout::UTF8)
-            } else {
-                None
+                let resolved_struct = get_struct_ident(&s);
+                if resolved_struct == RESOLVED_SUI_ID {
+                    Some(PrimitiveArgumentLayout::Address)
+                } else if resolved_struct == RESOLVED_ASCII_STR {
+                    Some(PrimitiveArgumentLayout::Ascii)
+                } else if resolved_struct == RESOLVED_UTF8_STR {
+                    Some(PrimitiveArgumentLayout::UTF8)
+                } else {
+                    None
+                }
             }
-        }
-    })
-}
+        })
+    }
 
-/***************************************************************************************************
- * Special serialization formats
- **************************************************************************************************/
+    /***************************************************************************************************
+     * Special serialization formats
+     **************************************************************************************************/
 
-/// Special enum for values that need additional validation, in other words
-/// There is validation to do on top of the BCS layout. Currently only needed for
-/// strings
-#[derive(Debug)]
-pub enum PrimitiveArgumentLayout {
-    /// An option
-    Option(Box<PrimitiveArgumentLayout>),
-    /// A vector
-    Vector(Box<PrimitiveArgumentLayout>),
-    /// An ASCII encoded string
-    Ascii,
-    /// A UTF8 encoded string
-    UTF8,
-    // needed for Option validation
-    Bool,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    U256,
-    Address,
-}
+    /// Special enum for values that need additional validation, in other words
+    /// There is validation to do on top of the BCS layout. Currently only needed for
+    /// strings
+    #[derive(Debug)]
+    pub enum PrimitiveArgumentLayout {
+        /// An option
+        Option(Box<PrimitiveArgumentLayout>),
+        /// A vector
+        Vector(Box<PrimitiveArgumentLayout>),
+        /// An ASCII encoded string
+        Ascii,
+        /// A UTF8 encoded string
+        UTF8,
+        // needed for Option validation
+        Bool,
+        U8,
+        U16,
+        U32,
+        U64,
+        U128,
+        U256,
+        Address,
+    }
 
-impl PrimitiveArgumentLayout {
-    /// returns true iff all BCS compatible bytes are actually values for this type.
-    /// For example, this function returns false for Option and Strings since they need additional
-    /// validation.
-    pub fn bcs_only(&self) -> bool {
-        match self {
-            // have additional restrictions past BCS
-            PrimitiveArgumentLayout::Option(_)
-            | PrimitiveArgumentLayout::Ascii
-            | PrimitiveArgumentLayout::UTF8 => false,
-            // Move primitives are BCS compatible and do not need additional validation
-            PrimitiveArgumentLayout::Bool
-            | PrimitiveArgumentLayout::U8
-            | PrimitiveArgumentLayout::U16
-            | PrimitiveArgumentLayout::U32
-            | PrimitiveArgumentLayout::U64
-            | PrimitiveArgumentLayout::U128
-            | PrimitiveArgumentLayout::U256
-            | PrimitiveArgumentLayout::Address => true,
-            // vector only needs validation if it's inner type does
-            PrimitiveArgumentLayout::Vector(inner) => inner.bcs_only(),
+    impl PrimitiveArgumentLayout {
+        /// returns true iff all BCS compatible bytes are actually values for this type.
+        /// For example, this function returns false for Option and Strings since they need additional
+        /// validation.
+        pub fn bcs_only(&self) -> bool {
+            match self {
+                // have additional restrictions past BCS
+                PrimitiveArgumentLayout::Option(_)
+                | PrimitiveArgumentLayout::Ascii
+                | PrimitiveArgumentLayout::UTF8 => false,
+                // Move primitives are BCS compatible and do not need additional validation
+                PrimitiveArgumentLayout::Bool
+                | PrimitiveArgumentLayout::U8
+                | PrimitiveArgumentLayout::U16
+                | PrimitiveArgumentLayout::U32
+                | PrimitiveArgumentLayout::U64
+                | PrimitiveArgumentLayout::U128
+                | PrimitiveArgumentLayout::U256
+                | PrimitiveArgumentLayout::Address => true,
+                // vector only needs validation if it's inner type does
+                PrimitiveArgumentLayout::Vector(inner) => inner.bcs_only(),
+            }
         }
     }
-}
 
-/// Checks the bytes against the `SpecialArgumentLayout` using `bcs`. It does not actually generate
-/// the deserialized value, only walks the bytes. While not necessary if the layout does not contain
-/// special arguments (e.g. Option or String) we check the BCS bytes for predictability
-pub fn bcs_argument_validate(
-    bytes: &[u8],
-    idx: u16,
-    layout: PrimitiveArgumentLayout,
-) -> Result<(), ExecutionError> {
-    bcs::from_bytes_seed(&layout, bytes).map_err(|_| {
-        ExecutionError::new_with_source(
-            ExecutionErrorKind::command_argument_error(CommandArgumentError::InvalidBCSBytes, idx),
-            format!("Function expects {layout} but provided argument's value does not match",),
-        )
-    })
-}
+    /// Checks the bytes against the `SpecialArgumentLayout` using `bcs`. It does not actually generate
+    /// the deserialized value, only walks the bytes. While not necessary if the layout does not contain
+    /// special arguments (e.g. Option or String) we check the BCS bytes for predictability
+    pub fn bcs_argument_validate(
+        bytes: &[u8],
+        idx: u16,
+        layout: PrimitiveArgumentLayout,
+    ) -> Result<(), ExecutionError> {
+        bcs::from_bytes_seed(&layout, bytes).map_err(|_| {
+            ExecutionError::new_with_source(
+                ExecutionErrorKind::command_argument_error(
+                    CommandArgumentError::InvalidBCSBytes,
+                    idx,
+                ),
+                format!("Function expects {layout} but provided argument's value does not match",),
+            )
+        })
+    }
 
-impl<'d> serde::de::DeserializeSeed<'d> for &PrimitiveArgumentLayout {
-    type Value = ();
-    fn deserialize<D: serde::de::Deserializer<'d>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
-        use serde::de::Error;
-        match self {
-            PrimitiveArgumentLayout::Ascii => {
-                let s: &str = serde::Deserialize::deserialize(deserializer)?;
-                if !s.is_ascii() {
-                    Err(D::Error::custom("not an ascii string"))
-                } else {
+    impl<'d> serde::de::DeserializeSeed<'d> for &PrimitiveArgumentLayout {
+        type Value = ();
+        fn deserialize<D: serde::de::Deserializer<'d>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            use serde::de::Error;
+            match self {
+                PrimitiveArgumentLayout::Ascii => {
+                    let s: &str = serde::Deserialize::deserialize(deserializer)?;
+                    if !s.is_ascii() {
+                        Err(D::Error::custom("not an ascii string"))
+                    } else {
+                        Ok(())
+                    }
+                }
+                PrimitiveArgumentLayout::UTF8 => {
+                    deserializer.deserialize_string(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::Option(layout) => {
+                    deserializer.deserialize_option(OptionElementVisitor(layout))
+                }
+                PrimitiveArgumentLayout::Vector(layout) => {
+                    deserializer.deserialize_seq(VectorElementVisitor(layout))
+                }
+                // primitive move value cases, which are hit to make sure the correct number of bytes
+                // are removed for elements of an option/vector
+                PrimitiveArgumentLayout::Bool => {
+                    deserializer.deserialize_bool(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U8 => {
+                    deserializer.deserialize_u8(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U16 => {
+                    deserializer.deserialize_u16(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U32 => {
+                    deserializer.deserialize_u32(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U64 => {
+                    deserializer.deserialize_u64(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U128 => {
+                    deserializer.deserialize_u128(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U256 => {
+                    U256::deserialize(deserializer)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::Address => {
+                    SuiAddress::deserialize(deserializer)?;
                     Ok(())
                 }
             }
-            PrimitiveArgumentLayout::UTF8 => {
-                deserializer.deserialize_string(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::Option(layout) => {
-                deserializer.deserialize_option(OptionElementVisitor(layout))
-            }
-            PrimitiveArgumentLayout::Vector(layout) => {
-                deserializer.deserialize_seq(VectorElementVisitor(layout))
-            }
-            // primitive move value cases, which are hit to make sure the correct number of bytes
-            // are removed for elements of an option/vector
-            PrimitiveArgumentLayout::Bool => {
-                deserializer.deserialize_bool(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U8 => {
-                deserializer.deserialize_u8(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U16 => {
-                deserializer.deserialize_u16(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U32 => {
-                deserializer.deserialize_u32(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U64 => {
-                deserializer.deserialize_u64(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U128 => {
-                deserializer.deserialize_u128(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U256 => {
-                U256::deserialize(deserializer)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::Address => {
-                SuiAddress::deserialize(deserializer)?;
-                Ok(())
+        }
+    }
+
+    struct VectorElementVisitor<'a>(&'a PrimitiveArgumentLayout);
+
+    impl<'d, 'a> serde::de::Visitor<'d> for VectorElementVisitor<'a> {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Vector")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'d>,
+        {
+            while seq.next_element_seed(self.0)?.is_some() {}
+            Ok(())
+        }
+    }
+
+    struct OptionElementVisitor<'a>(&'a PrimitiveArgumentLayout);
+
+    impl<'d, 'a> serde::de::Visitor<'d> for OptionElementVisitor<'a> {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Option")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(())
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'d>,
+        {
+            self.0.deserialize(deserializer)
+        }
+    }
+
+    impl fmt::Display for PrimitiveArgumentLayout {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                PrimitiveArgumentLayout::Vector(inner) => {
+                    write!(f, "vector<{inner}>")
+                }
+                PrimitiveArgumentLayout::Option(inner) => {
+                    write!(f, "std::option::Option<{inner}>")
+                }
+                PrimitiveArgumentLayout::Ascii => {
+                    write!(f, "std::{}::{}", RESOLVED_ASCII_STR.1, RESOLVED_ASCII_STR.2)
+                }
+                PrimitiveArgumentLayout::UTF8 => {
+                    write!(f, "std::{}::{}", RESOLVED_UTF8_STR.1, RESOLVED_UTF8_STR.2)
+                }
+                PrimitiveArgumentLayout::Bool => write!(f, "bool"),
+                PrimitiveArgumentLayout::U8 => write!(f, "u8"),
+                PrimitiveArgumentLayout::U16 => write!(f, "u16"),
+                PrimitiveArgumentLayout::U32 => write!(f, "u32"),
+                PrimitiveArgumentLayout::U64 => write!(f, "u64"),
+                PrimitiveArgumentLayout::U128 => write!(f, "u128"),
+                PrimitiveArgumentLayout::U256 => write!(f, "u256"),
+                PrimitiveArgumentLayout::Address => write!(f, "address"),
             }
         }
     }
-}
-
-struct VectorElementVisitor<'a>(&'a PrimitiveArgumentLayout);
-
-impl<'d, 'a> serde::de::Visitor<'d> for VectorElementVisitor<'a> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("Vector")
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: serde::de::SeqAccess<'d>,
-    {
-        while seq.next_element_seed(self.0)?.is_some() {}
-        Ok(())
-    }
-}
-
-struct OptionElementVisitor<'a>(&'a PrimitiveArgumentLayout);
-
-impl<'d, 'a> serde::de::Visitor<'d> for OptionElementVisitor<'a> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("Option")
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(())
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'d>,
-    {
-        self.0.deserialize(deserializer)
-    }
-}
-
-impl fmt::Display for PrimitiveArgumentLayout {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PrimitiveArgumentLayout::Vector(inner) => {
-                write!(f, "vector<{inner}>")
-            }
-            PrimitiveArgumentLayout::Option(inner) => {
-                write!(f, "std::option::Option<{inner}>")
-            }
-            PrimitiveArgumentLayout::Ascii => {
-                write!(f, "std::{}::{}", RESOLVED_ASCII_STR.1, RESOLVED_ASCII_STR.2)
-            }
-            PrimitiveArgumentLayout::UTF8 => {
-                write!(f, "std::{}::{}", RESOLVED_UTF8_STR.1, RESOLVED_UTF8_STR.2)
-            }
-            PrimitiveArgumentLayout::Bool => write!(f, "bool"),
-            PrimitiveArgumentLayout::U8 => write!(f, "u8"),
-            PrimitiveArgumentLayout::U16 => write!(f, "u16"),
-            PrimitiveArgumentLayout::U32 => write!(f, "u32"),
-            PrimitiveArgumentLayout::U64 => write!(f, "u64"),
-            PrimitiveArgumentLayout::U128 => write!(f, "u128"),
-            PrimitiveArgumentLayout::U256 => write!(f, "u256"),
-            PrimitiveArgumentLayout::Address => write!(f, "address"),
-        }
-    }
-}
-
 }

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -1,146 +1,150 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+pub use checked::*;
 
-use anyhow::Result;
-use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
-use move_bytecode_verifier::meter::Meter;
-use move_bytecode_verifier::verify_module_with_config_metered;
-use move_core_types::account_address::AccountAddress;
-use move_vm_config::{
-    runtime::{VMConfig, VMRuntimeLimitsConfig},
-    verifier::VerifierConfig,
-};
-use move_vm_runtime::{
-    move_vm::MoveVM, native_extensions::NativeContextExtensions,
-    native_functions::NativeFunctionTable,
-};
-use sui_move_natives::object_runtime;
-use sui_types::metrics::BytecodeVerifierMetrics;
-use sui_verifier::check_for_verifier_timeout;
-use tracing::instrument;
+#[sui_macros::with_checked_arithmetic]
+mod checked {
 
-use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
-use sui_protocol_config::ProtocolConfig;
-use sui_types::{
-    base_types::*,
-    error::ExecutionError,
-    error::{ExecutionErrorKind, SuiError},
-    metrics::LimitsMetrics,
-    storage::ChildObjectResolver,
-};
-use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
+    use std::{collections::BTreeMap, sync::Arc};
 
-sui_macros::checked_arithmetic! {
-
-pub fn default_verifier_config(
-    protocol_config: &ProtocolConfig,
-    is_metered: bool,
-) -> VerifierConfig {
-    let (
-        max_back_edges_per_function,
-        max_back_edges_per_module,
-        max_per_fun_meter_units,
-        max_per_mod_meter_units,
-    ) = if is_metered {
-        (
-            Some(protocol_config.max_back_edges_per_function() as usize),
-            Some(protocol_config.max_back_edges_per_module() as usize),
-            Some(protocol_config.max_verifier_meter_ticks_per_function() as u128),
-            Some(protocol_config.max_meter_ticks_per_module() as u128),
-        )
-    } else {
-        (None, None, None, None)
+    use anyhow::Result;
+    use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
+    use move_bytecode_verifier::meter::Meter;
+    use move_bytecode_verifier::verify_module_with_config_metered;
+    use move_core_types::account_address::AccountAddress;
+    use move_vm_config::{
+        runtime::{VMConfig, VMRuntimeLimitsConfig},
+        verifier::VerifierConfig,
     };
+    use move_vm_runtime::{
+        move_vm::MoveVM, native_extensions::NativeContextExtensions,
+        native_functions::NativeFunctionTable,
+    };
+    use sui_move_natives::object_runtime;
+    use sui_types::metrics::BytecodeVerifierMetrics;
+    use sui_verifier::check_for_verifier_timeout;
+    use tracing::instrument;
 
-    VerifierConfig {
-        max_loop_depth: Some(protocol_config.max_loop_depth() as usize),
-        max_generic_instantiation_length: Some(
-            protocol_config.max_generic_instantiation_length() as usize
-        ),
-        max_function_parameters: Some(protocol_config.max_function_parameters() as usize),
-        max_basic_blocks: Some(protocol_config.max_basic_blocks() as usize),
-        max_value_stack_size: protocol_config.max_value_stack_size() as usize,
-        max_type_nodes: Some(protocol_config.max_type_nodes() as usize),
-        max_push_size: Some(protocol_config.max_push_size() as usize),
-        max_dependency_depth: Some(protocol_config.max_dependency_depth() as usize),
-        max_fields_in_struct: Some(protocol_config.max_fields_in_struct() as usize),
-        max_function_definitions: Some(protocol_config.max_function_definitions() as usize),
-        max_struct_definitions: Some(protocol_config.max_struct_definitions() as usize),
-        max_constant_vector_len: Some(protocol_config.max_move_vector_len()),
-        max_back_edges_per_function,
-        max_back_edges_per_module,
-        max_basic_blocks_in_script: None,
-        max_per_fun_meter_units,
-        max_per_mod_meter_units,
-        max_idenfitier_len: protocol_config.max_move_identifier_len_as_option(), // Before protocol version 9, there was no limit
-    }
-}
+    use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::{
+        base_types::*,
+        error::ExecutionError,
+        error::{ExecutionErrorKind, SuiError},
+        metrics::LimitsMetrics,
+        storage::ChildObjectResolver,
+    };
+    use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
-pub fn new_move_vm(
-    natives: NativeFunctionTable,
-    protocol_config: &ProtocolConfig,
-    paranoid_type_checks: bool,
-) -> Result<MoveVM, SuiError> {
-    MoveVM::new_with_config(
-        natives,
-        VMConfig {
-            verifier: default_verifier_config(
-                protocol_config,
-                false, /* we do not enable metering in execution*/
+    pub fn default_verifier_config(
+        protocol_config: &ProtocolConfig,
+        is_metered: bool,
+    ) -> VerifierConfig {
+        let (
+            max_back_edges_per_function,
+            max_back_edges_per_module,
+            max_per_fun_meter_units,
+            max_per_mod_meter_units,
+        ) = if is_metered {
+            (
+                Some(protocol_config.max_back_edges_per_function() as usize),
+                Some(protocol_config.max_back_edges_per_module() as usize),
+                Some(protocol_config.max_verifier_meter_ticks_per_function() as u128),
+                Some(protocol_config.max_meter_ticks_per_module() as u128),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+        VerifierConfig {
+            max_loop_depth: Some(protocol_config.max_loop_depth() as usize),
+            max_generic_instantiation_length: Some(
+                protocol_config.max_generic_instantiation_length() as usize,
             ),
-            max_binary_format_version: protocol_config.move_binary_format_version(),
-            paranoid_type_checks,
-            runtime_limits_config: VMRuntimeLimitsConfig {
-                vector_len_max: protocol_config.max_move_vector_len(),
-                max_value_nest_depth: protocol_config.max_move_value_depth_as_option(),
+            max_function_parameters: Some(protocol_config.max_function_parameters() as usize),
+            max_basic_blocks: Some(protocol_config.max_basic_blocks() as usize),
+            max_value_stack_size: protocol_config.max_value_stack_size() as usize,
+            max_type_nodes: Some(protocol_config.max_type_nodes() as usize),
+            max_push_size: Some(protocol_config.max_push_size() as usize),
+            max_dependency_depth: Some(protocol_config.max_dependency_depth() as usize),
+            max_fields_in_struct: Some(protocol_config.max_fields_in_struct() as usize),
+            max_function_definitions: Some(protocol_config.max_function_definitions() as usize),
+            max_struct_definitions: Some(protocol_config.max_struct_definitions() as usize),
+            max_constant_vector_len: Some(protocol_config.max_move_vector_len()),
+            max_back_edges_per_function,
+            max_back_edges_per_module,
+            max_basic_blocks_in_script: None,
+            max_per_fun_meter_units,
+            max_per_mod_meter_units,
+            max_idenfitier_len: protocol_config.max_move_identifier_len_as_option(), // Before protocol version 9, there was no limit
+        }
+    }
+
+    pub fn new_move_vm(
+        natives: NativeFunctionTable,
+        protocol_config: &ProtocolConfig,
+        paranoid_type_checks: bool,
+    ) -> Result<MoveVM, SuiError> {
+        MoveVM::new_with_config(
+            natives,
+            VMConfig {
+                verifier: default_verifier_config(
+                    protocol_config,
+                    false, /* we do not enable metering in execution*/
+                ),
+                max_binary_format_version: protocol_config.move_binary_format_version(),
+                paranoid_type_checks,
+                runtime_limits_config: VMRuntimeLimitsConfig {
+                    vector_len_max: protocol_config.max_move_vector_len(),
+                    max_value_nest_depth: protocol_config.max_move_value_depth_as_option(),
+                },
+                enable_invariant_violation_check_in_swap_loc: !protocol_config
+                    .disable_invariant_violation_check_in_swap_loc(),
+                check_no_extraneous_bytes_during_deserialization: protocol_config
+                    .no_extraneous_module_bytes(),
+                // Don't augment errors with execution state on-chain
+                error_execution_state: false,
+                #[cfg(debug_assertions)]
+                profiler_config: Default::default(),
             },
-            enable_invariant_violation_check_in_swap_loc: !protocol_config
-                .disable_invariant_violation_check_in_swap_loc(),
-            check_no_extraneous_bytes_during_deserialization: protocol_config
-                .no_extraneous_module_bytes(),
-            // Don't augment errors with execution state on-chain
-            error_execution_state: false,
-            #[cfg(debug_assertions)] profiler_config: Default::default(),
-        },
-    )
-    .map_err(|_| SuiError::ExecutionInvariantViolation)
-}
+        )
+        .map_err(|_| SuiError::ExecutionInvariantViolation)
+    }
 
-pub fn new_native_extensions<'r>(
-    child_resolver: &'r dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-    is_metered: bool,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> NativeContextExtensions<'r> {
-    let mut extensions = NativeContextExtensions::default();
-    extensions.add(ObjectRuntime::new(
-        child_resolver,
-        input_objects,
-        is_metered,
-        protocol_config,
-        metrics,
-    ));
-    extensions.add(NativesCostTable::from_protocol_config(protocol_config));
-    extensions
-}
+    pub fn new_native_extensions<'r>(
+        child_resolver: &'r dyn ChildObjectResolver,
+        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
+        is_metered: bool,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> NativeContextExtensions<'r> {
+        let mut extensions = NativeContextExtensions::default();
+        extensions.add(ObjectRuntime::new(
+            child_resolver,
+            input_objects,
+            is_metered,
+            protocol_config,
+            metrics,
+        ));
+        extensions.add(NativesCostTable::from_protocol_config(protocol_config));
+        extensions
+    }
 
-/// Given a list of `modules` and an `object_id`, mutate each module's self ID (which must be
-/// 0x0) to be `object_id`.
-pub fn substitute_package_id(
-    modules: &mut [CompiledModule],
-    object_id: ObjectID,
-) -> Result<(), ExecutionError> {
-    let new_address = AccountAddress::from(object_id);
+    /// Given a list of `modules` and an `object_id`, mutate each module's self ID (which must be
+    /// 0x0) to be `object_id`.
+    pub fn substitute_package_id(
+        modules: &mut [CompiledModule],
+        object_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        let new_address = AccountAddress::from(object_id);
 
-    for module in modules.iter_mut() {
-        let self_handle = module.self_handle().clone();
-        let self_address_idx = self_handle.address;
+        for module in modules.iter_mut() {
+            let self_handle = module.self_handle().clone();
+            let self_address_idx = self_handle.address;
 
-        let addrs = &mut module.address_identifiers;
-        let Some(address_mut) = addrs.get_mut(self_address_idx.0 as usize) else {
+            let addrs = &mut module.address_identifiers;
+            let Some(address_mut) = addrs.get_mut(self_address_idx.0 as usize) else {
             let name = module.identifier_at(self_handle.name);
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PublishErrorNonZeroAddress,
@@ -148,49 +152,71 @@ pub fn substitute_package_id(
             ));
         };
 
-        if *address_mut != AccountAddress::ZERO {
-            let name = module.identifier_at(self_handle.name);
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PublishErrorNonZeroAddress,
-                format!("Publishing module {name} with non-zero address is not allowed"),
-            ));
-        };
+            if *address_mut != AccountAddress::ZERO {
+                let name = module.identifier_at(self_handle.name);
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::PublishErrorNonZeroAddress,
+                    format!("Publishing module {name} with non-zero address is not allowed"),
+                ));
+            };
 
-        *address_mut = new_address;
+            *address_mut = new_address;
+        }
+
+        Ok(())
     }
 
-    Ok(())
-}
-
-pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
-    format!(
+    pub fn missing_unwrapped_msg(id: &ObjectID) -> String {
+        format!(
         "Unable to unwrap object {}. Was unable to retrieve last known version in the parent sync",
         id
     )
-}
+    }
 
-/// Run the bytecode verifier with a meter limit
-///
-/// This function only fails if the verification does not complete within the limit.  If the
-/// modules fail to verify but verification completes within the meter limit, the function
-/// succeeds.
-#[instrument(level = "trace", skip_all)]
-pub fn run_metered_move_bytecode_verifier(
-    modules: &[CompiledModule],
-    protocol_config: &ProtocolConfig,
-    verifier_config: &VerifierConfig,
-    meter: &mut impl Meter,
-    metrics: &Arc<BytecodeVerifierMetrics>,
-) -> Result<(), SuiError> {
-    // run the Move verifier
-    for module in modules.iter() {
-        let per_module_meter_verifier_timer = metrics
-            .verifier_runtime_per_module_success_latency
-            .start_timer();
+    /// Run the bytecode verifier with a meter limit
+    ///
+    /// This function only fails if the verification does not complete within the limit.  If the
+    /// modules fail to verify but verification completes within the meter limit, the function
+    /// succeeds.
+    #[instrument(level = "trace", skip_all)]
+    pub fn run_metered_move_bytecode_verifier(
+        modules: &[CompiledModule],
+        protocol_config: &ProtocolConfig,
+        verifier_config: &VerifierConfig,
+        meter: &mut impl Meter,
+        metrics: &Arc<BytecodeVerifierMetrics>,
+    ) -> Result<(), SuiError> {
+        // run the Move verifier
+        for module in modules.iter() {
+            let per_module_meter_verifier_timer = metrics
+                .verifier_runtime_per_module_success_latency
+                .start_timer();
 
-        if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
-            // Check that the status indicates mtering timeout
-            if check_for_verifier_timeout(&e.major_status()) {
+            if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
+                // Check that the status indicates mtering timeout
+                if check_for_verifier_timeout(&e.major_status()) {
+                    // Discard success timer, but record timeout/failure timer
+                    metrics
+                        .verifier_runtime_per_module_timeout_latency
+                        .observe(per_module_meter_verifier_timer.stop_and_discard());
+                    metrics
+                        .verifier_timeout_metrics
+                        .with_label_values(&[
+                            BytecodeVerifierMetrics::MOVE_VERIFIER_TAG,
+                            BytecodeVerifierMetrics::TIMEOUT_TAG,
+                        ])
+                        .inc();
+                    return Err(SuiError::ModuleVerificationFailure {
+                        error: format!("Verification timedout: {}", e),
+                    });
+                };
+            } else if let Err(err) = sui_verify_module_metered_check_timeout_only(
+                protocol_config,
+                module,
+                &BTreeMap::new(),
+                meter,
+            ) {
+                // We only checked that the failure was due to timeout
                 // Discard success timer, but record timeout/failure timer
                 metrics
                     .verifier_runtime_per_module_timeout_latency
@@ -198,45 +224,22 @@ pub fn run_metered_move_bytecode_verifier(
                 metrics
                     .verifier_timeout_metrics
                     .with_label_values(&[
-                        BytecodeVerifierMetrics::MOVE_VERIFIER_TAG,
+                        BytecodeVerifierMetrics::SUI_VERIFIER_TAG,
                         BytecodeVerifierMetrics::TIMEOUT_TAG,
                     ])
                     .inc();
-                return Err(SuiError::ModuleVerificationFailure {
-                    error: format!("Verification timedout: {}", e),
-                });
-            };
-        } else if let Err(err) = sui_verify_module_metered_check_timeout_only(
-            protocol_config,
-            module,
-            &BTreeMap::new(),
-            meter,
-        ) {
-            // We only checked that the failure was due to timeout
-            // Discard success timer, but record timeout/failure timer
-            metrics
-                .verifier_runtime_per_module_timeout_latency
-                .observe(per_module_meter_verifier_timer.stop_and_discard());
+                return Err(err.into());
+            }
+            // Save the success timer
+            per_module_meter_verifier_timer.stop_and_record();
             metrics
                 .verifier_timeout_metrics
                 .with_label_values(&[
-                    BytecodeVerifierMetrics::SUI_VERIFIER_TAG,
-                    BytecodeVerifierMetrics::TIMEOUT_TAG,
+                    BytecodeVerifierMetrics::OVERALL_TAG,
+                    BytecodeVerifierMetrics::SUCCESS_TAG,
                 ])
                 .inc();
-            return Err(err.into());
         }
-        // Save the success timer
-        per_module_meter_verifier_timer.stop_and_record();
-        metrics
-            .verifier_timeout_metrics
-            .with_label_values(&[
-                BytecodeVerifierMetrics::OVERALL_TAG,
-                BytecodeVerifierMetrics::SUCCESS_TAG,
-            ])
-            .inc();
+        Ok(())
     }
-    Ok(())
-}
-
 }

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -1,740 +1,744 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::CompiledModule;
-use move_vm_runtime::move_vm::MoveVM;
-use once_cell::sync::Lazy;
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
-use sui_types::balance::{
-    BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
-    BALANCE_MODULE_NAME,
-};
-use sui_types::execution_mode::{self, ExecutionMode};
-use sui_types::gas_coin::GAS;
-use sui_types::metrics::LimitsMetrics;
-use sui_types::object::OBJECT_START_VERSION;
-use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use tracing::{info, instrument, trace, warn};
+pub use checked::*;
 
-use crate::programmable_transactions;
-use crate::type_layout_resolver::TypeLayoutResolver;
-use move_binary_format::access::ModuleAccess;
-use sui_macros::checked_arithmetic;
-use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
-use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
-use sui_types::committee::EpochId;
-use sui_types::effects::TransactionEffects;
-use sui_types::error::{ExecutionError, ExecutionErrorKind};
-use sui_types::execution_status::ExecutionStatus;
-use sui_types::gas::{GasCharger, GasCostSummary};
-use sui_types::messages_consensus::ConsensusCommitPrologue;
-use sui_types::storage::WriteKind;
-#[cfg(msim)]
-use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
-use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
-use sui_types::temporary_store::InnerTemporaryStore;
-use sui_types::temporary_store::TemporaryStore;
-use sui_types::transaction::{
-    Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
-    TransactionKind,
-};
-use sui_types::{
-    base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
-    object::Object,
-    sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
-    SUI_FRAMEWORK_ADDRESS,
-};
-use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID};
+#[sui_macros::with_checked_arithmetic]
+mod checked {
 
-/// If a transaction digest shows up in this list, when executing such transaction,
-/// we will always return `ExecutionError::CertificateDenied` without executing it (but still do
-/// gas smashing). Because this list is not gated by protocol version, there are a few important
-/// criteria for adding a digest to this list:
-/// 1. The certificate must be causing all validators to either panic or hang forever deterministically.
-/// 2. If we ever ship a fix to make it no longer panic or hang when executing such transaction,
-/// we must make sure the transaction is already in this list. Otherwise nodes running the newer version
-/// without these transactions in the list will generate forked result.
-/// Below is a scenario of when we need to use this list:
-/// 1. We detect that a specific transaction is causing all validators to either panic or hang forever deterministically.
-/// 2. We push a CertificateDenyConfig to deny such transaction to all validators asap.
-/// 3. To make sure that all fullnodes are able to sync to the latest version, we need to add the transaction digest
-/// to this list as well asap, and ship this binary to all fullnodes, so that they can sync past this transaction.
-/// 4. We then can start fixing the issue, and ship the fix to all nodes.
-/// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
-/// node that sync from genesis will fork on this transaction. We may be able to remove it once
-/// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
-pub fn get_denied_certificates() -> &'static HashSet<TransactionDigest> {
-    static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> = Lazy::new(|| HashSet::from([]));
-    Lazy::force(&DENIED_CERTIFICATES)
-}
-
-fn is_certificate_denied(
-    transaction_digest: &TransactionDigest,
-    certificate_deny_set: &HashSet<TransactionDigest>,
-) -> bool {
-    certificate_deny_set.contains(transaction_digest)
-        || get_denied_certificates().contains(transaction_digest)
-}
-
-checked_arithmetic! {
-
-#[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
-    shared_object_refs: Vec<ObjectRef>,
-    mut temporary_store: TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    transaction_signer: SuiAddress,
-    gas_charger: &mut GasCharger,
-    transaction_digest: TransactionDigest,
-    mut transaction_dependencies: BTreeSet<TransactionDigest>,
-    move_vm: &Arc<MoveVM>,
-    epoch_id: &EpochId,
-    epoch_timestamp_ms: u64,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool,
-    certificate_deny_set: &HashSet<TransactionDigest>,
-) -> (
-    InnerTemporaryStore,
-    TransactionEffects,
-    Result<Mode::ExecutionResults, ExecutionError>,
-) {
-    let mut tx_ctx = TxContext::new_from_components(
-        &transaction_signer,
-        &transaction_digest,
-        epoch_id,
-        epoch_timestamp_ms,
-    );
-
-    let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));
-
-    let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
-    let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
-        &mut temporary_store,
-        transaction_kind,
-        gas_charger,
-        &mut tx_ctx,
-        move_vm,
-        protocol_config,
-        metrics,
-        enable_expensive_checks,
-        deny_cert,
-    );
-
-    let status = if let Err(error) = &execution_result {
-        // Elaborate errors in logs if they are unexpected or their status is terse.
-        use ExecutionErrorKind as K;
-        match error.kind() {
-            K::InvariantViolation | K::VMInvariantViolation => {
-                #[skip_checked_arithmetic]
-                tracing::error!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "INVARIANT VIOLATION! Source: {:?}",
-                    error.source(),
-                );
-            }
-
-            K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                #[skip_checked_arithmetic]
-                tracing::debug!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "Verification Error. Source: {:?}",
-                    error.source(),
-                );
-            }
-
-            K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                #[skip_checked_arithmetic]
-                tracing::debug!(
-                    kind = ?error.kind(),
-                    tx_digest = ?transaction_digest,
-                    "Publish/Upgrade Error. Source: {:?}",
-                    error.source(),
-                )
-            }
-
-            _ => (),
-        };
-
-        let (status, command) = error.to_execution_status();
-        ExecutionStatus::new_failure(status, command)
-    } else {
-        ExecutionStatus::Success
+    use move_binary_format::CompiledModule;
+    use move_vm_runtime::move_vm::MoveVM;
+    use once_cell::sync::Lazy;
+    use std::{
+        collections::{BTreeSet, HashSet},
+        sync::Arc,
     };
+    use sui_types::balance::{
+        BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
+        BALANCE_MODULE_NAME,
+    };
+    use sui_types::execution_mode::{self, ExecutionMode};
+    use sui_types::gas_coin::GAS;
+    use sui_types::metrics::LimitsMetrics;
+    use sui_types::object::OBJECT_START_VERSION;
+    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+    use tracing::{info, instrument, trace, warn};
 
-    #[skip_checked_arithmetic]
-    trace!(
-        tx_digest = ?transaction_digest,
-        computation_gas_cost = gas_cost_summary.computation_cost,
-        storage_gas_cost = gas_cost_summary.storage_cost,
-        storage_gas_rebate = gas_cost_summary.storage_rebate,
-        "Finished execution of transaction with status {:?}",
-        status
-    );
+    use crate::programmable_transactions;
+    use crate::type_layout_resolver::TypeLayoutResolver;
+    use move_binary_format::access::ModuleAccess;
+    use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
+    use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
+    use sui_types::committee::EpochId;
+    use sui_types::effects::TransactionEffects;
+    use sui_types::error::{ExecutionError, ExecutionErrorKind};
+    use sui_types::execution_status::ExecutionStatus;
+    use sui_types::gas::{GasCharger, GasCostSummary};
+    use sui_types::messages_consensus::ConsensusCommitPrologue;
+    use sui_types::storage::WriteKind;
+    #[cfg(msim)]
+    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
+    use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
+    use sui_types::temporary_store::InnerTemporaryStore;
+    use sui_types::temporary_store::TemporaryStore;
+    use sui_types::transaction::{
+        Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
+        TransactionKind,
+    };
+    use sui_types::{
+        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        object::Object,
+        sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
+        SUI_FRAMEWORK_ADDRESS,
+    };
+    use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID};
 
-    // Remove from dependencies the generic hash
-    transaction_dependencies.remove(&TransactionDigest::genesis());
+    /// If a transaction digest shows up in this list, when executing such transaction,
+    /// we will always return `ExecutionError::CertificateDenied` without executing it (but still do
+    /// gas smashing). Because this list is not gated by protocol version, there are a few important
+    /// criteria for adding a digest to this list:
+    /// 1. The certificate must be causing all validators to either panic or hang forever deterministically.
+    /// 2. If we ever ship a fix to make it no longer panic or hang when executing such transaction,
+    /// we must make sure the transaction is already in this list. Otherwise nodes running the newer version
+    /// without these transactions in the list will generate forked result.
+    /// Below is a scenario of when we need to use this list:
+    /// 1. We detect that a specific transaction is causing all validators to either panic or hang forever deterministically.
+    /// 2. We push a CertificateDenyConfig to deny such transaction to all validators asap.
+    /// 3. To make sure that all fullnodes are able to sync to the latest version, we need to add the transaction digest
+    /// to this list as well asap, and ship this binary to all fullnodes, so that they can sync past this transaction.
+    /// 4. We then can start fixing the issue, and ship the fix to all nodes.
+    /// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
+    /// node that sync from genesis will fork on this transaction. We may be able to remove it once
+    /// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
+    pub fn get_denied_certificates() -> &'static HashSet<TransactionDigest> {
+        static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> =
+            Lazy::new(|| HashSet::from([]));
+        Lazy::force(&DENIED_CERTIFICATES)
+    }
 
-    if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
-        temporary_store
-            .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
-            .unwrap()
-    } // else, in dev inspect mode and anything goes--don't check
+    fn is_certificate_denied(
+        transaction_digest: &TransactionDigest,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+    ) -> bool {
+        certificate_deny_set.contains(transaction_digest)
+            || get_denied_certificates().contains(transaction_digest)
+    }
 
-    let (inner, effects) = temporary_store.to_effects(
-        shared_object_refs,
-        &transaction_digest,
-        transaction_dependencies.into_iter().collect(),
-        gas_cost_summary,
-        status,
-        gas_charger,
-        *epoch_id,
-    );
-    (inner, effects, execution_result)
-}
+    #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
+        shared_object_refs: Vec<ObjectRef>,
+        mut temporary_store: TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        gas_charger: &mut GasCharger,
+        transaction_digest: TransactionDigest,
+        mut transaction_dependencies: BTreeSet<TransactionDigest>,
+        move_vm: &Arc<MoveVM>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        let mut tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+        );
 
-#[instrument(name = "tx_execute", level = "debug", skip_all)]
-fn execute_transaction<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    gas_charger: &mut GasCharger,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool,
-    deny_cert: bool,
-) -> (
-    GasCostSummary,
-    Result<Mode::ExecutionResults, ExecutionError>,
-) {
-    gas_charger.smash_gas(temporary_store);
+        let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));
 
-    // At this point no charges have been applied yet
-    debug_assert!(
-        gas_charger.no_charges(),
-        "No gas charges must be applied yet"
-    );
-    let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
-    let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+        let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
+        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
+            &mut temporary_store,
+            transaction_kind,
+            gas_charger,
+            &mut tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            deny_cert,
+        );
 
-    // We must charge object read here during transaction execution, because if this fails
-    // we must still ensure an effect is committed and all objects versions incremented
-    let result = gas_charger.charge_input_objects(temporary_store);
-    let mut result = result.and_then(|()| {
-        let mut execution_result = if deny_cert {
-            Err(ExecutionError::new(
-                ExecutionErrorKind::CertificateDenied,
-                None,
-            ))
+        let status = if let Err(error) = &execution_result {
+            // Elaborate errors in logs if they are unexpected or their status is terse.
+            use ExecutionErrorKind as K;
+            match error.kind() {
+                K::InvariantViolation | K::VMInvariantViolation => {
+                    #[skip_checked_arithmetic]
+                    tracing::error!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "INVARIANT VIOLATION! Source: {:?}",
+                        error.source(),
+                    );
+                }
+
+                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+                    #[skip_checked_arithmetic]
+                    tracing::debug!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "Verification Error. Source: {:?}",
+                        error.source(),
+                    );
+                }
+
+                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+                    #[skip_checked_arithmetic]
+                    tracing::debug!(
+                        kind = ?error.kind(),
+                        tx_digest = ?transaction_digest,
+                        "Publish/Upgrade Error. Source: {:?}",
+                        error.source(),
+                    )
+                }
+
+                _ => (),
+            };
+
+            let (status, command) = error.to_execution_status();
+            ExecutionStatus::new_failure(status, command)
         } else {
-            execution_loop::<Mode>(
-                temporary_store,
-                transaction_kind,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics.clone(),
-            )
+            ExecutionStatus::Success
         };
 
-        let effects_estimated_size = temporary_store.estimate_effects_size_upperbound();
+        #[skip_checked_arithmetic]
+        trace!(
+            tx_digest = ?transaction_digest,
+            computation_gas_cost = gas_cost_summary.computation_cost,
+            storage_gas_cost = gas_cost_summary.storage_cost,
+            storage_gas_rebate = gas_cost_summary.storage_rebate,
+            "Finished execution of transaction with status {:?}",
+            status
+        );
 
-        // Check if a limit threshold was crossed.
-        // For metered transactions, there is not soft limit.
-        // For system transactions, we allow a soft limit with alerting, and a hard limit where we terminate
-        match check_limit_by_meter!(
-            !gas_charger.is_unmetered(),
-            effects_estimated_size,
-            protocol_config.max_serialized_tx_effects_size_bytes(),
-            protocol_config.max_serialized_tx_effects_size_bytes_system_tx(),
-            metrics.excessive_estimated_effects_size
-        ) {
-            LimitThresholdCrossed::None => (),
-            LimitThresholdCrossed::Soft(_, limit) => {
-                warn!(
-                    effects_estimated_size = effects_estimated_size,
-                    soft_limit = limit,
-                    "Estimated transaction effects size crossed soft limit",
-                )
-            }
-            LimitThresholdCrossed::Hard(_, lim) => {
-                execution_result = Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::EffectsTooLarge {
-                        current_size: effects_estimated_size as u64,
-                        max_size: lim as u64,
-                    },
-                    "Transaction effects are too large",
+        // Remove from dependencies the generic hash
+        transaction_dependencies.remove(&TransactionDigest::genesis());
+
+        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
+            temporary_store
+                .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
+                .unwrap()
+        } // else, in dev inspect mode and anything goes--don't check
+
+        let (inner, effects) = temporary_store.to_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies.into_iter().collect(),
+            gas_cost_summary,
+            status,
+            gas_charger,
+            *epoch_id,
+        );
+        (inner, effects, execution_result)
+    }
+
+    #[instrument(name = "tx_execute", level = "debug", skip_all)]
+    fn execute_transaction<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        gas_charger: &mut GasCharger,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        deny_cert: bool,
+    ) -> (
+        GasCostSummary,
+        Result<Mode::ExecutionResults, ExecutionError>,
+    ) {
+        gas_charger.smash_gas(temporary_store);
+
+        // At this point no charges have been applied yet
+        debug_assert!(
+            gas_charger.no_charges(),
+            "No gas charges must be applied yet"
+        );
+        let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
+        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+
+        // We must charge object read here during transaction execution, because if this fails
+        // we must still ensure an effect is committed and all objects versions incremented
+        let result = gas_charger.charge_input_objects(temporary_store);
+        let mut result = result.and_then(|()| {
+            let mut execution_result = if deny_cert {
+                Err(ExecutionError::new(
+                    ExecutionErrorKind::CertificateDenied,
+                    None,
                 ))
-            }
-        };
-        if execution_result.is_ok() {
-            // This limit is only present in Version 3 and up, so use this to gate it
-            if let (Some(normal_lim), Some(system_lim)) = (
-                protocol_config.max_size_written_objects_as_option(),
-                protocol_config.max_size_written_objects_system_tx_as_option(),
-            ) {
-                let written_objects_size = temporary_store.written_objects_size();
-
-                match check_limit_by_meter!(
-                    !gas_charger.is_unmetered(),
-                    written_objects_size,
-                    normal_lim,
-                    system_lim,
-                    metrics.excessive_written_objects_size
-                ) {
-                    LimitThresholdCrossed::None => (),
-                    LimitThresholdCrossed::Soft(_, limit) => {
-                        warn!(
-                            written_objects_size = written_objects_size,
-                            soft_limit = limit,
-                            "Written objects size crossed soft limit",
-                        )
-                    }
-                    LimitThresholdCrossed::Hard(_, lim) => {
-                        execution_result = Err(ExecutionError::new_with_source(
-                            ExecutionErrorKind::WrittenObjectsTooLarge {
-                                current_size: written_objects_size as u64,
-                                max_size: lim as u64,
-                            },
-                            "Written objects size crossed hard limit",
-                        ))
-                    }
-                };
-            }
-        }
-
-        execution_result
-    });
-
-    let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
-    // === begin SUI conservation checks ===
-    // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-    // information provided to check_sui_conserved, because we mint rewards, and burn
-    // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-    // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-    // We could probably clean up the code a bit.
-    // Put all the storage rebate accumulated in the system transaction
-    // to the 0x5 object so that it's not lost.
-    temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
-    if !is_genesis_tx && !Mode::allow_arbitrary_values() {
-        // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-        let conservation_result = {
-            let mut layout_resolver = TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-            temporary_store.check_sui_conserved(
-                &cost_summary,
-                advance_epoch_gas_summary,
-                &mut layout_resolver,
-                enable_expensive_checks,
-            )
-        };
-        if let Err(conservation_err) = conservation_result {
-            // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
-            // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
-            result = Err(conservation_err);
-            gas_charger.reset(temporary_store);
-            gas_charger.charge_gas(temporary_store, &mut result);
-            // check conservation once more more
-            let mut layout_resolver = TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-            if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                &cost_summary,
-                advance_epoch_gas_summary,
-                &mut layout_resolver,
-                enable_expensive_checks,
-            ) {
-                // if we still fail, it's a problem with gas
-                // charging that happens even in the "aborted" case--no other option but panic.
-                // we will create or destroy SUI otherwise
-                panic!(
-                    "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                    tx_ctx.digest(),
-                    recovery_err,
-                    gas_charger.summary()
+            } else {
+                execution_loop::<Mode>(
+                    temporary_store,
+                    transaction_kind,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
                 )
-            }
-        }
-    } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
-      // we're in the non-production dev inspect mode which allows us to violate conservation
-      // === end SUI conservation checks ===
-    (cost_summary, result)
-}
+            };
 
-fn execution_loop<Mode: ExecutionMode>(
-    temporary_store: &mut TemporaryStore<'_>,
-    transaction_kind: TransactionKind,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<Mode::ExecutionResults, ExecutionError> {
-    match transaction_kind {
-        TransactionKind::ChangeEpoch(change_epoch) => {
-            advance_epoch(
-                change_epoch,
-                temporary_store,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics,
-            )?;
-            Ok(Mode::empty_results())
-        }
-        TransactionKind::Genesis(GenesisTransaction { objects }) => {
-            if tx_ctx.epoch() != 0 {
-                panic!("BUG: Genesis Transactions can only be executed in epoch 0");
-            }
+            let effects_estimated_size = temporary_store.estimate_effects_size_upperbound();
 
-            for genesis_object in objects {
-                match genesis_object {
-                    sui_types::transaction::GenesisObject::RawObject { data, owner } => {
-                        let object = Object {
-                            data,
-                            owner,
-                            previous_transaction: tx_ctx.digest(),
-                            storage_rebate: 0,
-                        };
-                        temporary_store.write_object(object, WriteKind::Create);
-                    }
+            // Check if a limit threshold was crossed.
+            // For metered transactions, there is not soft limit.
+            // For system transactions, we allow a soft limit with alerting, and a hard limit where we terminate
+            match check_limit_by_meter!(
+                !gas_charger.is_unmetered(),
+                effects_estimated_size,
+                protocol_config.max_serialized_tx_effects_size_bytes(),
+                protocol_config.max_serialized_tx_effects_size_bytes_system_tx(),
+                metrics.excessive_estimated_effects_size
+            ) {
+                LimitThresholdCrossed::None => (),
+                LimitThresholdCrossed::Soft(_, limit) => {
+                    warn!(
+                        effects_estimated_size = effects_estimated_size,
+                        soft_limit = limit,
+                        "Estimated transaction effects size crossed soft limit",
+                    )
+                }
+                LimitThresholdCrossed::Hard(_, lim) => {
+                    execution_result = Err(ExecutionError::new_with_source(
+                        ExecutionErrorKind::EffectsTooLarge {
+                            current_size: effects_estimated_size as u64,
+                            max_size: lim as u64,
+                        },
+                        "Transaction effects are too large",
+                    ))
+                }
+            };
+            if execution_result.is_ok() {
+                // This limit is only present in Version 3 and up, so use this to gate it
+                if let (Some(normal_lim), Some(system_lim)) = (
+                    protocol_config.max_size_written_objects_as_option(),
+                    protocol_config.max_size_written_objects_system_tx_as_option(),
+                ) {
+                    let written_objects_size = temporary_store.written_objects_size();
+
+                    match check_limit_by_meter!(
+                        !gas_charger.is_unmetered(),
+                        written_objects_size,
+                        normal_lim,
+                        system_lim,
+                        metrics.excessive_written_objects_size
+                    ) {
+                        LimitThresholdCrossed::None => (),
+                        LimitThresholdCrossed::Soft(_, limit) => {
+                            warn!(
+                                written_objects_size = written_objects_size,
+                                soft_limit = limit,
+                                "Written objects size crossed soft limit",
+                            )
+                        }
+                        LimitThresholdCrossed::Hard(_, lim) => {
+                            execution_result = Err(ExecutionError::new_with_source(
+                                ExecutionErrorKind::WrittenObjectsTooLarge {
+                                    current_size: written_objects_size as u64,
+                                    max_size: lim as u64,
+                                },
+                                "Written objects size crossed hard limit",
+                            ))
+                        }
+                    };
                 }
             }
-            Ok(Mode::empty_results())
-        }
-        TransactionKind::ConsensusCommitPrologue(prologue) => {
-            setup_consensus_commit(
-                prologue,
-                temporary_store,
-                tx_ctx,
-                move_vm,
-                gas_charger,
-                protocol_config,
-                metrics,
-            )
-            .expect("ConsensusCommitPrologue cannot fail");
-            Ok(Mode::empty_results())
-        }
-        TransactionKind::ProgrammableTransaction(pt) => {
-            programmable_transactions::execution::execute::<Mode>(
-                protocol_config,
-                metrics,
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                pt,
-            )
-        }
-    }
-}
 
-fn mint_epoch_rewards_in_pt(
-    builder: &mut ProgrammableTransactionBuilder,
-    params: &AdvanceEpochParams,
-) -> (Argument, Argument) {
-    // Create storage rewards.
-    let storage_charge_arg = builder
-        .input(CallArg::Pure(
-            bcs::to_bytes(&params.storage_charge).unwrap(),
-        ))
-        .unwrap();
-    let storage_rewards = builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![storage_charge_arg],
-    );
+            execution_result
+        });
 
-    // Create computation rewards.
-    let computation_charge_arg = builder
-        .input(CallArg::Pure(
-            bcs::to_bytes(&params.computation_charge).unwrap(),
-        ))
-        .unwrap();
-    let computation_rewards = builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![computation_charge_arg],
-    );
-    (storage_rewards, computation_rewards)
-}
-
-pub fn construct_advance_epoch_pt(
-    params: &AdvanceEpochParams,
-) -> Result<ProgrammableTransaction, ExecutionError> {
-    let mut builder = ProgrammableTransactionBuilder::new();
-    // Step 1: Create storage and computation rewards.
-    let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
-
-    // Step 2: Advance the epoch.
-    let mut arguments = vec![storage_rewards, computation_rewards];
-    let call_arg_arguments = vec![
-        CallArg::SUI_SYSTEM_MUT,
-        CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_fund_reinvest_rate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.reward_slashing_rate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap()),
-    ]
-    .into_iter()
-    .map(|a| builder.input(a))
-    .collect::<Result<_, _>>();
-
-    assert_invariant!(
-        call_arg_arguments.is_ok(),
-        "Unable to generate args for advance_epoch transaction!"
-    );
-
-    arguments.append(&mut call_arg_arguments.unwrap());
-
-    info!("Call arguments to advance_epoch transaction: {:?}", params);
-
-    let storage_rebates = builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
-        SUI_SYSTEM_MODULE_NAME.to_owned(),
-        ADVANCE_EPOCH_FUNCTION_NAME.to_owned(),
-        vec![],
-        arguments,
-    );
-
-    // Step 3: Destroy the storage rebates.
-    builder.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        BALANCE_MODULE_NAME.to_owned(),
-        BALANCE_DESTROY_REBATES_FUNCTION_NAME.to_owned(),
-        vec![GAS::type_tag()],
-        vec![storage_rebates],
-    );
-    Ok(builder.finish())
-}
-
-pub fn construct_advance_epoch_safe_mode_pt(
-    params: &AdvanceEpochParams,
-    protocol_config: &ProtocolConfig,
-) -> Result<ProgrammableTransaction, ExecutionError> {
-    let mut builder = ProgrammableTransactionBuilder::new();
-    // Step 1: Create storage and computation rewards.
-    let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
-
-    // Step 2: Advance the epoch.
-    let mut arguments = vec![storage_rewards, computation_rewards];
-
-    let mut args = vec![
-        CallArg::SUI_SYSTEM_MUT,
-        CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
-        CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
-    ];
-
-    if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
-        args.push(CallArg::Pure(
-            bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap(),
-        ));
+        let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
+        // === begin SUI conservation checks ===
+        // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
+        // information provided to check_sui_conserved, because we mint rewards, and burn
+        // the rebates. We also need to pass in the unmetered_storage_rebate because storage
+        // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
+        // We could probably clean up the code a bit.
+        // Put all the storage rebate accumulated in the system transaction
+        // to the 0x5 object so that it's not lost.
+        temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
+        if !is_genesis_tx && !Mode::allow_arbitrary_values() {
+            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+            let conservation_result = {
+                let mut layout_resolver =
+                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                temporary_store.check_sui_conserved(
+                    &cost_summary,
+                    advance_epoch_gas_summary,
+                    &mut layout_resolver,
+                    enable_expensive_checks,
+                )
+            };
+            if let Err(conservation_err) = conservation_result {
+                // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
+                // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
+                result = Err(conservation_err);
+                gas_charger.reset(temporary_store);
+                gas_charger.charge_gas(temporary_store, &mut result);
+                // check conservation once more more
+                let mut layout_resolver =
+                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                if let Err(recovery_err) = temporary_store.check_sui_conserved(
+                    &cost_summary,
+                    advance_epoch_gas_summary,
+                    &mut layout_resolver,
+                    enable_expensive_checks,
+                ) {
+                    // if we still fail, it's a problem with gas
+                    // charging that happens even in the "aborted" case--no other option but panic.
+                    // we will create or destroy SUI otherwise
+                    panic!(
+                        "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
+                        tx_ctx.digest(),
+                        recovery_err,
+                        gas_charger.summary()
+                    )
+                }
+            }
+        } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
+          // we're in the non-production dev inspect mode which allows us to violate conservation
+          // === end SUI conservation checks ===
+        (cost_summary, result)
     }
 
-    let call_arg_arguments = args
+    fn execution_loop<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+        match transaction_kind {
+            TransactionKind::ChangeEpoch(change_epoch) => {
+                advance_epoch(
+                    change_epoch,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )?;
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::Genesis(GenesisTransaction { objects }) => {
+                if tx_ctx.epoch() != 0 {
+                    panic!("BUG: Genesis Transactions can only be executed in epoch 0");
+                }
+
+                for genesis_object in objects {
+                    match genesis_object {
+                        sui_types::transaction::GenesisObject::RawObject { data, owner } => {
+                            let object = Object {
+                                data,
+                                owner,
+                                previous_transaction: tx_ctx.digest(),
+                                storage_rebate: 0,
+                            };
+                            temporary_store.write_object(object, WriteKind::Create);
+                        }
+                    }
+                }
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ConsensusCommitPrologue(prologue) => {
+                setup_consensus_commit(
+                    prologue,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ProgrammableTransaction(pt) => {
+                programmable_transactions::execution::execute::<Mode>(
+                    protocol_config,
+                    metrics,
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    pt,
+                )
+            }
+        }
+    }
+
+    fn mint_epoch_rewards_in_pt(
+        builder: &mut ProgrammableTransactionBuilder,
+        params: &AdvanceEpochParams,
+    ) -> (Argument, Argument) {
+        // Create storage rewards.
+        let storage_charge_arg = builder
+            .input(CallArg::Pure(
+                bcs::to_bytes(&params.storage_charge).unwrap(),
+            ))
+            .unwrap();
+        let storage_rewards = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![storage_charge_arg],
+        );
+
+        // Create computation rewards.
+        let computation_charge_arg = builder
+            .input(CallArg::Pure(
+                bcs::to_bytes(&params.computation_charge).unwrap(),
+            ))
+            .unwrap();
+        let computation_rewards = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_CREATE_REWARDS_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![computation_charge_arg],
+        );
+        (storage_rewards, computation_rewards)
+    }
+
+    pub fn construct_advance_epoch_pt(
+        params: &AdvanceEpochParams,
+    ) -> Result<ProgrammableTransaction, ExecutionError> {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Step 1: Create storage and computation rewards.
+        let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
+
+        // Step 2: Advance the epoch.
+        let mut arguments = vec![storage_rewards, computation_rewards];
+        let call_arg_arguments = vec![
+            CallArg::SUI_SYSTEM_MUT,
+            CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_fund_reinvest_rate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.reward_slashing_rate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap()),
+        ]
         .into_iter()
         .map(|a| builder.input(a))
         .collect::<Result<_, _>>();
 
-    assert_invariant!(
-        call_arg_arguments.is_ok(),
-        "Unable to generate args for advance_epoch transaction!"
-    );
+        assert_invariant!(
+            call_arg_arguments.is_ok(),
+            "Unable to generate args for advance_epoch transaction!"
+        );
 
-    arguments.append(&mut call_arg_arguments.unwrap());
+        arguments.append(&mut call_arg_arguments.unwrap());
 
-    info!("Call arguments to advance_epoch transaction: {:?}", params);
+        info!("Call arguments to advance_epoch transaction: {:?}", params);
 
-    builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
-        SUI_SYSTEM_MODULE_NAME.to_owned(),
-        ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned(),
-        vec![],
-        arguments,
-    );
+        let storage_rebates = builder.programmable_move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            ADVANCE_EPOCH_FUNCTION_NAME.to_owned(),
+            vec![],
+            arguments,
+        );
 
-    Ok(builder.finish())
-}
+        // Step 3: Destroy the storage rebates.
+        builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            BALANCE_MODULE_NAME.to_owned(),
+            BALANCE_DESTROY_REBATES_FUNCTION_NAME.to_owned(),
+            vec![GAS::type_tag()],
+            vec![storage_rebates],
+        );
+        Ok(builder.finish())
+    }
 
-fn advance_epoch(
-    change_epoch: ChangeEpoch,
-    temporary_store: &mut TemporaryStore<'_>,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    let params = AdvanceEpochParams {
-        epoch: change_epoch.epoch,
-        next_protocol_version: change_epoch.protocol_version,
-        storage_charge: change_epoch.storage_charge,
-        computation_charge: change_epoch.computation_charge,
-        storage_rebate: change_epoch.storage_rebate,
-        non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
-        storage_fund_reinvest_rate: protocol_config.storage_fund_reinvest_rate(),
-        reward_slashing_rate: protocol_config.reward_slashing_rate(),
-        epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
-    };
-    let advance_epoch_pt = construct_advance_epoch_pt(&params)?;
-    let result = programmable_transactions::execution::execute::<execution_mode::System>(
-        protocol_config,
-        metrics.clone(),
-        move_vm,
-        temporary_store,
-        tx_ctx,
-        gas_charger,
-        advance_epoch_pt,
-    );
+    pub fn construct_advance_epoch_safe_mode_pt(
+        params: &AdvanceEpochParams,
+        protocol_config: &ProtocolConfig,
+    ) -> Result<ProgrammableTransaction, ExecutionError> {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Step 1: Create storage and computation rewards.
+        let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
 
-    #[cfg(msim)]
-    let result = maybe_modify_result(result, change_epoch.epoch);
+        // Step 2: Advance the epoch.
+        let mut arguments = vec![storage_rewards, computation_rewards];
 
-    if result.is_err() {
-        tracing::error!(
+        let mut args = vec![
+            CallArg::SUI_SYSTEM_MUT,
+            CallArg::Pure(bcs::to_bytes(&params.epoch).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.next_protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.storage_rebate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&params.non_refundable_storage_fee).unwrap()),
+        ];
+
+        if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
+            args.push(CallArg::Pure(
+                bcs::to_bytes(&params.epoch_start_timestamp_ms).unwrap(),
+            ));
+        }
+
+        let call_arg_arguments = args
+            .into_iter()
+            .map(|a| builder.input(a))
+            .collect::<Result<_, _>>();
+
+        assert_invariant!(
+            call_arg_arguments.is_ok(),
+            "Unable to generate args for advance_epoch transaction!"
+        );
+
+        arguments.append(&mut call_arg_arguments.unwrap());
+
+        info!("Call arguments to advance_epoch transaction: {:?}", params);
+
+        builder.programmable_move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned(),
+            vec![],
+            arguments,
+        );
+
+        Ok(builder.finish())
+    }
+
+    fn advance_epoch(
+        change_epoch: ChangeEpoch,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        let params = AdvanceEpochParams {
+            epoch: change_epoch.epoch,
+            next_protocol_version: change_epoch.protocol_version,
+            storage_charge: change_epoch.storage_charge,
+            computation_charge: change_epoch.computation_charge,
+            storage_rebate: change_epoch.storage_rebate,
+            non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
+            storage_fund_reinvest_rate: protocol_config.storage_fund_reinvest_rate(),
+            reward_slashing_rate: protocol_config.reward_slashing_rate(),
+            epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
+        };
+        let advance_epoch_pt = construct_advance_epoch_pt(&params)?;
+        let result = programmable_transactions::execution::execute::<execution_mode::System>(
+            protocol_config,
+            metrics.clone(),
+            move_vm,
+            temporary_store,
+            tx_ctx,
+            gas_charger,
+            advance_epoch_pt,
+        );
+
+        #[cfg(msim)]
+        let result = maybe_modify_result(result, change_epoch.epoch);
+
+        if result.is_err() {
+            tracing::error!(
             "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx data: {:?}",
             result.as_ref().err(),
             temporary_store.objects(),
             change_epoch,
         );
-        temporary_store.drop_writes();
-        // Must reset the storage rebate since we are re-executing.
-        gas_charger.reset_storage_cost_and_rebate();
+            temporary_store.drop_writes();
+            // Must reset the storage rebate since we are re-executing.
+            gas_charger.reset_storage_cost_and_rebate();
 
-        if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
-            temporary_store.advance_epoch_safe_mode(&params, protocol_config);
-        } else {
-            let advance_epoch_safe_mode_pt =
-                construct_advance_epoch_safe_mode_pt(&params, protocol_config)?;
-            programmable_transactions::execution::execute::<execution_mode::System>(
-                protocol_config,
-                metrics.clone(),
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                advance_epoch_safe_mode_pt,
-            )
-            .expect("Advance epoch with safe mode must succeed");
-        }
-    }
-
-    for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
-        let max_format_version = protocol_config.move_binary_format_version();
-        let deserialized_modules: Vec<_> = modules
-            .iter()
-            .map(|m| {
-                CompiledModule::deserialize_with_config(
-                    m,
-                    max_format_version,
-                    protocol_config.no_extraneous_module_bytes(),
+            if protocol_config.get_advance_epoch_start_time_in_safe_mode() {
+                temporary_store.advance_epoch_safe_mode(&params, protocol_config);
+            } else {
+                let advance_epoch_safe_mode_pt =
+                    construct_advance_epoch_safe_mode_pt(&params, protocol_config)?;
+                programmable_transactions::execution::execute::<execution_mode::System>(
+                    protocol_config,
+                    metrics.clone(),
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    advance_epoch_safe_mode_pt,
                 )
-                .unwrap()
-            })
-            .collect();
-
-        if version == OBJECT_START_VERSION {
-            let package_id = deserialized_modules.first().unwrap().address();
-            info!("adding new system package {package_id}");
-
-            let publish_pt = {
-                let mut b = ProgrammableTransactionBuilder::new();
-                b.command(Command::Publish(modules, dependencies));
-                b.finish()
-            };
-
-            programmable_transactions::execution::execute::<execution_mode::System>(
-                protocol_config,
-                metrics.clone(),
-                move_vm,
-                temporary_store,
-                tx_ctx,
-                gas_charger,
-                publish_pt,
-            )
-            .expect("System Package Publish must succeed");
-        } else {
-            let mut new_package = Object::new_system_package(
-                &deserialized_modules,
-                version,
-                dependencies,
-                tx_ctx.digest(),
-            );
-
-            info!(
-                "upgraded system package {:?}",
-                new_package.compute_object_reference()
-            );
-
-            // Decrement the version before writing the package so that the store can record the
-            // version growing by one in the effects.
-            new_package
-                .data
-                .try_as_package_mut()
-                .unwrap()
-                .decrement_version();
-
-            // upgrade of a previously existing framework module
-            temporary_store.write_object(new_package, WriteKind::Mutate);
+                .expect("Advance epoch with safe mode must succeed");
+            }
         }
+
+        for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
+            let max_format_version = protocol_config.move_binary_format_version();
+            let deserialized_modules: Vec<_> = modules
+                .iter()
+                .map(|m| {
+                    CompiledModule::deserialize_with_config(
+                        m,
+                        max_format_version,
+                        protocol_config.no_extraneous_module_bytes(),
+                    )
+                    .unwrap()
+                })
+                .collect();
+
+            if version == OBJECT_START_VERSION {
+                let package_id = deserialized_modules.first().unwrap().address();
+                info!("adding new system package {package_id}");
+
+                let publish_pt = {
+                    let mut b = ProgrammableTransactionBuilder::new();
+                    b.command(Command::Publish(modules, dependencies));
+                    b.finish()
+                };
+
+                programmable_transactions::execution::execute::<execution_mode::System>(
+                    protocol_config,
+                    metrics.clone(),
+                    move_vm,
+                    temporary_store,
+                    tx_ctx,
+                    gas_charger,
+                    publish_pt,
+                )
+                .expect("System Package Publish must succeed");
+            } else {
+                let mut new_package = Object::new_system_package(
+                    &deserialized_modules,
+                    version,
+                    dependencies,
+                    tx_ctx.digest(),
+                );
+
+                info!(
+                    "upgraded system package {:?}",
+                    new_package.compute_object_reference()
+                );
+
+                // Decrement the version before writing the package so that the store can record the
+                // version growing by one in the effects.
+                new_package
+                    .data
+                    .try_as_package_mut()
+                    .unwrap()
+                    .decrement_version();
+
+                // upgrade of a previously existing framework module
+                temporary_store.write_object(new_package, WriteKind::Mutate);
+            }
+        }
+
+        Ok(())
     }
 
-    Ok(())
-}
-
-/// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:
-///
-/// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
-///   consensus.
-fn setup_consensus_commit(
-    prologue: ConsensusCommitPrologue,
-    temporary_store: &mut TemporaryStore<'_>,
-    tx_ctx: &mut TxContext,
-    move_vm: &Arc<MoveVM>,
-    gas_charger: &mut GasCharger,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Result<(), ExecutionError> {
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let res = builder.move_call(
-            SUI_FRAMEWORK_ADDRESS.into(),
-            CLOCK_MODULE_NAME.to_owned(),
-            CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME.to_owned(),
-            vec![],
-            vec![
-                CallArg::CLOCK_MUT,
-                CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
-            ],
-        );
-        assert_invariant!(
-            res.is_ok(),
-            "Unable to generate consensus_commit_prologue transaction!"
-        );
-        builder.finish()
-    };
-    programmable_transactions::execution::execute::<execution_mode::System>(
-        protocol_config,
-        metrics,
-        move_vm,
-        temporary_store,
-        tx_ctx,
-        gas_charger,
-        pt,
-    )
-}
-
+    /// Perform metadata updates in preparation for the transactions in the upcoming checkpoint:
+    ///
+    /// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
+    ///   consensus.
+    fn setup_consensus_commit(
+        prologue: ConsensusCommitPrologue,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: &mut TxContext,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Result<(), ExecutionError> {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let res = builder.move_call(
+                SUI_FRAMEWORK_ADDRESS.into(),
+                CLOCK_MODULE_NAME.to_owned(),
+                CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME.to_owned(),
+                vec![],
+                vec![
+                    CallArg::CLOCK_MUT,
+                    CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
+                ],
+            );
+            assert_invariant!(
+                res.is_ok(),
+                "Unable to generate consensus_commit_prologue transaction!"
+            );
+            builder.finish()
+        };
+        programmable_transactions::execution::execute::<execution_mode::System>(
+            protocol_config,
+            metrics,
+            move_vm,
+            temporary_store,
+            tx_ctx,
+            gas_charger,
+            pt,
+        )
+    }
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -1,771 +1,791 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Arc,
-};
+pub use checked::*;
 
-use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
-use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
-use crate::error::convert_vm_error;
-use move_binary_format::{
-    errors::{Location, VMError, VMResult},
-    file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
-    CompiledModule,
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{ModuleId, StructTag, TypeTag},
-};
-#[cfg(debug_assertions)]
-use move_vm_profiler::GasProfiler;
-use move_vm_runtime::{move_vm::MoveVM, session::Session};
-#[cfg(debug_assertions)]
-use move_vm_types::gas::GasMeter;
-use move_vm_types::loaded_data::runtime_types::Type;
-use sui_move_natives::object_runtime::{
-    self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
-};
-use sui_protocol_config::ProtocolConfig;
-use sui_types::gas::GasCharger;
-use sui_types::{
-    balance::Balance,
-    base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
-    coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind},
-    execution::{
-        ExecutionResults, ExecutionState, InputObjectMetadata, InputValue, ObjectValue,
-        RawValueType, ResultValue, UsageKind,
-    },
-    metrics::LimitsMetrics,
-    move_package::MovePackage,
-    object::{Data, MoveObject, Object, Owner},
-    storage::{
-        BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
-        ObjectChange, WriteKind,
-    },
-    transaction::{Argument, CallArg, ObjectArg},
-    type_resolver::TypeTagResolver,
-};
-use sui_types::{
-    error::command_argument_error,
-    execution::{CommandKind, ObjectContents, TryFromValue, Value},
-    execution_mode::ExecutionMode,
-    execution_status::CommandArgumentError,
-};
+#[sui_macros::with_checked_arithmetic]
+mod checked {
 
-sui_macros::checked_arithmetic! {
+    use std::{
+        collections::{BTreeMap, BTreeSet, HashMap},
+        sync::Arc,
+    };
 
-/// Maintains all runtime state specific to programmable transactions
-pub struct ExecutionContext<'vm, 'state, 'a> {
-    /// The protocol config
-    pub protocol_config: &'a ProtocolConfig,
-    /// Metrics for reporting exceeded limits
-    pub metrics: Arc<LimitsMetrics>,
-    /// The MoveVM
-    pub vm: &'vm MoveVM,
-    /// The global state, used for resolving packages
-    pub state_view: &'state dyn ExecutionState,
-    /// A shared transaction context, contains transaction digest information and manages the
-    /// creation of new object IDs
-    pub tx_context: &'a mut TxContext,
-    /// The gas charger used for metering
-    pub gas_charger: &'a mut GasCharger,
-    /// The session used for interacting with Move types and calls
-    pub session: Session<'state, 'vm, LinkageView<'state>>,
-    /// Additional transfers not from the Move runtime
-    additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
-    /// Newly published packages
-    new_packages: Vec<Object>,
-    /// User events are claimed after each Move call
-    user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
-    // runtime data
-    /// The runtime value for the Gas coin, None if it has been taken/moved
-    gas: InputValue,
-    /// The runtime value for the inputs/call args, None if it has been taken/moved
-    inputs: Vec<InputValue>,
-    /// The results of a given command. For most commands, the inner vector will have length 1.
-    /// It will only not be 1 for Move calls with multiple return values.
-    /// Inner values are None if taken/moved by-value
-    results: Vec<Vec<ResultValue>>,
-    /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
-    /// This gets cleared out when new results are pushed, i.e. the end of a command
-    borrowed: HashMap<Argument, /* mut */ bool>,
-}
+    use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
+    use crate::error::convert_vm_error;
+    use crate::programmable_transactions::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
+    use move_binary_format::{
+        errors::{Location, VMError, VMResult},
+        file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
+        CompiledModule,
+    };
+    use move_core_types::{
+        account_address::AccountAddress,
+        language_storage::{ModuleId, StructTag, TypeTag},
+    };
+    #[cfg(debug_assertions)]
+    use move_vm_profiler::GasProfiler;
+    use move_vm_runtime::{move_vm::MoveVM, session::Session};
+    #[cfg(debug_assertions)]
+    use move_vm_types::gas::GasMeter;
+    use move_vm_types::loaded_data::runtime_types::Type;
+    use sui_move_natives::object_runtime::{
+        self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
+    };
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::gas::GasCharger;
+    use sui_types::{
+        balance::Balance,
+        base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
+        coin::Coin,
+        error::{ExecutionError, ExecutionErrorKind},
+        execution::{
+            ExecutionResults, ExecutionState, InputObjectMetadata, InputValue, ObjectValue,
+            RawValueType, ResultValue, UsageKind,
+        },
+        metrics::LimitsMetrics,
+        move_package::MovePackage,
+        object::{Data, MoveObject, Object, Owner},
+        storage::{
+            BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
+            ObjectChange, WriteKind,
+        },
+        transaction::{Argument, CallArg, ObjectArg},
+        type_resolver::TypeTagResolver,
+    };
+    use sui_types::{
+        error::command_argument_error,
+        execution::{CommandKind, ObjectContents, TryFromValue, Value},
+        execution_mode::ExecutionMode,
+        execution_status::CommandArgumentError,
+    };
 
-/// A write for an object that was generated outside of the Move ObjectRuntime
-struct AdditionalWrite {
-    /// The new owner of the object
-    recipient: Owner,
-    /// the type of the object,
-    type_: Type,
-    /// if the object has public transfer or not, i.e. if it has store
-    has_public_transfer: bool,
-    /// contents of the object
-    bytes: Vec<u8>,
-}
+    /// Maintains all runtime state specific to programmable transactions
+    pub struct ExecutionContext<'vm, 'state, 'a> {
+        /// The protocol config
+        pub protocol_config: &'a ProtocolConfig,
+        /// Metrics for reporting exceeded limits
+        pub metrics: Arc<LimitsMetrics>,
+        /// The MoveVM
+        pub vm: &'vm MoveVM,
+        /// The global state, used for resolving packages
+        pub state_view: &'state dyn ExecutionState,
+        /// A shared transaction context, contains transaction digest information and manages the
+        /// creation of new object IDs
+        pub tx_context: &'a mut TxContext,
+        /// The gas charger used for metering
+        pub gas_charger: &'a mut GasCharger,
+        /// The session used for interacting with Move types and calls
+        pub session: Session<'state, 'vm, LinkageView<'state>>,
+        /// Additional transfers not from the Move runtime
+        additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
+        /// Newly published packages
+        new_packages: Vec<Object>,
+        /// User events are claimed after each Move call
+        user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
+        // runtime data
+        /// The runtime value for the Gas coin, None if it has been taken/moved
+        gas: InputValue,
+        /// The runtime value for the inputs/call args, None if it has been taken/moved
+        inputs: Vec<InputValue>,
+        /// The results of a given command. For most commands, the inner vector will have length 1.
+        /// It will only not be 1 for Move calls with multiple return values.
+        /// Inner values are None if taken/moved by-value
+        results: Vec<Vec<ResultValue>>,
+        /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
+        /// This gets cleared out when new results are pushed, i.e. the end of a command
+        borrowed: HashMap<Argument, /* mut */ bool>,
+    }
 
-impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
-    pub fn new(
-        protocol_config: &'a ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        tx_context: &'a mut TxContext,
-        gas_charger: &'a mut GasCharger,
-        inputs: Vec<CallArg>,
-    ) -> Result<Self, ExecutionError> {
-        let init_linkage = if protocol_config.package_upgrades_supported() {
-            LinkageInfo::Unset
-        } else {
-            LinkageInfo::Universal
-        };
+    /// A write for an object that was generated outside of the Move ObjectRuntime
+    struct AdditionalWrite {
+        /// The new owner of the object
+        recipient: Owner,
+        /// the type of the object,
+        type_: Type,
+        /// if the object has public transfer or not, i.e. if it has store
+        has_public_transfer: bool,
+        /// contents of the object
+        bytes: Vec<u8>,
+    }
 
-        // we need a new session just for loading types, which is sad
-        // TODO remove this
-        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
-        let mut tmp_session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            BTreeMap::new(),
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics.clone(),
-        );
-        let mut input_object_map = BTreeMap::new();
-        let inputs = inputs
-            .into_iter()
-            .map(|call_arg| {
-                load_call_arg(
+    impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
+        pub fn new(
+            protocol_config: &'a ProtocolConfig,
+            metrics: Arc<LimitsMetrics>,
+            vm: &'vm MoveVM,
+            state_view: &'state dyn ExecutionState,
+            tx_context: &'a mut TxContext,
+            gas_charger: &'a mut GasCharger,
+            inputs: Vec<CallArg>,
+        ) -> Result<Self, ExecutionError> {
+            let init_linkage = if protocol_config.package_upgrades_supported() {
+                LinkageInfo::Unset
+            } else {
+                LinkageInfo::Universal
+            };
+
+            // we need a new session just for loading types, which is sad
+            // TODO remove this
+            let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
+            let mut tmp_session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                BTreeMap::new(),
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics.clone(),
+            );
+            let mut input_object_map = BTreeMap::new();
+            let inputs = inputs
+                .into_iter()
+                .map(|call_arg| {
+                    load_call_arg(
+                        vm,
+                        state_view,
+                        &mut tmp_session,
+                        &mut input_object_map,
+                        call_arg,
+                    )
+                })
+                .collect::<Result<_, ExecutionError>>()?;
+            let gas = if let Some(gas_coin) = gas_charger.gas_coin() {
+                let mut gas = load_object(
                     vm,
                     state_view,
                     &mut tmp_session,
                     &mut input_object_map,
-                    call_arg,
-                )
-            })
-            .collect::<Result<_, ExecutionError>>()?;
-        let gas = if let Some(gas_coin) = gas_charger.gas_coin() {
-            let mut gas = load_object(
-                vm,
-                state_view,
-                &mut tmp_session,
-                &mut input_object_map,
-                /* imm override */ false,
-                gas_coin,
-            )?;
-            // subtract the max gas budget. This amount is off limits in the programmable transaction,
-            // so to mimic this "off limits" behavior, we act as if the coin has less balance than
-            // it really does
-            let Some(Value::Object(ObjectValue {
+                    /* imm override */ false,
+                    gas_coin,
+                )?;
+                // subtract the max gas budget. This amount is off limits in the programmable transaction,
+                // so to mimic this "off limits" behavior, we act as if the coin has less balance than
+                // it really does
+                let Some(Value::Object(ObjectValue {
                 contents: ObjectContents::Coin(coin),
                 ..
             })) = &mut gas.inner.value else {
                 invariant_violation!("Gas object should be a populated coin")
             };
-            let max_gas_in_balance = gas_charger.gas_budget();
-            let Some(new_balance) = coin.balance.value().checked_sub(max_gas_in_balance) else {
+                let max_gas_in_balance = gas_charger.gas_budget();
+                let Some(new_balance) = coin.balance.value().checked_sub(max_gas_in_balance) else {
                 invariant_violation!(
                     "Transaction input checker should check that there is enough gas"
                 );
             };
-            coin.balance = Balance::new(new_balance);
-            gas
-        } else {
-            InputValue {
-                object_metadata: None,
-                inner: ResultValue {
-                    last_usage_kind: None,
-                    value: None,
-                },
+                coin.balance = Balance::new(new_balance);
+                gas
+            } else {
+                InputValue {
+                    object_metadata: None,
+                    inner: ResultValue {
+                        last_usage_kind: None,
+                        value: None,
+                    },
+                }
+            };
+            // the session was just used for ability and layout metadata fetching, no changes should
+            // exist. Plus, Sui Move does not use these changes or events
+            let (res, linkage) = tmp_session.finish();
+            let (change_set, move_events) =
+                res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
+            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+            assert_invariant!(move_events.is_empty(), "Events must be empty");
+            // make the real session
+            let session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                input_object_map,
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics.clone(),
+            );
+
+            // Set the profiler if in debug mode
+            #[cfg(debug_assertions)]
+            {
+                let tx_digest = tx_context.digest();
+                let remaining_gas: u64 =
+                    move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())
+                        .into();
+                gas_charger
+                    .move_gas_status_mut()
+                    .set_profiler(GasProfiler::init(
+                        &vm.config().profiler_config,
+                        format!("{}", tx_digest),
+                        remaining_gas,
+                    ));
             }
-        };
-        // the session was just used for ability and layout metadata fetching, no changes should
-        // exist. Plus, Sui Move does not use these changes or events
-        let (res, linkage) = tmp_session.finish();
-        let (change_set, move_events) =
-            res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
-        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-        assert_invariant!(move_events.is_empty(), "Events must be empty");
-        // make the real session
-        let session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            input_object_map,
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics.clone(),
-        );
 
-
-        // Set the profiler if in debug mode
-        #[cfg(debug_assertions)]
-        {
-            let tx_digest = tx_context.digest();
-            let remaining_gas: u64 =  move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status()).into();
-            gas_charger.move_gas_status_mut().set_profiler(GasProfiler::init(&vm.config().profiler_config, format!("{}", tx_digest), remaining_gas));
+            Ok(Self {
+                protocol_config,
+                metrics,
+                vm,
+                state_view,
+                tx_context,
+                gas_charger,
+                session,
+                gas,
+                inputs,
+                results: vec![],
+                additional_transfers: vec![],
+                new_packages: vec![],
+                user_events: vec![],
+                borrowed: HashMap::new(),
+            })
         }
 
-        Ok(Self {
-            protocol_config,
-            metrics,
-            vm,
-            state_view,
-            tx_context,
-            gas_charger,
-            session,
-            gas,
-            inputs,
-            results: vec![],
-            additional_transfers: vec![],
-            new_packages: vec![],
-            user_events: vec![],
-            borrowed: HashMap::new(),
-        })
-    }
-
-    /// Create a new ID and update the state
-    pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
-        let object_id = self.tx_context.fresh_id();
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        object_runtime
-            .new_id(object_id)
-            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
-        Ok(object_id)
-    }
-
-    /// Delete an ID and update the state
-    pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        object_runtime
-            .delete_id(object_id)
-            .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
-    }
-
-    /// Set the link context for the session from the linkage information in the MovePackage found
-    /// at `package_id`.  Returns the runtime ID of the link context package on success.
-    pub fn set_link_context(
-        &mut self,
-        package_id: ObjectID,
-    ) -> Result<AccountAddress, ExecutionError> {
-        let resolver = self.session.get_resolver();
-        if resolver.has_linkage(package_id) {
-            // Setting same context again, can skip.
-            return Ok(resolver.original_package_id().unwrap_or(*package_id));
+        /// Create a new ID and update the state
+        pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
+            let object_id = self.tx_context.fresh_id();
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            object_runtime
+                .new_id(object_id)
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
+            Ok(object_id)
         }
 
-        let package =
-            package_for_linkage(&self.session, package_id).map_err(|e| self.convert_vm_error(e))?;
-
-        set_linkage(&mut self.session, &package)
-    }
-
-    /// Set the link context for the session from the linkage information in the `package`.  Returns
-    /// the runtime ID of the link context package on success.
-    pub fn set_linkage(&mut self, package: &MovePackage) -> Result<AccountAddress, ExecutionError> {
-        set_linkage(&mut self.session, package)
-    }
-
-    /// Turn off linkage information, so that the next use of the session will need to set linkage
-    /// information to succeed.
-    pub fn reset_linkage(&mut self) {
-        reset_linkage(&mut self.session);
-    }
-
-    /// Reset the linkage context, and save it (if one exists)
-    pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
-        steal_linkage(&mut self.session)
-    }
-
-    /// Restore a previously stolen/saved link context.
-    pub fn restore_linkage(&mut self, saved: Option<SavedLinkage>) -> Result<(), ExecutionError> {
-        restore_linkage(&mut self.session, saved)
-    }
-
-    /// Load a type using the context's current session.
-    pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
-        load_type(&mut self.session, type_tag)
-    }
-
-    /// Takes the user events from the runtime and tags them with the Move module of the function
-    /// that was invoked for the command
-    pub fn take_user_events(
-        &mut self,
-        module_id: &ModuleId,
-        function: FunctionDefinitionIndex,
-        last_offset: CodeOffset,
-    ) -> Result<(), ExecutionError> {
-        let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
-        let events = object_runtime.take_user_events();
-        let num_events = self.user_events.len() + events.len();
-        let max_events = self.protocol_config.max_num_event_emit();
-        if num_events as u64 > max_events {
-            let err = max_event_error(max_events)
-                .at_code_offset(function, last_offset)
-                .finish(Location::Module(module_id.clone()));
-            return Err(self.convert_vm_error(err));
+        /// Delete an ID and update the state
+        pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            object_runtime
+                .delete_id(object_id)
+                .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
         }
-        let new_events = events
-            .into_iter()
-            .map(|(ty, tag, value)| {
-                let layout = self
-                    .session
-                    .type_to_type_layout(&ty)
-                    .map_err(|e| self.convert_vm_error(e))?;
-                let Some(bytes) = value.simple_serialize(&layout) else {
+
+        /// Set the link context for the session from the linkage information in the MovePackage found
+        /// at `package_id`.  Returns the runtime ID of the link context package on success.
+        pub fn set_link_context(
+            &mut self,
+            package_id: ObjectID,
+        ) -> Result<AccountAddress, ExecutionError> {
+            let resolver = self.session.get_resolver();
+            if resolver.has_linkage(package_id) {
+                // Setting same context again, can skip.
+                return Ok(resolver.original_package_id().unwrap_or(*package_id));
+            }
+
+            let package = package_for_linkage(&self.session, package_id)
+                .map_err(|e| self.convert_vm_error(e))?;
+
+            set_linkage(&mut self.session, &package)
+        }
+
+        /// Set the link context for the session from the linkage information in the `package`.  Returns
+        /// the runtime ID of the link context package on success.
+        pub fn set_linkage(
+            &mut self,
+            package: &MovePackage,
+        ) -> Result<AccountAddress, ExecutionError> {
+            set_linkage(&mut self.session, package)
+        }
+
+        /// Turn off linkage information, so that the next use of the session will need to set linkage
+        /// information to succeed.
+        pub fn reset_linkage(&mut self) {
+            reset_linkage(&mut self.session);
+        }
+
+        /// Reset the linkage context, and save it (if one exists)
+        pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
+            steal_linkage(&mut self.session)
+        }
+
+        /// Restore a previously stolen/saved link context.
+        pub fn restore_linkage(
+            &mut self,
+            saved: Option<SavedLinkage>,
+        ) -> Result<(), ExecutionError> {
+            restore_linkage(&mut self.session, saved)
+        }
+
+        /// Load a type using the context's current session.
+        pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
+            load_type(&mut self.session, type_tag)
+        }
+
+        /// Takes the user events from the runtime and tags them with the Move module of the function
+        /// that was invoked for the command
+        pub fn take_user_events(
+            &mut self,
+            module_id: &ModuleId,
+            function: FunctionDefinitionIndex,
+            last_offset: CodeOffset,
+        ) -> Result<(), ExecutionError> {
+            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let events = object_runtime.take_user_events();
+            let num_events = self.user_events.len() + events.len();
+            let max_events = self.protocol_config.max_num_event_emit();
+            if num_events as u64 > max_events {
+                let err = max_event_error(max_events)
+                    .at_code_offset(function, last_offset)
+                    .finish(Location::Module(module_id.clone()));
+                return Err(self.convert_vm_error(err));
+            }
+            let new_events = events
+                .into_iter()
+                .map(|(ty, tag, value)| {
+                    let layout = self
+                        .session
+                        .type_to_type_layout(&ty)
+                        .map_err(|e| self.convert_vm_error(e))?;
+                    let Some(bytes) = value.simple_serialize(&layout) else {
                     invariant_violation!("Failed to deserialize already serialized Move value");
                 };
-                Ok((module_id.clone(), tag, bytes))
-            })
-            .collect::<Result<Vec<_>, ExecutionError>>()?;
-        self.user_events.extend(new_events);
-        Ok(())
-    }
+                    Ok((module_id.clone(), tag, bytes))
+                })
+                .collect::<Result<Vec<_>, ExecutionError>>()?;
+            self.user_events.extend(new_events);
+            Ok(())
+        }
 
-    /// Get the argument value. Cloning the value if it is copyable, and setting its value to None
-    /// if it is not (making it unavailable).
-    /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
-    /// or if it is an object that cannot be taken by value (shared or immutable)
-    pub fn by_value_arg<V: TryFromValue>(
-        &mut self,
-        command_kind: CommandKind<'_>,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.by_value_arg_(command_kind, arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn by_value_arg_<V: TryFromValue>(
-        &mut self,
-        command_kind: CommandKind<'_>,
-        arg: Argument,
-    ) -> Result<V, CommandArgumentError> {
-        let is_borrowed = self.arg_is_borrowed(&arg);
-        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::ByValue)?;
-        let is_copyable = if let Some(val) = val_opt {
-            val.is_copyable()
-        } else {
-            return Err(CommandArgumentError::InvalidValueUsage);
-        };
-        // If it was taken, we catch this above.
-        // If it was not copyable and was borrowed, error as it creates a dangling reference in
-        // effect.
-        // We allow copyable values to be copied out even if borrowed, as we do not care about
-        // referential transparency at this level.
-        if !is_copyable && is_borrowed {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Get the argument value. Cloning the value if it is copyable, and setting its value to None
+        /// if it is not (making it unavailable).
+        /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
+        /// or if it is an object that cannot be taken by value (shared or immutable)
+        pub fn by_value_arg<V: TryFromValue>(
+            &mut self,
+            command_kind: CommandKind<'_>,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.by_value_arg_(command_kind, arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        // Gas coin cannot be taken by value, except in TransferObjects
-        if matches!(arg, Argument::GasCoin) && !matches!(command_kind, CommandKind::TransferObjects)
-        {
-            return Err(CommandArgumentError::InvalidGasCoinUsage);
+        fn by_value_arg_<V: TryFromValue>(
+            &mut self,
+            command_kind: CommandKind<'_>,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            let is_borrowed = self.arg_is_borrowed(&arg);
+            let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::ByValue)?;
+            let is_copyable = if let Some(val) = val_opt {
+                val.is_copyable()
+            } else {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            };
+            // If it was taken, we catch this above.
+            // If it was not copyable and was borrowed, error as it creates a dangling reference in
+            // effect.
+            // We allow copyable values to be copied out even if borrowed, as we do not care about
+            // referential transparency at this level.
+            if !is_copyable && is_borrowed {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            // Gas coin cannot be taken by value, except in TransferObjects
+            if matches!(arg, Argument::GasCoin)
+                && !matches!(command_kind, CommandKind::TransferObjects)
+            {
+                return Err(CommandArgumentError::InvalidGasCoinUsage);
+            }
+            // Immutable objects and shared objects cannot be taken by value
+            if matches!(
+                input_metadata_opt,
+                Some(InputObjectMetadata {
+                    owner: Owner::Immutable | Owner::Shared { .. },
+                    ..
+                })
+            ) {
+                return Err(CommandArgumentError::InvalidObjectByValue);
+            }
+            let val = if is_copyable {
+                val_opt.as_ref().unwrap().clone()
+            } else {
+                val_opt.take().unwrap()
+            };
+            V::try_from_value(val)
         }
-        // Immutable objects and shared objects cannot be taken by value
-        if matches!(
-            input_metadata_opt,
-            Some(InputObjectMetadata {
-                owner: Owner::Immutable | Owner::Shared { .. },
-                ..
-            })
-        ) {
-            return Err(CommandArgumentError::InvalidObjectByValue);
-        }
-        let val = if is_copyable {
-            val_opt.as_ref().unwrap().clone()
-        } else {
-            val_opt.take().unwrap()
-        };
-        V::try_from_value(val)
-    }
 
-    /// Mimic a mutable borrow by taking the argument value, setting its value to None,
-    /// making it unavailable. The value will be marked as borrowed and must be returned with
-    /// restore_arg
-    /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
-    /// or if it is an object that cannot be mutably borrowed (immutable)
-    pub fn borrow_arg_mut<V: TryFromValue>(
-        &mut self,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.borrow_arg_mut_(arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn borrow_arg_mut_<V: TryFromValue>(
-        &mut self,
-        arg: Argument,
-    ) -> Result<V, CommandArgumentError> {
-        // mutable borrowing requires unique usage
-        if self.arg_is_borrowed(&arg) {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Mimic a mutable borrow by taking the argument value, setting its value to None,
+        /// making it unavailable. The value will be marked as borrowed and must be returned with
+        /// restore_arg
+        /// Errors if out of bounds, if the argument is borrowed, if it is unavailable (already taken),
+        /// or if it is an object that cannot be mutably borrowed (immutable)
+        pub fn borrow_arg_mut<V: TryFromValue>(
+            &mut self,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.borrow_arg_mut_(arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        self.borrowed.insert(arg, /* is_mut */ true);
-        let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
-        let is_copyable = if let Some(val) = val_opt {
-            val.is_copyable()
-        } else {
-            // error if taken
-            return Err(CommandArgumentError::InvalidValueUsage);
-        };
-        if input_metadata_opt.is_some() && !input_metadata_opt.unwrap().is_mutable_input {
-            return Err(CommandArgumentError::InvalidObjectByMutRef);
+        fn borrow_arg_mut_<V: TryFromValue>(
+            &mut self,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            // mutable borrowing requires unique usage
+            if self.arg_is_borrowed(&arg) {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            self.borrowed.insert(arg, /* is_mut */ true);
+            let (input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowMut)?;
+            let is_copyable = if let Some(val) = val_opt {
+                val.is_copyable()
+            } else {
+                // error if taken
+                return Err(CommandArgumentError::InvalidValueUsage);
+            };
+            if input_metadata_opt.is_some() && !input_metadata_opt.unwrap().is_mutable_input {
+                return Err(CommandArgumentError::InvalidObjectByMutRef);
+            }
+            // if it is copyable, don't take it as we allow for the value to be copied even if
+            // mutably borrowed
+            let val = if is_copyable {
+                val_opt.as_ref().unwrap().clone()
+            } else {
+                val_opt.take().unwrap()
+            };
+            V::try_from_value(val)
         }
-        // if it is copyable, don't take it as we allow for the value to be copied even if
-        // mutably borrowed
-        let val = if is_copyable {
-            val_opt.as_ref().unwrap().clone()
-        } else {
-            val_opt.take().unwrap()
-        };
-        V::try_from_value(val)
-    }
 
-    /// Mimics an immutable borrow by cloning the argument value without setting its value to None
-    /// Errors if out of bounds, if the argument is mutably borrowed,
-    /// or if it is unavailable (already taken)
-    pub fn borrow_arg<V: TryFromValue>(
-        &mut self,
-        arg_idx: usize,
-        arg: Argument,
-    ) -> Result<V, ExecutionError> {
-        self.borrow_arg_(arg)
-            .map_err(|e| command_argument_error(e, arg_idx))
-    }
-    fn borrow_arg_<V: TryFromValue>(&mut self, arg: Argument) -> Result<V, CommandArgumentError> {
-        // immutable borrowing requires the value was not mutably borrowed.
-        // If it was copied, that is okay.
-        // If it was taken/moved, we will find out below
-        if self.arg_is_mut_borrowed(&arg) {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        /// Mimics an immutable borrow by cloning the argument value without setting its value to None
+        /// Errors if out of bounds, if the argument is mutably borrowed,
+        /// or if it is unavailable (already taken)
+        pub fn borrow_arg<V: TryFromValue>(
+            &mut self,
+            arg_idx: usize,
+            arg: Argument,
+        ) -> Result<V, ExecutionError> {
+            self.borrow_arg_(arg)
+                .map_err(|e| command_argument_error(e, arg_idx))
         }
-        self.borrowed.insert(arg, /* is_mut */ false);
-        let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowImm)?;
-        if val_opt.is_none() {
-            return Err(CommandArgumentError::InvalidValueUsage);
+        fn borrow_arg_<V: TryFromValue>(
+            &mut self,
+            arg: Argument,
+        ) -> Result<V, CommandArgumentError> {
+            // immutable borrowing requires the value was not mutably borrowed.
+            // If it was copied, that is okay.
+            // If it was taken/moved, we will find out below
+            if self.arg_is_mut_borrowed(&arg) {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            self.borrowed.insert(arg, /* is_mut */ false);
+            let (_input_metadata_opt, val_opt) = self.borrow_mut(arg, UsageKind::BorrowImm)?;
+            if val_opt.is_none() {
+                return Err(CommandArgumentError::InvalidValueUsage);
+            }
+            V::try_from_value(val_opt.as_ref().unwrap().clone())
         }
-        V::try_from_value(val_opt.as_ref().unwrap().clone())
-    }
 
-    /// Restore an argument after being mutably borrowed
-    pub fn restore_arg<Mode: ExecutionMode>(
-        &mut self,
-        updates: &mut Mode::ArgumentUpdates,
-        arg: Argument,
-        value: Value,
-    ) -> Result<(), ExecutionError> {
-        Mode::add_argument_update(self, updates, arg, &value)?;
-        let was_mut_opt = self.borrowed.remove(&arg);
-        assert_invariant!(
-            was_mut_opt.is_some() && was_mut_opt.unwrap(),
-            "Should never restore a non-mut borrowed value. \
+        /// Restore an argument after being mutably borrowed
+        pub fn restore_arg<Mode: ExecutionMode>(
+            &mut self,
+            updates: &mut Mode::ArgumentUpdates,
+            arg: Argument,
+            value: Value,
+        ) -> Result<(), ExecutionError> {
+            Mode::add_argument_update(self, updates, arg, &value)?;
+            let was_mut_opt = self.borrowed.remove(&arg);
+            assert_invariant!(
+                was_mut_opt.is_some() && was_mut_opt.unwrap(),
+                "Should never restore a non-mut borrowed value. \
             The take+restore is an implementation detail of mutable references"
-        );
-        // restore is exclusively used for mut
-        let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
+            );
+            // restore is exclusively used for mut
+            let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
             invariant_violation!("Should be able to borrow argument to restore it")
         };
-        let old_value = value_opt.replace(value);
-        assert_invariant!(
-            old_value.is_none() || old_value.unwrap().is_copyable(),
-            "Should never restore a non-taken value, unless it is copyable. \
+            let old_value = value_opt.replace(value);
+            assert_invariant!(
+                old_value.is_none() || old_value.unwrap().is_copyable(),
+                "Should never restore a non-taken value, unless it is copyable. \
             The take+restore is an implementation detail of mutable references"
-        );
-        Ok(())
-    }
+            );
+            Ok(())
+        }
 
-    /// Transfer the object to a new owner
-    pub fn transfer_object(
-        &mut self,
-        obj: ObjectValue,
-        addr: SuiAddress,
-    ) -> Result<(), ExecutionError> {
-        self.additional_transfers.push((addr, obj));
-        Ok(())
-    }
+        /// Transfer the object to a new owner
+        pub fn transfer_object(
+            &mut self,
+            obj: ObjectValue,
+            addr: SuiAddress,
+        ) -> Result<(), ExecutionError> {
+            self.additional_transfers.push((addr, obj));
+            Ok(())
+        }
 
-    /// Create a new package
-    pub fn new_package<'p>(
-        &self,
-        modules: &[CompiledModule],
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<Object, ExecutionError> {
-        Object::new_package(
-            modules,
-            self.tx_context.digest(),
-            self.protocol_config.max_move_package_size(),
-            dependencies,
-        )
-    }
+        /// Create a new package
+        pub fn new_package<'p>(
+            &self,
+            modules: &[CompiledModule],
+            dependencies: impl IntoIterator<Item = &'p MovePackage>,
+        ) -> Result<Object, ExecutionError> {
+            Object::new_package(
+                modules,
+                self.tx_context.digest(),
+                self.protocol_config.max_move_package_size(),
+                dependencies,
+            )
+        }
 
-    /// Create a package upgrade from `previous_package` with `new_modules` and `dependencies`
-    pub fn upgrade_package<'p>(
-        &self,
-        storage_id: ObjectID,
-        previous_package: &MovePackage,
-        new_modules: &[CompiledModule],
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<Object, ExecutionError> {
-        Object::new_upgraded_package(
-            previous_package,
-            storage_id,
-            new_modules,
-            self.tx_context.digest(),
-            self.protocol_config,
-            dependencies,
-        )
-    }
+        /// Create a package upgrade from `previous_package` with `new_modules` and `dependencies`
+        pub fn upgrade_package<'p>(
+            &self,
+            storage_id: ObjectID,
+            previous_package: &MovePackage,
+            new_modules: &[CompiledModule],
+            dependencies: impl IntoIterator<Item = &'p MovePackage>,
+        ) -> Result<Object, ExecutionError> {
+            Object::new_upgraded_package(
+                previous_package,
+                storage_id,
+                new_modules,
+                self.tx_context.digest(),
+                self.protocol_config,
+                dependencies,
+            )
+        }
 
-    /// Add a newly created package to write as an effect of the transaction
-    pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
-        assert_invariant!(package.is_package(), "Must be a package");
-        self.new_packages.push(package);
-        Ok(())
-    }
+        /// Add a newly created package to write as an effect of the transaction
+        pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
+            assert_invariant!(package.is_package(), "Must be a package");
+            self.new_packages.push(package);
+            Ok(())
+        }
 
-    /// Finish a command: clearing the borrows and adding the results to the result vector
-    pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
-        assert_invariant!(
-            self.borrowed.values().all(|is_mut| !is_mut),
-            "all mut borrows should be restored"
-        );
-        // clear borrow state
-        self.borrowed = HashMap::new();
-        self.results
-            .push(results.into_iter().map(ResultValue::new).collect());
-        Ok(())
-    }
+        /// Finish a command: clearing the borrows and adding the results to the result vector
+        pub fn push_command_results(&mut self, results: Vec<Value>) -> Result<(), ExecutionError> {
+            assert_invariant!(
+                self.borrowed.values().all(|is_mut| !is_mut),
+                "all mut borrows should be restored"
+            );
+            // clear borrow state
+            self.borrowed = HashMap::new();
+            self.results
+                .push(results.into_iter().map(ResultValue::new).collect());
+            Ok(())
+        }
 
-    /// Determine the object changes and collect all user events
-    pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
-        let Self {
-            protocol_config,
-            metrics,
-            vm,
-            state_view,
-            tx_context,
-            gas_charger,
-            session,
-            additional_transfers,
-            new_packages,
-            gas,
-            inputs,
-            results,
-            user_events,
-            ..
-        } = self;
-        let tx_digest = tx_context.digest();
-        let mut additional_writes = BTreeMap::new();
-        let mut input_object_metadata = BTreeMap::new();
-        // Any object value that has not been taken (still has `Some` for it's value) needs to
-        // written as it's value might have changed (and eventually it's sequence number will need
-        // to increase)
-        let mut by_value_inputs = BTreeSet::new();
-        let mut add_input_object_write = |input| -> Result<(), ExecutionError> {
-            let InputValue {
-                object_metadata: object_metadata_opt,
-                inner: ResultValue { value, .. },
-            } = input;
-            let Some(object_metadata) = object_metadata_opt else { return Ok(()) };
-            let is_mutable_input = object_metadata.is_mutable_input;
-            let owner = object_metadata.owner;
-            let id = object_metadata.id;
-            input_object_metadata.insert(object_metadata.id, object_metadata);
-            let Some(Value::Object(object_value)) = value else {
+        /// Determine the object changes and collect all user events
+        pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
+            let Self {
+                protocol_config,
+                metrics,
+                vm,
+                state_view,
+                tx_context,
+                gas_charger,
+                session,
+                additional_transfers,
+                new_packages,
+                gas,
+                inputs,
+                results,
+                user_events,
+                ..
+            } = self;
+            let tx_digest = tx_context.digest();
+            let mut additional_writes = BTreeMap::new();
+            let mut input_object_metadata = BTreeMap::new();
+            // Any object value that has not been taken (still has `Some` for it's value) needs to
+            // written as it's value might have changed (and eventually it's sequence number will need
+            // to increase)
+            let mut by_value_inputs = BTreeSet::new();
+            let mut add_input_object_write = |input| -> Result<(), ExecutionError> {
+                let InputValue {
+                    object_metadata: object_metadata_opt,
+                    inner: ResultValue { value, .. },
+                } = input;
+                let Some(object_metadata) = object_metadata_opt else { return Ok(()) };
+                let is_mutable_input = object_metadata.is_mutable_input;
+                let owner = object_metadata.owner;
+                let id = object_metadata.id;
+                input_object_metadata.insert(object_metadata.id, object_metadata);
+                let Some(Value::Object(object_value)) = value else {
                 by_value_inputs.insert(id);
                 return Ok(())
             };
-            if is_mutable_input {
-                add_additional_write(&mut additional_writes, owner, object_value)?;
+                if is_mutable_input {
+                    add_additional_write(&mut additional_writes, owner, object_value)?;
+                }
+                Ok(())
+            };
+            let gas_id_opt = gas.object_metadata.as_ref().map(|info| info.id);
+            add_input_object_write(gas)?;
+            for input in inputs {
+                add_input_object_write(input)?
             }
-            Ok(())
-        };
-        let gas_id_opt = gas.object_metadata.as_ref().map(|info| info.id);
-        add_input_object_write(gas)?;
-        for input in inputs {
-            add_input_object_write(input)?
-        }
-        // check for unused values
-        // disable this check for dev inspect
-        if !Mode::allow_arbitrary_values() {
-            for (i, command_result) in results.iter().enumerate() {
-                for (j, result_value) in command_result.iter().enumerate() {
-                    let ResultValue {
-                        last_usage_kind,
-                        value,
-                    } = result_value;
-                    match value {
-                        None => (),
-                        Some(Value::Object(_)) => {
-                            return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
-                                result_idx: i as u16,
-                                secondary_idx: j as u16,
+            // check for unused values
+            // disable this check for dev inspect
+            if !Mode::allow_arbitrary_values() {
+                for (i, command_result) in results.iter().enumerate() {
+                    for (j, result_value) in command_result.iter().enumerate() {
+                        let ResultValue {
+                            last_usage_kind,
+                            value,
+                        } = result_value;
+                        match value {
+                            None => (),
+                            Some(Value::Object(_)) => {
+                                return Err(ExecutionErrorKind::UnusedValueWithoutDrop {
+                                    result_idx: i as u16,
+                                    secondary_idx: j as u16,
+                                }
+                                .into())
                             }
-                            .into())
-                        }
-                        Some(Value::Raw(RawValueType::Any, _)) => (),
-                        Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
-                            // - nothing to check for drop
-                            // - if it does not have drop, but has copy,
-                            //   the last usage must be by value in order to "lie" and say that the
-                            //   last usage is actually a take instead of a clone
-                            // - Otherwise, an error
-                            if abilities.has_drop()
-                                || (abilities.has_copy()
-                                    && matches!(last_usage_kind, Some(UsageKind::ByValue)))
-                            {
-                            } else {
-                                let msg = if abilities.has_copy() {
-                                    "The value has copy, but not drop. \
-                                    Its last usage must be by-value so it can be taken."
+                            Some(Value::Raw(RawValueType::Any, _)) => (),
+                            Some(Value::Raw(RawValueType::Loaded { abilities, .. }, _)) => {
+                                // - nothing to check for drop
+                                // - if it does not have drop, but has copy,
+                                //   the last usage must be by value in order to "lie" and say that the
+                                //   last usage is actually a take instead of a clone
+                                // - Otherwise, an error
+                                if abilities.has_drop()
+                                    || (abilities.has_copy()
+                                        && matches!(last_usage_kind, Some(UsageKind::ByValue)))
+                                {
                                 } else {
-                                    "Unused value without drop"
-                                };
-                                return Err(ExecutionError::new_with_source(
-                                    ExecutionErrorKind::UnusedValueWithoutDrop {
-                                        result_idx: i as u16,
-                                        secondary_idx: j as u16,
-                                    },
-                                    msg,
-                                ));
+                                    let msg = if abilities.has_copy() {
+                                        "The value has copy, but not drop. \
+                                    Its last usage must be by-value so it can be taken."
+                                    } else {
+                                        "Unused value without drop"
+                                    };
+                                    return Err(ExecutionError::new_with_source(
+                                        ExecutionErrorKind::UnusedValueWithoutDrop {
+                                            result_idx: i as u16,
+                                            secondary_idx: j as u16,
+                                        },
+                                        msg,
+                                    ));
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-        // add transfers from TransferObjects command
-        for (recipient, object_value) in additional_transfers {
-            let owner = Owner::AddressOwner(recipient);
-            add_additional_write(&mut additional_writes, owner, object_value)?;
-        }
-        // Refund unused gas
-        if let Some(gas_id) = gas_id_opt {
-            refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
-        }
+            // add transfers from TransferObjects command
+            for (recipient, object_value) in additional_transfers {
+                let owner = Owner::AddressOwner(recipient);
+                add_additional_write(&mut additional_writes, owner, object_value)?;
+            }
+            // Refund unused gas
+            if let Some(gas_id) = gas_id_opt {
+                refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
+            }
 
-        let (res, linkage) = session.finish_with_extensions();
-        let (change_set, events, mut native_context_extensions) =
-            res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-        // Sui Move programs should never touch global state, so resources should be empty
-        assert_invariant!(
-            change_set.resources().next().is_none(),
-            "Change set must be empty"
-        );
-        // Sui Move no longer uses Move's internal event system
-        assert_invariant!(events.is_empty(), "Events must be empty");
-        let object_runtime: ObjectRuntime = native_context_extensions.remove();
-        let new_ids = object_runtime.new_ids().clone();
-        // tell the object runtime what input objects were taken and which were transferred
-        let external_transfers = additional_writes.keys().copied().collect();
-        let RuntimeResults {
-            writes,
-            deletions,
-            user_events: remaining_events,
-            loaded_child_objects,
-        } = object_runtime.finish(by_value_inputs, external_transfers)?;
-        assert_invariant!(
-            remaining_events.is_empty(),
-            "Events should be taken after every Move call"
-        );
-        let mut object_changes = BTreeMap::new();
-        for package in new_packages {
-            let id = package.id();
-            let change = ObjectChange::Write(package, WriteKind::Create);
-            object_changes.insert(id, change);
-        }
-        // we need a new session just for deserializing and fetching abilities. Which is sad
-        // TODO remove this
-        let tmp_session = new_session(
-            vm,
-            linkage,
-            state_view.as_child_resolver(),
-            BTreeMap::new(),
-            !gas_charger.is_unmetered(),
-            protocol_config,
-            metrics,
-        );
-        for (id, additional_write) in additional_writes {
-            let AdditionalWrite {
-                recipient,
-                type_,
-                has_public_transfer,
-                bytes,
-            } = additional_write;
-            let write_kind = if input_object_metadata.contains_key(&id)
-                || loaded_child_objects.contains_key(&id)
-            {
-                assert_invariant!(
-                    !new_ids.contains_key(&id),
-                    "new id should not be in mutations"
-                );
-                WriteKind::Mutate
-            } else if new_ids.contains_key(&id) {
-                WriteKind::Create
-            } else {
-                WriteKind::Unwrap
-            };
-            // safe given the invariant that the runtime correctly propagates has_public_transfer
-            let move_object = unsafe {
-                create_written_object(
-                    vm,
-                    &tmp_session,
-                    protocol_config,
-                    &input_object_metadata,
-                    &loaded_child_objects,
-                    id,
+            let (res, linkage) = session.finish_with_extensions();
+            let (change_set, events, mut native_context_extensions) =
+                res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
+            // Sui Move programs should never touch global state, so resources should be empty
+            assert_invariant!(
+                change_set.resources().next().is_none(),
+                "Change set must be empty"
+            );
+            // Sui Move no longer uses Move's internal event system
+            assert_invariant!(events.is_empty(), "Events must be empty");
+            let object_runtime: ObjectRuntime = native_context_extensions.remove();
+            let new_ids = object_runtime.new_ids().clone();
+            // tell the object runtime what input objects were taken and which were transferred
+            let external_transfers = additional_writes.keys().copied().collect();
+            let RuntimeResults {
+                writes,
+                deletions,
+                user_events: remaining_events,
+                loaded_child_objects,
+            } = object_runtime.finish(by_value_inputs, external_transfers)?;
+            assert_invariant!(
+                remaining_events.is_empty(),
+                "Events should be taken after every Move call"
+            );
+            let mut object_changes = BTreeMap::new();
+            for package in new_packages {
+                let id = package.id();
+                let change = ObjectChange::Write(package, WriteKind::Create);
+                object_changes.insert(id, change);
+            }
+            // we need a new session just for deserializing and fetching abilities. Which is sad
+            // TODO remove this
+            let tmp_session = new_session(
+                vm,
+                linkage,
+                state_view.as_child_resolver(),
+                BTreeMap::new(),
+                !gas_charger.is_unmetered(),
+                protocol_config,
+                metrics,
+            );
+            for (id, additional_write) in additional_writes {
+                let AdditionalWrite {
+                    recipient,
                     type_,
                     has_public_transfer,
                     bytes,
-                    write_kind,
-                )?
-            };
-            let object = Object::new_move(move_object, recipient, tx_digest);
-            let change = ObjectChange::Write(object, write_kind);
-            object_changes.insert(id, change);
-        }
+                } = additional_write;
+                let write_kind = if input_object_metadata.contains_key(&id)
+                    || loaded_child_objects.contains_key(&id)
+                {
+                    assert_invariant!(
+                        !new_ids.contains_key(&id),
+                        "new id should not be in mutations"
+                    );
+                    WriteKind::Mutate
+                } else if new_ids.contains_key(&id) {
+                    WriteKind::Create
+                } else {
+                    WriteKind::Unwrap
+                };
+                // safe given the invariant that the runtime correctly propagates has_public_transfer
+                let move_object = unsafe {
+                    create_written_object(
+                        vm,
+                        &tmp_session,
+                        protocol_config,
+                        &input_object_metadata,
+                        &loaded_child_objects,
+                        id,
+                        type_,
+                        has_public_transfer,
+                        bytes,
+                        write_kind,
+                    )?
+                };
+                let object = Object::new_move(move_object, recipient, tx_digest);
+                let change = ObjectChange::Write(object, write_kind);
+                object_changes.insert(id, change);
+            }
 
-        for (id, (write_kind, recipient, ty, value)) in writes {
-            let abilities = tmp_session
-                .get_type_abilities(&ty)
-                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
-            let has_public_transfer = abilities.has_store();
-            let layout = tmp_session
-                .type_to_type_layout(&ty)
-                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
-            let Some(bytes) = value.simple_serialize(&layout) else {
+            for (id, (write_kind, recipient, ty, value)) in writes {
+                let abilities = tmp_session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                let has_public_transfer = abilities.has_store();
+                let layout = tmp_session
+                    .type_to_type_layout(&ty)
+                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                let Some(bytes) = value.simple_serialize(&layout) else {
                 invariant_violation!("Failed to deserialize already serialized Move value");
             };
-            // safe because has_public_transfer has been determined by the abilities
-            let move_object = unsafe {
-                create_written_object(
-                    vm,
-                    &tmp_session,
-                    protocol_config,
-                    &input_object_metadata,
-                    &loaded_child_objects,
-                    id,
-                    ty,
-                    has_public_transfer,
-                    bytes,
-                    write_kind,
-                )?
-            };
-            let object = Object::new_move(move_object, recipient, tx_digest);
-            let change = ObjectChange::Write(object, write_kind);
-            object_changes.insert(id, change);
-        }
-        for (id, delete_kind) in deletions {
-            // For deleted and wrapped objects, the object must exist either in the input or was
-            // loaded as child object. We can read them to get the previous version.
-            // For unwrap_then_delete, in older protocol versions, we must consult the object store
-            // to see if there exists a tombstone, and if so we include it otherwise we skip it.
-            // In newer protocol versions, we can just skip it.
-            let delete_kind_with_seq = match delete_kind {
-                DeleteKind::Normal | DeleteKind::Wrap => {
-                    let old_version = match input_object_metadata.get(&id) {
+                // safe because has_public_transfer has been determined by the abilities
+                let move_object = unsafe {
+                    create_written_object(
+                        vm,
+                        &tmp_session,
+                        protocol_config,
+                        &input_object_metadata,
+                        &loaded_child_objects,
+                        id,
+                        ty,
+                        has_public_transfer,
+                        bytes,
+                        write_kind,
+                    )?
+                };
+                let object = Object::new_move(move_object, recipient, tx_digest);
+                let change = ObjectChange::Write(object, write_kind);
+                object_changes.insert(id, change);
+            }
+            for (id, delete_kind) in deletions {
+                // For deleted and wrapped objects, the object must exist either in the input or was
+                // loaded as child object. We can read them to get the previous version.
+                // For unwrap_then_delete, in older protocol versions, we must consult the object store
+                // to see if there exists a tombstone, and if so we include it otherwise we skip it.
+                // In newer protocol versions, we can just skip it.
+                let delete_kind_with_seq = match delete_kind {
+                    DeleteKind::Normal | DeleteKind::Wrap => {
+                        let old_version = match input_object_metadata.get(&id) {
                         Some(metadata) => {
                             assert_invariant!(
                                 !matches!(metadata.owner, Owner::Immutable),
@@ -780,488 +800,491 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
                             }
                         }
                     };
-                    if delete_kind == DeleteKind::Normal {
-                        DeleteKindWithOldVersion::Normal(old_version)
-                    } else {
-                        DeleteKindWithOldVersion::Wrap(old_version)
+                        if delete_kind == DeleteKind::Normal {
+                            DeleteKindWithOldVersion::Normal(old_version)
+                        } else {
+                            DeleteKindWithOldVersion::Wrap(old_version)
+                        }
                     }
-                }
-                DeleteKind::UnwrapThenDelete => {
-                    if protocol_config.simplified_unwrap_then_delete() {
-                        DeleteKindWithOldVersion::UnwrapThenDelete
-                    } else {
-                        let old_version = match state_view.get_latest_parent_entry_ref(id) {
-                            Ok(Some((_, previous_version, _))) => previous_version,
-                            // This object was not created this transaction but has never existed in
-                            // storage, skip it.
-                            Ok(None) => continue,
-                            Err(_) => invariant_violation!("{}", missing_unwrapped_msg(&id)),
-                        };
-                        DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(old_version)
+                    DeleteKind::UnwrapThenDelete => {
+                        if protocol_config.simplified_unwrap_then_delete() {
+                            DeleteKindWithOldVersion::UnwrapThenDelete
+                        } else {
+                            let old_version = match state_view.get_latest_parent_entry_ref(id) {
+                                Ok(Some((_, previous_version, _))) => previous_version,
+                                // This object was not created this transaction but has never existed in
+                                // storage, skip it.
+                                Ok(None) => continue,
+                                Err(_) => invariant_violation!("{}", missing_unwrapped_msg(&id)),
+                            };
+                            DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(old_version)
+                        }
                     }
-                }
-            };
-            object_changes.insert(id, ObjectChange::Delete(delete_kind_with_seq));
+                };
+                object_changes.insert(id, ObjectChange::Delete(delete_kind_with_seq));
+            }
+
+            let (res, linkage) = tmp_session.finish();
+            let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
+
+            // the session was just used for ability and layout metadata fetching, no changes should
+            // exist. Plus, Sui Move does not use these changes or events
+            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
+            assert_invariant!(move_events.is_empty(), "Events must be empty");
+
+            Ok(ExecutionResults {
+                object_changes,
+                user_events,
+            })
         }
 
-        let (res, linkage) = tmp_session.finish();
-        let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-
-        // the session was just used for ability and layout metadata fetching, no changes should
-        // exist. Plus, Sui Move does not use these changes or events
-        assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-        assert_invariant!(move_events.is_empty(), "Events must be empty");
-
-        Ok(ExecutionResults {
-            object_changes,
-            user_events,
-        })
-    }
-
-    /// Convert a VM Error to an execution one
-    pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-        crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
-    }
-
-    /// Special case errors for type arguments to Move functions
-    pub fn convert_type_argument_error(&self, idx: usize, error: VMError) -> ExecutionError {
-        use move_core_types::vm_status::StatusCode;
-        use sui_types::execution_status::TypeArgumentError;
-        match error.major_status() {
-            StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
-                ExecutionErrorKind::TypeArityMismatch.into()
-            }
-            StatusCode::TYPE_RESOLUTION_FAILURE => ExecutionErrorKind::TypeArgumentError {
-                argument_idx: idx as TypeParameterIndex,
-                kind: TypeArgumentError::TypeNotFound,
-            }
-            .into(),
-            StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
-                argument_idx: idx as TypeParameterIndex,
-                kind: TypeArgumentError::ConstraintNotSatisfied,
-            }
-            .into(),
-            _ => self.convert_vm_error(error),
+        /// Convert a VM Error to an execution one
+        pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
+            crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
         }
-    }
 
-    /// Returns true if the value at the argument's location is borrowed, mutably or immutably
-    fn arg_is_borrowed(&self, arg: &Argument) -> bool {
-        self.borrowed.contains_key(arg)
-    }
-
-    /// Returns true if the value at the argument's location is mutably borrowed
-    fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
-        matches!(self.borrowed.get(arg), Some(/* mut */ true))
-    }
-
-    /// Internal helper to borrow the value for an argument and update the most recent usage
-    fn borrow_mut(
-        &mut self,
-        arg: Argument,
-        usage: UsageKind,
-    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError> {
-        self.borrow_mut_impl(arg, Some(usage))
-    }
-
-    /// Internal helper to borrow the value for an argument
-    /// Updates the most recent usage if specified
-    fn borrow_mut_impl(
-        &mut self,
-        arg: Argument,
-        update_last_usage: Option<UsageKind>,
-    ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError> {
-        let (metadata, result_value) = match arg {
-            Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
-            Argument::Input(i) => {
-                let Some(input_value) = self.inputs.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
-                (input_value.object_metadata.as_ref(), &mut input_value.inner)
-            }
-            Argument::Result(i) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
-                if command_result.len() != 1 {
-                    return Err(CommandArgumentError::InvalidResultArity { result_idx: i });
+        /// Special case errors for type arguments to Move functions
+        pub fn convert_type_argument_error(&self, idx: usize, error: VMError) -> ExecutionError {
+            use move_core_types::vm_status::StatusCode;
+            use sui_types::execution_status::TypeArgumentError;
+            match error.major_status() {
+                StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
+                    ExecutionErrorKind::TypeArityMismatch.into()
                 }
-                (None, &mut command_result[0])
+                StatusCode::TYPE_RESOLUTION_FAILURE => ExecutionErrorKind::TypeArgumentError {
+                    argument_idx: idx as TypeParameterIndex,
+                    kind: TypeArgumentError::TypeNotFound,
+                }
+                .into(),
+                StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
+                    argument_idx: idx as TypeParameterIndex,
+                    kind: TypeArgumentError::ConstraintNotSatisfied,
+                }
+                .into(),
+                _ => self.convert_vm_error(error),
             }
-            Argument::NestedResult(i, j) => {
-                let Some(command_result) = self.results.get_mut(i as usize) else {
+        }
+
+        /// Returns true if the value at the argument's location is borrowed, mutably or immutably
+        fn arg_is_borrowed(&self, arg: &Argument) -> bool {
+            self.borrowed.contains_key(arg)
+        }
+
+        /// Returns true if the value at the argument's location is mutably borrowed
+        fn arg_is_mut_borrowed(&self, arg: &Argument) -> bool {
+            matches!(self.borrowed.get(arg), Some(/* mut */ true))
+        }
+
+        /// Internal helper to borrow the value for an argument and update the most recent usage
+        fn borrow_mut(
+            &mut self,
+            arg: Argument,
+            usage: UsageKind,
+        ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError>
+        {
+            self.borrow_mut_impl(arg, Some(usage))
+        }
+
+        /// Internal helper to borrow the value for an argument
+        /// Updates the most recent usage if specified
+        fn borrow_mut_impl(
+            &mut self,
+            arg: Argument,
+            update_last_usage: Option<UsageKind>,
+        ) -> Result<(Option<&InputObjectMetadata>, &mut Option<Value>), CommandArgumentError>
+        {
+            let (metadata, result_value) = match arg {
+                Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
+                Argument::Input(i) => {
+                    let Some(input_value) = self.inputs.get_mut(i as usize) else {
                     return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
                 };
-                let Some(result_value) = command_result.get_mut(j as usize) else {
+                    (input_value.object_metadata.as_ref(), &mut input_value.inner)
+                }
+                Argument::Result(i) => {
+                    let Some(command_result) = self.results.get_mut(i as usize) else {
+                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                };
+                    if command_result.len() != 1 {
+                        return Err(CommandArgumentError::InvalidResultArity { result_idx: i });
+                    }
+                    (None, &mut command_result[0])
+                }
+                Argument::NestedResult(i, j) => {
+                    let Some(command_result) = self.results.get_mut(i as usize) else {
+                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                };
+                    let Some(result_value) = command_result.get_mut(j as usize) else {
                     return Err(CommandArgumentError::SecondaryIndexOutOfBounds {
                         result_idx: i,
                         secondary_idx: j,
                     });
                 };
-                (None, result_value)
+                    (None, result_value)
+                }
+            };
+            if let Some(usage) = update_last_usage {
+                result_value.last_usage_kind = Some(usage);
             }
-        };
-        if let Some(usage) = update_last_usage {
-            result_value.last_usage_kind = Some(usage);
+            Ok((metadata, &mut result_value.value))
         }
-        Ok((metadata, &mut result_value.value))
-    }
-}
-
-impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
-    fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
-        self.session
-            .get_type_tag(type_)
-            .map_err(|e| self.convert_vm_error(e))
-    }
-}
-
-pub(crate) fn new_session<'state, 'vm>(
-    vm: &'vm MoveVM,
-    linkage: LinkageView<'state>,
-    child_resolver: &'state dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-    is_metered: bool,
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-) -> Session<'state, 'vm, LinkageView<'state>> {
-    vm.new_session_with_extensions(
-        linkage,
-        new_native_extensions(
-            child_resolver,
-            input_objects,
-            is_metered,
-            protocol_config,
-            metrics,
-        ),
-    )
-}
-
-// Create a new Session suitable for resolving type and type operations rather than execution
-pub(crate) fn new_session_for_linkage<'vm, 'state>(
-    vm: &'vm MoveVM,
-    linkage: LinkageView<'state>,
-) -> Session<'state, 'vm, LinkageView<'state>> {
-    vm.new_session(linkage)
-}
-
-/// Set the link context for the session from the linkage information in the `package`.
-pub fn set_linkage(
-    session: &mut Session<LinkageView>,
-    linkage: &MovePackage,
-) -> Result<AccountAddress, ExecutionError> {
-    session.get_resolver_mut().set_linkage(linkage)
-}
-
-/// Turn off linkage information, so that the next use of the session will need to set linkage
-/// information to succeed.
-pub fn reset_linkage(session: &mut Session<LinkageView>) {
-    session.get_resolver_mut().reset_linkage();
-}
-
-pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
-    session.get_resolver_mut().steal_linkage()
-}
-
-pub fn restore_linkage(
-    session: &mut Session<LinkageView>,
-    saved: Option<SavedLinkage>,
-) -> Result<(), ExecutionError> {
-    session.get_resolver_mut().restore_linkage(saved)
-}
-
-/// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
-/// if the object at that ID does not exist, or is not a package.
-fn package_for_linkage(
-    session: &Session<LinkageView>,
-    package_id: ObjectID,
-) -> VMResult<MovePackage> {
-    use move_binary_format::errors::PartialVMError;
-    use move_core_types::vm_status::StatusCode;
-
-    match session.get_resolver().get_package(&package_id) {
-        Ok(Some(package)) => Ok(package),
-        Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-            .with_message(format!("Cannot find link context {package_id} in store"))
-            .finish(Location::Undefined)),
-        Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-            .with_message(format!(
-                "Error loading link context {package_id} from store: {err}"
-            ))
-            .finish(Location::Undefined)),
-    }
-}
-
-/// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
-/// reset after this operation, because during the operation, it may change when loading a struct.
-pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
-    use move_binary_format::errors::PartialVMError;
-    use move_core_types::vm_status::StatusCode;
-
-    fn verification_error<T>(code: StatusCode) -> VMResult<T> {
-        Err(PartialVMError::new(code).finish(Location::Undefined))
     }
 
-    Ok(match type_tag {
-        TypeTag::Bool => Type::Bool,
-        TypeTag::U8 => Type::U8,
-        TypeTag::U16 => Type::U16,
-        TypeTag::U32 => Type::U32,
-        TypeTag::U64 => Type::U64,
-        TypeTag::U128 => Type::U128,
-        TypeTag::U256 => Type::U256,
-        TypeTag::Address => Type::Address,
-        TypeTag::Signer => Type::Signer,
+    impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
+        fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
+            self.session
+                .get_type_tag(type_)
+                .map_err(|e| self.convert_vm_error(e))
+        }
+    }
 
-        TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
-        TypeTag::Struct(struct_tag) => {
-            let StructTag {
-                address,
-                module,
-                name,
-                type_params,
-            } = struct_tag.as_ref();
+    pub(crate) fn new_session<'state, 'vm>(
+        vm: &'vm MoveVM,
+        linkage: LinkageView<'state>,
+        child_resolver: &'state dyn ChildObjectResolver,
+        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
+        is_metered: bool,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+    ) -> Session<'state, 'vm, LinkageView<'state>> {
+        vm.new_session_with_extensions(
+            linkage,
+            new_native_extensions(
+                child_resolver,
+                input_objects,
+                is_metered,
+                protocol_config,
+                metrics,
+            ),
+        )
+    }
 
-            // Load the package that the struct is defined in, in storage
-            let defining_id = ObjectID::from_address(*address);
-            let package = package_for_linkage(session, defining_id)?;
+    // Create a new Session suitable for resolving type and type operations rather than execution
+    pub(crate) fn new_session_for_linkage<'vm, 'state>(
+        vm: &'vm MoveVM,
+        linkage: LinkageView<'state>,
+    ) -> Session<'state, 'vm, LinkageView<'state>> {
+        vm.new_session(linkage)
+    }
 
-            // Set the defining package as the link context on the session while loading the
-            // struct
-            let original_address = set_linkage(session, &package).map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(e.to_string())
-                    .finish(Location::Undefined)
-            })?;
+    /// Set the link context for the session from the linkage information in the `package`.
+    pub fn set_linkage(
+        session: &mut Session<LinkageView>,
+        linkage: &MovePackage,
+    ) -> Result<AccountAddress, ExecutionError> {
+        session.get_resolver_mut().set_linkage(linkage)
+    }
 
-            let runtime_id = ModuleId::new(original_address, module.clone());
-            let res = session.load_struct(&runtime_id, name);
-            reset_linkage(session);
-            let (idx, struct_type) = res?;
+    /// Turn off linkage information, so that the next use of the session will need to set linkage
+    /// information to succeed.
+    pub fn reset_linkage(session: &mut Session<LinkageView>) {
+        session.get_resolver_mut().reset_linkage();
+    }
 
-            // Recursively load type parameters, if necessary
-            let type_param_constraints = struct_type.type_param_constraints();
-            if type_param_constraints.len() != type_params.len() {
-                return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
-            }
+    pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
+        session.get_resolver_mut().steal_linkage()
+    }
 
-            if type_params.is_empty() {
-                Type::Struct(idx)
-            } else {
-                let loaded_type_params = type_params
-                    .iter()
-                    .map(|type_param| load_type(session, type_param))
-                    .collect::<VMResult<Vec<_>>>()?;
+    pub fn restore_linkage(
+        session: &mut Session<LinkageView>,
+        saved: Option<SavedLinkage>,
+    ) -> Result<(), ExecutionError> {
+        session.get_resolver_mut().restore_linkage(saved)
+    }
 
-                // Verify that the type parameter constraints on the struct are met
-                for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
-                    let abilities = session.get_type_abilities(param)?;
-                    if !constraint.is_subset(abilities) {
-                        return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
-                    }
+    /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
+    /// if the object at that ID does not exist, or is not a package.
+    fn package_for_linkage(
+        session: &Session<LinkageView>,
+        package_id: ObjectID,
+    ) -> VMResult<MovePackage> {
+        use move_binary_format::errors::PartialVMError;
+        use move_core_types::vm_status::StatusCode;
+
+        match session.get_resolver().get_package(&package_id) {
+            Ok(Some(package)) => Ok(package),
+            Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Cannot find link context {package_id} in store"))
+                .finish(Location::Undefined)),
+            Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!(
+                    "Error loading link context {package_id} from store: {err}"
+                ))
+                .finish(Location::Undefined)),
+        }
+    }
+
+    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
+    /// reset after this operation, because during the operation, it may change when loading a struct.
+    pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
+        use move_binary_format::errors::PartialVMError;
+        use move_core_types::vm_status::StatusCode;
+
+        fn verification_error<T>(code: StatusCode) -> VMResult<T> {
+            Err(PartialVMError::new(code).finish(Location::Undefined))
+        }
+
+        Ok(match type_tag {
+            TypeTag::Bool => Type::Bool,
+            TypeTag::U8 => Type::U8,
+            TypeTag::U16 => Type::U16,
+            TypeTag::U32 => Type::U32,
+            TypeTag::U64 => Type::U64,
+            TypeTag::U128 => Type::U128,
+            TypeTag::U256 => Type::U256,
+            TypeTag::Address => Type::Address,
+            TypeTag::Signer => Type::Signer,
+
+            TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
+            TypeTag::Struct(struct_tag) => {
+                let StructTag {
+                    address,
+                    module,
+                    name,
+                    type_params,
+                } = struct_tag.as_ref();
+
+                // Load the package that the struct is defined in, in storage
+                let defining_id = ObjectID::from_address(*address);
+                let package = package_for_linkage(session, defining_id)?;
+
+                // Set the defining package as the link context on the session while loading the
+                // struct
+                let original_address = set_linkage(session, &package).map_err(|e| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(e.to_string())
+                        .finish(Location::Undefined)
+                })?;
+
+                let runtime_id = ModuleId::new(original_address, module.clone());
+                let res = session.load_struct(&runtime_id, name);
+                reset_linkage(session);
+                let (idx, struct_type) = res?;
+
+                // Recursively load type parameters, if necessary
+                let type_param_constraints = struct_type.type_param_constraints();
+                if type_param_constraints.len() != type_params.len() {
+                    return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
                 }
 
-                Type::StructInstantiation(idx, loaded_type_params)
-            }
-        }
-    })
-}
+                if type_params.is_empty() {
+                    Type::Struct(idx)
+                } else {
+                    let loaded_type_params = type_params
+                        .iter()
+                        .map(|type_param| load_type(session, type_param))
+                        .collect::<VMResult<Vec<_>>>()?;
 
-pub(crate) fn make_object_value<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    type_: MoveObjectType,
-    has_public_transfer: bool,
-    used_in_non_entry_move_call: bool,
-    contents: &[u8],
-) -> Result<ObjectValue, ExecutionError> {
-    let contents = if type_.is_coin() {
-        let Ok(coin) = Coin::from_bcs_bytes(contents) else {
+                    // Verify that the type parameter constraints on the struct are met
+                    for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
+                        let abilities = session.get_type_abilities(param)?;
+                        if !constraint.is_subset(abilities) {
+                            return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
+                        }
+                    }
+
+                    Type::StructInstantiation(idx, loaded_type_params)
+                }
+            }
+        })
+    }
+
+    pub(crate) fn make_object_value<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        type_: MoveObjectType,
+        has_public_transfer: bool,
+        used_in_non_entry_move_call: bool,
+        contents: &[u8],
+    ) -> Result<ObjectValue, ExecutionError> {
+        let contents = if type_.is_coin() {
+            let Ok(coin) = Coin::from_bcs_bytes(contents) else {
             invariant_violation!("Could not deserialize a coin")
         };
-        ObjectContents::Coin(coin)
-    } else {
-        ObjectContents::Raw(contents.to_vec())
-    };
+            ObjectContents::Coin(coin)
+        } else {
+            ObjectContents::Raw(contents.to_vec())
+        };
 
-    let tag: StructTag = type_.into();
-    let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
-        .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
-    Ok(ObjectValue {
-        type_,
-        has_public_transfer,
-        used_in_non_entry_move_call,
-        contents,
-    })
-}
+        let tag: StructTag = type_.into();
+        let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
+            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        Ok(ObjectValue {
+            type_,
+            has_public_transfer,
+            used_in_non_entry_move_call,
+            contents,
+        })
+    }
 
-pub(crate) fn value_from_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    object: &Object,
-) -> Result<ObjectValue, ExecutionError> {
-    let Object { data: Data::Move(object), .. } = object else {
+    pub(crate) fn value_from_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        object: &Object,
+    ) -> Result<ObjectValue, ExecutionError> {
+        let Object { data: Data::Move(object), .. } = object else {
         invariant_violation!("Expected a Move object");
     };
 
-    let used_in_non_entry_move_call = false;
-    make_object_value(
-        vm,
-        session,
-        object.type_().clone(),
-        object.has_public_transfer(),
-        used_in_non_entry_move_call,
-        object.contents(),
-    )
-}
+        let used_in_non_entry_move_call = false;
+        make_object_value(
+            vm,
+            session,
+            object.type_().clone(),
+            object.has_public_transfer(),
+            used_in_non_entry_move_call,
+            object.contents(),
+        )
+    }
 
-/// Load an input object from the state_view
-fn load_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    override_as_immutable: bool,
-    id: ObjectID,
-) -> Result<InputValue, ExecutionError> {
-    let Some(obj) = state_view.read_object(&id) else {
+    /// Load an input object from the state_view
+    fn load_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        override_as_immutable: bool,
+        id: ObjectID,
+    ) -> Result<InputValue, ExecutionError> {
+        let Some(obj) = state_view.read_object(&id) else {
         // protected by transaction input checker
         invariant_violation!("Object {} does not exist yet", id);
     };
-    // override_as_immutable ==> Owner::Shared
-    assert_invariant!(
-        !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
-        "override_as_immutable should only be set for shared objects"
-    );
-    let is_mutable_input = match obj.owner {
-        Owner::AddressOwner(_) => true,
-        Owner::Shared { .. } => !override_as_immutable,
-        Owner::Immutable => false,
-        Owner::ObjectOwner(_) => {
-            // protected by transaction input checker
-            invariant_violation!("ObjectOwner objects cannot be input")
-        }
-    };
-    let owner = obj.owner;
-    let version = obj.version();
-    let object_metadata = InputObjectMetadata {
-        id,
-        is_mutable_input,
-        owner,
-        version,
-    };
-    let obj_value = value_from_object(vm, session, obj)?;
-    let contained_uids = {
-        let fully_annotated_layout = session
-            .type_to_fully_annotated_layout(&obj_value.type_)
-            .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
-        let mut bytes = vec![];
-        obj_value.write_bcs_bytes(&mut bytes);
-        match get_all_uids(&fully_annotated_layout, &bytes) {
-            Err(e) => invariant_violation!(
-                "Unable to retrieve UIDs for object. Got error: {e}"
-            ),
-            Ok(uids) => uids,
-        }
-    };
-    let runtime_input = object_runtime::InputObject {
-        contained_uids,
-        owner,
-        version,
-    };
-    let prev = input_object_map.insert(id, runtime_input);
-    // protected by transaction input checker
-    assert_invariant!(prev.is_none(), "Duplicate input object {}", id);
-    Ok(InputValue::new_object(object_metadata, obj_value))
-}
-
-/// Load an a CallArg, either an object or a raw set of BCS bytes
-fn load_call_arg<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    call_arg: CallArg,
-) -> Result<InputValue, ExecutionError> {
-    Ok(match call_arg {
-        CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
-        CallArg::Object(obj_arg) => {
-            load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
-        }
-    })
-}
-
-/// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-fn load_object_arg<'vm, 'state>(
-    vm: &'vm MoveVM,
-    state_view: &'state dyn ExecutionState,
-    session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    obj_arg: ObjectArg,
-) -> Result<InputValue, ExecutionError> {
-    match obj_arg {
-        ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
-            vm,
-            state_view,
-            session,
-            input_object_map,
-            /* imm override */ false,
+        // override_as_immutable ==> Owner::Shared
+        assert_invariant!(
+            !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
+            "override_as_immutable should only be set for shared objects"
+        );
+        let is_mutable_input = match obj.owner {
+            Owner::AddressOwner(_) => true,
+            Owner::Shared { .. } => !override_as_immutable,
+            Owner::Immutable => false,
+            Owner::ObjectOwner(_) => {
+                // protected by transaction input checker
+                invariant_violation!("ObjectOwner objects cannot be input")
+            }
+        };
+        let owner = obj.owner;
+        let version = obj.version();
+        let object_metadata = InputObjectMetadata {
             id,
-        ),
-        ObjectArg::SharedObject { id, mutable, .. } => load_object(
-            vm,
-            state_view,
-            session,
-            input_object_map,
-            /* imm override */ !mutable,
-            id,
-        ),
+            is_mutable_input,
+            owner,
+            version,
+        };
+        let obj_value = value_from_object(vm, session, obj)?;
+        let contained_uids = {
+            let fully_annotated_layout =
+                session
+                    .type_to_fully_annotated_layout(&obj_value.type_)
+                    .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+            let mut bytes = vec![];
+            obj_value.write_bcs_bytes(&mut bytes);
+            match get_all_uids(&fully_annotated_layout, &bytes) {
+                Err(e) => {
+                    invariant_violation!("Unable to retrieve UIDs for object. Got error: {e}")
+                }
+                Ok(uids) => uids,
+            }
+        };
+        let runtime_input = object_runtime::InputObject {
+            contained_uids,
+            owner,
+            version,
+        };
+        let prev = input_object_map.insert(id, runtime_input);
+        // protected by transaction input checker
+        assert_invariant!(prev.is_none(), "Duplicate input object {}", id);
+        Ok(InputValue::new_object(object_metadata, obj_value))
     }
-}
 
-/// Generate an additional write for an ObjectValue
-fn add_additional_write(
-    additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
-    owner: Owner,
-    object_value: ObjectValue,
-) -> Result<(), ExecutionError> {
-    let ObjectValue {
-        type_,
-        has_public_transfer,
-        contents,
-        ..
-    } = object_value;
-    let bytes = match contents {
-        ObjectContents::Coin(coin) => coin.to_bcs_bytes(),
-        ObjectContents::Raw(bytes) => bytes,
-    };
-    let object_id = MoveObject::id_opt(&bytes).map_err(|e| {
-        ExecutionError::invariant_violation(format!("No id for Raw object bytes. {e}"))
-    })?;
-    let additional_write = AdditionalWrite {
-        recipient: owner,
-        type_,
-        has_public_transfer,
-        bytes,
-    };
-    additional_writes.insert(object_id, additional_write);
-    Ok(())
-}
+    /// Load an a CallArg, either an object or a raw set of BCS bytes
+    fn load_call_arg<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        call_arg: CallArg,
+    ) -> Result<InputValue, ExecutionError> {
+        Ok(match call_arg {
+            CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
+            CallArg::Object(obj_arg) => {
+                load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
+            }
+        })
+    }
 
-/// The max budget was deducted from the gas coin at the beginning of the transaction,
-/// now we return exactly that amount. Gas will be charged by the execution engine
-fn refund_max_gas_budget(
-    additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
-    gas_charger: &mut GasCharger,
-    gas_id: ObjectID,
-) -> Result<(), ExecutionError> {
-    let Some(AdditionalWrite { bytes,.. }) = additional_writes.get_mut(&gas_id) else {
+    /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
+    fn load_object_arg<'vm, 'state>(
+        vm: &'vm MoveVM,
+        state_view: &'state dyn ExecutionState,
+        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+        input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
+        obj_arg: ObjectArg,
+    ) -> Result<InputValue, ExecutionError> {
+        match obj_arg {
+            ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
+                vm,
+                state_view,
+                session,
+                input_object_map,
+                /* imm override */ false,
+                id,
+            ),
+            ObjectArg::SharedObject { id, mutable, .. } => load_object(
+                vm,
+                state_view,
+                session,
+                input_object_map,
+                /* imm override */ !mutable,
+                id,
+            ),
+        }
+    }
+
+    /// Generate an additional write for an ObjectValue
+    fn add_additional_write(
+        additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
+        owner: Owner,
+        object_value: ObjectValue,
+    ) -> Result<(), ExecutionError> {
+        let ObjectValue {
+            type_,
+            has_public_transfer,
+            contents,
+            ..
+        } = object_value;
+        let bytes = match contents {
+            ObjectContents::Coin(coin) => coin.to_bcs_bytes(),
+            ObjectContents::Raw(bytes) => bytes,
+        };
+        let object_id = MoveObject::id_opt(&bytes).map_err(|e| {
+            ExecutionError::invariant_violation(format!("No id for Raw object bytes. {e}"))
+        })?;
+        let additional_write = AdditionalWrite {
+            recipient: owner,
+            type_,
+            has_public_transfer,
+            bytes,
+        };
+        additional_writes.insert(object_id, additional_write);
+        Ok(())
+    }
+
+    /// The max budget was deducted from the gas coin at the beginning of the transaction,
+    /// now we return exactly that amount. Gas will be charged by the execution engine
+    fn refund_max_gas_budget(
+        additional_writes: &mut BTreeMap<ObjectID, AdditionalWrite>,
+        gas_charger: &mut GasCharger,
+        gas_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        let Some(AdditionalWrite { bytes,.. }) = additional_writes.get_mut(&gas_id) else {
         invariant_violation!("Gas object cannot be wrapped or destroyed")
     };
-    let Ok(mut coin) = Coin::from_bcs_bytes(bytes) else {
+        let Ok(mut coin) = Coin::from_bcs_bytes(bytes) else {
         invariant_violation!("Gas object must be a coin")
     };
-    let Some(new_balance) = coin
+        let Some(new_balance) = coin
         .balance
         .value()
         .checked_add(gas_charger.gas_budget()) else {
@@ -1270,63 +1293,62 @@ fn refund_max_gas_budget(
                 "Gas coin too large after returning the max gas budget",
             ));
         };
-    coin.balance = Balance::new(new_balance);
-    *bytes = coin.to_bcs_bytes();
-    Ok(())
-}
+        coin.balance = Balance::new(new_balance);
+        *bytes = coin.to_bcs_bytes();
+        Ok(())
+    }
 
-/// Generate an MoveObject given an updated/written object
-/// # Safety
-///
-/// This function assumes proper generation of has_public_transfer, either from the abilities of
-/// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<'vm, 'state>(
-    vm: &'vm MoveVM,
-    session: &Session<'state, 'vm, LinkageView<'state>>,
-    protocol_config: &ProtocolConfig,
-    input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
-    loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
-    id: ObjectID,
-    type_: Type,
-    has_public_transfer: bool,
-    contents: Vec<u8>,
-    write_kind: WriteKind,
-) -> Result<MoveObject, ExecutionError> {
-    debug_assert_eq!(
-        id,
-        MoveObject::id_opt(&contents).expect("object contents should start with an id")
-    );
-    let metadata_opt = input_object_metadata.get(&id);
-    let loaded_child_version_opt = loaded_child_objects.get(&id);
-    assert_invariant!(
-        metadata_opt.is_none() || loaded_child_version_opt.is_none(),
-        "Loaded {id} as a child, but that object was an input object",
-    );
+    /// Generate an MoveObject given an updated/written object
+    /// # Safety
+    ///
+    /// This function assumes proper generation of has_public_transfer, either from the abilities of
+    /// the StructTag, or from the runtime correctly propagating from the inputs
+    unsafe fn create_written_object<'vm, 'state>(
+        vm: &'vm MoveVM,
+        session: &Session<'state, 'vm, LinkageView<'state>>,
+        protocol_config: &ProtocolConfig,
+        input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
+        loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
+        id: ObjectID,
+        type_: Type,
+        has_public_transfer: bool,
+        contents: Vec<u8>,
+        write_kind: WriteKind,
+    ) -> Result<MoveObject, ExecutionError> {
+        debug_assert_eq!(
+            id,
+            MoveObject::id_opt(&contents).expect("object contents should start with an id")
+        );
+        let metadata_opt = input_object_metadata.get(&id);
+        let loaded_child_version_opt = loaded_child_objects.get(&id);
+        assert_invariant!(
+            metadata_opt.is_none() || loaded_child_version_opt.is_none(),
+            "Loaded {id} as a child, but that object was an input object",
+        );
 
-    let old_obj_ver = metadata_opt
-        .map(|metadata| metadata.version)
-        .or_else(|| loaded_child_version_opt.copied());
+        let old_obj_ver = metadata_opt
+            .map(|metadata| metadata.version)
+            .or_else(|| loaded_child_version_opt.copied());
 
-    debug_assert!(
-        (write_kind == WriteKind::Mutate) == old_obj_ver.is_some(),
-        "Inconsistent state: write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
-    );
+        debug_assert!(
+            (write_kind == WriteKind::Mutate) == old_obj_ver.is_some(),
+            "Inconsistent state: write_kind: {write_kind:?}, old ver: {old_obj_ver:?}"
+        );
 
-    let type_tag = session
-        .get_type_tag(&type_)
-        .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        let type_tag = session
+            .get_type_tag(&type_)
+            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
 
-    let struct_tag = match type_tag {
-        TypeTag::Struct(inner) => *inner,
-        _ => invariant_violation!("Non struct type for object"),
-    };
-    MoveObject::new_from_execution(
-        struct_tag.into(),
-        has_public_transfer,
-        old_obj_ver.unwrap_or_else(SequenceNumber::new),
-        contents,
-        protocol_config,
-    )
-}
-
+        let struct_tag = match type_tag {
+            TypeTag::Struct(inner) => *inner,
+            _ => invariant_violation!("Non struct type for object"),
+        };
+        MoveObject::new_from_execution(
+            struct_tag.into(),
+            has_public_transfer,
+            old_obj_ver.unwrap_or_else(SequenceNumber::new),
+            contents,
+            protocol_config,
+        )
+    }
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
@@ -1,221 +1,224 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    sync::Arc,
-};
+pub use checked::*;
 
-use move_binary_format::{
-    access::ModuleAccess,
-    compatibility::{Compatibility, InclusionCheck},
-    errors::{Location, PartialVMResult, VMResult},
-    file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
-    normalized, CompiledModule,
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    identifier::IdentStr,
-    language_storage::{ModuleId, StructTag, TypeTag},
-    u256::U256,
-};
-use move_vm_runtime::{
-    move_vm::MoveVM,
-    session::{LoadedFunctionInstantiation, SerializedReturnValues},
-};
-use move_vm_types::loaded_data::runtime_types::{StructType, Type};
-use serde::{de::DeserializeSeed, Deserialize};
-use sui_move_natives::object_runtime::ObjectRuntime;
-use sui_protocol_config::ProtocolConfig;
-use sui_types::{
-    base_types::{
-        MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
-        RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
-    },
-    coin::Coin,
-    error::{command_argument_error, ExecutionError, ExecutionErrorKind},
-    event::Event,
-    execution::{
-        CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue, RawValueType,
-        Value,
-    },
-    gas::GasCharger,
-    id::{RESOLVED_SUI_ID, UID},
-    metrics::LimitsMetrics,
-    move_package::{
-        normalize_deserialized_modules, MovePackage, TypeOrigin, UpgradeCap, UpgradePolicy,
-        UpgradeReceipt, UpgradeTicket,
-    },
-    storage::get_packages,
-    transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
-    Identifier, SUI_FRAMEWORK_ADDRESS,
-};
-use sui_types::{
-    execution_mode::ExecutionMode,
-    execution_status::{CommandArgumentError, PackageUpgradeError},
-};
-use sui_verifier::{
-    private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
-    INIT_FN_NAME,
-};
+#[sui_macros::with_checked_arithmetic]
+mod checked {
 
-use super::context::*;
-use crate::adapter::substitute_package_id;
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fmt,
+        sync::Arc,
+    };
 
-sui_macros::checked_arithmetic! {
+    use move_binary_format::{
+        access::ModuleAccess,
+        compatibility::{Compatibility, InclusionCheck},
+        errors::{Location, PartialVMResult, VMResult},
+        file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
+        normalized, CompiledModule,
+    };
+    use move_core_types::{
+        account_address::AccountAddress,
+        identifier::IdentStr,
+        language_storage::{ModuleId, StructTag, TypeTag},
+        u256::U256,
+    };
+    use move_vm_runtime::{
+        move_vm::MoveVM,
+        session::{LoadedFunctionInstantiation, SerializedReturnValues},
+    };
+    use move_vm_types::loaded_data::runtime_types::{StructType, Type};
+    use serde::{de::DeserializeSeed, Deserialize};
+    use sui_move_natives::object_runtime::ObjectRuntime;
+    use sui_protocol_config::ProtocolConfig;
+    use sui_types::{
+        base_types::{
+            MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
+            RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
+        },
+        coin::Coin,
+        error::{command_argument_error, ExecutionError, ExecutionErrorKind},
+        event::Event,
+        execution::{
+            CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue,
+            RawValueType, Value,
+        },
+        gas::GasCharger,
+        id::{RESOLVED_SUI_ID, UID},
+        metrics::LimitsMetrics,
+        move_package::{
+            normalize_deserialized_modules, MovePackage, TypeOrigin, UpgradeCap, UpgradePolicy,
+            UpgradeReceipt, UpgradeTicket,
+        },
+        storage::get_packages,
+        transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
+        Identifier, SUI_FRAMEWORK_ADDRESS,
+    };
+    use sui_types::{
+        execution_mode::ExecutionMode,
+        execution_status::{CommandArgumentError, PackageUpgradeError},
+    };
+    use sui_verifier::{
+        private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
+        INIT_FN_NAME,
+    };
 
-pub fn execute<Mode: ExecutionMode>(
-    protocol_config: &ProtocolConfig,
-    metrics: Arc<LimitsMetrics>,
-    vm: &MoveVM,
-    state_view: &mut dyn ExecutionState,
-    tx_context: &mut TxContext,
-    gas_charger: &mut GasCharger,
-    pt: ProgrammableTransaction,
-) -> Result<Mode::ExecutionResults, ExecutionError> {
-    let ProgrammableTransaction { inputs, commands } = pt;
-    let mut context = ExecutionContext::new(
-        protocol_config,
-        metrics,
-        vm,
-        state_view,
-        tx_context,
-        gas_charger,
-        inputs,
-    )?;
-    // execute commands
-    let mut mode_results = Mode::empty_results();
-    for (idx, command) in commands.into_iter().enumerate() {
-        if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
-            let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
-            // We still need to record the loaded child objects for replay
-            let loaded_child_objects = object_runtime.loaded_child_objects();
-            drop(context);
-            state_view.save_loaded_child_objects(loaded_child_objects);
-            return Err(err.with_command_index(idx));
-        };
+    use crate::adapter::substitute_package_id;
+    use crate::programmable_transactions::context::*;
+
+    pub fn execute<Mode: ExecutionMode>(
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        vm: &MoveVM,
+        state_view: &mut dyn ExecutionState,
+        tx_context: &mut TxContext,
+        gas_charger: &mut GasCharger,
+        pt: ProgrammableTransaction,
+    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+        let ProgrammableTransaction { inputs, commands } = pt;
+        let mut context = ExecutionContext::new(
+            protocol_config,
+            metrics,
+            vm,
+            state_view,
+            tx_context,
+            gas_charger,
+            inputs,
+        )?;
+        // execute commands
+        let mut mode_results = Mode::empty_results();
+        for (idx, command) in commands.into_iter().enumerate() {
+            if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
+                let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+                // We still need to record the loaded child objects for replay
+                let loaded_child_objects = object_runtime.loaded_child_objects();
+                drop(context);
+                state_view.save_loaded_child_objects(loaded_child_objects);
+                return Err(err.with_command_index(idx));
+            };
+        }
+
+        // Save loaded objects table in case we fail in post execution
+        let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
+        // We still need to record the loaded child objects for replay
+        let loaded_child_objects = object_runtime.loaded_child_objects();
+
+        // apply changes
+        let finished = context.finish::<Mode>();
+        // Save loaded objects for debug. We dont want to lose the info
+        state_view.save_loaded_child_objects(loaded_child_objects);
+
+        let ExecutionResults {
+            object_changes,
+            user_events,
+        } = finished?;
+        state_view.apply_object_changes(object_changes);
+        for (module_id, tag, contents) in user_events {
+            state_view.log_event(Event::new(
+                module_id.address(),
+                module_id.name(),
+                tx_context.sender(),
+                tag,
+                contents,
+            ))
+        }
+        Ok(mode_results)
     }
 
-    // Save loaded objects table in case we fail in post execution
-    let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
-    // We still need to record the loaded child objects for replay
-    let loaded_child_objects = object_runtime.loaded_child_objects();
-
-    // apply changes
-    let finished = context.finish::<Mode>();
-    // Save loaded objects for debug. We dont want to lose the info
-    state_view.save_loaded_child_objects(loaded_child_objects);
-
-    let ExecutionResults {
-        object_changes,
-        user_events,
-    } = finished?;
-    state_view.apply_object_changes(object_changes);
-    for (module_id, tag, contents) in user_events {
-        state_view.log_event(Event::new(
-            module_id.address(),
-            module_id.name(),
-            tx_context.sender(),
-            tag,
-            contents,
-        ))
-    }
-    Ok(mode_results)
-}
-
-/// Execute a single command
-fn execute_command<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    mode_results: &mut Mode::ExecutionResults,
-    command: Command,
-) -> Result<(), ExecutionError> {
-    let mut argument_updates = Mode::empty_arguments();
-    let results = match command {
-        Command::MakeMoveVec(tag_opt, args) if args.is_empty() => {
-            let Some(tag) = tag_opt else {
+    /// Execute a single command
+    fn execute_command<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        mode_results: &mut Mode::ExecutionResults,
+        command: Command,
+    ) -> Result<(), ExecutionError> {
+        let mut argument_updates = Mode::empty_arguments();
+        let results = match command {
+            Command::MakeMoveVec(tag_opt, args) if args.is_empty() => {
+                let Some(tag) = tag_opt else {
                 invariant_violation!(
                     "input checker ensures if args are empty, there is a type specified"
                 );
             };
-            let elem_ty = context
-                .load_type(&tag)
-                .map_err(|e| context.convert_vm_error(e))?;
-            let ty = Type::Vector(Box::new(elem_ty));
-            let abilities = context
-                .session
-                .get_type_abilities(&ty)
-                .map_err(|e| context.convert_vm_error(e))?;
-            // BCS layout for any empty vector should be the same
-            let bytes = bcs::to_bytes::<Vec<u8>>(&vec![]).unwrap();
-            vec![Value::Raw(
-                RawValueType::Loaded {
-                    ty,
-                    abilities,
-                    used_in_non_entry_move_call: false,
-                },
-                bytes,
-            )]
-        }
-        Command::MakeMoveVec(tag_opt, args) => {
-            let mut res = vec![];
-            leb128::write::unsigned(&mut res, args.len() as u64).unwrap();
-            let mut arg_iter = args.into_iter().enumerate();
-            let (mut used_in_non_entry_move_call, elem_ty) = match tag_opt {
-                Some(tag) => {
-                    let elem_ty = context
-                        .load_type(&tag)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    (false, elem_ty)
-                }
-                // If no tag specified, it _must_ be an object
-                None => {
-                    // empty args covered above
-                    let (idx, arg) = arg_iter.next().unwrap();
-                    let obj: ObjectValue =
-                        context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                    obj.write_bcs_bytes(&mut res);
-                    (obj.used_in_non_entry_move_call, obj.type_)
-                }
-            };
-            for (idx, arg) in arg_iter {
-                let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                check_param_type::<Mode>(context, idx, &value, &elem_ty)?;
-                used_in_non_entry_move_call =
-                    used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
-                value.write_bcs_bytes(&mut res);
+                let elem_ty = context
+                    .load_type(&tag)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                let ty = Type::Vector(Box::new(elem_ty));
+                let abilities = context
+                    .session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                // BCS layout for any empty vector should be the same
+                let bytes = bcs::to_bytes::<Vec<u8>>(&vec![]).unwrap();
+                vec![Value::Raw(
+                    RawValueType::Loaded {
+                        ty,
+                        abilities,
+                        used_in_non_entry_move_call: false,
+                    },
+                    bytes,
+                )]
             }
-            let ty = Type::Vector(Box::new(elem_ty));
-            let abilities = context
-                .session
-                .get_type_abilities(&ty)
-                .map_err(|e| context.convert_vm_error(e))?;
-            vec![Value::Raw(
-                RawValueType::Loaded {
-                    ty,
-                    abilities,
-                    used_in_non_entry_move_call,
-                },
-                res,
-            )]
-        }
-        Command::TransferObjects(objs, addr_arg) => {
-            let objs: Vec<ObjectValue> = objs
-                .into_iter()
-                .enumerate()
-                .map(|(idx, arg)| context.by_value_arg(CommandKind::TransferObjects, idx, arg))
-                .collect::<Result<_, _>>()?;
-            let addr: SuiAddress =
-                context.by_value_arg(CommandKind::TransferObjects, objs.len(), addr_arg)?;
-            for obj in objs {
-                obj.ensure_public_transfer_eligible()?;
-                context.transfer_object(obj, addr)?;
+            Command::MakeMoveVec(tag_opt, args) => {
+                let mut res = vec![];
+                leb128::write::unsigned(&mut res, args.len() as u64).unwrap();
+                let mut arg_iter = args.into_iter().enumerate();
+                let (mut used_in_non_entry_move_call, elem_ty) = match tag_opt {
+                    Some(tag) => {
+                        let elem_ty = context
+                            .load_type(&tag)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        (false, elem_ty)
+                    }
+                    // If no tag specified, it _must_ be an object
+                    None => {
+                        // empty args covered above
+                        let (idx, arg) = arg_iter.next().unwrap();
+                        let obj: ObjectValue =
+                            context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
+                        obj.write_bcs_bytes(&mut res);
+                        (obj.used_in_non_entry_move_call, obj.type_)
+                    }
+                };
+                for (idx, arg) in arg_iter {
+                    let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
+                    check_param_type::<Mode>(context, idx, &value, &elem_ty)?;
+                    used_in_non_entry_move_call =
+                        used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
+                    value.write_bcs_bytes(&mut res);
+                }
+                let ty = Type::Vector(Box::new(elem_ty));
+                let abilities = context
+                    .session
+                    .get_type_abilities(&ty)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                vec![Value::Raw(
+                    RawValueType::Loaded {
+                        ty,
+                        abilities,
+                        used_in_non_entry_move_call,
+                    },
+                    res,
+                )]
             }
-            vec![]
-        }
-        Command::SplitCoins(coin_arg, amount_args) => {
-            let mut obj: ObjectValue = context.borrow_arg_mut(0, coin_arg)?;
-            let ObjectContents::Coin(coin) = &mut obj.contents else {
+            Command::TransferObjects(objs, addr_arg) => {
+                let objs: Vec<ObjectValue> = objs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, arg)| context.by_value_arg(CommandKind::TransferObjects, idx, arg))
+                    .collect::<Result<_, _>>()?;
+                let addr: SuiAddress =
+                    context.by_value_arg(CommandKind::TransferObjects, objs.len(), addr_arg)?;
+                for obj in objs {
+                    obj.ensure_public_transfer_eligible()?;
+                    context.transfer_object(obj, addr)?;
+                }
+                vec![]
+            }
+            Command::SplitCoins(coin_arg, amount_args) => {
+                let mut obj: ObjectValue = context.borrow_arg_mut(0, coin_arg)?;
+                let ObjectContents::Coin(coin) = &mut obj.contents else {
                 let e = ExecutionErrorKind::command_argument_error(
                     CommandArgumentError::TypeMismatch,
                     0,
@@ -223,26 +226,26 @@ fn execute_command<Mode: ExecutionMode>(
                 let msg = "Expected a coin but got an non coin object".to_owned();
                 return Err(ExecutionError::new_with_source(e, msg));
             };
-            let split_coins = amount_args
-                .into_iter()
-                .map(|amount_arg| {
-                    let amount: u64 =
-                        context.by_value_arg(CommandKind::SplitCoins, 1, amount_arg)?;
-                    let new_coin_id = context.fresh_id()?;
-                    let new_coin = coin.split(amount, UID::new(new_coin_id))?;
-                    let coin_type = obj.type_.clone();
-                    // safe because we are propagating the coin type, and relying on the internal
-                    // invariant that coin values have a coin type
-                    let new_coin = unsafe { ObjectValue::coin(coin_type, new_coin) };
-                    Ok(Value::Object(new_coin))
-                })
-                .collect::<Result<_, ExecutionError>>()?;
-            context.restore_arg::<Mode>(&mut argument_updates, coin_arg, Value::Object(obj))?;
-            split_coins
-        }
-        Command::MergeCoins(target_arg, coin_args) => {
-            let mut target: ObjectValue = context.borrow_arg_mut(0, target_arg)?;
-            let ObjectContents::Coin(target_coin) = &mut target.contents else {
+                let split_coins = amount_args
+                    .into_iter()
+                    .map(|amount_arg| {
+                        let amount: u64 =
+                            context.by_value_arg(CommandKind::SplitCoins, 1, amount_arg)?;
+                        let new_coin_id = context.fresh_id()?;
+                        let new_coin = coin.split(amount, UID::new(new_coin_id))?;
+                        let coin_type = obj.type_.clone();
+                        // safe because we are propagating the coin type, and relying on the internal
+                        // invariant that coin values have a coin type
+                        let new_coin = unsafe { ObjectValue::coin(coin_type, new_coin) };
+                        Ok(Value::Object(new_coin))
+                    })
+                    .collect::<Result<_, ExecutionError>>()?;
+                context.restore_arg::<Mode>(&mut argument_updates, coin_arg, Value::Object(obj))?;
+                split_coins
+            }
+            Command::MergeCoins(target_arg, coin_args) => {
+                let mut target: ObjectValue = context.borrow_arg_mut(0, target_arg)?;
+                let ObjectContents::Coin(target_coin) = &mut target.contents else {
                 let e = ExecutionErrorKind::command_argument_error(
                     CommandArgumentError::TypeMismatch,
                     0,
@@ -250,438 +253,438 @@ fn execute_command<Mode: ExecutionMode>(
                 let msg = "Expected a coin but got an non coin object".to_owned();
                 return Err(ExecutionError::new_with_source(e, msg));
             };
-            let coins: Vec<ObjectValue> = coin_args
-                .into_iter()
-                .enumerate()
-                .map(|(idx, arg)| context.by_value_arg(CommandKind::MergeCoins, idx + 1, arg))
-                .collect::<Result<_, _>>()?;
-            for (idx, coin) in coins.into_iter().enumerate() {
-                if target.type_ != coin.type_ {
-                    let e = ExecutionErrorKind::command_argument_error(
-                        CommandArgumentError::TypeMismatch,
-                        (idx + 1) as u16,
-                    );
-                    let msg = "Coins do not have the same type".to_owned();
-                    return Err(ExecutionError::new_with_source(e, msg));
-                }
-                let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
+                let coins: Vec<ObjectValue> = coin_args
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, arg)| context.by_value_arg(CommandKind::MergeCoins, idx + 1, arg))
+                    .collect::<Result<_, _>>()?;
+                for (idx, coin) in coins.into_iter().enumerate() {
+                    if target.type_ != coin.type_ {
+                        let e = ExecutionErrorKind::command_argument_error(
+                            CommandArgumentError::TypeMismatch,
+                            (idx + 1) as u16,
+                        );
+                        let msg = "Coins do not have the same type".to_owned();
+                        return Err(ExecutionError::new_with_source(e, msg));
+                    }
+                    let ObjectContents::Coin(Coin { id, balance }) = coin.contents else {
                     invariant_violation!(
                         "Target coin was a coin, and we already checked for the same type. \
                         This should be a coin"
                     );
                 };
-                context.delete_id(*id.object_id())?;
-                target_coin.add(balance)?;
+                    context.delete_id(*id.object_id())?;
+                    target_coin.add(balance)?;
+                }
+                context.restore_arg::<Mode>(
+                    &mut argument_updates,
+                    target_arg,
+                    Value::Object(target),
+                )?;
+                vec![]
             }
-            context.restore_arg::<Mode>(
-                &mut argument_updates,
-                target_arg,
-                Value::Object(target),
-            )?;
-            vec![]
-        }
-        Command::MoveCall(move_call) => {
-            let ProgrammableMoveCall {
-                package,
-                module,
-                function,
-                type_arguments,
-                arguments,
-            } = *move_call;
+            Command::MoveCall(move_call) => {
+                let ProgrammableMoveCall {
+                    package,
+                    module,
+                    function,
+                    type_arguments,
+                    arguments,
+                } = *move_call;
 
-            // Convert type arguments to `Type`s
-            let mut loaded_type_arguments = Vec::with_capacity(type_arguments.len());
-            for (ix, type_arg) in type_arguments.into_iter().enumerate() {
-                let ty = context
-                    .load_type(&type_arg)
-                    .map_err(|e| context.convert_type_argument_error(ix, e))?;
-                loaded_type_arguments.push(ty);
+                // Convert type arguments to `Type`s
+                let mut loaded_type_arguments = Vec::with_capacity(type_arguments.len());
+                for (ix, type_arg) in type_arguments.into_iter().enumerate() {
+                    let ty = context
+                        .load_type(&type_arg)
+                        .map_err(|e| context.convert_type_argument_error(ix, e))?;
+                    loaded_type_arguments.push(ty);
+                }
+
+                let original_address = context.set_link_context(package)?;
+                let runtime_id = ModuleId::new(original_address, module);
+                let return_values = execute_move_call::<Mode>(
+                    context,
+                    &mut argument_updates,
+                    &runtime_id,
+                    &function,
+                    loaded_type_arguments,
+                    arguments,
+                    /* is_init */ false,
+                );
+
+                context.reset_linkage();
+                return_values?
             }
+            Command::Publish(modules, dep_ids) => {
+                execute_move_publish::<Mode>(context, &mut argument_updates, modules, dep_ids)?
+            }
+            Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
+                execute_move_upgrade::<Mode>(
+                    context,
+                    modules,
+                    dep_ids,
+                    current_package_id,
+                    upgrade_ticket,
+                )?
+            }
+        };
 
-            let original_address = context.set_link_context(package)?;
-            let runtime_id = ModuleId::new(original_address, module);
-            let return_values = execute_move_call::<Mode>(
-                context,
-                &mut argument_updates,
-                &runtime_id,
-                &function,
-                loaded_type_arguments,
-                arguments,
-                /* is_init */ false,
-            );
-
-            context.reset_linkage();
-            return_values?
-        }
-        Command::Publish(modules, dep_ids) => {
-            execute_move_publish::<Mode>(context, &mut argument_updates, modules, dep_ids)?
-        }
-        Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
-            execute_move_upgrade::<Mode>(
-                context,
-                modules,
-                dep_ids,
-                current_package_id,
-                upgrade_ticket,
-            )?
-        }
-    };
-
-    Mode::finish_command(context, mode_results, argument_updates, &results)?;
-    context.push_command_results(results)?;
-    Ok(())
-}
-
-/// Execute a single Move call
-fn execute_move_call<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: Vec<Type>,
-    arguments: Vec<Argument>,
-    is_init: bool,
-) -> Result<Vec<Value>, ExecutionError> {
-    // check that the function is either an entry function or a valid public function
-    let LoadedFunctionInfo {
-        kind,
-        signature,
-        return_value_kinds,
-        index,
-        last_instr,
-    } = check_visibility_and_signature::<Mode>(
-        context,
-        module_id,
-        function,
-        &type_arguments,
-        is_init,
-    )?;
-    // build the arguments, storing meta data about by-mut-ref args
-    let (tx_context_kind, by_mut_ref, serialized_arguments) =
-        build_move_args::<Mode>(context, module_id, function, kind, &signature, &arguments)?;
-    // invoke the VM
-    let SerializedReturnValues {
-        mutable_reference_outputs,
-        return_values,
-    } = vm_move_call(
-        context,
-        module_id,
-        function,
-        type_arguments,
-        tx_context_kind,
-        serialized_arguments,
-    )?;
-    assert_invariant!(
-        by_mut_ref.len() == mutable_reference_outputs.len(),
-        "lost mutable input"
-    );
-
-    context.take_user_events(module_id, index, last_instr)?;
-
-    // save the link context because calls to `make_value` below can set new ones, and we don't want
-    // it to be clobbered.
-    let saved_linkage = context.steal_linkage();
-    // write back mutable inputs. We also update if they were used in non entry Move calls
-    // though we do not care for immutable usages of objects or other values
-    let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
-    let res = write_back_results::<Mode>(
-        context,
-        argument_updates,
-        &arguments,
-        used_in_non_entry_move_call,
-        mutable_reference_outputs
-            .into_iter()
-            .map(|(i, bytes, _layout)| (i, bytes)),
-        by_mut_ref,
-        return_values.into_iter().map(|(bytes, _layout)| bytes),
-        return_value_kinds,
-    );
-
-    context.restore_linkage(saved_linkage)?;
-    res
-}
-
-fn write_back_results<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    arguments: &[Argument],
-    non_entry_move_call: bool,
-    mut_ref_values: impl IntoIterator<Item = (u8, Vec<u8>)>,
-    mut_ref_kinds: impl IntoIterator<Item = (u8, ValueKind)>,
-    return_values: impl IntoIterator<Item = Vec<u8>>,
-    return_value_kinds: impl IntoIterator<Item = ValueKind>,
-) -> Result<Vec<Value>, ExecutionError> {
-    for ((i, bytes), (j, kind)) in mut_ref_values.into_iter().zip(mut_ref_kinds) {
-        assert_invariant!(i == j, "lost mutable input");
-        let arg_idx = i as usize;
-        let value = make_value(context, kind, bytes, non_entry_move_call)?;
-        context.restore_arg::<Mode>(argument_updates, arguments[arg_idx], value)?;
+        Mode::finish_command(context, mode_results, argument_updates, &results)?;
+        context.push_command_results(results)?;
+        Ok(())
     }
 
-    return_values
-        .into_iter()
-        .zip(return_value_kinds)
-        .map(|(bytes, kind)| {
-            // only non entry functions have return values
-            make_value(
-                context, kind, bytes, /* used_in_non_entry_move_call */ true,
-            )
-        })
-        .collect()
-}
+    /// Execute a single Move call
+    fn execute_move_call<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: Vec<Type>,
+        arguments: Vec<Argument>,
+        is_init: bool,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        // check that the function is either an entry function or a valid public function
+        let LoadedFunctionInfo {
+            kind,
+            signature,
+            return_value_kinds,
+            index,
+            last_instr,
+        } = check_visibility_and_signature::<Mode>(
+            context,
+            module_id,
+            function,
+            &type_arguments,
+            is_init,
+        )?;
+        // build the arguments, storing meta data about by-mut-ref args
+        let (tx_context_kind, by_mut_ref, serialized_arguments) =
+            build_move_args::<Mode>(context, module_id, function, kind, &signature, &arguments)?;
+        // invoke the VM
+        let SerializedReturnValues {
+            mutable_reference_outputs,
+            return_values,
+        } = vm_move_call(
+            context,
+            module_id,
+            function,
+            type_arguments,
+            tx_context_kind,
+            serialized_arguments,
+        )?;
+        assert_invariant!(
+            by_mut_ref.len() == mutable_reference_outputs.len(),
+            "lost mutable input"
+        );
 
-fn make_value(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    value_info: ValueKind,
-    bytes: Vec<u8>,
-    used_in_non_entry_move_call: bool,
-) -> Result<Value, ExecutionError> {
-    Ok(match value_info {
-        ValueKind::Object {
-            type_,
-            has_public_transfer,
-        } => Value::Object(make_object_value(
-            context.vm,
-            &mut context.session,
-            type_,
-            has_public_transfer,
+        context.take_user_events(module_id, index, last_instr)?;
+
+        // save the link context because calls to `make_value` below can set new ones, and we don't want
+        // it to be clobbered.
+        let saved_linkage = context.steal_linkage();
+        // write back mutable inputs. We also update if they were used in non entry Move calls
+        // though we do not care for immutable usages of objects or other values
+        let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
+        let res = write_back_results::<Mode>(
+            context,
+            argument_updates,
+            &arguments,
             used_in_non_entry_move_call,
-            &bytes,
-        )?),
-        ValueKind::Raw(ty, abilities) => Value::Raw(
-            RawValueType::Loaded {
-                ty,
-                abilities,
+            mutable_reference_outputs
+                .into_iter()
+                .map(|(i, bytes, _layout)| (i, bytes)),
+            by_mut_ref,
+            return_values.into_iter().map(|(bytes, _layout)| bytes),
+            return_value_kinds,
+        );
+
+        context.restore_linkage(saved_linkage)?;
+        res
+    }
+
+    fn write_back_results<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        arguments: &[Argument],
+        non_entry_move_call: bool,
+        mut_ref_values: impl IntoIterator<Item = (u8, Vec<u8>)>,
+        mut_ref_kinds: impl IntoIterator<Item = (u8, ValueKind)>,
+        return_values: impl IntoIterator<Item = Vec<u8>>,
+        return_value_kinds: impl IntoIterator<Item = ValueKind>,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        for ((i, bytes), (j, kind)) in mut_ref_values.into_iter().zip(mut_ref_kinds) {
+            assert_invariant!(i == j, "lost mutable input");
+            let arg_idx = i as usize;
+            let value = make_value(context, kind, bytes, non_entry_move_call)?;
+            context.restore_arg::<Mode>(argument_updates, arguments[arg_idx], value)?;
+        }
+
+        return_values
+            .into_iter()
+            .zip(return_value_kinds)
+            .map(|(bytes, kind)| {
+                // only non entry functions have return values
+                make_value(
+                    context, kind, bytes, /* used_in_non_entry_move_call */ true,
+                )
+            })
+            .collect()
+    }
+
+    fn make_value(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        value_info: ValueKind,
+        bytes: Vec<u8>,
+        used_in_non_entry_move_call: bool,
+    ) -> Result<Value, ExecutionError> {
+        Ok(match value_info {
+            ValueKind::Object {
+                type_,
+                has_public_transfer,
+            } => Value::Object(make_object_value(
+                context.vm,
+                &mut context.session,
+                type_,
+                has_public_transfer,
                 used_in_non_entry_move_call,
-            },
-            bytes,
-        ),
-    })
-}
+                &bytes,
+            )?),
+            ValueKind::Raw(ty, abilities) => Value::Raw(
+                RawValueType::Loaded {
+                    ty,
+                    abilities,
+                    used_in_non_entry_move_call,
+                },
+                bytes,
+            ),
+        })
+    }
 
-/// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
-/// published package on success.
-fn execute_move_publish<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    module_bytes: Vec<Vec<u8>>,
-    dep_ids: Vec<ObjectID>,
-) -> Result<Vec<Value>, ExecutionError> {
-    assert_invariant!(
-        !module_bytes.is_empty(),
-        "empty package is checked in transaction input checker"
-    );
-    context
-        .gas_charger
-        .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
+    /// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
+    /// published package on success.
+    fn execute_move_publish<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        module_bytes: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        assert_invariant!(
+            !module_bytes.is_empty(),
+            "empty package is checked in transaction input checker"
+        );
+        context
+            .gas_charger
+            .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
 
-    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
+        let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
 
-    // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
-    // runtime does not to know about new packages created, since Move objects and Move packages
-    // cannot interact
-    let runtime_id = if Mode::packages_are_predefined() {
-        // do not calculate or substitute id for predefined packages
-        (*modules[0].self_id().address()).into()
-    } else {
-        let id = context.tx_context.fresh_id();
-        substitute_package_id(&mut modules, id)?;
-        id
-    };
+        // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
+        // runtime does not to know about new packages created, since Move objects and Move packages
+        // cannot interact
+        let runtime_id = if Mode::packages_are_predefined() {
+            // do not calculate or substitute id for predefined packages
+            (*modules[0].self_id().address()).into()
+        } else {
+            let id = context.tx_context.fresh_id();
+            substitute_package_id(&mut modules, id)?;
+            id
+        };
 
-    // For newly published packages, runtime ID matches storage ID.
-    let storage_id = runtime_id;
+        // For newly published packages, runtime ID matches storage ID.
+        let storage_id = runtime_id;
 
-    // Preserve the old order of operations when package upgrades are not supported, because it
-    // affects the order in which error cases are checked.
-    let package_obj = if context.protocol_config.package_upgrades_supported() {
-        let dependencies = fetch_packages(context, &dep_ids)?;
-        let package_obj = context.new_package(&modules, &dependencies)?;
+        // Preserve the old order of operations when package upgrades are not supported, because it
+        // affects the order in which error cases are checked.
+        let package_obj = if context.protocol_config.package_upgrades_supported() {
+            let dependencies = fetch_packages(context, &dep_ids)?;
+            let package_obj = context.new_package(&modules, &dependencies)?;
 
-        let Some(package) = package_obj.data.try_as_package() else {
+            let Some(package) = package_obj.data.try_as_package() else {
             invariant_violation!("Newly created package object is not a package");
         };
 
-        context.set_linkage(package)?;
-        let res = publish_and_verify_modules(context, runtime_id, &modules)
-            .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
-        context.reset_linkage();
-        res?;
+            context.set_linkage(package)?;
+            let res = publish_and_verify_modules(context, runtime_id, &modules)
+                .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
+            context.reset_linkage();
+            res?;
 
-        package_obj
-    } else {
-        // FOR THE LOVE OF ALL THAT IS GOOD DO NOT RE-ORDER THIS.  It looks redundant, but is
-        // required to maintain backwards compatibility.
-        publish_and_verify_modules(context, runtime_id, &modules)?;
+            package_obj
+        } else {
+            // FOR THE LOVE OF ALL THAT IS GOOD DO NOT RE-ORDER THIS.  It looks redundant, but is
+            // required to maintain backwards compatibility.
+            publish_and_verify_modules(context, runtime_id, &modules)?;
+            let dependencies = fetch_packages(context, &dep_ids)?;
+            let package = context.new_package(&modules, &dependencies)?;
+            init_modules::<Mode>(context, argument_updates, &modules)?;
+            package
+        };
+
+        context.write_package(package_obj)?;
+        let values = if Mode::packages_are_predefined() {
+            // no upgrade cap for genesis modules
+            vec![]
+        } else {
+            let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
+            vec![Value::Object(make_object_value(
+                context.vm,
+                &mut context.session,
+                UpgradeCap::type_().into(),
+                /* has_public_transfer */ true,
+                /* used_in_non_entry_move_call */ false,
+                &bcs::to_bytes(cap).unwrap(),
+            )?)]
+        };
+        Ok(values)
+    }
+
+    /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
+    fn execute_move_upgrade<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_bytes: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+        current_package_id: ObjectID,
+        upgrade_ticket_arg: Argument,
+    ) -> Result<Vec<Value>, ExecutionError> {
+        // Check that package upgrades are supported.
+        context
+            .protocol_config
+            .check_package_upgrades_supported()
+            .map_err(|_| ExecutionError::from_kind(ExecutionErrorKind::FeatureNotYetSupported))?;
+
+        assert_invariant!(
+            !module_bytes.is_empty(),
+            "empty package is checked in transaction input checker"
+        );
+
+        let upgrade_ticket_type = context
+            .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
+            .map_err(|e| context.convert_vm_error(e))?;
+        let upgrade_receipt_type = context
+            .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        let upgrade_ticket: UpgradeTicket = {
+            let mut ticket_bytes = Vec::new();
+            let ticket_val: Value =
+                context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
+            check_param_type::<Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
+            ticket_val.write_bcs_bytes(&mut ticket_bytes);
+            bcs::from_bytes(&ticket_bytes).map_err(|_| {
+                ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
+                    arg_idx: 0,
+                    kind: CommandArgumentError::InvalidBCSBytes,
+                })
+            })?
+        };
+
+        // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
+        if current_package_id != upgrade_ticket.package.bytes {
+            return Err(ExecutionError::from_kind(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
+                        package_id: current_package_id,
+                        ticket_id: upgrade_ticket.package.bytes,
+                    },
+                },
+            ));
+        }
+
+        // Check digest.
+        let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
+            &module_bytes,
+            &dep_ids,
+            context.protocol_config.package_digest_hash_module(),
+        )
+        .to_vec();
+        if computed_digest != upgrade_ticket.digest {
+            return Err(ExecutionError::from_kind(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
+                        digest: computed_digest,
+                    },
+                },
+            ));
+        }
+
+        // Check that this package ID points to a package and get the package we're upgrading.
+        let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
+
+        let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
+        let runtime_id = current_package.original_package_id();
+        substitute_package_id(&mut modules, runtime_id)?;
+
+        // Upgraded packages share their predecessor's runtime ID but get a new storage ID.
+        let storage_id = context.tx_context.fresh_id();
+
         let dependencies = fetch_packages(context, &dep_ids)?;
-        let package = context.new_package(&modules, &dependencies)?;
-        init_modules::<Mode>(context, argument_updates, &modules)?;
-        package
-    };
+        let package_obj =
+            context.upgrade_package(storage_id, &current_package, &modules, &dependencies)?;
 
-    context.write_package(package_obj)?;
-    let values = if Mode::packages_are_predefined() {
-        // no upgrade cap for genesis modules
-        vec![]
-    } else {
-        let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
-        vec![Value::Object(make_object_value(
-            context.vm,
-            &mut context.session,
-            UpgradeCap::type_().into(),
-            /* has_public_transfer */ true,
-            /* used_in_non_entry_move_call */ false,
-            &bcs::to_bytes(cap).unwrap(),
-        )?)]
-    };
-    Ok(values)
-}
-
-/// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
-fn execute_move_upgrade<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_bytes: Vec<Vec<u8>>,
-    dep_ids: Vec<ObjectID>,
-    current_package_id: ObjectID,
-    upgrade_ticket_arg: Argument,
-) -> Result<Vec<Value>, ExecutionError> {
-    // Check that package upgrades are supported.
-    context
-        .protocol_config
-        .check_package_upgrades_supported()
-        .map_err(|_| ExecutionError::from_kind(ExecutionErrorKind::FeatureNotYetSupported))?;
-
-    assert_invariant!(
-        !module_bytes.is_empty(),
-        "empty package is checked in transaction input checker"
-    );
-
-    let upgrade_ticket_type = context
-        .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
-        .map_err(|e| context.convert_vm_error(e))?;
-    let upgrade_receipt_type = context
-        .load_type(&TypeTag::Struct(Box::new(UpgradeReceipt::type_())))
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    let upgrade_ticket: UpgradeTicket = {
-        let mut ticket_bytes = Vec::new();
-        let ticket_val: Value =
-            context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
-        check_param_type::<Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
-        ticket_val.write_bcs_bytes(&mut ticket_bytes);
-        bcs::from_bytes(&ticket_bytes).map_err(|_| {
-            ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
-                arg_idx: 0,
-                kind: CommandArgumentError::InvalidBCSBytes,
-            })
-        })?
-    };
-
-    // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
-    if current_package_id != upgrade_ticket.package.bytes {
-        return Err(ExecutionError::from_kind(
-            ExecutionErrorKind::PackageUpgradeError {
-                upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
-                    package_id: current_package_id,
-                    ticket_id: upgrade_ticket.package.bytes,
-                },
-            },
-        ));
-    }
-
-    // Check digest.
-    let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
-        &module_bytes,
-        &dep_ids,
-        context.protocol_config.package_digest_hash_module(),
-    )
-    .to_vec();
-    if computed_digest != upgrade_ticket.digest {
-        return Err(ExecutionError::from_kind(
-            ExecutionErrorKind::PackageUpgradeError {
-                upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
-                    digest: computed_digest,
-                },
-            },
-        ));
-    }
-
-    // Check that this package ID points to a package and get the package we're upgrading.
-    let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
-
-    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
-    let runtime_id = current_package.original_package_id();
-    substitute_package_id(&mut modules, runtime_id)?;
-
-    // Upgraded packages share their predecessor's runtime ID but get a new storage ID.
-    let storage_id = context.tx_context.fresh_id();
-
-    let dependencies = fetch_packages(context, &dep_ids)?;
-    let package_obj =
-        context.upgrade_package(storage_id, &current_package, &modules, &dependencies)?;
-
-    let Some(package) = package_obj.data.try_as_package() else {
+        let Some(package) = package_obj.data.try_as_package() else {
         invariant_violation!("Newly created package object is not a package");
     };
 
-    // Populate loader with all previous types.
-    if !context
-        .protocol_config
-        .disallow_adding_abilities_on_upgrade()
-    {
-        for TypeOrigin {
-            module_name,
-            struct_name,
-            package: origin,
-        } in package.type_origin_table()
+        // Populate loader with all previous types.
+        if !context
+            .protocol_config
+            .disallow_adding_abilities_on_upgrade()
         {
-            if package.id() == *origin {
+            for TypeOrigin {
+                module_name,
+                struct_name,
+                package: origin,
+            } in package.type_origin_table()
+            {
+                if package.id() == *origin {
+                    continue;
+                }
+
+                let Ok(module) = Identifier::new(module_name.as_str()) else {
                 continue;
+            };
+
+                let Ok(name) = Identifier::new(struct_name.as_str()) else {
+                continue;
+            };
+
+                let _ = context.load_type(&TypeTag::Struct(Box::new(StructTag {
+                    address: (*origin).into(),
+                    module,
+                    name,
+                    type_params: vec![],
+                })));
             }
-
-            let Ok(module) = Identifier::new(module_name.as_str()) else {
-                continue;
-            };
-
-            let Ok(name) = Identifier::new(struct_name.as_str()) else {
-                continue;
-            };
-
-            let _ = context.load_type(&TypeTag::Struct(Box::new(StructTag {
-                address: (*origin).into(),
-                module,
-                name,
-                type_params: vec![],
-            })));
         }
+
+        context.set_linkage(package)?;
+        let res = publish_and_verify_modules(context, runtime_id, &modules);
+        context.reset_linkage();
+        res?;
+
+        check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
+
+        context.write_package(package_obj)?;
+        Ok(vec![Value::Raw(
+            RawValueType::Loaded {
+                ty: upgrade_receipt_type,
+                abilities: AbilitySet::EMPTY,
+                used_in_non_entry_move_call: false,
+            },
+            bcs::to_bytes(&UpgradeReceipt::new(upgrade_ticket, storage_id)).unwrap(),
+        )])
     }
 
-    context.set_linkage(package)?;
-    let res = publish_and_verify_modules(context, runtime_id, &modules);
-    context.reset_linkage();
-    res?;
-
-    check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
-
-    context.write_package(package_obj)?;
-    Ok(vec![Value::Raw(
-        RawValueType::Loaded {
-            ty: upgrade_receipt_type,
-            abilities: AbilitySet::EMPTY,
-            used_in_non_entry_move_call: false,
-        },
-        bcs::to_bytes(&UpgradeReceipt::new(upgrade_ticket, storage_id)).unwrap(),
-    )])
-}
-
-fn check_compatibility<'a>(
-    context: &ExecutionContext,
-    existing_package: &MovePackage,
-    upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
-    policy: u8,
-) -> Result<(), ExecutionError> {
-    // Make sure this is a known upgrade policy.
-    let Ok(policy) = UpgradePolicy::try_from(policy) else {
+    fn check_compatibility<'a>(
+        context: &ExecutionContext,
+        existing_package: &MovePackage,
+        upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
+        policy: u8,
+    ) -> Result<(), ExecutionError> {
+        // Make sure this is a known upgrade policy.
+        let Ok(policy) = UpgradePolicy::try_from(policy) else {
         return Err(ExecutionError::from_kind(
             ExecutionErrorKind::PackageUpgradeError {
                 upgrade_error: PackageUpgradeError::UnknownUpgradePolicy { policy },
@@ -689,7 +692,7 @@ fn check_compatibility<'a>(
         ));
     };
 
-    let Ok(current_normalized) = existing_package
+        let Ok(current_normalized) = existing_package
         .normalize(
             context.protocol_config.move_binary_format_version(),
             context.protocol_config.no_extraneous_module_bytes(),
@@ -698,9 +701,9 @@ fn check_compatibility<'a>(
         invariant_violation!("Tried to normalize modules in existing package but failed")
     };
 
-    let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
-    for (name, cur_module) in current_normalized {
-        let Some(new_module) = new_normalized.remove(&name) else {
+        let mut new_normalized = normalize_deserialized_modules(upgrading_modules.into_iter());
+        for (name, cur_module) in current_normalized {
+            let Some(new_module) = new_normalized.remove(&name) else {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
@@ -709,314 +712,312 @@ fn check_compatibility<'a>(
             ));
         };
 
-        check_module_compatibility(
-            &policy,
-            context.protocol_config,
-            &cur_module,
-            &new_module,
-        )?;
-    }
-
-    Ok(())
-}
-
-fn check_module_compatibility(
-    policy: &UpgradePolicy,
-    protocol_config: &ProtocolConfig,
-    cur_module: &normalized::Module,
-    new_module: &normalized::Module,
-) -> Result<(), ExecutionError> {
-    match policy {
-        UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
-        UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
-        UpgradePolicy::Compatible => {
-            let disallowed_new_abilities = if protocol_config.disallow_adding_abilities_on_upgrade() {
-                AbilitySet::ALL
-            } else {
-                AbilitySet::EMPTY
-            };
-
-            let compatibility = Compatibility {
-                check_struct_and_pub_function_linking: true,
-                check_struct_layout: true,
-                check_friend_linking: false,
-                check_private_entry_linking: false,
-                disallowed_new_abilities,
-                disallow_change_struct_type_params: protocol_config
-                    .disallow_change_struct_type_params_on_upgrade(),
-            };
-
-            compatibility.check(cur_module, new_module)
+            check_module_compatibility(&policy, context.protocol_config, &cur_module, &new_module)?;
         }
-    }
-    .map_err(|e| ExecutionError::new_with_source(
-        ExecutionErrorKind::PackageUpgradeError {
-            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
-        },
-        e,
-    ))
-}
 
-fn fetch_package(
-    context: &ExecutionContext<'_, '_, '_>,
-    package_id: &ObjectID,
-) -> Result<MovePackage, ExecutionError> {
-    let mut fetched_packages = fetch_packages(context, vec![package_id])?;
-    assert_invariant!(
-        fetched_packages.len() == 1,
-        "Number of fetched packages must match the number of package object IDs if successful."
-    );
-    match fetched_packages.pop() {
-        Some(pkg) => Ok(pkg),
-        None => invariant_violation!(
-            "We should always fetch a package for each object or return a dependency error."
-        ),
-    }
-}
-
-fn fetch_packages<'ctx, 'vm, 'state, 'a>(
-    context: &'ctx ExecutionContext<'vm, 'state, 'a>,
-    package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
-) -> Result<Vec<MovePackage>, ExecutionError> {
-    let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
-    match get_packages(&context.state_view, package_ids) {
-        Err(e) => Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::PublishUpgradeMissingDependency,
-            e,
-        )),
-        Ok(Err(missing_deps)) => {
-            let msg = format!(
-                "Missing dependencies: {}",
-                missing_deps
-                    .into_iter()
-                    .map(|dep| format!("{}", dep))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::PublishUpgradeMissingDependency,
-                msg,
-            ))
-        }
-        Ok(Ok(pkgs)) => Ok(pkgs),
-    }
-}
-
-/***************************************************************************************************
- * Move execution
- **************************************************************************************************/
-
-fn vm_move_call(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: Vec<Type>,
-    tx_context_kind: TxContextKind,
-    mut serialized_arguments: Vec<Vec<u8>>,
-) -> Result<SerializedReturnValues, ExecutionError> {
-    match tx_context_kind {
-        TxContextKind::None => (),
-        TxContextKind::Mutable | TxContextKind::Immutable => {
-            serialized_arguments.push(context.tx_context.to_vec());
-        }
-    }
-    // script visibility checked manually for entry points
-    let mut result = context
-        .session
-        .execute_function_bypass_visibility(
-            module_id,
-            function,
-            type_arguments,
-            serialized_arguments,
-            context.gas_charger.move_gas_status_mut(),
-        )
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    // When this function is used during publishing, it
-    // may be executed several times, with objects being
-    // created in the Move VM in each Move call. In such
-    // case, we need to update TxContext value so that it
-    // reflects what happened each time we call into the
-    // Move VM (e.g. to account for the number of created
-    // objects).
-    if tx_context_kind == TxContextKind::Mutable {
-        let Some((_, ctx_bytes, _)) = result.mutable_reference_outputs.pop() else {
-            invariant_violation!("Missing TxContext in reference outputs");
-        };
-        let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).map_err(|e| {
-            ExecutionError::invariant_violation(format!(
-                "Unable to deserialize TxContext bytes. {e}"
-            ))
-        })?;
-        context.tx_context.update_state(updated_ctx)?;
-    }
-    Ok(result)
-}
-
-#[allow(clippy::extra_unused_type_parameters)]
-fn deserialize_modules<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_bytes: &[Vec<u8>],
-) -> Result<Vec<CompiledModule>, ExecutionError> {
-    let modules = module_bytes
-        .iter()
-        .map(|b| {
-            CompiledModule::deserialize_with_config(
-                b,
-                context.protocol_config.move_binary_format_version(),
-                context.protocol_config.no_extraneous_module_bytes(),
-            )
-            .map_err(|e| e.finish(Location::Undefined))
-        })
-        .collect::<VMResult<Vec<CompiledModule>>>()
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    assert_invariant!(
-        !modules.is_empty(),
-        "input checker ensures package is not empty"
-    );
-
-    Ok(modules)
-}
-
-fn publish_and_verify_modules(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    package_id: ObjectID,
-    modules: &[CompiledModule],
-) -> Result<(), ExecutionError> {
-    // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
-    let new_module_bytes: Vec<_> = modules
-        .iter()
-        .map(|m| {
-            let mut bytes = Vec::new();
-            m.serialize(&mut bytes).unwrap();
-            bytes
-        })
-        .collect();
-    context
-        .session
-        .publish_module_bundle(
-            new_module_bytes,
-            AccountAddress::from(package_id),
-            // TODO: publish_module_bundle() currently doesn't charge gas.
-            // Do we want to charge there?
-            context.gas_charger.move_gas_status_mut(),
-        )
-        .map_err(|e| context.convert_vm_error(e))?;
-
-    // run the Sui verifier
-    for module in modules {
-        // Run Sui bytecode verifier, which runs some additional checks that assume the Move
-        // bytecode verifier has passed.
-        sui_verifier::verifier::sui_verify_module_unmetered(
-            context.protocol_config,
-            module,
-            &BTreeMap::new(),
-        )?;
+        Ok(())
     }
 
-    Ok(())
-}
+    fn check_module_compatibility(
+        policy: &UpgradePolicy,
+        protocol_config: &ProtocolConfig,
+        cur_module: &normalized::Module,
+        new_module: &normalized::Module,
+    ) -> Result<(), ExecutionError> {
+        match policy {
+            UpgradePolicy::Additive => InclusionCheck::Subset.check(cur_module, new_module),
+            UpgradePolicy::DepOnly => InclusionCheck::Equal.check(cur_module, new_module),
+            UpgradePolicy::Compatible => {
+                let disallowed_new_abilities =
+                    if protocol_config.disallow_adding_abilities_on_upgrade() {
+                        AbilitySet::ALL
+                    } else {
+                        AbilitySet::EMPTY
+                    };
 
-fn init_modules<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    argument_updates: &mut Mode::ArgumentUpdates,
-    modules: &[CompiledModule],
-) -> Result<(), ExecutionError> {
-    let modules_to_init = modules.iter().filter_map(|module| {
-        for fdef in &module.function_defs {
-            let fhandle = module.function_handle_at(fdef.function);
-            let fname = module.identifier_at(fhandle.name);
-            if fname == INIT_FN_NAME {
-                return Some(module.self_id());
+                let compatibility = Compatibility {
+                    check_struct_and_pub_function_linking: true,
+                    check_struct_layout: true,
+                    check_friend_linking: false,
+                    check_private_entry_linking: false,
+                    disallowed_new_abilities,
+                    disallow_change_struct_type_params: protocol_config
+                        .disallow_change_struct_type_params_on_upgrade(),
+                };
+
+                compatibility.check(cur_module, new_module)
             }
         }
-        None
-    });
-
-    for module_id in modules_to_init {
-        let return_values = execute_move_call::<Mode>(
-            context,
-            argument_updates,
-            &module_id,
-            INIT_FN_NAME,
-            vec![],
-            vec![],
-            /* is_init */ true,
-        )?;
-
-        assert_invariant!(
-            return_values.is_empty(),
-            "init should not have return values"
-        )
+        .map_err(|e| {
+            ExecutionError::new_with_source(
+                ExecutionErrorKind::PackageUpgradeError {
+                    upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+                },
+                e,
+            )
+        })
     }
 
-    Ok(())
-}
-
-/***************************************************************************************************
- * Move signatures
- **************************************************************************************************/
-
-/// Helper marking what function we are invoking
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum FunctionKind {
-    PrivateEntry,
-    PublicEntry,
-    NonEntry,
-    Init,
-}
-
-/// Used to remember type information about a type when resolving the signature
-enum ValueKind {
-    Object {
-        type_: MoveObjectType,
-        has_public_transfer: bool,
-    },
-    Raw(Type, AbilitySet),
-}
-
-struct LoadedFunctionInfo {
-    /// The kind of the function, e.g. public or private or init
-    kind: FunctionKind,
-    /// The signature information of the function
-    signature: LoadedFunctionInstantiation,
-    /// Object or type information for the return values
-    return_value_kinds: Vec<ValueKind>,
-    /// Definition index of the function
-    index: FunctionDefinitionIndex,
-    /// The length of the function used for setting error information, or 0 if native
-    last_instr: CodeOffset,
-}
-
-/// Checks that the function to be called is either
-/// - an entry function
-/// - a public function that does not return references
-/// - module init (only internal usage)
-fn check_visibility_and_signature<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    type_arguments: &[Type],
-    from_init: bool,
-) -> Result<LoadedFunctionInfo, ExecutionError> {
-    if from_init {
-        // the session is weird and does not load the module on publishing. This is a temporary
-        // work around, since loading the function through the session will cause the module
-        // to be loaded through the sessions data store.
-        let result = context
-            .session
-            .load_function(module_id, function, type_arguments);
+    fn fetch_package(
+        context: &ExecutionContext<'_, '_, '_>,
+        package_id: &ObjectID,
+    ) -> Result<MovePackage, ExecutionError> {
+        let mut fetched_packages = fetch_packages(context, vec![package_id])?;
         assert_invariant!(
-            result.is_ok(),
-            "The modules init should be able to be loaded"
+            fetched_packages.len() == 1,
+            "Number of fetched packages must match the number of package object IDs if successful."
         );
+        match fetched_packages.pop() {
+            Some(pkg) => Ok(pkg),
+            None => invariant_violation!(
+                "We should always fetch a package for each object or return a dependency error."
+            ),
+        }
     }
-    let module = context
-        .vm
-        .load_module(module_id, context.session.get_resolver())
-        .map_err(|e| context.convert_vm_error(e))?;
-    let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
+
+    fn fetch_packages<'ctx, 'vm, 'state, 'a>(
+        context: &'ctx ExecutionContext<'vm, 'state, 'a>,
+        package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
+    ) -> Result<Vec<MovePackage>, ExecutionError> {
+        let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
+        match get_packages(&context.state_view, package_ids) {
+            Err(e) => Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::PublishUpgradeMissingDependency,
+                e,
+            )),
+            Ok(Err(missing_deps)) => {
+                let msg = format!(
+                    "Missing dependencies: {}",
+                    missing_deps
+                        .into_iter()
+                        .map(|dep| format!("{}", dep))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::PublishUpgradeMissingDependency,
+                    msg,
+                ))
+            }
+            Ok(Ok(pkgs)) => Ok(pkgs),
+        }
+    }
+
+    /***************************************************************************************************
+     * Move execution
+     **************************************************************************************************/
+
+    fn vm_move_call(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: Vec<Type>,
+        tx_context_kind: TxContextKind,
+        mut serialized_arguments: Vec<Vec<u8>>,
+    ) -> Result<SerializedReturnValues, ExecutionError> {
+        match tx_context_kind {
+            TxContextKind::None => (),
+            TxContextKind::Mutable | TxContextKind::Immutable => {
+                serialized_arguments.push(context.tx_context.to_vec());
+            }
+        }
+        // script visibility checked manually for entry points
+        let mut result = context
+            .session
+            .execute_function_bypass_visibility(
+                module_id,
+                function,
+                type_arguments,
+                serialized_arguments,
+                context.gas_charger.move_gas_status_mut(),
+            )
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        // When this function is used during publishing, it
+        // may be executed several times, with objects being
+        // created in the Move VM in each Move call. In such
+        // case, we need to update TxContext value so that it
+        // reflects what happened each time we call into the
+        // Move VM (e.g. to account for the number of created
+        // objects).
+        if tx_context_kind == TxContextKind::Mutable {
+            let Some((_, ctx_bytes, _)) = result.mutable_reference_outputs.pop() else {
+            invariant_violation!("Missing TxContext in reference outputs");
+        };
+            let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).map_err(|e| {
+                ExecutionError::invariant_violation(format!(
+                    "Unable to deserialize TxContext bytes. {e}"
+                ))
+            })?;
+            context.tx_context.update_state(updated_ctx)?;
+        }
+        Ok(result)
+    }
+
+    #[allow(clippy::extra_unused_type_parameters)]
+    fn deserialize_modules<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_bytes: &[Vec<u8>],
+    ) -> Result<Vec<CompiledModule>, ExecutionError> {
+        let modules = module_bytes
+            .iter()
+            .map(|b| {
+                CompiledModule::deserialize_with_config(
+                    b,
+                    context.protocol_config.move_binary_format_version(),
+                    context.protocol_config.no_extraneous_module_bytes(),
+                )
+                .map_err(|e| e.finish(Location::Undefined))
+            })
+            .collect::<VMResult<Vec<CompiledModule>>>()
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        assert_invariant!(
+            !modules.is_empty(),
+            "input checker ensures package is not empty"
+        );
+
+        Ok(modules)
+    }
+
+    fn publish_and_verify_modules(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        package_id: ObjectID,
+        modules: &[CompiledModule],
+    ) -> Result<(), ExecutionError> {
+        // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
+        let new_module_bytes: Vec<_> = modules
+            .iter()
+            .map(|m| {
+                let mut bytes = Vec::new();
+                m.serialize(&mut bytes).unwrap();
+                bytes
+            })
+            .collect();
+        context
+            .session
+            .publish_module_bundle(
+                new_module_bytes,
+                AccountAddress::from(package_id),
+                // TODO: publish_module_bundle() currently doesn't charge gas.
+                // Do we want to charge there?
+                context.gas_charger.move_gas_status_mut(),
+            )
+            .map_err(|e| context.convert_vm_error(e))?;
+
+        // run the Sui verifier
+        for module in modules {
+            // Run Sui bytecode verifier, which runs some additional checks that assume the Move
+            // bytecode verifier has passed.
+            sui_verifier::verifier::sui_verify_module_unmetered(
+                context.protocol_config,
+                module,
+                &BTreeMap::new(),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn init_modules<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        argument_updates: &mut Mode::ArgumentUpdates,
+        modules: &[CompiledModule],
+    ) -> Result<(), ExecutionError> {
+        let modules_to_init = modules.iter().filter_map(|module| {
+            for fdef in &module.function_defs {
+                let fhandle = module.function_handle_at(fdef.function);
+                let fname = module.identifier_at(fhandle.name);
+                if fname == INIT_FN_NAME {
+                    return Some(module.self_id());
+                }
+            }
+            None
+        });
+
+        for module_id in modules_to_init {
+            let return_values = execute_move_call::<Mode>(
+                context,
+                argument_updates,
+                &module_id,
+                INIT_FN_NAME,
+                vec![],
+                vec![],
+                /* is_init */ true,
+            )?;
+
+            assert_invariant!(
+                return_values.is_empty(),
+                "init should not have return values"
+            )
+        }
+
+        Ok(())
+    }
+
+    /***************************************************************************************************
+     * Move signatures
+     **************************************************************************************************/
+
+    /// Helper marking what function we are invoking
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    enum FunctionKind {
+        PrivateEntry,
+        PublicEntry,
+        NonEntry,
+        Init,
+    }
+
+    /// Used to remember type information about a type when resolving the signature
+    enum ValueKind {
+        Object {
+            type_: MoveObjectType,
+            has_public_transfer: bool,
+        },
+        Raw(Type, AbilitySet),
+    }
+
+    struct LoadedFunctionInfo {
+        /// The kind of the function, e.g. public or private or init
+        kind: FunctionKind,
+        /// The signature information of the function
+        signature: LoadedFunctionInstantiation,
+        /// Object or type information for the return values
+        return_value_kinds: Vec<ValueKind>,
+        /// Definition index of the function
+        index: FunctionDefinitionIndex,
+        /// The length of the function used for setting error information, or 0 if native
+        last_instr: CodeOffset,
+    }
+
+    /// Checks that the function to be called is either
+    /// - an entry function
+    /// - a public function that does not return references
+    /// - module init (only internal usage)
+    fn check_visibility_and_signature<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        type_arguments: &[Type],
+        from_init: bool,
+    ) -> Result<LoadedFunctionInfo, ExecutionError> {
+        if from_init {
+            // the session is weird and does not load the module on publishing. This is a temporary
+            // work around, since loading the function through the session will cause the module
+            // to be loaded through the sessions data store.
+            let result = context
+                .session
+                .load_function(module_id, function, type_arguments);
+            assert_invariant!(
+                result.is_ok(),
+                "The modules init should be able to be loaded"
+            );
+        }
+        let module = context
+            .vm
+            .load_module(module_id, context.session.get_resolver())
+            .map_err(|e| context.convert_vm_error(e))?;
+        let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
         module.identifier_at(module.function_handle_at(fdef.function).name) == function
     }) else {
         return Err(ExecutionError::new_with_source(
@@ -1028,325 +1029,327 @@ fn check_visibility_and_signature<Mode: ExecutionMode>(
         ));
     };
 
-    // entry on init is now banned, so ban invoking it
-    if !from_init && function == INIT_FN_NAME && context.protocol_config.ban_entry_init() {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            "Cannot call 'init'",
-        ));
-    }
-
-    let last_instr: CodeOffset = fdef
-        .code
-        .as_ref()
-        .map(|code| code.code.len() - 1)
-        .unwrap_or(0) as CodeOffset;
-    let function_kind = match (fdef.visibility, fdef.is_entry) {
-        (Visibility::Private | Visibility::Friend, true) => FunctionKind::PrivateEntry,
-        (Visibility::Public, true) => FunctionKind::PublicEntry,
-        (Visibility::Public, false) => FunctionKind::NonEntry,
-        (Visibility::Private, false) if from_init => {
-            assert_invariant!(
-                function == INIT_FN_NAME,
-                "module init specified non-init function"
-            );
-            FunctionKind::Init
-        }
-        (Visibility::Private | Visibility::Friend, false)
-            if Mode::allow_arbitrary_function_calls() =>
-        {
-            FunctionKind::NonEntry
-        }
-        (Visibility::Private | Visibility::Friend, false) => {
+        // entry on init is now banned, so ban invoking it
+        if !from_init && function == INIT_FN_NAME && context.protocol_config.ban_entry_init() {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
-                "Can only call `entry` or `public` functions",
+                "Cannot call 'init'",
             ));
         }
-    };
-    let signature = context
-        .session
-        .load_function(module_id, function, type_arguments)
-        .map_err(|e| context.convert_vm_error(e))?;
-    let signature =
-        subst_signature(signature, type_arguments).map_err(|e| context.convert_vm_error(e))?;
-    let return_value_kinds = match function_kind {
-        FunctionKind::Init => {
-            assert_invariant!(
-                signature.return_.is_empty(),
-                "init functions must have no return values"
-            );
-            vec![]
-        }
-        FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
-            check_non_entry_signature::<Mode>(context, module_id, function, &signature)?
-        }
-    };
-    check_private_generics(context, module_id, function, type_arguments)?;
-    Ok(LoadedFunctionInfo {
-        kind: function_kind,
-        signature,
-        return_value_kinds,
-        index: FunctionDefinitionIndex(index as u16),
-        last_instr,
-    })
-}
 
-/// substitutes the type arguments into the parameter and return types
-fn subst_signature(
-    signature: LoadedFunctionInstantiation,
-    type_arguments: &[Type],
-) -> VMResult<LoadedFunctionInstantiation> {
-    let LoadedFunctionInstantiation {
-        parameters,
-        return_,
-    } = signature;
-    let parameters = parameters
-        .into_iter()
-        .map(|ty| ty.subst(type_arguments))
-        .collect::<PartialVMResult<Vec<_>>>()
-        .map_err(|err| err.finish(Location::Undefined))?;
-    let return_ = return_
-        .into_iter()
-        .map(|ty| ty.subst(type_arguments))
-        .collect::<PartialVMResult<Vec<_>>>()
-        .map_err(|err| err.finish(Location::Undefined))?;
-    Ok(LoadedFunctionInstantiation {
-        parameters,
-        return_,
-    })
-}
-
-/// Checks that the non-entry function does not return references. And marks the return values
-/// as object or non-object return values
-fn check_non_entry_signature<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    _module_id: &ModuleId,
-    _function: &IdentStr,
-    signature: &LoadedFunctionInstantiation,
-) -> Result<Vec<ValueKind>, ExecutionError> {
-    signature
-        .return_
-        .iter()
-        .enumerate()
-        .map(|(idx, return_type)| {
-            let return_type = match return_type {
-                // for dev-inspect, just dereference the value
-                Type::Reference(inner) | Type::MutableReference(inner)
-                    if Mode::allow_arbitrary_values() =>
-                {
-                    inner
-                }
-                Type::Reference(_) | Type::MutableReference(_) => {
-                    return Err(ExecutionError::from_kind(
-                        ExecutionErrorKind::InvalidPublicFunctionReturnType { idx: idx as u16 },
-                    ))
-                }
-                t => t,
-            };
-            let abilities = context
-                .session
-                .get_type_abilities(return_type)
-                .map_err(|e| context.convert_vm_error(e))?;
-            Ok(match return_type {
-                Type::MutableReference(_) | Type::Reference(_) => unreachable!(),
-                Type::TyParam(_) => invariant_violation!("TyParam should have been substituted"),
-                Type::Struct(_) | Type::StructInstantiation(_, _) if abilities.has_key() => {
-                    let type_tag = context
-                        .session
-                        .get_type_tag(return_type)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    let TypeTag::Struct(struct_tag) = type_tag else {
-                        invariant_violation!("Struct type make a non struct type tag")
-                    };
-                    ValueKind::Object {
-                        type_: MoveObjectType::from(*struct_tag),
-                        has_public_transfer: abilities.has_store(),
-                    }
-                }
-                Type::Struct(_)
-                | Type::StructInstantiation(_, _)
-                | Type::Bool
-                | Type::U8
-                | Type::U64
-                | Type::U128
-                | Type::Address
-                | Type::Signer
-                | Type::Vector(_)
-                | Type::U16
-                | Type::U32
-                | Type::U256 => ValueKind::Raw(return_type.clone(), abilities),
-            })
+        let last_instr: CodeOffset = fdef
+            .code
+            .as_ref()
+            .map(|code| code.code.len() - 1)
+            .unwrap_or(0) as CodeOffset;
+        let function_kind = match (fdef.visibility, fdef.is_entry) {
+            (Visibility::Private | Visibility::Friend, true) => FunctionKind::PrivateEntry,
+            (Visibility::Public, true) => FunctionKind::PublicEntry,
+            (Visibility::Public, false) => FunctionKind::NonEntry,
+            (Visibility::Private, false) if from_init => {
+                assert_invariant!(
+                    function == INIT_FN_NAME,
+                    "module init specified non-init function"
+                );
+                FunctionKind::Init
+            }
+            (Visibility::Private | Visibility::Friend, false)
+                if Mode::allow_arbitrary_function_calls() =>
+            {
+                FunctionKind::NonEntry
+            }
+            (Visibility::Private | Visibility::Friend, false) => {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::NonEntryFunctionInvoked,
+                    "Can only call `entry` or `public` functions",
+                ));
+            }
+        };
+        let signature = context
+            .session
+            .load_function(module_id, function, type_arguments)
+            .map_err(|e| context.convert_vm_error(e))?;
+        let signature =
+            subst_signature(signature, type_arguments).map_err(|e| context.convert_vm_error(e))?;
+        let return_value_kinds = match function_kind {
+            FunctionKind::Init => {
+                assert_invariant!(
+                    signature.return_.is_empty(),
+                    "init functions must have no return values"
+                );
+                vec![]
+            }
+            FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
+                check_non_entry_signature::<Mode>(context, module_id, function, &signature)?
+            }
+        };
+        check_private_generics(context, module_id, function, type_arguments)?;
+        Ok(LoadedFunctionInfo {
+            kind: function_kind,
+            signature,
+            return_value_kinds,
+            index: FunctionDefinitionIndex(index as u16),
+            last_instr,
         })
-        .collect()
-}
-
-fn check_private_generics(
-    _context: &mut ExecutionContext,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    _type_arguments: &[Type],
-) -> Result<(), ExecutionError> {
-    let module_ident = (module_id.address(), module_id.name());
-    if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE) {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            format!("Cannot directly call functions in sui::{}", EVENT_MODULE),
-        ));
     }
 
-    if module_ident == (&SUI_FRAMEWORK_ADDRESS, TRANSFER_MODULE)
-        && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
-    {
-        let msg = format!(
-            "Cannot directly call sui::{m}::{f}. \
-            Use the public variant instead, sui::{m}::public_{f}",
-            m = TRANSFER_MODULE,
-            f = function
-        );
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::NonEntryFunctionInvoked,
-            msg,
-        ));
+    /// substitutes the type arguments into the parameter and return types
+    fn subst_signature(
+        signature: LoadedFunctionInstantiation,
+        type_arguments: &[Type],
+    ) -> VMResult<LoadedFunctionInstantiation> {
+        let LoadedFunctionInstantiation {
+            parameters,
+            return_,
+        } = signature;
+        let parameters = parameters
+            .into_iter()
+            .map(|ty| ty.subst(type_arguments))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        let return_ = return_
+            .into_iter()
+            .map(|ty| ty.subst(type_arguments))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        Ok(LoadedFunctionInstantiation {
+            parameters,
+            return_,
+        })
     }
 
-    Ok(())
-}
-
-type ArgInfo = (
-    TxContextKind,
-    /* mut ref */
-    Vec<(LocalIndex, ValueKind)>,
-    Vec<Vec<u8>>,
-);
-
-/// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
-/// each value
-fn build_move_args<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    module_id: &ModuleId,
-    function: &IdentStr,
-    function_kind: FunctionKind,
-    signature: &LoadedFunctionInstantiation,
-    args: &[Argument],
-) -> Result<ArgInfo, ExecutionError> {
-    // check the arity
-    let parameters = &signature.parameters;
-    let tx_ctx_kind = match parameters.last() {
-        Some(t) => is_tx_context(context, t)?,
-        None => TxContextKind::None,
-    };
-    // an init function can have one or two arguments, with the last one always being of type
-    // &mut TxContext and the additional (first) one representing a one time witness type (see
-    // one_time_witness verifier pass for additional explanation)
-    let has_one_time_witness = function_kind == FunctionKind::Init && parameters.len() == 2;
-    let has_tx_context = tx_ctx_kind != TxContextKind::None;
-    let num_args = args.len() + (has_one_time_witness as usize) + (has_tx_context as usize);
-    if num_args != parameters.len() {
-        return Err(ExecutionError::new_with_source(
-            ExecutionErrorKind::ArityMismatch,
-            format!(
-                "Expected {:?} argument{} calling function '{}', but found {:?}",
-                parameters.len(),
-                if parameters.len() == 1 { "" } else { "s" },
-                function,
-                num_args
-            ),
-        ));
-    }
-
-    // check the types and remember which are by mutable ref
-    let mut by_mut_ref = vec![];
-    let mut serialized_args = Vec::with_capacity(num_args);
-    let command_kind = CommandKind::MoveCall {
-        package: (*module_id.address()).into(),
-        module: module_id.name(),
-        function,
-    };
-    // an init function can have one or two arguments, with the last one always being of type
-    // &mut TxContext and the additional (first) one representing a one time witness type (see
-    // one_time_witness verifier pass for additional explanation)
-    if has_one_time_witness {
-        // one time witness type is a struct with a single bool filed which in bcs is encoded as
-        // 0x01
-        let bcs_true_value = bcs::to_bytes(&true).unwrap();
-        serialized_args.push(bcs_true_value)
-    }
-    for ((idx, arg), param_ty) in args.iter().copied().enumerate().zip(parameters) {
-        let (value, non_ref_param_ty): (Value, &Type) = match param_ty {
-            Type::MutableReference(inner) => {
-                let value = context.borrow_arg_mut(idx, arg)?;
-                let object_info = if let Value::Object(ObjectValue {
-                    type_,
-                    has_public_transfer,
-                    ..
-                }) = &value
-                {
-                    let type_tag = context
-                        .session
-                        .get_type_tag(type_)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    let TypeTag::Struct(struct_tag) = type_tag else {
+    /// Checks that the non-entry function does not return references. And marks the return values
+    /// as object or non-object return values
+    fn check_non_entry_signature<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        _module_id: &ModuleId,
+        _function: &IdentStr,
+        signature: &LoadedFunctionInstantiation,
+    ) -> Result<Vec<ValueKind>, ExecutionError> {
+        signature
+            .return_
+            .iter()
+            .enumerate()
+            .map(|(idx, return_type)| {
+                let return_type = match return_type {
+                    // for dev-inspect, just dereference the value
+                    Type::Reference(inner) | Type::MutableReference(inner)
+                        if Mode::allow_arbitrary_values() =>
+                    {
+                        inner
+                    }
+                    Type::Reference(_) | Type::MutableReference(_) => {
+                        return Err(ExecutionError::from_kind(
+                            ExecutionErrorKind::InvalidPublicFunctionReturnType { idx: idx as u16 },
+                        ))
+                    }
+                    t => t,
+                };
+                let abilities = context
+                    .session
+                    .get_type_abilities(return_type)
+                    .map_err(|e| context.convert_vm_error(e))?;
+                Ok(match return_type {
+                    Type::MutableReference(_) | Type::Reference(_) => unreachable!(),
+                    Type::TyParam(_) => {
+                        invariant_violation!("TyParam should have been substituted")
+                    }
+                    Type::Struct(_) | Type::StructInstantiation(_, _) if abilities.has_key() => {
+                        let type_tag = context
+                            .session
+                            .get_type_tag(return_type)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        let TypeTag::Struct(struct_tag) = type_tag else {
                         invariant_violation!("Struct type make a non struct type tag")
                     };
-                    let type_ = (*struct_tag).into();
-                    ValueKind::Object {
-                        type_,
-                        has_public_transfer: *has_public_transfer,
+                        ValueKind::Object {
+                            type_: MoveObjectType::from(*struct_tag),
+                            has_public_transfer: abilities.has_store(),
+                        }
                     }
-                } else {
-                    let abilities = context
-                        .session
-                        .get_type_abilities(inner)
-                        .map_err(|e| context.convert_vm_error(e))?;
-                    ValueKind::Raw((**inner).clone(), abilities)
-                };
-                by_mut_ref.push((idx as LocalIndex, object_info));
-                (value, inner)
-            }
-            Type::Reference(inner) => (context.borrow_arg(idx, arg)?, inner),
-            t => {
-                let value = context.by_value_arg(command_kind, idx, arg)?;
-                (value, t)
-            }
-        };
-        if matches!(
-            function_kind,
-            FunctionKind::PrivateEntry | FunctionKind::Init
-        ) && value.was_used_in_non_entry_move_call()
-        {
-            return Err(command_argument_error(
-                CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
-                idx,
+                    Type::Struct(_)
+                    | Type::StructInstantiation(_, _)
+                    | Type::Bool
+                    | Type::U8
+                    | Type::U64
+                    | Type::U128
+                    | Type::Address
+                    | Type::Signer
+                    | Type::Vector(_)
+                    | Type::U16
+                    | Type::U32
+                    | Type::U256 => ValueKind::Raw(return_type.clone(), abilities),
+                })
+            })
+            .collect()
+    }
+
+    fn check_private_generics(
+        _context: &mut ExecutionContext,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        _type_arguments: &[Type],
+    ) -> Result<(), ExecutionError> {
+        let module_ident = (module_id.address(), module_id.name());
+        if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE) {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::NonEntryFunctionInvoked,
+                format!("Cannot directly call functions in sui::{}", EVENT_MODULE),
             ));
         }
-        check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
-        let bytes = {
-            let mut v = vec![];
-            value.write_bcs_bytes(&mut v);
-            v
-        };
-        serialized_args.push(bytes);
-    }
-    Ok((tx_ctx_kind, by_mut_ref, serialized_args))
-}
 
-/// checks that the value is compatible with the specified type
-fn check_param_type<Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    idx: usize,
-    value: &Value,
-    param_ty: &Type,
-) -> Result<(), ExecutionError> {
-    let ty = match value {
-        // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
-        // be violated (like for string or Option)
-        Value::Raw(RawValueType::Any, _) if Mode::allow_arbitrary_values() => return Ok(()),
-        // Any means this was just some bytes passed in as an argument (as opposed to being
-        // generated from a Move function). Meaning we only allow "primitive" values
-        // and might need to run validation in addition to the BCS layout
-        Value::Raw(RawValueType::Any, bytes) => {
-            let Some(layout) = primitive_serialization_layout(context, param_ty)? else {
+        if module_ident == (&SUI_FRAMEWORK_ADDRESS, TRANSFER_MODULE)
+            && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
+        {
+            let msg = format!(
+                "Cannot directly call sui::{m}::{f}. \
+            Use the public variant instead, sui::{m}::public_{f}",
+                m = TRANSFER_MODULE,
+                f = function
+            );
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::NonEntryFunctionInvoked,
+                msg,
+            ));
+        }
+
+        Ok(())
+    }
+
+    type ArgInfo = (
+        TxContextKind,
+        /* mut ref */
+        Vec<(LocalIndex, ValueKind)>,
+        Vec<Vec<u8>>,
+    );
+
+    /// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
+    /// each value
+    fn build_move_args<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        module_id: &ModuleId,
+        function: &IdentStr,
+        function_kind: FunctionKind,
+        signature: &LoadedFunctionInstantiation,
+        args: &[Argument],
+    ) -> Result<ArgInfo, ExecutionError> {
+        // check the arity
+        let parameters = &signature.parameters;
+        let tx_ctx_kind = match parameters.last() {
+            Some(t) => is_tx_context(context, t)?,
+            None => TxContextKind::None,
+        };
+        // an init function can have one or two arguments, with the last one always being of type
+        // &mut TxContext and the additional (first) one representing a one time witness type (see
+        // one_time_witness verifier pass for additional explanation)
+        let has_one_time_witness = function_kind == FunctionKind::Init && parameters.len() == 2;
+        let has_tx_context = tx_ctx_kind != TxContextKind::None;
+        let num_args = args.len() + (has_one_time_witness as usize) + (has_tx_context as usize);
+        if num_args != parameters.len() {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::ArityMismatch,
+                format!(
+                    "Expected {:?} argument{} calling function '{}', but found {:?}",
+                    parameters.len(),
+                    if parameters.len() == 1 { "" } else { "s" },
+                    function,
+                    num_args
+                ),
+            ));
+        }
+
+        // check the types and remember which are by mutable ref
+        let mut by_mut_ref = vec![];
+        let mut serialized_args = Vec::with_capacity(num_args);
+        let command_kind = CommandKind::MoveCall {
+            package: (*module_id.address()).into(),
+            module: module_id.name(),
+            function,
+        };
+        // an init function can have one or two arguments, with the last one always being of type
+        // &mut TxContext and the additional (first) one representing a one time witness type (see
+        // one_time_witness verifier pass for additional explanation)
+        if has_one_time_witness {
+            // one time witness type is a struct with a single bool filed which in bcs is encoded as
+            // 0x01
+            let bcs_true_value = bcs::to_bytes(&true).unwrap();
+            serialized_args.push(bcs_true_value)
+        }
+        for ((idx, arg), param_ty) in args.iter().copied().enumerate().zip(parameters) {
+            let (value, non_ref_param_ty): (Value, &Type) = match param_ty {
+                Type::MutableReference(inner) => {
+                    let value = context.borrow_arg_mut(idx, arg)?;
+                    let object_info = if let Value::Object(ObjectValue {
+                        type_,
+                        has_public_transfer,
+                        ..
+                    }) = &value
+                    {
+                        let type_tag = context
+                            .session
+                            .get_type_tag(type_)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        let TypeTag::Struct(struct_tag) = type_tag else {
+                        invariant_violation!("Struct type make a non struct type tag")
+                    };
+                        let type_ = (*struct_tag).into();
+                        ValueKind::Object {
+                            type_,
+                            has_public_transfer: *has_public_transfer,
+                        }
+                    } else {
+                        let abilities = context
+                            .session
+                            .get_type_abilities(inner)
+                            .map_err(|e| context.convert_vm_error(e))?;
+                        ValueKind::Raw((**inner).clone(), abilities)
+                    };
+                    by_mut_ref.push((idx as LocalIndex, object_info));
+                    (value, inner)
+                }
+                Type::Reference(inner) => (context.borrow_arg(idx, arg)?, inner),
+                t => {
+                    let value = context.by_value_arg(command_kind, idx, arg)?;
+                    (value, t)
+                }
+            };
+            if matches!(
+                function_kind,
+                FunctionKind::PrivateEntry | FunctionKind::Init
+            ) && value.was_used_in_non_entry_move_call()
+            {
+                return Err(command_argument_error(
+                    CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
+                    idx,
+                ));
+            }
+            check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
+            let bytes = {
+                let mut v = vec![];
+                value.write_bcs_bytes(&mut v);
+                v
+            };
+            serialized_args.push(bytes);
+        }
+        Ok((tx_ctx_kind, by_mut_ref, serialized_args))
+    }
+
+    /// checks that the value is compatible with the specified type
+    fn check_param_type<Mode: ExecutionMode>(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        idx: usize,
+        value: &Value,
+        param_ty: &Type,
+    ) -> Result<(), ExecutionError> {
+        let ty = match value {
+            // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
+            // be violated (like for string or Option)
+            Value::Raw(RawValueType::Any, _) if Mode::allow_arbitrary_values() => return Ok(()),
+            // Any means this was just some bytes passed in as an argument (as opposed to being
+            // generated from a Move function). Meaning we only allow "primitive" values
+            // and might need to run validation in addition to the BCS layout
+            Value::Raw(RawValueType::Any, bytes) => {
+                let Some(layout) = primitive_serialization_layout(context, param_ty)? else {
                 let msg = format!(
                     "Non-primitive argument at index {}. If it is an object, it must be \
                     populated by an object",
@@ -1360,323 +1363,325 @@ fn check_param_type<Mode: ExecutionMode>(
                     msg,
                 ));
             };
-            bcs_argument_validate(bytes, idx as u16, layout)?;
-            return Ok(());
+                bcs_argument_validate(bytes, idx as u16, layout)?;
+                return Ok(());
+            }
+            Value::Raw(RawValueType::Loaded { ty, abilities, .. }, _) => {
+                assert_invariant!(
+                    Mode::allow_arbitrary_values() || !abilities.has_key(),
+                    "Raw value should never be an object"
+                );
+                ty
+            }
+            Value::Object(obj) => &obj.type_,
+        };
+        if ty != param_ty {
+            Err(command_argument_error(
+                CommandArgumentError::TypeMismatch,
+                idx,
+            ))
+        } else {
+            Ok(())
         }
-        Value::Raw(RawValueType::Loaded { ty, abilities, .. }, _) => {
-            assert_invariant!(
-                Mode::allow_arbitrary_values() || !abilities.has_key(),
-                "Raw value should never be an object"
-            );
-            ty
-        }
-        Value::Object(obj) => &obj.type_,
-    };
-    if ty != param_ty {
-        Err(command_argument_error(
-            CommandArgumentError::TypeMismatch,
-            idx,
-        ))
-    } else {
-        Ok(())
     }
-}
 
-fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
-    let module_id = &s.defining_id;
-    let struct_name = &s.name;
-    (
-        module_id.address(),
-        module_id.name(),
-        struct_name.as_ident_str(),
-    )
-}
+    fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
+        let module_id = &s.defining_id;
+        let struct_name = &s.name;
+        (
+            module_id.address(),
+            module_id.name(),
+            struct_name.as_ident_str(),
+        )
+    }
 
-// Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
-// a MutableReference, and Immutable otherwise.
-// Returns None for all other types
-pub fn is_tx_context(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    t: &Type,
-) -> Result<TxContextKind, ExecutionError> {
-    let (is_mut, inner) = match t {
-        Type::MutableReference(inner) => (true, inner),
-        Type::Reference(inner) => (false, inner),
-        _ => return Ok(TxContextKind::None),
-    };
-    let Type::Struct(idx) = &**inner else { return Ok(TxContextKind::None) };
-    let Some(s) = context.session.get_struct_type(*idx) else {
+    // Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
+    // a MutableReference, and Immutable otherwise.
+    // Returns None for all other types
+    pub fn is_tx_context(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        t: &Type,
+    ) -> Result<TxContextKind, ExecutionError> {
+        let (is_mut, inner) = match t {
+            Type::MutableReference(inner) => (true, inner),
+            Type::Reference(inner) => (false, inner),
+            _ => return Ok(TxContextKind::None),
+        };
+        let Type::Struct(idx) = &**inner else { return Ok(TxContextKind::None) };
+        let Some(s) = context.session.get_struct_type(*idx) else {
         invariant_violation!("Loaded struct not found")
     };
-    let (module_addr, module_name, struct_name) = get_struct_ident(&s);
-    let is_tx_context_type = module_addr == &SUI_FRAMEWORK_ADDRESS
-        && module_name == TX_CONTEXT_MODULE_NAME
-        && struct_name == TX_CONTEXT_STRUCT_NAME;
-    Ok(if is_tx_context_type {
-        if is_mut {
-            TxContextKind::Mutable
+        let (module_addr, module_name, struct_name) = get_struct_ident(&s);
+        let is_tx_context_type = module_addr == &SUI_FRAMEWORK_ADDRESS
+            && module_name == TX_CONTEXT_MODULE_NAME
+            && struct_name == TX_CONTEXT_STRUCT_NAME;
+        Ok(if is_tx_context_type {
+            if is_mut {
+                TxContextKind::Mutable
+            } else {
+                TxContextKind::Immutable
+            }
         } else {
-            TxContextKind::Immutable
-        }
-    } else {
-        TxContextKind::None
-    })
-}
+            TxContextKind::None
+        })
+    }
 
-/// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
-fn primitive_serialization_layout(
-    context: &mut ExecutionContext<'_, '_, '_>,
-    param_ty: &Type,
-) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
-    Ok(match param_ty {
-        Type::Signer => return Ok(None),
-        Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
-            invariant_violation!("references and type parameters should be checked elsewhere")
-        }
-        Type::Bool => Some(PrimitiveArgumentLayout::Bool),
-        Type::U8 => Some(PrimitiveArgumentLayout::U8),
-        Type::U16 => Some(PrimitiveArgumentLayout::U16),
-        Type::U32 => Some(PrimitiveArgumentLayout::U32),
-        Type::U64 => Some(PrimitiveArgumentLayout::U64),
-        Type::U128 => Some(PrimitiveArgumentLayout::U128),
-        Type::U256 => Some(PrimitiveArgumentLayout::U256),
-        Type::Address => Some(PrimitiveArgumentLayout::Address),
+    /// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
+    fn primitive_serialization_layout(
+        context: &mut ExecutionContext<'_, '_, '_>,
+        param_ty: &Type,
+    ) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
+        Ok(match param_ty {
+            Type::Signer => return Ok(None),
+            Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
+                invariant_violation!("references and type parameters should be checked elsewhere")
+            }
+            Type::Bool => Some(PrimitiveArgumentLayout::Bool),
+            Type::U8 => Some(PrimitiveArgumentLayout::U8),
+            Type::U16 => Some(PrimitiveArgumentLayout::U16),
+            Type::U32 => Some(PrimitiveArgumentLayout::U32),
+            Type::U64 => Some(PrimitiveArgumentLayout::U64),
+            Type::U128 => Some(PrimitiveArgumentLayout::U128),
+            Type::U256 => Some(PrimitiveArgumentLayout::U256),
+            Type::Address => Some(PrimitiveArgumentLayout::Address),
 
-        Type::Vector(inner) => {
-            let info_opt = primitive_serialization_layout(context, inner)?;
-            info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
-        }
-        Type::StructInstantiation(idx, targs) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
+            Type::Vector(inner) => {
+                let info_opt = primitive_serialization_layout(context, inner)?;
+                info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
+            }
+            Type::StructInstantiation(idx, targs) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
                 invariant_violation!("Loaded struct not found")
             };
-            let resolved_struct = get_struct_ident(&s);
-            // is option of a string
-            if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
-                let info_opt = primitive_serialization_layout(context, &targs[0])?;
-                info_opt.map(|layout| PrimitiveArgumentLayout::Option(Box::new(layout)))
-            } else {
-                None
+                let resolved_struct = get_struct_ident(&s);
+                // is option of a string
+                if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
+                    let info_opt = primitive_serialization_layout(context, &targs[0])?;
+                    info_opt.map(|layout| PrimitiveArgumentLayout::Option(Box::new(layout)))
+                } else {
+                    None
+                }
             }
-        }
-        Type::Struct(idx) => {
-            let Some(s) = context.session.get_struct_type(*idx) else {
+            Type::Struct(idx) => {
+                let Some(s) = context.session.get_struct_type(*idx) else {
                 invariant_violation!("Loaded struct not found")
             };
-            let resolved_struct = get_struct_ident(&s);
-            if resolved_struct == RESOLVED_SUI_ID {
-                Some(PrimitiveArgumentLayout::Address)
-            } else if resolved_struct == RESOLVED_ASCII_STR {
-                Some(PrimitiveArgumentLayout::Ascii)
-            } else if resolved_struct == RESOLVED_UTF8_STR {
-                Some(PrimitiveArgumentLayout::UTF8)
-            } else {
-                None
+                let resolved_struct = get_struct_ident(&s);
+                if resolved_struct == RESOLVED_SUI_ID {
+                    Some(PrimitiveArgumentLayout::Address)
+                } else if resolved_struct == RESOLVED_ASCII_STR {
+                    Some(PrimitiveArgumentLayout::Ascii)
+                } else if resolved_struct == RESOLVED_UTF8_STR {
+                    Some(PrimitiveArgumentLayout::UTF8)
+                } else {
+                    None
+                }
             }
-        }
-    })
-}
+        })
+    }
 
-/***************************************************************************************************
- * Special serialization formats
- **************************************************************************************************/
+    /***************************************************************************************************
+     * Special serialization formats
+     **************************************************************************************************/
 
-/// Special enum for values that need additional validation, in other words
-/// There is validation to do on top of the BCS layout. Currently only needed for
-/// strings
-#[derive(Debug)]
-pub enum PrimitiveArgumentLayout {
-    /// An option
-    Option(Box<PrimitiveArgumentLayout>),
-    /// A vector
-    Vector(Box<PrimitiveArgumentLayout>),
-    /// An ASCII encoded string
-    Ascii,
-    /// A UTF8 encoded string
-    UTF8,
-    // needed for Option validation
-    Bool,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    U256,
-    Address,
-}
+    /// Special enum for values that need additional validation, in other words
+    /// There is validation to do on top of the BCS layout. Currently only needed for
+    /// strings
+    #[derive(Debug)]
+    pub enum PrimitiveArgumentLayout {
+        /// An option
+        Option(Box<PrimitiveArgumentLayout>),
+        /// A vector
+        Vector(Box<PrimitiveArgumentLayout>),
+        /// An ASCII encoded string
+        Ascii,
+        /// A UTF8 encoded string
+        UTF8,
+        // needed for Option validation
+        Bool,
+        U8,
+        U16,
+        U32,
+        U64,
+        U128,
+        U256,
+        Address,
+    }
 
-impl PrimitiveArgumentLayout {
-    /// returns true iff all BCS compatible bytes are actually values for this type.
-    /// For example, this function returns false for Option and Strings since they need additional
-    /// validation.
-    pub fn bcs_only(&self) -> bool {
-        match self {
-            // have additional restrictions past BCS
-            PrimitiveArgumentLayout::Option(_)
-            | PrimitiveArgumentLayout::Ascii
-            | PrimitiveArgumentLayout::UTF8 => false,
-            // Move primitives are BCS compatible and do not need additional validation
-            PrimitiveArgumentLayout::Bool
-            | PrimitiveArgumentLayout::U8
-            | PrimitiveArgumentLayout::U16
-            | PrimitiveArgumentLayout::U32
-            | PrimitiveArgumentLayout::U64
-            | PrimitiveArgumentLayout::U128
-            | PrimitiveArgumentLayout::U256
-            | PrimitiveArgumentLayout::Address => true,
-            // vector only needs validation if it's inner type does
-            PrimitiveArgumentLayout::Vector(inner) => inner.bcs_only(),
+    impl PrimitiveArgumentLayout {
+        /// returns true iff all BCS compatible bytes are actually values for this type.
+        /// For example, this function returns false for Option and Strings since they need additional
+        /// validation.
+        pub fn bcs_only(&self) -> bool {
+            match self {
+                // have additional restrictions past BCS
+                PrimitiveArgumentLayout::Option(_)
+                | PrimitiveArgumentLayout::Ascii
+                | PrimitiveArgumentLayout::UTF8 => false,
+                // Move primitives are BCS compatible and do not need additional validation
+                PrimitiveArgumentLayout::Bool
+                | PrimitiveArgumentLayout::U8
+                | PrimitiveArgumentLayout::U16
+                | PrimitiveArgumentLayout::U32
+                | PrimitiveArgumentLayout::U64
+                | PrimitiveArgumentLayout::U128
+                | PrimitiveArgumentLayout::U256
+                | PrimitiveArgumentLayout::Address => true,
+                // vector only needs validation if it's inner type does
+                PrimitiveArgumentLayout::Vector(inner) => inner.bcs_only(),
+            }
         }
     }
-}
 
-/// Checks the bytes against the `SpecialArgumentLayout` using `bcs`. It does not actually generate
-/// the deserialized value, only walks the bytes. While not necessary if the layout does not contain
-/// special arguments (e.g. Option or String) we check the BCS bytes for predictability
-pub fn bcs_argument_validate(
-    bytes: &[u8],
-    idx: u16,
-    layout: PrimitiveArgumentLayout,
-) -> Result<(), ExecutionError> {
-    bcs::from_bytes_seed(&layout, bytes).map_err(|_| {
-        ExecutionError::new_with_source(
-            ExecutionErrorKind::command_argument_error(CommandArgumentError::InvalidBCSBytes, idx),
-            format!("Function expects {layout} but provided argument's value does not match",),
-        )
-    })
-}
+    /// Checks the bytes against the `SpecialArgumentLayout` using `bcs`. It does not actually generate
+    /// the deserialized value, only walks the bytes. While not necessary if the layout does not contain
+    /// special arguments (e.g. Option or String) we check the BCS bytes for predictability
+    pub fn bcs_argument_validate(
+        bytes: &[u8],
+        idx: u16,
+        layout: PrimitiveArgumentLayout,
+    ) -> Result<(), ExecutionError> {
+        bcs::from_bytes_seed(&layout, bytes).map_err(|_| {
+            ExecutionError::new_with_source(
+                ExecutionErrorKind::command_argument_error(
+                    CommandArgumentError::InvalidBCSBytes,
+                    idx,
+                ),
+                format!("Function expects {layout} but provided argument's value does not match",),
+            )
+        })
+    }
 
-impl<'d> serde::de::DeserializeSeed<'d> for &PrimitiveArgumentLayout {
-    type Value = ();
-    fn deserialize<D: serde::de::Deserializer<'d>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
-        use serde::de::Error;
-        match self {
-            PrimitiveArgumentLayout::Ascii => {
-                let s: &str = serde::Deserialize::deserialize(deserializer)?;
-                if !s.is_ascii() {
-                    Err(D::Error::custom("not an ascii string"))
-                } else {
+    impl<'d> serde::de::DeserializeSeed<'d> for &PrimitiveArgumentLayout {
+        type Value = ();
+        fn deserialize<D: serde::de::Deserializer<'d>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            use serde::de::Error;
+            match self {
+                PrimitiveArgumentLayout::Ascii => {
+                    let s: &str = serde::Deserialize::deserialize(deserializer)?;
+                    if !s.is_ascii() {
+                        Err(D::Error::custom("not an ascii string"))
+                    } else {
+                        Ok(())
+                    }
+                }
+                PrimitiveArgumentLayout::UTF8 => {
+                    deserializer.deserialize_string(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::Option(layout) => {
+                    deserializer.deserialize_option(OptionElementVisitor(layout))
+                }
+                PrimitiveArgumentLayout::Vector(layout) => {
+                    deserializer.deserialize_seq(VectorElementVisitor(layout))
+                }
+                // primitive move value cases, which are hit to make sure the correct number of bytes
+                // are removed for elements of an option/vector
+                PrimitiveArgumentLayout::Bool => {
+                    deserializer.deserialize_bool(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U8 => {
+                    deserializer.deserialize_u8(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U16 => {
+                    deserializer.deserialize_u16(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U32 => {
+                    deserializer.deserialize_u32(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U64 => {
+                    deserializer.deserialize_u64(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U128 => {
+                    deserializer.deserialize_u128(serde::de::IgnoredAny)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::U256 => {
+                    U256::deserialize(deserializer)?;
+                    Ok(())
+                }
+                PrimitiveArgumentLayout::Address => {
+                    SuiAddress::deserialize(deserializer)?;
                     Ok(())
                 }
             }
-            PrimitiveArgumentLayout::UTF8 => {
-                deserializer.deserialize_string(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::Option(layout) => {
-                deserializer.deserialize_option(OptionElementVisitor(layout))
-            }
-            PrimitiveArgumentLayout::Vector(layout) => {
-                deserializer.deserialize_seq(VectorElementVisitor(layout))
-            }
-            // primitive move value cases, which are hit to make sure the correct number of bytes
-            // are removed for elements of an option/vector
-            PrimitiveArgumentLayout::Bool => {
-                deserializer.deserialize_bool(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U8 => {
-                deserializer.deserialize_u8(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U16 => {
-                deserializer.deserialize_u16(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U32 => {
-                deserializer.deserialize_u32(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U64 => {
-                deserializer.deserialize_u64(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U128 => {
-                deserializer.deserialize_u128(serde::de::IgnoredAny)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::U256 => {
-                U256::deserialize(deserializer)?;
-                Ok(())
-            }
-            PrimitiveArgumentLayout::Address => {
-                SuiAddress::deserialize(deserializer)?;
-                Ok(())
+        }
+    }
+
+    struct VectorElementVisitor<'a>(&'a PrimitiveArgumentLayout);
+
+    impl<'d, 'a> serde::de::Visitor<'d> for VectorElementVisitor<'a> {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Vector")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'d>,
+        {
+            while seq.next_element_seed(self.0)?.is_some() {}
+            Ok(())
+        }
+    }
+
+    struct OptionElementVisitor<'a>(&'a PrimitiveArgumentLayout);
+
+    impl<'d, 'a> serde::de::Visitor<'d> for OptionElementVisitor<'a> {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Option")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(())
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'d>,
+        {
+            self.0.deserialize(deserializer)
+        }
+    }
+
+    impl fmt::Display for PrimitiveArgumentLayout {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                PrimitiveArgumentLayout::Vector(inner) => {
+                    write!(f, "vector<{inner}>")
+                }
+                PrimitiveArgumentLayout::Option(inner) => {
+                    write!(f, "std::option::Option<{inner}>")
+                }
+                PrimitiveArgumentLayout::Ascii => {
+                    write!(f, "std::{}::{}", RESOLVED_ASCII_STR.1, RESOLVED_ASCII_STR.2)
+                }
+                PrimitiveArgumentLayout::UTF8 => {
+                    write!(f, "std::{}::{}", RESOLVED_UTF8_STR.1, RESOLVED_UTF8_STR.2)
+                }
+                PrimitiveArgumentLayout::Bool => write!(f, "bool"),
+                PrimitiveArgumentLayout::U8 => write!(f, "u8"),
+                PrimitiveArgumentLayout::U16 => write!(f, "u16"),
+                PrimitiveArgumentLayout::U32 => write!(f, "u32"),
+                PrimitiveArgumentLayout::U64 => write!(f, "u64"),
+                PrimitiveArgumentLayout::U128 => write!(f, "u128"),
+                PrimitiveArgumentLayout::U256 => write!(f, "u256"),
+                PrimitiveArgumentLayout::Address => write!(f, "address"),
             }
         }
     }
-}
-
-struct VectorElementVisitor<'a>(&'a PrimitiveArgumentLayout);
-
-impl<'d, 'a> serde::de::Visitor<'d> for VectorElementVisitor<'a> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("Vector")
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: serde::de::SeqAccess<'d>,
-    {
-        while seq.next_element_seed(self.0)?.is_some() {}
-        Ok(())
-    }
-}
-
-struct OptionElementVisitor<'a>(&'a PrimitiveArgumentLayout);
-
-impl<'d, 'a> serde::de::Visitor<'d> for OptionElementVisitor<'a> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("Option")
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(())
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'d>,
-    {
-        self.0.deserialize(deserializer)
-    }
-}
-
-impl fmt::Display for PrimitiveArgumentLayout {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PrimitiveArgumentLayout::Vector(inner) => {
-                write!(f, "vector<{inner}>")
-            }
-            PrimitiveArgumentLayout::Option(inner) => {
-                write!(f, "std::option::Option<{inner}>")
-            }
-            PrimitiveArgumentLayout::Ascii => {
-                write!(f, "std::{}::{}", RESOLVED_ASCII_STR.1, RESOLVED_ASCII_STR.2)
-            }
-            PrimitiveArgumentLayout::UTF8 => {
-                write!(f, "std::{}::{}", RESOLVED_UTF8_STR.1, RESOLVED_UTF8_STR.2)
-            }
-            PrimitiveArgumentLayout::Bool => write!(f, "bool"),
-            PrimitiveArgumentLayout::U8 => write!(f, "u8"),
-            PrimitiveArgumentLayout::U16 => write!(f, "u16"),
-            PrimitiveArgumentLayout::U32 => write!(f, "u32"),
-            PrimitiveArgumentLayout::U64 => write!(f, "u64"),
-            PrimitiveArgumentLayout::U128 => write!(f, "u128"),
-            PrimitiveArgumentLayout::U256 => write!(f, "u256"),
-            PrimitiveArgumentLayout::Address => write!(f, "address"),
-        }
-    }
-}
-
 }


### PR DESCRIPTION
## Description 

Usage of the `checked_arithmetic` macro was causing a number of quality-of-life issues for development around formatting and LSP support. However, converting to an attribute-based procedural macro for adding checked arithmetic operations solves all of these issues (LSPs and autoformatters should now work with it).

Note that this only works on explicitly declared modules due to (current) Rust restrictions, and you cannot annotate a file-based module with this attribute macro.

This also required expanding the applicability of the `with_checked_arithmetic` macro to work over more forms than it previously handled, however the change is pretty straightforward.

The one downside to it is that this introduces some slight boilerplate of

```rust
pub use checked::*;
mod checked {
// what was previously inside the `checked_aritmetic` macro + imports
}
```

## Test Plan 

Added an additional test to make sure the behavior of code within a module annotated with `with_checked_arithmetic` behaves in the same way as code within a `checked_arithmetic` block. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
