### PR TITLE
Updating diesel to support max_length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -1575,7 +1575,7 @@ version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -1643,6 +1643,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitmaps"
@@ -2087,7 +2093,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -2101,7 +2107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
@@ -2130,7 +2136,7 @@ checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.5.0",
  "strsim 0.10.0",
 ]
@@ -2493,7 +2499,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.8.0",
  "libc",
  "mio 0.7.14",
@@ -2509,7 +2515,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
  "mio 0.7.14",
@@ -2525,7 +2531,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
  "mio 0.8.5",
@@ -2954,11 +2960,11 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
 name = "diesel"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4391a22b19c916e50bec4d6140f29bdda3e3bb187223fe6e3ea0b6e4d1021c04"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -2982,25 +2988,34 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2 1.0.58",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
  "diesel",
  "migrations_internals",
  "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3868,7 +3883,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -4100,7 +4115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -4520,7 +4535,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd079157ad94a32f7511b2e13037f3ae417ad80a6a9b0de29154d48b86f5d6c8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm 0.25.0",
  "dyn-clone",
  "lazy_static",
@@ -5102,19 +5117,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
  "serde",
- "toml 0.5.10",
+ "toml 0.7.4",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.58",
@@ -6619,7 +6634,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -6632,7 +6647,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
 ]
@@ -7685,7 +7700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -8017,7 +8032,7 @@ version = "10.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -8114,7 +8129,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -8309,7 +8324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -8495,7 +8510,7 @@ version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -8509,7 +8524,7 @@ version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.1",
  "io-lifetimes",
  "libc",
@@ -8596,7 +8611,7 @@ version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "clipboard-win",
  "dirs-next",
@@ -8758,7 +8773,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -12142,7 +12157,7 @@ checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "async-compression",
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12331,7 +12346,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cassowary",
  "crossterm 0.22.1",
  "unicode-segmentation",
@@ -13192,7 +13207,8 @@ dependencies = [
  "bit-vec",
  "bitcoin-private",
  "bitcoin_hashes",
- "bitflags",
+ "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bitmaps",
  "bitvec",
  "blake2",
@@ -13316,6 +13332,7 @@ dependencies = [
  "diesel-derive-enum",
  "diesel_derives",
  "diesel_migrations",
+ "diesel_table_macro_syntax",
  "diff",
  "difference",
  "difflib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ derivative = "2.2.0"
 derive-syn-parse = "0.1.5"
 derive_builder = "0.12.0"
 derive_more = "0.99.17"
-diesel = { version = "2.0.3", features = ["chrono", "postgres", "r2d2", "serde_json", "64-column-tables"] }
+diesel = { version = "2.1.0", features = ["chrono", "postgres", "r2d2", "serde_json", "64-column-tables"] }
 diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 diesel_migrations = { version = "2.0.0" }
 dirs = "4.0.0"

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -18,9 +18,12 @@ pub mod sql_types {
 
 diesel::table! {
     active_addresses (account_address) {
+        #[max_length = 66]
         account_address -> Varchar,
+        #[max_length = 44]
         first_appearance_tx -> Varchar,
         first_appearance_time -> Int8,
+        #[max_length = 44]
         last_appearance_tx -> Varchar,
         last_appearance_time -> Int8,
     }
@@ -39,9 +42,12 @@ diesel::table! {
 
 diesel::table! {
     addresses (account_address) {
+        #[max_length = 66]
         account_address -> Varchar,
+        #[max_length = 44]
         first_appearance_tx -> Varchar,
         first_appearance_time -> Int8,
+        #[max_length = 44]
         last_appearance_tx -> Varchar,
         last_appearance_time -> Int8,
     }
@@ -59,9 +65,11 @@ diesel::table! {
 diesel::table! {
     changed_objects (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
         checkpoint_sequence_number -> Int8,
         epoch -> Int8,
+        #[max_length = 66]
         object_id -> Varchar,
         object_change_type -> Text,
         object_version -> Int8,
@@ -84,9 +92,11 @@ diesel::table! {
 diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Int8,
+        #[max_length = 255]
         checkpoint_digest -> Varchar,
         epoch -> Int8,
         transactions -> Array<Nullable<Text>>,
+        #[max_length = 255]
         previous_checkpoint_digest -> Nullable<Varchar>,
         end_of_epoch -> Bool,
         total_gas_cost -> Int8,
@@ -132,9 +142,12 @@ diesel::table! {
 diesel::table! {
     events (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
         event_sequence -> Int8,
+        #[max_length = 66]
         sender -> Varchar,
+        #[max_length = 66]
         package -> Varchar,
         module -> Text,
         event_type -> Text,
@@ -146,9 +159,11 @@ diesel::table! {
 diesel::table! {
     input_objects (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
         checkpoint_sequence_number -> Int8,
         epoch -> Int8,
+        #[max_length = 66]
         object_id -> Varchar,
         object_version -> Nullable<Int8>,
     }
@@ -157,9 +172,11 @@ diesel::table! {
 diesel::table! {
     move_calls (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
         checkpoint_sequence_number -> Int8,
         epoch -> Int8,
+        #[max_length = 66]
         sender -> Varchar,
         move_package -> Text,
         move_module -> Text,
@@ -176,12 +193,16 @@ diesel::table! {
     objects (object_id) {
         epoch -> Int8,
         checkpoint -> Int8,
+        #[max_length = 66]
         object_id -> Varchar,
         version -> Int8,
+        #[max_length = 44]
         object_digest -> Varchar,
         owner_type -> OwnerType,
+        #[max_length = 66]
         owner_address -> Nullable<Varchar>,
         initial_shared_version -> Nullable<Int8>,
+        #[max_length = 44]
         previous_transaction -> Varchar,
         object_type -> Varchar,
         object_status -> ObjectStatus,
@@ -200,14 +221,19 @@ diesel::table! {
     objects_history (object_id, version, checkpoint) {
         epoch -> Int8,
         checkpoint -> Int8,
+        #[max_length = 66]
         object_id -> Varchar,
         version -> Int8,
+        #[max_length = 44]
         object_digest -> Varchar,
         owner_type -> OwnerType,
+        #[max_length = 66]
         owner_address -> Nullable<Varchar>,
         old_owner_type -> Nullable<OwnerType>,
+        #[max_length = 66]
         old_owner_address -> Nullable<Varchar>,
         initial_shared_version -> Nullable<Int8>,
+        #[max_length = 44]
         previous_transaction -> Varchar,
         object_type -> Varchar,
         object_status -> ObjectStatus,
@@ -222,8 +248,10 @@ diesel::table! {
     use super::sql_types::BcsBytes;
 
     packages (package_id, version) {
+        #[max_length = 66]
         package_id -> Varchar,
         version -> Int8,
+        #[max_length = 66]
         author -> Varchar,
         data -> Array<Nullable<BcsBytes>>,
     }
@@ -232,10 +260,13 @@ diesel::table! {
 diesel::table! {
     recipients (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
         checkpoint_sequence_number -> Int8,
         epoch -> Int8,
+        #[max_length = 66]
         sender -> Varchar,
+        #[max_length = 66]
         recipient -> Varchar,
     }
 }
@@ -270,15 +301,19 @@ diesel::table! {
 diesel::table! {
     transactions (id) {
         id -> Int8,
+        #[max_length = 44]
         transaction_digest -> Varchar,
+        #[max_length = 255]
         sender -> Varchar,
         checkpoint_sequence_number -> Nullable<Int8>,
         timestamp_ms -> Nullable<Int8>,
         transaction_kind -> Text,
         transaction_count -> Int8,
         execution_success -> Bool,
+        #[max_length = 66]
         gas_object_id -> Varchar,
         gas_object_sequence -> Int8,
+        #[max_length = 66]
         gas_object_digest -> Varchar,
         gas_budget -> Int8,
         total_gas_cost -> Int8,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -106,7 +106,8 @@ bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
-bitflags = { version = "1" }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
 bitmaps = { version = "2" }
 bitvec = { version = "0.20", default-features = false, features = ["std"] }
 blake2 = { version = "0.10" }
@@ -822,7 +823,8 @@ bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
-bitflags = { version = "1" }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
 bitmaps = { version = "2" }
 bitvec = { version = "0.20", default-features = false, features = ["std"] }
 blake2 = { version = "0.10" }
@@ -935,8 +937,9 @@ determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
 diesel = { version = "2", features = ["64-column-tables", "chrono", "postgres", "r2d2", "serde_json"] }
 diesel-derive-enum = { version = "2", default-features = false, features = ["postgres"] }
-diesel_derives = { version = "2", features = ["64-column-tables", "postgres", "with-deprecated"] }
+diesel_derives = { version = "2", features = ["64-column-tables", "postgres", "r2d2", "with-deprecated"] }
 diesel_migrations = { version = "2" }
+diesel_table_macro_syntax = { version = "0.1", default-features = false }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
 difflib = { version = "0.4", default-features = false }


### PR DESCRIPTION
## Description 

diesel added support for column max sizes in 2.1.0

example is as follows:
```
    active_addresses (account_address) {
        #[max_length = 66]
        account_address -> Varchar,

```

Need to update cargo to pull in this newer version

## Test Plan 

Tested on my pipeline dev server

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
