### PR TITLE
add basic scalar skeletoon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10302,9 +10302,11 @@ dependencies = [
 
 [[package]]
 name = "sui-graphql-rpc"
-version = "1.8.0"
+version = "0.0.0"
 dependencies = [
  "async-graphql",
+ "move-core-types",
+ "serde",
  "workspace-hack",
 ]
 

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-graphql-rpc"
-version.workspace = true
+version = "0.0.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
@@ -9,4 +9,7 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
+serde.workspace = true
+move-core-types.workspace = true
+
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_core_types::u256::U256;
+
+struct Base64(String);
+
+/// TODO: implement Base64 scalar type
+#[Scalar]
+impl ScalarType for Base64 {
+    fn parse(_value: Value) -> InputValueResult<Self> {
+        unimplemented!()
+    }
+
+    fn to_value(&self) -> Value {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use move_core_types::u256::U256;
 
 struct Base64(String);
 

--- a/crates/sui-graphql-rpc/src/types/big_int.rs
+++ b/crates/sui-graphql-rpc/src/types/big_int.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_core_types::u256::U256;
+
+struct BigInt(U256);
+
+/// TODO: implement BigInt scalar type using u256
+#[Scalar]
+impl ScalarType for BigInt {
+    fn parse(_value: Value) -> InputValueResult<Self> {
+        unimplemented!()
+    }
+
+    fn to_value(&self) -> Value {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/date_time.rs
+++ b/crates/sui-graphql-rpc/src/types/date_time.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use move_core_types::u256::U256;
 
 // ISO-8601 Date and Time
 // Encoded as a 64-bit unix timestamp

--- a/crates/sui-graphql-rpc/src/types/date_time.rs
+++ b/crates/sui-graphql-rpc/src/types/date_time.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_core_types::u256::U256;
+
+// ISO-8601 Date and Time
+// Encoded as a 64-bit unix timestamp
+struct DateTime(u64);
+
+/// TODO: implement DateTime scalar type
+#[Scalar]
+impl ScalarType for DateTime {
+    fn parse(_value: Value) -> InputValueResult<Self> {
+        unimplemented!()
+    }
+
+    fn to_value(&self) -> Value {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -1,4 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod types;
+mod base64;
+mod big_int;
+mod date_time;
+mod sui_address;

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use serde::{Deserialize, Serialize};
+
+const SUI_ADDRESS_LENGTH: usize = 32;
+
+#[derive(Serialize, Deserialize)]
+struct SuiAddress([u8; SUI_ADDRESS_LENGTH]);
+
+scalar!(SuiAddress, "SuiAddress", "Representation of Sui Addresses");


### PR DESCRIPTION
## Description 

Adds skeletons for SuiAddress, BigInt, Base64, DateTime scalars which are needed for other types.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
