### PR TITLE
[move-compiler] Fixed abstract interpreter bug

### DIFF
--- a/external-crates/move/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/move-compiler/src/cfgir/absint.rs
@@ -120,14 +120,14 @@ pub trait AbstractInterpreter: TransferFunctions {
                                 // the same post
                             }
                             JoinResult::Changed => {
+                                // Pre has changed, the post condition is now unknown for the block
+                                next_block_invariant.post = BlockPostcondition::Unprocessed;
                                 // If the cur->successor is a back edge, jump back to the beginning
                                 // of the loop, instead of the normal next block
                                 if cfg.is_back_edge(block_label, *next_block_id) {
                                     next_block_candidate = Some(*next_block_id);
                                     break;
                                 }
-                                // Pre has changed, the post condition is now unknown for the block
-                                next_block_invariant.post = BlockPostcondition::Unprocessed
                             }
                         }
                     }

--- a/external-crates/move/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/move-compiler/src/cfgir/absint.rs
@@ -124,6 +124,7 @@ pub trait AbstractInterpreter: TransferFunctions {
                                 // of the loop, instead of the normal next block
                                 if cfg.is_back_edge(block_label, *next_block_id) {
                                     next_block_candidate = Some(*next_block_id);
+                                    break;
                                 }
                                 // Pre has changed, the post condition is now unknown for the block
                                 next_block_invariant.post = BlockPostcondition::Unprocessed

--- a/external-crates/move/move-compiler/tests/move_check/liveness/implicit_copy_with_continue.move
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/implicit_copy_with_continue.move
@@ -1,0 +1,27 @@
+module 0x42::m {
+    public fun bar() {
+        abort 0
+    }
+
+    public fun foo(_: &u64) {
+        abort 0
+    }
+
+    public fun a() {
+        let index: u64 = 0;
+        let sum = 0;
+        while (index < 10) {
+
+            if (index % 2 == 0) {
+                sum = sum + index
+            } else {
+                index = index + 1;
+                bar();
+                continue
+            };
+
+            index = index + 1;
+        };
+        foo(&sum);
+    }
+}


### PR DESCRIPTION
## Description 

- Fixed abs int bug that was fixed in the bytecode verifier, but not the compiler
- Addressing https://github.com/move-language/move/issues/1068

## Test Plan 

- Added a test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fixed an edge-case bug with the Move compiler that could result in control-flow sensitive errors not being caught before reaching the bytecode verifier. 