### PR TITLE
[Narwhal] add test for primary and worker RPC authorizations

### DIFF
--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -64,28 +64,6 @@ impl Authority {
         }
     }
 
-    // Allows creating Authority in tests.
-    pub fn new_for_test(
-        protocol_key: PublicKey,
-        stake: Stake,
-        primary_address: Multiaddr,
-        network_key: NetworkPublicKey,
-        hostname: String,
-    ) -> Self {
-        let protocol_key_bytes = PublicKeyBytes::from(&protocol_key);
-
-        Self {
-            id: Default::default(),
-            protocol_key,
-            protocol_key_bytes,
-            stake,
-            primary_address,
-            network_key,
-            hostname,
-            initialised: true,
-        }
-    }
-
     fn initialise(&mut self, id: AuthorityIdentifier) {
         self.id = id;
         self.initialised = true;

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -64,6 +64,28 @@ impl Authority {
         }
     }
 
+    // Allows creating Authority in tests.
+    pub fn new_for_test(
+        protocol_key: PublicKey,
+        stake: Stake,
+        primary_address: Multiaddr,
+        network_key: NetworkPublicKey,
+        hostname: String,
+    ) -> Self {
+        let protocol_key_bytes = PublicKeyBytes::from(&protocol_key);
+
+        Self {
+            id: Default::default(),
+            protocol_key,
+            protocol_key_bytes,
+            stake,
+            primary_address,
+            network_key,
+            hostname,
+            initialised: true,
+        }
+    }
+
     fn initialise(&mut self, id: AuthorityIdentifier) {
         self.id = id;
         self.initialised = true;

--- a/narwhal/network/src/client.rs
+++ b/narwhal/network/src/client.rs
@@ -3,12 +3,13 @@
 
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use anemo::{PeerId, Request};
+use anemo::{Network, PeerId, Request};
 use async_trait::async_trait;
 use crypto::{traits::KeyPair, NetworkKeyPair, NetworkPublicKey};
 use mysten_common::sync::notify_once::NotifyOnce;
 use parking_lot::RwLock;
 use tokio::{select, time::sleep};
+use tracing::error;
 use types::{
     error::LocalClientError, FetchBatchesRequest, FetchBatchesResponse, PrimaryToWorker,
     WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerSynchronizeMessage, WorkerToPrimary,
@@ -30,8 +31,9 @@ pub struct NetworkClient {
 }
 
 struct Inner {
-    // The private-public network key pair of this authority.
     primary_peer_id: PeerId,
+    primary_network: Option<Network>,
+    worker_network: BTreeMap<PeerId, Network>,
     worker_to_primary_handler: Option<Arc<dyn WorkerToPrimary>>,
     primary_to_worker_handler: BTreeMap<PeerId, Arc<dyn PrimaryToWorker>>,
     shutdown: bool,
@@ -45,6 +47,8 @@ impl NetworkClient {
         Self {
             inner: Arc::new(RwLock::new(Inner {
                 primary_peer_id,
+                primary_network: None,
+                worker_network: BTreeMap::new(),
                 worker_to_primary_handler: None,
                 primary_to_worker_handler: BTreeMap::new(),
                 shutdown: false,
@@ -59,7 +63,57 @@ impl NetworkClient {
 
     pub fn new_with_empty_id() -> Self {
         // ED25519_PUBLIC_KEY_LENGTH is 32 bytes.
-        Self::new(empty_peer_id())
+        Self::new(PeerId([0u8; 32]))
+    }
+
+    pub fn set_primary_network(&self, network: Network) {
+        let mut inner = self.inner.write();
+        if inner.primary_network.is_some() {
+            error!("Primary network is already set");
+        }
+        inner.primary_network = Some(network);
+    }
+
+    pub fn set_worker_network(&self, peer_id: PeerId, network: Network) {
+        let mut inner = self.inner.write();
+        if inner.worker_network.insert(peer_id, network).is_some() {
+            error!("Worker {} network is already set", peer_id);
+        }
+    }
+
+    pub async fn get_primary_network(&self) -> Result<Network, anemo::rpc::Status> {
+        for _ in 0..Self::GET_CLIENT_RETRIES {
+            {
+                let inner = self.inner.read();
+                if inner.shutdown {
+                    return Err(anemo::rpc::Status::internal("This node has shutdown"));
+                }
+                if let Some(network) = &inner.primary_network {
+                    return Ok(network.clone());
+                }
+            }
+            sleep(Self::GET_CLIENT_INTERVAL).await;
+        }
+        Err(anemo::rpc::Status::internal("Primary has not started"))
+    }
+
+    pub async fn get_worker_network(&self, peer_id: PeerId) -> Result<Network, anemo::rpc::Status> {
+        for _ in 0..Self::GET_CLIENT_RETRIES {
+            {
+                let inner = self.inner.read();
+                if inner.shutdown {
+                    return Err(anemo::rpc::Status::internal("This node has shutdown"));
+                }
+                if let Some(network) = inner.worker_network.get(&peer_id) {
+                    return Ok(network.clone());
+                }
+            }
+            sleep(Self::GET_CLIENT_INTERVAL).await;
+        }
+        Err(anemo::rpc::Status::internal(format!(
+            "The worker {} has not started",
+            peer_id
+        )))
     }
 
     pub fn set_worker_to_primary_local_handler(&self, handler: Arc<dyn WorkerToPrimary>) {
@@ -202,8 +256,4 @@ impl WorkerToPrimaryClient for NetworkClient {
             },
         }
     }
-}
-
-fn empty_peer_id() -> PeerId {
-    PeerId([0u8; 32])
 }

--- a/narwhal/network/src/p2p.rs
+++ b/narwhal/network/src/p2p.rs
@@ -99,7 +99,7 @@ impl ReliableNetwork<WorkerBatchMessage> for anemo::Network {
 impl WorkerRpc for anemo::Network {
     async fn request_batches(
         &self,
-        peer: NetworkPublicKey,
+        peer: &NetworkPublicKey,
         request: impl anemo::types::request::IntoRequest<RequestBatchesRequest> + Send,
     ) -> Result<RequestBatchesResponse> {
         let peer_id = PeerId(peer.0.to_bytes());

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -74,7 +74,7 @@ pub trait WorkerToPrimaryClient {
 pub trait WorkerRpc {
     async fn request_batches(
         &self,
-        peer: NetworkPublicKey,
+        peer: &NetworkPublicKey,
         request: impl anemo::types::request::IntoRequest<RequestBatchesRequest> + Send,
     ) -> Result<RequestBatchesResponse>;
 }

--- a/narwhal/primary/src/lib.rs
+++ b/narwhal/primary/src/lib.rs
@@ -25,6 +25,10 @@ mod metrics;
 #[path = "tests/certificate_tests.rs"]
 mod certificate_tests;
 
+#[cfg(test)]
+#[path = "tests/rpc_tests.rs"]
+mod rpc_tests;
+
 pub use crate::{
     metrics::PrimaryChannelMetrics,
     primary::{Primary, CHANNEL_CAPACITY, NUM_SHUTDOWN_RECEIVERS},

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -164,7 +164,6 @@ impl Primary {
             .replace_registered_new_certificates_metric(registry, Box::new(new_certificates_gauge));
 
         let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(0u64);
-        let (tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
         let synchronizer = Arc::new(Synchronizer::new(
             authority.id(),
@@ -178,7 +177,6 @@ impl Primary {
             tx_new_certificates,
             tx_parents,
             rx_consensus_round_updates.clone(),
-            rx_synchronizer_network,
             node_metrics.clone(),
             &primary_channel_metrics,
         ));
@@ -360,9 +358,7 @@ impl Primary {
                 }
             }
         }
-        if tx_synchronizer_network.send(network.clone()).is_err() {
-            panic!("Failed to send Network to Synchronizer!");
-        }
+        client.set_primary_network(network.clone());
 
         info!("Primary {} listening on {}", authority.id(), address);
 

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -17,7 +17,6 @@ use prometheus::Registry;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use storage::CertificateStore;
 use storage::NodeStorage;
-use tokio::sync::oneshot;
 
 use consensus::consensus::ConsensusRound;
 use test_utils::{latest_protocol_version, temp_dir, CommitteeFixture};
@@ -157,7 +156,6 @@ async fn fetch_certificates_basic() {
     // Signal rounds
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
         watch::channel(ConsensusRound::new(0, 0));
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Make a synchronizer for certificates.
     let synchronizer = Arc::new(Synchronizer::new(
@@ -172,7 +170,6 @@ async fn fetch_certificates_basic() {
         tx_new_certificates.clone(),
         tx_parents.clone(),
         rx_consensus_round_updates.clone(),
-        rx_synchronizer_network,
         metrics.clone(),
         &primary_channel_metrics,
     ));

--- a/narwhal/primary/src/tests/certifier_tests.rs
+++ b/narwhal/primary/src/tests/certifier_tests.rs
@@ -41,7 +41,6 @@ async fn propose_header() {
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
         watch::channel(ConsensusRound::new(0, 0));
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
     // Create a fake header.
@@ -113,7 +112,6 @@ async fn propose_header() {
         tx_new_certificates.clone(),
         tx_parents.clone(),
         rx_consensus_round_updates.clone(),
-        rx_synchronizer_network,
         metrics.clone(),
         &primary_channel_metrics,
     ));
@@ -159,7 +157,6 @@ async fn propose_header_failure() {
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
         watch::channel(ConsensusRound::default());
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
     // Create a fake header.
@@ -214,7 +211,6 @@ async fn propose_header_failure() {
         tx_new_certificates.clone(),
         tx_parents.clone(),
         rx_consensus_round_updates.clone(),
-        rx_synchronizer_network,
         metrics.clone(),
         &primary_channel_metrics,
     ));
@@ -281,7 +277,6 @@ async fn run_vote_aggregator_with_param(
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
         watch::channel(ConsensusRound::new(0, 0));
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
     let (header_store, certificate_store, payload_store) = create_db_stores();
 
     // Create a fake header.
@@ -348,7 +343,6 @@ async fn run_vote_aggregator_with_param(
         tx_new_certificates.clone(),
         tx_parents.clone(),
         rx_consensus_round_updates.clone(),
-        rx_synchronizer_network,
         metrics.clone(),
         &primary_channel_metrics,
     ));
@@ -402,7 +396,6 @@ async fn shutdown_core() {
     let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
     let (_tx_consensus_round_updates, rx_consensus_round_updates) =
         watch::channel(ConsensusRound::new(0, 0));
-    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
 
     // Create test stores.
     let (header_store, certificate_store, payload_store) = create_db_stores();
@@ -420,7 +413,6 @@ async fn shutdown_core() {
         tx_new_certificates.clone(),
         tx_parents.clone(),
         rx_consensus_round_updates.clone(),
-        rx_synchronizer_network,
         metrics.clone(),
         &primary_channel_metrics,
     ));

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -7,9 +7,8 @@ use crate::{
     synchronizer::Synchronizer,
     NUM_SHUTDOWN_RECEIVERS,
 };
-use config::{utils::get_available_port, Authority, AuthorityIdentifier, Committee, Parameters};
+use config::{AuthorityIdentifier, Committee, Parameters};
 use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
-use crypto::{KeyPair, NetworkKeyPair};
 use fastcrypto::{
     encoding::{Encoding, Hex},
     hash::Hash,
@@ -17,10 +16,8 @@ use fastcrypto::{
     traits::KeyPair as _,
 };
 use itertools::Itertools;
-use mysten_network::Multiaddr;
-use network::{client::NetworkClient, PrimaryToPrimaryRpc};
+use network::client::NetworkClient;
 use prometheus::Registry;
-use rand::thread_rng;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     num::NonZeroUsize,
@@ -35,7 +32,6 @@ use types::{
     MockPrimaryToWorker, PreSubscribedBroadcastSender, PrimaryToPrimary, RequestVoteRequest,
 };
 use worker::{metrics::initialise_metrics, TrivialTransactionValidator, Worker};
-
 
 #[tokio::test]
 async fn test_get_network_peers_from_admin_server() {

--- a/narwhal/primary/src/tests/rpc_tests.rs
+++ b/narwhal/primary/src/tests/rpc_tests.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anemo::PeerId;
+use config::AuthorityIdentifier;
+use network::{PrimaryToPrimaryRpc, WorkerRpc};
+use test_utils::cluster::Cluster;
+use types::{FetchCertificatesRequest, RequestBatchesRequest};
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_server_authorizations() {
+    // Set up primaries and workers with a committee.
+    let mut test_cluster = Cluster::new(None);
+    test_cluster.start(Some(4), Some(1), None).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let test_authority = test_cluster.authority(0);
+    let test_client = test_authority.client.clone();
+    let test_committee = test_cluster.committee.clone();
+    let test_worker_cache = test_cluster.worker_cache.clone();
+
+    // Reachable to primaries in the same committee.
+    {
+        let target_authority = test_committee.authority(&AuthorityIdentifier(1)).unwrap();
+
+        let primary_network = test_client.get_primary_network().await.unwrap();
+        let primary_target_name = target_authority.network_key();
+        let request = anemo::Request::new(FetchCertificatesRequest::default())
+            .with_timeout(Duration::from_secs(5));
+        primary_network
+            .fetch_certificates(&primary_target_name, request)
+            .await
+            .unwrap();
+
+        let worker_network = test_client.get_worker_network(0).await.unwrap();
+        let worker_target_name = test_worker_cache
+            .workers
+            .get(target_authority.protocol_key())
+            .unwrap()
+            .0
+            .get(&0)
+            .unwrap()
+            .name
+            .clone();
+        let request = anemo::Request::new(RequestBatchesRequest::default())
+            .with_timeout(Duration::from_secs(5));
+        worker_network
+            .request_batches(&worker_target_name, request)
+            .await
+            .unwrap();
+    }
+
+    // Set up primaries and workers with a another committee.
+    let mut unreachable_cluster = Cluster::new(None);
+    unreachable_cluster.start(Some(4), Some(1), None).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // test_client should not reach unreachable_authority.
+    {
+        let unreachable_committee = unreachable_cluster.committee.clone();
+        let unreachable_worker_cache = unreachable_cluster.worker_cache.clone();
+
+        let unreachable_authority = unreachable_committee
+            .authority(&AuthorityIdentifier(0))
+            .unwrap();
+        let primary_target_name = unreachable_authority.network_key();
+        let primary_peer_id: PeerId = PeerId(primary_target_name.0.to_bytes());
+        let primary_address = unreachable_authority.primary_address();
+        let primary_network = test_client.get_primary_network().await.unwrap();
+        primary_network
+            .connect_with_peer_id(primary_address.to_anemo_address().unwrap(), primary_peer_id)
+            .await
+            .unwrap();
+        let request = anemo::Request::new(FetchCertificatesRequest::default())
+            .with_timeout(Duration::from_secs(5));
+        // Removing the AllowedPeers RequireAuthorizationLayer for primary should make this succeed.
+        assert!(primary_network
+            .fetch_certificates(&primary_target_name, request)
+            .await
+            .is_err());
+
+        let worker_network = test_client.get_worker_network(0).await.unwrap();
+        let worker_target_name = unreachable_worker_cache
+            .workers
+            .get(unreachable_authority.protocol_key())
+            .unwrap()
+            .0
+            .get(&0)
+            .unwrap()
+            .name
+            .clone();
+        let request = anemo::Request::new(RequestBatchesRequest::default())
+            .with_timeout(Duration::from_secs(5));
+        // Removing the AllowedPeers RequireAuthorizationLayer for workers should make this succeed.
+        assert!(worker_network
+            .request_batches(&worker_target_name, request)
+            .await
+            .is_err());
+    }
+}

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -502,7 +502,7 @@ pub struct AuthorityDetails {
     pub id: usize,
     pub name: AuthorityIdentifier,
     pub public_key: PublicKey,
-    client: NetworkClient,
+    pub client: NetworkClient,
     internal: Arc<RwLock<AuthorityDetailsInternal>>,
 }
 
@@ -681,7 +681,7 @@ impl AuthorityDetails {
     }
 
     /// Returns the current primary node running as a clone. If the primary
-    ///node stops and starts again and it's needed by the user then this
+    /// node stops and starts again and it's needed by the user then this
     /// method should be called again to get the latest one.
     pub async fn primary(&self) -> PrimaryNodeDetails {
         let internal = self.internal.read().await;

--- a/narwhal/types/src/worker.rs
+++ b/narwhal/types/src/worker.rs
@@ -17,7 +17,7 @@ pub struct WorkerBatchMessage {
 }
 
 /// Used by primary to bulk request batches from workers local store.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RequestBatchesRequest {
     pub batch_digests: Vec<BatchDigest>,
 }

--- a/narwhal/worker/src/batch_fetcher.rs
+++ b/narwhal/worker/src/batch_fetcher.rs
@@ -333,7 +333,7 @@ impl RequestBatchesNetwork for RequestBatchesNetworkImpl {
     ) -> anyhow::Result<RequestBatchesResponse> {
         let request =
             anemo::Request::new(RequestBatchesRequest { batch_digests }).with_timeout(timeout);
-        self.network.request_batches(worker, request).await
+        self.network.request_batches(&worker, request).await
     }
 }
 

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -257,7 +257,6 @@ impl Worker {
 
         let network;
         let mut retries_left = 90;
-
         loop {
             let network_result = anemo::Network::bind(addr.clone())
                 .server_name("narwhal")
@@ -284,6 +283,7 @@ impl Worker {
                 }
             }
         }
+        client.set_worker_network(worker_peer_id, network.clone());
 
         info!("Worker {} listening to worker messages on {}", id, address);
 

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -283,7 +283,7 @@ impl Worker {
                 }
             }
         }
-        client.set_worker_network(worker_peer_id, network.clone());
+        client.set_worker_network(id, network.clone());
 
         info!("Worker {} listening to worker messages on {}", id, address);
 


### PR DESCRIPTION
## Description 

Use `NetworkClient` to plumb `anemo::Network` to components and tests.

Add a test for primary and worker RPC authorizations.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
