### PR TITLE
sort objects with HashMap

### DIFF
--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -69,28 +69,6 @@ where
             .execute_transaction_block(tx_bytes, signatures, Some(fast_path_options), request_type)
             .await?;
 
-        // TODO(gegaowp): turn off DB commits on fast-path for now
-        // let fast_path_resp: FastPathTransactionBlockResponse =
-        //     sui_transaction_response.clone().try_into()?;
-        // let effects = &fast_path_resp.effects;
-        // let epoch = effects.executed_epoch();
-
-        // let object_changes = get_object_changes(effects);
-        // let changed_objects = fetch_changed_objects(self.fullnode.clone(), object_changes).await?;
-        // let changed_db_objects =
-        //     to_changed_db_objects(changed_objects, epoch, /* checkpoint */ None);
-        // let deleted_db_objects = get_deleted_db_objects(effects, epoch, /* checkpoint */ None);
-        // let tx_object_changes = TransactionObjectChanges {
-        //     changed_objects: changed_db_objects,
-        //     deleted_objects: deleted_db_objects,
-        // };
-
-        // let transaction_store: TemporaryTransactionBlockResponseStore = fast_path_resp.into();
-        // let transaction: Transaction = transaction_store.try_into()?;
-        // self.state
-        //     .persist_fast_path(transaction, tx_object_changes)
-        //     .await?;
-
         Ok(SuiTransactionBlockResponseWithOptions {
             response: sui_transaction_response,
             options: options.unwrap_or_default(),

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, str::FromStr};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
 
 use diesel::deserialize::FromSql;
 use diesel::pg::{Pg, PgValue};
@@ -13,6 +16,7 @@ use diesel_derive_enum::DbEnum;
 use fastcrypto::encoding::{Base64, Encoding};
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::collections::hash_map::Entry;
 
 use move_bytecode_utils::module_cache::GetModule;
 use sui_json_rpc_types::{SuiObjectData, SuiObjectRef, SuiRawData};
@@ -444,29 +448,23 @@ pub fn compose_object_bulk_insert_query(objects: &[Object]) -> String {
     bulk_insert_query
 }
 
-pub fn group_and_sort_objects(objects: Vec<Object>) -> Vec<Vec<Object>> {
-    let mut objects_sorted = objects;
-    objects_sorted.sort_by(|a, b| a.object_id.cmp(&b.object_id));
-    // Group objects by object_id
-    let mut groups: Vec<Vec<Object>> = vec![];
-    let mut current_group: Vec<Object> = vec![];
-    let mut current_object_id = String::new();
-    for object in objects_sorted {
-        if object.object_id != current_object_id {
-            if !current_group.is_empty() {
-                // Sort the group by version, in a reverse order to be popped later
-                current_group.sort_by(|a, b| b.version.cmp(&a.version));
-                groups.push(current_group);
+pub fn filter_latest_objects(objects: Vec<Object>) -> Vec<Object> {
+    // Transactions in checkpoint are ordered by causal depedencies.
+    // But HashMap is not a lot more costly than HashSet, and it
+    // may be good to still keep the relative order of objects in
+    // the checkpoint.
+    let mut latest_objects = HashMap::new();
+    for object in objects {
+        match latest_objects.entry(object.object_id.clone()) {
+            Entry::Vacant(e) => {
+                e.insert(object);
             }
-            current_group = vec![];
-            current_object_id = object.object_id.clone();
+            Entry::Occupied(mut e) => {
+                if object.version > e.get().version {
+                    e.insert(object);
+                }
+            }
         }
-        current_group.push(object);
     }
-    // Sort the last group by version, in a reverse order to be popped later
-    if !current_group.is_empty() {
-        current_group.sort_by(|a, b| b.version.cmp(&a.version));
-        groups.push(current_group);
-    }
-    groups
+    latest_objects.into_values().collect()
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -211,11 +211,6 @@ pub trait IndexerStore {
     async fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
     async fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;
 
-    async fn persist_fast_path(
-        &self,
-        tx: Transaction,
-        tx_object_changes: TransactionObjectChanges,
-    ) -> Result<usize, IndexerError>;
     async fn persist_checkpoint_transactions(
         &self,
         checkpoint: &Checkpoint,


### PR DESCRIPTION
## Description 

1. remove fast path commit method. We came to the consensus that indexer will not rely on fast path.
2. for object changes, instead of grouping and returning a nested vector, using a HashMap and return the latest objects.
3. for mutated objects, apply chunks.
4. clean up experimental code


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
1. remove fast path commit method. We came to the consensus that indexer will not rely on fast path. 2. for object changes, instead of grouping and returning a nested vector, using a HashMap and return the latest objects. 3. clean up experimental code