### PR TITLE
[move-compiler] Suppressed linter warnings in Sui stdlib

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/display.move
+++ b/crates/sui-framework/packages/sui-framework/sources/display.move
@@ -102,6 +102,7 @@ module sui::display {
 
     // === Entry functions: Create ===
 
+    #[lint_allow(self_transfer)]
     /// Create a new empty Display<T> object and keep it.
     entry public fun create_and_keep<T: key>(pub: &Publisher, ctx: &mut TxContext) {
         transfer::public_transfer(new<T>(pub, ctx), sender(ctx))

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -173,6 +173,7 @@ module sui::kiosk {
 
     // === Kiosk packing and unpacking ===
 
+    #[lint_allow(self_transfer, share_owned)]
     /// Creates a new Kiosk in a default configuration: sender receives the
     /// `KioskOwnerCap` and becomes the Owner, the `Kiosk` is shared.
     entry fun default(ctx: &mut TxContext) {

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -128,6 +128,7 @@ module sui::transfer_policy {
         )
     }
 
+    #[lint_allow(self_transfer, share_owned)]
     /// Initialize the Tranfer Policy in the default scenario: Create and share
     /// the `TransferPolicy`, transfer `TransferPolicyCap` to the transaction
     /// sender.

--- a/crates/sui-framework/packages/sui-framework/sources/package.move
+++ b/crates/sui-framework/packages/sui-framework/sources/package.move
@@ -102,6 +102,7 @@ module sui::package {
         }
     }
 
+    #[lint_allow(self_transfer)]
     /// Claim a Publisher object and send it to transaction sender.
     /// Since this function can only be called in the module initializer,
     /// the sender is the publisher.

--- a/crates/sui-framework/packages/sui-framework/sources/pay.move
+++ b/crates/sui-framework/packages/sui-framework/sources/pay.move
@@ -11,6 +11,7 @@ module sui::pay {
     /// For when empty vector is supplied into join function.
     const ENoCoins: u64 = 0;
 
+    #[lint_allow(self_transfer)]
     /// Transfer `c` to the sender of the current transaction
     public fun keep<T>(c: Coin<T>, ctx: &TxContext) {
         transfer::public_transfer(c, tx_context::sender(ctx))
@@ -45,6 +46,7 @@ module sui::pay {
     }
 
 
+    #[lint_allow(self_transfer)]
     /// Divide coin `self` into `n - 1` coins with equal balances. If the balance is
     /// not evenly divisible by `n`, the remainder is left in `self`.
     public entry fun divide_and_keep<T>(


### PR DESCRIPTION
## Description 

Recently added support for suppressing linter warnings (https://github.com/MystenLabs/sui/pull/13012) allows us to suppress linter warning in Sui stdlib so that developers building Move sources only see warnings pertaining to their own code.

Perhaps some of these suppressions should actually result in the rewrite of the library but this is beyond the scope of this PR.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Developers trying recently introduced linters might have seen linter warnings coming from Sui standard library which are from now on going to be suppressed