### PR TITLE
[wallet-ext] exclude transactions from Ethos 8192 from analytics tracking 

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -22,6 +22,12 @@ export type TransactionRequestProps = {
 	txRequest: TransactionApprovalRequest;
 };
 
+// Some applications require *a lot* of transactions to interact with, and this
+// eats up our analytics event quota. As a short-term solution so we don't have
+// to stop tracking this event entirely, we'll just manually exclude application
+// origins with this list
+const appOriginsToExcludeFromAnalytics = ['https://sui8192.ethoswallet.xyz'];
+
 export function TransactionRequest({ txRequest }: TransactionRequestProps) {
 	const addressForTransaction = txRequest.tx.account;
 	const signer = useSigner(addressForTransaction);
@@ -73,11 +79,13 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
 							clientIdentifier,
 						}),
 					);
-					ampli.respondedToTransactionRequest({
-						applicationUrl: txRequest.origin,
-						approvedTransaction: approved,
-						receivedFailureWarning: false,
-					});
+					if (!appOriginsToExcludeFromAnalytics.includes(txRequest.origin)) {
+						ampli.respondedToTransactionRequest({
+							applicationUrl: txRequest.origin,
+							approvedTransaction: approved,
+							receivedFailureWarning: false,
+						});
+					}
 				}}
 				address={addressForTransaction}
 				approveLoading={isLoading || isConfirmationVisible}


### PR DESCRIPTION
## Description 
Ethos 8192 requires a lot of transactions to play, and it's starting to eat into our Amplitude event quota (5 mil events a day at this rate). Since we don't have the governance add-on, we can just manually exclude these transactions with a simple blocklist for the time being. 


## Test Plan 
- Manual testing
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
