### PR TITLE
[wallet-ext] - assets page fixes

### DIFF
--- a/apps/core/src/hooks/useOnScreen.ts
+++ b/apps/core/src/hooks/useOnScreen.ts
@@ -1,32 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useEffect, type MutableRefObject, useRef } from 'react';
+import { useState, useEffect, MutableRefObject } from 'react';
 
-export const useOnScreen = (ref: MutableRefObject<Element | null>) => {
+export const useOnScreen = (elementRef: MutableRefObject<Element | null>) => {
 	const [isIntersecting, setIsIntersecting] = useState(false);
 
-	const observerRef = useRef<IntersectionObserver>();
-	if (!observerRef.current) {
-		observerRef.current = new IntersectionObserver(
-			([entry]) => setIsIntersecting(entry.isIntersecting),
-			{
-				threshold: [0.01],
-			},
-		);
-	}
-
 	useEffect(() => {
-		const currObserver = observerRef.current;
+		const node = elementRef.current;
+		if (!node) return;
 
-		if (ref.current && currObserver) {
-			currObserver.observe(ref.current);
-		}
-
-		return () => {
-			currObserver && currObserver.disconnect();
-		};
-	});
+		const observer = new IntersectionObserver(
+			([entry]: IntersectionObserverEntry[]): void => {
+				setIsIntersecting(entry.isIntersecting);
+			},
+			{ threshold: 0.01 },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [elementRef]);
 
 	return { isIntersecting };
 };

--- a/apps/wallet/src/ui/app/components/nft-display/Kiosk.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/Kiosk.tsx
@@ -19,35 +19,32 @@ const clipPath = '[clip-path:inset(0_0_7px_0_round_12px)] group-hover:[clip-path
 
 const timing = 'transition-all duration-300 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)]';
 const cardStyles = [
-	`scale-100 group-hover:scale-95 object-cover origin-bottom z-20 group-hover:translate-y-0 translate-y-2 group-hover:shadow-md`,
-	`scale-[0.95] group-hover:-rotate-6 group-hover:-translate-x-5 group-hover:-translate-y-2 z-10 translate-y-0 group-hover:shadow-md`,
-	`scale-[0.90] group-hover:rotate-6 group-hover:translate-x-5 group-hover:-translate-y-2 z-0 -translate-y-2 group-hover:shadow-xl`,
+	`scale-100 group-hover:scale-95 object-cover origin-bottom z-30 group-hover:translate-y-0 translate-y-2 group-hover:shadow-md`,
+	`scale-[0.95] group-hover:-rotate-6 group-hover:-translate-x-5 group-hover:-translate-y-2 z-20 translate-y-0 group-hover:shadow-md`,
+	`scale-[0.90] group-hover:rotate-6 group-hover:translate-x-5 group-hover:-translate-y-2 z-10 -translate-y-2 group-hover:shadow-xl`,
 ];
 
 export function Kiosk({ object, orientation, ...nftImageProps }: KioskProps) {
 	const address = useActiveAddress();
 	const { data: kioskData, isLoading } = useGetKioskContents(address);
 
-	if (isLoading) return null;
 	const kioskId = getKioskIdFromOwnerCap(object);
 	const kiosk = kioskData?.kiosks.get(kioskId!);
 	const itemsWithDisplay = kiosk?.items.filter((item) => hasDisplayData(item)) ?? [];
-	const items = kiosk?.items?.sort((item) => (hasDisplayData(item) ? -1 : 1)) ?? [];
 
 	const showCardStackAnimation = itemsWithDisplay.length > 1 && orientation !== 'horizontal';
 	const imagesToDisplay = orientation !== 'horizontal' ? 3 : 1;
+	const items = kiosk?.items.slice(0, imagesToDisplay) ?? [];
+
+	if (isLoading) return null;
 
 	return (
-		<div
-			className={cl(
-				'relative hover:bg-transparent group rounded-xl transform-gpu overflow-visible w-36 h-36',
-			)}
-		>
+		<div className="relative hover:bg-transparent group rounded-xl transform-gpu overflow-visible w-36 h-36">
 			<div className="absolute z-0">
 				{itemsWithDisplay.length === 0 ? (
 					<NftImage animateHover src={null} name="Kiosk" {...nftImageProps} />
-				) : items?.length ? (
-					items.slice(0, imagesToDisplay).map((item, idx) => {
+				) : (
+					items.map((item, idx) => {
 						const display = getObjectDisplay(item)?.data;
 						return (
 							<div
@@ -69,7 +66,7 @@ export function Kiosk({ object, orientation, ...nftImageProps }: KioskProps) {
 							</div>
 						);
 					})
-				) : null}
+				)}
 			</div>
 			{orientation !== 'horizontal' && (
 				<div

--- a/apps/wallet/src/ui/app/pages/home/kiosk-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/kiosk-details/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { hasDisplayData, useGetKioskContents } from '@mysten/core';
+import { useGetKioskContents } from '@mysten/core';
 import { formatAddress } from '@mysten/sui.js/utils';
 import { useSearchParams, Link } from 'react-router-dom';
 
@@ -11,6 +11,7 @@ import { LabelValuesContainer } from '_src/ui/app/components/LabelValuesContaine
 import { ErrorBoundary } from '_src/ui/app/components/error-boundary';
 import ExplorerLink from '_src/ui/app/components/explorer-link';
 import { ExplorerLinkType } from '_src/ui/app/components/explorer-link/ExplorerLinkType';
+import Loading from '_src/ui/app/components/loading';
 import { NFTDisplayCard } from '_src/ui/app/components/nft-display';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 import { Collapse } from '_src/ui/app/shared/collapse';
@@ -19,23 +20,22 @@ function KioskDetailsPage() {
 	const [searchParams] = useSearchParams();
 	const kioskId = searchParams.get('kioskId');
 	const accountAddress = useActiveAddress();
-	const { data: kioskData } = useGetKioskContents(accountAddress);
+	const { data: kioskData, isLoading } = useGetKioskContents(accountAddress);
 	const kiosk = kioskData?.kiosks.get(kioskId!);
 	const items = kiosk?.items;
 
 	return (
 		<div className="flex flex-1 flex-col flex-nowrap gap-3.75 mb-10">
 			<PageTitle title="Kiosk" back />
-			{!items?.length ? (
-				<div className="flex flex-1 items-center self-center text-caption font-semibold text-steel-darker">
-					Kiosk is empty
-				</div>
-			) : (
-				<>
-					<div className="grid grid-cols-3 gap-3 items-center justify-center mb-auto">
-						{items
-							?.sort((item) => (hasDisplayData(item) ? -1 : 1))
-							.map((item) => (
+			<Loading loading={isLoading}>
+				{!items?.length ? (
+					<div className="flex flex-1 items-center self-center text-caption font-semibold text-steel-darker">
+						Kiosk is empty
+					</div>
+				) : (
+					<>
+						<div className="grid grid-cols-3 gap-3 items-center justify-center mb-auto">
+							{items.map((item) => (
 								<Link
 									to={`/nft-details?${new URLSearchParams({
 										objectId: item.data?.objectId!,
@@ -55,26 +55,27 @@ function KioskDetailsPage() {
 									</ErrorBoundary>
 								</Link>
 							))}
-					</div>
-				</>
-			)}
-			<Collapse initialIsOpen title="Details">
-				<LabelValuesContainer>
-					<LabelValueItem label="Number of Items" value={items?.length || '0'} />
-					<LabelValueItem
-						label="Kiosk ID"
-						value={
-							<ExplorerLink
-								className="text-hero-dark no-underline font-mono"
-								objectID={kioskId!}
-								type={ExplorerLinkType.object}
-							>
-								{formatAddress(kioskId!)}
-							</ExplorerLink>
-						}
-					/>
-				</LabelValuesContainer>
-			</Collapse>
+						</div>
+					</>
+				)}
+				<Collapse initialIsOpen title="Details">
+					<LabelValuesContainer>
+						<LabelValueItem label="Number of Items" value={items?.length || '0'} />
+						<LabelValueItem
+							label="Kiosk ID"
+							value={
+								<ExplorerLink
+									className="text-hero-dark no-underline font-mono"
+									objectID={kioskId!}
+									type={ExplorerLinkType.object}
+								>
+									{formatAddress(kioskId!)}
+								</ExplorerLink>
+							}
+						/>
+					</LabelValuesContainer>
+				</Collapse>
+			</Loading>
 		</div>
 	);
 }

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -45,7 +45,7 @@ function NftsPage() {
 		if (isIntersecting && hasNextPage && !isFetchingNextPage) {
 			fetchNextPage();
 		}
-	}, [ownedAssets.length, isIntersecting, fetchNextPage, hasNextPage, isFetchingNextPage]);
+	}, [isIntersecting, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
 	useEffect(() => {
 		(async () => {
@@ -219,13 +219,6 @@ function NftsPage() {
 								</div>
 							</Link>
 						))}
-						<div ref={observerElem}>
-							{isSpinnerVisible ? (
-								<div className="mt-1 flex w-full justify-center">
-									<LoadingSpinner />
-								</div>
-							) : null}
-						</div>
 					</div>
 				) : (
 					<div className="flex flex-1 items-center self-center text-caption font-semibold text-steel-darker">
@@ -233,6 +226,13 @@ function NftsPage() {
 					</div>
 				)}
 			</Loading>
+			<div className="mb-5" ref={observerElem}>
+				{isSpinnerVisible ? (
+					<div className="mt-1 flex w-full justify-center">
+						<LoadingSpinner />
+					</div>
+				) : null}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Description 

Fixes a few issues that I noticed with the assets page / kiosks that didn't present themselves in local development for some reason (maybe due to minifying / webpack config 🤨)

- While debugging, I noticed that `useOnScreen` was triggering a large amount of re-renders, so I cleaned it up a bit and it seems to be happy now :) 
- Removed sorting by `display` as this was causing inconsistencies in rendering between the Asset page and Kiosk detail page. This wasn't really needed in the first place
- Added a loading spinner to the Kiosk detail page

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
