### PR TITLE
[Cleanup] fix logging and CI config

### DIFF
--- a/.github/workflows/nightly-narwhal.yml
+++ b/.github/workflows/nightly-narwhal.yml
@@ -48,7 +48,7 @@ jobs:
       # These are considered the end-to-end "slow" tests for us
       - name: cargo nextest
         run: |
-          cargo nextest run -E 'kind(test) and not test(test_get_collections_with_missing_certificates) and package(narwhal-primary) + package(narwhal-consensus)' --profile narwhalnightly --run-ignored ignored-only
+          cargo nextest run -E 'kind(test) and (package(narwhal-primary) + package(narwhal-consensus))' --profile narwhalnightly --run-ignored ignored-only
 
   report-status:
     name: Report Status

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -297,7 +297,7 @@ impl AuthorityStorePruner {
         } else {
             latest_archived_checkpoint
         };
-        info!("Max eligible checkpoint {}", max_eligible_checkpoint);
+        debug!("Max eligible checkpoint {}", max_eligible_checkpoint);
         Self::prune_for_eligible_epochs(
             perpetual_db,
             checkpoint_store,


### PR DESCRIPTION
## Description 

1. For some reason, `info!("Max eligible checkpoint {}", max_eligible_checkpoint);` is pretty noisy in simtests. Downgrading it to `debug`.
2. Remove test that no longer exists from Narwhal nightly CI config

## Test Plan 

CI
Locally run
```
cargo nextest run -E 'kind(test) and (package(narwhal-primary) + package(narwhal-consensus))' --profile narwhalnightly --run-ignored ignored-only
``` 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
