### PR TITLE
Use kv store fallback in coin_api rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9895,6 +9895,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-swarm",
  "sui-swarm-config",
  "sui-test-transaction-builder",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2803,13 +2803,11 @@ impl AuthorityState {
     pub async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
-    ) -> SuiResult<(VerifiedTransaction, TransactionEffects)> {
-        let transaction = self.database.get_transaction_block(&digest)?;
-        let effects = self.database.get_executed_effects(&digest)?;
-        match (transaction, effects) {
-            (Some(transaction), Some(effects)) => Ok((transaction, effects)),
-            _ => Err(SuiError::TransactionNotFound { digest }),
-        }
+        kv_store: &Arc<TransactionKeyValueStore>,
+    ) -> SuiResult<(Transaction, TransactionEffects)> {
+        let transaction = kv_store.get_tx(digest).await?;
+        let effects = kv_store.get_fx_by_tx_digest(digest).await?;
+        Ok((transaction, effects))
     }
 
     pub fn multi_get_transaction_checkpoint(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2803,7 +2803,7 @@ impl AuthorityState {
     pub async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
-        kv_store: &Arc<TransactionKeyValueStore>,
+        kv_store: Arc<TransactionKeyValueStore>,
     ) -> SuiResult<(Transaction, TransactionEffects)> {
         let transaction = kv_store.get_tx(digest).await?;
         let effects = kv_store.get_fx_by_tx_digest(digest).await?;

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -42,6 +42,7 @@ sui-json-rpc.workspace = true
 sui-node.workspace = true
 sui-macros.workspace = true
 sui-simulator.workspace = true
+sui-storage.workspace = true
 mysten-metrics.workspace = true
 sui-tool.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -804,6 +804,12 @@ async fn test_full_node_event_query_by_module_ok() {
 async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
+    let metrics = KeyValueStoreMetrics::new_for_tests();
+    let kv_store = Arc::new(TransactionKeyValueStore::new(
+        "rocksdb",
+        metrics,
+        self.clone(),
+    ));
 
     let context = &mut test_cluster.wallet;
     let transaction_orchestrator = fullnode.with(|node| {
@@ -849,7 +855,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert!(is_executed_locally);
     assert_eq!(events.digest(), txn_events.digest());
     // verify that the node has sequenced and executed the txn
-    fullnode.state().get_executed_transaction_and_effects(digest).await
+    fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForLocalExecution: {:?}", digest, e));
 
     // Test WaitForEffectsCert
@@ -883,7 +889,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         .notify_read_executed_effects(vec![digest])
         .await
         .unwrap();
-    fullnode.state().get_executed_transaction_and_effects(digest).await
+    fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {:?} that was executed with WaitForEffectsCert: {:?}", digest, e));
 
     Ok(())

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::Registry;
+use std::sync::Arc;
 use std::time::Duration;
 use sui_core::authority::EffectsNotifyRead;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
+use sui_storage::key_value_store::TransactionKeyValueStore;
+use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
 use sui_test_transaction_builder::{
     batch_make_transfer_transactions, make_transfer_sui_transaction,
 };
@@ -83,7 +86,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let kv_store = Arc::new(TransactionKeyValueStore::new(
         "rocksdb",
         metrics,
-        self.clone(),
+        handle.state(),
     ));
 
     assert!(handle

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -79,9 +79,16 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let (_, _, executed_locally) = *result;
     assert!(executed_locally);
 
+    let metrics = KeyValueStoreMetrics::new_for_tests();
+    let kv_store = Arc::new(TransactionKeyValueStore::new(
+        "rocksdb",
+        metrics,
+        self.clone(),
+    ));
+
     assert!(handle
         .state()
-        .get_executed_transaction_and_effects(digest)
+        .get_executed_transaction_and_effects(digest, kv_store)
         .await
         .is_ok());
 

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -21,13 +21,20 @@ use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{Balance, Coin as SuiCoin};
 use sui_json_rpc_types::{CoinPage, SuiCoinMetadata};
 use sui_open_rpc::Module;
-use sui_storage::key_value_store::TransactionKeyValueStore;
+use sui_storage::key_value_store::{
+    KVStoreCheckpointData, KVStoreTransactionData, TransactionKeyValueStore,
+    TransactionKeyValueStoreTrait,
+};
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::coin::{CoinMetadata, TreasuryCap};
+use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas_coin::GAS;
+use sui_types::messages_checkpoint::{
+    CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+};
 use sui_types::object::{Object, ObjectRead};
 use sui_types::parse_sui_struct_tag;
 
@@ -53,6 +60,7 @@ fn parse_to_type_tag(coin_type: Option<String>) -> Result<TypeTag, SuiRpcInputEr
 pub struct CoinReadApi {
     // Trait object w/ Box as we do not need to share this across multiple threads
     internal: Box<dyn CoinReadInternal + Send + Sync>,
+    transaction_kv_store: Arc<TransactionKeyValueStore>,
 }
 
 impl CoinReadApi {
@@ -62,16 +70,13 @@ impl CoinReadApi {
         metrics: Arc<JsonRpcMetrics>,
     ) -> Self {
         Self {
-            internal: Box::new(CoinReadInternalImpl::new(
-                state,
-                transaction_kv_store,
-                metrics,
-            )),
+            internal: Box::new(CoinReadInternalImpl::new(state, metrics)),
+            transaction_kv_store,
         }
     }
 
     pub fn get_kv_store(&self) -> Arc<TransactionKeyValueStore> {
-        self.internal.get_kv_store()
+        self.transaction_kv_store.clone()
     }
 }
 
@@ -264,14 +269,29 @@ pub trait State {
     async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
-        kv_store: &Arc<TransactionKeyValueStore>,
+        kv_store: Arc<TransactionKeyValueStore>,
     ) -> SuiResult<(Transaction, TransactionEffects)>;
     async fn get_balance(&self, owner: SuiAddress, coin_type: TypeTag) -> SuiResult<TotalBalance>;
     async fn get_all_balance(
         &self,
         owner: SuiAddress,
     ) -> SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>;
+    async fn multi_get(
+        &self,
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> SuiResult<KVStoreTransactionData>;
+    async fn multi_get_checkpoints(
+        &self,
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> SuiResult<KVStoreCheckpointData>;
 }
+
+pub trait TransactionKeyValueStoreTraitWithState: TransactionKeyValueStoreTrait + State {}
 
 #[async_trait]
 impl State for AuthorityState {
@@ -310,7 +330,7 @@ impl State for AuthorityState {
     async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
-        kv_store: &Arc<TransactionKeyValueStore>,
+        kv_store: Arc<TransactionKeyValueStore>,
     ) -> SuiResult<(Transaction, TransactionEffects)> {
         self.get_executed_transaction_and_effects(digest, kv_store)
             .await
@@ -334,6 +354,38 @@ impl State for AuthorityState {
             .get_all_balance(owner)
             .await
     }
+
+    async fn multi_get(
+        &self,
+        transactions: &[TransactionDigest],
+        effects: &[TransactionDigest],
+        events: &[TransactionEventsDigest],
+    ) -> SuiResult<KVStoreTransactionData> {
+        <AuthorityState as TransactionKeyValueStoreTrait>::multi_get(
+            self,
+            transactions,
+            effects,
+            events,
+        )
+        .await
+    }
+
+    async fn multi_get_checkpoints(
+        &self,
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> SuiResult<KVStoreCheckpointData> {
+        <AuthorityState as TransactionKeyValueStoreTrait>::multi_get_checkpoints(
+            self,
+            checkpoint_summaries,
+            checkpoint_contents,
+            checkpoint_summaries_by_digest,
+            checkpoint_contents_by_digest,
+        )
+        .await
+    }
 }
 
 #[cached(
@@ -352,7 +404,7 @@ async fn find_package_object_id(
         let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
 
         let (_, effect) = state
-            .get_executed_transaction_and_effects(publish_txn_digest, &kv_store)
+            .get_executed_transaction_and_effects(publish_txn_digest, kv_store)
             .await?;
 
         for ((id, _, _), _) in effect.created() {
@@ -379,7 +431,6 @@ async fn find_package_object_id(
 #[async_trait]
 pub trait CoinReadInternal {
     fn get_state(&self) -> Arc<dyn State + Send + Sync>;
-    fn get_kv_store(&self) -> Arc<TransactionKeyValueStore>;
     async fn get_object(&self, object_id: &ObjectID) -> RpcInterimResult<Option<Object>>;
     async fn get_balance(
         &self,
@@ -408,21 +459,12 @@ pub trait CoinReadInternal {
 pub struct CoinReadInternalImpl {
     // Trait object w/ Arc as we have methods that require sharing this across multiple threads
     state: Arc<dyn State + Send + Sync>,
-    pub transaction_kv_store: Arc<TransactionKeyValueStore>,
     pub metrics: Arc<JsonRpcMetrics>,
 }
 
 impl CoinReadInternalImpl {
-    pub fn new(
-        state: Arc<AuthorityState>,
-        transaction_kv_store: Arc<TransactionKeyValueStore>,
-        metrics: Arc<JsonRpcMetrics>,
-    ) -> Self {
-        Self {
-            state,
-            transaction_kv_store,
-            metrics,
-        }
+    pub fn new(state: Arc<AuthorityState>, metrics: Arc<JsonRpcMetrics>) -> Self {
+        Self { state, metrics }
     }
 }
 
@@ -430,10 +472,6 @@ impl CoinReadInternalImpl {
 impl CoinReadInternal for CoinReadInternalImpl {
     fn get_state(&self) -> Arc<dyn State + Send + Sync> {
         self.state.clone()
-    }
-
-    fn get_kv_store(&self) -> Arc<TransactionKeyValueStore> {
-        self.transaction_kv_store.clone()
     }
 
     async fn get_object(&self, object_id: &ObjectID) -> RpcInterimResult<Option<Object>> {
@@ -500,12 +538,14 @@ impl CoinReadInternal for CoinReadInternalImpl {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use expect_test::expect;
     use jsonrpsee::types::ErrorObjectOwned;
     use mockall::predicate;
     use move_core_types::account_address::AccountAddress;
     use move_core_types::language_storage::StructTag;
     use sui_json_rpc_types::Coin;
+    use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
     use sui_types::balance::Supply;
     use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
     use sui_types::coin::TreasuryCap;
@@ -516,6 +556,60 @@ mod tests {
     use sui_types::object::Object;
     use sui_types::utils::create_fake_transaction;
     use sui_types::{parse_sui_struct_tag, TypeTag};
+
+    #[async_trait]
+    impl TransactionKeyValueStoreTrait for MockState {
+        async fn multi_get(
+            &self,
+            transactions: &[TransactionDigest],
+            effects: &[TransactionDigest],
+            events: &[TransactionEventsDigest],
+        ) -> SuiResult<KVStoreTransactionData> {
+            <MockState as State>::multi_get(self, transactions, effects, events).await
+        }
+
+        async fn multi_get_checkpoints(
+            &self,
+            checkpoint_summaries: &[CheckpointSequenceNumber],
+            checkpoint_contents: &[CheckpointSequenceNumber],
+            checkpoint_summaries_by_digest: &[CheckpointDigest],
+            checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+        ) -> SuiResult<KVStoreCheckpointData> {
+            <MockState as State>::multi_get_checkpoints(
+                self,
+                checkpoint_summaries,
+                checkpoint_contents,
+                checkpoint_summaries_by_digest,
+                checkpoint_contents_by_digest,
+            )
+            .await
+        }
+    }
+
+    impl CoinReadInternalImpl {
+        pub fn new_for_tests(state: Arc<MockState>) -> Self {
+            Self {
+                state,
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            }
+        }
+    }
+
+    impl CoinReadApi {
+        pub fn new_for_tests(state: Arc<MockState>) -> Self {
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                state.clone(),
+            ));
+
+            Self {
+                internal: Box::new(CoinReadInternalImpl::new_for_tests(state)),
+                transaction_kv_store,
+            }
+        }
+    }
 
     fn get_test_owner() -> SuiAddress {
         AccountAddress::ONE.into()
@@ -608,21 +702,8 @@ mod tests {
                     predicate::eq(true),
                 )
                 .return_once(move |_, _, _, _| Ok(vec![gas_coin_clone]));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
 
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api.get_coins(owner, None, None, None).await;
             assert!(response.is_ok());
             let result = response.unwrap();
@@ -656,21 +737,8 @@ mod tests {
                     predicate::eq(true),
                 )
                 .return_once(move |_, _, _, _| Ok(coins_clone));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
 
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, None, Some(coins[0].coin_object_id), Some(limit))
                 .await;
@@ -706,21 +774,8 @@ mod tests {
                     predicate::eq(true),
                 )
                 .return_once(move |_, _, _, _| Ok(vec![coin_clone]));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
 
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type), None, None)
                 .await;
@@ -763,21 +818,8 @@ mod tests {
                     predicate::eq(true),
                 )
                 .return_once(move |_, _, _, _| Ok(coins_clone));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
 
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type), Some(cursor), Some(limit))
                 .await;
@@ -799,11 +841,8 @@ mod tests {
         async fn test_invalid_coin_type() {
             let owner = get_test_owner();
             let coin_type = "0x2::invalid::struct::tag";
-            let mock_internal = MockCoinReadInternal::new();
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(mock_internal),
-            };
-
+            let mock_state = MockState::new();
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type.to_string()), None, None)
                 .await;
@@ -821,11 +860,8 @@ mod tests {
         async fn test_unrecognized_token() {
             let owner = get_test_owner();
             let coin_type = "0x2::sui:🤵";
-            let mock_internal = MockCoinReadInternal::new();
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(mock_internal),
-            };
-
+            let mock_state = MockState::new();
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type.to_string()), None, None)
                 .await;
@@ -849,21 +885,7 @@ mod tests {
             mock_state
                 .expect_get_owned_coins()
                 .returning(move |_, _, _, _| Err(SuiError::IndexStoreNotAvailable));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type.to_string()), None, None)
                 .await;
@@ -889,21 +911,7 @@ mod tests {
                 .returning(move |_, _, _, _| {
                     Err(TypedStoreError::RocksDBError("mock rocksdb error".to_string()).into())
                 });
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coins(owner, Some(coin_type.to_string()), None, None)
                 .await;
@@ -942,20 +950,7 @@ mod tests {
                     predicate::eq(false),
                 )
                 .return_once(move |_, _, _, _| Ok(vec![gas_coin_clone]));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_all_coins(owner, None, Some(51))
                 .await
@@ -997,20 +992,7 @@ mod tests {
                     predicate::eq(false),
                 )
                 .return_once(move |_, _, _, _| Ok(coins_clone));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_all_coins(owner, Some(coins[0].coin_object_id), Some(limit))
                 .await
@@ -1033,21 +1015,7 @@ mod tests {
                     panic!("should not be called with any other object id")
                 }
             });
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_all_coins(owner, Some(object_id), None)
                 .await;
@@ -1069,22 +1037,7 @@ mod tests {
             let mut mock_state = MockState::new();
             mock_state.expect_get_object().returning(move |_| Ok(None));
 
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_all_coins(owner, Some(object_id), None)
                 .await;
@@ -1103,7 +1056,6 @@ mod tests {
         use super::super::*;
         use super::*;
         use jsonrpsee::types::ErrorObjectOwned;
-
         // Success scenarios
         #[tokio::test]
         async fn test_gas_coin() {
@@ -1123,22 +1075,7 @@ mod tests {
                         num_coins: 9,
                     })
                 });
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api.get_balance(owner, None).await;
 
             assert!(response.is_ok());
@@ -1172,22 +1109,7 @@ mod tests {
                         num_coins: 11,
                     })
                 });
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_balance(owner, Some(coin.coin_type.clone()))
                 .await;
@@ -1210,11 +1132,8 @@ mod tests {
         async fn test_invalid_coin_type() {
             let owner = get_test_owner();
             let coin_type = "0x2::invalid::struct::tag";
-            let mock_internal = MockCoinReadInternal::new();
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(mock_internal),
-            };
-
+            let mock_state = MockState::new();
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_balance(owner, Some(coin_type.to_string()))
                 .await;
@@ -1237,21 +1156,7 @@ mod tests {
             mock_state
                 .expect_get_balance()
                 .returning(move |_, _| Err(SuiError::IndexStoreNotAvailable));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_balance(owner, Some(coin_type.to_string()))
                 .await;
@@ -1276,21 +1181,7 @@ mod tests {
             mock_state
                 .expect_get_balance()
                 .returning(move |_, _| Err(SuiError::ExecutionError("mock db error".to_string())));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_balance(owner, Some(coin_type.to_string()))
                 .await;
@@ -1343,20 +1234,7 @@ mod tests {
                     );
                     Ok(Arc::new(hash_map))
                 });
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api.get_all_balances(owner).await;
 
             assert!(response.is_ok());
@@ -1394,21 +1272,7 @@ mod tests {
             mock_state
                 .expect_get_all_balance()
                 .returning(move |_| Err(SuiError::IndexStoreNotAvailable));
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api.get_all_balances(owner).await;
 
             assert!(response.is_err());
@@ -1463,8 +1327,17 @@ mod tests {
                         panic!("should not be called with any other object id")
                     }
                 });
+
+            let mock_state = MockState::new();
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                Arc::new(mock_state),
+            ));
             let coin_read_api = CoinReadApi {
                 internal: Box::new(mock_internal),
+                transaction_kv_store,
             };
 
             let response = coin_read_api.get_coin_metadata(coin_name.clone()).await;
@@ -1485,24 +1358,9 @@ mod tests {
                 .return_once(move |_| Ok(transaction_digest));
             mock_state
                 .expect_get_executed_transaction_and_effects()
-                .return_once(move |_| Ok((create_fake_transaction(), transaction_effects)));
+                .return_once(move |_, _| Ok((create_fake_transaction(), transaction_effects)));
 
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api
                 .get_coin_metadata("0x2::sui::SUI".to_string())
                 .await;
@@ -1540,8 +1398,17 @@ mod tests {
                         panic!("should not be called with any other object id")
                     }
                 });
+
+            let mock_state = MockState::new();
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                Arc::new(mock_state),
+            ));
             let coin_read_api = CoinReadApi {
                 internal: Box::new(mock_internal),
+                transaction_kv_store,
             };
 
             let response = coin_read_api.get_coin_metadata(coin_name.clone()).await;
@@ -1561,8 +1428,17 @@ mod tests {
         async fn test_success_response_for_gas_coin() {
             let coin_type = "0x2::sui::SUI";
             let mock_internal = MockCoinReadInternal::new();
+
+            let mock_state = MockState::new();
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                Arc::new(mock_state),
+            ));
             let coin_read_api = CoinReadApi {
                 internal: Box::new(mock_internal),
+                transaction_kv_store,
             };
 
             let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
@@ -1592,8 +1468,17 @@ mod tests {
                         panic!("should not be called with any other object id")
                     }
                 });
+
+            let mock_state = MockState::new();
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                Arc::new(mock_state),
+            ));
             let coin_read_api = CoinReadApi {
                 internal: Box::new(mock_internal),
+                transaction_kv_store,
             };
 
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;
@@ -1618,24 +1503,9 @@ mod tests {
                 .return_once(move |_| Ok(transaction_digest));
             mock_state
                 .expect_get_executed_transaction_and_effects()
-                .return_once(move |_| Ok((create_fake_transaction(), transaction_effects)));
+                .return_once(move |_, _| Ok((create_fake_transaction(), transaction_effects)));
 
-            let metrics = KeyValueStoreMetrics::new_for_tests();
-            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
-                "rocksdb",
-                metrics,
-                self.clone(),
-            ));
-
-            let internal = CoinReadInternalImpl {
-                state: Arc::new(mock_state),
-                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
-                transaction_kv_store,
-            };
-            let coin_read_api = CoinReadApi {
-                internal: Box::new(internal),
-            };
-
+            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state));
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;
 
             assert!(response.is_err());
@@ -1677,8 +1547,17 @@ mod tests {
                         panic!("should not be called with any other object id")
                     }
                 });
+
+            let mock_state = MockState::new();
+            let metrics = KeyValueStoreMetrics::new_for_tests();
+            let transaction_kv_store = Arc::new(TransactionKeyValueStore::new(
+                "rocksdb",
+                metrics,
+                Arc::new(mock_state),
+            ));
             let coin_read_api = CoinReadApi {
                 internal: Box::new(mock_internal),
+                transaction_kv_store,
             };
 
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1493,7 +1493,11 @@ pub async fn build_server(
         kv_store.clone(),
         metrics.clone(),
     ))?;
-    server.register_module(CoinReadApi::new(state.clone(), metrics.clone()))?;
+    server.register_module(CoinReadApi::new(
+        state.clone(),
+        kv_store.clone(),
+        metrics.clone(),
+    ))?;
     server.register_module(TransactionBuilderApi::new(state.clone()))?;
     server.register_module(GovernanceReadApi::new(state.clone(), metrics.clone()))?;
 

--- a/crates/sui-storage/src/key_value_store.rs
+++ b/crates/sui-storage/src/key_value_store.rs
@@ -18,6 +18,19 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::transaction::Transaction;
 
+pub type KVStoreTransactionData = (
+    Vec<Option<Transaction>>,
+    Vec<Option<TransactionEffects>>,
+    Vec<Option<TransactionEvents>>,
+);
+
+pub type KVStoreCheckpointData = (
+    Vec<Option<CertifiedCheckpointSummary>>,
+    Vec<Option<CheckpointContents>>,
+    Vec<Option<CertifiedCheckpointSummary>>,
+    Vec<Option<CheckpointContents>>,
+);
+
 pub struct TransactionKeyValueStore {
     store_name: &'static str,
     metrics: Arc<KeyValueStoreMetrics>,
@@ -384,11 +397,7 @@ pub trait TransactionKeyValueStoreTrait {
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
         events: &[TransactionEventsDigest],
-    ) -> SuiResult<(
-        Vec<Option<Transaction>>,
-        Vec<Option<TransactionEffects>>,
-        Vec<Option<TransactionEvents>>,
-    )>;
+    ) -> SuiResult<KVStoreTransactionData>;
 
     /// Generic multi_get to allow implementors to get heterogenous values with a single round trip.
     async fn multi_get_checkpoints(
@@ -397,12 +406,7 @@ pub trait TransactionKeyValueStoreTrait {
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
         checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> SuiResult<(
-        Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
-        Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
-    )>;
+    ) -> SuiResult<KVStoreCheckpointData>;
 }
 
 /// A TransactionKeyValueStoreTrait that falls back to a secondary store for any key for which the


### PR DESCRIPTION
## Description 

As in title 

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
