### PR TITLE
Reduce time spent completing & creating checkpoints

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1999,13 +1999,13 @@ impl AuthorityPerEpochStore {
             .map(|s| s.summary))
     }
 
-    pub fn builder_included_transaction_in_checkpoint(
+    pub fn builder_included_transactions_in_checkpoint<'a>(
         &self,
-        digest: &TransactionDigest,
-    ) -> Result<bool, TypedStoreError> {
+        digests: impl Iterator<Item = &'a TransactionDigest>,
+    ) -> Result<Vec<bool>, TypedStoreError> {
         self.tables
             .builder_digest_to_checkpoint
-            .contains_key(digest)
+            .multi_contains_keys(digests)
     }
 
     pub fn get_pending_checkpoint_signatures_iter(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -672,6 +672,13 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub fn effects_signatures_exists<'a>(
+        &self,
+        digests: impl IntoIterator<Item = &'a TransactionDigest>,
+    ) -> Result<Vec<bool>, TypedStoreError> {
+        self.tables.effects_signatures.multi_contains_keys(digests)
+    }
+
     pub fn get_effects_signature(
         &self,
         tx_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1099,8 +1099,7 @@ impl AuthorityPerEpochStore {
                 self.are_consensus_messages_processed(keys.iter())?
                     .into_iter(),
             )
-            .filter(|(_, processed)| !processed)
-            .map(|(key, _)| *key)
+            .filter_map(|(key, processed)| if !processed { Some(*key) } else { None })
             .collect::<Vec<SequencedConsensusTransactionKey>>();
         let registrations = self.consensus_notify_read.register_all(unprocessed_keys);
         join_all(registrations).await;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1079,7 +1079,7 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn are_consensus_messages_processed<'a>(
+    pub fn check_consensus_messages_processed<'a>(
         &self,
         keys: impl Iterator<Item = &'a SequencedConsensusTransactionKey>,
     ) -> SuiResult<Vec<bool>> {
@@ -1097,7 +1097,7 @@ impl AuthorityPerEpochStore {
 
         let unprocessed_keys_registrations = registrations
             .into_iter()
-            .zip(self.are_consensus_messages_processed(keys.iter())?)
+            .zip(self.check_consensus_messages_processed(keys.iter())?)
             .filter(|(_, processed)| !processed)
             .map(|(registration, _)| registration);
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1610,21 +1610,24 @@ impl AuthorityStore {
             .map(|v| v.map(|v| v.into()))
     }
 
-    pub fn get_transaction_and_serialized_size(
+    pub fn get_transactions_and_serialized_sizes<'a>(
         &self,
-        tx_digest: &TransactionDigest,
-    ) -> Result<Option<(VerifiedTransaction, usize)>, TypedStoreError> {
+        digests: impl IntoIterator<Item = &'a TransactionDigest>,
+    ) -> Result<Vec<Option<(VerifiedTransaction, usize)>>, TypedStoreError> {
         self.perpetual_tables
             .transactions
-            .get_raw_bytes(tx_digest)
-            .and_then(|v| match v {
-                Some(tx_bytes) => {
-                    let tx: VerifiedTransaction =
-                        bcs::from_bytes::<TrustedTransaction>(&tx_bytes)?.into();
-                    Ok(Some((tx, tx_bytes.len())))
-                }
-                None => Ok(None),
+            .multi_get_raw_bytes(digests)?
+            .into_iter()
+            .map(|raw_bytes_option| {
+                raw_bytes_option
+                    .map(|tx_bytes| {
+                        let tx: VerifiedTransaction =
+                            bcs::from_bytes::<TrustedTransaction>(&tx_bytes)?.into();
+                        Ok((tx, tx_bytes.len()))
+                    })
+                    .transpose()
             })
+            .collect()
     }
 
     // TODO: Transaction Orchestrator also calls this, which is not ideal.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -997,12 +997,6 @@ impl CheckpointBuilder {
                     epoch_commitments,
                 })
             } else {
-                self.accumulator.accumulate_checkpoint(
-                    effects.clone(),
-                    sequence_number,
-                    self.epoch_store.clone(),
-                )?;
-
                 None
             };
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -880,22 +880,22 @@ impl CheckpointBuilder {
                 all_effects_and_transaction_sizes.len()
             );
 
-            for (effect, transaction_and_size) in all_effects
+            for (effects, transaction_and_size) in all_effects
                 .into_iter()
                 .zip(transactions_and_sizes.into_iter())
             {
                 let (transaction, size) = transaction_and_size
-                    .unwrap_or_else(|| panic!("Could not find executed transaction {:?}", effect));
+                    .unwrap_or_else(|| panic!("Could not find executed transaction {:?}", effects));
                 // ConsensusCommitPrologue is guaranteed to be processed before we reach here
                 if !matches!(
                     transaction.inner().transaction_data().kind(),
                     TransactionKind::ConsensusCommitPrologue(_)
                 ) {
                     transaction_keys.push(SequencedConsensusTransactionKey::External(
-                        ConsensusTransactionKey::Certificate(*effect.transaction_digest()),
+                        ConsensusTransactionKey::Certificate(*effects.transaction_digest()),
                     ));
                 }
-                all_effects_and_transaction_sizes.push((effect.clone(), size));
+                all_effects_and_transaction_sizes.push((effects, size));
             }
 
             self.epoch_store


### PR DESCRIPTION
## Description 

Using `multi_gets` / `multi_contains`  to reduce the time spent completing & creating checkpoints. Also removed the accumulation of checkpoints step in non end-of-epoch scenarios and leave that for the checkpoint executor. 

## Test Plan 

Tested in private-testnet

before 
![Screenshot 2023-07-28 at 10 19 43 AM](https://github.com/MystenLabs/sui/assets/97870774/b482e12c-671b-408a-ad23-240a5c897ba3)

![Screenshot 2023-07-28 at 12 15 32 PM](https://github.com/MystenLabs/sui/assets/97870774/74648a42-9533-4b77-9f7f-9d3f17e412b9)


after
![Screenshot 2023-07-28 at 12 10 53 PM](https://github.com/MystenLabs/sui/assets/97870774/4434f685-e9c6-4ef6-a95a-968de0cb585b)

![Screenshot 2023-07-28 at 12 14 46 PM](https://github.com/MystenLabs/sui/assets/97870774/916b523f-8a85-4547-bb2f-44932d54d9ad)
