### PR TITLE
[move-compiler] Suppress warnings for dependency packages

### DIFF
--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_compiler::{
-    diagnostics::codes::{DiagnosticsID, WarningFilter},
-    expansion::ast as E,
-};
+use move_compiler::{diagnostics::codes::WarningFilter, expansion::ast as E};
 use move_ir_types::location::Loc;
 
 pub mod coin_field;
@@ -50,36 +47,28 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
         E::AttributeName_::Unknown(ALLOW_ATTR_NAME.into()),
         vec![
             WarningFilter::All(Some(LINT_WARNING_PREFIX)),
-            WarningFilter::Code(
-                DiagnosticsID::new(
-                    LinterDiagCategory::ShareOwned as u8,
-                    LINTER_DEFAULT_DIAG_CODE,
-                    Some(LINT_WARNING_PREFIX),
-                ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::ShareOwned as u8,
+                LINTER_DEFAULT_DIAG_CODE,
                 Some(SHARE_OWNED_FILTER_NAME),
             ),
-            WarningFilter::Code(
-                DiagnosticsID::new(
-                    LinterDiagCategory::SelfTransfer as u8,
-                    LINTER_DEFAULT_DIAG_CODE,
-                    Some(LINT_WARNING_PREFIX),
-                ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::SelfTransfer as u8,
+                LINTER_DEFAULT_DIAG_CODE,
                 Some(SELF_TRANSFER_FILTER_NAME),
             ),
-            WarningFilter::Code(
-                DiagnosticsID::new(
-                    LinterDiagCategory::CustomStateChange as u8,
-                    LINTER_DEFAULT_DIAG_CODE,
-                    Some(LINT_WARNING_PREFIX),
-                ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::CustomStateChange as u8,
+                LINTER_DEFAULT_DIAG_CODE,
                 Some(CUSTOM_STATE_CHANGE_FILTER_NAME),
             ),
-            WarningFilter::Code(
-                DiagnosticsID::new(
-                    LinterDiagCategory::CoinField as u8,
-                    LINTER_DEFAULT_DIAG_CODE,
-                    Some(LINT_WARNING_PREFIX),
-                ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::CoinField as u8,
+                LINTER_DEFAULT_DIAG_CODE,
                 Some(COIN_FIELD_FILTER_NAME),
             ),
         ],

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -10,7 +10,7 @@ use move_command_line_common::{
 use move_compiler::{
     cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::move_check_for_errors,
-    diagnostics::codes::{self, CategoryID, DiagnosticsID, WarningFilter},
+    diagnostics::codes::{self, WarningFilter},
     editions::Flavor,
     expansion::ast as E,
     shared::{NumericalAddress, PackageConfig},
@@ -42,16 +42,15 @@ fn linter_tests(path: &Path) -> datatest_stable::Result<()> {
 pub fn known_filters_for_test() -> (E::AttributeName_, Vec<WarningFilter>) {
     let (filter_attr_name, mut filters) = known_filters();
 
-    let unused_function_code_filter = WarningFilter::Code(
-        DiagnosticsID::new(
-            codes::Category::UnusedItem as u8,
-            codes::UnusedItem::Function as u8,
-            Some(LINT_WARNING_PREFIX),
-        ),
+    let unused_function_code_filter = WarningFilter::code(
+        Some(LINT_WARNING_PREFIX),
+        codes::Category::UnusedItem as u8,
+        codes::UnusedItem::Function as u8,
         Some("code_suppression_should_not_work"),
     );
-    let unused_function_category_filter = WarningFilter::Category(
-        CategoryID::new(codes::Category::UnusedItem as u8, Some(LINT_WARNING_PREFIX)),
+    let unused_function_category_filter = WarningFilter::category(
+        Some(LINT_WARNING_PREFIX),
+        codes::Category::UnusedItem as u8,
         Some("category_suppression_should_not_work"),
     );
     filters.push(unused_function_code_filter);

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -6,6 +6,8 @@
 // Main types
 //**************************************************************************************************
 
+use crate::shared::FILTER_ALL;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum Severity {
     Warning = 0,
@@ -16,27 +18,18 @@ pub enum Severity {
 
 /// A an optional prefix to distinguish between different types of warnings (internal vs. possibly
 /// multiple externally provided ones).
-type ExternalPrefix = Option<&'static str>;
-
-/// Identifies a warning category. Includes an external prefix to distinguish warnings from
-/// different sources.
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
-pub struct CategoryID {
-    category: u8,
-    external_prefix: ExternalPrefix,
-}
-
-/// Identifies a warning diagnostic through a warning category ID and a warning code.
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
-pub struct DiagnosticsID {
-    category_id: CategoryID,
-    code: u8,
-}
+pub type ExternalPrefix = Option<&'static str>;
+/// The name for a well-known filter.
+pub type WellKnownFilterName = &'static str;
+/// The ID for a diagnostic, consisting of an optional prefix, a category, and a code.
+pub type DiagnosticsID = (ExternalPrefix, u8, u8);
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct DiagnosticInfo {
     severity: Severity,
-    id: DiagnosticsID,
+    category: u8,
+    code: u8,
+    external_prefix: ExternalPrefix,
     message: &'static str,
 }
 
@@ -53,7 +46,9 @@ pub(crate) trait DiagnosticCode: Copy {
         let (code, message) = self.code_and_message();
         DiagnosticInfo {
             severity,
-            id: DiagnosticsID::new(category, code, None),
+            category,
+            code,
+            external_prefix: None,
             message,
         }
     }
@@ -65,9 +60,18 @@ pub enum WarningFilter {
     /// Filters all warnings
     All(ExternalPrefix),
     /// Filters all warnings of a specific category. Only known filters have names.
-    Category(CategoryID, /* name */ Option<&'static str>),
+    Category {
+        prefix: ExternalPrefix,
+        category: u8,
+        name: Option<WellKnownFilterName>,
+    },
     /// Filters a single warning, as defined by codes below. Only known filters have names.
-    Code(DiagnosticsID, /* name */ Option<&'static str>),
+    Code {
+        prefix: ExternalPrefix,
+        category: u8,
+        code: u8,
+        name: Option<WellKnownFilterName>,
+    },
 }
 
 /// The text used in the attribute for warning suppression
@@ -91,13 +95,9 @@ pub const fn custom(
     assert!(category <= 99);
     DiagnosticInfo {
         severity,
-        id: DiagnosticsID {
-            category_id: CategoryID {
-                category,
-                external_prefix: Some(external_prefix),
-            },
-            code,
-        },
+        category,
+        code,
+        external_prefix: Some(external_prefix),
         message,
     }
 }
@@ -320,9 +320,8 @@ codes!(
 impl WarningFilter {
     pub fn to_str(self) -> Option<&'static str> {
         match self {
-            Self::All(_) => Some("all"),
-            Self::Category(_, n) => n,
-            Self::Code(_, n) => n,
+            Self::All(_) => Some(FILTER_ALL),
+            Self::Category { name, .. } | Self::Code { name, .. } => name,
         }
     }
 }
@@ -331,62 +330,13 @@ impl WarningFilter {
 // impls
 //**************************************************************************************************
 
-impl CategoryID {
-    pub fn new(category: u8, external_prefix: ExternalPrefix) -> Self {
-        CategoryID {
-            category,
-            external_prefix,
-        }
-    }
-
-    pub fn category(&self) -> u8 {
-        self.category
-    }
-
-    pub fn external_prefix(&self) -> Option<&'static str> {
-        self.external_prefix
-    }
-}
-
-impl DiagnosticsID {
-    pub fn new(category: u8, code: u8, external_prefix: ExternalPrefix) -> Self {
-        let category_id = CategoryID {
-            category,
-            external_prefix,
-        };
-        DiagnosticsID { category_id, code }
-    }
-
-    pub fn category(&self) -> u8 {
-        self.category_id.category
-    }
-
-    pub fn code(&self) -> u8 {
-        self.code
-    }
-
-    pub fn external_prefix(&self) -> ExternalPrefix {
-        self.category_id.external_prefix
-    }
-
-    pub fn category_id(&self) -> CategoryID {
-        self.category_id
-    }
-}
-
 impl DiagnosticInfo {
     pub fn render(self) -> (/* code */ String, /* message */ &'static str) {
         let Self {
             severity,
-            id:
-                DiagnosticsID {
-                    category_id:
-                        CategoryID {
-                            category,
-                            external_prefix,
-                        },
-                    code,
-                },
+            category,
+            code,
+            external_prefix,
             message,
         } = self;
         let sev_prefix = match severity {
@@ -408,11 +358,15 @@ impl DiagnosticInfo {
     }
 
     pub fn category(&self) -> u8 {
-        self.id.category_id.category
+        self.category
     }
 
     pub fn code(&self) -> u8 {
-        self.id.code
+        self.code
+    }
+
+    pub fn id(&self) -> DiagnosticsID {
+        (self.external_prefix, self.category, self.code)
     }
 
     pub fn message(&self) -> &'static str {
@@ -420,15 +374,11 @@ impl DiagnosticInfo {
     }
 
     pub fn is_external(&self) -> bool {
-        self.id.category_id.external_prefix.is_some()
+        self.external_prefix.is_some()
     }
 
-    pub fn id(&self) -> DiagnosticsID {
-        self.id
-    }
-
-    pub fn category_id(&self) -> CategoryID {
-        self.id.category_id
+    pub fn external_prefix(&self) -> Option<&'static str> {
+        self.external_prefix
     }
 }
 

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -324,6 +324,32 @@ impl WarningFilter {
             Self::Category { name, .. } | Self::Code { name, .. } => name,
         }
     }
+
+    pub fn code(
+        prefix: ExternalPrefix,
+        category: u8,
+        code: u8,
+        name: Option<WellKnownFilterName>,
+    ) -> Self {
+        Self::Code {
+            prefix,
+            category,
+            code,
+            name,
+        }
+    }
+
+    pub fn category(
+        prefix: ExternalPrefix,
+        category: u8,
+        name: Option<WellKnownFilterName>,
+    ) -> Self {
+        Self::Category {
+            prefix,
+            category,
+            name,
+        }
+    }
 }
 
 //**************************************************************************************************

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -4,10 +4,7 @@
 
 use crate::{
     diag,
-    diagnostics::{
-        codes::{CategoryID, WarningFilter},
-        Diagnostic, WarningFilters,
-    },
+    diagnostics::{codes::WarningFilter, Diagnostic, WarningFilters},
     expansion::{
         aliases::{AliasMap, AliasSet},
         ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_, SpecId},
@@ -40,8 +37,12 @@ struct Context<'env, 'map> {
     address: Option<Address>,
     aliases: AliasMap,
     is_source_definition: bool,
+    current_package: Option<Symbol>,
     in_spec_context: bool,
     exp_specs: BTreeMap<SpecId, E::SpecBlock>,
+    // Cached warning filters for all available prefixes. Used by non-source defs
+    // and dependency packages
+    all_filter_alls: WarningFilters,
     env: &'env mut CompilationEnv,
 }
 impl<'env, 'map> Context<'env, 'map> {
@@ -49,6 +50,12 @@ impl<'env, 'map> Context<'env, 'map> {
         compilation_env: &'env mut CompilationEnv,
         module_members: UniqueMap<ModuleIdent, ModuleMembers>,
     ) -> Self {
+        let mut all_filter_alls = WarningFilters::new();
+        for allow in compilation_env.filter_attributes() {
+            for f in compilation_env.filter_from_str(FILTER_ALL, allow.clone()) {
+                all_filter_alls.add(f);
+            }
+        }
         Self {
             module_members,
             env: compilation_env,
@@ -56,8 +63,10 @@ impl<'env, 'map> Context<'env, 'map> {
             address: None,
             aliases: AliasMap::new(),
             is_source_definition: false,
+            current_package: None,
             in_spec_context: false,
             exp_specs: BTreeMap::new(),
+            all_filter_alls,
         }
     }
 
@@ -148,6 +157,7 @@ pub fn program(
         def,
     } in source_definitions
     {
+        context.current_package = package;
         context.named_address_mapping = Some(named_address_maps.get(named_address_map));
         definition(
             &mut context,
@@ -165,6 +175,7 @@ pub fn program(
         def,
     } in lib_definitions
     {
+        context.current_package = package;
         context.named_address_mapping = Some(named_address_maps.get(named_address_map));
         definition(
             &mut context,
@@ -174,6 +185,7 @@ pub fn program(
             def,
         )
     }
+    context.current_package = None;
 
     for (mident, module) in lib_module_map {
         if let Err((mident, old_loc)) = source_module_map.add(mident, module) {
@@ -403,7 +415,7 @@ fn module_(
         members,
     } = mdef;
     let attributes = flatten_attributes(context, AttributePosition::Module, attributes);
-    let mut warning_filter = warning_filter(context, &attributes);
+    let mut warning_filter = module_warning_filter(context, &attributes);
     let config = context.env.package_config(package_name);
     warning_filter.union(&config.warning_filter);
 
@@ -724,6 +736,27 @@ fn attribute_value(
     ))
 }
 
+/// Like warning_filter, but it will filter _all_ warnings for non-source definitions (or for any
+/// dependency packages)
+fn module_warning_filter(
+    context: &mut Context,
+    attributes: &UniqueMap<E::AttributeName, E::Attribute>,
+) -> WarningFilters {
+    let filters = warning_filter(context, attributes);
+    let is_dep = !context.is_source_definition
+        || context
+            .env
+            .package_config(context.current_package)
+            .is_dependency;
+    if is_dep {
+        // For dependencies (non source defs or package deps), we check the filters for errors
+        // but then throw them away and actually ignore _all_ warnings
+        context.all_filters.clone()
+    } else {
+        filters
+    }
+}
+
 fn warning_filter(
     context: &mut Context,
     attributes: &UniqueMap<E::AttributeName, E::Attribute>,
@@ -742,10 +775,11 @@ fn warning_filter(
                 let msg = format!(
                     "Expected list of warnings, e.g. '{}({})'",
                     DiagnosticAttribute::ALLOW,
-                    WarningFilter::Category(
-                        CategoryID::new(Category::UnusedItem as u8, None),
-                        Some(FILTER_UNUSED)
-                    )
+                    WarningFilter::Category {
+                        prefix: None,
+                        category: Category::UnusedItem as u8,
+                        name: Some(FILTER_UNUSED)
+                    }
                     .to_str()
                     .unwrap(),
                 );
@@ -770,9 +804,7 @@ fn warning_filter(
                     n
                 }
             };
-            let filters = context
-                .env
-                .filter_from_str(name_.to_string(), allow.clone());
+            let filters = context.env.filter_from_str(name_, allow.clone());
             if filters.is_empty() {
                 let msg = format!("Unknown warning filter '{name_}'");
                 context

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -751,7 +751,7 @@ fn module_warning_filter(
     if is_dep {
         // For dependencies (non source defs or package deps), we check the filters for errors
         // but then throw them away and actually ignore _all_ warnings
-        context.all_filters.clone()
+        context.all_filter_alls.clone()
     } else {
         filters
     }

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/Move.toml
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Test"
+version = "0.0.0"
+
+[dependencies]
+SomeDep = { local = "dep" }

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
@@ -1,0 +1,24 @@
+Command `build`:
+INCLUDING DEPENDENCY SomeDep
+BUILDING Test
+Command `disassemble --package Test --name m`:
+// Move bytecode v6
+module 43.m {
+
+
+public aborts() {
+B0:
+	0: LdU64(42)
+	1: Abort
+}
+}
+Command `build -p dep`:
+BUILDING SomeDep
+warning[W09002]: unused variable
+  ┌─ ./sources/has_warning.move:2:16
+  │
+2 │ public fun foo(x: u64): u64 {
+  │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
@@ -15,10 +15,10 @@ B0:
 Command `build -p dep`:
 BUILDING SomeDep
 warning[W09002]: unused variable
-  ┌─ ./sources/has_warning.move:2:16
+  ┌─ ./sources/has_warning.move:2:20
   │
-2 │ public fun foo(x: u64): u64 {
-  │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+2 │     public fun foo(x: u64): u64 {
+  │                    ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
   │
   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.txt
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/args.txt
@@ -1,0 +1,3 @@
+build
+disassemble --package Test --name m
+build -p dep

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/Move.toml
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "SomeDep"
+version = "0.0.0"

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/sources/has_warning.move
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/sources/has_warning.move
@@ -1,0 +1,5 @@
+module 0x42::m {
+public fun foo(x: u64): u64 {
+    1 + 1
+}
+}

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/sources/has_warning.move
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/dep/sources/has_warning.move
@@ -1,5 +1,5 @@
 module 0x42::m {
-public fun foo(x: u64): u64 {
-    1 + 1
-}
+    public fun foo(x: u64): u64 {
+        1 + 1
+    }
 }

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/sources/m.move
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_dep_warnings/sources/m.move
@@ -1,0 +1,5 @@
+module 0x43::m {
+public fun aborts() {
+    abort 42
+}
+}

--- a/external-crates/move/tools/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/tools/move-package/src/compilation/build_plan.rs
@@ -95,7 +95,10 @@ impl BuildPlan {
                     immediate_dependencies_names.contains(&package_name),
                     dep_source_paths,
                     &dep_package.resolved_table,
-                    dep_package.compiler_config(&self.resolution_graph.build_options),
+                    dep_package.compiler_config(
+                        /* is_dependency */ true,
+                        &self.resolution_graph.build_options,
+                    ),
                 )
             })
             .collect();

--- a/external-crates/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/tools/move-package/src/compilation/compiled_package.rs
@@ -929,7 +929,10 @@ pub(crate) fn make_source_and_deps_for_compiler(
     let source_package_paths = PackagePaths {
         name: Some((
             root.source_package.package.name,
-            root.compiler_config(&resolution_graph.build_options),
+            root.compiler_config(
+                /* is_dependency */ false,
+                &resolution_graph.build_options,
+            ),
         )),
         paths: sources,
         named_address_map: root_named_addrs,

--- a/external-crates/move/tools/move-package/src/compilation/model_builder.rs
+++ b/external-crates/move/tools/move-package/src/compilation/model_builder.rs
@@ -59,7 +59,10 @@ impl ModelBuilder {
                     *nm,
                     dep_source_paths,
                     &pkg.resolved_table,
-                    pkg.compiler_config(&self.resolution_graph.build_options),
+                    pkg.compiler_config(
+                        /* is_dependency */ true,
+                        &self.resolution_graph.build_options,
+                    ),
                 )))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/external-crates/move/tools/move-package/src/lib.rs
+++ b/external-crates/move/tools/move-package/src/lib.rs
@@ -87,6 +87,11 @@ pub struct BuildConfig {
     /// Default edition for move compilation, if not specified in the package's config
     #[clap(long = "default-move-edition", global = true)]
     pub default_edition: Option<Edition>,
+
+    /// If set, dependency packages are treated as root packages. Notably, this will remove
+    /// warning suppression in dependency packages.
+    #[clap(long = "dependencies-are-root", global = true)]
+    pub deps_as_root: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/external-crates/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -441,8 +441,13 @@ impl Package {
             .collect())
     }
 
-    pub(crate) fn compiler_config(&self, config: &BuildConfig) -> PackageConfig {
+    pub(crate) fn compiler_config(
+        &self,
+        is_dependency: bool,
+        config: &BuildConfig,
+    ) -> PackageConfig {
         PackageConfig {
+            is_dependency,
             flavor: self
                 .source_package
                 .package
@@ -455,7 +460,7 @@ impl Package {
                 .edition
                 .or(config.default_edition)
                 .unwrap_or_default(),
-            warning_filter: WarningFilters::Empty,
+            warning_filter: WarningFilters::new(),
         }
     }
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps/Move.compiled
@@ -21,5 +21,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -120,6 +120,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
@@ -24,5 +24,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -94,6 +94,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -96,6 +96,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -110,6 +110,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -127,6 +127,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -154,6 +154,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -108,6 +108,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -152,6 +152,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -162,6 +162,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -162,6 +162,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
@@ -24,5 +24,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -94,6 +94,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/external/Move.resolved
@@ -71,6 +71,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -111,6 +111,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -77,6 +77,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -67,6 +67,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
@@ -25,5 +25,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -75,6 +75,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_override/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_override/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_renamed/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_renamed/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -48,6 +48,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/tools/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -27,6 +27,7 @@ ResolvedGraph {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/tools/move-package/tests/test_sources/test_symlinks/Move.compiled
+++ b/external-crates/move/tools/move-package/tests/test_sources/test_symlinks/Move.compiled
@@ -23,5 +23,6 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         default_flavor: None,
         default_edition: None,
+        deps_as_root: false,
     },
 }


### PR DESCRIPTION
## Description 

- Fixed issues with warning filter unions not respecting prefixes
- Added a notion of dependency packages
- Dependency packages and non-source definitions now have all warnings filtered for all possible filter attributes

## Test Plan 

- Added a move-cli test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
