### PR TITLE
Add metrics to key value store, refactor

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1935,109 +1935,39 @@ impl GetModule for AuthorityStore {
 }
 
 #[async_trait]
-impl key_value_store::TransactionKeyValueStore for AuthorityStore {
-    /// Generic multi_get, allows implementors to get heterogenous values with a single round trip.
+impl key_value_store::TransactionKeyValueStoreTrait for AuthorityStore {
     async fn multi_get(
         &self,
-        keys: &[key_value_store::Key],
-    ) -> SuiResult<Vec<Option<key_value_store::Value>>> {
-        let mut tx_keys = Vec::new();
-        let mut fx_keys = Vec::new();
-        let mut fx_by_tx_digest_keys = Vec::new();
-        let mut events_keys = Vec::new();
-
-        for key in keys {
-            match key {
-                key_value_store::Key::Tx(digest) => tx_keys.push(*digest),
-                key_value_store::Key::Fx(digest) => fx_keys.push(*digest),
-                key_value_store::Key::Events(digest) => events_keys.push(*digest),
-                key_value_store::Key::FxByTxDigest(digest) => fx_by_tx_digest_keys.push(*digest),
-            }
-        }
-
-        let tx_results = if !tx_keys.is_empty() {
-            self.multi_get_tx(&tx_keys).await?
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> SuiResult<(
+        Vec<Option<Transaction>>,
+        Vec<Option<TransactionEffects>>,
+        Vec<Option<TransactionEvents>>,
+    )> {
+        let txns = if !transactions.is_empty() {
+            self.multi_get_transaction_blocks(transactions)?
+                .into_iter()
+                .map(|t| t.map(|t| t.into_inner()))
+                .collect()
         } else {
-            Vec::new()
+            vec![]
         };
 
-        let fx_results = if !fx_keys.is_empty() {
-            self.multi_get_fx(&fx_keys).await?
+        let fx = if !effects.is_empty() {
+            self.multi_get_executed_effects(effects)?
         } else {
-            Vec::new()
+            vec![]
         };
 
-        let events_results = if !events_keys.is_empty() {
-            key_value_store::TransactionKeyValueStore::multi_get_events(self, &events_keys).await?
+        let evts = if !events.is_empty() {
+            self.multi_get_events(events)?
         } else {
-            Vec::new()
+            vec![]
         };
 
-        let fx_by_tx_digest_results = if !fx_by_tx_digest_keys.is_empty() {
-            self.multi_get_fx_by_tx_digest(&fx_by_tx_digest_keys)
-                .await?
-        } else {
-            Vec::new()
-        };
-
-        // re-assemble original order
-        let mut tx_iter = tx_results.into_iter();
-        let mut fx_iter = fx_results.into_iter();
-        let mut events_iter = events_results.into_iter();
-        let mut fx_by_tx_digest_iter = fx_by_tx_digest_results.into_iter();
-
-        let mut results = Vec::new();
-
-        for key in keys {
-            match key {
-                key_value_store::Key::Tx(_) => {
-                    results.push(tx_iter.next().unwrap().map(|tx| tx.into()))
-                }
-                key_value_store::Key::Fx(_) => {
-                    results.push(fx_iter.next().unwrap().map(|fx| fx.into()))
-                }
-                key_value_store::Key::Events(_) => {
-                    results.push(events_iter.next().unwrap().map(|e| e.into()))
-                }
-                key_value_store::Key::FxByTxDigest(_) => {
-                    results.push(fx_by_tx_digest_iter.next().unwrap().map(|fx| fx.into()))
-                }
-            }
-        }
-
-        Ok(results)
-    }
-
-    async fn multi_get_tx(
-        &self,
-        keys: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<Transaction>>> {
-        Ok(self
-            .multi_get_transaction_blocks(keys)?
-            .into_iter()
-            .map(|t| t.map(|t| t.into_inner()))
-            .collect())
-    }
-
-    async fn multi_get_fx(
-        &self,
-        keys: &[TransactionEffectsDigest],
-    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
-        Ok(self.multi_get_effects(keys.iter())?)
-    }
-
-    async fn multi_get_events(
-        &self,
-        keys: &[TransactionEventsDigest],
-    ) -> SuiResult<Vec<Option<TransactionEvents>>> {
-        Ok(self.multi_get_events(keys)?)
-    }
-
-    async fn multi_get_fx_by_tx_digest(
-        &self,
-        keys: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
-        Ok(self.multi_get_executed_effects(keys)?)
+        Ok((txns, fx, evts))
     }
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -58,7 +58,7 @@ const MAX_DISPLAY_NESTED_LEVEL: usize = 10;
 #[derive(Clone)]
 pub struct ReadApi {
     pub state: Arc<AuthorityState>,
-    pub transaction_kv_store: Arc<dyn TransactionKeyValueStore + Send + Sync>,
+    pub transaction_kv_store: Arc<TransactionKeyValueStore>,
     pub metrics: Arc<JsonRpcMetrics>,
 }
 
@@ -94,7 +94,7 @@ impl IntermediateTransactionResponse {
 impl ReadApi {
     pub fn new(
         state: Arc<AuthorityState>,
-        transaction_kv_store: Arc<dyn TransactionKeyValueStore + Send + Sync>,
+        transaction_kv_store: Arc<TransactionKeyValueStore>,
         metrics: Arc<JsonRpcMetrics>,
     ) -> Self {
         Self {
@@ -182,9 +182,8 @@ impl ReadApi {
 
         // Fetch effects when `show_events` is true because events relies on effects
         if opts.require_effects() {
-            let transaction_kv_store = self.transaction_kv_store.clone();
             let digests_clone = digests.clone();
-            let effects_list = transaction_kv_store
+            let effects_list = self.transaction_kv_store
                 .multi_get_fx_by_tx_digest(&digests_clone)
                 .await
                 .tap_err(

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -97,6 +97,7 @@ use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
 use sui_storage::{
     http_key_value_store::HttpKVStore,
     key_value_store::{FallbackTransactionKVStore, TransactionKeyValueStore},
+    key_value_store_metrics::KeyValueStoreMetrics,
 };
 use sui_storage::{FileCompression, IndexStore, StorageFormat};
 use sui_types::base_types::{AuthorityName, EpochId};
@@ -1420,14 +1421,16 @@ fn send_trusted_peer_change(
 fn build_kv_store(
     state: &Arc<AuthorityState>,
     config: &NodeConfig,
-) -> Result<Arc<dyn TransactionKeyValueStore + Send + Sync>> {
-    let db_store = state.db();
+    registry: &Registry,
+) -> Result<Arc<TransactionKeyValueStore>> {
+    let metrics = KeyValueStoreMetrics::new(registry);
+    let db_store = TransactionKeyValueStore::new("rocksdb", metrics.clone(), state.db());
 
     let base_url = &config.transaction_kv_store_config.base_url;
 
     if base_url.is_empty() {
         info!("no http kv store url provided, using local db only");
-        return Ok(db_store);
+        return Ok(Arc::new(db_store));
     }
 
     let base_url: url::Url = base_url.parse().tap_err(|e| {
@@ -1442,15 +1445,18 @@ fn build_kv_store(
         Some(Chain::Testnet) => "/testnet",
         _ => {
             info!("using local db only for kv store for unknown chain");
-            return Ok(db_store);
+            return Ok(Arc::new(db_store));
         }
     };
 
     let base_url = base_url.join(network_str)?.to_string();
-    let http_store = Arc::new(HttpKVStore::new(&base_url)?);
+    let http_store = HttpKVStore::new_kv(&base_url, metrics.clone())?;
     info!("using local key-value store with fallback to http key-value store");
-    Ok(Arc::new(FallbackTransactionKVStore::new(
-        db_store, http_store,
+    Ok(Arc::new(FallbackTransactionKVStore::new_kv(
+        db_store,
+        http_store,
+        metrics,
+        "json_rpc_fallback",
     )))
 }
 
@@ -1466,14 +1472,16 @@ pub async fn build_server(
         return Ok(None);
     }
 
-    let db = state.database.clone();
-
     let mut server = JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry);
 
-    let kv_store = build_kv_store(&state, config)?;
+    let kv_store = build_kv_store(&state, config, prometheus_registry)?;
 
     let metrics = Arc::new(JsonRpcMetrics::new(prometheus_registry));
-    server.register_module(ReadApi::new(state.clone(), kv_store, metrics.clone()))?;
+    server.register_module(ReadApi::new(
+        state.clone(),
+        kv_store.clone(),
+        metrics.clone(),
+    ))?;
     server.register_module(CoinReadApi::new(state.clone(), metrics.clone()))?;
     server.register_module(TransactionBuilderApi::new(state.clone()))?;
     server.register_module(GovernanceReadApi::new(state.clone(), metrics.clone()))?;
@@ -1488,7 +1496,7 @@ pub async fn build_server(
 
     server.register_module(IndexerApi::new(
         state.clone(),
-        ReadApi::new(state.clone(), db, metrics.clone()),
+        ReadApi::new(state.clone(), kv_store, metrics.clone()),
         config.name_service_package_address,
         config.name_service_registry_id,
         config.name_service_reverse_registry_id,

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -12,16 +12,17 @@ use serde::Deserialize;
 use std::str::FromStr;
 use std::sync::Arc;
 use sui_types::{
+    digests::{TransactionDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{SuiError, SuiResult},
-    message_envelope::Message,
     transaction::Transaction,
 };
 use tap::TapFallible;
 use tracing::{error, info, trace, warn};
 use url::Url;
 
-use crate::key_value_store::{Key, TransactionKeyValueStore, Value};
+use crate::key_value_store::{TransactionKeyValueStore, TransactionKeyValueStoreTrait};
+use crate::key_value_store_metrics::KeyValueStoreMetrics;
 
 pub struct HttpKVStore {
     base_url: Url,
@@ -45,21 +46,37 @@ where
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Key {
+    Tx(TransactionDigest),
+    Fx(TransactionDigest),
+    Events(TransactionEventsDigest),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Value {
+    Tx(Box<Transaction>),
+    Fx(Box<TransactionEffects>),
+    Events(Box<TransactionEvents>),
+}
+
 fn key_to_path_elements(key: &Key) -> SuiResult<(String, &'static str)> {
     match key {
         Key::Tx(digest) => Ok((encode_digest(digest), "tx")),
-        Key::Fx(digest) => Err(SuiError::UnsupportedFeatureError {
-            error: format!(
-                "fetching fx by fx digest not supported (digest: {:?})",
-                digest
-            ),
-        }),
-        Key::Events(digest) => Ok((encode_digest(digest), "events")),
-        Key::FxByTxDigest(digest) => Ok((encode_digest(digest), "fx")),
+        Key::Fx(digest) => Ok((encode_digest(digest), "fx")),
+        Key::Events(digest) => Ok((encode_digest(digest), "ev")),
     }
 }
 
 impl HttpKVStore {
+    pub fn new_kv(
+        base_url: &str,
+        metrics: Arc<KeyValueStoreMetrics>,
+    ) -> SuiResult<TransactionKeyValueStore> {
+        let inner = Arc::new(Self::new(base_url)?);
+        Ok(TransactionKeyValueStore::new("http", metrics, inner))
+    }
+
     pub fn new(base_url: &str) -> SuiResult<Self> {
         info!("creating HttpKVStore with base_url: {}", base_url);
         let http = HttpsConnectorBuilder::new()
@@ -95,7 +112,7 @@ impl HttpKVStore {
         Uri::from_str(joined.as_str()).into_sui_result()
     }
 
-    async fn multi_fetch(&self, uris: &[Key]) -> Vec<SuiResult<Bytes>> {
+    async fn multi_fetch(&self, uris: Vec<Key>) -> Vec<SuiResult<Option<Bytes>>> {
         let uris_vec = uris.to_vec();
         let fetches = stream::iter(
             uris_vec
@@ -106,23 +123,31 @@ impl HttpKVStore {
         fetches.buffered(uris.len()).collect::<Vec<_>>().await
     }
 
-    async fn fetch(&self, key: Key) -> SuiResult<Bytes> {
+    async fn fetch(&self, key: Key) -> SuiResult<Option<Bytes>> {
         let uri = self.get_url(&key)?;
         trace!("fetching uri: {}", uri);
         let resp = self.client.get(uri.clone()).await.into_sui_result()?;
         trace!(
-            "got response for uri: {}, len: {}",
+            "got response {} for uri: {}, len: {}",
             uri,
+            resp.status(),
             resp.headers().len()
         );
-        hyper::body::to_bytes(resp.into_body())
-            .await
-            .into_sui_result()
+        // return None if 400
+        if resp.status().is_success() {
+            hyper::body::to_bytes(resp.into_body())
+                .await
+                .map(Some)
+                .into_sui_result()
+        } else {
+            Ok(None)
+        }
     }
 }
 
-fn deser<T>(key: &Key, bytes: &[u8]) -> Option<T>
+fn deser<K, T>(key: &K, bytes: &[u8]) -> Option<T>
 where
+    K: std::fmt::Debug,
     T: for<'de> Deserialize<'de>,
 {
     bcs::from_bytes(bytes)
@@ -131,87 +156,111 @@ where
 }
 
 #[async_trait]
-impl TransactionKeyValueStore for HttpKVStore {
-    async fn multi_get(&self, keys: &[Key]) -> SuiResult<Vec<Option<Value>>> {
-        let fetches = self.multi_fetch(keys).await;
+impl TransactionKeyValueStoreTrait for HttpKVStore {
+    async fn multi_get(
+        &self,
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> SuiResult<(
+        Vec<Option<Transaction>>,
+        Vec<Option<TransactionEffects>>,
+        Vec<Option<TransactionEvents>>,
+    )> {
+        let num_txns = transactions.len();
+        let num_effects = effects.len();
+        let num_events = events.len();
 
-        let values: Vec<_> = fetches
-            .into_iter()
-            .zip(keys.iter())
-            .map(|(fetch, key)| match fetch {
-                Ok(bytes) => Some((bytes, key)),
+        let keys = transactions
+            .iter()
+            .map(|tx| Key::Tx(*tx))
+            .chain(effects.iter().map(|fx| Key::Fx(*fx)))
+            .chain(events.iter().map(|events| Key::Events(*events)))
+            .collect::<Vec<_>>();
+
+        let fetches = self.multi_fetch(keys).await;
+        let txn_slice = fetches[..num_txns].to_vec();
+        let fx_slice = fetches[num_txns..num_txns + num_effects].to_vec();
+        let events_slice = fetches[num_txns + num_effects..].to_vec();
+
+        fn map_fetch<'a, Digest>(
+            fetch: (&'a SuiResult<Option<Bytes>>, &'a Digest),
+        ) -> Option<(&'a Bytes, &'a Digest)>
+        where
+            Digest: std::fmt::Debug,
+        {
+            let (fetch, digest) = fetch;
+            match fetch {
+                Ok(Some(bytes)) => Some((bytes, digest)),
+                Ok(None) => None,
                 Err(err) => {
-                    warn!("Error fetching key: {:?}, error: {:?}", key, err);
+                    warn!("Error fetching key: {:?}, error: {:?}", digest, err);
+                    None
+                }
+            }
+        }
+
+        fn deser_check_digest<T, D: std::fmt::Debug>(
+            digest: &D,
+            bytes: &Bytes,
+            get_expected_digest: impl FnOnce(&T) -> D,
+        ) -> Option<T>
+        where
+            D: std::fmt::Debug + PartialEq,
+            T: for<'de> Deserialize<'de>,
+        {
+            deser(digest, bytes).and_then(|o: T| {
+                let expected_digest = get_expected_digest(&o);
+                if expected_digest == *digest {
+                    Some(o)
+                } else {
+                    error!(
+                        "Digest mismatch - expected: {:?}, got: {:?}",
+                        digest, expected_digest,
+                    );
                     None
                 }
             })
-            .map(|maybe_bytes| match maybe_bytes {
-                Some((bytes, key)) => match key {
-                    Key::Tx(digest) => {
-                        let tx = deser(key, &bytes).and_then(|tx: Transaction| {
-                            if tx.digest() == digest {
-                                Some(tx)
-                            } else {
-                                error!(
-                                    "Digest mismatch for tx, expected: {:?}, got: {:?}",
-                                    digest,
-                                    tx.digest()
-                                );
-                                None
-                            }
-                        })?;
-                        Some(Value::Tx(Box::new(tx)))
-                    }
-                    Key::Fx(digest) => {
-                        let fx = deser(key, &bytes).and_then(|fx: TransactionEffects| {
-                            if fx.digest() == *digest {
-                                Some(fx)
-                            } else {
-                                error!(
-                                    "Digest mismatch for fx, expected: {:?}, got: {:?}",
-                                    digest,
-                                    fx.digest()
-                                );
-                                None
-                            }
-                        })?;
-                        Some(Value::Fx(Box::new(fx)))
-                    }
-                    Key::Events(digest) => {
-                        let events = deser(key, &bytes).and_then(|events: TransactionEvents| {
-                            if events.digest() == *digest {
-                                Some(events)
-                            } else {
-                                error!(
-                                    "Digest mismatch for events, expected: {:?}, got: {:?}",
-                                    digest,
-                                    events.digest()
-                                );
-                                None
-                            }
-                        })?;
-                        Some(Value::Events(Box::new(events)))
-                    }
-                    Key::FxByTxDigest(digest) => {
-                        let fx = deser(key, &bytes).and_then(|fx: TransactionEffects| {
-                            let tx_digest = fx.transaction_digest();
-                            if tx_digest == digest {
-                                Some(fx)
-                            } else {
-                                error!(
-                                    "expected TransactionEffects for tx: {:?}, got: {:?}",
-                                    digest, tx_digest
-                                );
-                                None
-                            }
-                        })?;
-                        Some(Value::Fx(Box::new(fx)))
-                    }
-                },
-                None => None,
-            })
-            .collect();
+        }
 
-        Ok(values)
+        let txn_results = txn_slice
+            .iter()
+            .take(num_txns)
+            .zip(transactions.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, digest)| {
+                    deser_check_digest(digest, bytes, |tx: &Transaction| *tx.digest())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let fx_results = fx_slice
+            .iter()
+            .take(num_effects)
+            .zip(effects.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, digest)| {
+                    deser_check_digest(digest, bytes, |fx: &TransactionEffects| {
+                        *fx.transaction_digest()
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let events_results = events_slice
+            .iter()
+            .take(num_events)
+            .zip(events.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, digest)| {
+                    deser_check_digest(digest, bytes, |events: &TransactionEvents| events.digest())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Ok((txn_results, fx_results, events_results))
     }
 }

--- a/crates/sui-storage/src/key_value_store_metrics.rs
+++ b/crates/sui-storage/src/key_value_store_metrics.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use mysten_metrics::histogram::HistogramVec;
+use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
+use std::sync::Arc;
+
+pub struct KeyValueStoreMetrics {
+    pub key_value_store_num_fetches_success: IntCounterVec,
+    pub key_value_store_num_fetches_not_found: IntCounterVec,
+    pub key_value_store_num_fetches_error: IntCounterVec,
+
+    pub key_value_store_num_fetches_latency_ms: HistogramVec,
+    pub key_value_store_num_fetches_batch_size: HistogramVec,
+}
+
+impl KeyValueStoreMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            key_value_store_num_fetches_success: register_int_counter_vec_with_registry!(
+                "key_value_store_num_fetches_success",
+                "Number of successful fetches from key value store",
+                &["store", "type"],
+                registry,
+            )
+            .unwrap(),
+            key_value_store_num_fetches_not_found: register_int_counter_vec_with_registry!(
+                "key_value_store_num_fetches_not_found",
+                "Number of fetches from key value store that returned not found",
+                &["store", "type"],
+                registry,
+            )
+            .unwrap(),
+            key_value_store_num_fetches_error: register_int_counter_vec_with_registry!(
+                "key_value_store_num_fetches_error",
+                "Number of fetches from key value store that returned an error",
+                &["store", "type"],
+                registry,
+            )
+            .unwrap(),
+
+            key_value_store_num_fetches_latency_ms: HistogramVec::new_in_registry(
+                "key_value_store_num_fetches_latency_ms",
+                "Latency of fetches from key value store",
+                &["store"],
+                registry,
+            ),
+
+            key_value_store_num_fetches_batch_size: HistogramVec::new_in_registry(
+                "key_value_store_num_fetches_batch_size",
+                "Number of keys fetched per batch",
+                &["store"],
+                registry,
+            ),
+        })
+    }
+
+    pub fn new_for_tests() -> Arc<Self> {
+        Self::new(&Registry::new())
+    }
+}

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -24,6 +24,7 @@ use tracing::debug;
 pub mod blob;
 pub mod http_key_value_store;
 pub mod key_value_store;
+pub mod key_value_store_metrics;
 pub mod mutex_table;
 pub mod object_store;
 pub mod package_object_cache;


### PR DESCRIPTION
This required a pretty extensive refactoring to avoid adding duplicated metrics code to different impls, but the end result is much nicer anyway.