### PR TITLE
[cleanup] remove fast path from indexer

### DIFF
--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -22,16 +22,6 @@ use sui_types::base_types::SuiAddress;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::sui_serde::BigInt;
 
-// TODO(gegaowp): temp. disable fast-path
-// use crate::handlers::checkpoint_handler::{
-//     fetch_changed_objects, get_deleted_db_objects, get_object_changes, to_changed_db_objects,
-// };
-// use crate::models::transactions::Transaction;
-// use crate::store::{IndexerStore, TransactionObjectChanges};
-// use crate::types::{
-//         FastPathTransactionBlockResponse, SuiTransactionBlockResponseWithOptions,
-//         TemporaryTransactionBlockResponseStore,
-//     };
 use crate::store::IndexerStore;
 use crate::types::SuiTransactionBlockResponseWithOptions;
 


### PR DESCRIPTION
## Description 

There will be no fast path in indexer.

## Test Plan 

The code is not in used anyway.
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
remove fast path from indexer