### PR TITLE
[simple] Unignore package upgrade test in CLI tests

### DIFF
--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -901,10 +901,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
     Ok(())
 }
 
-// TODO(tzakian): When we remove the upgrade feature flag un-ignore this test.
-// This test will fail until the protocol config allows upgrades (doesn't work with an override).
 #[sim_test]
-#[ignore]
 async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let mut test_cluster = TestClusterBuilder::new().build().await;


### PR DESCRIPTION
## Description 

When this test was added it needed to be ignored because package upgrades were not allowed at the current protocol version. However they are now supported so this test should be run.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
