### PR TITLE
[Explorer]: move copy icon inline with address name

### DIFF
--- a/apps/explorer/src/ui/PageHeader.tsx
+++ b/apps/explorer/src/ui/PageHeader.tsx
@@ -50,42 +50,40 @@ export function PageHeader({ title, subtitle, type, before, error, loading }: Pa
 					</div>
 				)}
 				<div>
-					<div className="flex">
-						<div>
-							<div className="mb-1 flex items-center gap-2">
-								{Icon && <Icon className="text-steel-dark" />}
-								{loading ? (
-									<Placeholder rounded="lg" width="140px" />
-								) : (
-									<Heading variant="heading6/semibold" color="steel-darker">
-										{type in TYPE_TO_COPY ? TYPE_TO_COPY[type] : type}
-									</Heading>
-								)}
-							</div>
-							<div className="min-w-0 break-words break-all">
-								{loading ? (
-									<Placeholder rounded="lg" width="540px" height="20px" />
-								) : (
+					<div>
+						<div className="mb-1 flex items-center gap-2">
+							{Icon && <Icon className="text-steel-dark" />}
+							{loading ? (
+								<Placeholder rounded="lg" width="140px" />
+							) : (
+								<Heading variant="heading6/semibold" color="steel-darker">
+									{type in TYPE_TO_COPY ? TYPE_TO_COPY[type] : type}
+								</Heading>
+							)}
+						</div>
+						<div className="min-w-0 break-words break-all">
+							{loading ? (
+								<Placeholder rounded="lg" width="540px" height="20px" />
+							) : (
+								<div className="flex items-center">
 									<Heading as="h3" variant="heading3/semibold" color="gray-90" mono>
 										{title}
 									</Heading>
-								)}
-							</div>
-							{subtitle && (
-								<div className="mt-2 break-words">
-									{loading ? (
-										<Placeholder rounded="lg" width="540px" height="20px" />
-									) : (
-										<Heading variant="heading4/semibold" color="gray-75">
-											{subtitle}
-										</Heading>
-									)}
+									<div className="ml-2 h-4 w-4 self-center sm:self-end md:h-6 md:w-6">
+										<CopyToClipboard size="lg" color="steel" copyText={title} />
+									</div>
 								</div>
 							)}
 						</div>
-						{!loading && (
-							<div className="ml-2 h-4 w-4 self-center sm:self-end md:h-6 md:w-6">
-								<CopyToClipboard size="lg" color="steel" copyText={title} />
+						{subtitle && (
+							<div className="mt-2 break-words">
+								{loading ? (
+									<Placeholder rounded="lg" width="540px" height="20px" />
+								) : (
+									<Heading variant="heading4/semibold" color="gray-75">
+										{subtitle}
+									</Heading>
+								)}
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
## Description 

- Move Copy icon inlined with large address name

Current
<img width="927" alt="Screenshot 2023-07-28 at 10 27 59 PM" src="https://github.com/MystenLabs/sui/assets/127577476/cc5d3bef-a5ed-4b73-90ff-8ff717390150">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
