### PR TITLE
indexer: temp disable ws due to split of reader & writer

### DIFF
--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -14,7 +14,6 @@ use jsonrpsee::{RpcModule, SubscriptionSink};
 use move_core_types::identifier::Identifier;
 use sui_core::subscription_handler::SubscriptionHandler;
 use sui_json_rpc::api::{cap_page_limit, IndexerApiClient, IndexerApiServer};
-use sui_json_rpc::indexer_api::spawn_subscription;
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page, SuiObjectDataFilter,
@@ -33,7 +32,7 @@ use crate::store::IndexerStore;
 pub(crate) struct IndexerApi<S> {
     state: S,
     fullnode: HttpClient,
-    subscription_handler: Arc<SubscriptionHandler>,
+    _subscription_handler: Arc<SubscriptionHandler>,
     migrated_methods: Vec<String>,
 }
 
@@ -41,13 +40,13 @@ impl<S: IndexerStore> IndexerApi<S> {
     pub fn new(
         state: S,
         fullnode_client: HttpClient,
-        subscription_handler: Arc<SubscriptionHandler>,
+        _subscription_handler: Arc<SubscriptionHandler>,
         migrated_methods: Vec<String>,
     ) -> Self {
         Self {
             state,
             fullnode: fullnode_client,
-            subscription_handler,
+            _subscription_handler,
             migrated_methods,
         }
     }
@@ -454,20 +453,22 @@ where
         df_obj_resp
     }
 
-    fn subscribe_event(&self, sink: SubscriptionSink, filter: EventFilter) -> SubscriptionResult {
-        spawn_subscription(sink, self.subscription_handler.subscribe_events(filter));
+    fn subscribe_event(&self, _sink: SubscriptionSink, _filter: EventFilter) -> SubscriptionResult {
+        // TODO: need to re-implement subscription for events after splitting of readers and writers
+        // spawn_subscription(sink, self.subscription_handler.subscribe_events(filter));
         Ok(())
     }
 
     fn subscribe_transaction(
         &self,
-        sink: SubscriptionSink,
-        filter: TransactionFilter,
+        _sink: SubscriptionSink,
+        _filter: TransactionFilter,
     ) -> SubscriptionResult {
-        spawn_subscription(
-            sink,
-            self.subscription_handler.subscribe_transactions(filter),
-        );
+        // TODO: need to re-implement subscription for events after splitting of readers and writers
+        // spawn_subscription(
+        //     sink,
+        //     self.subscription_handler.subscribe_transactions(filter),
+        // );
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

indexer ws does not work after splitting of readers and writers, but on testnet, some unknown subscribers are constantly hitting the endpoint and slow down Explorer.

Steps forward:
- disable ws on indexer as it does not work and to avoid unknown clients slowing down explorer;
- we might want to split the RPC reader and WS reader in the long run, and open to discuss that.

## Test Plan 

local run

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
