### PR TITLE
[graphql/rpc] schema export and snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10305,6 +10305,8 @@ name = "sui-graphql-rpc"
 version = "0.0.0"
 dependencies = [
  "async-graphql",
+ "clap 3.2.23",
+ "insta",
  "move-core-types",
  "serde",
  "workspace-hack",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -9,7 +9,11 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
+clap.workspace = true
 serde.workspace = true
 move-core-types.workspace = true
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::*;
+
+#[derive(Parser)]
+#[clap(
+    name = "sui-graphql-rpc",
+    about = "Sui GraphQL RPC",
+    rename_all = "kebab-case",
+    author,
+    version
+)]
+pub enum Command {
+    GenerateSchema,
+}

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -1,4 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod types;
+use async_graphql::*;
+
+pub mod commands;
+pub mod types;
+
+use crate::types::query::Query;
+
+pub fn schema_sdl_export() -> String {
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+    schema.sdl()
+}

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -1,4 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-fn main() {}
+use clap::Parser;
+use sui_graphql_rpc::commands::Command;
+use sui_graphql_rpc::schema_sdl_export;
+
+fn main() {
+    let cmd: Command = Command::parse();
+    match cmd {
+        Command::GenerateSchema => {
+            println!("{}", &schema_sdl_export());
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod base64;
-mod big_int;
-mod date_time;
-mod sui_address;
+pub mod base64;
+pub mod big_int;
+pub mod date_time;
+pub mod query;
+pub mod sui_address;

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+pub struct Query;
+
+#[allow(unreachable_code)]
+#[Object]
+impl Query {
+    async fn chain_identifier(&self) -> String {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshot_tests.rs
+++ b/crates/sui-graphql-rpc/tests/snapshot_tests.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use insta::assert_snapshot;
+
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_schema_sdl_export() {
+        let sdl = sui_graphql_rpc::schema_sdl_export();
+        assert_snapshot!(sdl);
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -1,0 +1,17 @@
+---
+source: crates/sui-graphql-rpc/tests/snapshot_tests.rs
+expression: sdl
+---
+
+
+
+
+type Query {
+	chainIdentifier: String!
+}
+
+
+schema {
+	query: Query
+}
+


### PR DESCRIPTION
## Description 

* Adds snapshot tests to ensure schema stability

* Adds command to dump the schema

```
$  ./target/debug/sui-graphql-rpc generate-schema

type Query {
        chainIdentifier: String!
}


schema {
        query: Query
}

```

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
