### PR TITLE
[graphql/rpc] Graphql impl part5 address stubs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ CHANGELOG.md
 /crates/sui-framework/src/natives/ @oxade
 
 # GraphQL RPC working group
-/crates/sui-graphql-rpc/ @oxade @amn @wlmyng @bmwill @longbowlu @mystenmark @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
+/crates/sui-graphql-rpc/ @oxade @ammn @wlmyng @bmwill @longbowlu @mystenmark @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
 
 # Notify Narwhal changes to interested folks.
 /narwhal/crypto/ @joyqvq @kchalkias

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ CHANGELOG.md
 /crates/sui-framework/src/natives/ @oxade
 
 # GraphQL RPC working group
-/crates/sui-graphql-rpc/ @oxade @ammn @wlmyng @bmwill @longbowlu @mystenmark @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
+/crates/sui-graphql-rpc/ @oxade @amnn @wlmyng @bmwill @longbowlu @mystenmark @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
 
 # Notify Narwhal changes to interested folks.
 /narwhal/crypto/ @joyqvq @kchalkias

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,9 @@ CHANGELOG.md
 # When native functions change, so we can evaluate cost impact
 /crates/sui-framework/src/natives/ @oxade
 
+# GraphQL RPC working group
+/crates/sui-graphql-rpc/ @oxade @amn @wlmyng @bmwill @longbowlu @mystenmark @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
+
 # Notify Narwhal changes to interested folks.
 /narwhal/crypto/ @joyqvq @kchalkias
 /narwhal/executor/ @asonnino @akichidis @laura-makdah

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -4,20 +4,43 @@
 use async_graphql::*;
 
 use super::{
-    balance::Balance,
+    balance::{Balance, BalanceConnection},
     coin::CoinConnection,
     name_service::NameServiceConnection,
     object::{ObjectConnection, ObjectFilter},
     stake::StakeConnection,
     sui_address::SuiAddress,
+    transaction_block::{TransactionBlockConnection, TransactionBlockFilter},
 };
 
 pub(crate) struct Address;
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum AddressTransactionBlockRelationship {
+    Sign, // Transactions this address has signed
+    Sent, // Transactions that transferred objects from this address
+    Recv, // Transactions that received objects into this address
+    Paid, // Transactions that were paid for by this address
+}
 
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 #[Object]
 impl Address {
+    async fn transaction_block_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        relation: Option<AddressTransactionBlockRelationship>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Option<TransactionBlockConnection> {
+        unimplemented!()
+    }
+
+    // =========== Owner interface methods =============
+
     pub async fn location(&self) -> SuiAddress {
         unimplemented!()
     }
@@ -43,7 +66,7 @@ impl Address {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Option<ObjectConnection> {
+    ) -> Option<BalanceConnection> {
         unimplemented!()
     }
 

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -19,7 +19,7 @@ impl Balance {
 #[allow(unused_variables)]
 #[Object]
 impl BalanceConnection {
-    async fn id(&self) -> ID {
+    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -19,7 +19,7 @@ impl Coin {
 #[allow(unused_variables)]
 #[Object]
 impl CoinConnection {
-    async fn id(&self) -> ID {
+    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod owner;
 pub(crate) mod query;
 pub(crate) mod stake;
 pub(crate) mod sui_address;
+pub(crate) mod transaction_block;

--- a/crates/sui-graphql-rpc/src/types/name_service.rs
+++ b/crates/sui-graphql-rpc/src/types/name_service.rs
@@ -3,23 +3,13 @@
 
 use async_graphql::*;
 
-pub(crate) struct NameService;
 pub(crate) struct NameServiceConnection;
 
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 #[Object]
-impl NameService {
-    async fn id(&self) -> ID {
-        unimplemented!()
-    }
-}
-
-#[allow(unreachable_code)]
-#[allow(unused_variables)]
-#[Object]
 impl NameServiceConnection {
-    async fn id(&self) -> ID {
+    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -4,8 +4,11 @@
 use async_graphql::*;
 
 use super::{
-    balance::Balance, coin::CoinConnection, name_service::NameServiceConnection,
-    stake::StakeConnection, sui_address::SuiAddress,
+    balance::{Balance, BalanceConnection},
+    coin::CoinConnection,
+    name_service::NameServiceConnection,
+    stake::StakeConnection,
+    sui_address::SuiAddress,
 };
 
 pub(crate) struct Object;
@@ -13,19 +16,21 @@ pub(crate) struct ObjectConnection;
 
 #[derive(InputObject)]
 pub(crate) struct ObjectFilter {
-    package: SuiAddress,
-    module: String,
-    ty: String,
+    package: Option<SuiAddress>,
+    module: Option<String>,
+    ty: Option<String>,
 
-    owner: SuiAddress,
-    object_id: SuiAddress,
-    version: u64,
+    owner: Option<SuiAddress>,
+    object_id: Option<SuiAddress>,
+    version: Option<u64>,
 }
 
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 #[Object]
 impl Object {
+    // =========== Owner interface methods =============
+
     pub async fn location(&self) -> SuiAddress {
         unimplemented!()
     }
@@ -51,7 +56,7 @@ impl Object {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Option<ObjectConnection> {
+    ) -> Option<BalanceConnection> {
         unimplemented!()
     }
 
@@ -95,7 +100,7 @@ impl Object {
 #[allow(unused_variables)]
 #[Object]
 impl ObjectConnection {
-    async fn id(&self) -> ID {
+    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -30,7 +30,7 @@ use super::address::Address;
     ),
     field(
         name = "balance_connection",
-        type = "Option<ObjectConnection>",
+        type = "Option<BalanceConnection>",
         arg(name = "first", type = "Option<u64>"),
         arg(name = "after", type = "Option<String>"),
         arg(name = "last", type = "Option<u64>"),
@@ -100,7 +100,7 @@ impl AmbiguousOwner {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Option<ObjectConnection> {
+    ) -> Option<BalanceConnection> {
         unimplemented!()
     }
 

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -19,7 +19,7 @@ impl Stake {
 #[allow(unused_variables)]
 #[Object]
 impl StakeConnection {
-    async fn id(&self) -> ID {
+    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use super::sui_address::SuiAddress;
+
+pub(crate) struct TransactionBlock;
+pub(crate) struct TransactionBlockConnection;
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum TransactionBlockKindInput {
+    ConsensusCommitPrologue,
+    Genesis,
+    ChangeEpoch,
+    Programmable,
+}
+
+#[derive(InputObject)]
+pub(crate) struct TransactionBlockFilter {
+    package: Option<SuiAddress>,
+    module: Option<String>,
+    function: Option<String>,
+
+    kind: Option<TransactionBlockKindInput>,
+    checkpoint: Option<u64>,
+
+    sign_address: Option<SuiAddress>,
+    sent_address: Option<SuiAddress>,
+    recv_address: Option<SuiAddress>,
+    paid_address: Option<SuiAddress>,
+
+    input_object: Option<SuiAddress>,
+    changed_object: Option<SuiAddress>,
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl TransactionBlock {
+    async fn id(&self) -> ID {
+        unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl TransactionBlockConnection {
+    async fn unimplemented(&self) -> bool {
+        unimplemented!()
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -3,21 +3,29 @@ source: crates/sui-graphql-rpc/tests/snapshot_tests.rs
 expression: sdl
 ---
 type Address implements Owner {
+	transactionBlockConnection(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter): TransactionBlockConnection
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance!
-	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
 	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
 }
 
+enum AddressTransactionBlockRelationship {
+	SIGN
+	SENT
+	RECV
+	PAID
+}
+
 type AmbiguousOwner implements Owner {
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance!
-	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
@@ -28,23 +36,27 @@ type Balance {
 	id: ID!
 }
 
+type BalanceConnection {
+	unimplemented: Boolean!
+}
+
 
 type CoinConnection {
-	id: ID!
+	unimplemented: Boolean!
 }
 
 
 
 
 type NameServiceConnection {
-	id: ID!
+	unimplemented: Boolean!
 }
 
 type Object implements Owner {
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance!
-	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
@@ -52,23 +64,23 @@ type Object implements Owner {
 }
 
 type ObjectConnection {
-	id: ID!
+	unimplemented: Boolean!
 }
 
 input ObjectFilter {
-	package: SuiAddress!
-	module: String!
-	ty: String!
-	owner: SuiAddress!
-	objectId: SuiAddress!
-	version: Int!
+	package: SuiAddress
+	module: String
+	ty: String
+	owner: SuiAddress
+	objectId: SuiAddress
+	version: Int
 }
 
 interface Owner {
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance!
-	balanceConnection(first: Int, after: String, last: Int, before: String): ObjectConnection
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
@@ -83,7 +95,7 @@ type Query {
 }
 
 type StakeConnection {
-	id: ID!
+	unimplemented: Boolean!
 }
 
 
@@ -91,6 +103,31 @@ type StakeConnection {
 Representation of Sui Addresses
 """
 scalar SuiAddress
+
+type TransactionBlockConnection {
+	unimplemented: Boolean!
+}
+
+input TransactionBlockFilter {
+	package: SuiAddress
+	module: String
+	function: String
+	kind: TransactionBlockKindInput
+	checkpoint: Int
+	signAddress: SuiAddress
+	sentAddress: SuiAddress
+	recvAddress: SuiAddress
+	paidAddress: SuiAddress
+	inputObject: SuiAddress
+	changedObject: SuiAddress
+}
+
+enum TransactionBlockKindInput {
+	CONSENSUS_COMMIT_PROLOGUE
+	GENESIS
+	CHANGE_EPOCH
+	PROGRAMMABLE
+}
 
 schema {
 	query: Query


### PR DESCRIPTION
## Description 

Sets up all the stubs for `Address` and cleans up some nits.
Adds reviewers to codeowners

## Test Plan 

Snapshot


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
