### PR TITLE
[Explorer]: fix object view page

### DIFF
--- a/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
+++ b/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
@@ -24,7 +24,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
 	const [activeFieldName, setActiveFieldName] = useState('');
 	const objectType =
 		data?.data?.type ?? data?.data?.content?.dataType === 'package'
-			? 'package'
+			? data.data.type
 			: data?.data?.content?.type;
 
 	// Get the packageId, moduleName, functionName from the objectType


### PR DESCRIPTION
## Description 

- Currently the `ObjectFieldsCard` always renders invalid values for `package` due to `enabled` being false and the spinner runs endlessly (Slack ref https://mysten-labs.slack.com/archives/C032676BWGN/p1690883106846709)

Parsing by data.type will give correct value for `sui_getNormalizedMoveStruct` query

<img width="1468" alt="Screenshot 2023-08-01 at 3 14 01 PM" src="https://github.com/MystenLabs/sui/assets/127577476/cb2e88c1-26cb-4330-b910-036905e523bd">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
