### PR TITLE
make non recoverable error client error

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -801,8 +801,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Index store not available on this Fullnode."];
             expected.assert_eq(error_object.message());
         }
@@ -832,8 +834,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Storage error"];
             expected.assert_eq(error_object.message());
         }
@@ -1129,8 +1133,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Index store not available on this Fullnode."];
             expected.assert_eq(error_object.message());
         }
@@ -1160,8 +1166,10 @@ mod tests {
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
 
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Error executing mock db error"];
             expected.assert_eq(error_object.message());
         }
@@ -1259,8 +1267,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Index store not available on this Fullnode."];
             expected.assert_eq(error_object.message());
         }
@@ -1429,8 +1439,10 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            let expected = expect!["-32000"];
-            expected.assert_eq(&error_object.code().to_string());
+            assert_eq!(
+                error_object.code(),
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE
+            );
             let expected = expect!["Failure deserializing object in the requested format: \"Unable to deserialize TreasuryCap object: remaining input\""];
             expected.assert_eq(error_object.message());
         }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -77,6 +77,7 @@ impl From<SuiError> for Error {
 }
 
 impl Error {
+    /// `InvalidParams`/`INVALID_PARAMS_CODE` for client errors.
     pub fn to_rpc_error(self) -> RpcError {
         match self {
             Error::UserInputError(user_input_error) => {
@@ -93,8 +94,13 @@ impl Error {
             },
             Error::QuorumDriverError(err) => match err {
                 QuorumDriverError::NonRecoverableTransactionError { errors } => {
-                    let error_object =
-                        ErrorObject::owned(-32000, NON_RECOVERABLE_ERROR_MSG, Some(errors));
+                    // Note: we probably want a more precise error than `INVALID_PARAMS_CODE`
+                    // but to keep the error code consistent we still use `INVALID_PARAMS_CODE`
+                    let error_object = ErrorObject::owned(
+                        jsonrpsee::types::error::INVALID_PARAMS_CODE,
+                        NON_RECOVERABLE_ERROR_MSG,
+                        Some(errors),
+                    );
                     RpcError::Call(CallError::Custom(error_object))
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -221,7 +221,7 @@ impl Logger for MetricsLogger {
             .observe(req_latency_secs);
 
         if let Some(code) = error_code {
-            if code == -32000 {
+            if code == jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE {
                 self.metrics
                     .server_errors_by_route
                     .with_label_values(&[method_name])


### PR DESCRIPTION
## Description 

`QuorumDriverError::NonRecoverableTransactionError` indicates an error in the user transaction, so should be a client error.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Change `QuorumDriverError::NonRecoverableTransactionError`'s error code from -32000 to -32602