### PR TITLE
[vm] reduce duplicate frame names

### DIFF
--- a/external-crates/move/move-vm/profiler/src/lib.rs
+++ b/external-crates/move/move-vm/profiler/src/lib.rs
@@ -139,18 +139,18 @@ impl GasProfiler {
         frame_display_name: String,
         metadata: String,
     ) -> u64 {
-        *self
-            .shared
-            .frame_table
-            .entry(frame_name.clone())
-            .or_insert({
+        match self.shared.frame_table.get(frame_name.as_str()) {
+            Some(idx) => *idx as u64,
+            None => {
                 let val = self.shared.frames.len() as u64;
                 self.shared.frames.push(FrameName {
                     name: frame_display_name,
                     file: metadata,
                 });
-                val as usize
-            }) as u64
+                self.shared.frame_table.insert(frame_name, val as usize);
+                val
+            }
+        }
     }
 
     pub fn open_frame(&mut self, frame_name: String, metadata: String, gas_start: u64) {


### PR DESCRIPTION
## Description 

Fixes a bug causing unused data in gas profiler output.
Reduced size of profile considerably (15MB to 5MB in test).

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
