### PR TITLE
[protocol version] increase protocol version to 20 & enable nw new leader schedule

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -61,6 +61,9 @@ const MAX_PROTOCOL_VERSION: u64 = 20;
 // Version 19: Changes to sui-system package to enable liquid staking.
 //             Add limit for total size of events.
 //             Increase limit for number of events emitted to 1024.
+// Version 20: Enabling the flag `narwhal_new_leader_election_schedule` for the new narwhal leader
+//             schedule algorithm for enhanced fault tolerance and sets the bad node stake threshold
+//             value. Both values are set for all the environments except mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1352,6 +1355,12 @@ impl ProtocolConfig {
             20 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.feature_flags.commit_root_state_digest = true;
+
+                if chain != Chain::Mainnet {
+                    cfg.feature_flags.narwhal_new_leader_election_schedule = true;
+                    cfg.consensus_bad_nodes_stake_threshold = Some(20);
+                }
+
                 cfg
             }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_20.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_20.snap
@@ -23,6 +23,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -186,4 +187,5 @@ hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
 execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_20.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_20.snap
@@ -24,6 +24,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -187,4 +188,5 @@ hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
 execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
 

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -371,7 +371,6 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
     certificates.extend(out);
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_narwhal_new_leader_election_schedule(true);
     config.set_consensus_bad_nodes_stake_threshold(33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use storage::{ConsensusStore, NodeStorage};
 use sui_protocol_config::ProtocolConfig;
 use telemetry_subscribers::TelemetryGuards;
-use test_utils::{latest_protocol_version, mock_certificate};
+use test_utils::{get_protocol_config, latest_protocol_version, mock_certificate};
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
@@ -42,12 +42,11 @@ async fn test_consensus_recovery_with_bullshark() {
 
     // TODO: remove once the new leader schedule has been enabled.
     // Run with default config settings where the new leader schedule is disabled
-    let config: ProtocolConfig = latest_protocol_version();
+    let config: ProtocolConfig = get_protocol_config(19);
     test_consensus_recovery_with_bullshark_with_config(config).await;
 
     // Run with the new leader election schedule enabled
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_narwhal_new_leader_election_schedule(true);
     config.set_consensus_bad_nodes_stake_threshold(33);
     test_consensus_recovery_with_bullshark_with_config(config).await;
 }

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -22,9 +22,9 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use storage::ConsensusStore;
 use sui_protocol_config::ProtocolConfig;
-use test_utils::latest_protocol_version;
 use test_utils::mock_certificate_with_rand;
 use test_utils::CommitteeFixture;
+use test_utils::{get_protocol_config, latest_protocol_version};
 #[allow(unused_imports)]
 use tokio::sync::mpsc::channel;
 use types::CertificateAPI;
@@ -76,13 +76,12 @@ impl ExecutionPlan {
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn bullshark_randomised_tests() {
     // Run the consensus tests without the new consensus schedule changes
-    let protocol_config = latest_protocol_version();
+    let protocol_config = get_protocol_config(19);
     bullshark_randomised_tests_with_config(protocol_config).await;
 
     // TODO: remove once the new leader election schedule feature is enabled on a protocol version
     // Run the consensus tests with the new consensus schedule changes enabled
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_narwhal_new_leader_election_schedule(true);
     config.set_consensus_bad_nodes_stake_threshold(33);
     bullshark_randomised_tests_with_config(config).await;
 }


### PR DESCRIPTION
## Description 

The PR is:
* enabling the new narwhal leader election schedule algorithm for version 20 for all the environments except `Mainnet`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
