### PR TITLE
[ts-sdk] add publicKeyFromSuiBytes to multisig package

### DIFF
--- a/dapps/multisig-toolkit/src/routes/signature-analyzer.tsx
+++ b/dapps/multisig-toolkit/src/routes/signature-analyzer.tsx
@@ -10,7 +10,7 @@ import { AlertCircle } from 'lucide-react';
 import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { publicKeyFromBytes } from '@mysten/sui.js/verify';
+import { publicKeyFromRawBytes } from '@mysten/sui.js/verify';
 import { parsePartialSignatures } from '@mysten/sui.js/multisig';
 
 interface SignaturePubkeyPair {
@@ -115,7 +115,7 @@ export default function SignatureAnalyzer() {
 							setListSignaturePubkeys([
 								{
 									signatureScheme: parsedSignature.signatureScheme,
-									publicKey: publicKeyFromBytes(
+									publicKey: publicKeyFromRawBytes(
 										parsedSignature.signatureScheme,
 										parsedSignature.publicKey,
 									),

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -119,7 +119,7 @@ export {
 export {
 	/** @deprecated This type will be removed because it cant accurately represent parsed signatures */
 	type SignaturePubkeyPair,
-	/** @deprecated use `publicKeyFromBytes` from `@mysten/sui.j/verify` instead */
+	/** @deprecated use `publicKeyFromRawBytes` from `@mysten/sui.j/verify` instead */
 	publicKeyFromSerialized,
 	/** @deprecated use `parseSerializedSignature` from `@mysten/sui.j/cryptography` instead */
 	toParsedSignaturePubkeyPair,

--- a/sdk/typescript/src/multisig/index.ts
+++ b/sdk/typescript/src/multisig/index.ts
@@ -1,4 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import { fromB64 } from '@mysten/bcs';
+import { publicKeyFromRawBytes } from '../verify/index.js';
+import type { SignatureFlag } from '../cryptography/index.js';
+import { SIGNATURE_FLAG_TO_SCHEME } from '../cryptography/index.js';
 
 export * from './publickey.js';
+
+export function publicKeyFromSuiBytes(publicKey: string | Uint8Array) {
+	const bytes = typeof publicKey === 'string' ? fromB64(publicKey) : publicKey;
+
+	const signatureScheme = SIGNATURE_FLAG_TO_SCHEME[bytes[0] as SignatureFlag];
+
+	return publicKeyFromRawBytes(signatureScheme, bytes.slice(1));
+}

--- a/sdk/typescript/src/multisig/publickey.ts
+++ b/sdk/typescript/src/multisig/publickey.ts
@@ -18,7 +18,7 @@ import {
 import { normalizeSuiAddress } from '../utils/sui-types.js';
 import { builder } from '../builder/bcs.js';
 // eslint-disable-next-line import/no-cycle
-import { publicKeyFromBytes } from '../verify/index.js';
+import { publicKeyFromRawBytes } from '../verify/index.js';
 
 type CompressedSignature =
 	| { ED25519: number[] }
@@ -87,7 +87,7 @@ export class MultiSigPublicKey extends PublicKey {
 		this.publicKeys = this.multisigPublicKey.pk_map.map(({ pubKey, weight }) => {
 			const [scheme, bytes] = Object.entries(pubKey)[0] as [SignatureScheme, number[]];
 			return {
-				publicKey: publicKeyFromBytes(scheme, Uint8Array.from(bytes)),
+				publicKey: publicKeyFromRawBytes(scheme, Uint8Array.from(bytes)),
 				weight,
 			};
 		});
@@ -270,7 +270,7 @@ export function parsePartialSignatures(multisig: MultiSigStruct): ParsedPartialM
 			throw new Error('MultiSig is not supported inside MultiSig');
 		}
 
-		const publicKey = publicKeyFromBytes(signatureScheme, pkBytes);
+		const publicKey = publicKeyFromRawBytes(signatureScheme, pkBytes);
 
 		res[i] = {
 			signatureScheme,

--- a/sdk/typescript/src/verify/index.ts
+++ b/sdk/typescript/src/verify/index.ts
@@ -68,14 +68,20 @@ function parseSignature(signature: SerializedSignature) {
 		};
 	}
 
-	const publicKey = publicKeyFromBytes(parsedSignature.signatureScheme, parsedSignature.publicKey);
+	const publicKey = publicKeyFromRawBytes(
+		parsedSignature.signatureScheme,
+		parsedSignature.publicKey,
+	);
 	return {
 		...parsedSignature,
 		publicKey,
 	};
 }
 
-export function publicKeyFromBytes(signatureScheme: SignatureScheme, bytes: Uint8Array): PublicKey {
+export function publicKeyFromRawBytes(
+	signatureScheme: SignatureScheme,
+	bytes: Uint8Array,
+): PublicKey {
 	switch (signatureScheme) {
 		case 'ED25519':
 			return new Ed25519PublicKey(bytes);


### PR DESCRIPTION
## Description 

publicKeyFromBytes hasn't been released, I wanted to rename it to publicKeyFromRawBytes to keep things more clear, and add a `publicKeyFromSuiBytes` to the multisig package, since it will be fairly useful there.  

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
