### PR TITLE
mlogan cherry pick ckpt kv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9939,6 +9939,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-swarm",
  "sui-swarm-config",
  "sui-test-transaction-builder",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2803,13 +2803,11 @@ impl AuthorityState {
     pub async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,
-    ) -> SuiResult<(VerifiedTransaction, TransactionEffects)> {
-        let transaction = self.database.get_transaction_block(&digest)?;
-        let effects = self.database.get_executed_effects(&digest)?;
-        match (transaction, effects) {
-            (Some(transaction), Some(effects)) => Ok((transaction, effects)),
-            _ => Err(SuiError::TransactionNotFound { digest }),
-        }
+        kv_store: Arc<TransactionKeyValueStore>,
+    ) -> SuiResult<(Transaction, TransactionEffects)> {
+        let transaction = kv_store.get_tx(digest).await?;
+        let effects = kv_store.get_fx_by_tx_digest(digest).await?;
+        Ok((transaction, effects))
     }
 
     pub fn multi_get_transaction_checkpoint(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -7,7 +7,6 @@ use std::ops::Not;
 use std::sync::Arc;
 use std::{iter, mem, thread};
 
-use async_trait::async_trait;
 use either::Either;
 use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
@@ -43,7 +42,6 @@ use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfigura
 use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use mysten_common::sync::notify_read::NotifyRead;
-use sui_storage::key_value_store;
 use sui_storage::package_object_cache::PackageObjectCache;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -1931,43 +1929,6 @@ impl GetModule for AuthorityStore {
 
     fn get_module_by_id(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>, Self::Error> {
         get_module_by_id(self, id)
-    }
-}
-
-#[async_trait]
-impl key_value_store::TransactionKeyValueStoreTrait for AuthorityStore {
-    async fn multi_get(
-        &self,
-        transactions: &[TransactionDigest],
-        effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
-    ) -> SuiResult<(
-        Vec<Option<Transaction>>,
-        Vec<Option<TransactionEffects>>,
-        Vec<Option<TransactionEvents>>,
-    )> {
-        let txns = if !transactions.is_empty() {
-            self.multi_get_transaction_blocks(transactions)?
-                .into_iter()
-                .map(|t| t.map(|t| t.into_inner()))
-                .collect()
-        } else {
-            vec![]
-        };
-
-        let fx = if !effects.is_empty() {
-            self.multi_get_executed_effects(effects)?
-        } else {
-            vec![]
-        };
-
-        let evts = if !events.is_empty() {
-            self.multi_get_events(events)?
-        } else {
-            vec![]
-        };
-
-        Ok((txns, fx, evts))
     }
 }
 

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -42,6 +42,7 @@ sui-json-rpc.workspace = true
 sui-node.workspace = true
 sui-macros.workspace = true
 sui-simulator.workspace = true
+sui-storage.workspace = true
 mysten-metrics.workspace = true
 sui-tool.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -204,46 +204,55 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
     .await;
     let digest = response.digest;
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::MoveFunction {
-            package: package_ref.0,
-            module: Some("counter".to_string()),
-            function: Some("increment".to_string()),
-        }),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::MoveFunction {
+                package: package_ref.0,
+                module: Some("counter".to_string()),
+                function: Some("increment".to_string()),
+            }),
+            None,
+            None,
+            false,
+        )
+        .await?;
 
     assert_eq!(txes.len(), 1);
     assert_eq!(txes[0], digest);
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::MoveFunction {
-            package: package_ref.0,
-            module: None,
-            function: None,
-        }),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::MoveFunction {
+                package: package_ref.0,
+                module: None,
+                function: None,
+            }),
+            None,
+            None,
+            false,
+        )
+        .await?;
 
     // 2 transactions in the package i.e create and increment counter
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     eprint!("start...");
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::MoveFunction {
-            package: package_ref.0,
-            module: Some("counter".to_string()),
-            function: None,
-        }),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::MoveFunction {
+                package: package_ref.0,
+                module: Some("counter".to_string()),
+                function: None,
+            }),
+            None,
+            None,
+            false,
+        )
+        .await?;
 
     // 2 transactions in the package i.e publish and increment
     assert_eq!(txes.len(), 2);
@@ -264,61 +273,79 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
 
     let (transferred_object, sender, receiver, digest, _) = transfer_coin(context).await?;
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::InputObject(transferred_object)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::InputObject(transferred_object)),
+            None,
+            None,
+            false,
+        )
+        .await?;
 
     assert_eq!(txes.len(), 1);
     assert_eq!(txes[0], digest);
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::ChangedObject(transferred_object)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::ChangedObject(transferred_object)),
+            None,
+            None,
+            false,
+        )
+        .await?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::FromAddress(sender)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::FromAddress(sender)),
+            None,
+            None,
+            false,
+        )
+        .await?;
     assert_eq!(txes.len(), 1);
     assert_eq!(txes[0], digest);
 
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::ToAddress(receiver)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::ToAddress(receiver)),
+            None,
+            None,
+            false,
+        )
+        .await?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     // Note that this is also considered a tx to the sender, because it mutated
     // one or more of the sender's objects.
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::ToAddress(sender)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::ToAddress(sender)),
+            None,
+            None,
+            false,
+        )
+        .await?;
     assert_eq!(txes.len(), 2);
     assert_eq!(txes[1], digest);
 
     // No transactions have originated from the receiver
-    let txes = node.state().get_transactions(
-        Some(TransactionFilter::FromAddress(receiver)),
-        None,
-        None,
-        false,
-    )?;
+    let txes = node
+        .state()
+        .get_transactions_for_tests(
+            Some(TransactionFilter::FromAddress(receiver)),
+            None,
+            None,
+            false,
+        )
+        .await?;
     assert_eq!(txes.len(), 0);
 
     // This is a poor substitute for the post processing taking some time
@@ -705,12 +732,13 @@ async fn test_full_node_event_read_api_ok() {
 
     let txes = node
         .state()
-        .get_transactions(
+        .get_transactions_for_tests(
             Some(TransactionFilter::InputObject(transferred_object)),
             None,
             None,
             false,
         )
+        .await
         .unwrap();
 
     if gas_id_1 == transferred_object {

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -201,7 +201,14 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             // Retrieve 1 extra item for next cursor
             let mut digests = self
                 .state
-                .get_transactions(query.filter, cursor, Some(limit + 1), descending)
+                .get_transactions(
+                    &self.transaction_kv_store,
+                    query.filter,
+                    cursor,
+                    Some(limit + 1),
+                    descending,
+                )
+                .await
                 .map_err(Error::from)?;
 
             // extract next cursor

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -36,11 +36,15 @@ use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::collection_types::VecMap;
 use sui_types::crypto::default_hash;
+use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::SuiObjectResponseError;
-use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointTimestamp};
+use sui_types::error::{SuiObjectResponseError, SuiResult};
+use sui_types::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
+    CheckpointTimestamp,
+};
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
 use sui_types::sui_serde::BigInt;
@@ -110,38 +114,89 @@ impl ReadApi {
         }
     }
 
-    fn get_checkpoint_internal(&self, id: CheckpointId) -> Result<Checkpoint, Error> {
+    async fn get_checkpoint_internal(&self, id: CheckpointId) -> Result<Checkpoint, Error> {
         Ok(match id {
             CheckpointId::SequenceNumber(seq) => {
-                let verified_summary =
-                    self.state.get_verified_checkpoint_by_sequence_number(seq)?;
+                let verified_summary = self
+                    .transaction_kv_store
+                    .get_checkpoint_summary(seq)
+                    .await?;
                 let content = self
-                    .state
-                    .get_checkpoint_contents(verified_summary.content_digest)?;
+                    .transaction_kv_store
+                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
-                (
-                    verified_summary.into_inner().into_data(),
-                    content,
-                    signature,
-                )
-                    .into()
+                (verified_summary.into_data(), content, signature).into()
             }
             CheckpointId::Digest(digest) => {
                 let verified_summary = self
-                    .state
-                    .get_verified_checkpoint_summary_by_digest(digest)?;
+                    .transaction_kv_store
+                    .get_checkpoint_summary_by_digest(digest)
+                    .await?;
                 let content = self
-                    .state
-                    .get_checkpoint_contents(verified_summary.content_digest)?;
+                    .transaction_kv_store
+                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
-                (
-                    verified_summary.into_inner().into_data(),
-                    content,
-                    signature,
-                )
-                    .into()
+                (verified_summary.into_data(), content, signature).into()
             }
         })
+    }
+
+    pub async fn get_checkpoints_internal(
+        state: Arc<AuthorityState>,
+        transaction_kv_store: Arc<TransactionKeyValueStore>,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<CheckpointSequenceNumber>,
+        limit: u64,
+        descending_order: bool,
+    ) -> SuiResult<Vec<Checkpoint>> {
+        let max_checkpoint = state.get_latest_checkpoint_sequence_number()?;
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        let verified_checkpoints = transaction_kv_store
+            .multi_get_checkpoints_summaries(&checkpoint_numbers)
+            .await?;
+
+        let checkpoint_summaries_and_signatures: Vec<(
+            CheckpointSummary,
+            AggregateAuthoritySignature,
+        )> = verified_checkpoints
+            .into_iter()
+            .flatten()
+            .map(|check| {
+                (
+                    check.clone().into_summary_and_sequence().1,
+                    check.get_validator_signature(),
+                )
+            })
+            .collect();
+
+        let checkpoint_contents_digest: Vec<CheckpointContentsDigest> =
+            checkpoint_summaries_and_signatures
+                .iter()
+                .map(|summary| summary.0.content_digest)
+                .collect();
+        let checkpoint_contents = transaction_kv_store
+            .multi_get_checkpoints_contents_by_digest(checkpoint_contents_digest.as_slice())
+            .await?;
+        let contents: Vec<CheckpointContents> = checkpoint_contents.into_iter().flatten().collect();
+
+        let mut checkpoints: Vec<Checkpoint> = vec![];
+
+        for (summary_and_sig, content) in checkpoint_summaries_and_signatures
+            .into_iter()
+            .zip(contents.into_iter())
+        {
+            checkpoints.push(Checkpoint::from((
+                summary_and_sig.0,
+                content,
+                summary_and_sig.1,
+            )));
+        }
+
+        Ok(checkpoints)
     }
 
     async fn multi_get_transaction_blocks_internal(
@@ -233,8 +288,9 @@ impl ReadApi {
 
         // fetch timestamp from the DB
         let timestamps = self
-            .state
-            .multi_get_checkpoint_by_sequence_number(&unique_checkpoint_numbers)
+            .transaction_kv_store
+            .multi_get_checkpoints_summaries(&unique_checkpoint_numbers)
+            .await
             .map_err(|e| {
                 Error::UnexpectedError(format!("Failed to fetch checkpoint summaries by these checkpoint ids: {unique_checkpoint_numbers:?} with error: {e:?}"))
             })?
@@ -685,24 +741,25 @@ impl ReadApiServer for ReadApi {
                         error!("Failed to retrieve checkpoint sequence for transaction {digest:?} with error: {e:?}");
                         Error::from(e)
                     })
-            }).await.map_err(Error::from)??
-        {
-            temp_response.checkpoint_seq = Some(seq);
-        }
+            }).await.map_err(Error::from)?? {
+                temp_response.checkpoint_seq = Some(seq);
+            }
 
             if let Some(checkpoint_seq) = &temp_response.checkpoint_seq {
-                let state = self.state.clone();
+                let kv_store = self.transaction_kv_store.clone();
                 let checkpoint_seq = *checkpoint_seq;
                 let checkpoint = spawn_monitored_task!(async move {
-                state
-                // safe to unwrap because we have checked `is_some` above
-                .get_checkpoint_by_sequence_number(checkpoint_seq)
-                .map_err(|e| {
-                    error!("Failed to get checkpoint by sequence number: {checkpoint_seq:?} with error: {e:?}");
-                    Error::from(e)
-                })}).await.map_err(Error::from)??;
+                    kv_store
+                    // safe to unwrap because we have checked `is_some` above
+                    .get_checkpoint_summary(checkpoint_seq)
+                    .await
+                    .map_err(|e| {
+                        error!("Failed to get checkpoint by sequence number: {checkpoint_seq:?} with error: {e:?}");
+                        Error::from(e)
+                    })
+                }).await.map_err(Error::from)??;
                 // TODO(chris): we don't need to fetch the whole checkpoint summary
-                temp_response.timestamp = checkpoint.as_ref().map(|c| c.timestamp_ms);
+                temp_response.timestamp = Some(checkpoint.timestamp_ms);
             }
 
             if opts.show_events && temp_response.effects.is_some() {
@@ -861,7 +918,7 @@ impl ReadApiServer for ReadApi {
 
     #[instrument(skip(self))]
     async fn get_checkpoint(&self, id: CheckpointId) -> RpcResult<Checkpoint> {
-        with_tracing!(async move { self.get_checkpoint_internal(id) })
+        with_tracing!(self.get_checkpoint_internal(id))
     }
 
     #[instrument(skip(self))]
@@ -876,12 +933,17 @@ impl ReadApiServer for ReadApi {
             let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
 
             let state = self.state.clone();
+            let kv_store = self.transaction_kv_store.clone();
 
             self.metrics.get_checkpoints_limit.report(limit as u64);
 
-            let mut data = spawn_monitored_task!(async move {
-                state.get_checkpoints(cursor.map(|s| *s), limit as u64 + 1, descending_order)
-            })
+            let mut data = spawn_monitored_task!(Self::get_checkpoints_internal(
+                state,
+                kv_store,
+                cursor.map(|s| *s),
+                limit as u64 + 1,
+                descending_order,
+            ))
             .await
             .map_err(Error::from)?
             .map_err(Error::from)?;
@@ -1348,4 +1410,126 @@ fn convert_to_response(
         response.object_changes = cache.object_changes;
     }
     Ok(response)
+}
+
+fn calculate_checkpoint_numbers(
+    // If `Some`, the query will start from the next item after the specified cursor
+    cursor: Option<CheckpointSequenceNumber>,
+    limit: u64,
+    descending_order: bool,
+    max_checkpoint: CheckpointSequenceNumber,
+) -> Vec<CheckpointSequenceNumber> {
+    let (start_index, end_index) = match cursor {
+        Some(t) => {
+            if descending_order {
+                let start = std::cmp::min(t.saturating_sub(1), max_checkpoint);
+                let end = start.saturating_sub(limit - 1);
+                (end, start)
+            } else {
+                let start =
+                    std::cmp::min(t.checked_add(1).unwrap_or(max_checkpoint), max_checkpoint);
+                let end = std::cmp::min(
+                    start.checked_add(limit - 1).unwrap_or(max_checkpoint),
+                    max_checkpoint,
+                );
+                (start, end)
+            }
+        }
+        None => {
+            if descending_order {
+                (max_checkpoint.saturating_sub(limit - 1), max_checkpoint)
+            } else {
+                (0, std::cmp::min(limit - 1, max_checkpoint))
+            }
+        }
+    };
+
+    if descending_order {
+        (start_index..=end_index).rev().collect()
+    } else {
+        (start_index..=end_index).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_checkpoint_numbers() {
+        let cursor = Some(10);
+        let limit = 5;
+        let descending_order = true;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, vec![9, 8, 7, 6, 5]);
+    }
+
+    #[test]
+    fn test_calculate_checkpoint_numbers_descending_no_cursor() {
+        let cursor = None;
+        let limit = 5;
+        let descending_order = true;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, vec![15, 14, 13, 12, 11]);
+    }
+
+    #[test]
+    fn test_calculate_checkpoint_numbers_ascending_no_cursor() {
+        let cursor = None;
+        let limit = 5;
+        let descending_order = false;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_calculate_checkpoint_numbers_ascending_with_cursor() {
+        let cursor = Some(10);
+        let limit = 5;
+        let descending_order = false;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, vec![11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn test_calculate_checkpoint_numbers_ascending_limit_exceeds_max() {
+        let cursor = None;
+        let limit = 20;
+        let descending_order = false;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, (0..=15).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_calculate_checkpoint_numbers_descending_limit_exceeds_max() {
+        let cursor = None;
+        let limit = 20;
+        let descending_order = true;
+        let max_checkpoint = 15;
+
+        let checkpoint_numbers =
+            calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
+
+        assert_eq!(checkpoint_numbers, (0..=15).rev().collect::<Vec<_>>());
+    }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1493,7 +1493,11 @@ pub async fn build_server(
         kv_store.clone(),
         metrics.clone(),
     ))?;
-    server.register_module(CoinReadApi::new(state.clone(), metrics.clone()))?;
+    server.register_module(CoinReadApi::new(
+        state.clone(),
+        kv_store.clone(),
+        metrics.clone(),
+    ))?;
     server.register_module(TransactionBuilderApi::new(state.clone()))?;
     server.register_module(GovernanceReadApi::new(state.clone(), metrics.clone()))?;
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1435,7 +1435,7 @@ fn build_kv_store(
     registry: &Registry,
 ) -> Result<Arc<TransactionKeyValueStore>> {
     let metrics = KeyValueStoreMetrics::new(registry);
-    let db_store = TransactionKeyValueStore::new("rocksdb", metrics.clone(), state.db());
+    let db_store = TransactionKeyValueStore::new("rocksdb", metrics.clone(), state.clone());
 
     let base_url = &config.transaction_kv_store_read_config.base_url;
 

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -5,18 +5,22 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
 use hyper::client::HttpConnector;
+use hyper::header::{HeaderValue, CONTENT_LENGTH};
 use hyper::Client;
 use hyper::Uri;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::{
-    digests::{TransactionDigest, TransactionEventsDigest},
+    digests::{
+        CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
+    },
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{SuiError, SuiResult},
-    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
+    },
     transaction::Transaction,
 };
 use tap::TapFallible;
@@ -65,14 +69,18 @@ pub enum Key {
     Fx(TransactionDigest),
     Events(TransactionEventsDigest),
     CheckpointContents(CheckpointSequenceNumber),
+    CheckpointSummary(CheckpointSequenceNumber),
+    CheckpointContentsByDigest(CheckpointContentsDigest),
+    CheckpointSummaryByDigest(CheckpointDigest),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 enum Value {
     Tx(Box<Transaction>),
     Fx(Box<TransactionEffects>),
     Events(Box<TransactionEvents>),
     CheckpointContents(Box<CheckpointContents>),
+    CheckpointSummary(Box<CertifiedCheckpointSummary>),
 }
 
 fn key_to_path_elements(key: &Key) -> SuiResult<(String, &'static str)> {
@@ -84,6 +92,12 @@ fn key_to_path_elements(key: &Key) -> SuiResult<(String, &'static str)> {
             encoded_tagged_key(&TaggedKey::CheckpointSequenceNumber(*seq)),
             "cc",
         )),
+        Key::CheckpointSummary(seq) => Ok((
+            encoded_tagged_key(&TaggedKey::CheckpointSequenceNumber(*seq)),
+            "cs",
+        )),
+        Key::CheckpointContentsByDigest(digest) => Ok((encode_digest(digest), "cc")),
+        Key::CheckpointSummaryByDigest(digest) => Ok((encode_digest(digest), "cs")),
     }
 }
 
@@ -147,10 +161,12 @@ impl HttpKVStore {
         trace!("fetching uri: {}", uri);
         let resp = self.client.get(uri.clone()).await.into_sui_result()?;
         trace!(
-            "got response {} for uri: {}, len: {}",
+            "got response {} for uri: {}, len: {:?}",
             uri,
             resp.status(),
-            resp.headers().len()
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap_or(&HeaderValue::from_static("0"))
         );
         // return None if 400
         if resp.status().is_success() {
@@ -189,6 +205,42 @@ where
     }
 }
 
+fn multi_split_slice<'a, T>(slice: &'a [T], lengths: &'a [usize]) -> Vec<&'a [T]> {
+    let mut start = 0;
+    lengths
+        .iter()
+        .map(|length| {
+            let end = start + length;
+            let result = &slice[start..end];
+            start = end;
+            result
+        })
+        .collect()
+}
+
+fn deser_check_digest<T, D: std::fmt::Debug>(
+    digest: &D,
+    bytes: &Bytes,
+    get_expected_digest: impl FnOnce(&T) -> D,
+) -> Option<T>
+where
+    D: std::fmt::Debug + PartialEq,
+    T: for<'de> Deserialize<'de>,
+{
+    deser(digest, bytes).and_then(|o: T| {
+        let expected_digest = get_expected_digest(&o);
+        if expected_digest == *digest {
+            Some(o)
+        } else {
+            error!(
+                "Digest mismatch - expected: {:?}, got: {:?}",
+                digest, expected_digest,
+            );
+            None
+        }
+    })
+}
+
 #[async_trait]
 impl TransactionKeyValueStoreTrait for HttpKVStore {
     async fn multi_get(
@@ -216,29 +268,6 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
         let txn_slice = fetches[..num_txns].to_vec();
         let fx_slice = fetches[num_txns..num_txns + num_effects].to_vec();
         let events_slice = fetches[num_txns + num_effects..].to_vec();
-
-        fn deser_check_digest<T, D: std::fmt::Debug>(
-            digest: &D,
-            bytes: &Bytes,
-            get_expected_digest: impl FnOnce(&T) -> D,
-        ) -> Option<T>
-        where
-            D: std::fmt::Debug + PartialEq,
-            T: for<'de> Deserialize<'de>,
-        {
-            deser(digest, bytes).and_then(|o: T| {
-                let expected_digest = get_expected_digest(&o);
-                if expected_digest == *digest {
-                    Some(o)
-                } else {
-                    error!(
-                        "Digest mismatch - expected: {:?}, got: {:?}",
-                        digest, expected_digest,
-                    );
-                    None
-                }
-            })
-        }
 
         let txn_results = txn_slice
             .iter()
@@ -281,26 +310,100 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
         Ok((txn_results, fx_results, events_results))
     }
 
-    async fn multi_get_checkpoints_contents(
+    async fn multi_get_checkpoints(
         &self,
-        checkpoints: &[CheckpointSequenceNumber],
-    ) -> SuiResult<Vec<Option<CheckpointContents>>> {
-        let keys = checkpoints
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> SuiResult<(
+        Vec<Option<CertifiedCheckpointSummary>>,
+        Vec<Option<CheckpointContents>>,
+        Vec<Option<CertifiedCheckpointSummary>>,
+        Vec<Option<CheckpointContents>>,
+    )> {
+        let keys = checkpoint_summaries
             .iter()
-            .map(|cp| Key::CheckpointContents(*cp))
+            .map(|cp| Key::CheckpointSummary(*cp))
+            .chain(
+                checkpoint_contents
+                    .iter()
+                    .map(|cp| Key::CheckpointContents(*cp)),
+            )
+            .chain(
+                checkpoint_summaries_by_digest
+                    .iter()
+                    .map(|cp| Key::CheckpointSummaryByDigest(*cp)),
+            )
+            .chain(
+                checkpoint_contents_by_digest
+                    .iter()
+                    .map(|cp| Key::CheckpointContentsByDigest(*cp)),
+            )
             .collect::<Vec<_>>();
+
+        let summaries_len = checkpoint_summaries.len();
+        let contents_len = checkpoint_contents.len();
+        let summaries_by_digest_len = checkpoint_summaries_by_digest.len();
+        let contents_by_digest_len = checkpoint_contents_by_digest.len();
 
         let fetches = self.multi_fetch(keys).await;
 
-        let results = fetches
+        let input_slices = [
+            summaries_len,
+            contents_len,
+            summaries_by_digest_len,
+            contents_by_digest_len,
+        ];
+
+        let result_slices = multi_split_slice(&fetches, &input_slices);
+
+        let summaries_results = result_slices[0]
             .iter()
-            .zip(checkpoints.iter())
+            .zip(checkpoint_summaries.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes
+                    .and_then(|(bytes, seq)| deser::<_, CertifiedCheckpointSummary>(seq, bytes))
+            })
+            .collect::<Vec<_>>();
+
+        let contents_results = result_slices[1]
+            .iter()
+            .zip(checkpoint_contents.iter())
             .map(map_fetch)
             .map(|maybe_bytes| {
                 maybe_bytes.and_then(|(bytes, seq)| deser::<_, CheckpointContents>(seq, bytes))
             })
             .collect::<Vec<_>>();
 
-        Ok(results)
+        let summaries_by_digest_results = result_slices[2]
+            .iter()
+            .zip(checkpoint_summaries_by_digest.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, digest)| {
+                    deser_check_digest(digest, bytes, |s: &CertifiedCheckpointSummary| *s.digest())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let contents_by_digest_results = result_slices[3]
+            .iter()
+            .zip(checkpoint_contents_by_digest.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, digest)| {
+                    deser_check_digest(digest, bytes, |c: &CheckpointContents| *c.digest())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Ok((
+            summaries_results,
+            contents_results,
+            summaries_by_digest_results,
+            contents_by_digest_results,
+        ))
     }
 }

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -16,6 +16,7 @@ use sui_types::{
     digests::{TransactionDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{SuiError, SuiResult},
+    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
     transaction::Transaction,
 };
 use tap::TapFallible;
@@ -40,6 +41,11 @@ pub enum TaggedKey {
     CheckpointSequenceNumber(CheckpointSequenceNumber),
 }
 
+pub fn encoded_tagged_key(key: &TaggedKey) -> String {
+    let bytes = bcs::to_bytes(key).expect("failed to serialize key");
+    base64_url::encode(&bytes)
+}
+
 trait IntoSuiResult<T> {
     fn into_sui_result(self) -> SuiResult<T>;
 }
@@ -58,6 +64,7 @@ pub enum Key {
     Tx(TransactionDigest),
     Fx(TransactionDigest),
     Events(TransactionEventsDigest),
+    CheckpointContents(CheckpointSequenceNumber),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -65,6 +72,7 @@ enum Value {
     Tx(Box<Transaction>),
     Fx(Box<TransactionEffects>),
     Events(Box<TransactionEvents>),
+    CheckpointContents(Box<CheckpointContents>),
 }
 
 fn key_to_path_elements(key: &Key) -> SuiResult<(String, &'static str)> {
@@ -72,6 +80,10 @@ fn key_to_path_elements(key: &Key) -> SuiResult<(String, &'static str)> {
         Key::Tx(digest) => Ok((encode_digest(digest), "tx")),
         Key::Fx(digest) => Ok((encode_digest(digest), "fx")),
         Key::Events(digest) => Ok((encode_digest(digest), "ev")),
+        Key::CheckpointContents(seq) => Ok((
+            encoded_tagged_key(&TaggedKey::CheckpointSequenceNumber(*seq)),
+            "cc",
+        )),
     }
 }
 
@@ -162,6 +174,21 @@ where
         .ok()
 }
 
+fn map_fetch<'a, K>(fetch: (&'a SuiResult<Option<Bytes>>, &'a K)) -> Option<(&'a Bytes, &'a K)>
+where
+    K: std::fmt::Debug,
+{
+    let (fetch, key) = fetch;
+    match fetch {
+        Ok(Some(bytes)) => Some((bytes, key)),
+        Ok(None) => None,
+        Err(err) => {
+            warn!("Error fetching key: {:?}, error: {:?}", key, err);
+            None
+        }
+    }
+}
+
 #[async_trait]
 impl TransactionKeyValueStoreTrait for HttpKVStore {
     async fn multi_get(
@@ -189,23 +216,6 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
         let txn_slice = fetches[..num_txns].to_vec();
         let fx_slice = fetches[num_txns..num_txns + num_effects].to_vec();
         let events_slice = fetches[num_txns + num_effects..].to_vec();
-
-        fn map_fetch<'a, Digest>(
-            fetch: (&'a SuiResult<Option<Bytes>>, &'a Digest),
-        ) -> Option<(&'a Bytes, &'a Digest)>
-        where
-            Digest: std::fmt::Debug,
-        {
-            let (fetch, digest) = fetch;
-            match fetch {
-                Ok(Some(bytes)) => Some((bytes, digest)),
-                Ok(None) => None,
-                Err(err) => {
-                    warn!("Error fetching key: {:?}, error: {:?}", digest, err);
-                    None
-                }
-            }
-        }
 
         fn deser_check_digest<T, D: std::fmt::Debug>(
             digest: &D,
@@ -269,5 +279,28 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
             .collect::<Vec<_>>();
 
         Ok((txn_results, fx_results, events_results))
+    }
+
+    async fn multi_get_checkpoints_contents(
+        &self,
+        checkpoints: &[CheckpointSequenceNumber],
+    ) -> SuiResult<Vec<Option<CheckpointContents>>> {
+        let keys = checkpoints
+            .iter()
+            .map(|cp| Key::CheckpointContents(*cp))
+            .collect::<Vec<_>>();
+
+        let fetches = self.multi_fetch(keys).await;
+
+        let results = fetches
+            .iter()
+            .zip(checkpoints.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| {
+                maybe_bytes.and_then(|(bytes, seq)| deser::<_, CheckpointContents>(seq, bytes))
+            })
+            .collect::<Vec<_>>();
+
+        Ok(results)
     }
 }

--- a/crates/sui-storage/src/key_value_store.rs
+++ b/crates/sui-storage/src/key_value_store.rs
@@ -18,6 +18,19 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::transaction::Transaction;
 
+pub type KVStoreTransactionData = (
+    Vec<Option<Transaction>>,
+    Vec<Option<TransactionEffects>>,
+    Vec<Option<TransactionEvents>>,
+);
+
+pub type KVStoreCheckpointData = (
+    Vec<Option<CertifiedCheckpointSummary>>,
+    Vec<Option<CheckpointContents>>,
+    Vec<Option<CertifiedCheckpointSummary>>,
+    Vec<Option<CheckpointContents>>,
+);
+
 pub struct TransactionKeyValueStore {
     store_name: &'static str,
     metrics: Arc<KeyValueStoreMetrics>,
@@ -384,11 +397,7 @@ pub trait TransactionKeyValueStoreTrait {
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
         events: &[TransactionEventsDigest],
-    ) -> SuiResult<(
-        Vec<Option<Transaction>>,
-        Vec<Option<TransactionEffects>>,
-        Vec<Option<TransactionEvents>>,
-    )>;
+    ) -> SuiResult<KVStoreTransactionData>;
 
     /// Generic multi_get to allow implementors to get heterogenous values with a single round trip.
     async fn multi_get_checkpoints(
@@ -397,12 +406,7 @@ pub trait TransactionKeyValueStoreTrait {
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
         checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> SuiResult<(
-        Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
-        Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
-    )>;
+    ) -> SuiResult<KVStoreCheckpointData>;
 }
 
 /// A TransactionKeyValueStoreTrait that falls back to a secondary store for any key for which the

--- a/crates/sui-storage/src/key_value_store.rs
+++ b/crates/sui-storage/src/key_value_store.rs
@@ -311,7 +311,7 @@ impl TransactionKeyValueStore {
 
     /// Convenience method for fetching single checkpoint, and returning an error if it's not found.
     /// Prefer using multi_get_checkpoints_summaries whenever possible.
-    pub async fn get_checkpoint_summaries(
+    pub async fn get_checkpoint_summary(
         &self,
         checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult<CertifiedCheckpointSummary> {
@@ -343,7 +343,7 @@ impl TransactionKeyValueStore {
 
     /// Convenience method for fetching single checkpoint, and returning an error if it's not found.
     /// Prefer using multi_get_checkpoints_summaries_by_digest whenever possible.
-    pub async fn get_checkpoint_summaries_by_digest(
+    pub async fn get_checkpoint_summary_by_digest(
         &self,
         digest: CheckpointDigest,
     ) -> SuiResult<CertifiedCheckpointSummary> {

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -12,6 +12,7 @@ use sui_types::digests::{TransactionDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::SuiResult;
 use sui_types::event::Event;
+use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
 use sui_types::transaction::Transaction;
 
 use sui_storage::key_value_store::*;
@@ -119,6 +120,13 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         }
 
         Ok((txs, fxs, evts))
+    }
+
+    async fn multi_get_checkpoints_contents(
+        &self,
+        _checkpoints: &[CheckpointSequenceNumber],
+    ) -> SuiResult<Vec<Option<CheckpointContents>>> {
+        todo!()
     }
 }
 

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -6,13 +6,20 @@ use futures::FutureExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::random_object_ref;
+use sui_types::base_types::{random_object_ref, ExecutionDigests};
+use sui_types::committee::Committee;
+use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
-use sui_types::digests::{TransactionDigest, TransactionEventsDigest};
+use sui_types::digests::{
+    CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
+};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::SuiResult;
 use sui_types::event::Event;
-use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
+use sui_types::messages_checkpoint::{
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+    SignedCheckpointSummary,
+};
 use sui_types::transaction::Transaction;
 
 use sui_storage::key_value_store::*;
@@ -36,19 +43,22 @@ fn random_events() -> TransactionEvents {
     TransactionEvents { data: vec![event] }
 }
 
+#[derive(Default)]
 struct MockTxStore {
     txs: HashMap<TransactionDigest, Transaction>,
     fxs: HashMap<TransactionDigest, TransactionEffects>,
     events: HashMap<TransactionEventsDigest, TransactionEvents>,
+    checkpoint_summaries: HashMap<CheckpointSequenceNumber, CertifiedCheckpointSummary>,
+    checkpoint_contents: HashMap<CheckpointSequenceNumber, CheckpointContents>,
+    checkpoint_summaries_by_digest: HashMap<CheckpointDigest, CertifiedCheckpointSummary>,
+    checkpoint_contents_by_digest: HashMap<CheckpointContentsDigest, CheckpointContents>,
+
+    next_seq_number: u64,
 }
 
 impl MockTxStore {
     fn new() -> Self {
-        Self {
-            txs: HashMap::new(),
-            fxs: HashMap::new(),
-            events: HashMap::new(),
-        }
+        Self::default()
     }
 
     fn add_tx(&mut self, tx: Transaction) {
@@ -79,6 +89,48 @@ impl MockTxStore {
         let events = random_events();
         self.add_events(events.clone());
         events
+    }
+
+    fn add_random_checkpoint(&mut self) -> (CertifiedCheckpointSummary, CheckpointContents) {
+        let contents = CheckpointContents::new_with_causally_ordered_transactions(
+            [ExecutionDigests::random()].into_iter(),
+        );
+
+        let next_seq = self.next_seq_number;
+        self.next_seq_number += 1;
+
+        let (committee, keys) = Committee::new_simple_test_committee_of_size(1);
+        let summary = CheckpointSummary::new(
+            committee.epoch,
+            next_seq,
+            1,
+            &contents,
+            None,
+            Default::default(),
+            None,
+            0,
+        );
+
+        let signed = SignedCheckpointSummary::new(
+            committee.epoch,
+            summary.clone(),
+            &keys[0],
+            keys[0].public().into(),
+        );
+        let sign_info = signed.into_sig();
+
+        let certified =
+            CertifiedCheckpointSummary::new(summary.clone(), vec![sign_info], &committee).unwrap();
+
+        self.checkpoint_summaries
+            .insert(summary.sequence_number, certified.clone());
+        self.checkpoint_contents
+            .insert(summary.sequence_number, contents.clone());
+        self.checkpoint_summaries_by_digest
+            .insert(*certified.digest(), certified.clone());
+        self.checkpoint_contents_by_digest
+            .insert(*contents.digest(), contents.clone());
+        (certified, contents)
     }
 }
 
@@ -122,11 +174,39 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         Ok((txs, fxs, evts))
     }
 
-    async fn multi_get_checkpoints_contents(
+    async fn multi_get_checkpoints(
         &self,
-        _checkpoints: &[CheckpointSequenceNumber],
-    ) -> SuiResult<Vec<Option<CheckpointContents>>> {
-        todo!()
+        checkpoint_summaries: &[CheckpointSequenceNumber],
+        checkpoint_contents: &[CheckpointSequenceNumber],
+        checkpoint_summaries_by_digest: &[CheckpointDigest],
+        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
+    ) -> SuiResult<(
+        Vec<Option<CertifiedCheckpointSummary>>,
+        Vec<Option<CheckpointContents>>,
+        Vec<Option<CertifiedCheckpointSummary>>,
+        Vec<Option<CheckpointContents>>,
+    )> {
+        let mut summaries = Vec::new();
+        for digest in checkpoint_summaries {
+            summaries.push(self.checkpoint_summaries.get(digest).cloned());
+        }
+
+        let mut contents = Vec::new();
+        for digest in checkpoint_contents {
+            contents.push(self.checkpoint_contents.get(digest).cloned());
+        }
+
+        let mut summaries_by_digest = Vec::new();
+        for digest in checkpoint_summaries_by_digest {
+            summaries_by_digest.push(self.checkpoint_summaries_by_digest.get(digest).cloned());
+        }
+
+        let mut contents_by_digest = Vec::new();
+        for digest in checkpoint_contents_by_digest {
+            contents_by_digest.push(self.checkpoint_contents_by_digest.get(digest).cloned());
+        }
+
+        Ok((summaries, contents, summaries_by_digest, contents_by_digest))
     }
 }
 
@@ -226,6 +306,36 @@ async fn test_multi_get() {
         .now_or_never()
         .unwrap();
     assert_eq!(result.unwrap(), vec![None]);
+}
+
+#[tokio::test]
+async fn test_checkpoints() {
+    let mut store = MockTxStore::new();
+    let (s1, _c1) = store.add_random_checkpoint();
+    let (s2, c2) = store.add_random_checkpoint();
+
+    let store = TransactionKeyValueStore::from(store);
+
+    let result = store
+        .multi_get_checkpoints(
+            &[s1.sequence_number, s2.sequence_number],
+            &[s1.sequence_number, s2.sequence_number],
+            &[*s1.digest(), *s2.digest()],
+            &[s1.content_digest, s2.content_digest],
+        )
+        .now_or_never()
+        .unwrap()
+        .unwrap();
+
+    let summaries_by_seq = result.0;
+    let contents_by_seq = result.1;
+    let summaries_by_digest = result.2;
+    let contents_by_digest = result.3;
+
+    assert_eq!(summaries_by_seq[0].as_ref().unwrap().data(), s1.data());
+    assert_eq!(contents_by_seq[1].as_ref().unwrap(), &c2);
+    assert_eq!(summaries_by_digest[0].as_ref().unwrap().data(), s1.data());
+    assert_eq!(contents_by_digest[1].as_ref().unwrap(), &c2);
 }
 
 #[tokio::test]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -352,7 +352,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let kv_store = Arc::new(TransactionKeyValueStore::new(
             "rocksdb",
             metrics,
-            validator.db(),
+            validator.clone(),
         ));
 
         let mut test_adapter = Self {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -278,16 +278,20 @@ impl CertifiedCheckpointSummary {
 
         Ok(())
     }
-}
 
-impl VerifiedCheckpoint {
     pub fn into_summary_and_sequence(self) -> (CheckpointSequenceNumber, CheckpointSummary) {
-        let summary = self.into_inner().into_data();
+        let summary = self.into_data();
         (summary.sequence_number, summary)
     }
 
     pub fn get_validator_signature(self) -> AggregateAuthoritySignature {
         self.auth_sig().signature.clone()
+    }
+}
+
+impl VerifiedCheckpoint {
+    pub fn into_summary_and_sequence(self) -> (CheckpointSequenceNumber, CheckpointSummary) {
+        self.into_inner().into_summary_and_sequence()
     }
 }
 


### PR DESCRIPTION
- Load checkpoint contents from KV store (#13262)
- Complete checkpoint fetching code (#13279)
- Use kv store for checkpoint loading (#13282)
- Use kv store fallback in coin_api rpc (#13280)
