### PR TITLE
[kiosk] Remove the key+store constraint on rules

### DIFF
--- a/kiosk/examples/collectible.move
+++ b/kiosk/examples/collectible.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[test_only]
 /// The module which defines the `Collectible` type. It is an all-in-one
 /// package to create a `Display`, a `Publisher` and a `TransferPolicy` to
 /// enable `Kiosk` trading from the start.

--- a/kiosk/sources/rules/floor_price_rule.move
+++ b/kiosk/sources/rules/floor_price_rule.move
@@ -10,7 +10,7 @@
 /// Use cases:
 /// - Defining a floor price for all trades of type T.
 /// - Prevent trading of locked items with low amounts (e.g. by using purchase_cap).
-/// 
+///
 module kiosk::floor_price_rule {
     use sui::transfer_policy::{
         Self as policy,
@@ -34,7 +34,7 @@ module kiosk::floor_price_rule {
 
     /// Creator action: Add the Floor Price Rule for the `T`.
     /// Pass in the `TransferPolicy`, `TransferPolicyCap` and `floor_price`.
-    public fun add<T: key + store>(
+    public fun add<T>(
         policy: &mut TransferPolicy<T>,
         cap: &TransferPolicyCap<T>,
         floor_price: u64
@@ -43,14 +43,14 @@ module kiosk::floor_price_rule {
     }
 
     /// Buyer action: Prove that the amount is higher or equal to the floor_price.
-    public fun prove<T: key + store>(
+    public fun prove<T>(
         policy: &mut TransferPolicy<T>,
         request: &mut TransferRequest<T>
     ) {
         let config: &Config = policy::get_rule(Rule {}, policy);
 
         assert!(policy::paid(request) >= config.floor_price, EPriceTooSmall);
-        
+
         policy::add_receipt(Rule {}, request)
     }
 }

--- a/kiosk/sources/rules/royalty_rule.move
+++ b/kiosk/sources/rules/royalty_rule.move
@@ -63,7 +63,7 @@ module kiosk::royalty_rule {
     /// Creator action: Add the Royalty Rule for the `T`.
     /// Pass in the `TransferPolicy`, `TransferPolicyCap` and the configuration
     /// for the policy: `amount_bp` and `min_amount`.
-    public fun add<T: key + store>(
+    public fun add<T>(
         policy: &mut TransferPolicy<T>,
         cap: &TransferPolicyCap<T>,
         amount_bp: u16,
@@ -74,7 +74,7 @@ module kiosk::royalty_rule {
     }
 
     /// Buyer action: Pay the royalty fee for the transfer.
-    public fun pay<T: key + store>(
+    public fun pay<T>(
         policy: &mut TransferPolicy<T>,
         request: &mut TransferRequest<T>,
         payment: Coin<SUI>
@@ -90,7 +90,7 @@ module kiosk::royalty_rule {
 
     /// Helper function to calculate the amount to be paid for the transfer.
     /// Can be used dry-runned to estimate the fee amount based on the Kiosk listing price.
-    public fun fee_amount<T: key + store>(policy: &TransferPolicy<T>, paid: u64): u64 {
+    public fun fee_amount<T>(policy: &TransferPolicy<T>, paid: u64): u64 {
         let config: &Config = policy::get_rule(Rule {}, policy);
         let amount = (((paid as u128) * (config.amount_bp as u128) / 10_000) as u64);
 

--- a/kiosk/sources/rules/witness_rule.move
+++ b/kiosk/sources/rules/witness_rule.move
@@ -31,7 +31,7 @@ module kiosk::witness_rule {
 
     /// Creator action: adds the Rule.
     /// Requires a "Proof" witness confirmation on every transfer.
-    public fun add<T: key + store, Proof: drop>(
+    public fun add<T, Proof: drop>(
         policy: &mut TransferPolicy<T>,
         cap: &TransferPolicyCap<T>
     ) {
@@ -40,7 +40,7 @@ module kiosk::witness_rule {
 
     /// Buyer action: follow the policy.
     /// Present the required "Proof" instance to get a receipt.
-    public fun prove<T: key + store, Proof: drop>(
+    public fun prove<T, Proof: drop>(
         _proof: Proof,
         policy: &TransferPolicy<T>,
         request: &mut TransferRequest<T>


### PR DESCRIPTION
## Description 

Removes the `key + store` constraint on existing rules as it is very limiting.

## Test Plan 

Code builds

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- Kiosk rules now don't constrain the type to `key + store` 
