### PR TITLE
[graphql/rpc] owner interface and stubs

### DIFF
--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -4,7 +4,7 @@
 use async_graphql::*;
 
 pub mod commands;
-pub mod types;
+pub(crate) mod types;
 
 use crate::types::query::Query;
 

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use super::{
+    balance::Balance,
+    coin::CoinConnection,
+    name_service::NameServiceConnection,
+    object::{ObjectConnection, ObjectFilter},
+    stake::StakeConnection,
+    sui_address::SuiAddress,
+};
+
+pub(crate) struct Address;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl Address {
+    pub async fn location(&self) -> SuiAddress {
+        unimplemented!()
+    }
+
+    pub async fn object_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn balance(&self, type_: Option<String>) -> Balance {
+        unimplemented!()
+    }
+
+    pub async fn balance_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn coin_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        type_: Option<String>,
+    ) -> Option<CoinConnection> {
+        unimplemented!()
+    }
+
+    pub async fn stake_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<StakeConnection> {
+        unimplemented!()
+    }
+
+    pub async fn default_name_service_name(&self) -> Option<String> {
+        unimplemented!()
+    }
+
+    pub async fn name_service_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<NameServiceConnection> {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+pub(crate) struct Balance;
+pub(crate) struct BalanceConnection;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl Balance {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl BalanceConnection {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+pub(crate) struct Coin;
+pub(crate) struct CoinConnection;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl Coin {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl CoinConnection {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -1,8 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod base64;
-pub mod big_int;
-pub mod date_time;
-pub mod query;
-pub mod sui_address;
+pub(crate) mod address;
+pub(crate) mod balance;
+pub(crate) mod base64;
+pub(crate) mod big_int;
+pub(crate) mod coin;
+pub(crate) mod date_time;
+pub(crate) mod name_service;
+pub(crate) mod object;
+pub(crate) mod owner;
+pub(crate) mod query;
+pub(crate) mod stake;
+pub(crate) mod sui_address;

--- a/crates/sui-graphql-rpc/src/types/name_service.rs
+++ b/crates/sui-graphql-rpc/src/types/name_service.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+pub(crate) struct NameService;
+pub(crate) struct NameServiceConnection;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl NameService {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl NameServiceConnection {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use super::{
+    balance::Balance, coin::CoinConnection, name_service::NameServiceConnection,
+    stake::StakeConnection, sui_address::SuiAddress,
+};
+
+pub(crate) struct Object;
+pub(crate) struct ObjectConnection;
+
+#[derive(InputObject)]
+pub(crate) struct ObjectFilter {
+    package: SuiAddress,
+    module: String,
+    ty: String,
+
+    owner: SuiAddress,
+    object_id: SuiAddress,
+    version: u64,
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl Object {
+    pub async fn location(&self) -> SuiAddress {
+        unimplemented!()
+    }
+
+    pub async fn object_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn balance(&self, type_: Option<String>) -> Balance {
+        unimplemented!()
+    }
+
+    pub async fn balance_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn coin_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        type_: Option<String>,
+    ) -> Option<CoinConnection> {
+        unimplemented!()
+    }
+
+    pub async fn stake_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<StakeConnection> {
+        unimplemented!()
+    }
+
+    pub async fn default_name_service_name(&self) -> Option<String> {
+        unimplemented!()
+    }
+
+    pub async fn name_service_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<NameServiceConnection> {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl ObjectConnection {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::balance::*;
+use crate::types::coin::*;
+use crate::types::name_service::*;
+use crate::types::object::*;
+use crate::types::stake::*;
+use crate::types::sui_address::SuiAddress;
+use async_graphql::*;
+
+use super::address::Address;
+
+#[derive(Interface)]
+#[graphql(
+    field(name = "location", type = "SuiAddress"),
+    field(
+        name = "object_connection",
+        type = "Option<ObjectConnection>",
+        arg(name = "first", type = "Option<u64>"),
+        arg(name = "after", type = "Option<String>"),
+        arg(name = "last", type = "Option<u64>"),
+        arg(name = "before", type = "Option<String>"),
+        arg(name = "filter", type = "Option<ObjectFilter>")
+    ),
+    field(
+        name = "balance",
+        type = "Balance",
+        arg(name = "type", type = "Option<String>")
+    ),
+    field(
+        name = "balance_connection",
+        type = "Option<ObjectConnection>",
+        arg(name = "first", type = "Option<u64>"),
+        arg(name = "after", type = "Option<String>"),
+        arg(name = "last", type = "Option<u64>"),
+        arg(name = "before", type = "Option<String>")
+    ),
+    field(
+        name = "coin_connection",
+        type = "Option<CoinConnection>",
+        arg(name = "first", type = "Option<u64>"),
+        arg(name = "after", type = "Option<String>"),
+        arg(name = "last", type = "Option<u64>"),
+        arg(name = "before", type = "Option<String>"),
+        arg(name = "type", type = "Option<String>")
+    ),
+    field(
+        name = "stake_connection",
+        type = "Option<StakeConnection>",
+        arg(name = "first", type = "Option<u64>"),
+        arg(name = "after", type = "Option<String>"),
+        arg(name = "last", type = "Option<u64>"),
+        arg(name = "before", type = "Option<String>")
+    ),
+    field(name = "default_name_service_name", type = "Option<String>"),
+    field(
+        name = "name_service_connection",
+        type = "Option<NameServiceConnection>",
+        arg(name = "first", type = "Option<u64>"),
+        arg(name = "after", type = "Option<String>"),
+        arg(name = "last", type = "Option<u64>"),
+        arg(name = "before", type = "Option<String>")
+    )
+)]
+pub(crate) enum Owner {
+    Address(Address),
+    AmbiguousOwner(AmbiguousOwner),
+    Object(Object),
+}
+
+pub(crate) struct AmbiguousOwner;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl AmbiguousOwner {
+    pub async fn location(&self) -> SuiAddress {
+        unimplemented!()
+    }
+
+    pub async fn object_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn balance(&self, type_: Option<String>) -> Balance {
+        unimplemented!()
+    }
+
+    pub async fn balance_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<ObjectConnection> {
+        unimplemented!()
+    }
+
+    pub async fn coin_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        type_: Option<String>,
+    ) -> Option<CoinConnection> {
+        unimplemented!()
+    }
+
+    pub async fn stake_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<StakeConnection> {
+        unimplemented!()
+    }
+
+    pub async fn default_name_service_name(&self) -> Option<String> {
+        unimplemented!()
+    }
+
+    pub async fn name_service_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Option<NameServiceConnection> {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -3,12 +3,27 @@
 
 use async_graphql::*;
 
-pub struct Query;
+use super::{address::Address, object::Object, owner::Owner, sui_address::SuiAddress};
+
+pub(crate) struct Query;
 
 #[allow(unreachable_code)]
+#[allow(unused_variables)]
 #[Object]
 impl Query {
     async fn chain_identifier(&self) -> String {
+        unimplemented!()
+    }
+
+    async fn owner(&self, address: SuiAddress) -> Option<Owner> {
+        unimplemented!()
+    }
+
+    async fn object(&self, address: SuiAddress, version: Option<u64>) -> Option<Object> {
+        unimplemented!()
+    }
+
+    async fn address(&self, address: SuiAddress) -> Option<Address> {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+pub(crate) struct Stake;
+pub(crate) struct StakeConnection;
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl Stake {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl StakeConnection {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -7,6 +7,6 @@ use serde::{Deserialize, Serialize};
 const SUI_ADDRESS_LENGTH: usize = 32;
 
 #[derive(Serialize, Deserialize)]
-struct SuiAddress([u8; SUI_ADDRESS_LENGTH]);
+pub(crate) struct SuiAddress([u8; SUI_ADDRESS_LENGTH]);
 
 scalar!(SuiAddress, "SuiAddress", "Representation of Sui Addresses");

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -2,14 +2,95 @@
 source: crates/sui-graphql-rpc/tests/snapshot_tests.rs
 expression: sdl
 ---
+type Address implements Owner {
+	location: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance!
+	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	defaultNameServiceName: String
+	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
+}
+
+type AmbiguousOwner implements Owner {
+	location: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance!
+	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	defaultNameServiceName: String
+	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
+}
+
+type Balance {
+	id: ID!
+}
+
+
+type CoinConnection {
+	id: ID!
+}
 
 
 
+
+type NameServiceConnection {
+	id: ID!
+}
+
+type Object implements Owner {
+	location: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance!
+	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	defaultNameServiceName: String
+	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
+}
+
+type ObjectConnection {
+	id: ID!
+}
+
+input ObjectFilter {
+	package: SuiAddress!
+	module: String!
+	ty: String!
+	owner: SuiAddress!
+	objectId: SuiAddress!
+	version: Int!
+}
+
+interface Owner {
+	location: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance!
+	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	defaultNameServiceName: String
+	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
+}
 
 type Query {
 	chainIdentifier: String!
+	owner(address: SuiAddress!): Owner
+	object(address: SuiAddress!, version: Int): Object
+	address(address: SuiAddress!): Address
 }
 
+type StakeConnection {
+	id: ID!
+}
+
+
+"""
+Representation of Sui Addresses
+"""
+scalar SuiAddress
 
 schema {
 	query: Query


### PR DESCRIPTION
## Description 

Adds the `Owner` interface and the required stubs to get it to work

## Test Plan 

Snapshot

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
