### PR TITLE
Remove unused NW code now that we moved past V11

### DIFF
--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -415,10 +415,10 @@ impl Subscriber {
             .batch_execution_latency
             .observe(batch_fetch_duration);
         debug!(
-                "Batch {:?} took {} seconds since it has been created to when it has been fetched for execution",
-                digest,
-                batch_fetch_duration,
-            );
+            "Batch {:?} took {} seconds since it has been created to when it has been fetched for execution",
+            digest,
+            batch_fetch_duration,
+        );
     }
 }
 

--- a/narwhal/network/src/client.rs
+++ b/narwhal/network/src/client.rs
@@ -11,8 +11,7 @@ use parking_lot::RwLock;
 use tokio::{select, time::sleep};
 use types::{
     error::LocalClientError, FetchBatchesRequest, FetchBatchesResponse, PrimaryToWorker,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
-    WorkerSynchronizeMessage, WorkerToPrimary,
+    WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerSynchronizeMessage, WorkerToPrimary,
 };
 
 use crate::traits::{PrimaryToWorkerClient, WorkerToPrimaryClient};
@@ -172,22 +171,6 @@ impl PrimaryToWorkerClient for NetworkClient {
 
 #[async_trait]
 impl WorkerToPrimaryClient for NetworkClient {
-    // TODO: Remove once we have upgraded to protocol version 12.
-    async fn report_our_batch(
-        &self,
-        request: WorkerOurBatchMessage,
-    ) -> Result<(), LocalClientError> {
-        let c = self.get_worker_to_primary_handler().await?;
-        select! {
-            resp = c.report_our_batch(Request::new(request)) => {
-                resp.map_err(|e| LocalClientError::Internal(format!("{e:?}")))?;
-                Ok(())
-            },
-            () = self.shutdown_notify.wait() => {
-                Err(LocalClientError::ShuttingDown)
-            },
-        }
-    }
     async fn report_own_batch(
         &self,
         request: WorkerOwnBatchMessage,

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -7,8 +7,7 @@ use crypto::NetworkPublicKey;
 use types::{
     error::LocalClientError, FetchBatchesRequest, FetchBatchesResponse, FetchCertificatesRequest,
     FetchCertificatesResponse, RequestBatchesRequest, RequestBatchesResponse,
-    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerOwnBatchMessage,
-    WorkerSynchronizeMessage,
+    WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerSynchronizeMessage,
 };
 
 pub trait ReliableNetwork<Request: Clone + Send + Sync> {
@@ -60,12 +59,6 @@ pub trait PrimaryToWorkerClient {
 
 #[async_trait]
 pub trait WorkerToPrimaryClient {
-    // TODO: Remove once we have upgraded to protocol version 12.
-    async fn report_our_batch(
-        &self,
-        request: WorkerOurBatchMessage,
-    ) -> Result<(), LocalClientError>;
-
     async fn report_own_batch(
         &self,
         request: WorkerOwnBatchMessage,

--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -13,8 +13,8 @@ use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, HeaderV1Builder,
-    Metadata, MetadataV1, VersionedMetadata, WorkerOthersBatchMessage, WorkerOurBatchMessage,
-    WorkerOwnBatchMessage, WorkerSynchronizeMessage,
+    MetadataV1, VersionedMetadata, WorkerOthersBatchMessage, WorkerOwnBatchMessage,
+    WorkerSynchronizeMessage,
 };
 
 #[allow(clippy::mutable_key_type)]
@@ -112,12 +112,7 @@ fn get_registry() -> Result<Registry> {
     );
     tracer.trace_value(&mut samples, &worker_index)?;
 
-    let our_batch = WorkerOurBatchMessage {
-        digest: BatchDigest([0u8; 32]),
-        worker_id: 0,
-        metadata: Metadata { created_at: 0 },
-    };
-    let our_batch_v2 = WorkerOwnBatchMessage {
+    let own_batch = WorkerOwnBatchMessage {
         digest: BatchDigest([0u8; 32]),
         worker_id: 0,
         metadata: VersionedMetadata::V1(MetadataV1 {
@@ -135,8 +130,7 @@ fn get_registry() -> Result<Registry> {
         is_certified: true,
     };
 
-    tracer.trace_value(&mut samples, &our_batch)?;
-    tracer.trace_value(&mut samples, &our_batch_v2)?;
+    tracer.trace_value(&mut samples, &own_batch)?;
     tracer.trace_value(&mut samples, &others_batch)?;
     tracer.trace_value(&mut samples, &sync)?;
 

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -113,13 +113,6 @@ WorkerOthersBatchMessage:
     - digest:
         TYPENAME: BatchDigest
     - worker_id: U32
-WorkerOurBatchMessage:
-  STRUCT:
-    - digest:
-        TYPENAME: BatchDigest
-    - worker_id: U32
-    - metadata:
-        TYPENAME: Metadata
 WorkerOwnBatchMessage:
   STRUCT:
     - digest:

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -36,9 +36,9 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
 use types::{
-    Batch, BatchDigest, Certificate, CertificateAPI, CertificateDigest, FetchBatchesRequest,
-    FetchBatchesResponse, FetchCertificatesRequest, FetchCertificatesResponse, Header, HeaderAPI,
-    HeaderV1Builder, PrimaryToPrimary, PrimaryToPrimaryServer, PrimaryToWorker,
+    Batch, BatchDigest, BatchV1, Certificate, CertificateAPI, CertificateDigest,
+    FetchBatchesRequest, FetchBatchesResponse, FetchCertificatesRequest, FetchCertificatesResponse,
+    Header, HeaderAPI, HeaderV1Builder, PrimaryToPrimary, PrimaryToPrimaryServer, PrimaryToWorker,
     PrimaryToWorkerServer, RequestBatchesRequest, RequestBatchesResponse, RequestVoteRequest,
     RequestVoteResponse, Round, SendCertificateRequest, SendCertificateResponse, TimestampMs,
     Transaction, Vote, VoteAPI, WorkerBatchMessage, WorkerSynchronizeMessage, WorkerToWorker,
@@ -352,7 +352,12 @@ impl WorkerToWorker for WorkerToWorkerMockServer {
 
 // Fixture
 pub fn batch(protocol_config: &ProtocolConfig) -> Batch {
-    Batch::new(vec![transaction(), transaction()], protocol_config)
+    let transactions = vec![transaction(), transaction()];
+    // TODO: Remove once we have removed BatchV1 from the codebase.
+    if protocol_config.version < ProtocolVersion::new(12) {
+        return Batch::V1(BatchV1::new(transactions));
+    }
+    Batch::new(transactions, protocol_config)
 }
 
 /// generate multiple fixture batches. The number of generated batches

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -109,16 +109,6 @@ fn build_anemo_services(out_dir: &Path) {
         .name("WorkerToPrimary")
         .package("narwhal")
         .attributes(automock_attribute.clone())
-        // TODO: Remove once we have upgraded to protocol version 12.
-        .method(
-            anemo_build::manual::Method::builder()
-                .name("report_our_batch")
-                .route_name("ReportOurBatch")
-                .request_type("crate::WorkerOurBatchMessage")
-                .response_type("()")
-                .codec_path(codec_path)
-                .build(),
-        )
         .method(
             anemo_build::manual::Method::builder()
                 .name("report_own_batch")

--- a/narwhal/worker/src/batch_fetcher.rs
+++ b/narwhal/worker/src/batch_fetcher.rs
@@ -122,21 +122,16 @@ impl BatchFetcher {
                             // Also persist the batches, so they are available after restarts.
                             let mut write_batch = self.batch_store.batch();
 
-                            // TODO: Remove once we have upgraded to protocol version 12.
-                            if self.protocol_config.narwhal_versioned_metadata() {
-                                // Set received_at timestamp for remote batches.
-                                let mut updated_new_batches = HashMap::new();
-                                for (digest, batch) in new_batches {
-                                    let mut batch = (*batch).clone();
-                                    batch.versioned_metadata_mut().set_received_at(now());
-                                    updated_new_batches.insert(*digest, batch.clone());
-                                }
-                                fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
-                                write_batch.insert_batch(&self.batch_store, updated_new_batches).unwrap();
-                            } else {
-                                fetched_batches.extend(new_batches.iter().map(|(d, b)| (**d, (*b).clone())));
-                                write_batch.insert_batch(&self.batch_store, new_batches).unwrap();
+                            // Set received_at timestamp for remote batches.
+                            let mut updated_new_batches = HashMap::new();
+                            for (digest, batch) in new_batches {
+                                let mut batch = (*batch).clone();
+                                batch.versioned_metadata_mut().set_received_at(now());
+                                updated_new_batches.insert(*digest, batch.clone());
                             }
+                            fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
+                            write_batch.insert_batch(&self.batch_store, updated_new_batches).unwrap();
+
 
                             write_batch.write().unwrap();
                             if remaining_digests.is_empty() {
@@ -275,7 +270,7 @@ impl BatchFetcher {
             )
             .await?;
         for batch in batches {
-            // TODO: Remove once we have upgraded to protocol version 12.
+            // TODO: Remove once we have removed BatchV1 from the codebase.
             validate_batch_version(&batch, &self.protocol_config)
                 .map_err(|err| anyhow::anyhow!("[Protocol violation] Invalid batch: {err}"))?;
 
@@ -351,66 +346,20 @@ mod tests {
     use itertools::Itertools;
     use rand::rngs::StdRng;
     use std::collections::HashMap;
-    use test_utils::{get_protocol_config, latest_protocol_version};
+    use test_utils::latest_protocol_version;
     use tokio::time::timeout;
+    use types::BatchV1;
 
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #1: Receive BatchV1 and network has not upgraded to 12 so we are okay
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v1_and_network_v11() {
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let v11_protocol_config = get_protocol_config(11);
-        let batchv1_1 = Batch::new(vec![vec![1]], &v11_protocol_config);
-        let batchv1_2 = Batch::new(vec![vec![2]], &v11_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv1_1.digest(), batchv1_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv1_1.clone());
-        network.put(&[2, 3], batchv1_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: v11_protocol_config,
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batchv1_1.digest(), batchv1_1.clone()),
-            (batchv1_2.digest(), batchv1_2.clone()),
-        ]);
-        let fetched_batches = fetcher.fetch(digests, known_workers).await;
-        assert_eq!(fetched_batches, expected_batches);
-        assert_eq!(
-            batch_store
-                .get(&batchv1_1.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv1_1.digest()
-        );
-        assert_eq!(
-            batch_store
-                .get(&batchv1_2.digest())
-                .unwrap()
-                .unwrap()
-                .digest(),
-            batchv1_2.digest()
-        );
-    }
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #2: Receive BatchV1 but network has upgraded to 12 so we fail because we expect BatchV2
+    // TODO: Remove once we have removed BatchV1 from the codebase.
+    // Case #1: Receive BatchV1 but network is upgraded past v11 so we fail because we expect BatchV2
     #[tokio::test]
     pub async fn test_fetcher_with_batch_v1_and_network_v12() {
         telemetry_subscribers::init_for_testing();
         let mut network = TestRequestBatchesNetwork::new();
         let batch_store = test_utils::create_batch_store();
         let latest_protocol_config = latest_protocol_version();
-        let v11_protocol_config = &get_protocol_config(11);
-        let batchv1_1 = Batch::new(vec![vec![1]], v11_protocol_config);
-        let batchv1_2 = Batch::new(vec![vec![2]], v11_protocol_config);
+        let batchv1_1 = Batch::V1(BatchV1::new(vec![vec![1]]));
+        let batchv1_2 = Batch::V1(BatchV1::new(vec![vec![2]]));
         let (digests, known_workers) = (
             HashSet::from_iter(vec![batchv1_1.digest(), batchv1_2.digest()]),
             HashSet::from_iter(test_pks(&[1, 2])),
@@ -432,40 +381,8 @@ mod tests {
         assert!(fetch_result.is_err());
     }
 
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #3: Receive BatchV2 but network is still in v11 so we fail because we expect BatchV1
-    #[tokio::test]
-    pub async fn test_fetcher_with_batch_v2_and_network_v11() {
-        telemetry_subscribers::init_for_testing();
-        let mut network = TestRequestBatchesNetwork::new();
-        let batch_store = test_utils::create_batch_store();
-        let latest_protocol_config = &latest_protocol_version();
-        let v11_protocol_config = get_protocol_config(11);
-        let batchv2_1 = Batch::new(vec![vec![1]], latest_protocol_config);
-        let batchv2_2 = Batch::new(vec![vec![2]], latest_protocol_config);
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batchv2_1.digest(), batchv2_2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batchv2_1.clone());
-        network.put(&[2, 3], batchv2_2.clone());
-        let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
-            batch_store: batch_store.clone(),
-            metrics: Arc::new(WorkerMetrics::default()),
-            protocol_config: v11_protocol_config,
-        };
-        let fetch_result = timeout(
-            Duration::from_secs(1),
-            fetcher.fetch(digests, known_workers),
-        )
-        .await;
-        assert!(fetch_result.is_err());
-    }
-
-    // TODO: Remove once we have upgraded to protocol version 12.
-    // Case #4: Receive BatchV2 and network is upgraded to 12 so we are okay
+    // TODO: Remove once we have removed BatchV1 from the codebase.
+    // Case #2: Receive BatchV2 and network is upgraded past v11 so we are okay
     #[tokio::test]
     pub async fn test_fetcher_with_batch_v2_and_network_v12() {
         let mut network = TestRequestBatchesNetwork::new();

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tracing::{error, warn};
 use types::{
     error::DagError, now, Batch, BatchAPI, BatchDigest, ConditionalBroadcastReceiver, MetadataAPI,
-    Transaction, TxResponse, WorkerOurBatchMessage, WorkerOwnBatchMessage,
+    Transaction, TxResponse, WorkerOwnBatchMessage,
 };
 
 #[cfg(feature = "trace_transaction")]
@@ -268,95 +268,48 @@ impl BatchMaker {
         let store = self.store.clone();
         let worker_id = self.id;
 
-        // TODO: Remove once we have upgraded to protocol version 12.
-        if self.protocol_config.narwhal_versioned_metadata() {
-            // The batch has been sealed so we can officially set its creation time
-            // for latency calculations.
-            batch.versioned_metadata_mut().set_created_at(now());
-            let metadata = batch.versioned_metadata().clone();
+        // The batch has been sealed so we can officially set its creation time
+        // for latency calculations.
+        batch.versioned_metadata_mut().set_created_at(now());
+        let metadata = batch.versioned_metadata().clone();
 
-            Some(Box::pin(async move {
-                // Now save it to disk
-                let digest = batch.digest();
+        Some(Box::pin(async move {
+            // Now save it to disk
+            let digest = batch.digest();
 
-                if let Err(e) = store.insert(&digest, &batch) {
-                    error!("Store failed with error: {:?}", e);
-                    return;
-                }
+            if let Err(e) = store.insert(&digest, &batch) {
+                error!("Store failed with error: {:?}", e);
+                return;
+            }
 
-                // Also wait for sending to be done here
-                //
-                // TODO: Here if we get back Err it means that potentially this was not send
-                //       to a quorum. However, if that happens we can still proceed on the basis
-                //       that an other authority will request the batch from us, and we will deliver
-                //       it since it is now stored. So ignore the error for the moment.
-                let _ = done_sending.await;
+            // Also wait for sending to be done here
+            //
+            // TODO: Here if we get back Err it means that potentially this was not send
+            //       to a quorum. However, if that happens we can still proceed on the basis
+            //       that an other authority will request the batch from us, and we will deliver
+            //       it since it is now stored. So ignore the error for the moment.
+            let _ = done_sending.await;
 
-                // Send the batch to the primary.
-                let message = WorkerOwnBatchMessage {
-                    digest,
-                    worker_id,
-                    metadata,
-                };
-                if let Err(e) = client.report_own_batch(message).await {
-                    warn!("Failed to report our batch: {}", e);
-                    // Drop all response handers to signal error, since we
-                    // cannot ensure the primary has actually signaled the
-                    // batch will eventually be sent.
-                    // The transaction submitter will see the error and retry.
-                    return;
-                }
+            // Send the batch to the primary.
+            let message = WorkerOwnBatchMessage {
+                digest,
+                worker_id,
+                metadata,
+            };
+            if let Err(e) = client.report_own_batch(message).await {
+                warn!("Failed to report our batch: {}", e);
+                // Drop all response handers to signal error, since we
+                // cannot ensure the primary has actually signaled the
+                // batch will eventually be sent.
+                // The transaction submitter will see the error and retry.
+                return;
+            }
 
-                // We now signal back to the transaction sender that the transaction is in a
-                // batch and also the digest of the batch.
-                for response in responses {
-                    let _ = response.send(digest);
-                }
-            }))
-        } else {
-            // The batch has been sealed so we can officially set its creation time
-            // for latency calculations.
-            batch.metadata_mut().created_at = now();
-            let metadata = batch.metadata().clone();
-
-            Some(Box::pin(async move {
-                // Now save it to disk
-                let digest = batch.digest();
-
-                if let Err(e) = store.insert(&digest, &batch) {
-                    error!("Store failed with error: {:?}", e);
-                    return;
-                }
-
-                // Also wait for sending to be done here
-                //
-                // TODO: Here if we get back Err it means that potentially this was not send
-                //       to a quorum. However, if that happens we can still proceed on the basis
-                //       that an other authority will request the batch from us, and we will deliver
-                //       it since it is now stored. So ignore the error for the moment.
-                let _ = done_sending.await;
-
-                // Send the batch to the primary.
-                let message = WorkerOurBatchMessage {
-                    digest,
-                    worker_id,
-                    metadata,
-                };
-                if let Err(e) = client.report_our_batch(message).await {
-                    warn!("Failed to report our batch: {}", e);
-                    // Drop all response handers to signal error, since we
-                    // cannot ensure the primary has actually signaled the
-                    // batch will eventually be sent.
-                    // The transaction submitter will see the error and retry.
-                    return;
-                }
-
-                // We now signal back to the transaction sender that the transaction is in a
-                // batch and also the digest of the batch.
-                for response in responses {
-                    let _ = response.send(digest);
-                }
-            }))
-        }
+            // We now signal back to the transaction sender that the transaction is in a
+            // batch and also the digest of the batch.
+            for response in responses {
+                let _ = response.send(digest);
+            }
+        }))
     }
 }

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -57,11 +57,8 @@ impl<V: TransactionValidator> WorkerToWorker for WorkerReceiverHandler<V> {
 
         let mut batch = message.batch.clone();
 
-        // TODO: Remove once we have upgraded to protocol version 12.
-        if self.protocol_config.narwhal_versioned_metadata() {
-            // Set received_at timestamp for remote batch.
-            batch.versioned_metadata_mut().set_received_at(now());
-        }
+        // Set received_at timestamp for remote batch.
+        batch.versioned_metadata_mut().set_received_at(now());
         self.store.insert(&digest, &batch).map_err(|e| {
             anemo::rpc::Status::internal(format!("failed to write to batch store: {e:?}"))
         })?;
@@ -224,7 +221,7 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                 }
             }
 
-            // TODO: Remove once we have upgraded to protocol version 12.
+            // TODO: Remove once we have removed BatchV1 from the codebase.
             validate_batch_version(batch, &self.protocol_config).map_err(|err| {
                 anemo::rpc::Status::new_with_message(
                     StatusCode::BadRequest,
@@ -234,11 +231,8 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
 
             let digest = batch.digest();
             if missing.remove(&digest) {
-                // TODO: Remove once we have upgraded to protocol version 12.
-                if self.protocol_config.narwhal_versioned_metadata() {
-                    // Set received_at timestamp for remote batch.
-                    batch.versioned_metadata_mut().set_received_at(now());
-                }
+                // Set received_at timestamp for remote batch.
+                batch.versioned_metadata_mut().set_received_at(now());
                 self.store.insert(&digest, batch).map_err(|e| {
                     anemo::rpc::Status::internal(format!("failed to write to batch store: {e:?}"))
                 })?;


### PR DESCRIPTION
## Description 

We have moved past protocol version 11 so we can remove some of the unused code. However because Batch store expects the original Batch enum format we cannot remove BatchV1 completely without causing issues to the schema. To fully remove BatchV1 we will have to create a new Batch store that only uses BatchV2 instead of the Batch versioned enum.

## Test Plan 

[Tested version upgrade in labnet](https://metrics.sui.io/d/HH91BjB4z/throughput?orgId=1&from=1690435970447&to=1690437139251&var-Environment=mysten-metrics-internal&var-network=labnet&var-validator=All)