### PR TITLE
[wallet-ext] - asset filtering / more kiosk polish

### DIFF
--- a/apps/core/src/hooks/useGetKioskContents.ts
+++ b/apps/core/src/hooks/useGetKioskContents.ts
@@ -1,17 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiObjectResponse } from '@mysten/sui.js/client';
-import { KIOSK_ITEM, KioskData, KioskItem, fetchKiosk, getOwnedKiosks } from '@mysten/kiosk';
+import { KIOSK_ITEM, KioskItem, fetchKiosk, getOwnedKiosks } from '@mysten/kiosk';
 import { useQuery } from '@tanstack/react-query';
 import { useRpcClient } from '../api/RpcClientContext';
 import { ORIGINBYTE_KIOSK_OWNER_TOKEN, getKioskIdFromOwnerCap } from '../utils/kiosk';
-import { SuiClient } from '@mysten/sui.js/client';
-
-export type KioskContents = Omit<KioskData, 'items'> & {
-	items: Partial<KioskItem & SuiObjectResponse>[];
-	ownerCap?: string;
-};
+import { SuiClient, SuiObjectResponse } from '@mysten/sui.js/src/client';
 
 export enum KioskTypes {
 	SUI = 'sui',
@@ -19,7 +13,8 @@ export enum KioskTypes {
 }
 
 export type Kiosk = {
-	items: Partial<KioskItem & SuiObjectResponse>[];
+	items: Partial<SuiObjectResponse & KioskItem>[];
+	itemIds: string[];
 	kioskId: string;
 	type: KioskTypes;
 	ownerCap?: string;
@@ -36,7 +31,6 @@ async function getOriginByteKioskContents(address: string, client: SuiClient) {
 		},
 	});
 	const ids = data.data.map((object) => getKioskIdFromOwnerCap(object));
-	const kiosks = new Map<string, Kiosk>();
 
 	// fetch the user's kiosks
 	const ownedKiosks = await client.multiGetObjects({
@@ -46,66 +40,63 @@ async function getOriginByteKioskContents(address: string, client: SuiClient) {
 		},
 	});
 
-	// find object IDs within a kiosk
-	await Promise.all(
-		ownedKiosks.map(async (kiosk) => {
-			if (!kiosk.data?.objectId) return [];
-			const objects = await client.getDynamicFields({
-				parentId: kiosk.data.objectId,
-			});
+	const contents = await Promise.all(
+		ownedKiosks
+			.map(async (kiosk) => {
+				if (!kiosk.data) return;
+				const objects = await client.getDynamicFields({
+					parentId: kiosk.data.objectId,
+				});
 
-			const objectIds = objects.data
-				.filter((obj) => obj.name.type === KIOSK_ITEM)
-				.map((obj) => obj.objectId);
+				const objectIds = objects.data
+					.filter((obj) => obj.name.type === KIOSK_ITEM)
+					.map((obj) => obj.objectId);
 
-			// fetch the contents of the objects within a kiosk
-			const kioskContent = await client.multiGetObjects({
-				ids: objectIds,
-				options: {
-					showDisplay: true,
-					showType: true,
-				},
-			});
+				// fetch the contents of the objects within a kiosk
+				const kioskContent = await client.multiGetObjects({
+					ids: objectIds,
+					options: {
+						showDisplay: true,
+						showType: true,
+					},
+				});
 
-			kiosks.set(kiosk.data.objectId, {
-				items: kioskContent.map((item) => ({ ...item, kioskId: kiosk.data?.objectId })),
-				kioskId: kiosk.data.objectId,
-				type: KioskTypes.ORIGINBYTE,
-			});
-		}),
+				return {
+					itemIds: objectIds,
+					items: kioskContent.map((item) => ({ ...item, kioskId: kiosk.data?.objectId })),
+					kioskId: kiosk.data.objectId,
+					type: KioskTypes.ORIGINBYTE,
+				};
+			})
+			.filter(Boolean) as Promise<Kiosk>[],
 	);
-
-	return kiosks;
+	return contents;
 }
 
 async function getSuiKioskContents(address: string, client: SuiClient) {
 	const ownedKiosks = await getOwnedKiosks(client, address!);
-	const kiosks = new Map<string, Kiosk>();
 
-	await Promise.all(
+	const contents = await Promise.all(
 		ownedKiosks.kioskIds.map(async (id) => {
 			const kiosk = await fetchKiosk(client, id, { limit: 1000 }, {});
 			const contents = await client.multiGetObjects({
 				ids: kiosk.data.itemIds,
 				options: { showDisplay: true, showContent: true },
 			});
-
 			const items = contents.map((object) => {
 				const kioskData = kiosk.data.items.find((item) => item.objectId === object.data?.objectId);
 				return { ...object, ...kioskData, kioskId: id };
 			});
-
-			kiosks.set(id, {
-				...kiosk.data,
+			return {
+				itemIds: kiosk.data.itemIds,
 				items,
 				kioskId: id,
 				type: KioskTypes.SUI,
 				ownerCap: ownedKiosks.kioskOwnerCaps.find((k) => k.kioskId === id)?.objectId,
-			});
-		}, kiosks),
+			};
+		}),
 	);
-
-	return kiosks;
+	return contents;
 }
 
 export function useGetKioskContents(address?: string | null, disableOriginByteKiosk?: boolean) {
@@ -115,24 +106,24 @@ export function useGetKioskContents(address?: string | null, disableOriginByteKi
 		queryKey: ['get-kiosk-contents', address, disableOriginByteKiosk],
 		queryFn: async () => {
 			const suiKiosks = await getSuiKioskContents(address!, rpc);
-			const obKiosks = !disableOriginByteKiosk
-				? await getOriginByteKioskContents(address!, rpc)
-				: new Map();
+			const obKiosks = await getOriginByteKioskContents(address!, rpc);
+			return [...suiKiosks, ...obKiosks];
+		},
+		select(data) {
+			const kiosks = new Map<string, Kiosk>();
+			const lookup = new Map<string, string>();
 
-			const list = [...Array.from(suiKiosks.values()), ...Array.from(obKiosks.values())].flatMap(
-				(d) => d.items,
-			);
-			const kiosks = new Map([...suiKiosks, ...obKiosks]) as Map<string, Kiosk>;
-			// a map of object ID to Kiosk ID
-			const lookup = list.reduce((acc, curr) => {
-				acc.set(curr.data.objectId, curr.kioskId);
-				return acc;
-			}, new Map<string, string>());
+			data.forEach((kiosk) => {
+				kiosks.set(kiosk.kioskId, kiosk);
+				kiosk.itemIds.forEach((id) => {
+					lookup.set(id, kiosk.kioskId);
+				});
+			});
 
 			return {
-				list,
-				lookup,
 				kiosks,
+				list: data.flatMap((kiosk) => kiosk.items),
+				lookup,
 			};
 		},
 	});

--- a/apps/core/src/hooks/useMultiGetObjects.ts
+++ b/apps/core/src/hooks/useMultiGetObjects.ts
@@ -1,12 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { SuiObjectDataOptions } from '@mysten/sui.js/client';
 import { useRpcClient } from '../api/RpcClientContext';
 import { useQuery } from '@tanstack/react-query';
 import { chunkArray } from '../utils/chunkArray';
+import { SuiObjectDataOptions } from '@mysten/sui.js/src/client';
 
-export function useMultiGetObjects(ids: string[], options: SuiObjectDataOptions) {
+export function useMultiGetObjects(
+	ids: string[],
+	options: SuiObjectDataOptions,
+	queryOptions?: { keepPreviousData?: boolean },
+) {
 	const rpc = useRpcClient();
 	return useQuery({
 		queryKey: ['multiGetObjects', ids],
@@ -22,5 +26,6 @@ export function useMultiGetObjects(ids: string[], options: SuiObjectDataOptions)
 			return responses.flat();
 		},
 		enabled: !!ids?.length,
+		...queryOptions,
 	});
 }

--- a/apps/wallet/src/ui/app/components/navigation/index.tsx
+++ b/apps/wallet/src/ui/app/components/navigation/index.tsx
@@ -37,7 +37,7 @@ function Navigation({ className }: NavigationProps) {
 					<Tokens32 className="w-8 h-8" />
 					<span className={st.title}>Coins</span>
 				</NavLink>
-				<NavLink to="./nfts" className={makeLinkCls} title="NFTs">
+				<NavLink to="./nfts" className={makeLinkCls} title="Assets">
 					<Nft132 className="w-8 h-8" />
 					<span className={st.title}>Assets</span>
 				</NavLink>

--- a/apps/wallet/src/ui/app/components/nft-display/Kiosk.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/Kiosk.tsx
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { getKioskIdFromOwnerCap, hasDisplayData, useGetKioskContents } from '@mysten/core';
+
 import { type SuiObjectResponse } from '@mysten/sui.js/client';
+import { getObjectDisplay } from '@mysten/sui.js/types';
 import cl from 'classnames';
 
 import { NftImage, type NftImageProps } from './NftImage';
@@ -17,12 +19,19 @@ type KioskProps = {
 // (clip-path is used instead of overflow-hidden as it can be animated)
 const clipPath = '[clip-path:inset(0_0_7px_0_round_12px)] group-hover:[clip-path:inset(0_0_0_0)]';
 
-const timing = 'transition-all duration-300 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)]';
+const timing =
+	'transition-all group-hover:delay-[0.25s] duration-300 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)]';
 const cardStyles = [
 	`scale-100 group-hover:scale-95 object-cover origin-bottom z-30 group-hover:translate-y-0 translate-y-2 group-hover:shadow-md`,
 	`scale-[0.95] group-hover:-rotate-6 group-hover:-translate-x-5 group-hover:-translate-y-2 z-20 translate-y-0 group-hover:shadow-md`,
 	`scale-[0.90] group-hover:rotate-6 group-hover:translate-x-5 group-hover:-translate-y-2 z-10 -translate-y-2 group-hover:shadow-xl`,
 ];
+
+function getLabel(item?: SuiObjectResponse) {
+	if (!item) return;
+	const display = getObjectDisplay(item)?.data;
+	return display?.name ?? display?.description ?? item.data?.objectId;
+}
 
 export function Kiosk({ object, orientation, ...nftImageProps }: KioskProps) {
 	const address = useActiveAddress();
@@ -35,6 +44,9 @@ export function Kiosk({ object, orientation, ...nftImageProps }: KioskProps) {
 	const showCardStackAnimation = itemsWithDisplay.length > 1 && orientation !== 'horizontal';
 	const imagesToDisplay = orientation !== 'horizontal' ? 3 : 1;
 	const items = kiosk?.items.slice(0, imagesToDisplay) ?? [];
+
+	// get the label for the first item to show on hover
+	const displayName = getLabel(items[0]);
 
 	if (isLoading) return null;
 
@@ -72,13 +84,23 @@ export function Kiosk({ object, orientation, ...nftImageProps }: KioskProps) {
 				<div
 					className={cl(
 						timing,
-						'right-1.5 bottom-1.5 flex items-center justify-center absolute h-6 w-6 bg-gray-100 text-white rounded-md',
 						{ 'group-hover:-translate-x-0.5 group-hover:scale-95': showCardStackAnimation },
+						'bottom-1.5 absolute gap-3 flex items-center justify-end w-full overflow-hidden px-2',
 					)}
 				>
-					<Text variant="subtitle" weight="medium">
-						{items?.length}
-					</Text>
+					{displayName ? (
+						<div className="flex items-center justify-center group-hover:opacity-100 opacity-0 px-2 py-1.5 bg-white/90 rounded-md overflow-hidden">
+							<Text variant="subtitleSmall" weight="semibold" mono color="steel-darker" truncate>
+								{displayName}
+							</Text>
+						</div>
+					) : null}
+
+					<div className="flex-shrink-0 flex items-center justify-center h-6 w-6 bg-gray-100 text-white rounded-md">
+						<Text variant="subtitle" weight="medium">
+							{kiosk?.items.length}
+						</Text>
+					</div>
 				</div>
 			)}
 		</div>

--- a/apps/wallet/src/ui/app/components/nft-display/index.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/index.tsx
@@ -3,10 +3,11 @@
 
 import { isKioskOwnerToken, useGetObject } from '@mysten/core';
 import { formatAddress } from '@mysten/sui.js/utils';
-import { cva, cx } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 
 import { Kiosk } from './Kiosk';
 import { useResolveVideo } from '../../hooks/useResolveVideo';
+import { Text } from '../../shared/text';
 import { Heading } from '_app/shared/heading';
 import Loading from '_components/loading';
 import { NftImage, type NftImageProps } from '_components/nft-display/NftImage';
@@ -14,7 +15,7 @@ import { useGetNFTMeta, useFileExtensionType } from '_hooks';
 
 import type { VariantProps } from 'class-variance-authority';
 
-const nftDisplayCardStyles = cva('flex flex-nowrap items-center h-full', {
+const nftDisplayCardStyles = cva('flex flex-nowrap items-center h-full relative', {
 	variants: {
 		animateHover: {
 			true: 'group',
@@ -79,7 +80,6 @@ export function NFTDisplayCard({
 					<NftImage
 						name={nftName}
 						src={nftImageUrl}
-						title={nftMeta?.description || ''}
 						animateHover={animateHover}
 						showLabel={shouldShowLabel}
 						borderRadius={borderRadius}
@@ -102,17 +102,18 @@ export function NFTDisplayCard({
 						</div>
 					</div>
 				)}
-				{showLabel && !wideView && (
-					<div
-						className={cx(
-							'flex-1 text-steel-dark truncate overflow-hidden max-w-full',
-							animateHover ? 'group-hover:text-black duration-200 ease-ease-in-out-cubic' : '',
-							orientation === 'horizontal' ? 'ml-2' : 'mt-2',
-						)}
-					>
-						{isOwnerToken ? 'Kiosk' : nftName}
+
+				{orientation === 'horizontal' ? (
+					<div className="flex-1 text-steel-dark overflow-hidden max-w-full ml-2">{nftName}</div>
+				) : !isOwnerToken ? (
+					<div className="w-10/12 absolute bottom-2 bg-white/90 rounded-lg left-1/2 -translate-x-1/2 flex items-center justify-center opacity-0 group-hover:opacity-100">
+						<div className="mt-0.5 px-2 py-1 overflow-hidden">
+							<Text variant="subtitleSmall" weight="semibold" mono color="steel-darker" truncate>
+								{nftName}
+							</Text>
+						</div>
 					</div>
-				)}
+				) : null}
 			</Loading>
 		</div>
 	);

--- a/apps/wallet/src/ui/app/pages/enoki-onboarding/ForgotPassword.tsx
+++ b/apps/wallet/src/ui/app/pages/enoki-onboarding/ForgotPassword.tsx
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export function ForgotPassword() {
+	return <div>implement me</div>;
+}

--- a/apps/wallet/src/ui/app/pages/home/assets/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/assets/index.tsx
@@ -3,13 +3,16 @@
 
 import { Routes, Route } from 'react-router-dom';
 import { HiddenAssetsPage, NftsPage } from '..';
+import { HiddenAssetsProvider } from '../hidden-assets/HiddenAssetsProvider';
 
 function AssetsPage() {
 	return (
-		<Routes>
-			<Route path="/hidden-assets" element={<HiddenAssetsPage />} />
-			<Route path="/*" element={<NftsPage />} />
-		</Routes>
+		<HiddenAssetsProvider>
+			<Routes>
+				<Route path="/hidden-assets" element={<HiddenAssetsPage />} />
+				<Route path="/:filterType?/*" element={<NftsPage />} />
+			</Routes>
+		</HiddenAssetsProvider>
 	);
 }
 

--- a/apps/wallet/src/ui/app/pages/home/hidden-assets/HiddenAssetsProvider.tsx
+++ b/apps/wallet/src/ui/app/pages/home/hidden-assets/HiddenAssetsProvider.tsx
@@ -1,0 +1,220 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Check12 } from '@mysten/icons';
+import { get, set } from 'idb-keyval';
+import { type ReactNode, createContext, useCallback, useEffect, useState, useContext } from 'react';
+import { toast } from 'react-hot-toast';
+import { Link as InlineLink } from '../../../shared/Link';
+import { Text } from '_src/ui/app/shared/text';
+
+const HIDDEN_ASSET_IDS = 'hidden-asset-ids';
+
+interface HiddenAssetContext {
+	hiddenAssetIds: string[];
+	setHiddenAssetIds: (hiddenAssetIds: string[]) => void;
+	hideAsset: (assetId: string) => void;
+	showAsset: (assetId: string) => void;
+}
+
+export const HiddenAssetsContext = createContext<HiddenAssetContext>({
+	hiddenAssetIds: [],
+	setHiddenAssetIds: () => {},
+	hideAsset: () => {},
+	showAsset: () => {},
+});
+
+export const HiddenAssetsProvider = ({ children }: { children: ReactNode }) => {
+	const [hiddenAssetIds, setHiddenAssetIds] = useState<string[]>([]);
+
+	useEffect(() => {
+		(async () => {
+			const hiddenAssets = await get<string[]>(HIDDEN_ASSET_IDS);
+			if (hiddenAssets) {
+				setHiddenAssetIds(hiddenAssets);
+			}
+		})();
+	}, []);
+
+	const hideAssetId = useCallback(
+		async (newAssetId: string) => {
+			if (hiddenAssetIds.includes(newAssetId)) return;
+
+			const newHiddenAssetIds = [...hiddenAssetIds, newAssetId];
+			setHiddenAssetIds(newHiddenAssetIds);
+			await set(HIDDEN_ASSET_IDS, newHiddenAssetIds);
+
+			const undoHideAsset = async (assetId: string) => {
+				try {
+					let updatedHiddenAssetIds;
+					setHiddenAssetIds((prevIds) => {
+						updatedHiddenAssetIds = prevIds.filter((id) => id !== assetId);
+						return updatedHiddenAssetIds;
+					});
+					await set(HIDDEN_ASSET_IDS, updatedHiddenAssetIds);
+				} catch (error) {
+					// Handle any error that occurred during the unhide process
+					toast.error('Failed to unhide asset.');
+					// Restore the asset ID back to the hidden asset IDs list
+					setHiddenAssetIds([...hiddenAssetIds, assetId]);
+					await set(HIDDEN_ASSET_IDS, hiddenAssetIds);
+				}
+			};
+
+			const showAssetHiddenToast = async (objectId: string) => {
+				toast.custom(
+					(t) => (
+						<div
+							className="flex items-center justify-between gap-2 bg-white w-full shadow-notification border-solid border-gray-45 rounded-full px-3 py-2"
+							style={{
+								animation: 'fade-in-up 200ms ease-in-out',
+							}}
+						>
+							<div className="flex gap-2 items-center">
+								<Check12 className="text-gray-90" />
+								<div
+									onClick={() => {
+										toast.dismiss(t.id);
+									}}
+								>
+									<InlineLink
+										to="/nfts/hidden-assets"
+										color="hero"
+										weight="medium"
+										before={
+											<Text variant="body" color="gray-80">
+												Moved to
+											</Text>
+										}
+										text="Hidden Assets"
+										onClick={() => toast.dismiss(t.id)}
+									/>
+								</div>
+							</div>
+
+							<div className="w-auto">
+								<InlineLink
+									size="bodySmall"
+									onClick={() => {
+										undoHideAsset(objectId);
+										toast.dismiss(t.id);
+									}}
+									color="hero"
+									weight="medium"
+									text="UNDO"
+								/>
+							</div>
+						</div>
+					),
+					{
+						duration: 4000,
+					},
+				);
+			};
+
+			showAssetHiddenToast(newAssetId);
+		},
+		[hiddenAssetIds],
+	);
+
+	const showAssetId = useCallback(
+		async (newAssetId: string) => {
+			if (!hiddenAssetIds.includes(newAssetId)) return;
+
+			try {
+				const updatedHiddenAssetIds = hiddenAssetIds.filter((id) => id !== newAssetId);
+				setHiddenAssetIds(updatedHiddenAssetIds);
+				await set(HIDDEN_ASSET_IDS, updatedHiddenAssetIds);
+			} catch (error) {
+				// Handle any error that occurred during the unhide process
+				toast.error('Failed to show asset.');
+				// Restore the asset ID back to the hidden asset IDs list
+				setHiddenAssetIds([...hiddenAssetIds, newAssetId]);
+				await set(HIDDEN_ASSET_IDS, hiddenAssetIds);
+			}
+
+			const undoShowAsset = async (assetId: string) => {
+				let newHiddenAssetIds;
+				setHiddenAssetIds((prevIds) => {
+					return (newHiddenAssetIds = [...prevIds, assetId]);
+				});
+				await set(HIDDEN_ASSET_IDS, newHiddenAssetIds);
+			};
+
+			const assetShownToast = async (objectId: string) => {
+				toast.custom(
+					(t) => (
+						<div
+							className="flex items-center justify-between gap-2 bg-white w-full shadow-notification border-solid border-gray-45 rounded-full px-3 py-2"
+							style={{
+								animation: 'fade-in-up 200ms ease-in-out',
+							}}
+						>
+							<div className="flex gap-1 items-center">
+								<Check12 className="text-gray-90" />
+								<div
+									onClick={() => {
+										toast.dismiss(t.id);
+									}}
+								>
+									<InlineLink
+										to="/nfts"
+										color="hero"
+										weight="medium"
+										before={
+											<Text variant="body" color="gray-80">
+												Moved to
+											</Text>
+										}
+										text="Visual Assets"
+										onClick={() => toast.dismiss(t.id)}
+									/>
+								</div>
+							</div>
+
+							<div className="w-auto">
+								<InlineLink
+									size="bodySmall"
+									onClick={() => {
+										undoShowAsset(objectId);
+										toast.dismiss(t.id);
+									}}
+									color="hero"
+									weight="medium"
+									text="UNDO"
+								/>
+							</div>
+						</div>
+					),
+					{
+						duration: 4000,
+					},
+				);
+			};
+
+			assetShownToast(newAssetId);
+		},
+		[hiddenAssetIds],
+	);
+
+	const showAsset = (objectId: string) => {
+		showAssetId(objectId);
+	};
+
+	return (
+		<HiddenAssetsContext.Provider
+			value={{
+				hiddenAssetIds: Array.from(new Set(hiddenAssetIds)),
+				setHiddenAssetIds,
+				hideAsset: hideAssetId,
+				showAsset,
+			}}
+		>
+			{children}
+		</HiddenAssetsContext.Provider>
+	);
+};
+
+export const useHiddenAssets = () => {
+	return useContext(HiddenAssetsContext);
+};

--- a/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
@@ -168,7 +168,7 @@ function NFTDetailsPage() {
 								</Collapse>
 							) : null}
 
-							{isContainedInKiosk && kioskItem.isLocked ? (
+							{isContainedInKiosk && kioskItem?.isLocked ? (
 								<div className="flex flex-col gap-2 mb-3">
 									<Button
 										after={<ArrowUpRight12 />}

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -37,7 +37,6 @@ export function TransferNFTForm({
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 	const { clientIdentifier, notificationModal } = useQredoTransaction();
-
 	const { data: kiosk } = useGetKioskContents(activeAddress);
 	const transferKioskItem = useTransferKioskItem({ objectId, objectType });
 	const isContainedInKiosk = kiosk?.list.some((kioskItem) => kioskItem.data?.objectId === objectId);

--- a/apps/wallet/src/ui/app/pages/home/nfts/AssetsOptionsMenu.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/AssetsOptionsMenu.tsx
@@ -23,14 +23,14 @@ const AssetsOptionsMenu = () => {
 				<div className="rounded-md w-full h-full p-2 shadow-summary-card">
 					<Menu.Item>
 						{({ active }) => (
-							<div className="p-3 hover:bg-sui-light bg-opacity-50 rounded-md">
-								<Link
-									to="/nfts/hidden-assets"
-									className="no-underline text-steel-darker hover:text-steel-darker focus:text-steel-darker disabled:text-steel-darker font-medium text-bodySmall"
-								>
+							<Link
+								to="/nfts/hidden-assets"
+								className="no-underline text-steel-darker hover:text-steel-darker focus:text-steel-darker disabled:text-steel-darker font-medium text-bodySmall"
+							>
+								<div className="p-3 hover:bg-sui-light bg-opacity-50 rounded-md">
 									View Hidden Assets
-								</Link>
-							</div>
+								</div>
+							</Link>
 						)}
 					</Menu.Item>
 				</div>

--- a/apps/wallet/src/ui/app/pages/home/nfts/NonVisualAssets.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/NonVisualAssets.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SuiObjectData } from '@mysten/sui.js/client';
+import { parseStructTag, formatAddress } from '@mysten/sui.js/utils';
+import ExplorerLink from '_src/ui/app/components/explorer-link';
+import { ExplorerLinkType } from '_src/ui/app/components/explorer-link/ExplorerLinkType';
+import { Text } from '_src/ui/app/shared/text';
+
+export default function NonVisualAssets({ items }: { items: SuiObjectData[] }) {
+	return (
+		<div className="flex flex-col items-center gap-4 w-full flex-1">
+			{items?.length ? (
+				<div className="flex flex-col flex-wrap w-full divide-y divide-solid divide-gray-40 divide-x-0 gap-3 mb-5">
+					{items.map((item) => {
+						const { address, module, name } = parseStructTag(item.type!);
+						return (
+							<div className="grid grid-cols-3 pt-3" key={item.objectId}>
+								<ExplorerLink
+									className="text-hero-dark no-underline"
+									objectID={item.objectId!}
+									type={ExplorerLinkType.object}
+								>
+									<Text variant="pBody">{formatAddress(item.objectId!)}</Text>
+								</ExplorerLink>
+
+								<div className="break-all col-span-2">
+									<Text
+										variant="pBodySmall"
+										weight="normal"
+										mono
+										color="steel"
+										title={item.type ?? ''}
+									>
+										{`${formatAddress(address)}::${module}::${name}`}
+									</Text>
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			) : (
+				<div className="flex flex-1 items-center self-center text-caption font-semibold text-steel-darker">
+					No Assets found
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/wallet/src/ui/app/pages/home/nfts/VisualAssets.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/VisualAssets.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getKioskIdFromOwnerCap, isKioskOwnerToken } from '@mysten/core';
+import { EyeClose16 } from '@mysten/icons';
+import { type SuiObjectData } from '@mysten/sui.js/client';
+import { Link } from 'react-router-dom';
+import { useHiddenAssets } from '../hidden-assets/HiddenAssetsProvider';
+import { ErrorBoundary } from '_components/error-boundary';
+import { ampli } from '_src/shared/analytics/ampli';
+import { NFTDisplayCard } from '_src/ui/app/components/nft-display';
+import { Button } from '_src/ui/app/shared/ButtonUI';
+
+export default function VisualAssets({ items }: { items: SuiObjectData[] }) {
+	const { hideAsset } = useHiddenAssets();
+	return (
+		<div className="grid w-full grid-cols-2 gap-x-3.5 gap-y-4 mb-5">
+			{items.map((object) => (
+				<Link
+					to={
+						isKioskOwnerToken(object)
+							? `/kiosk?${new URLSearchParams({
+									kioskId: getKioskIdFromOwnerCap(object),
+							  })}`
+							: `/nft-details?${new URLSearchParams({
+									objectId: object.objectId,
+							  }).toString()}`
+					}
+					onClick={() => {
+						ampli.clickedCollectibleCard({
+							objectId: object.objectId,
+							collectibleType: object.type!,
+						});
+					}}
+					key={object.objectId}
+					className="no-underline relative"
+				>
+					<div className="group">
+						<div className="w-full h-full justify-center z-10 absolute pointer-events-auto text-gray-60 transition-colors duration-200 p-0">
+							{!isKioskOwnerToken(object) ? (
+								<div className="absolute top-2 right-3 rounded-md h-8 w-8 opacity-0 group-hover:opacity-100">
+									<Button
+										variant="hidden"
+										size="icon"
+										onClick={(event) => {
+											event.preventDefault();
+											event.stopPropagation();
+											ampli.clickedHideAsset({
+												objectId: object.objectId,
+												collectibleType: object.type!,
+											});
+											hideAsset(object.objectId);
+										}}
+										after={<EyeClose16 />}
+									/>
+								</div>
+							) : null}
+						</div>
+						<ErrorBoundary>
+							<NFTDisplayCard objectId={object.objectId} size="lg" animateHover borderRadius="xl" />
+						</ErrorBoundary>
+					</div>
+				</Link>
+			))}
+		</div>
+	);
+}

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -1,31 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getKioskIdFromOwnerCap, isKioskOwnerToken, useOnScreen } from '@mysten/core';
-import { Check12, EyeClose16 } from '@mysten/icons';
-import { get, set } from 'idb-keyval';
-import { useRef, useEffect, useCallback, useState, useMemo } from 'react';
-import toast from 'react-hot-toast';
-import { Link } from 'react-router-dom';
+import { useOnScreen } from '@mysten/core';
+import { useRef, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 
 import AssetsOptionsMenu from './AssetsOptionsMenu';
-import { Link as InlineLink } from '../../../shared/Link';
-import { Text } from '../../../shared/text';
+import NonVisualAssets from './NonVisualAssets';
+import VisualAssets from './VisualAssets';
 import { useActiveAddress } from '_app/hooks/useActiveAddress';
 import Alert from '_components/alert';
-import { ErrorBoundary } from '_components/error-boundary';
+import FiltersPortal from '_components/filters-tags';
 import Loading from '_components/loading';
 import LoadingSpinner from '_components/loading/LoadingIndicator';
-import { NFTDisplayCard } from '_components/nft-display';
-import { ampli } from '_src/shared/analytics/ampli';
-import { useGetNFTs } from '_src/ui/app/hooks/useGetNFTs';
-import { Button } from '_src/ui/app/shared/ButtonUI';
+import { setToSessionStorage } from '_src/background/storage-utils';
+import { AssetFilterTypes, useGetNFTs } from '_src/ui/app/hooks/useGetNFTs';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
-const HIDDEN_ASSET_IDS = 'hidden-asset-ids';
-
 function NftsPage() {
-	const [internalHiddenAssetIds, internalSetHiddenAssetIds] = useState<string[]>([]);
 	const accountAddress = useActiveAddress();
 	const {
 		data: ownedAssets,
@@ -47,105 +39,14 @@ function NftsPage() {
 		}
 	}, [isIntersecting, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-	useEffect(() => {
-		(async () => {
-			const hiddenAssets = await get<string[]>(HIDDEN_ASSET_IDS);
-			if (hiddenAssets) {
-				internalSetHiddenAssetIds(hiddenAssets);
-			}
-		})();
-	}, []);
-
-	const hideAssetId = useCallback(
-		async (newAssetId: string) => {
-			if (internalHiddenAssetIds.includes(newAssetId)) return;
-
-			const newHiddenAssetIds = [...internalHiddenAssetIds, newAssetId];
-			internalSetHiddenAssetIds(newHiddenAssetIds);
-			await set(HIDDEN_ASSET_IDS, newHiddenAssetIds);
-
-			const undoHideAsset = async (assetId: string) => {
-				try {
-					let updatedHiddenAssetIds;
-					internalSetHiddenAssetIds((prevIds) => {
-						updatedHiddenAssetIds = prevIds.filter((id) => id !== assetId);
-						return updatedHiddenAssetIds;
-					});
-					await set(HIDDEN_ASSET_IDS, updatedHiddenAssetIds);
-				} catch (error) {
-					// Handle any error that occurred during the unhide process
-					toast.error('Failed to unhide asset.');
-					// Restore the asset ID back to the hidden asset IDs list
-					internalSetHiddenAssetIds([...internalHiddenAssetIds, assetId]);
-					await set(HIDDEN_ASSET_IDS, internalHiddenAssetIds);
-				}
-			};
-
-			const showAssetHiddenToast = async (objectId: string) => {
-				toast.custom(
-					(t) => (
-						<div
-							className="flex items-center justify-between gap-2 bg-white w-full shadow-notification border-solid border-gray-45 rounded-full px-3 py-2"
-							style={{
-								animation: 'fade-in-up 200ms ease-in-out',
-							}}
-						>
-							<div className="flex gap-2 items-center">
-								<Check12 className="text-gray-90" />
-								<div
-									onClick={() => {
-										toast.dismiss(t.id);
-									}}
-								>
-									<InlineLink
-										to="/nfts/hidden-assets"
-										color="hero"
-										weight="medium"
-										before={
-											<Text variant="body" color="gray-80">
-												Moved to
-											</Text>
-										}
-										text="Hidden Assets"
-										onClick={() => toast.dismiss(t.id)}
-									/>
-								</div>
-							</div>
-
-							<div className="w-auto">
-								<InlineLink
-									size="bodySmall"
-									onClick={() => {
-										undoHideAsset(objectId);
-										toast.dismiss(t.id);
-									}}
-									color="hero"
-									weight="medium"
-									text="UNDO"
-								/>
-							</div>
-						</div>
-					),
-					{
-						duration: 4000,
-					},
-				);
-			};
-
-			showAssetHiddenToast(newAssetId);
-		},
-		[internalHiddenAssetIds],
-	);
-
-	const hideAsset = (objectId: string, event: React.MouseEvent<HTMLButtonElement>) => {
-		event.stopPropagation();
-		event.preventDefault();
-		hideAssetId(objectId);
+	const handleFilterChange = async (tag: any) => {
+		await setToSessionStorage<string>('NFTS_PAGE_NAVIGATION', tag.link);
 	};
-
+	const { filterType } = useParams();
 	const filteredNFTs = useMemo(() => {
-		return ownedAssets?.filter((nft) => !internalHiddenAssetIds.includes(nft.objectId));
-	}, [ownedAssets, internalHiddenAssetIds]);
+		if (!filterType) return ownedAssets?.visual;
+		return ownedAssets?.[filterType as AssetFilterTypes] ?? [];
+	}, [ownedAssets, filterType]);
 
 	if (isInitialLoading) {
 		return (
@@ -155,9 +56,17 @@ function NftsPage() {
 		);
 	}
 
+	const tags = [
+		{ name: 'Visual Assets', link: 'nfts' },
+		{ name: 'Everything Else', link: 'nfts/other' },
+	];
+
 	return (
 		<div className="flex flex-1 flex-col flex-nowrap items-center gap-4">
 			<PageTitle title="Assets" after={<AssetsOptionsMenu />} />
+			{!!ownedAssets?.other.length && (
+				<FiltersPortal firstLastMargin tags={tags} callback={handleFilterChange} />
+			)}
 			<Loading loading={isLoading}>
 				{isError ? (
 					<Alert>
@@ -168,58 +77,11 @@ function NftsPage() {
 					</Alert>
 				) : null}
 				{filteredNFTs?.length ? (
-					<div className="grid w-full grid-cols-2 gap-x-3.5 gap-y-4 mb-5">
-						{filteredNFTs.map((object) => (
-							<Link
-								to={
-									isKioskOwnerToken(object)
-										? `/kiosk?${new URLSearchParams({
-												kioskId: getKioskIdFromOwnerCap(object),
-										  })}`
-										: `/nft-details?${new URLSearchParams({
-												objectId: object.objectId,
-										  }).toString()}`
-								}
-								onClick={() => {
-									ampli.clickedCollectibleCard({
-										objectId: object.objectId,
-										collectibleType: object.type!,
-									});
-								}}
-								key={object.objectId}
-								className="no-underline relative"
-							>
-								<div className="group">
-									<div className="w-full h-full justify-center z-10 absolute pointer-events-auto text-gray-60 transition-colors duration-200 p-0">
-										{!isKioskOwnerToken(object) ? (
-											<div className="absolute top-2 right-3 rounded-md h-8 w-8 opacity-0 group-hover:opacity-100">
-												<Button
-													variant="hidden"
-													size="icon"
-													onClick={(event: any) => {
-														ampli.clickedHideAsset({
-															objectId: object.objectId,
-															collectibleType: object.type!,
-														});
-														hideAsset(object.objectId, event);
-													}}
-													after={<EyeClose16 />}
-												/>
-											</div>
-										) : null}
-									</div>
-									<ErrorBoundary>
-										<NFTDisplayCard
-											objectId={object.objectId}
-											size="lg"
-											animateHover
-											borderRadius="xl"
-										/>
-									</ErrorBoundary>
-								</div>
-							</Link>
-						))}
-					</div>
+					filterType === AssetFilterTypes.other ? (
+						<NonVisualAssets items={filteredNFTs} />
+					) : (
+						<VisualAssets items={filteredNFTs} />
+					)
 				) : (
 					<div className="flex flex-1 items-center self-center text-caption font-semibold text-steel-darker">
 						No Assets found

--- a/apps/wallet/src/ui/app/shared/toaster/index.tsx
+++ b/apps/wallet/src/ui/app/shared/toaster/index.tsx
@@ -17,7 +17,7 @@ const commonToastClasses =
 	'!px-0 !py-1 !text-pBodySmall !font-medium !rounded-2lg !shadow-notification';
 export function Toaster({ bottomNavEnabled }: ToasterProps) {
 	const { pathname } = useLocation();
-	const isExtraNavTabsVisible = pathname.startsWith('/apps');
+	const isExtraNavTabsVisible = ['/apps', '/nfts'].includes(pathname);
 	const menuVisible = useMenuIsOpen();
 	const isBottomNavVisible = useAppSelector(getNavIsVisible);
 	const includeBottomNavSpace = !menuVisible && isBottomNavVisible && bottomNavEnabled;


### PR DESCRIPTION
## Description 

Includes various changes to the Assets / NFTs page, mainly: 
- Adds ability to filter by Visual / Non-Visual assets. (note: I split this out into two pages for now but could probably be rolled back into one since it's really just a grid / list view) 
- Moved the show / hide asset logic into a provider which cleans things up a bit. We could also potentially expand this in the future if we add more types of filtering / functionality
- Addressed some remaining feedback / UI polish for kiosks


https://github.com/MystenLabs/sui/assets/122397493/caebcb96-27d2-4a96-a280-98838ae878fc




## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
