### PR TITLE
Update Cargo.toml - thiserror version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,7 @@ tabled = { version = "0.12" }
 tap = "1.0.1"
 tempfile = "3.3.0"
 test-fuzz = "3.0.4"
-thiserror = "1.0.40"
+thiserror = "1.0.39"
 tiny-bip39 = "1.0.0"
 tokio = "1.28.1"
 tokio-retry = "0.3"


### PR DESCRIPTION
ark-circom is not compatable with versions ^1.0.40

## Description 

Includes v1.0.39 of thiserror. Allows Sui Rust-SDK to work with Ark-Circom.

## Test Plan 

Cloned repository and built with no errors.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
