### PR TITLE
do not download objects data for tx data, and others

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -77,7 +77,6 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             .map(|_| create_transaction(sequence_number))
             .collect(),
         events: vec![],
-        packages: vec![],
         input_objects: vec![],
         changed_objects: vec![],
         move_calls: vec![],

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -181,8 +181,8 @@ impl Indexer {
             "Sui indexer of version {:?} started...",
             env!("CARGO_PKG_VERSION")
         );
+        mysten_metrics::init_metrics(registry);
         let subscription_handler = Arc::new(SubscriptionHandler::new(registry));
-
         if config.rpc_server_worker && config.fullnode_sync_worker {
             info!("Starting indexer with both fullnode sync and RPC server");
             // let JSON RPC server run forever.

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -28,6 +28,7 @@ pub struct IndexerMetrics {
     pub latest_indexer_object_checkpoint_sequence_number: IntGauge,
     // checkpoint E2E latency is:
     // fullnode_download_latency + checkpoint_index_latency + db_commit_latency
+    pub fullnode_checkpoint_data_download_latency: Histogram,
     pub fullnode_checkpoint_wait_and_download_latency: Histogram,
     pub fullnode_transaction_download_latency: Histogram,
     pub fullnode_object_download_latency: Histogram,
@@ -133,6 +134,13 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            fullnode_checkpoint_data_download_latency: register_histogram_with_registry!(
+                "fullnode_checkpoint_data_download_latency",
+                "Time spent in downloading checkpoint and transation for a new checkpoint from the Full Node",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
             fullnode_checkpoint_wait_and_download_latency: register_histogram_with_registry!(
                 "fullnode_checkpoint_wait_and_download_latency",
                 "Time spent in waiting for a new checkpoint from the Full Node",
@@ -140,6 +148,7 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+
             fullnode_transaction_download_latency: register_histogram_with_registry!(
                 "fullnode_transaction_download_latency",
                 "Time spent in waiting for a new transaction from the Full Node",

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -1,17 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use prometheus::{Histogram, IntCounter};
 
 use move_core_types::identifier::Identifier;
 use sui_json_rpc_types::{
     Checkpoint as RpcCheckpoint, CheckpointId, EpochInfo, EventFilter, EventPage, MoveCallMetrics,
-    NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseOptions,
+    NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionBlockEffects,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, SuiAddress, VersionNumber};
-use sui_types::digests::CheckpointDigest;
+use sui_types::digests::{CheckpointDigest, TransactionDigest};
 use sui_types::error::SuiError;
 use sui_types::event::EventID;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -296,26 +298,26 @@ pub trait IndexerStore {
 }
 
 #[derive(Clone, Debug)]
-pub struct CheckpointData {
+pub struct CheckpointTxData {
     pub checkpoint: RpcCheckpoint,
     pub transactions: Vec<CheckpointTransactionBlockResponse>,
-    pub changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
+    // For epoch indexing, only populated in epoch change and genesis
+    // We use `Vec` here beacause the list is very small.
+    pub system_state_objects: Vec<sui_types::object::Object>,
 }
 
-impl ObjectStore for CheckpointData {
+// CheckpointTxData can ONLY be used as a ObjectStore
+// for SuiSystemState Object.
+impl ObjectStore for CheckpointTxData {
     fn get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<sui_types::object::Object>, SuiError> {
         Ok(self
-            .changed_objects
+            .system_state_objects
             .iter()
-            .find_map(|(status, o)| match status {
-                ObjectStatus::Created | ObjectStatus::Mutated if &o.object_id == object_id => {
-                    o.clone().try_into().ok()
-                }
-                _ => None,
-            }))
+            .find(|o| o.id() == *object_id)
+            .cloned())
     }
 
     fn get_object_by_key(
@@ -324,17 +326,21 @@ impl ObjectStore for CheckpointData {
         version: VersionNumber,
     ) -> Result<Option<sui_types::object::Object>, SuiError> {
         Ok(self
-            .changed_objects
+            .system_state_objects
             .iter()
-            .find_map(|(status, o)| match status {
-                ObjectStatus::Created | ObjectStatus::Mutated
-                    if &o.object_id == object_id && o.version == version =>
-                {
-                    o.clone().try_into().ok()
-                }
-                _ => None,
-            }))
+            .find(|o| o.id() == *object_id && o.version() == version)
+            .cloned())
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckpointObjectData {
+    pub epoch: EpochId,
+    pub checkpoint_seq: CheckpointSequenceNumber,
+    // SuiAddress is tx sender
+    pub transactions: Vec<(TransactionDigest, SuiTransactionBlockEffects)>,
+    pub transaction_senders: HashMap<TransactionDigest, SuiAddress>,
+    pub changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
 }
 
 // Per checkpoint indexing
@@ -343,7 +349,6 @@ pub struct TemporaryCheckpointStore {
     pub checkpoint: Checkpoint,
     pub transactions: Vec<Transaction>,
     pub events: Vec<Event>,
-    pub packages: Vec<Package>,
     pub input_objects: Vec<InputObject>,
     pub changed_objects: Vec<ChangedObject>,
     pub move_calls: Vec<MoveCall>,


### PR DESCRIPTION
## Description 

This PR improves indexer ingestion latency, including the following notable changes:
1. avoid downloading object data for txes/checkpoints indexing. To keep epoch indexing working, we will special handle system state objects when the checkpoint is either Genesis or ChangeEpoch. Also move package indexing to object indexing pipeline.
2. use `metered_channels` so we can easily identify the bottlenecks.
3. make some of queue sizes configuration. As in experiments, they turned out to be too small.
4. get rid of unnecessary `Arc<Mutex>>` around sender/receivers.
5. use a dedicated tokio task to poll fullnode checkpoint number, to avoid adding this latency in every download attempt.


Note: I also tried to use `lru` (crate) to cache the preliminary transaction data for object indexing, so they don't get downloaded twice. However the use of Mutex in fact slows things down. I didn't investigate though, because currently the bottleneck is on the write side.

## Test Plan 

deployed to experiments.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves indexer ingestion latency.