### PR TITLE
indexer fix: split commits of obj mutation and deletion

### DIFF
--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -224,7 +224,7 @@ pub trait IndexerStore {
         tx_object_changes: &[TransactionObjectChanges],
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
-        counter_committed_object: IntCounter,
+        object_commit_chunk_counter: IntCounter,
     ) -> Result<(), IndexerError>;
     async fn persist_events(&self, events: &[Event]) -> Result<(), IndexerError>;
     async fn persist_addresses(

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1266,7 +1266,7 @@ impl PgIndexerStore {
         tx_object_changes: &[TransactionObjectChanges],
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
-        counter_committed_object: IntCounter,
+        object_commit_chunk_counter: IntCounter,
     ) -> Result<(), IndexerError> {
         let mutated_objects: Vec<Object> = tx_object_changes
             .iter()
@@ -1281,13 +1281,22 @@ impl PgIndexerStore {
             .map(|deleted_object| deleted_object.clone().into())
             .collect();
         transactional_blocking!(&self.blocking_cp, |conn| {
-            persist_transaction_object_changes(
+            persist_object_mutations(
                 conn,
                 mutated_objects,
-                deleted_objects,
                 object_mutation_latency,
+                object_commit_chunk_counter.clone(),
+            )?;
+            Ok::<(), IndexerError>(())
+        })?;
+        // commit object deletions after mutations b/c objects cannot be mutated after deletion,
+        // otherwise object mutations might override object deletions.
+        transactional_blocking!(&self.blocking_cp, |conn| {
+            persist_object_deletions(
+                conn,
+                deleted_objects,
                 object_deletion_latency,
-                counter_committed_object,
+                object_commit_chunk_counter,
             )?;
             Ok::<(), IndexerError>(())
         })?;
@@ -2252,7 +2261,7 @@ impl IndexerStore for PgIndexerStore {
         tx_object_changes: &[TransactionObjectChanges],
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,
-        counter_committed_object: IntCounter,
+        object_commit_chunk_counter: IntCounter,
     ) -> Result<(), IndexerError> {
         let tx_object_changes = tx_object_changes.to_owned();
         self.spawn_blocking(move |this| {
@@ -2260,7 +2269,7 @@ impl IndexerStore for PgIndexerStore {
                 &tx_object_changes,
                 object_mutation_latency,
                 object_deletion_latency,
-                counter_committed_object,
+                object_commit_chunk_counter,
             )
         })
         .await
@@ -2434,19 +2443,13 @@ impl IndexerStore for PgIndexerStore {
     }
 }
 
-fn persist_transaction_object_changes(
+fn persist_object_mutations(
     conn: &mut PgConnection,
     mutated_objects: Vec<Object>,
-    deleted_objects: Vec<Object>,
     object_mutation_latency: Histogram,
-    object_deletion_latency: Histogram,
-    committed_object_counter: IntCounter,
+    object_commit_chunk_counter: IntCounter,
 ) -> Result<(), IndexerError> {
-    // NOTE: to avoid error of `ON CONFLICT DO UPDATE command cannot affect row a second time`,
-    // we have to limit update of one object once in a query.
-    // Also we only need to update the latest object into DB.
     let mutated_objects = filter_latest_objects(mutated_objects);
-
     let object_mutation_guard = object_mutation_latency.start_timer();
     // bulk insert/update via UNNEST trick to bypass the 65535 parameters limit
     // ref: https://klotzandrew.com/blog/postgres-passing-65535-parameter-limit
@@ -2460,7 +2463,16 @@ fn persist_transaction_object_changes(
             ))
         })?;
     object_mutation_guard.stop_and_record();
+    object_commit_chunk_counter.inc();
+    Ok(())
+}
 
+fn persist_object_deletions(
+    conn: &mut PgConnection,
+    deleted_objects: Vec<Object>,
+    object_deletion_latency: Histogram,
+    object_commit_chunk_counter: IntCounter,
+) -> Result<(), IndexerError> {
     let object_deletion_guard = object_deletion_latency.start_timer();
     for deleted_object_change_chunk in deleted_objects.chunks(PG_COMMIT_CHUNK_SIZE) {
         diesel::insert_into(objects::table)
@@ -2481,10 +2493,9 @@ fn persist_transaction_object_changes(
                     e
                 ))
             })?;
-        committed_object_counter.inc();
+        object_commit_chunk_counter.inc();
     }
     object_deletion_guard.stop_and_record();
-
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

this is a bug but did not manifest when we committed each checkpoint one by one.
after recent change of writing multiple checkpoints together, an error of ON CONFLICT DO UPDATE would happen.
specifically, if in an object commit batch, an object is mutated first and then deleted later, this error will show up.
thanks to @bschwab for detecting and reporting this.

## Test Plan 

test locally and with bryan on the snowflake pipeline.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
