### PR TITLE
indexer: read statement timeouts from env variables

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -301,8 +301,8 @@ struct PgConectionPoolConfig {
 
 impl PgConectionPoolConfig {
     const DEFAULT_POOL_SIZE: u32 = 100;
-    const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
-    const DEFAULT_STATEMENT_TIMEOUT: Duration = Duration::from_secs(5);
+    const DEFAULT_CONNECTION_TIMEOUT: u64 = 30;
+    const DEFAULT_STATEMENT_TIMEOUT: u64 = 30;
 
     fn connection_config(&self) -> PgConnectionConfig {
         PgConnectionConfig {
@@ -317,10 +317,19 @@ impl Default for PgConectionPoolConfig {
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(Self::DEFAULT_POOL_SIZE);
+        let conn_timeout_secs = std::env::var("DB_CONNECTION_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(Self::DEFAULT_CONNECTION_TIMEOUT);
+        let statement_timeout_secs = std::env::var("DB_STATEMENT_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(Self::DEFAULT_STATEMENT_TIMEOUT);
+
         Self {
             pool_size: db_pool_size,
-            connection_timeout: Self::DEFAULT_CONNECTION_TIMEOUT,
-            statement_timeout: Self::DEFAULT_STATEMENT_TIMEOUT,
+            connection_timeout: Duration::from_secs(conn_timeout_secs),
+            statement_timeout: Duration::from_secs(statement_timeout_secs),
         }
     }
 }


### PR DESCRIPTION
## Description 

the epoch commit sometimes takes longer than that b/c it has triggers which are relatively slow.

## Test Plan 

test in tnt production

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
