### PR TITLE
Do not read from DB to collect storage rebate

### DIFF
--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use crate::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
+    digests::ObjectDigest,
     error::{ExecutionError, ExecutionErrorKind, SuiError},
     execution_status::CommandArgumentError,
     object::Owner,
@@ -78,6 +79,12 @@ pub struct InputObjectMetadata {
     pub is_mutable_input: bool,
     pub owner: Owner,
     pub version: SequenceNumber,
+}
+
+pub struct LoadedChildObjectMetadata {
+    pub version: SequenceNumber,
+    pub digest: ObjectDigest,
+    pub storage_rebate: u64,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -81,6 +81,7 @@ pub struct InputObjectMetadata {
     pub version: SequenceNumber,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct LoadedChildObjectMetadata {
     pub version: SequenceNumber,
     pub digest: ObjectDigest,

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -8,6 +8,7 @@ use crate::digests::{
 };
 use crate::effects::{TransactionEffects, TransactionEvents};
 use crate::error::SuiError;
+use crate::execution::LoadedChildObjectMetadata;
 use crate::message_envelope::Message;
 use crate::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, FullCheckpointContents, VerifiedCheckpoint,
@@ -132,7 +133,7 @@ pub trait Storage {
 
     fn save_loaded_child_objects(
         &mut self,
-        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
     );
 }
 

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -3,6 +3,7 @@
 
 use crate::committee::EpochId;
 use crate::effects::{TransactionEffects, TransactionEvents};
+use crate::execution::LoadedChildObjectMetadata;
 use crate::execution_status::ExecutionStatus;
 use crate::storage::{DeleteKindWithOldVersion, ObjectStore};
 use crate::sui_system_state::{
@@ -179,7 +180,7 @@ pub struct TemporaryStore<'backing> {
     deleted: BTreeMap<ObjectID, DeleteKindWithOldVersion>,
     /// Child objects loaded during dynamic field opers
     /// Currently onply populated for full nodes, not for validators
-    loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+    loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
     /// Ordered sequence of events emitted by execution
     events: Vec<Event>,
     protocol_config: ProtocolConfig,
@@ -315,7 +316,11 @@ impl<'backing> TemporaryStore<'backing> {
             deleted,
             events: TransactionEvents { data: self.events },
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
-            loaded_child_objects: self.loaded_child_objects,
+            loaded_child_objects: self
+                .loaded_child_objects
+                .into_iter()
+                .map(|(id, metadata)| (id, metadata.version))
+                .collect(),
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
             runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.read().clone(),
         }
@@ -574,7 +579,7 @@ impl<'backing> TemporaryStore<'backing> {
     }
     pub fn save_loaded_child_objects(
         &mut self,
-        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
     ) {
         #[cfg(debug_assertions)]
         {
@@ -784,17 +789,18 @@ impl<'backing> TemporaryStore<'backing> {
 
 impl<'backing> TemporaryStore<'backing> {
     /// Return the storage rebate of object `id`
-    fn get_input_storage_rebate(&self, id: &ObjectID, expected_version: SequenceNumber) -> u64 {
+    fn get_input_storage_rebate(&self, id: &ObjectID) -> u64 {
+        // A mutated object must either be from input object or child object.
         if let Some(old_obj) = self.input_objects.get(id) {
             old_obj.storage_rebate
+        } else if let Some(metadata) = self.loaded_child_objects.get(id) {
+            metadata.storage_rebate
         } else {
-            // else, this is a dynamic field, not an input object
-            if let Ok(Some(old_obj)) = self.store.get_object_by_key(id, expected_version) {
-                old_obj.storage_rebate
-            } else {
-                // not a lot we can do safely and under this condition everything is broken
-                panic!("Looking up storage rebate of mutated object should not fail")
-            }
+            // not a lot we can do safely and under this condition everything is broken
+            panic!(
+                "Looking up storage rebate of mutated object {:?} should not fail",
+                id
+            )
         }
     }
 
@@ -863,10 +869,9 @@ impl<'backing> TemporaryStore<'backing> {
     pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
         for (object_id, kind) in &self.deleted {
             match kind {
-                DeleteKindWithOldVersion::Wrap(version)
-                | DeleteKindWithOldVersion::Normal(version) => {
+                DeleteKindWithOldVersion::Wrap(_) | DeleteKindWithOldVersion::Normal(_) => {
                     // get and track the deleted object `storage_rebate`
-                    let storage_rebate = self.get_input_storage_rebate(object_id, *version);
+                    let storage_rebate = self.get_input_storage_rebate(object_id);
                     gas_charger.track_storage_mutation(0, storage_rebate);
                 }
                 DeleteKindWithOldVersion::UnwrapThenDelete
@@ -1162,7 +1167,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
 
     fn save_loaded_child_objects(
         &mut self,
-        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
     ) {
         TemporaryStore::save_loaded_child_objects(self, loaded_child_objects)
     }

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -17,7 +17,7 @@ use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber},
     error::VMMemoryLimitExceededSubStatusCode,
     metrics::LimitsMetrics,
-    object::{Data, MoveObject, Owner},
+    object::{Data, MoveObject, Object, Owner},
     storage::ChildObjectResolver,
 };
 
@@ -47,7 +47,7 @@ struct Inner<'a> {
     root_version: BTreeMap<ObjectID, SequenceNumber>,
     // cached objects from the resolver. An object might be in this map but not in the store
     // if it's existence was queried, but the value was not used.
-    cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
+    cached_objects: BTreeMap<ObjectID, Option<Object>>,
     // whether or not this TX is gas metered
     is_metered: bool,
     // Local protocol config used to enforce limits
@@ -132,7 +132,7 @@ impl<'a> Inner<'a> {
                             ),
                         ))
                     }
-                    Data::Move(mo @ MoveObject { .. }) => Some(mo),
+                    Data::Move(_) => Some(object),
                 }
             } else {
                 None
@@ -159,7 +159,17 @@ impl<'a> Inner<'a> {
 
             e.insert(obj_opt);
         }
-        Ok(self.cached_objects.get(&child).unwrap().as_ref())
+        Ok(self
+            .cached_objects
+            .get(&child)
+            .unwrap()
+            .as_ref()
+            .map(|obj| {
+                obj.data
+                    .try_as_move()
+                    // unwrap safe because we only insert Move objects
+                    .unwrap()
+            }))
     }
 
     fn fetch_object_impl(
@@ -391,7 +401,7 @@ impl<'a> ObjectStore<'a> {
         Ok(())
     }
 
-    pub(super) fn cached_objects(&self) -> &BTreeMap<ObjectID, Option<MoveObject>> {
+    pub(super) fn cached_objects(&self) -> &BTreeMap<ObjectID, Option<Object>> {
         &self.inner.cached_objects
     }
 

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -23,6 +23,7 @@ use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolC
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     error::{ExecutionError, ExecutionErrorKind, VMMemoryLimitExceededSubStatusCode},
+    execution::LoadedChildObjectMetadata,
     id::UID,
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
@@ -400,11 +401,22 @@ impl<'a> ObjectRuntime<'a> {
         self.object_store.all_active_objects()
     }
 
-    pub fn loaded_child_objects(&self) -> BTreeMap<ObjectID, SequenceNumber> {
+    pub fn loaded_child_objects(&self) -> BTreeMap<ObjectID, LoadedChildObjectMetadata> {
         self.object_store
             .cached_objects()
             .iter()
-            .filter_map(|(id, obj_opt)| Some((*id, obj_opt.as_ref()?.version())))
+            .filter_map(|(id, obj_opt)| {
+                obj_opt.as_ref().map(|obj| {
+                    (
+                        *id,
+                        LoadedChildObjectMetadata {
+                            version: obj.version(),
+                            digest: obj.digest(),
+                            storage_rebate: obj.storage_rebate,
+                        },
+                    )
+                })
+            })
             .collect()
     }
 }

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
@@ -17,7 +17,7 @@ use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber},
     error::VMMemoryLimitExceededSubStatusCode,
     metrics::LimitsMetrics,
-    object::{Data, MoveObject, Owner},
+    object::{Data, MoveObject, Object, Owner},
     storage::ChildObjectResolver,
 };
 
@@ -47,7 +47,7 @@ struct Inner<'a> {
     root_version: BTreeMap<ObjectID, SequenceNumber>,
     // cached objects from the resolver. An object might be in this map but not in the store
     // if it's existence was queried, but the value was not used.
-    cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
+    cached_objects: BTreeMap<ObjectID, Option<Object>>,
     // whether or not this TX is gas metered
     is_metered: bool,
     // Local protocol config used to enforce limits
@@ -132,7 +132,7 @@ impl<'a> Inner<'a> {
                             ),
                         ))
                     }
-                    Data::Move(mo @ MoveObject { .. }) => Some(mo),
+                    Data::Move(_) => Some(object),
                 }
             } else {
                 None
@@ -159,7 +159,12 @@ impl<'a> Inner<'a> {
 
             e.insert(obj_opt);
         }
-        Ok(self.cached_objects.get(&child).unwrap().as_ref())
+        Ok(self
+            .cached_objects
+            .get(&child)
+            .unwrap()
+            .as_ref()
+            .map(|obj| obj.data.try_as_move().unwrap()))
     }
 
     fn fetch_object_impl(
@@ -391,7 +396,7 @@ impl<'a> ObjectStore<'a> {
         Ok(())
     }
 
-    pub(super) fn cached_objects(&self) -> &BTreeMap<ObjectID, Option<MoveObject>> {
+    pub(super) fn cached_objects(&self) -> &BTreeMap<ObjectID, Option<Object>> {
         &self.inner.cached_objects
     }
 


### PR DESCRIPTION
## Description 

When collecting storage rebate from mutated objects, for child object we read from the DB. This is a waste because we already loaded all of them in memory at runtime. This PR populates that information back to the temporary store.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
