### PR TITLE
[CLI] Improve warning message for source verification failure

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -368,7 +368,7 @@ pub enum SuiError {
     ModuleVerificationFailure { error: String },
     #[error("Failed to deserialize the Move module, reason: {error:?}.")]
     ModuleDeserializationFailure { error: String },
-    #[error("Failed to publish the Move module(s), reason: {error:?}.")]
+    #[error("Failed to publish the Move module(s), reason: {error}")]
     ModulePublishFailure { error: String },
     #[error("Failed to build Move modules: {error}.")]
     ModuleBuildFailure { error: String },

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1310,7 +1310,7 @@ async fn compile_package(
         CompiledPackage,
         Result<ObjectID, PublishedAtError>,
     ),
-    anemo::Error,
+    anyhow::Error,
 > {
     let config = resolve_lock_file_path(build_config, Some(package_path.clone()))?;
     let run_bytecode_verifier = true;
@@ -1339,7 +1339,7 @@ async fn compile_package(
             return Err(SuiError::ModulePublishFailure {
                 error: format!(
                     "Modules must all have 0x0 as their addresses. \
-                           Violated by module {:?}",
+                     Violated by module {:?}",
                     already_published.self_id(),
                 ),
             }
@@ -1351,15 +1351,30 @@ async fn compile_package(
     }
     let compiled_modules = compiled_package.get_package_bytes(with_unpublished_dependencies);
     if !skip_dependency_verification {
-        BytecodeSourceVerifier::new(client.read_api())
-            .verify_package_deps(&compiled_package)
-            .await?;
-        eprintln!(
-            "{}",
-            "Successfully verified dependencies on-chain against source."
-                .bold()
-                .green(),
-        );
+        let verifier = BytecodeSourceVerifier::new(client.read_api());
+        if let Err(e) = verifier.verify_package_deps(&compiled_package).await {
+            return Err(SuiError::ModulePublishFailure {
+                error: format!(
+                    "[warning] {e}\n\
+                     \n\
+                     This may indicate that the on-chain version(s) of your package's dependencies \
+                     may behave differently than the source version(s) your package was built \
+                     against.\n\
+                     \n\
+                     Fix this by rebuilding your packages with source versions matching on-chain \
+                     versions of dependencies, or ignore this warning by re-running with the \
+                     --skip-dependency-verification flag."
+                )
+            }
+            .into())
+        } else {
+            eprintln!(
+                "{}",
+                "Successfully verified dependencies on-chain against source."
+                    .bold()
+                    .green(),
+            );
+        }
     } else {
         eprintln!("{}", "Skipping dependency verification".bold().yellow());
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1364,9 +1364,9 @@ async fn compile_package(
                      Fix this by rebuilding your packages with source versions matching on-chain \
                      versions of dependencies, or ignore this warning by re-running with the \
                      --skip-dependency-verification flag."
-                )
+                ),
             }
-            .into())
+            .into());
         } else {
             eprintln!(
                 "{}",


### PR DESCRIPTION
## Description

...when publishing or upgrading packages via the CLI.  Improvements are as follows:

- Preserve formatting in the error (newlines, etc) by removing debug formatting.
- Add context explaining what the warning means, and that it can be ignored using a command-line flag.

## Test Plan

- Create two packages: `test` depending on `dep`.
- Publish `dep`, and update its manifest with its published location.
- Modify `dep`'s source to be different from the version that was published.
- Try to publish `test`, expect a source verification error, which now looks like this:

```
Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain 
version at b33d80d795a038ce44d1f67b84047493f8775ab29d7f856271f705c6e1fd329f::Dep::dep

This may indicate that the on-chain version(s) of your package's dependencies may behave differently 
than the source version(s) your package was built against.

Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, 
or ignore this warning by re-running with the --skip-dependency-verification flag.
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

The source verification failure warning from package publish and upgrade CLI commands has improved formatting and suggests ways to fix the issue or silence the warning.