### PR TITLE
[move-compiler][sui-mode] Add init and one-time witness rules

### DIFF
--- a/crates/sui-framework/packages/sui-framework/tests/verifier_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/verifier_tests.move
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[test_only]
 /// Tests if normally illegal (in terms of Sui bytecode verification) code is allowed in tests.
 module sui::verifier_tests {
     struct VERIFIER_TESTS has drop {}
 
-    #[allow(unused_function)]
     fun init(otw: VERIFIER_TESTS, _: &mut sui::tx_context::TxContext) {
         assert!(sui::types::is_one_time_witness(&otw), 0);
     }

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -142,7 +142,7 @@ impl BuildConfig {
                     SelfTransferVerifier.visitor(),
                     CustomStateChangeVerifier.visitor(),
                     CoinFieldVisitor.visitor(),
-                    FreezeWrappedVisitor::default().visitor(),
+                    FreezeWrappedVisitor.visitor(),
                     CollectionEqualityVisitor.visitor(),
                 ];
                 let (filter_attr_name, filters) = known_filters();

--- a/crates/sui-move-build/src/linters/coin_field.rs
+++ b/crates/sui-move-build/src/linters/coin_field.rs
@@ -11,7 +11,7 @@ use move_compiler::{
     expansion::ast as E,
     naming::ast as N,
     shared::{CompilationEnv, Identifier},
-    typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
+    typing::{ast as T, core::TypingProgramInfo, visitor::TypingVisitor},
 };
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
@@ -36,7 +36,7 @@ impl TypingVisitor for CoinFieldVisitor {
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
-        _program_info: &ProgramInfo,
+        _program_info: &TypingProgramInfo,
         program: &mut T::Program,
     ) {
         for (_, _, mdef) in program.modules.iter() {

--- a/crates/sui-move-build/src/linters/collection_equality.rs
+++ b/crates/sui-move-build/src/linters/collection_equality.rs
@@ -11,7 +11,11 @@ use move_compiler::{
     naming::ast as N,
     parser::ast as P,
     shared::{CompilationEnv, Identifier},
-    typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
+    typing::{
+        ast as T,
+        core::ProgramInfo,
+        visitor::{TypingVisitorConstructor, TypingVisitorContext},
+    },
 };
 
 use super::{
@@ -50,15 +54,24 @@ const COLLECTION_TYPES: &[(&str, &str, &str)] = &[
 ];
 
 pub struct CollectionEqualityVisitor;
+pub struct Context<'a> {
+    env: &'a mut CompilationEnv,
+}
 
-impl TypingVisitor for CollectionEqualityVisitor {
-    fn visit_exp_custom(
-        &mut self,
-        exp: &T::Exp,
-        env: &mut CompilationEnv,
-        _program_info: &ProgramInfo,
+impl TypingVisitorConstructor for CollectionEqualityVisitor {
+    type Context<'a> = Context<'a>;
+
+    fn context<'a>(
+        env: &'a mut CompilationEnv,
+        _program_info: &'a ProgramInfo,
         _program: &T::Program,
-    ) -> bool {
+    ) -> Self::Context<'a> {
+        Context { env }
+    }
+}
+
+impl TypingVisitorContext for Context<'_> {
+    fn visit_exp_custom(&mut self, exp: &mut T::Exp) -> bool {
         use T::UnannotatedExp_ as E;
         if let E::BinopExp(_, op, t, _) = &exp.exp.value {
             if op.value != P::BinOp_::Eq && op.value != P::BinOp_::Neq {
@@ -87,10 +100,18 @@ impl TypingVisitor for CollectionEqualityVisitor {
                     format!("Equality for collections of type '{caddr}::{cmodule}::{cname}' IS NOT a structural check based on content");
                 let mut d = diag!(COLLECTIONS_EQUALITY_DIAG, (op.loc, msg),);
                 d.add_note(note_msg);
-                env.add_diag(d);
+                self.env.add_diag(d);
                 return true;
             }
         }
         false
+    }
+
+    fn add_warning_filter_scope(&mut self, filter: move_compiler::diagnostics::WarningFilters) {
+        self.env.add_warning_filter_scope(filter)
+    }
+
+    fn pop_warning_filter_scope(&mut self) {
+        self.env.pop_warning_filter_scope()
     }
 }

--- a/crates/sui-move-build/src/linters/collection_equality.rs
+++ b/crates/sui-move-build/src/linters/collection_equality.rs
@@ -13,7 +13,7 @@ use move_compiler::{
     shared::{CompilationEnv, Identifier},
     typing::{
         ast as T,
-        core::ProgramInfo,
+        core::TypingProgramInfo,
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
 };
@@ -63,7 +63,7 @@ impl TypingVisitorConstructor for CollectionEqualityVisitor {
 
     fn context<'a>(
         env: &'a mut CompilationEnv,
-        _program_info: &'a ProgramInfo,
+        _program_info: &'a TypingProgramInfo,
         _program: &T::Program,
     ) -> Self::Context<'a> {
         Context { env }

--- a/crates/sui-move-build/src/linters/freeze_wrapped.rs
+++ b/crates/sui-move-build/src/linters/freeze_wrapped.rs
@@ -12,11 +12,11 @@ use move_compiler::{
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
     expansion::ast as E,
     naming::ast as N,
-    parser::ast as P,
+    parser::ast::{self as P, Ability_},
     shared::{CompilationEnv, Identifier},
     typing::{
         ast as T,
-        core::ProgramInfo,
+        core::TypingProgramInfo,
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
 };
@@ -41,31 +41,13 @@ const FREEZE_FUNCTIONS: &[(&str, &str, &str)] = &[
     (SUI_PKG_NAME, TRANSFER_MOD_NAME, FREEZE_FUN),
 ];
 
-/// Information about a field.
-#[derive(Debug, Clone)]
-struct FieldInfo {
+/// Information about a field that wraps other objects.
+#[derive(Debug, Clone, Copy)]
+struct WrappingFieldInfo {
     /// Name of the field
     fname: Symbol,
     /// Location of the field type
     ftype_loc: Loc,
-    /// Abilities of the field type
-    abilities: Option<E::AbilitySet>,
-}
-
-impl FieldInfo {
-    fn new(fname: Symbol, ftype_loc: Loc, abilities: Option<E::AbilitySet>) -> Self {
-        Self {
-            fname,
-            ftype_loc,
-            abilities,
-        }
-    }
-}
-
-/// Information about a field that wraps other objects.
-#[derive(Debug, Clone)]
-struct WrappingFieldInfo {
-    finfo: FieldInfo,
     /// Location of the type of the wrapped object.
     wrapped_type_loc: Loc,
     /// Is the wrapping direct or indirect
@@ -74,28 +56,12 @@ struct WrappingFieldInfo {
 
 impl WrappingFieldInfo {
     fn new(fname: Symbol, ftype_loc: Loc, wrapped_type_loc: Loc, direct: bool) -> Self {
-        let finfo = FieldInfo::new(fname, ftype_loc, None);
         Self {
-            finfo,
+            fname,
+            ftype_loc,
             wrapped_type_loc,
             direct,
         }
-    }
-
-    fn fname(&self) -> Symbol {
-        self.finfo.fname
-    }
-
-    fn ftype_loc(&self) -> Loc {
-        self.finfo.ftype_loc
-    }
-
-    fn wrapped_type_loc(&self) -> Loc {
-        self.wrapped_type_loc
-    }
-
-    fn direct(&self) -> bool {
-        self.direct
     }
 }
 
@@ -106,7 +72,7 @@ pub struct FreezeWrappedVisitor;
 
 pub struct Context<'a> {
     env: &'a mut CompilationEnv,
-    program_info: &'a ProgramInfo,
+    program_info: &'a TypingProgramInfo,
     /// Memoizes information about struct fields wrapping other objects as they are discovered
     wrapping_fields: WrappingFields,
 }
@@ -116,7 +82,7 @@ impl TypingVisitorConstructor for FreezeWrappedVisitor {
 
     fn context<'a>(
         env: &'a mut CompilationEnv,
-        program_info: &'a ProgramInfo,
+        program_info: &'a TypingProgramInfo,
         _program: &T::Program,
     ) -> Self::Context<'a> {
         Context {
@@ -135,28 +101,23 @@ impl<'a> TypingVisitorContext for Context<'a> {
                 fun.module.value.is(*addr, *module) && &fun.name.value().as_str() == fname
             }) {
                 let Some(bt) = base_type(&fun.type_arguments[0]) else {
-                        // not an (potentially dereferenced) N::Type_::Apply nor N::Type_::Param
-                        return false;
-                    };
+                    // not an (potentially dereferenced) N::Type_::Apply nor N::Type_::Param
+                    return false;
+                };
                 let N::Type_::Apply(_,tname, _) = &bt.value else {
-                        // not a struct type
-                        return false;
-                    };
+                    // not a struct type
+                    return false;
+                };
                 let N::TypeName_::ModuleType(mident, sname) = tname.value else {
-                        // struct with a given name not found
-                        return true;
-                    };
-                if let Some(wrapping_field_info) = self.find_wrapping_field_loc(
-                    mident, sname, /* outer_field_info */ None, /* field_depth  */ 0,
-                ) {
+                    // struct with a given name not found
+                    return false;
+                };
+                if let Some(wrapping_field_info) = self.find_wrapping_field_loc(mident, sname) {
                     add_diag(
                         self.env,
                         fun.arguments.exp.loc,
                         sname.value(),
-                        wrapping_field_info.fname(),
-                        wrapping_field_info.ftype_loc(),
-                        wrapping_field_info.wrapped_type_loc(),
-                        wrapping_field_info.direct(),
+                        wrapping_field_info,
                     );
                 }
             }
@@ -175,58 +136,38 @@ impl<'a> TypingVisitorContext for Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn struct_fields(
-        &mut self,
-        sname: &P::StructName,
-        mident: &E::ModuleIdent,
-    ) -> Option<(&'a E::Fields<N::Type>, Loc)> {
-        let sdef = self.program_info.struct_definition(mident, sname);
-        if let N::StructFields::Defined(sfields) = &sdef.fields {
-            let loc = self.program_info.struct_declared_loc(mident, sname);
-            return Some((sfields, loc));
-        }
-        None
-    }
-
     /// Checks if a given field (identified by ftype and fname) wraps other objects and, if so,
     /// returns its location and information on whether wrapping is direct or indirect.
     fn wraps_object(
         &mut self,
-        ftype: &N::Type,
-        fname: Symbol,
-        field_depth: usize,
+        sp!(_, ftype_): &N::Type,
     ) -> Option<(Loc, /* direct wrapping */ bool)> {
         use N::Type_ as T;
-        let Some(bt) = base_type(ftype) else{
-            return None;
-        };
-        let sp!(_, bt) = bt;
-        match bt {
+        match ftype_ {
             T::Param(p) => {
                 if p.abilities.has_ability_(P::Ability_::Key) {
-                    return Some((p.user_specified_name.loc, field_depth == 1));
+                    Some((p.user_specified_name.loc, true))
+                } else {
+                    None
                 }
-                None
             }
-            T::Apply(abilities, tname, _) => {
-                if let N::TypeName_::ModuleType(mident, sname) = tname.value {
-                    // don't have to check all variants of H::TypeName_ as only H::TypeName_::ModuleType
-                    // can be a struct or have abilities
-                    if let Some(wrapping_field_info) = self.find_wrapping_field_loc(
-                        mident,
-                        sname,
-                        Some(FieldInfo::new(fname, ftype.loc, abilities.clone())),
-                        field_depth,
-                    ) {
-                        return Some((
-                            wrapping_field_info.wrapped_type_loc,
-                            wrapping_field_info.direct,
-                        ));
-                    }
+            T::Apply(Some(abilities), sp!(_, N::TypeName_::ModuleType(mident, sname)), _) => {
+                if abilities.has_ability_(Ability_::Key) {
+                    let sloc = self.program_info.struct_declared_loc(mident, sname);
+                    Some((sloc, true))
+                } else {
+                    self.find_wrapping_field_loc(*mident, *sname)
+                        .as_ref()
+                        .map(|info| (info.wrapped_type_loc, false))
                 }
-                None
             }
-            T::Unit | T::Ref(_, _) | T::Var(_) | T::Anything | T::UnresolvedError => None,
+            T::Apply(None, _, _) => unreachable!("ICE type expansion should have occurred"),
+            T::Apply(_, _, _)
+            | T::Unit
+            | T::Ref(_, _)
+            | T::Var(_)
+            | T::Anything
+            | T::UnresolvedError => None,
         }
     }
 
@@ -238,110 +179,40 @@ impl<'a> Context<'a> {
         &mut self,
         mident: E::ModuleIdent,
         sname: P::StructName,
-        outer_field_info: Option<FieldInfo>,
-        field_depth: usize,
     ) -> Option<WrappingFieldInfo> {
-        let (wrapping_field_info, info_inserted) = self.get_wrapping_field(&mident, &sname);
-        if wrapping_field_info.is_some() {
-            // found memoized field wrapping an object
-            return wrapping_field_info;
+        let memoized_info = self
+            .wrapping_fields
+            .get(&mident)
+            .and_then(|m| m.get(&sname));
+        if memoized_info.is_none() {
+            let info = self.find_wrapping_field_loc_impl(mident, sname);
+            self.wrapping_fields
+                .entry(mident)
+                .or_default()
+                .insert(sname, info);
         }
-        if info_inserted {
-            // did not find fields wrapping object in the past - makes no sense to keep looking
-            return None;
-        }
-        let Some((sfields, sloc)) = self.struct_fields(&sname, &mident) else {
-            return None;
-        };
-
-        // In this function we may be either looking at the top level struct (to find whether it has
-        // fields wrapping object) or for a nested struct representing a type of one of the outer
-        // fields (to find whether it is a wrapped object or its fields have wrapped object). In the
-        // latter case (that's when struct_abilities is Some) we need to check if the struct itself
-        // is an object.
-        if let Some(outer_info) = outer_field_info {
-            if let Some(ability_set) = outer_info.abilities {
-                if ability_set.has_ability_(P::Ability_::Key) {
-                    return Some(WrappingFieldInfo::new(
-                        outer_info.fname,
-                        outer_info.ftype_loc,
-                        sloc,
-                        field_depth == 1,
-                    ));
-                }
-            }
-        }
-
-        let wrapping_field_info = sfields.iter().find_map(|(_, fname, (_, ftype))| {
-            let res = self.wraps_object(ftype, *fname, field_depth + 1);
-            if let Some((wrapped_tloc, direct)) = res {
-                // a field wrapping an object found - memoize it
-                return Some(self.insert_wrapping_field(
-                    mident,
-                    sname,
-                    *fname,
-                    ftype.loc,
-                    wrapped_tloc,
-                    direct,
-                ));
-            }
-            None
-        });
-
-        if wrapping_field_info.is_none() {
-            // no field containing wrapped objects was found in a given struct
-            self.insert_no_wrapping_field(mident, sname);
-        }
-        wrapping_field_info
+        *self
+            .wrapping_fields
+            .get(&mident)
+            .and_then(|m| m.get(&sname))
+            .unwrap()
     }
 
-    /// Memoizes information about a field wrapping other objects in WrappingFields.
-    fn insert_wrapping_field(
+    fn find_wrapping_field_loc_impl(
         &mut self,
         mident: E::ModuleIdent,
         sname: P::StructName,
-        fname: Symbol,
-        ftype_loc: Loc,
-        wrapped_type_loc: Loc,
-        direct: bool,
-    ) -> WrappingFieldInfo {
-        let wrapping_field_info =
-            WrappingFieldInfo::new(fname, ftype_loc, wrapped_type_loc, direct);
-        self.wrapping_fields
-            .entry(mident)
-            .or_insert_with(BTreeMap::new)
-            .insert(sname, Some(wrapping_field_info.clone()));
-        wrapping_field_info
-    }
-
-    /// Memoizes information about lack of fields wrapping other object in a given struct in
-    /// WrappingFields.
-    fn insert_no_wrapping_field(&mut self, mident: E::ModuleIdent, sname: P::StructName) {
-        self.wrapping_fields
-            .entry(mident)
-            .or_insert_with(BTreeMap::new)
-            .insert(sname, None);
-    }
-
-    /// Returns information about whether there exists a memoized field of a given struct wrapping
-    /// other objects:
-    /// - (Some(WrappingfieldInfo), true) if info was inserted and there is such a field
-    /// - (None, true)                    if info was inserted and there is no such a field
-    /// - (None, false)                   if info was not inserted previously
-    fn get_wrapping_field(
-        &self,
-        mident: &E::ModuleIdent,
-        sname: &P::StructName,
-    ) -> (Option<WrappingFieldInfo>, bool) {
-        let mut info_inserted = false;
-        let Some(structs) = self.wrapping_fields.get(mident) else {
-            return (None, info_inserted);
+    ) -> Option<WrappingFieldInfo> {
+        let sdef = self.program_info.struct_definition(&mident, &sname);
+        let N::StructFields::Defined(sfields) = &sdef.fields else {
+            return None
         };
-        let Some(wrapping_field_info) = structs.get(sname) else {
-            return (None, info_inserted);
-        };
-        info_inserted = true;
-        (wrapping_field_info.clone(), info_inserted)
+        sfields.iter().find_map(|(_, fname, (_, ftype))| {
+            let res = self.wraps_object(ftype);
+            res.map(|(wrapped_tloc, direct)| {
+                WrappingFieldInfo::new(*fname, ftype.loc, wrapped_tloc, direct)
+            })
+        })
     }
 }
 
@@ -349,11 +220,14 @@ fn add_diag(
     env: &mut CompilationEnv,
     freeze_arg_loc: Loc,
     frozen_struct_name: Symbol,
-    frozen_field_name: Symbol,
-    frozen_field_tloc: Loc,
-    wrapped_tloc: Loc,
-    direct: bool,
+    info: WrappingFieldInfo,
 ) {
+    let WrappingFieldInfo {
+        fname: frozen_field_name,
+        ftype_loc: frozen_field_tloc,
+        wrapped_type_loc: wrapped_tloc,
+        direct,
+    } = info;
     let msg = format!(
         "Freezing an object of type '{frozen_struct_name}' also \
          freezes all objects wrapped in its field '{frozen_field_name}'."

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -69,7 +69,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         SelfTransferVerifier.visitor(),
         CustomStateChangeVerifier.visitor(),
         CoinFieldVisitor.visitor(),
-        FreezeWrappedVisitor::default().visitor(),
+        FreezeWrappedVisitor.visitor(),
         CollectionEqualityVisitor.visitor(),
     ];
     let (filter_attr_name, filters) = known_filters_for_test();

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 6-16:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last (and at most second) parameter for _::m::init to be &mut sui::tx_context::TxContext or &sui::tx_context::TxContext; optional first parameter must be of one-time witness type whose name is the same as the capitalized module name (_::m::M) and which has no fields or a single field of type bool"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.mvir
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Incorrect, more than one field means not a OTW
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+
+    struct M has drop { some_field: bool, some_field2: bool  }
+
+    init(_otw: Self.M, _ctx: &mut tx_context.TxContext) {
+        label l0:
+        return;
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.exp
@@ -1,0 +1,6 @@
+processed 1 task
+
+task 0 'publish'. lines 6-14:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4005200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.mvir
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Since it is not a OTW (because of the multiple fields), we can pack it
+
+//# publish
+module 0x0.m {
+    struct M has drop { some_field: bool, some_field2: bool  }
+
+    public new(): Self.M {
+        label l0:
+        return M { some_field: false, some_field2: true };
+    }
+}

--- a/external-crates/move/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/move-compiler/src/expansion/ast.rs
@@ -187,7 +187,7 @@ pub enum StructFields {
 // Functions
 //**************************************************************************************************
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Visibility {
     Public(Loc),
     Friend(Loc),

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -611,6 +611,23 @@ impl Type_ {
             _ => None,
         }
     }
+
+    pub fn type_name(&self) -> Option<&TypeName> {
+        match self {
+            Type_::Apply(_, tn, _) => Some(tn),
+            _ => None,
+        }
+    }
+
+    pub fn is(
+        &self,
+        address: impl AsRef<str>,
+        module: impl AsRef<str>,
+        name: impl AsRef<str>,
+    ) -> bool {
+        self.type_name()
+            .is_some_and(|tn| tn.value.is(address, module, name))
+    }
 }
 
 impl Value_ {

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -8,7 +8,9 @@ use crate::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes, Fields,
         Friend, ModuleIdent, SpecId, Value, Value_, Visibility,
     },
-    parser::ast::{BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER},
+    parser::ast::{
+        Ability_, BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER,
+    },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
@@ -627,6 +629,28 @@ impl Type_ {
     ) -> bool {
         self.type_name()
             .is_some_and(|tn| tn.value.is(address, module, name))
+    }
+
+    pub fn abilities(&self, loc: Loc) -> Option<AbilitySet> {
+        match self {
+            Type_::Apply(abilities, _, _) => abilities.clone(),
+            Type_::Param(tp) => Some(tp.abilities.clone()),
+            Type_::Unit => Some(AbilitySet::collection(loc)),
+            Type_::Ref(_, _) => Some(AbilitySet::references(loc)),
+            Type_::Anything | Type_::UnresolvedError => Some(AbilitySet::all(loc)),
+            Type_::Var(_) => None,
+        }
+    }
+
+    pub fn has_ability_(&self, ability: Ability_) -> Option<bool> {
+        match self {
+            Type_::Apply(abilities, _, _) => abilities.as_ref().map(|s| s.has_ability_(ability)),
+            Type_::Param(tp) => Some(tp.abilities.has_ability_(ability)),
+            Type_::Unit => Some(AbilitySet::COLLECTION.contains(&ability)),
+            Type_::Ref(_, _) => Some(AbilitySet::REFERENCES.contains(&ability)),
+            Type_::Anything | Type_::UnresolvedError => Some(true),
+            Type_::Var(_) => None,
+        }
     }
 }
 

--- a/external-crates/move/move-compiler/src/shared/unique_map.rs
+++ b/external-crates/move/move-compiler/src/shared/unique_map.rs
@@ -178,6 +178,11 @@ impl<K: TName, V> UniqueMap<K, V> {
         self.into_iter()
     }
 
+    pub fn key_cloned_iter_mut(&mut self) -> impl Iterator<Item = (K, &mut V)> {
+        self.into_iter()
+            .map(|(loc, k_, v)| (K::add_loc(loc, k_.clone()), v))
+    }
+
     pub fn maybe_from_opt_iter(
         iter: impl Iterator<Item = Option<(K, V)>>,
     ) -> Option<Result<UniqueMap<K, V>, (K::Key, K::Loc, K::Loc)>> {

--- a/external-crates/move/move-compiler/src/shared/unique_map.rs
+++ b/external-crates/move/move-compiler/src/shared/unique_map.rs
@@ -69,7 +69,21 @@ impl<K: TName, V> UniqueMap<K, V> {
     }
 
     pub fn get_key(&self, key: &K) -> Option<&K::Key> {
-        self.0.get_key_value(key.borrow().1).map(|(k, _v)| k)
+        self.get_key_(key.borrow().1)
+    }
+
+    pub fn get_key_(&self, key: &K::Key) -> Option<&K::Key> {
+        self.0.get_key_value(key).map(|(k, _v)| k)
+    }
+
+    pub fn get_full_key(&self, key: &K) -> Option<K> {
+        self.get_full_key_(key.borrow().1)
+    }
+
+    pub fn get_full_key_(&self, key: &K::Key) -> Option<K> {
+        self.0
+            .get_key_value(key)
+            .map(|(k, (loc, _))| K::add_loc(*loc, k.clone()))
     }
 
     pub fn remove(&mut self, key: &K) -> Option<V> {

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -68,3 +68,31 @@ pub const ENTRY_FUN_SIGNATURE_DIAG: DiagnosticInfo = custom(
     /* code */ 2,
     "invalid 'entry' function signature",
 );
+pub const INIT_FUN_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 3,
+    "invalid 'init' function",
+);
+pub const OTW_DECL_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 4,
+    "invalid one-time witness declaration",
+);
+pub const OTW_USAGE_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 5,
+    "invalid one-time witness usage",
+);
+pub const INIT_CALL_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 6,
+    "invalid 'init' call",
+);

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -28,6 +28,8 @@ pub const UID_TYPE_NAME: Symbol = symbol!("UID");
 pub const ID_TYPE_NAME: Symbol = symbol!("ID");
 pub const TX_CONTEXT_MODULE_NAME: Symbol = symbol!("tx_context");
 pub const TX_CONTEXT_TYPE_NAME: Symbol = symbol!("TxContext");
+pub const SUI_MODULE_NAME: Symbol = symbol!("sui");
+pub const SUI_OTW_NAME: Symbol = symbol!("SUI");
 
 pub const SUI_SYSTEM_ADDR_NAME: Symbol = symbol!("sui_system");
 pub const SUI_SYSTEM_MODULE_NAME: Symbol = symbol!("sui_system");

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -87,11 +87,11 @@ pub struct Context<'env> {
 }
 
 impl ProgramInfo {
-    fn module(&self, m: &ModuleIdent) -> &ModuleInfo {
+    pub fn module(&self, m: &ModuleIdent) -> &ModuleInfo {
         self.0.get(m).expect("ICE should have failed in naming")
     }
 
-    fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
+    pub fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
         let minfo = self.module(m);
         minfo
             .structs
@@ -104,10 +104,14 @@ impl ProgramInfo {
     }
 
     pub fn struct_declared_loc(&self, m: &ModuleIdent, n: &StructName) -> Loc {
+        self.struct_declared_loc_(m, &n.0.value)
+    }
+
+    pub fn struct_declared_loc_(&self, m: &ModuleIdent, n: &Symbol) -> Loc {
         let minfo = self.module(m);
         *minfo
             .structs
-            .get_loc(n)
+            .get_loc_(n)
             .expect("ICE should have failed in naming")
     }
 

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -46,8 +46,8 @@ pub fn program(
     assert!(context.constraints.is_empty());
     recursive_structs::modules(context.env, &modules);
     infinite_instantiations::modules(context.env, &modules);
-    let module_info = context.modules;
     let mut prog = T::Program { modules, scripts };
+    let module_info = core::TypingProgramInfo::new(pre_compiled_lib, &prog);
     for v in &compilation_env.visitors().typing {
         let mut v = v.borrow_mut();
         v.visit(compilation_env, &module_info, &mut prog);

--- a/external-crates/move/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/move-compiler/src/typing/visitor.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::WarningFilters;
 use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::FunctionName;
 use crate::shared::CompilationEnv;
-use crate::typing::{ast as T, core::ProgramInfo};
+use crate::typing::{ast as T, core::TypingProgramInfo};
 use move_symbol_pool::Symbol;
 
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
@@ -15,7 +15,7 @@ pub trait TypingVisitor {
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
+        program_info: &TypingProgramInfo,
         program: &mut T::Program,
     );
 
@@ -32,14 +32,14 @@ pub trait TypingVisitorConstructor {
 
     fn context<'a>(
         env: &'a mut CompilationEnv,
-        program_info: &'a ProgramInfo,
+        program_info: &'a TypingProgramInfo,
         program: &T::Program,
     ) -> Self::Context<'a>;
 
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
+        program_info: &TypingProgramInfo,
         program: &mut T::Program,
     ) {
         let mut context = Self::context(env, program_info, program);
@@ -210,7 +210,7 @@ impl<V: TypingVisitorConstructor> TypingVisitor for V {
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
+        program_info: &TypingProgramInfo,
         program: &mut T::Program,
     ) {
         self.visit(env, program_info, program)

--- a/external-crates/move/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/move-compiler/src/typing/visitor.rs
@@ -2,142 +2,189 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::command_line::compiler::Visitor;
+use crate::diagnostics::WarningFilters;
+use crate::expansion::ast::ModuleIdent;
+use crate::parser::ast::FunctionName;
 use crate::shared::CompilationEnv;
 use crate::typing::{ast as T, core::ProgramInfo};
+use move_symbol_pool::Symbol;
 
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
 
 pub trait TypingVisitor {
+    fn visit(
+        &mut self,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &mut T::Program,
+    );
+
     fn visitor(self) -> Visitor
     where
         Self: 'static + Sized,
     {
         Visitor::TypingVisitor(Box::new(self))
     }
+}
 
-    /// By default, the visitor will visit all all expressions in all functions in all modules. A
-    /// custom version should of this function should be created if different type of analysis is
-    /// required.
+pub trait TypingVisitorConstructor {
+    type Context<'a>: Sized + TypingVisitorContext;
+
+    fn context<'a>(
+        env: &'a mut CompilationEnv,
+        program_info: &'a ProgramInfo,
+        program: &T::Program,
+    ) -> Self::Context<'a>;
+
     fn visit(
         &mut self,
         env: &mut CompilationEnv,
         program_info: &ProgramInfo,
         program: &mut T::Program,
     ) {
-        for (_, _, mdef) in program.modules.iter() {
-            env.add_warning_filter_scope(mdef.warning_filter.clone());
+        let mut context = Self::context(env, program_info, program);
+        context.visit(program);
+    }
+}
 
-            for (_, _, fdef) in mdef.functions.iter() {
-                env.add_warning_filter_scope(fdef.warning_filter.clone());
+pub trait TypingVisitorContext {
+    fn add_warning_filter_scope(&mut self, filter: WarningFilters);
+    fn pop_warning_filter_scope(&mut self);
 
-                if let T::FunctionBody_::Defined(seq) = &fdef.body.value {
-                    self.visit_seq(seq, env, program_info, program);
-                }
+    fn visit_module_custom(
+        &mut self,
+        _ident: ModuleIdent,
+        _mdef: &mut T::ModuleDefinition,
+    ) -> bool {
+        false
+    }
+    fn visit_script_custom(&mut self, _name: Symbol, _script: &mut T::Script) -> bool {
+        false
+    }
 
-                env.pop_warning_filter_scope();
+    /// By default, the visitor will visit all all expressions in all functions in all modules. A
+    /// custom version should of this function should be created if different type of analysis is
+    /// required.
+    fn visit(&mut self, program: &mut T::Program) {
+        for (mident, mdef) in program.modules.key_cloned_iter_mut() {
+            self.add_warning_filter_scope(mdef.warning_filter.clone());
+            if self.visit_module_custom(mident, mdef) {
+                self.pop_warning_filter_scope();
+                continue;
             }
 
-            env.pop_warning_filter_scope();
+            for (function_name, fdef) in mdef.functions.key_cloned_iter_mut() {
+                self.visit_function(Some(mident), function_name, fdef)
+            }
+
+            self.pop_warning_filter_scope();
+        }
+        for (name, script) in &mut program.scripts {
+            self.add_warning_filter_scope(script.warning_filter.clone());
+            if self.visit_script_custom(*name, script) {
+                self.pop_warning_filter_scope();
+                continue;
+            }
+
+            self.visit_function(None, script.function_name, &mut script.function);
+            self.pop_warning_filter_scope();
         }
     }
 
-    fn visit_seq(
+    fn visit_function_custom(
         &mut self,
-        seq: &T::Sequence,
-        env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
-        program: &T::Program,
+        _module: Option<ModuleIdent>,
+        _function_name: FunctionName,
+        _fdef: &mut T::Function,
+    ) -> bool {
+        false
+    }
+    fn visit_function(
+        &mut self,
+        module: Option<ModuleIdent>,
+        function_name: FunctionName,
+        fdef: &mut T::Function,
     ) {
+        self.add_warning_filter_scope(fdef.warning_filter.clone());
+        if self.visit_function_custom(module, function_name, fdef) {
+            self.pop_warning_filter_scope();
+            return;
+        }
+        if let T::FunctionBody_::Defined(seq) = &mut fdef.body.value {
+            self.visit_seq(seq);
+        }
+        self.pop_warning_filter_scope();
+    }
+
+    fn visit_seq(&mut self, seq: &mut T::Sequence) {
         for s in seq {
-            self.visit_seq_item(s, env, program_info, program);
+            self.visit_seq_item(s);
         }
     }
 
-    fn visit_seq_item(
-        &mut self,
-        sp!(_, seq_item): &T::SequenceItem,
-        env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
-        program: &T::Program,
-    ) {
+    fn visit_seq_item(&mut self, sp!(_, seq_item): &mut T::SequenceItem) {
         use T::SequenceItem_ as SI;
         match seq_item {
-            SI::Seq(e) => self.visit_exp(e, env, program_info, program),
+            SI::Seq(e) => self.visit_exp(e),
             SI::Declare(_) => (),
-            SI::Bind(_, _, e) => self.visit_exp(e, env, program_info, program),
+            SI::Bind(_, _, e) => self.visit_exp(e),
         }
     }
 
     /// Custom visit for an expression. It will skip `visit_exp` if `visit_exp_custom` returns true.
-    fn visit_exp_custom(
-        &mut self,
-        _exp: &T::Exp,
-        _env: &mut CompilationEnv,
-        _program_info: &ProgramInfo,
-        _program: &T::Program,
-    ) -> bool {
+    fn visit_exp_custom(&mut self, _exp: &mut T::Exp) -> bool {
         false
     }
 
-    fn visit_exp(
-        &mut self,
-        exp: &T::Exp,
-        env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
-        program: &T::Program,
-    ) {
+    fn visit_exp(&mut self, exp: &mut T::Exp) {
         use T::UnannotatedExp_ as E;
-        if self.visit_exp_custom(exp, env, program_info, program) {
+        if self.visit_exp_custom(exp) {
             return;
         }
-        let sp!(_, uexp) = &exp.exp;
+        let sp!(_, uexp) = &mut exp.exp;
         match uexp {
-            E::ModuleCall(c) => self.visit_exp(&c.arguments, env, program_info, program),
-            E::Builtin(_, e) => self.visit_exp(e, env, program_info, program),
-            E::Vector(_, _, _, e) => self.visit_exp(e, env, program_info, program),
+            E::ModuleCall(c) => self.visit_exp(&mut c.arguments),
+            E::Builtin(_, e) => self.visit_exp(e),
+            E::Vector(_, _, _, e) => self.visit_exp(e),
             E::IfElse(e1, e2, e3) => {
-                self.visit_exp(e1, env, program_info, program);
-                self.visit_exp(e2, env, program_info, program);
-                self.visit_exp(e3, env, program_info, program);
+                self.visit_exp(e1);
+                self.visit_exp(e2);
+                self.visit_exp(e3);
             }
             E::While(e1, e2) => {
-                self.visit_exp(e1, env, program_info, program);
-                self.visit_exp(e2, env, program_info, program);
+                self.visit_exp(e1);
+                self.visit_exp(e2);
             }
-            E::Loop { has_break: _, body } => self.visit_exp(body, env, program_info, program),
-            E::Block(seq) => self.visit_seq(seq, env, program_info, program),
-            E::Assign(_, _, e) => self.visit_exp(e, env, program_info, program),
+            E::Loop { has_break: _, body } => self.visit_exp(body),
+            E::Block(seq) => self.visit_seq(seq),
+            E::Assign(_, _, e) => self.visit_exp(e),
             E::Mutate(e1, e2) => {
-                self.visit_exp(e1, env, program_info, program);
-                self.visit_exp(e2, env, program_info, program);
+                self.visit_exp(e1);
+                self.visit_exp(e2);
             }
-            E::Return(e) => self.visit_exp(e, env, program_info, program),
-            E::Abort(e) => self.visit_exp(e, env, program_info, program),
-            E::Dereference(e) => self.visit_exp(e, env, program_info, program),
-            E::UnaryExp(_, e) => self.visit_exp(e, env, program_info, program),
+            E::Return(e) => self.visit_exp(e),
+            E::Abort(e) => self.visit_exp(e),
+            E::Dereference(e) => self.visit_exp(e),
+            E::UnaryExp(_, e) => self.visit_exp(e),
             E::BinopExp(e1, _, _, e2) => {
-                self.visit_exp(e1, env, program_info, program);
-                self.visit_exp(e2, env, program_info, program);
+                self.visit_exp(e1);
+                self.visit_exp(e2);
             }
             E::Pack(_, _, _, fields) => fields
-                .iter()
-                .for_each(|(_, _, (_, (_, e)))| self.visit_exp(e, env, program_info, program)),
+                .iter_mut()
+                .for_each(|(_, _, (_, (_, e)))| self.visit_exp(e)),
             E::ExpList(list) => {
                 for l in list {
                     match l {
-                        T::ExpListItem::Single(e, _) => {
-                            self.visit_exp(e, env, program_info, program)
-                        }
-                        T::ExpListItem::Splat(_, e, _) => {
-                            self.visit_exp(e, env, program_info, program)
-                        }
+                        T::ExpListItem::Single(e, _) => self.visit_exp(e),
+                        T::ExpListItem::Splat(_, e, _) => self.visit_exp(e),
                     }
                 }
             }
-            E::Borrow(_, e, _) => self.visit_exp(e, env, program_info, program),
-            E::TempBorrow(_, e) => self.visit_exp(e, env, program_info, program),
-            E::Cast(e, _) => self.visit_exp(e, env, program_info, program),
-            E::Annotate(e, _) => self.visit_exp(e, env, program_info, program),
+            E::Borrow(_, e, _) => self.visit_exp(e),
+            E::TempBorrow(_, e) => self.visit_exp(e),
+            E::Cast(e, _) => self.visit_exp(e),
+            E::Annotate(e, _) => self.visit_exp(e),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }
@@ -156,5 +203,16 @@ pub trait TypingVisitor {
 impl<V: TypingVisitor + 'static> From<V> for TypingVisitorObj {
     fn from(value: V) -> Self {
         Box::new(value)
+    }
+}
+
+impl<V: TypingVisitorConstructor> TypingVisitor for V {
+    fn visit(
+        &mut self,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &mut T::Program,
+    ) {
+        self.visit(env, program_info, program)
     }
 }

--- a/external-crates/move/move-compiler/tests/sui_mode/init/cannot_call_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/cannot_call_init.exp
@@ -1,0 +1,8 @@
+error[Sui E02006]: invalid 'init' call
+  ┌─ tests/sui_mode/init/cannot_call_init.move:9:9
+  │
+9 │         init(ctx)
+  │         ^^^^^^^^^ Invalid call to '(a=0x42)::m::init'. Module initializers cannot be called directly
+  │
+  = Module initializers are called implicitly upon publishing. If you need to reuse this function (or want to call it from a test), consider extracting the logic into a new function and calling that instead.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/cannot_call_init.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/cannot_call_init.move
@@ -1,0 +1,15 @@
+// cannot directly call init
+module a::m {
+    use sui::tx_context;
+    fun init(_ctx: &mut tx_context::TxContext) {
+        abort 0
+    }
+
+    public entry fun init_again(ctx: &mut tx_context::TxContext) {
+        init(ctx)
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/imm_tx_context.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/imm_tx_context.move
@@ -1,0 +1,11 @@
+// TxContext can be immutable, even for init
+module a::m {
+    use sui::tx_context;
+    fun init(_ctx: &tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/must_have_txn_context.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/must_have_txn_context.exp
@@ -1,0 +1,19 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/init/must_have_txn_context.move:3:9
+  │
+3 │     fun init() {
+  │         ^^^^
+  │         │
+  │         Invalid 'init' function declaration
+  │         'init' functions must have their last parameter as '&sui::tx_context::TxContext' or '&mut sui::tx_context::TxContext'
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/init/must_have_txn_context.move:11:9
+   │
+11 │     fun init(_ctx: &mut tx_context::TxContext, _ctx2: &mut tx_context::TxContext) {
+   │         ^^^^       -------------------------- Invalid parameter '_ctx' of type '&mut (sui=0x2)::tx_context::TxContext'. Expected a one-time witness type, '(a=0x42)::n::N
+   │         │           
+   │         Invalid 'init' function declaration
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/must_have_txn_context.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/must_have_txn_context.move
@@ -1,0 +1,18 @@
+// must have TxContext
+module a::m {
+    fun init() {
+        abort 0
+    }
+}
+
+// cannot have mroe than one TxContext
+module a::n {
+    use sui::tx_context;
+    fun init(_ctx: &mut tx_context::TxContext, _ctx2: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_generic.exp
@@ -1,0 +1,8 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/init/not_generic.move:4:9
+  │
+4 │     fun init<T>(_ctx: &mut tx_context::TxContext) {
+  │         ^^^^ - 'init' functions cannot have type parameters
+  │         │     
+  │         Invalid 'init' function declaration
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_generic.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_generic.move
@@ -1,0 +1,11 @@
+// init functions cannot have generics
+module a::m {
+    use sui::tx_context;
+    fun init<T>(_ctx: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_private.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_private.exp
@@ -1,0 +1,24 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/init/not_private.move:4:16
+  │
+4 │     public fun init(_ctxctx: &mut tx_context::TxContext) {
+  │     ------     ^^^^ Invalid 'init' function declaration
+  │     │           
+  │     'init' functions must be internal to their module
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/init/not_private.move:11:15
+   │
+11 │     entry fun init(_ctx: &mut tx_context::TxContext) {
+   │     -----     ^^^^ Invalid 'init' function declaration
+   │     │          
+   │     'init' functions cannot be 'entry' functions
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/init/not_private.move:18:24
+   │
+18 │     public(friend) fun init(_ctx: &mut tx_context::TxContext) {
+   │     --------------     ^^^^ Invalid 'init' function declaration
+   │     │                   
+   │     'init' functions must be internal to their module
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_private.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_private.move
@@ -1,0 +1,25 @@
+// init functions cannot be public, cannot have entry, cannot be public(friend)
+module a::m0 {
+    use sui::tx_context;
+    public fun init(_ctxctx: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module a::m1 {
+    use sui::tx_context;
+    entry fun init(_ctx: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module a::m2 {
+    use sui::tx_context;
+    public(friend) fun init(_ctx: &mut tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_txn_context.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_txn_context.exp
@@ -1,0 +1,24 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/init/not_txn_context.move:3:9
+  │
+3 │     fun init(_: u64) {
+  │         ^^^^    --- 'init' functions must have their last parameter as '&sui::tx_context::TxContext' or '&mut sui::tx_context::TxContext'
+  │         │        
+  │         Invalid 'init' function declaration
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/init/not_txn_context.move:10:9
+   │
+10 │     fun init(_: TxContext) {
+   │         ^^^^    --------- 'init' functions must have their last parameter as '&sui::tx_context::TxContext' or '&mut sui::tx_context::TxContext'
+   │         │        
+   │         Invalid 'init' function declaration
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/init/not_txn_context.move:17:9
+   │
+17 │     fun init(_: tx_context::TxContext) {
+   │         ^^^^    --------------------- 'init' functions must have their last parameter as '&sui::tx_context::TxContext' or '&mut sui::tx_context::TxContext'
+   │         │        
+   │         Invalid 'init' function declaration
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/not_txn_context.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/not_txn_context.move
@@ -1,0 +1,24 @@
+// init must have & or &mut sui::tx_context::TxContext as first argument
+module a::m1 {
+    fun init(_: u64) {
+        abort 0
+    }
+}
+
+module a::tx_context {
+    struct TxContext { value: u64 }
+    fun init(_: TxContext) {
+        abort 0
+    }
+}
+
+module a::m2 {
+    use sui::tx_context;
+    fun init(_: tx_context::TxContext) {
+        abort 0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/ok.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/ok.move
@@ -1,0 +1,10 @@
+// valid init function
+module a::m {
+    use sui::tx_context;
+    fun init(_: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/return_values.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/return_values.exp
@@ -1,0 +1,8 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/init/return_values.move:4:9
+  │
+4 │     fun init(_: &mut tx_context::TxContext): u64 {
+  │         ^^^^                                 --- 'init' functions must have a return type of '()'
+  │         │                                     
+  │         Invalid 'init' function declaration
+

--- a/external-crates/move/move-compiler/tests/sui_mode/init/return_values.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/return_values.move
@@ -1,0 +1,11 @@
+// init cannot have return values
+module a::m {
+    use sui::tx_context;
+    fun init(_: &mut tx_context::TxContext): u64 {
+        0
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/init/unused_function.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/init/unused_function.move
@@ -1,4 +1,8 @@
 // init is unused but does not error because we are in Sui mode
 module a::m {
-    fun init() {}
+    fun init(_: &mut sui::tx_context::TxContext) {}
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
 }

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/bool_field.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/bool_field.exp
@@ -1,0 +1,12 @@
+warning[W09004]: unnecessary trailing semicolon
+  ┌─ tests/sui_mode/one_time_witness/bool_field.move:9:15
+  │
+9 │         return;
+  │         ------^
+  │         │     │
+  │         │     Invalid trailing ';'
+  │         │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+  │         Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/bool_field.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/bool_field.move
@@ -1,0 +1,15 @@
+// correct, bool field specified at source level
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { some_field: bool }
+
+    fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+        return;
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/instantiate.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/instantiate.exp
@@ -1,0 +1,8 @@
+error[Sui E02005]: invalid one-time witness usage
+   ┌─ tests/sui_mode/one_time_witness/instantiate.move:12:9
+   │
+12 │         M { dummy: false }
+   │         ^^^^^^^^^^^^^^^^^^ Invalid one-time witness construction. One-time witness types cannot be created manually, but are passed as an argument 'init'
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/instantiate.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/instantiate.move
@@ -1,0 +1,18 @@
+// invalid, otw type packed
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { dummy: bool }
+
+    fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+    }
+
+    fun pack(): M {
+        M { dummy: false }
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
@@ -1,12 +1,12 @@
 error[Sui E02004]: invalid one-time witness declaration
-  ┌─ tests/sui_mode/one_time_witness/wrong_field_type_with_init.move:6:12
+  ┌─ tests/sui_mode/one_time_witness/many_fields_invalid.move:5:12
   │
-6 │     struct M has drop { value: u64 }
-  │            ^            ----- One-time witness types must have no fields, or exactly one field of type 'bool'
-  │            │             
+5 │     struct M has drop { some_field: bool, some_field2: bool  }
+  │            ^                              ----------- One-time witness types must have no fields, or exactly one field of type 'bool'
+  │            │                               
   │            Invalid one-time witness declaration
-7 │ 
-8 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+6 │ 
+7 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
   │                    - Used as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.move
@@ -1,0 +1,13 @@
+// Incorrect, more than one field means not a OTW
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { some_field: bool, some_field2: bool  }
+
+    fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_valid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_valid.move
@@ -1,0 +1,8 @@
+// Since it is not a OTW (because of the multiple fields), we can pack it
+module a::n {
+    struct N has drop { some_field: bool, some_field2: bool  }
+
+    public fun new(): N {
+        N { some_field: false, some_field2: true }
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/more_abilities.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/more_abilities.exp
@@ -1,0 +1,30 @@
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/more_abilities.move:6:12
+  │
+6 │     struct M1 has drop, copy { dummy: bool }
+  │            ^^           ---- One-time witness types can only have the have the 'drop' ability
+  │            │             
+  │            Invalid one-time witness declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+
+error[Sui E02004]: invalid one-time witness declaration
+   ┌─ tests/sui_mode/one_time_witness/more_abilities.move:16:12
+   │
+16 │     struct M2 has drop, store { dummy: bool }
+   │            ^^           ----- One-time witness types can only have the have the 'drop' ability
+   │            │             
+   │            Invalid one-time witness declaration
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+
+error[Sui E02004]: invalid one-time witness declaration
+   ┌─ tests/sui_mode/one_time_witness/more_abilities.move:26:12
+   │
+26 │     struct M3 has drop, copy, store { dummy: bool }
+   │            ^^           ---- One-time witness types can only have the have the 'drop' ability
+   │            │             
+   │            Invalid one-time witness declaration
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/more_abilities.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/more_abilities.move
@@ -1,0 +1,35 @@
+// invalid, struct type has abilities beyond drop
+
+module a::m1 {
+    use sui::tx_context;
+
+    struct M1 has drop, copy { dummy: bool }
+
+    fun init(_otw: M1, _ctx: &mut tx_context::TxContext) {
+    }
+
+}
+
+module a::m2 {
+    use sui::tx_context;
+
+    struct M2 has drop, store { dummy: bool }
+
+    fun init(_otw: M2, _ctx: &mut tx_context::TxContext) {
+    }
+
+}
+
+module a::m3 {
+    use sui::tx_context;
+
+    struct M3 has drop, copy, store { dummy: bool }
+
+    fun init(_otw: M3, _ctx: &mut tx_context::TxContext) {
+    }
+
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_drop.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_drop.exp
@@ -1,0 +1,11 @@
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/no_drop.move:7:12
+  │
+7 │     struct M { dummy: bool }
+  │            ^
+  │            │
+  │            Invalid one-time witness declaration
+  │            One-time witness types can only have the have the 'drop' ability
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_drop.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_drop.move
@@ -1,0 +1,16 @@
+// invalid, one-time witness type has no drop ability
+
+//# publish
+module a::m {
+    use sui::tx_context;
+
+    struct M { dummy: bool }
+
+    fun init(otw: M, _ctx: &mut tx_context::TxContext) {
+        let M { dummy: _ } = otw;
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_field.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_field.move
@@ -1,0 +1,15 @@
+// structs are always given a field in the source language
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop {}
+
+    fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+    }
+
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_init_arg.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_init_arg.exp
@@ -1,0 +1,11 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/no_init_arg.move:8:20
+  │
+6 │     struct M has drop { dummy: bool }
+  │            - One-time witness declared here
+7 │ 
+8 │     fun init(_ctx: &mut tx_context::TxContext) {
+  │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid first parameter to 'init'. Expected this module's one-time witness type '(a=0x42)::m::M'
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_init_arg.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/no_init_arg.move
@@ -1,0 +1,14 @@
+// invalid, no one-time witness type parameter in init
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { dummy: bool }
+
+    fun init(_ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/other_mod_def.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/other_mod_def.exp
@@ -1,0 +1,10 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/other_mod_def.move:7:9
+  │
+7 │     fun init(_otw: sui::SUI, _ctx: &mut tx_context::TxContext) {
+  │         ^^^^       -------- Invalid parameter '_otw' of type '(sui=0x2)::sui::SUI'. Expected a one-time witness type, '(a=0x42)::n::N
+  │         │           
+  │         Invalid 'init' function declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/other_mod_def.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/other_mod_def.move
@@ -1,0 +1,19 @@
+// invalid, one-time witness type candidate used in a different module
+
+module a::n {
+    use sui::sui;
+    use sui::tx_context;
+
+    fun init(_otw: sui::SUI, _ctx: &mut tx_context::TxContext) {
+    }
+
+}
+
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}
+
+module sui::sui {
+    struct SUI has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/type_param.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/type_param.exp
@@ -1,0 +1,39 @@
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/type_param.move:7:12
+  │
+7 │     struct M<phantom T> has drop { dummy: bool }
+  │            ^         - One-time witness types cannot have type parameters
+  │            │          
+  │            Invalid one-time witness declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/type_param.move:9:9
+  │
+9 │     fun init<T>(_otw: M<T>, _ctx: &mut tx_context::TxContext) {
+  │         ^^^^ - 'init' functions cannot have type parameters
+  │         │     
+  │         Invalid 'init' function declaration
+
+error[Sui E02004]: invalid one-time witness declaration
+   ┌─ tests/sui_mode/one_time_witness/type_param.move:16:12
+   │
+16 │     struct X<phantom T> has drop { dummy: bool }
+   │            ^         - One-time witness types cannot have type parameters
+   │            │          
+   │            Invalid one-time witness declaration
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+
+error[Sui E02003]: invalid 'init' function
+   ┌─ tests/sui_mode/one_time_witness/type_param.move:18:20
+   │
+16 │     struct X<phantom T> has drop { dummy: bool }
+   │            - One-time witness declared here
+17 │ 
+18 │     fun init(_ctx: &mut tx_context::TxContext) {
+   │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid first parameter to 'init'. Expected this module's one-time witness type '(a=0x42)::x::X'
+   │
+   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/type_param.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/type_param.move
@@ -1,0 +1,24 @@
+// invalid, struct type has type param
+
+//# publish
+module a::m {
+    use sui::tx_context;
+
+    struct M<phantom T> has drop { dummy: bool }
+
+    fun init<T>(_otw: M<T>, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module a::x {
+    use sui::tx_context;
+
+    struct X<phantom T> has drop { dummy: bool }
+
+    fun init(_ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type.move
@@ -1,0 +1,19 @@
+// correct, wrong struct field type but not one-time witness candidate
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { value: u64 }
+
+    fun init(_ctx: &mut tx_context::TxContext) {
+    }
+
+    fun foo() {
+        _ = M { value: 7 };
+        _ = M { value: 42 };
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
@@ -1,0 +1,10 @@
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/wrong_field_type_with_init.move:6:12
+  │
+6 │     struct M has drop { value: u64 }
+  │            ^            ----- One-time witness types must have no fields, or exactly one field of type 'bool'
+  │            │             
+  │            Invalid one-time witness declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.move
@@ -1,0 +1,14 @@
+// invalid, wrong struct field type
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { value: u64 }
+
+    fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_init_type.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_init_type.exp
@@ -1,0 +1,10 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/wrong_init_type.move:9:9
+  │
+9 │     fun init(_otw: N, _ctx: &mut tx_context::TxContext) {
+  │         ^^^^       - Invalid parameter '_otw' of type '(a=0x42)::m::N'. Expected a one-time witness type, '(a=0x42)::m::M
+  │         │           
+  │         Invalid 'init' function declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_init_type.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_init_type.move
@@ -1,0 +1,15 @@
+// invalid, wrong type of the init function's first param
+
+module a::m {
+    use sui::tx_context;
+
+    struct M has drop { dummy: bool }
+    struct N has drop { dummy: bool }
+
+    fun init(_otw: N, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name.exp
@@ -1,0 +1,10 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/wrong_name.move:8:9
+  │
+8 │     fun init(_otw: OneTimeWitness, _ctx: &mut tx_context::TxContext) {
+  │         ^^^^       -------------- Invalid parameter '_otw' of type '(a=0x42)::m::OneTimeWitness'. Expected a one-time witness type, '(a=0x42)::m::M
+  │         │           
+  │         Invalid 'init' function declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name.move
@@ -1,0 +1,14 @@
+// invalid, wrong one-time witness type name
+
+module a::m {
+    use sui::tx_context;
+
+    struct OneTimeWitness has drop { dummy: bool }
+
+    fun init(_otw: OneTimeWitness, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name_format.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name_format.exp
@@ -1,0 +1,10 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/wrong_name_format.move:8:9
+  │
+8 │     fun init(_mod: Mod, _ctx: &mut tx_context::TxContext) {
+  │         ^^^^       --- Invalid parameter '_mod' of type '(a=0x42)::mod::Mod'. Expected a one-time witness type, '(a=0x42)::mod::MOD
+  │         │           
+  │         Invalid 'init' function declaration
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name_format.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_name_format.move
@@ -1,0 +1,14 @@
+// invalid, wrong one-time witness type name format
+
+module a::mod {
+    use sui::tx_context;
+
+    struct Mod has drop { dummy: bool }
+
+    fun init(_mod: Mod, _ctx: &mut tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/move-symbol-pool/src/lib.rs
@@ -69,6 +69,7 @@ static_symbols!(
     "tx_context",
     "TxContext",
     "ID",
+    "SUI",
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

- Added init and one-time witness rules to the compiler's Sui mode

## Test Plan 

- Migrated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

In this release, the Move compiler will now error on incorrect declarations (or usage) of `init` functions and one-time witnesses. 
