### PR TITLE
[Explorer]: add dynamic spacing for tabs

### DIFF
--- a/apps/explorer/src/components/Activity/index.tsx
+++ b/apps/explorer/src/components/Activity/index.tsx
@@ -3,6 +3,7 @@
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 // import { Filter16 } from '@mysten/icons';
+import { Heading } from '@mysten/ui';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 
@@ -64,10 +65,16 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 		<div>
 			<Tabs size="lg" value={activeTab} onValueChange={setActiveTab}>
 				<div className="relative">
-					<TabsList>
-						<TabsTrigger value="transactions">Transaction Blocks</TabsTrigger>
-						<TabsTrigger value="epochs">Epochs</TabsTrigger>
-						<TabsTrigger value="checkpoints">Checkpoints</TabsTrigger>
+					<TabsList dynamicSpacing>
+						<TabsTrigger value="transactions">
+							<Heading variant="heading4/semibold">Transaction Blocks</Heading>
+						</TabsTrigger>
+						<TabsTrigger value="epochs">
+							<Heading variant="heading4/semibold">Epochs</Heading>
+						</TabsTrigger>
+						<TabsTrigger value="checkpoints">
+							<Heading variant="heading4/semibold">Checkpoints</Heading>
+						</TabsTrigger>
 					</TabsList>
 					<div className="absolute inset-y-0 -top-1 right-0 flex items-center gap-3 text-2xl">
 						{/* TODO re-enable this when index is stable */}

--- a/apps/explorer/src/components/Activity/index.tsx
+++ b/apps/explorer/src/components/Activity/index.tsx
@@ -65,7 +65,7 @@ export function Activity({ initialTab, initialLimit, disablePagination }: Props)
 		<div>
 			<Tabs size="lg" value={activeTab} onValueChange={setActiveTab}>
 				<div className="relative">
-					<TabsList dynamicSpacing>
+					<TabsList>
 						<TabsTrigger value="transactions">
 							<Heading variant="heading4/semibold">Transaction Blocks</Heading>
 						</TabsTrigger>

--- a/apps/explorer/src/ui/FilterList.tsx
+++ b/apps/explorer/src/ui/FilterList.tsx
@@ -13,7 +13,7 @@ export interface FilterListProps<T extends string = string> {
 	value: T;
 	disabled?: boolean;
 	size?: ComponentProps<typeof Tabs>['size'];
-	lessSpacing?: ComponentProps<typeof TabsList>['lessSpacing'];
+	lessSpacing?: boolean;
 	onChange(value: T): void;
 }
 
@@ -33,7 +33,7 @@ export function FilterList<T extends string>({
 				onChange(value as T);
 			}}
 		>
-			<TabsList disableBottomBorder lessSpacing={lessSpacing}>
+			<TabsList disableBottomBorder gap={lessSpacing ? 3 : 6}>
 				{options.map((option) => (
 					<TabsTrigger disabled={disabled} key={option} value={option}>
 						{option}

--- a/apps/explorer/src/ui/Tabs.tsx
+++ b/apps/explorer/src/ui/Tabs.tsx
@@ -55,13 +55,16 @@ const TabsList = forwardRef<
 		fullWidth?: boolean;
 		disableBottomBorder?: boolean;
 		lessSpacing?: boolean;
+		dynamicSpacing?: boolean;
 	}
->(({ fullWidth, disableBottomBorder, lessSpacing, ...props }, ref) => (
+>(({ fullWidth, disableBottomBorder, lessSpacing, dynamicSpacing, ...props }, ref) => (
 	<TabsPrimitive.List
 		ref={ref}
 		className={clsx(
 			'flex items-center border-gray-45',
-			lessSpacing ? 'gap-3' : 'gap-6',
+			lessSpacing && !dynamicSpacing && 'gap-3',
+			!lessSpacing && !dynamicSpacing && 'gap-6',
+			!lessSpacing && dynamicSpacing && 'gap-4 sm:gap-6',
 			fullWidth && 'flex-1',
 			!disableBottomBorder && 'border-b',
 		)}

--- a/apps/explorer/src/ui/Tabs.tsx
+++ b/apps/explorer/src/ui/Tabs.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import clsx from 'clsx';
 import {
 	type ComponentPropsWithoutRef,
@@ -40,6 +40,27 @@ const tabStyles = cva(
 	},
 );
 
+const tabListStyles = cva(['flex items-center border-gray-45'], {
+	variants: {
+		fullWidth: {
+			true: 'flex-1',
+		},
+		disableBottomBorder: {
+			true: '',
+			false: '!border-b',
+		},
+		gap: {
+			3: 'gap-3',
+			6: 'gap-4 sm:gap-6',
+		},
+	},
+	defaultVariants: {
+		gap: 6,
+	},
+});
+
+type TabListStylesProps = VariantProps<typeof tabListStyles>;
+
 const Tabs = forwardRef<
 	ElementRef<typeof TabsPrimitive.Root>,
 	ComponentPropsWithoutRef<typeof TabsPrimitive.Root> & { size?: TabSize }
@@ -51,23 +72,11 @@ const Tabs = forwardRef<
 
 const TabsList = forwardRef<
 	ElementRef<typeof TabsPrimitive.List>,
-	ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
-		fullWidth?: boolean;
-		disableBottomBorder?: boolean;
-		lessSpacing?: boolean;
-		dynamicSpacing?: boolean;
-	}
->(({ fullWidth, disableBottomBorder, lessSpacing, dynamicSpacing, ...props }, ref) => (
+	ComponentPropsWithoutRef<typeof TabsPrimitive.List> & TabListStylesProps
+>(({ fullWidth, disableBottomBorder, gap, ...props }, ref) => (
 	<TabsPrimitive.List
 		ref={ref}
-		className={clsx(
-			'flex items-center border-gray-45',
-			lessSpacing && !dynamicSpacing && 'gap-3',
-			!lessSpacing && !dynamicSpacing && 'gap-6',
-			!lessSpacing && dynamicSpacing && 'gap-4 sm:gap-6',
-			fullWidth && 'flex-1',
-			!disableBottomBorder && 'border-b',
-		)}
+		className={tabListStyles({ fullWidth, disableBottomBorder, gap })}
 		{...props}
 	/>
 ));


### PR DESCRIPTION
## Description 
- Fit full name for tab lists
- Dynamically switching tab spacing for smaller mobile views

<img width="385" alt="Screenshot 2023-08-04 at 4 20 27 PM" src="https://github.com/MystenLabs/sui/assets/127577476/23f9229a-ed07-4ba0-bc4d-c6e3ab659034">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
