### PR TITLE
Rework the transaction block is method

### DIFF
--- a/.changeset/kind-insects-shake.md
+++ b/.changeset/kind-insects-shake.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Add new `isTransactionBlock` method, and deprecate the previous `TransactionBlock.is` method

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { isTransactionBlock } from '@mysten/sui.js/transactions';
 import { toB64, fromB64 } from '@mysten/sui.js/utils';
 import {
 	SUI_CHAINS,
@@ -234,7 +234,7 @@ export class SuiWallet implements Wallet {
 	};
 
 	#signTransactionBlock: SuiSignTransactionBlockMethod = async (input) => {
-		if (!TransactionBlock.is(input.transactionBlock)) {
+		if (!isTransactionBlock(input.transactionBlock)) {
 			throw new Error(
 				'Unexpect transaction format found. Ensure that you are using the `Transaction` class.',
 			);
@@ -256,7 +256,7 @@ export class SuiWallet implements Wallet {
 	};
 
 	#signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod = async (input) => {
-		if (!TransactionBlock.is(input.transactionBlock)) {
+		if (!isTransactionBlock(input.transactionBlock)) {
 			throw new Error(
 				'Unexpect transaction format found. Ensure that you are using the `Transaction` class.',
 			);

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -134,11 +134,17 @@ interface BuildOptions {
 	limits?: Limits;
 }
 
+export function isTransactionBlock(obj: unknown): obj is TransactionBlock {
+	return !!obj && typeof obj === 'object' && (obj as any)[TRANSACTION_BRAND] === true;
+}
+
 /**
  * Transaction Builder
  */
 export class TransactionBlock {
-	/** Returns `true` if the object is an instance of the Transaction builder class. */
+	/** Returns `true` if the object is an instance of the Transaction builder class.
+	 * @deprecated Use `isTransactionBlock` from `@mysten/sui.js/transactions` instead.
+	 */
 	static is(obj: unknown): obj is TransactionBlock {
 		return !!obj && typeof obj === 'object' && (obj as any)[TRANSACTION_BRAND] === true;
 	}

--- a/sdk/typescript/src/builder/export.ts
+++ b/sdk/typescript/src/builder/export.ts
@@ -3,4 +3,4 @@
 
 export { Inputs } from './Inputs.js';
 export { Transactions, type TransactionArgument } from './Transactions.js';
-export { TransactionBlock } from './TransactionBlock.js';
+export { TransactionBlock, isTransactionBlock } from './TransactionBlock.js';

--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -55,7 +55,8 @@ import {
 } from '../utils/sui-types.js';
 import { fromB58, toB64, toHEX } from '@mysten/bcs';
 import type { SerializedSignature } from '../cryptography/signature.js';
-import { TransactionBlock } from '../builder/index.js';
+import type { TransactionBlock } from '../builder/index.js';
+import { isTransactionBlock } from '../builder/index.js';
 import { SuiHTTPTransport } from './http-transport.js';
 import type { SuiTransport } from './http-transport.js';
 import type { Keypair } from '../cryptography/index.js';
@@ -569,7 +570,7 @@ export class SuiClient {
 		epoch?: string | null;
 	}): Promise<DevInspectResults> {
 		let devInspectTxBytes;
-		if (TransactionBlock.is(input.transactionBlock)) {
+		if (isTransactionBlock(input.transactionBlock)) {
 			input.transactionBlock.setSenderIfNotSet(input.sender);
 			devInspectTxBytes = toB64(
 				await input.transactionBlock.build({

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -52,7 +52,8 @@ import { fromB58, toB64, toHEX } from '@mysten/bcs';
 import type { SerializedSignature } from '../cryptography/signature.js';
 import type { Connection } from '../rpc/connection.js';
 import { devnetConnection } from '../rpc/connection.js';
-import { TransactionBlock } from '../builder/index.js';
+import type { TransactionBlock } from '../builder/index.js';
+import { isTransactionBlock } from '../builder/index.js';
 import { CheckpointPage } from '../types/checkpoints.js';
 import { NetworkMetrics, AddressMetrics, AllEpochsAddressMetrics } from '../types/metrics.js';
 import { EpochInfo, EpochPage } from '../types/epochs.js';
@@ -611,7 +612,7 @@ export class JsonRpcProvider {
 		epoch?: string | null;
 	}): Promise<DevInspectResults> {
 		let devInspectTxBytes;
-		if (TransactionBlock.is(input.transactionBlock)) {
+		if (isTransactionBlock(input.transactionBlock)) {
 			input.transactionBlock.setSenderIfNotSet(input.sender);
 			devInspectTxBytes = toB64(
 				await input.transactionBlock.build({

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromB64, toB64 } from '@mysten/bcs';
-import { TransactionBlock } from '../builder/TransactionBlock.js';
+import type { TransactionBlock } from '../builder/TransactionBlock.js';
+import { isTransactionBlock } from '../builder/TransactionBlock.js';
 import { TransactionBlockDataBuilder } from '../builder/TransactionBlockData.js';
 import type { SerializedSignature } from '../cryptography/signature.js';
 import type { JsonRpcProvider } from '../providers/json-rpc-provider.js';
@@ -87,7 +88,7 @@ export abstract class SignerWithProvider implements Signer {
 	}
 
 	protected async prepareTransactionBlock(transactionBlock: Uint8Array | TransactionBlock) {
-		if (TransactionBlock.is(transactionBlock)) {
+		if (isTransactionBlock(transactionBlock)) {
 			// If the sender has not yet been set on the transaction, then set it.
 			// NOTE: This allows for signing transactions with mis-matched senders, which is important for sponsored transactions.
 			transactionBlock.setSenderIfNotSet(await this.getAddress());
@@ -153,7 +154,7 @@ export abstract class SignerWithProvider implements Signer {
 	 * @returns transaction digest
 	 */
 	async getTransactionBlockDigest(tx: Uint8Array | TransactionBlock): Promise<string> {
-		if (TransactionBlock.is(tx)) {
+		if (isTransactionBlock(tx)) {
 			tx.setSenderIfNotSet(await this.getAddress());
 			return tx.getDigest({ provider: this.provider });
 		} else if (tx instanceof Uint8Array) {
@@ -185,7 +186,7 @@ export abstract class SignerWithProvider implements Signer {
 		transactionBlock: TransactionBlock | string | Uint8Array;
 	}): Promise<DryRunTransactionBlockResponse> {
 		let dryRunTxBytes: Uint8Array;
-		if (TransactionBlock.is(input.transactionBlock)) {
+		if (isTransactionBlock(input.transactionBlock)) {
 			input.transactionBlock.setSenderIfNotSet(await this.getAddress());
 			dryRunTxBytes = await input.transactionBlock.build({
 				client: this.client,


### PR DESCRIPTION
## Description 

Change `TransactionBlock.is()` to be `isTransactionBlock`. When we have module-level tree shaking, this will let the entire builder get treeshaked (shooked? treeshaken?) out of the bundle leaving just a small utility method.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
