### PR TITLE
[narwhal] align low scoring detection on submission with leader schedule

### DIFF
--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -143,8 +143,8 @@ fn update_low_scoring_authorities_v2(
         total_stake += stake;
 
         let included = if total_stake
-            <= (protocol_config.consensus_bad_nodes_stake_threshold()
-                * committee.total_stake()) / 100 as Stake
+            <= (protocol_config.consensus_bad_nodes_stake_threshold() * committee.total_stake())
+                / 100 as Stake
         {
             final_low_scoring_map.insert(authority, score);
             true
@@ -527,7 +527,7 @@ mod tests {
                 .unwrap(),
             40_u64
         );
-        assert_eq!(low_scoring.load().len(), 1);
+        assert_eq!(low_scoring.load().len(), 11);
     }
 
     #[test]

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::AuthorityName;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// Updates list of authorities that are deemed to have low reputation scores by consensus
 /// these may be lagging behind the network, byzantine, or not reliably participating for any reason.

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -154,7 +154,7 @@ fn update_low_scoring_authorities_v2(
 
         if let Some(hostname) = authority_names_to_hostnames.get(&authority) {
             info!(
-                "low scoring authority {} has score {}, included: {}",
+                "authority {} has score {}, is low scoring: {}",
                 hostname, score, included
             );
         }

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -88,7 +88,7 @@ fn update_low_scoring_authorities_v2(
     metrics: &Arc<AuthorityMetrics>,
     protocol_config: &ProtocolConfig,
 ) {
-    assert!((0.0..=0.33).contains(&protocol_config.consensus_bad_nodes_stake_threshold()), "The bad_nodes_stake_threshold should be in range [0.0 - 0.33], out of bounds parameter detected");
+    assert!((0..=33).contains(&protocol_config.consensus_bad_nodes_stake_threshold()), "The bad_nodes_stake_threshold should be in range [0 - 33], out of bounds parameter detected");
 
     if !reputation_scores.final_of_schedule {
         return;
@@ -144,7 +144,7 @@ fn update_low_scoring_authorities_v2(
 
         let included = if total_stake
             <= (protocol_config.consensus_bad_nodes_stake_threshold()
-                * committee.total_stake() as f64) as Stake
+                * committee.total_stake()) / 100 as Stake
         {
             final_low_scoring_map.insert(authority, score);
             true
@@ -348,7 +348,7 @@ mod tests {
         protocol_config.set_narwhal_new_leader_election_schedule(true);
 
         // WHEN
-        protocol_config.set_consensus_bad_nodes_stake_threshold(0.33); // 0.33 * 8 = 2.64 maximum stake that will considered low scoring
+        protocol_config.set_consensus_bad_nodes_stake_threshold(33); // 33 * 8 / 100 = 2 maximum stake that will considered low scoring
 
         update_low_scoring_authorities(
             low_scoring.clone(),
@@ -371,7 +371,7 @@ mod tests {
         );
 
         // WHEN setting the threshold to lower
-        protocol_config.set_consensus_bad_nodes_stake_threshold(0.2); // 0.2 * 8 = 1.6 maximum
+        protocol_config.set_consensus_bad_nodes_stake_threshold(20); // 20 * 8 / 100 = 1 maximum
         update_low_scoring_authorities(
             low_scoring.clone(),
             &committee,

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -8,11 +8,12 @@ use fastcrypto::traits::ToFromBytes;
 use narwhal_config::{Committee, Stake};
 use narwhal_crypto::PublicKey;
 use narwhal_types::ReputationScores;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::AuthorityName;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Updates list of authorities that are deemed to have low reputation scores by consensus
 /// these may be lagging behind the network, byzantine, or not reliably participating for any reason.
@@ -49,8 +50,20 @@ pub fn update_low_scoring_authorities(
     metrics: &Arc<AuthorityMetrics>,
     protocol_config: &ProtocolConfig,
 ) {
-    if protocol_config.scoring_decision_with_validity_cutoff() {
-        update_low_scoring_authorities_with_no_disable_mechanism(
+    // The new scoring mechanism will get enabled at the same time when the new leader election schedule
+    // is enabled as well. Before that there isn't much of a gain doing so.
+    if protocol_config.narwhal_new_leader_election_schedule() {
+        update_low_scoring_authorities_v2(
+            low_scoring_authorities,
+            committee,
+            reputation_scores,
+            authority_names_to_hostnames,
+            metrics,
+            protocol_config,
+        );
+    } else {
+        // TODO remove after the last version upgrade
+        update_low_scoring_authorities_v1(
             low_scoring_authorities,
             committee,
             reputation_scores,
@@ -59,125 +72,101 @@ pub fn update_low_scoring_authorities(
             protocol_config.scoring_decision_mad_divisor(),
             protocol_config.scoring_decision_cutoff_value(),
         );
-    } else {
-        // TODO remove this after the protocol version upgrade to 5
-        static MAD_DIVISOR: f64 = 1.2;
-        static CUTOFF_VALUE: f64 = 3.0;
-
-        update_low_scoring_authorities_with_previous_disable_mechanism(
-            low_scoring_authorities,
-            committee,
-            reputation_scores,
-            authority_names_to_hostnames,
-            metrics,
-            MAD_DIVISOR,
-            CUTOFF_VALUE,
-        );
     }
 }
 
-// TODO: remove after validators have upgraded to protocol version 5.
-fn update_low_scoring_authorities_with_previous_disable_mechanism(
+/// This version is flagging as low scoring authorities all the validators that have the lowest scores
+/// up to the defined protocol_config.consensus_bad_nodes_stake_threshold. This is done to align the
+/// submission side with the Narwhal leader election schedule. Practically we don't want to submit
+/// transactions for sequencing to validators that have low scores and are not part of the leader
+/// schedule since the chances of getting them sequenced are lower.
+fn update_low_scoring_authorities_v2(
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     committee: &Committee,
     reputation_scores: ReputationScores,
     authority_names_to_hostnames: HashMap<AuthorityName, String>,
     metrics: &Arc<AuthorityMetrics>,
-    mad_divisor: f64,
-    cut_off_value: f64,
+    protocol_config: &ProtocolConfig,
 ) {
+    assert!((0.0..=0.33).contains(&protocol_config.consensus_bad_nodes_stake_threshold()), "The bad_nodes_stake_threshold should be in range [0.0 - 0.33], out of bounds parameter detected");
+
     if !reputation_scores.final_of_schedule {
         return;
     }
 
     // Convert the narwhal authority ids to the corresponding AuthorityName in SUI
     // Also capture the stake so can calculate later is strong quorum is reached for the non-low scoring authorities.
-    let scores_per_authority: HashMap<AuthorityName, (u64, Stake)> = reputation_scores
+    let mut scores_per_authority: Vec<(AuthorityName, u64, Stake)> = reputation_scores
         .scores_per_authority
         .into_iter()
         .map(|(authority_id, score)| {
             let authority = committee.authority(&authority_id).unwrap();
             let name: AuthorityName = authority.protocol_key().into();
-
             // report the scores
             if let Some(hostname) = authority_names_to_hostnames.get(&name) {
                 info!("authority {} has score {}", hostname, score);
-
                 metrics
                     .consensus_handler_scores
                     .with_label_values(&[&format!("{:?}", hostname)])
                     .set(score as i64);
             }
 
-            (name, (score, authority.stake()))
+            (name, score, authority.stake())
         })
         .collect();
 
+    // sort the low scoring authorities in asc order
+    // Keep marking low scoring authorities up to f.
+    // Important: the ordering has to be deterministic, otherwise different validators will see
+    // different order and latency might increase. Here we order with the following properties:
+    // * by score ascending
+    // * if scores are equal, then we order by stake ascending
+    // * if stakes are equal, then we do order by name (where we can't have equality unless is the same validator)
+    scores_per_authority.sort_by(|(name1, score1, stake1), (name2, score2, stake2)| {
+        match score1.cmp(score2) {
+            // if scores are equal, then consider lower scorer an authority with lower stake
+            Ordering::Equal => {
+                match stake1.cmp(stake2) {
+                    // if stake is equal, then just order by name.
+                    Ordering::Equal => name1.cmp(name2),
+                    result => result,
+                }
+            }
+            result => result,
+        }
+    });
     let mut final_low_scoring_map = HashMap::new();
 
-    let mut score_list = vec![];
-    let mut nonzero_scores = vec![];
-    for (score, _stake) in scores_per_authority.values() {
-        score_list.push(*score as f64);
-        if score != &0_u64 {
-            nonzero_scores.push(*score as f64);
-        }
-    }
+    // take low scoring authorities while we haven't reached validity threshold (f+1)
+    let mut total_stake = 0;
+    for (authority, score, stake) in scores_per_authority {
+        total_stake += stake;
 
-    let median_value = median(&nonzero_scores);
-    let mut deviations = vec![];
-    let mut abs_deviations = vec![];
-    for (i, _) in score_list.clone().iter().enumerate() {
-        deviations.push(score_list[i] - median_value);
-        if score_list[i] != 0.0 {
-            abs_deviations.push((score_list[i] - median_value).abs());
-        }
-    }
-
-    // adjusted median absolute deviation
-    let mad = median(&abs_deviations) / mad_divisor;
-    let mut low_scoring = vec![];
-    let mut rest = vec![];
-    for (i, (a, (score, stake))) in scores_per_authority.iter().enumerate() {
-        let temp = deviations[i] / mad;
-        if temp < -cut_off_value {
-            low_scoring.push((a, *score));
+        let included = if total_stake
+            <= (protocol_config.consensus_bad_nodes_stake_threshold()
+                * committee.total_stake() as f64) as Stake
+        {
+            final_low_scoring_map.insert(authority, score);
+            true
         } else {
-            rest.push((a, *stake));
+            false
+        };
+
+        if let Some(hostname) = authority_names_to_hostnames.get(&authority) {
+            info!(
+                "low scoring authority {} has score {}, included: {}",
+                hostname, score, included
+            );
         }
     }
-
-    // report new scores
-    let len_low_scoring = low_scoring.len();
+    // Report the actual flagged final low scoring authorities
     metrics
         .consensus_handler_num_low_scoring_authorities
-        .set(len_low_scoring as i64);
-
-    info!("{:?} low scoring authorities calculated", len_low_scoring);
-
-    for (authority, score) in low_scoring {
-        final_low_scoring_map.insert(*authority, score);
-        if let Some(hostname) = authority_names_to_hostnames.get(authority) {
-            info!("low scoring authority {} has score {}", hostname, score);
-        }
-    }
-
-    // make sure the rest have at least quorum
-    let remaining_stake = rest.into_iter().map(|(_, stake)| stake).sum::<Stake>();
-    let quorum_threshold = committee.quorum_threshold();
-    if remaining_stake < quorum_threshold {
-        warn!(
-            "too many low reputation-scoring authorities, temporarily disabling scoring mechanism"
-        );
-
-        low_scoring_authorities.swap(Arc::new(HashMap::new()));
-        return;
-    }
-
+        .set(final_low_scoring_map.len() as i64);
     low_scoring_authorities.swap(Arc::new(final_low_scoring_map));
 }
 
-fn update_low_scoring_authorities_with_no_disable_mechanism(
+fn update_low_scoring_authorities_v1(
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     committee: &Committee,
     reputation_scores: ReputationScores,
@@ -307,16 +296,75 @@ mod tests {
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::crypto::NetworkPublicKey;
 
-    fn protocol_v4() -> ProtocolConfig {
-        // There are no chain specific protocol config options at this version
-        // so the chain is irrelevant
-        ProtocolConfig::get_for_version(ProtocolVersion::new(4), Chain::Unknown)
-    }
-
     fn protocol_v5() -> ProtocolConfig {
         // There are no chain specific protocol config options at this version
         // so the chain is irrelevant
         ProtocolConfig::get_for_version(ProtocolVersion::new(5), Chain::Unknown)
+    }
+
+    #[test]
+    pub fn test_update_low_scoring_authorities_v2() {
+        // GIVEN
+        let peer_id_map = HashMap::new();
+        let committee = generate_committee(8);
+        let mut authorities = committee.authorities();
+        let a1 = authorities.next().unwrap();
+        let a2 = authorities.next().unwrap();
+        let a3 = authorities.next().unwrap();
+        let a4 = authorities.next().unwrap();
+        let a5 = authorities.next().unwrap();
+        let a6 = authorities.next().unwrap();
+        let a7 = authorities.next().unwrap();
+        let a8 = authorities.next().unwrap();
+
+        let low_scoring = Arc::new(ArcSwap::from_pointee(HashMap::new()));
+
+        let mut inner = HashMap::new();
+        inner.insert(a1.protocol_key().into(), 50);
+
+        low_scoring.swap(Arc::new(inner));
+
+        let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
+
+        // there is a low outlier in the non zero scores, exclude it as well as down nodes
+        let mut scores = HashMap::new();
+        scores.insert(a1.id(), 350_u64);
+        scores.insert(a2.id(), 390_u64);
+        scores.insert(a3.id(), 350_u64);
+        scores.insert(a4.id(), 50_u64);
+        scores.insert(a5.id(), 0_u64); // down node
+        scores.insert(a6.id(), 300_u64);
+        scores.insert(a7.id(), 340_u64);
+        scores.insert(a8.id(), 310_u64);
+        let reputation_scores = ReputationScores {
+            scores_per_authority: scores,
+            final_of_schedule: true,
+        };
+
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_narwhal_new_leader_election_schedule(true);
+        protocol_config.set_consensus_bad_nodes_stake_threshold(0.33);
+
+        // WHEN
+        update_low_scoring_authorities(
+            low_scoring.clone(),
+            &committee,
+            reputation_scores,
+            peer_id_map,
+            &metrics,
+            &protocol_config,
+        );
+
+        // THEN
+        assert_eq!(low_scoring.load().len(), 2);
+        assert_eq!(
+            *low_scoring.load().get(&a4.protocol_key().into()).unwrap(),
+            50
+        );
+        assert_eq!(
+            *low_scoring.load().get(&a5.protocol_key().into()).unwrap(),
+            0
+        );
     }
 
     #[test]
@@ -332,7 +380,7 @@ mod tests {
 
         let mut inner = HashMap::new();
         inner.insert(a1.protocol_key().into(), 50);
-        let reputation_scores_1 = ReputationScores {
+        let reputation_scores = ReputationScores {
             scores_per_authority: Default::default(),
             final_of_schedule: false,
         };
@@ -340,69 +388,6 @@ mod tests {
         let peer_id_map = HashMap::new();
 
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
-
-        // when final of schedule is false, calling update_low_scoring_authorities will not change the
-        // low_scoring_authorities map
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores_1,
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-
-        assert_eq!(
-            *low_scoring.load().get(&a1.protocol_key().into()).unwrap(),
-            50_u64
-        );
-        assert_eq!(low_scoring.load().len(), 1);
-
-        // there is a clear low outlier in the scores, exclude it
-        let mut scores = HashMap::new();
-        scores.insert(a1.id(), 607_u64);
-        scores.insert(a2.id(), 611_u64);
-        scores.insert(a3.id(), 607_u64);
-        scores.insert(a4.id(), 455_u64);
-        let reputation_scores = ReputationScores {
-            scores_per_authority: scores,
-            final_of_schedule: true,
-        };
-
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores,
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-        assert_eq!(
-            *low_scoring.load().get(&a4.protocol_key().into()).unwrap(),
-            455_u64
-        );
-        assert_eq!(low_scoring.load().len(), 1);
-
-        // one authority has score which is a bit lower, but should not be excluded
-        let mut scores = HashMap::new();
-        scores.insert(a1.id(), 607_u64);
-        scores.insert(a2.id(), 751_u64);
-        scores.insert(a3.id(), 707_u64);
-        scores.insert(a4.id(), 650_u64);
-        let reputation_scores = ReputationScores {
-            scores_per_authority: scores,
-            final_of_schedule: true,
-        };
-
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-        assert_eq!(low_scoring.load().len(), 0);
 
         // When with protocol 5
         update_low_scoring_authorities(
@@ -426,17 +411,6 @@ mod tests {
             final_of_schedule: true,
         };
 
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-
-        assert_eq!(low_scoring.load().len(), 0);
-
         // when with protocol 5
         update_low_scoring_authorities(
             low_scoring.clone(),
@@ -459,16 +433,6 @@ mod tests {
             scores_per_authority: scores,
             final_of_schedule: true,
         };
-
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-        assert_eq!(low_scoring.load().len(), 0);
 
         // When protocol v5
         update_low_scoring_authorities(
@@ -505,17 +469,6 @@ mod tests {
             final_of_schedule: true,
         };
 
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-
-        assert_eq!(low_scoring.load().len(), 0);
-
         // When protocol v5
         update_low_scoring_authorities(
             low_scoring.clone(),
@@ -534,22 +487,6 @@ mod tests {
             scores_per_authority: scores,
             final_of_schedule: true,
         };
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-
-        assert_eq!(
-            *low_scoring
-                .load()
-                .get(&authorities[final_idx].protocol_key().into())
-                .unwrap(),
-            40_u64
-        );
 
         // When protocol 5
         update_low_scoring_authorities(
@@ -558,7 +495,7 @@ mod tests {
             reputation_scores,
             peer_id_map,
             &metrics,
-            &protocol_v4(),
+            &protocol_v5(),
         );
 
         assert_eq!(
@@ -608,24 +545,6 @@ mod tests {
             final_of_schedule: true,
         };
 
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            HashMap::new(),
-            &metrics,
-            &protocol_v4(),
-        );
-        assert_eq!(
-            *low_scoring.load().get(&a4.protocol_key().into()).unwrap(),
-            50_u64
-        );
-        assert_eq!(
-            *low_scoring.load().get(&a5.protocol_key().into()).unwrap(),
-            0_u64
-        );
-        assert_eq!(low_scoring.load().len(), 2);
-
         // When protocol v5
         update_low_scoring_authorities(
             low_scoring.clone(),
@@ -633,7 +552,7 @@ mod tests {
             reputation_scores,
             HashMap::new(),
             &metrics,
-            &protocol_v4(),
+            &protocol_v5(),
         );
         assert_eq!(
             *low_scoring.load().get(&a4.protocol_key().into()).unwrap(),
@@ -683,16 +602,6 @@ mod tests {
             scores_per_authority: scores,
             final_of_schedule: true,
         };
-
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            HashMap::new(),
-            &metrics,
-            &protocol_v4(),
-        );
-        assert_eq!(low_scoring.load().len(), 0);
 
         // When protocol v5
         update_low_scoring_authorities(
@@ -766,16 +675,6 @@ mod tests {
         };
 
         let peer_id_map = HashMap::new();
-        update_low_scoring_authorities(
-            low_scoring.clone(),
-            &committee,
-            reputation_scores.clone(),
-            peer_id_map.clone(),
-            &metrics,
-            &protocol_v4(),
-        );
-
-        assert_eq!(low_scoring.load().len(), 3);
 
         // When protocol v5
         update_low_scoring_authorities(

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -90,7 +90,8 @@ impl LeaderSwapTable {
         );
 
         // calculating the bad nodes
-        // we revert the sorted authorities to score ascending so we get the first f low scorers
+        // we revert the sorted authorities to score ascending so we get the first low scorers
+        // up to the dictated stake threshold.
         let bad_nodes = Self::retrieve_first_nodes(
             committee,
             reputation_scores
@@ -103,7 +104,6 @@ impl LeaderSwapTable {
         .map(|authority| (authority.id(), authority))
         .collect::<HashMap<AuthorityIdentifier, Authority>>();
 
-        // print the good nodes
         good_nodes.iter().for_each(|good_node| {
             debug!(
                 "Good node on round {}: {} -> {}",

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -372,6 +372,7 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
 
     let mut config: ProtocolConfig = latest_protocol_version();
     config.set_narwhal_new_leader_election_schedule(true);
+    config.set_consensus_bad_nodes_stake_threshold(33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let gc_depth = 50;

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -326,6 +326,127 @@ async fn not_enough_support_with_leader_schedule_change() {
     assert_eq!(total_15_certs, 4);
 }
 
+// We test here the leader schedule change when we experience a long period of asynchrony. That prohibit
+// us from committing for 8 rounds where 2 schedule changes should have happened given our setup. Then
+// once we manage to commit on round 15 we observe 2 schedule changes happening and 5 commits.
+#[tokio::test]
+async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
+    // GIVEN
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+
+    let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
+    let genesis = Certificate::genesis(&committee)
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+
+    let mut certificates: VecDeque<Certificate> = VecDeque::new();
+    let mut leader_configs = HashMap::new();
+
+    // A vector of tuples (leader_round, leader_authority_id)
+    let leaders_with_weak_support = vec![(6, 2), (8, 3), (10, 0), (12, 1)];
+
+    // We make the leaders for the corresponding rounds receive weak support, so we can't commit immediately
+    for (round, authority_id) in leaders_with_weak_support {
+        leader_configs.insert(
+            round,
+            test_utils::TestLeaderConfiguration {
+                round,
+                authority: AuthorityIdentifier(authority_id),
+                should_omit: false,
+                support: Some(test_utils::TestLeaderSupport::Weak),
+            },
+        );
+    }
+
+    let (out, _parents) = test_utils::make_certificates_with_leader_configuration(
+        &committee,
+        &latest_protocol_version(),
+        1..=15,
+        &genesis,
+        &ids,
+        leader_configs,
+    );
+    certificates.extend(out);
+
+    let mut config: ProtocolConfig = latest_protocol_version();
+    config.set_narwhal_new_leader_election_schedule(true);
+
+    let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
+    let gc_depth = 50;
+    let sub_dags_per_schedule = 4;
+    let mut state = ConsensusState::new(metrics.clone(), gc_depth);
+    let store = make_consensus_store(&test_utils::temp_dir());
+    let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
+    let mut bullshark = Bullshark::new(
+        committee.clone(),
+        store,
+        config,
+        metrics,
+        sub_dags_per_schedule,
+        schedule,
+    );
+
+    let mut total = 0;
+    for certificate in certificates {
+        let (outcome, committed) = bullshark
+            .process_certificate(&mut state, certificate.clone())
+            .unwrap();
+
+        if certificate.round() == 7
+            || certificate.round() == 9
+            || certificate.round() == 11
+            || certificate.round() == 13
+        {
+            assert_eq!(outcome, Outcome::NotEnoughSupportForLeader);
+        }
+
+        if certificate.round() == 15 {
+            total += 1;
+
+            if total == 2 {
+                assert_eq!(committed.len(), 5);
+
+                let committed_dag_6 = &committed[0];
+                let committed_dag_8 = &committed[1];
+                let committed_dag_10 = &committed[2];
+                let committed_dag_12 = &committed[3];
+                let committed_dag_14 = &committed[4];
+
+                assert_eq!(committed_dag_6.leader_round(), 6);
+                assert_eq!(committed_dag_8.leader_round(), 8);
+                assert_eq!(committed_dag_10.leader_round(), 10);
+                assert_eq!(committed_dag_12.leader_round(), 12);
+                assert_eq!(committed_dag_14.leader_round(), 14);
+
+                // Two schedule changes have happened during this commit
+                assert!(committed_dag_6.reputation_score.final_of_schedule);
+                assert!(committed_dag_14.reputation_score.final_of_schedule);
+
+                // Originally, as we do round robin the leaders in testing, we would expect the
+                // leader of round 10 to be the Authority 0. However, since a reputation scores update
+                // happened the leader schedule changed and now the Authority 0 is flagged as low
+                // score and it will be swapped with Authority 3.
+                assert_eq!(committed_dag_10.leader.origin(), AuthorityIdentifier(3));
+
+                // The leaders of round 12 & 14 shouldn't change from the "original" schedule
+                let schedule = LeaderSchedule::new(committee, LeaderSwapTable::default());
+
+                assert_eq!(committed_dag_12.leader.origin(), schedule.leader(12).id());
+                assert_eq!(committed_dag_14.leader.origin(), schedule.leader(14).id());
+
+                assert_eq!(outcome, Outcome::Commit);
+
+                break;
+            }
+        }
+    }
+
+    // ensure that we actually reached the point of processing two certificates of round 15.
+    assert_eq!(total, 2);
+}
+
 // Run for 4 dag rounds in ideal conditions (all nodes reference all other nodes). We should commit
 // the leader of round 2.
 #[tokio::test]


### PR DESCRIPTION
## Description 

The changes on the new leader schedule algorithm will always exclude the X% by stake of validators with the worst scores. Practically we don't have good reason to continue submitting transactions to those validators to sequence in consensus as they'll never be leaders hence they have slimmer chances of sequencing transactions.

It makes sense to align the low scoring detection on the submission side with the logic of the leader election schedule. Thus we'll make sure that only the validators who participate on the latest (updated) schedule will receive transactions to sequence them. For that reason we are removing the `MED` approach and we go with a flat exclusion always of the validators with the lowest scores and up to the designated `consensus_bad_nodes_stake_threshold` . For instance, if the `consensus_bad_nodes_stake_threshold = 0.2` then the nodes with the lowest scores and accumulated up to 20% of stake will be flagged as low scorers.

**Pros:**
* We make sure that we don't send transactions to any validators that are not part of the leader schedule committee, thus we maximize the changes of getting transactions sequenced in time
* Although MED is a great technique, it's hard to tune under different network properties and harder to reasoning. Now things are more straightforward and predictable

**Cons**
* The algorithm will always account "low scorers" - up to the dictated fraction - even if we had all validators with perfect scores. This is more of a concern for small environments (a few nodes) rather than in environments like `testnet`or `mainnet` where we do have even the current MED approach flagging a good amount of nodes as low scorers
* To tackle the above we could introduce some manual threshold, but needs more experimentation/iteration

This PR is also 
1. cleaning up the `update_low_scoring_authorities_with_previous_disable_mechanism` method which should be now completely unused.
2. Shoehorning a test for long period of asynchrony for the new leader election schedule algorithm

**Note:**  that doesn't mean that a low scorer node will not be able to sequence any transaction, for example the checkpoint signatures or the capability notification messages will still be able to get sequenced.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
