### PR TITLE
[keytool] use a table format output and add json output support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "bytemuck"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +4349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_to_table"
+version = "0.6.0"
+source = "git+https://github.com/zhiburt/tabled/?rev=e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4#e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4"
+dependencies = [
+ "serde_json",
+ "tabled",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6697,6 +6712,17 @@ dependencies = [
  "elliptic-curve 0.13.4",
  "primeorder",
  "sha2 0.10.6",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -9105,6 +9131,7 @@ dependencies = [
  "git-version",
  "inquire",
  "jemalloc-ctl",
+ "json_to_table",
  "move-bytecode-verifier",
  "move-core-types",
  "move-package",
@@ -9142,6 +9169,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-types",
  "sui-verifier-latest",
+ "tabled",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -11102,6 +11130,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.58",
+ "quote 1.0.26",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "tabular"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12795,6 +12847,7 @@ dependencies = [
  "bumpalo",
  "byte-slice-cast",
  "bytecode-interpreter-crypto",
+ "bytecount",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -13047,6 +13100,7 @@ dependencies = [
  "jemalloc-sys",
  "jobserver",
  "js-sys",
+ "json_to_table",
  "jsonpath_lib",
  "jsonrpsee",
  "jsonrpsee-client-transport",
@@ -13188,6 +13242,7 @@ dependencies = [
  "overload",
  "owo-colors",
  "p256",
+ "papergrid",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "parking",
@@ -13412,6 +13467,8 @@ dependencies = [
  "sync_wrapper",
  "synstructure",
  "sysinfo",
+ "tabled",
+ "tabled_derive",
  "tabular",
  "tap",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,7 @@ itertools = "0.10.5"
 jemalloc-ctl = "^0.5"
 jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["full", "http-client", "jsonrpsee-core"] }
 jsonrpsee-proc-macros = {git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8"}
+json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4"}
 leb128 = "0.2.5"
 linked-hash-map = "0.5.6"
 lru = "0.10"
@@ -351,6 +352,7 @@ syn = { version = "1.0.104", features = ["full", "derive", "extra-traits"] }
 # syn = { version = "2", features = ["full", "fold", "extra-traits"] }
 synstructure = "0.12"
 sysinfo = "0.27.5"
+tabled = { version = "0.12" }
 tap = "1.0.1"
 tempfile = "3.3.0"
 test-fuzz = "3.0.4"

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 edition = "2021"
 
 [dependencies]
+json_to_table.workspace = true
+tabled.workspace = true
 anemo.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -503,7 +503,7 @@ impl KeyToolCommand {
                 let keys = keystore
                     .keys()
                     .into_iter()
-                    .map(|key| Key::from(key))
+                    .map(Key::from)
                     .collect::<Vec<_>>();
 
                 CommandOutput::List(keys)

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -14,12 +14,16 @@ use fastcrypto_zkp::bn254::zk_login::OAuthProvider;
 use fastcrypto_zkp::bn254::zk_login::{
     big_int_str_to_bytes, AuxInputs, PublicInputs, SupportedKeyClaim, ZkLoginProof,
 };
+use json_to_table::{json_to_table, Orientation};
 use num_bigint::{BigInt, Sign};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rusoto_core::Region;
 use rusoto_kms::{Kms, KmsClient, SignRequest};
+use serde::Serialize;
+use serde_json::json;
 use shared_crypto::intent::{Intent, IntentMessage};
+use std::fmt::{Debug, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -42,6 +46,10 @@ use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::zk_login_util::AddressParams;
 use tracing::info;
 
+use tabled::builder::Builder;
+use tabled::settings::Rotate;
+use tabled::settings::{object::Rows, Modify, Width};
+
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
 mod keytool_tests;
@@ -50,6 +58,22 @@ mod keytool_tests;
 #[derive(Subcommand)]
 #[clap(rename_all = "kebab-case")]
 pub enum KeyToolCommand {
+    /// Convert private key from wallet format (hex of 32 byte private key) to sui.keystore format
+    /// (base64 of 33 byte flag || private key) or vice versa.
+    Convert { value: String },
+    /// Given a Base64 encoded transaction bytes, decode its components.
+    DecodeTxBytes {
+        #[clap(long)]
+        tx_bytes: String,
+    },
+    /// Given a Base64 encoded MultiSig signature, decode its components.
+    /// If tx_bytes is passed in, verify the multisig.
+    DecodeMultiSig {
+        #[clap(long)]
+        multisig: MultiSig,
+        #[clap(long)]
+        tx_bytes: Option<String>,
+    },
     /// Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1}
     /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
     /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word
@@ -58,85 +82,39 @@ pub enum KeyToolCommand {
     ///
     /// The keypair file is output to the current directory. The content of the file is
     /// a Base64 encoded string of 33-byte `flag || privkey`. Note: To generate and add keypair
-    /// to sui.keystore, use `sui client new-address`), see more at [enum SuiClientCommands].
+    /// to sui.keystore, use `sui client new-address`).
     Generate {
         key_scheme: SignatureScheme,
         word_length: Option<String>,
         derivation_path: Option<DerivationPath>,
     },
-    /// This reads the content at the provided file path. The accepted format can be
-    /// [enum SuiKeyPair] (Base64 encoded of 33-byte `flag || privkey`) or `type AuthorityKeyPair`
-    /// (Base64 encoded `privkey`). It prints its Base64 encoded public key and the key scheme flag.
-    Show {
-        file: PathBuf,
+    /// Input the address seed and show the address based on iss,
+    /// key_claim_name and address_sed.
+    GenerateZkLoginAddress {
+        #[clap(long)]
+        address_seed: String,
     },
-    /// This takes [enum SuiKeyPair] of Base64 encoded of 33-byte `flag || privkey`). It
-    /// outputs the keypair into a file at the current directory, and prints out its Sui
-    /// address, Base64 encoded public key, and the key scheme flag.
-    Unpack {
-        keypair: SuiKeyPair,
-    },
-    /// List all keys by its Sui address, Base64 encoded public key, key scheme name in
-    /// sui.keystore.
-    List,
-    /// Create signature using the private key for for the given address in sui keystore.
-    /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
-    /// of the BCS serialized transaction bytes itself (the result of
-    /// [transaction builder API](https://docs.sui.io/sui-jsonrpc) and its intent. If
-    /// intent is absent, default will be used. See [struct IntentMessage] and [struct Intent]
-    /// for more details.
-    Sign {
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
-        address: SuiAddress,
-        #[clap(long)]
-        data: String,
-        #[clap(long)]
-        intent: Option<Intent>,
-    },
-    /// Creates a signature by leveraging AWS KMS. Pass in a key-id to leverage Amazon
-    /// KMS to sign a message and the base64 pubkey.
-    /// Generate PubKey from pem using MystenLabs/base64pemkey
-    /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
-    /// of the BCS serialized transaction bytes itself (the result of
-    /// [transaction builder API](https://docs.sui.io/sui-jsonrpc) and its intent. If
-    /// intent is absent, default will be used. See [struct IntentMessage] and [struct Intent]
-    /// for more details.
-    SignKMS {
-        #[clap(long)]
-        data: String,
-        #[clap(long)]
-        keyid: String,
-        #[clap(long)]
-        intent: Option<Intent>,
-        #[clap(long)]
-        base64pk: String,
-    },
-    /// Add a new key to sui.keystore using either the input mnemonic phrase or a private key (from the Wallet), the key scheme flag {ed25519 | secp256k1 | secp256r1}
-    /// and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
+    /// Converts a hexadecimal string to its Base64 encoded representation.
+    HexToBase64 { hex: String },
+    /// Converts a hexadecimal string to its corresponding bytes.
+    HexToBytes { hex: String },
+    /// Add a new key to sui.keystore using either the input mnemonic phrase or a private key (from the Wallet),
+    /// the key scheme flag {ed25519 | secp256k1 | secp256r1} and an optional derivation path,
+    /// default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
     /// or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24.
     Import {
         input_string: String,
         key_scheme: SignatureScheme,
         derivation_path: Option<DerivationPath>,
     },
-    /// Convert private key from wallet format (hex of 32 byte private key) to sui.keystore format
-    /// (base64 of 33 byte flag || private key) or vice versa.
-    Convert {
-        value: String,
-    },
-
+    /// List all keys by its Sui address, Base64 encoded public key, key scheme name in
+    /// sui.keystore.
+    List,
     /// This reads the content at the provided file path. The accepted format can be
     /// [enum SuiKeyPair] (Base64 encoded of 33-byte `flag || privkey`) or `type AuthorityKeyPair`
     /// (Base64 encoded `privkey`). This prints out the account keypair as Base64 encoded `flag || privkey`,
     /// the network keypair, worker keypair, protocol keypair as Base64 encoded `privkey`.
-    LoadKeypair {
-        file: PathBuf,
-    },
-
-    Base64PubKeyToAddress {
-        base64_key: String,
-    },
-
+    LoadKeypair { file: PathBuf },
     /// To MultiSig Sui Address. Pass in a list of all public keys `flag || pk` in Base64.
     /// See `keytool list` for example public keys.
     MultiSigAddress {
@@ -147,7 +125,6 @@ pub enum KeyToolCommand {
         #[clap(long, multiple_occurrences = false, multiple_values = true)]
         weights: Vec<WeightUnit>,
     },
-
     /// Provides a list of participating signatures (`flag || sig || pk` encoded in Base64),
     /// threshold, a list of all public keys and a list of their weights that define the
     /// MultiSig address. Returns a valid MultiSig signature and its sender address. The
@@ -167,7 +144,6 @@ pub enum KeyToolCommand {
         #[clap(long)]
         threshold: ThresholdUnit,
     },
-
     MultiSigCombinePartialSigLegacy {
         #[clap(long, multiple_occurrences = false, multiple_values = true)]
         sigs: Vec<Signature>,
@@ -178,66 +154,6 @@ pub enum KeyToolCommand {
         #[clap(long)]
         threshold: ThresholdUnit,
     },
-
-    /// Given a Base64 encoded MultiSig signature, decode its components.
-    /// If tx_bytes is passed in, verify the multisig.
-    DecodeMultiSig {
-        #[clap(long)]
-        multisig: MultiSig,
-        #[clap(long)]
-        tx_bytes: Option<String>,
-    },
-
-    /// Given a Base64 encoded transaction bytes, decode its components.
-    DecodeTxBytes {
-        #[clap(long)]
-        tx_bytes: String,
-    },
-
-    /// Converts a Base64 encoded string to its hexadecimal representation.
-    Base64ToHex {
-        base64: String,
-    },
-
-    /// Converts a hexadecimal string to its Base64 encoded representation.
-    HexToBase64 {
-        hex: String,
-    },
-
-    /// Converts a hexadecimal string to its corresponding bytes.
-    HexToBytes {
-        hex: String,
-    },
-
-    /// Converts an array of bytes to its hexadecimal string representation.
-    BytesToHex {
-        bytes: Vec<u8>,
-    },
-
-    /// Decodes a Base64 encoded string to its corresponding bytes.
-    Base64ToBytes {
-        base64: String,
-    },
-
-    /// Encodes an array of bytes to its Base64 string representation.
-    BytesToBase64 {
-        bytes: Vec<u8>,
-    },
-
-    /// Input the max epoch and generate a nonce with max_epoch,
-    /// ephemeral_pubkey and a randomoness.
-    ZkLogInPrepare {
-        #[clap(long)]
-        max_epoch: String,
-    },
-
-    /// Input the address seed and show the address based on iss,
-    /// key_claim_name and address_sed.
-    GenerateZkLoginAddress {
-        #[clap(long)]
-        address_seed: String,
-    },
-
     /// Given the proof in string, public inputs in string, aux inputs in
     /// string and base64 encoded string user signature, serialize into
     /// a GenericSignature::ZkLoginAuthenticator.
@@ -251,106 +167,302 @@ pub enum KeyToolCommand {
         #[clap(long)]
         user_signature: String,
     },
+    /// Read the content at the provided file path. The accepted format can be
+    /// [enum SuiKeyPair] (Base64 encoded of 33-byte `flag || privkey`) or `type AuthorityKeyPair`
+    /// (Base64 encoded `privkey`). It prints its Base64 encoded public key and the key scheme flag.
+    Show { file: PathBuf },
+    /// Create signature using the private key for for the given address in sui keystore.
+    /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
+    /// of the BCS serialized transaction bytes itself and its intent. If intent is absent,
+    /// default will be used.
+    Sign {
+        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        address: SuiAddress,
+        #[clap(long)]
+        data: String,
+        #[clap(long)]
+        intent: Option<Intent>,
+    },
+    /// Creates a signature by leveraging AWS KMS. Pass in a key-id to leverage Amazon
+    /// KMS to sign a message and the base64 pubkey.
+    /// Generate PubKey from pem using MystenLabs/base64pemkey
+    /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
+    /// of the BCS serialized transaction bytes itself and its intent. If intent is absent,
+    /// default will be used.
+    SignKMS {
+        #[clap(long)]
+        data: String,
+        #[clap(long)]
+        keyid: String,
+        #[clap(long)]
+        intent: Option<Intent>,
+        #[clap(long)]
+        base64pk: String,
+    },
+    /// This takes [enum SuiKeyPair] of Base64 encoded of 33-byte `flag || privkey`). It
+    /// outputs the keypair into a file at the current directory where the address is the filename,
+    /// and prints out its Sui address, Base64 encoded public key, the key scheme, and the key scheme flag.
+    Unpack { keypair: SuiKeyPair },
+    /// Input the max epoch and generate a nonce with max_epoch,
+    /// ephemeral_pubkey and a randomoness.
+    ZkLogInPrepare {
+        #[clap(long)]
+        max_epoch: String,
+    },
+}
+
+// Command Output types
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodedMultiSig {
+    public_base64_key: String,
+    sig_base64: String,
+    weight: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodedMultiSigOutput {
+    multisig_address: SuiAddress,
+    participating_keys_signatures: Vec<DecodedMultiSig>,
+    pub_keys: Vec<MultiSigOutput>,
+    threshold: usize,
+    transaction_result: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Key {
+    sui_address: SuiAddress,
+    public_base64_key: String,
+    key_scheme: String,
+    flag: u8,
+    mnemonic: Option<String>,
+    peer_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeypairData {
+    account_keypair: String,
+    network_keypair: Option<String>,
+    worker_keypair: Option<String>,
+    key_scheme: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiSigAddress {
+    multisig_address: String,
+    multisig: Vec<MultiSigOutput>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiSigCombinePartialSig {
+    multisig_address: SuiAddress,
+    multisig_parsed: GenericSignature,
+    multisig_serialized: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiSigCombinePartialSigLegacyOutput {
+    multisig_address: SuiAddress,
+    multisig_legacy_parsed: GenericSignature,
+    multisig_legacy_serialized: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiSigOutput {
+    address: SuiAddress,
+    public_base64_key: String,
+    weight: u8,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateKeyBase64 {
+    base64: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedSig {
+    serialized_sig_base64: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignData {
+    sui_address: SuiAddress,
+    // Base64 encoded string of serialized transaction data.
+    raw_tx_data: String,
+    // Intent struct used, see [struct Intent] for field definitions.
+    intent: Intent,
+    // Base64 encoded [struct IntentMessage] consisting of (intent || message)
+    // where message can be `TransactionData` etc.
+    raw_intent_msg: String,
+    // Base64 encoded blake2b hash of the intent message, this is what the signature commits to.
+    digest: String,
+    // Base64 encoded `flag || signature || pubkey` for a complete
+    // serialized Sui signature to be send for executing the transaction.
+    sui_signature: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZkLogInPrepare {
+    ephemeral_pubkey: String,
+    ephemeral_keypair: String,
+    nonce: String,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum CommandOutput {
+    DecodeMultiSig(DecodedMultiSigOutput),
+    DecodeTxBytes(TransactionData),
+    Error(String),
+    HexToBase64(Base64),
+    HexToBytes(Vec<u8>),
+    Generate(Key),
+    GenerateZkLoginAddress(SuiAddress, AddressParams),
+    Import(Key),
+    List(Vec<Key>),
+    LoadKeypair(KeypairData),
+    MultiSigAddress(MultiSigAddress),
+    MultiSigCombinePartialSig(MultiSigCombinePartialSig),
+    MultiSigCombinePartialSigLegacy(MultiSigCombinePartialSigLegacyOutput),
+    PrivateKeyBase64(PrivateKeyBase64),
+    SerializeZkLoginAuthenticator(SerializedSig),
+    Show(Key),
+    Sign(SignData),
+    SignKMS(SerializedSig),
+    ZkLogInPrepare(ZkLogInPrepare),
 }
 
 impl KeyToolCommand {
-    pub async fn execute(self, keystore: &mut Keystore) -> Result<(), anyhow::Error> {
-        match self {
+    pub async fn execute(self, keystore: &mut Keystore) -> Result<CommandOutput, anyhow::Error> {
+        let cmd_result = Ok(match self {
+            KeyToolCommand::Convert { value } => {
+                let result = convert_private_key_to_base64(value)?;
+                CommandOutput::PrivateKeyBase64(PrivateKeyBase64 { base64: result })
+            }
+
+            KeyToolCommand::DecodeMultiSig { multisig, tx_bytes } => {
+                let pks = multisig.get_pk().pubkeys();
+                let sigs = multisig.get_sigs();
+                let bitmap = multisig.get_indices()?;
+                let address = SuiAddress::from(multisig.get_pk());
+
+                let pub_keys = pks
+                    .iter()
+                    .map(|(pk, w)| MultiSigOutput {
+                        address: (pk).into(),
+                        public_base64_key: pk.encode_base64(),
+                        weight: *w,
+                    })
+                    .collect::<Vec<MultiSigOutput>>();
+
+                let threshold = *multisig.get_pk().threshold() as usize;
+
+                let mut output = DecodedMultiSigOutput {
+                    multisig_address: address,
+                    participating_keys_signatures: vec![],
+                    pub_keys,
+                    threshold,
+                    transaction_result: "".to_string(),
+                };
+
+                for (sig, i) in sigs.iter().zip(bitmap) {
+                    let (pk, w) = pks
+                        .get(i as usize)
+                        .ok_or(anyhow!("Invalid public keys index".to_string()))?;
+                    output.participating_keys_signatures.push(DecodedMultiSig {
+                        public_base64_key: Base64::encode(sig.as_ref()).clone(),
+                        sig_base64: pk.encode_base64().clone(),
+                        weight: w.to_string(),
+                    })
+                }
+
+                if tx_bytes.is_some() {
+                    let tx_bytes = Base64::decode(&tx_bytes.unwrap())
+                        .map_err(|e| anyhow!("Invalid base64 tx bytes: {:?}", e))?;
+                    let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
+                    let res = GenericSignature::MultiSig(multisig).verify_authenticator(
+                        &IntentMessage::new(Intent::sui_transaction(), tx_data),
+                        address,
+                        None,
+                        &VerifyParams::default(),
+                    );
+                    output.transaction_result = format!("{:?}", res);
+                };
+
+                CommandOutput::DecodeMultiSig(output)
+            }
+
+            KeyToolCommand::DecodeTxBytes { tx_bytes } => {
+                let tx_bytes = Base64::decode(&tx_bytes)
+                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
+                CommandOutput::DecodeTxBytes(tx_data)
+            }
+
             KeyToolCommand::Generate {
                 key_scheme,
                 derivation_path,
                 word_length,
-            } => {
-                if "bls12381" == key_scheme.to_string() {
-                    // Generate BLS12381 key for authority without key derivation.
-                    // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
-                    let (address, keypair) = get_authority_key_pair();
-                    let file_name = format!("bls-{address}.key");
-                    write_authority_keypair_to_file(&keypair, file_name)?;
-                } else {
-                    let (address, kp, scheme, phrase) =
+            } => match key_scheme {
+                SignatureScheme::BLS12381 => {
+                    let (sui_address, kp) = get_authority_key_pair();
+                    let file_name = format!("bls-{sui_address}.key");
+                    write_authority_keypair_to_file(&kp, file_name)?;
+                    CommandOutput::Generate(Key {
+                        sui_address,
+                        public_base64_key: kp.public().encode_base64(),
+                        key_scheme: key_scheme.to_string(),
+                        flag: SignatureScheme::BLS12381.flag(),
+                        mnemonic: None,
+                        peer_id: None,
+                    })
+                }
+                _ => {
+                    let (sui_address, skp, _scheme, phrase) =
                         generate_new_key(key_scheme, derivation_path, word_length)?;
-                    let file = format!("{address}.key");
-                    write_keypair_to_file(&kp, &file)?;
-                    println!(
-                        "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
-                        file, scheme
-                    );
-                    println!("Secret Recovery Phrase : [{phrase}]");
+                    let file = format!("{sui_address}.key");
+                    write_keypair_to_file(&skp, file)?;
+                    let mut key = Key::from(&skp);
+                    key.mnemonic = Some(phrase);
+                    CommandOutput::Generate(key)
                 }
-            }
-            KeyToolCommand::Show { file } => {
-                let res = read_keypair_from_file(&file);
-                match res {
-                    Ok(keypair) => {
-                        println!("Public Key: {}", keypair.public().encode_base64());
-                        println!("Flag: {}", keypair.public().flag());
-                        if let PublicKey::Ed25519(public_key) = keypair.public() {
-                            let peer_id = anemo::PeerId(public_key.0);
-                            println!("PeerId: {}", peer_id);
-                        }
-                    }
-                    Err(_) => {
-                        let res = read_authority_keypair_from_file(&file);
-                        match res {
-                            Ok(keypair) => {
-                                println!("Public Key: {}", keypair.public().encode_base64());
-                                println!("Flag: {}", SignatureScheme::BLS12381);
-                            }
-                            Err(e) => {
-                                println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-                            }
-                        }
-                    }
-                }
+            },
+
+            KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
+                let mut hasher = DefaultHash::default();
+                hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
+                let address_params = AddressParams::new(
+                    OAuthProvider::Google.get_config().0.to_owned(),
+                    SupportedKeyClaim::Sub.to_string(),
+                );
+                hasher.update(bcs::to_bytes(&address_params).unwrap());
+                hasher.update(big_int_str_to_bytes(&address_seed));
+                let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
+                CommandOutput::GenerateZkLoginAddress(user_address, address_params)
             }
 
-            KeyToolCommand::Unpack { keypair } => {
-                store_and_print_keypair((&keypair.public()).into(), keypair)
+            KeyToolCommand::HexToBase64 { hex } => {
+                let bytes =
+                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let base64 = Base64::from_bytes(&bytes);
+                CommandOutput::HexToBase64(base64)
             }
-            KeyToolCommand::List => {
-                println!(
-                    " {0: ^42} | {1: ^45} | {2: ^6}",
-                    "Sui Address", "Public Key (Base64)", "Scheme"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for pub_key in keystore.keys() {
-                    println!(
-                        " {0: ^42} | {1: ^45} | {2: ^6}",
-                        Into::<SuiAddress>::into(&pub_key),
-                        pub_key.encode_base64(),
-                        pub_key.scheme().to_string()
-                    );
-                }
-            }
-            KeyToolCommand::Sign {
-                address,
-                data,
-                intent,
-            } => {
-                println!("Signer address: {}", address);
-                println!("Raw tx_bytes to execute: {}", data);
-                let intent = intent.unwrap_or_else(Intent::sui_transaction);
-                println!("Intent: {:?}", intent);
-                let msg: TransactionData =
-                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-                    })?)?;
-                let intent_msg = IntentMessage::new(intent, msg);
-                println!(
-                    "Raw intent message: {:?}",
-                    Base64::encode(bcs::to_bytes(&intent_msg)?)
-                );
-                let mut hasher = DefaultHash::default();
-                hasher.update(bcs::to_bytes(&intent_msg)?);
-                let digest = hasher.finalize().digest;
-                println!("Digest to sign: {:?}", Base64::encode(digest));
-                let sui_signature =
-                    keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
-                println!(
-                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-                    sui_signature.encode_base64()
-                );
+
+            KeyToolCommand::HexToBytes { hex } => {
+                let bytes =
+                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                CommandOutput::HexToBytes(bytes)
             }
 
             KeyToolCommand::Import {
@@ -364,100 +476,211 @@ impl KeyToolCommand {
                         anyhow!("Private key is malformed. Importing private key failed.")
                     })?;
                     match key_scheme {
-                        SignatureScheme::ED25519 => {
-                            let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
-                            let skp = SuiKeyPair::Ed25519(kp);
-                            let address: SuiAddress = Into::<SuiAddress>::into(&skp.public());
-                            keystore.add_key(skp)?;
-                            eprintln!("Private key imported successfully.");
-                            println!("{address}")
+                            SignatureScheme::ED25519 => {
+                                let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
+                                let skp = SuiKeyPair::Ed25519(kp);
+                                let key = Key::from(&skp);
+                                keystore.add_key(skp)?;
+                                CommandOutput::Import(key)
+                            }
+                            _ => return Err(anyhow!(
+                                "Only ed25519 signature scheme is supported for importing private keys at the moment."
+                            ))
                         }
-                        _ => return Err(anyhow!(
-                            "Only ed25519 signature scheme is supported for private keys at the moment."
-                        ))
-                    }
                 } else {
-                    let address = keystore.import_from_mnemonic(
+                    let sui_address = keystore.import_from_mnemonic(
                         &input_string,
                         key_scheme,
                         derivation_path,
                     )?;
-                    eprintln!("Mnemonic imported successfully.");
-                    println!("{address}")
+                    let skp = keystore.get_key(&sui_address)?;
+                    let key = Key::from(skp);
+                    CommandOutput::Import(key)
                 }
             }
 
-            KeyToolCommand::Convert { value } => {
-                let base64 = convert_string_to_base64(value)?;
-                eprintln!("Successfully converted private key to base64.");
-                println!("{base64}");
-            }
+            KeyToolCommand::List => {
+                let keys = keystore
+                    .keys()
+                    .into_iter()
+                    .map(|key| Key::from(key))
+                    .collect::<Vec<_>>();
 
-            KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
-                let pk = PublicKey::decode_base64(&base64_key)
-                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let address = SuiAddress::from(&pk);
-                println!("Address {:?}", address);
-            }
-
-            KeyToolCommand::Base64ToHex { base64 } => {
-                let bytes =
-                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let hex = Hex::from_bytes(&bytes);
-                println!("{:?}", hex);
-            }
-
-            KeyToolCommand::HexToBase64 { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let base64 = Base64::from_bytes(&bytes);
-                println!("{:?}", base64);
-            }
-
-            KeyToolCommand::HexToBytes { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                println!("Bytes {:?}", bytes);
-            }
-
-            KeyToolCommand::BytesToHex { bytes } => {
-                let hex = Hex::from_bytes(&bytes);
-                println!("{:?}", hex);
-            }
-
-            KeyToolCommand::Base64ToBytes { base64 } => {
-                let bytes =
-                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                println!("Bytes {:?}", bytes);
-            }
-
-            KeyToolCommand::BytesToBase64 { bytes } => {
-                let base64 = Base64::from_bytes(&bytes);
-                println!("{:?}", base64);
+                CommandOutput::List(keys)
             }
 
             KeyToolCommand::LoadKeypair { file } => {
-                match read_keypair_from_file(&file) {
+                let output = match read_keypair_from_file(&file) {
                     Ok(keypair) => {
                         // Account keypair is encoded with the key scheme flag {},
                         // and network and worker keypair are not.
-                        println!("Account Keypair: {}", keypair.encode_base64());
-                        if let SuiKeyPair::Ed25519(kp) = keypair {
-                            println!("Network Keypair: {}", kp.encode_base64());
-                            println!("Worker Keypair: {}", kp.encode_base64());
+                        let network_worker_keypair = match &keypair {
+                            SuiKeyPair::Ed25519(kp) => kp.encode_base64(),
+                            SuiKeyPair::Secp256k1(kp) => kp.encode_base64(),
+                            SuiKeyPair::Secp256r1(kp) => kp.encode_base64(),
                         };
+                        KeypairData {
+                            account_keypair: keypair.encode_base64(),
+                            network_keypair: Some(network_worker_keypair.clone()),
+                            worker_keypair: Some(network_worker_keypair),
+                            key_scheme: keypair.public().scheme().to_string(),
+                        }
                     }
                     Err(_) => {
                         // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
                         match read_authority_keypair_from_file(&file) {
-                            Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
+                            Ok(keypair) => KeypairData {
+                                account_keypair: keypair.encode_base64(),
+                                network_keypair: None,
+                                worker_keypair: None,
+                                key_scheme: SignatureScheme::BLS12381.to_string(),
+                            },
                             Err(e) => {
-                                println!("Failed to read keypair at path {:?} err: {:?}", file, e)
+                                return Err(anyhow!(format!(
+                                    "Failed to read keypair at path {:?} err: {:?}",
+                                    file, e
+                                )));
                             }
                         }
                     }
+                };
+                CommandOutput::LoadKeypair(output)
+            }
+
+            KeyToolCommand::MultiSigAddress {
+                threshold,
+                pks,
+                weights,
+            } => {
+                let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
+                let address: SuiAddress = (&multisig_pk).into();
+                let mut output = MultiSigAddress {
+                    multisig_address: address.to_string(),
+                    multisig: vec![],
+                };
+
+                for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
+                    output.multisig.push(MultiSigOutput {
+                        address: Into::<SuiAddress>::into(&pk),
+                        public_base64_key: pk.encode_base64(),
+                        weight: w,
+                    });
+                }
+                CommandOutput::MultiSigAddress(output)
+            }
+
+            KeyToolCommand::MultiSigCombinePartialSig {
+                sigs,
+                pks,
+                weights,
+                threshold,
+            } => {
+                let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
+                let address: SuiAddress = (&multisig_pk).into();
+                let multisig = MultiSig::combine(sigs, multisig_pk)?;
+                let generic_sig: GenericSignature = multisig.into();
+                let multisig_serialized = generic_sig.encode_base64();
+                CommandOutput::MultiSigCombinePartialSig(MultiSigCombinePartialSig {
+                    multisig_address: address,
+                    multisig_parsed: generic_sig,
+                    multisig_serialized,
+                })
+            }
+
+            KeyToolCommand::MultiSigCombinePartialSigLegacy {
+                sigs,
+                pks,
+                weights,
+                threshold,
+            } => {
+                let multisig_pk = MultiSigPublicKeyLegacy::new(pks, weights, threshold)?;
+                let address: SuiAddress = (&multisig_pk).into();
+                let multisig = MultiSigLegacy::combine(sigs, multisig_pk)?;
+                let generic_sig: GenericSignature = multisig.into();
+                let multisig_legacy_serialized = generic_sig.encode_base64();
+
+                CommandOutput::MultiSigCombinePartialSigLegacy(
+                    MultiSigCombinePartialSigLegacyOutput {
+                        multisig_address: address,
+                        multisig_legacy_parsed: generic_sig,
+                        multisig_legacy_serialized,
+                    },
+                )
+            }
+
+            KeyToolCommand::SerializeZkLoginAuthenticator {
+                proof_str,
+                public_inputs_str,
+                aux_inputs_str,
+                user_signature,
+            } => {
+                let authenticator = ZkLoginAuthenticator::new(
+                    ZkLoginProof::from_json(&proof_str)?,
+                    PublicInputs::from_json(&public_inputs_str)?,
+                    AuxInputs::from_json(&aux_inputs_str)?,
+                    Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
+                );
+                let sig = GenericSignature::from(authenticator);
+                CommandOutput::SerializeZkLoginAuthenticator(SerializedSig {
+                    serialized_sig_base64: sig.encode_base64(),
+                })
+            }
+
+            KeyToolCommand::Show { file } => {
+                let res = read_keypair_from_file(&file);
+                match res {
+                    Ok(skp) => {
+                        let key = Key::from(&skp);
+                        CommandOutput::Show(key)
+                    }
+                    Err(_) => match read_authority_keypair_from_file(&file) {
+                        Ok(keypair) => {
+                            let public_base64_key = keypair.public().encode_base64();
+                            CommandOutput::Show(Key {
+                                sui_address: (keypair.public()).into(),
+                                public_base64_key,
+                                key_scheme: SignatureScheme::BLS12381.to_string(),
+                                flag: SignatureScheme::BLS12381.flag(),
+                                peer_id: None,
+                                mnemonic: None,
+                            })
+                        }
+                        Err(e) => CommandOutput::Error(format!(
+                            "Failed to read keypair at path {:?}, err: {e}",
+                            file
+                        )),
+                    },
                 }
             }
+
+            KeyToolCommand::Sign {
+                address,
+                data,
+                intent,
+            } => {
+                let intent = intent.unwrap_or_else(Intent::sui_transaction);
+                let intent_clone = intent.clone();
+                let msg: TransactionData =
+                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+                    })?)?;
+                let intent_msg = IntentMessage::new(intent, msg);
+                let raw_intent_msg: String = Base64::encode(bcs::to_bytes(&intent_msg)?);
+                let mut hasher = DefaultHash::default();
+                hasher.update(bcs::to_bytes(&intent_msg)?);
+                let digest = hasher.finalize().digest;
+                let sui_signature =
+                    keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
+                CommandOutput::Sign(SignData {
+                    sui_address: address,
+                    raw_tx_data: data,
+                    intent: intent_clone,
+                    raw_intent_msg,
+                    digest: Base64::encode(digest),
+                    sui_signature: sui_signature.encode_base64(),
+                })
+            }
+
             KeyToolCommand::SignKMS {
                 data,
                 keyid,
@@ -468,23 +691,23 @@ impl KeyToolCommand {
                 let pk_owner = PublicKey::decode_base64(&base64pk)
                     .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
                 let address_owner = SuiAddress::from(&pk_owner);
-                println!("Address For Corresponding KMS Key: {}", address_owner);
-                println!("Raw tx_bytes to execute: {}", data);
+                info!("Address For Corresponding KMS Key: {}", address_owner);
+                info!("Raw tx_bytes to execute: {}", data);
                 let intent = intent.unwrap_or_else(Intent::sui_transaction);
-                println!("Intent: {:?}", intent);
+                info!("Intent: {:?}", intent);
                 let msg: TransactionData =
                     bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
                         anyhow!("Cannot deserialize data as TransactionData {:?}", e)
                     })?)?;
                 let intent_msg = IntentMessage::new(intent, msg);
-                println!(
+                info!(
                     "Raw intent message: {:?}",
                     Base64::encode(bcs::to_bytes(&intent_msg)?)
                 );
                 let mut hasher = DefaultHash::default();
                 hasher.update(bcs::to_bytes(&intent_msg)?);
                 let digest = hasher.finalize().digest;
-                println!("Digest to sign: {:?}", Base64::encode(digest));
+                info!("Digest to sign: {:?}", Base64::encode(digest));
 
                 // Set up the KMS client in default region.
                 let region: Region = Region::default();
@@ -515,128 +738,29 @@ impl KeyToolCommand {
                 serialized_sig.extend_from_slice(&sig_compact);
                 serialized_sig.extend_from_slice(pk_owner.as_ref());
                 let serialized_sig = Base64::encode(&serialized_sig);
-                println!(
-                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-                    serialized_sig
-                );
-                return Ok(());
-            }
-            KeyToolCommand::MultiSigAddress {
-                threshold,
-                pks,
-                weights,
-            } => {
-                let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
-                let address: SuiAddress = (&multisig_pk).into();
-                println!("MultiSig address: {address}");
-
-                println!("Participating parties:");
-                println!(
-                    " {0: ^42} | {1: ^50} | {2: ^6}",
-                    "Sui Address", "Public Key (Base64)", "Weight"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
-                    println!(
-                        " {0: ^42} | {1: ^45} | {2: ^6}",
-                        Into::<SuiAddress>::into(&pk),
-                        pk.encode_base64(),
-                        w
-                    );
-                }
-            }
-            KeyToolCommand::MultiSigCombinePartialSig {
-                sigs,
-                pks,
-                weights,
-                threshold,
-            } => {
-                let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
-                let address: SuiAddress = (&multisig_pk).into();
-                let multisig = MultiSig::combine(sigs, multisig_pk)?;
-                let generic_sig: GenericSignature = multisig.into();
-                println!("MultiSig address: {address}");
-                println!("MultiSig parsed: {:?}", generic_sig);
-                println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
+                CommandOutput::SignKMS(SerializedSig {
+                    serialized_sig_base64: serialized_sig,
+                })
             }
 
-            KeyToolCommand::MultiSigCombinePartialSigLegacy {
-                sigs,
-                pks,
-                weights,
-                threshold,
-            } => {
-                let multisig_pk = MultiSigPublicKeyLegacy::new(pks, weights, threshold)?;
-                let address: SuiAddress = (&multisig_pk).into();
-                let multisig = MultiSigLegacy::combine(sigs, multisig_pk)?;
-                let generic_sig: GenericSignature = multisig.into();
-                println!("MultiSig address: {address}");
-                println!("MultiSig legacy parsed: {:?}", generic_sig);
-                println!(
-                    "MultiSig legacy serialized: {:?}",
-                    generic_sig.encode_base64()
+            KeyToolCommand::Unpack { keypair } => {
+                let key = Key::from(&keypair);
+                let path_str = format!("{}.key", key.sui_address).to_lowercase();
+                let path = Path::new(&path_str);
+                let out_str = format!(
+                    "address: {}\nkeypair: {}\nflag: {}",
+                    key.sui_address,
+                    keypair.encode_base64(),
+                    key.flag
                 );
-            }
-
-            KeyToolCommand::DecodeMultiSig { multisig, tx_bytes } => {
-                let pks = multisig.get_pk().pubkeys();
-                let sigs = multisig.get_sigs();
-                let bitmap = multisig.get_indices()?;
-                println!(
-                    "All pubkeys: {:?}, threshold: {:?}",
-                    pks.iter()
-                        .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
-                        .collect::<Vec<String>>(),
-                    multisig.get_pk().threshold()
-                );
-                println!("Participating signatures and pubkeys");
-                println!(
-                    " {0: ^45} | {1: ^45} | {2: ^6}",
-                    "Public Key (Base64)", "Sig (Base64)", "Weight"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for (sig, i) in sigs.iter().zip(bitmap) {
-                    let (pk, w) = pks
-                        .get(i as usize)
-                        .ok_or(anyhow!("Invalid public keys index".to_string()))?;
-                    println!(
-                        " {0: ^45} | {1: ^45} | {2: ^6}",
-                        Base64::encode(sig.as_ref()),
-                        pk.encode_base64(),
-                        w
-                    );
-                }
-
-                let author = SuiAddress::from(multisig.get_pk());
-                println!("Multisig address: {:?}", author);
-
-                if tx_bytes.is_some() {
-                    let tx_bytes = Base64::decode(&tx_bytes.unwrap())
-                        .map_err(|e| anyhow!("Invalid base64 tx bytes: {:?}", e))?;
-                    let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-                    let res = GenericSignature::MultiSig(multisig).verify_authenticator(
-                        &IntentMessage::new(Intent::sui_transaction(), tx_data),
-                        author,
-                        None,
-                        &VerifyParams::default(),
-                    );
-                    println!("Verify multisig: {:?}", res);
-                };
-            }
-
-            KeyToolCommand::DecodeTxBytes { tx_bytes } => {
-                let tx_bytes = Base64::decode(&tx_bytes)
-                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-                println!("Transaction data: {:?}", tx_data);
+                fs::write(path, out_str).unwrap();
+                CommandOutput::Show(key)
             }
 
             KeyToolCommand::ZkLogInPrepare { max_epoch } => {
                 // todo: unhardcode keypair and jwt_randomness and max_epoch.
                 let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
                 let skp = SuiKeyPair::Ed25519(kp.copy());
-                println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
-                println!("Ephemeral keypair: {:?}", skp.encode_base64());
 
                 // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
                 // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
@@ -654,81 +778,137 @@ impl KeyToolCommand {
                 )
                 .unwrap();
                 let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
-                println!("Nonce: {:?}", hash.to_string());
+                CommandOutput::ZkLogInPrepare(ZkLogInPrepare {
+                    ephemeral_pubkey: skp.public().encode_base64(),
+                    ephemeral_keypair: skp.encode_base64(),
+                    nonce: hash.to_string(),
+                })
             }
+        });
 
-            KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
-                let mut hasher = DefaultHash::default();
-                hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
-                let address_params = AddressParams::new(
-                    OAuthProvider::Google.get_config().0.to_owned(),
-                    SupportedKeyClaim::Sub.to_string(),
-                );
-                println!("Address params: {:?}", address_params);
-                hasher.update(bcs::to_bytes(&address_params).unwrap());
-                hasher.update(big_int_str_to_bytes(&address_seed));
-                let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
-                println!("Sui Address: {:?}", user_address);
-            }
-
-            KeyToolCommand::SerializeZkLoginAuthenticator {
-                proof_str,
-                public_inputs_str,
-                aux_inputs_str,
-                user_signature,
-            } => {
-                let authenticator = ZkLoginAuthenticator::new(
-                    ZkLoginProof::from_json(&proof_str)?,
-                    PublicInputs::from_json(&public_inputs_str)?,
-                    AuxInputs::from_json(&aux_inputs_str)?,
-                    Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
-                );
-                let sig = GenericSignature::from(authenticator);
-                println!(
-                    "ZkLogin Authenticator Signature Serialized: {:?}",
-                    sig.encode_base64()
-                );
-            }
-        }
-        Ok(())
+        cmd_result
     }
 }
 
-fn convert_string_to_base64(value: String) -> Result<String, anyhow::Error> {
+impl From<&SuiKeyPair> for Key {
+    fn from(skp: &SuiKeyPair) -> Self {
+        Key::from(skp.public())
+    }
+}
+
+impl From<PublicKey> for Key {
+    fn from(key: PublicKey) -> Self {
+        Key {
+            sui_address: Into::<SuiAddress>::into(&key),
+            public_base64_key: key.encode_base64(),
+            key_scheme: key.scheme().to_string(),
+            mnemonic: None,
+            flag: key.flag(),
+            peer_id: anemo_styling(&key),
+        }
+    }
+}
+
+impl Display for CommandOutput {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Sign needs to be manually built because we need to wrap the very long
+            // rawTxData string and rawIntentMsg strings into multiple rows due to
+            // their lengths, which we cannot do with a JsonTable
+            CommandOutput::Sign(data) => {
+                let intent_table = json_to_table(&json!(&data.intent))
+                    .with(tabled::settings::Style::rounded().horizontals([]))
+                    .to_string();
+
+                let mut builder = Builder::default();
+                builder
+                    .set_header([
+                        "suiSignature",
+                        "digest",
+                        "rawIntentMsg",
+                        "intent",
+                        "rawTxData",
+                        "suiAddress",
+                    ])
+                    .push_record([
+                        &data.sui_signature,
+                        &data.digest,
+                        &data.raw_intent_msg,
+                        &intent_table,
+                        &data.raw_tx_data,
+                        &data.sui_address.to_string(),
+                    ]);
+                let mut table = builder.build();
+                table.with(Rotate::Left);
+                table.with(tabled::settings::Style::rounded().horizontals([]));
+                table.with(Modify::new(Rows::new(0..)).with(Width::wrap(160).keep_words()));
+                write!(formatter, "{}", table)
+            }
+            _ => {
+                let json_obj = json![self];
+                let mut table = json_to_table(&json_obj);
+                let style = tabled::settings::Style::rounded().horizontals([]);
+                table.with(style);
+                table.array_orientation(Orientation::Column);
+                write!(formatter, "{}", table)
+            }
+        }
+    }
+}
+
+impl CommandOutput {
+    pub fn print(&self, pretty: bool) {
+        let line = if pretty {
+            format!("{self}")
+        } else {
+            format!("{:?}", self)
+        };
+        // Log line by line
+        for line in line.lines() {
+            // Logs write to a file on the side.  Print to stdout and also log to file, for tests to pass.
+            println!("{line}");
+            info!("{line}")
+        }
+    }
+}
+
+// when --json flag is used, any output result is transformed into a JSON pretty string and sent to std output
+impl Debug for CommandOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string_pretty(self) {
+            Ok(json) => write!(f, "{json}"),
+            Err(err) => write!(f, "Error serializing JSON: {err}"),
+        }
+    }
+}
+
+fn convert_private_key_to_base64(value: String) -> Result<String, anyhow::Error> {
     match Base64::decode(&value) {
         Ok(decoded) => {
-            assert_eq!(decoded.len(), 33);
-            let hex_encoded = Hex::encode(&decoded[1..]);
-            info!("Wallet formatted private key: 0x{}", hex_encoded);
-            Ok(hex_encoded)
+            if decoded.len() != 33 {
+                return Err(anyhow!(format!("Private key is malformed and cannot base64 decode it. Fed 33 length but got {}", decoded.len())));
+            }
+            Ok(Hex::encode(&decoded[1..]))
         }
         Err(_) => match Hex::decode(&value) {
             Ok(decoded) => {
-                assert_eq!(decoded.len(), 32);
+                if decoded.len() != 32 {
+                    return Err(anyhow!(format!("Private key is malformed and cannot hex decode it. Expected 32 length but got {}", decoded.len())));
+                }
                 let mut res = Vec::new();
                 res.extend_from_slice(&[SignatureScheme::ED25519.flag()]);
                 res.extend_from_slice(&decoded);
-                info!("Keystore formatted private key: {:?}", Base64::encode(&res));
                 Ok(Base64::encode(&res))
             }
-            Err(_) => {
-                info!("Invalid private key format");
-                Err(anyhow!("Invalid private key format"))
-            }
+            Err(_) => Err(anyhow!("Invalid private key format".to_string())),
         },
     }
 }
 
-fn store_and_print_keypair(address: SuiAddress, keypair: SuiKeyPair) {
-    let path_str = format!("{}.key", address).to_lowercase();
-    let path = Path::new(&path_str);
-    let address = format!("{}", address);
-    let kp = keypair.encode_base64();
-    let flag = keypair.public().flag();
-    let out_str = format!("address: {}\nkeypair: {}\nflag: {}", address, kp, flag);
-    fs::write(path, out_str).unwrap();
-    println!(
-        "Address, keypair and key scheme written to {}",
-        path.to_str().unwrap()
-    );
+fn anemo_styling(pk: &PublicKey) -> Option<String> {
+    if let PublicKey::Ed25519(public_key) = pk {
+        Some(anemo::PeerId(public_key.0).to_string())
+    } else {
+        None
+    }
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -94,10 +94,6 @@ pub enum KeyToolCommand {
         #[clap(long)]
         address_seed: String,
     },
-    /// Converts a hexadecimal string to its Base64 encoded representation.
-    HexToBase64 { hex: String },
-    /// Converts a hexadecimal string to its corresponding bytes.
-    HexToBytes { hex: String },
     /// Add a new key to sui.keystore using either the input mnemonic phrase or a private key (from the Wallet),
     /// the key scheme flag {ed25519 | secp256k1 | secp256r1} and an optional derivation path,
     /// default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
@@ -325,8 +321,6 @@ pub enum CommandOutput {
     DecodeMultiSig(DecodedMultiSigOutput),
     DecodeTxBytes(TransactionData),
     Error(String),
-    HexToBase64(Base64),
-    HexToBytes(Vec<u8>),
     Generate(Key),
     GenerateZkLoginAddress(SuiAddress, AddressParams),
     Import(Key),
@@ -450,19 +444,6 @@ impl KeyToolCommand {
                 hasher.update(big_int_str_to_bytes(&address_seed));
                 let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
                 CommandOutput::GenerateZkLoginAddress(user_address, address_params)
-            }
-
-            KeyToolCommand::HexToBase64 { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let base64 = Base64::from_bytes(&bytes);
-                CommandOutput::HexToBase64(base64)
-            }
-
-            KeyToolCommand::HexToBytes { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                CommandOutput::HexToBytes(bytes)
             }
 
             KeyToolCommand::Import {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -95,6 +95,9 @@ pub enum SuiCommand {
     KeyTool {
         #[clap(long)]
         keystore_path: Option<PathBuf>,
+        ///Return command outputs in json format
+        #[clap(long, global = true)]
+        json: bool,
         /// Subcommands.
         #[clap(subcommand)]
         cmd: KeyToolCommand,
@@ -258,11 +261,16 @@ impl SuiCommand {
                 .await
             }
             SuiCommand::GenesisCeremony(cmd) => run(cmd),
-            SuiCommand::KeyTool { keystore_path, cmd } => {
+            SuiCommand::KeyTool {
+                keystore_path,
+                json,
+                cmd,
+            } => {
                 let keystore_path =
                     keystore_path.unwrap_or(sui_config_dir()?.join(SUI_KEYSTORE_FILENAME));
                 let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-                cmd.execute(&mut keystore).await
+                cmd.execute(&mut keystore).await?.print(!json);
+                Ok(())
             }
             SuiCommand::Console { config } => {
                 let config = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -104,6 +104,7 @@ bstr = { version = "1" }
 bulletproofs = { version = "4" }
 byte-slice-cast = { version = "1" }
 bytecode-interpreter-crypto = { path = "../../external-crates/move/move-prover/interpreter/crypto" }
+bytecount = { version = "0.6", default-features = false }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
@@ -302,6 +303,7 @@ is-terminal = { version = "0.4", default-features = false }
 itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
+json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4", default-features = false }
 jsonpath_lib = { version = "0.3", default-features = false }
 jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
 jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
@@ -418,6 +420,7 @@ ouroboros-3575ec1268b04181 = { package = "ouroboros", version = "0.15" }
 overload = { version = "0.1", default-features = false }
 owo-colors = { version = "3", default-features = false }
 p256 = { version = "0.13" }
+papergrid = { version = "0.9", default-features = false, features = ["std"] }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parking = { version = "2", default-features = false }
 parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
@@ -582,6 +585,7 @@ subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 sysinfo = { version = "0.27" }
+tabled = { version = "0.12" }
 tabular = { version = "0.2", features = ["ansi-cell"] }
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
@@ -793,6 +797,7 @@ bulletproofs = { version = "4" }
 bumpalo = { version = "3" }
 byte-slice-cast = { version = "1" }
 bytecode-interpreter-crypto = { path = "../../external-crates/move/move-prover/interpreter/crypto" }
+bytecount = { version = "0.6", default-features = false }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
@@ -1025,6 +1030,7 @@ itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
+json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4", default-features = false }
 jsonpath_lib = { version = "0.3", default-features = false }
 jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
 jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
@@ -1154,6 +1160,7 @@ ouroboros_macro-3575ec1268b04181 = { package = "ouroboros_macro", version = "0.1
 overload = { version = "0.1", default-features = false }
 owo-colors = { version = "3", default-features = false }
 p256 = { version = "0.13" }
+papergrid = { version = "0.9", default-features = false, features = ["std"] }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parity-scale-codec-derive = { version = "2", default-features = false, features = ["max-encoded-len"] }
 parking = { version = "2", default-features = false }
@@ -1360,6 +1367,8 @@ syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-trai
 sync_wrapper = { version = "0.1", default-features = false }
 synstructure = { version = "0.12" }
 sysinfo = { version = "0.27" }
+tabled = { version = "0.12" }
+tabled_derive = { version = "0.6", default-features = false }
 tabular = { version = "0.2", features = ["ansi-cell"] }
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }


### PR DESCRIPTION
## Description 

Revamp the keytool CLI command to pretty print output as formatted tables and add support for json output. This is the first experimental step to gain feedback before moving to other CLI commands.

The PR also removes seven commands that should not be part of the CLI and were OK'ed by @siomari and @ammn to be removed:
* Base64PubKeyToAddress
* BytesToBase64
* Base64ToBytes
* Base64ToHex
* BytesToHex
* HexToBase64
* HexToBytes

## Test Plan 

Executed the existing tests. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR modifies the `CLI keytool` as follows:
* Adds support for `json` output. Use the `--json` flag when invoking any `keytool` command (such as `keytool list --json`).
* Changes the default output to the terminal to formatted tables with headers to improve consistency across different commands. Use `--json` if you need to parse/pipe output data.
* Removes the following seven commands, which you can replace by calls to the `base64` and `xxd` utilities: 
```
Base64PubKeyToAddress
BytesToBase64
Base64ToBytes
Base64ToHex -> input | base64 -d | xxd -p
BytesToHex
HexToBase64 -> input | xxd -r -p | base64
HexToBytes 
```
