### PR TITLE
indexer: turn off sync write on cache

### DIFF
--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -2577,7 +2577,7 @@ impl PartitionManager {
 }
 
 // Run this function only once every `time` seconds
-#[once(time = 60, sync_writes = true, result = true)]
+#[once(time = 20, result = true)]
 fn get_network_metrics_cached(cp: &PgConnectionPool) -> Result<NetworkMetrics, IndexerError> {
     let metrics = read_only_blocking!(cp, |conn| diesel::sql_query(
         "SELECT * FROM network_metrics;"


### PR DESCRIPTION
## Description 

Turn off cache sync write of TPS metric

## Test Plan 

Tested and deployed to testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
