### PR TITLE
jwk: change JWK mapping to (kid, iss) -> jwk, add twich and fb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-graphql-axum"
+version = "5.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777d02b4b35c1eb15bb63391f45b4622206fe1199940fa8b4b6136904fae035c"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "axum",
+ "bytes",
+ "futures-util",
+ "http-body",
+ "serde_json",
+ "tokio-util 0.7.4",
+ "tower-service",
+]
+
+[[package]]
 name = "async-graphql-derive"
 version = "5.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1518,7 @@ checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.21.2",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -1519,8 +1537,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tower-layer",
@@ -3635,7 +3655,62 @@ dependencies = [
  "ed25519-consensus",
  "elliptic-curve 0.13.4",
  "eyre",
- "fastcrypto-derive",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1)",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "lazy_static",
+ "merlin",
+ "once_cell",
+ "p256",
+ "rand 0.8.5",
+ "readonly",
+ "rfc6979 0.4.0",
+ "rsa",
+ "schemars",
+ "secp256k1",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
+ "signature 2.0.0",
+ "static_assertions",
+ "thiserror",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "fastcrypto"
+version = "0.1.5"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a#d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "ark-ec",
+ "ark-ff",
+ "ark-secp256r1",
+ "ark-serialize",
+ "auto_ops",
+ "base64ct",
+ "bincode",
+ "blake2",
+ "blake3",
+ "blst",
+ "bs58",
+ "bulletproofs",
+ "cbc",
+ "ctr",
+ "curve25519-dalek-ng",
+ "derive_more",
+ "digest 0.10.6",
+ "ecdsa 0.16.6",
+ "ed25519-consensus",
+ "elliptic-curve 0.13.4",
+ "eyre",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "generic-array",
  "hex",
  "hkdf",
@@ -3674,6 +3749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastcrypto-derive"
+version = "0.1.3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a#d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2 1.0.58",
+ "quote 1.0.26",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "fastcrypto-zkp"
 version = "0.1.1"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1#c961a01596a87e76f590c7e43aca9d57106dbbb1"
@@ -3689,7 +3775,34 @@ dependencies = [
  "blst",
  "byte-slice-cast",
  "derive_more",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1)",
+ "num-bigint",
+ "once_cell",
+ "poseidon-ark",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "fastcrypto-zkp"
+version = "0.1.1"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a#d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize",
+ "blst",
+ "byte-slice-cast",
+ "derive_more",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "im",
  "num-bigint",
  "once_cell",
  "poseidon-ark",
@@ -6352,7 +6465,7 @@ version = "0.11.0"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
  "indexmap",
@@ -6398,7 +6511,7 @@ dependencies = [
 name = "narwhal-config"
 version = "0.1.0"
 dependencies = [
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "insta",
  "match_opt",
  "mysten-network",
@@ -6424,7 +6537,7 @@ dependencies = [
  "bincode",
  "cfg-if",
  "criterion",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "indexmap",
  "match_opt",
@@ -6455,7 +6568,7 @@ dependencies = [
  "bcs",
  "bincode",
  "criterion",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "hex-literal",
  "proptest",
  "proptest-derive",
@@ -6476,7 +6589,7 @@ dependencies = [
  "bcs",
  "bincode",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "indexmap",
  "itertools",
@@ -6548,7 +6661,7 @@ dependencies = [
  "cfg-if",
  "clap 2.34.0",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "mysten-metrics",
  "mysten-network",
@@ -6597,7 +6710,7 @@ dependencies = [
  "bincode",
  "bytes",
  "dashmap",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "governor",
  "indexmap",
@@ -6641,7 +6754,7 @@ name = "narwhal-storage"
 version = "0.1.0"
 dependencies = [
  "dashmap",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "lru",
  "mysten-common",
@@ -6665,7 +6778,7 @@ name = "narwhal-test-utils"
 version = "0.1.0"
 dependencies = [
  "anemo",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "fdlimit",
  "indexmap",
  "itertools",
@@ -6707,7 +6820,7 @@ dependencies = [
  "criterion",
  "derive_builder",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "indexmap",
  "mockall",
@@ -6753,7 +6866,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "governor",
  "itertools",
@@ -9306,7 +9419,7 @@ version = "0.0.0"
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "serde",
  "serde_repr",
  "workspace-hack",
@@ -9675,8 +9788,8 @@ dependencies = [
  "const-str",
  "csv",
  "expect-test",
- "fastcrypto",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "fs_extra",
  "git-version",
  "inquire",
@@ -9805,7 +9918,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "ed25519-consensus",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "indicatif",
  "integer-encoding",
@@ -9846,7 +9959,7 @@ dependencies = [
  "clap 3.2.23",
  "comfy-table",
  "duration-str",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "hdrhistogram",
  "indicatif",
@@ -9898,7 +10011,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "clap 3.2.23",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "jsonrpsee",
  "move-core-types",
@@ -9940,7 +10053,7 @@ dependencies = [
  "bcs",
  "csv",
  "dirs",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "insta",
  "move-binary-format",
  "move-core-types",
@@ -9979,8 +10092,8 @@ dependencies = [
  "enum_dispatch",
  "expect-test",
  "eyre",
- "fastcrypto",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "fs_extra",
  "futures",
  "im",
@@ -10084,7 +10197,7 @@ dependencies = [
  "bcs",
  "clap 3.2.23",
  "expect-test",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "fs_extra",
  "futures",
  "indexmap",
@@ -10275,7 +10388,7 @@ dependencies = [
  "camino",
  "csv",
  "dirs",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "insta",
  "move-binary-format",
  "move-core-types",
@@ -10328,7 +10441,7 @@ dependencies = [
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "itertools",
  "jsonrpsee",
@@ -10369,7 +10482,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -10396,7 +10509,7 @@ dependencies = [
  "cached",
  "expect-test",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "hyper",
  "itertools",
@@ -10479,7 +10592,7 @@ dependencies = [
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "itertools",
  "move-binary-format",
  "move-bytecode-utils",
@@ -10504,7 +10617,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bip32",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -10584,7 +10697,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "const-str",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "git-version",
  "jemalloc-ctl",
@@ -10625,7 +10738,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "datatest-stable",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -10650,8 +10763,8 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "linked-hash-map",
  "move-binary-format",
  "move-core-types",
@@ -10670,8 +10783,8 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "linked-hash-map",
  "move-binary-format",
  "move-core-types",
@@ -10694,7 +10807,7 @@ dependencies = [
  "anyhow",
  "dashmap",
  "ed25519-consensus",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "governor",
  "mysten-metrics",
@@ -10730,7 +10843,7 @@ dependencies = [
  "axum",
  "clap 3.2.23",
  "const-str",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "git-version",
  "mysten-common",
@@ -10773,7 +10886,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap 3.2.23",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "move-core-types",
  "pretty_assertions",
  "rand 0.8.5",
@@ -10881,7 +10994,7 @@ dependencies = [
  "bytes",
  "clap 3.2.23",
  "const-str",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "git-version",
  "http-body",
  "hyper",
@@ -10970,7 +11083,7 @@ dependencies = [
  "chrono",
  "clap 3.2.23",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "hyper",
  "move-bytecode-utils",
@@ -11065,7 +11178,7 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "dirs",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -11095,7 +11208,7 @@ version = "0.7.0"
 dependencies = [
  "anemo",
  "anemo-tower",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "lru",
  "move-package",
  "msim",
@@ -11121,7 +11234,7 @@ dependencies = [
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "integer-encoding",
  "num_enum",
@@ -11215,7 +11328,7 @@ dependencies = [
  "clap 4.3.3",
  "criterion",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "hyper",
  "hyper-rustls 0.24.0",
@@ -11319,7 +11432,7 @@ dependencies = [
  "camino",
  "csv",
  "dirs",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "insta",
  "move-binary-format",
  "move-core-types",
@@ -11349,7 +11462,7 @@ dependencies = [
 name = "sui-telemetry"
 version = "0.1.0"
 dependencies = [
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "reqwest",
  "serde",
  "sui-core",
@@ -11397,7 +11510,7 @@ dependencies = [
  "axum",
  "axum-server",
  "ed25519",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "pkcs8 0.9.0",
  "rand 0.8.5",
  "rcgen",
@@ -11423,7 +11536,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "futures",
  "hex",
  "indicatif",
@@ -11489,7 +11602,7 @@ dependencies = [
  "bcs",
  "bimap",
  "clap 3.2.23",
- "fastcrypto",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
@@ -11532,8 +11645,8 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a)",
  "im",
  "indexmap",
  "itertools",
@@ -12182,6 +12295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12588,6 +12713,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12858,6 +13002,12 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -13388,6 +13538,7 @@ dependencies = [
  "assert_cmd",
  "async-compression",
  "async-graphql",
+ "async-graphql-axum",
  "async-graphql-derive",
  "async-graphql-parser",
  "async-graphql-value",
@@ -13465,7 +13616,6 @@ dependencies = [
  "bs58",
  "bstr",
  "bulletproofs",
- "bumpalo",
  "byte-slice-cast",
  "bytecode-interpreter-crypto",
  "bytecount",
@@ -13616,9 +13766,9 @@ dependencies = [
  "eyre",
  "fail",
  "fast_chemail",
- "fastcrypto",
- "fastcrypto-derive",
- "fastcrypto-zkp",
+ "fastcrypto 0.1.5 (git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1)",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1)",
+ "fastcrypto-zkp 0.1.1 (git+https://github.com/MystenLabs/fastcrypto?rev=c961a01596a87e76f590c7e43aca9d57106dbbb1)",
  "fastrand",
  "fd-lock",
  "fdlimit",
@@ -13657,9 +13807,6 @@ dependencies = [
  "glob",
  "globset",
  "globwalk",
- "gloo-net",
- "gloo-timers",
- "gloo-utils",
  "governor",
  "group 0.12.1",
  "group 0.13.0",
@@ -13725,7 +13872,6 @@ dependencies = [
  "jemalloc-ctl",
  "jemalloc-sys",
  "jobserver",
- "js-sys",
  "json_to_table",
  "jsonpath_lib",
  "jsonrpsee",
@@ -13735,7 +13881,6 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
- "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "k256",
  "keccak",
@@ -14026,7 +14171,6 @@ dependencies = [
  "semver 0.11.0",
  "semver 1.0.16",
  "semver-parser",
- "send_wrapper",
  "serde",
  "serde-name",
  "serde-reflection",
@@ -14133,6 +14277,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-rustls 0.24.0",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util 0.7.4",
  "toml 0.5.10",
  "toml 0.7.4",
@@ -14161,6 +14306,7 @@ dependencies = [
  "try-lock",
  "ttl_cache",
  "tui",
+ "tungstenite",
  "twox-hash",
  "typed-arena",
  "typenum",
@@ -14190,6 +14336,7 @@ dependencies = [
  "unzip-n",
  "url",
  "urlencoding",
+ "utf-8",
  "utf8parse",
  "uuid",
  "variant_count",
@@ -14204,13 +14351,6 @@ dependencies = [
  "waker-fn",
  "walkdir",
  "want",
- "wasm-bindgen",
- "wasm-bindgen-backend",
- "wasm-bindgen-futures",
- "wasm-bindgen-macro",
- "wasm-bindgen-macro-support",
- "wasm-bindgen-shared",
- "web-sys",
  "webpki",
  "webpki-roots",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -413,8 +413,8 @@ move-stackless-bytecode = { path = "external-crates/move/move-prover/bytecode" }
 move-symbol-pool = { path = "external-crates/move/move-symbol-pool" }
 move-abstract-stack = { path = "external-crates/move/move-abstract-stack" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c961a01596a87e76f590c7e43aca9d57106dbbb1" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c961a01596a87e76f590c7e43aca9d57106dbbb1", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d4e25fa7bbc1d385bfb5cba44ca7a5d745dd2e3a", package = "fastcrypto-zkp" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f222820a20b586088ea7a2941478a159" }

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use either::Either;
+use fastcrypto_zkp::bn254::zk_login::OAuthProviderContent;
 use futures::pin_mut;
 use im::hashmap::HashMap as ImHashMap;
 use itertools::izip;
@@ -275,17 +276,15 @@ impl SignatureVerifier {
         });
     }
 
-    /// Insert a JWK into the verifier state. Returns true if the kid of the JWK has not already
+    /// Insert a JWK into the verifier state based on provider. Returns true if the kid of the JWK has not already
     /// been inserted.
-    pub(crate) fn insert_oauth_jwk(&self, content: &OAuthProviderContent) -> bool {
+    pub(crate) fn insert_oauth_jwk(&self, content: &OAuthProviderContent, iss: String) -> bool {
         let mut oauth_provider_jwk = self.oauth_provider_jwk.write();
-
-        if oauth_provider_jwk.contains_key(content.kid()) {
+        if oauth_provider_jwk.contains_key(&(content.kid().to_string(), iss.clone())) {
             return false;
         }
-
         let kid = content.kid().to_string();
-        oauth_provider_jwk.insert(kid, content.clone());
+        oauth_provider_jwk.insert((kid, iss), content.clone());
         true
     }
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -60,6 +60,7 @@ asn1-rs = { version = "0.5", features = ["datetime"] }
 assert_cmd = { version = "2", default-features = false }
 async-compression = { version = "0.3", features = ["brotli", "gzip", "tokio", "zlib"] }
 async-graphql = { version = "5" }
+async-graphql-axum = { version = "5", default-features = false }
 async-graphql-parser = { version = "5", default-features = false }
 async-graphql-value = { version = "5", default-features = false }
 async-lock = { version = "2", default-features = false }
@@ -89,7 +90,7 @@ aws-smithy-query = { version = "0.55", default-features = false }
 aws-smithy-types = { version = "0.55", default-features = false }
 aws-smithy-xml = { version = "0.55", default-features = false }
 aws-types = { version = "0.55", default-features = false }
-axum = { version = "0.6", default-features = false, features = ["form", "headers", "http1", "http2", "json", "matched-path", "original-uri", "query", "tokio"] }
+axum = { version = "0.6", features = ["headers", "http2", "ws"] }
 axum-core = { version = "0.3", default-features = false }
 axum-extra = { version = "0.4" }
 axum-server = { version = "0.4", default-features = false, features = ["tls-rustls"] }
@@ -268,7 +269,7 @@ futures-io = { version = "0.3", features = ["unstable"] }
 futures-lite = { version = "1" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
-futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
+futures-timer = { version = "3", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
@@ -279,9 +280,6 @@ git-version = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
 globset = { version = "0.4" }
 globwalk = { version = "0.8", default-features = false }
-gloo-net = { version = "0.2", default-features = false, features = ["json", "websocket"] }
-gloo-timers = { version = "0.2", features = ["futures"] }
-gloo-utils = { version = "0.1", default-features = false, features = ["serde"] }
 governor = { version = "0.5" }
 group-594e8ee84c453af0 = { package = "group", version = "0.13", default-features = false, features = ["alloc"] }
 group-5ef9efb8ec2df382 = { package = "group", version = "0.12", default-features = false }
@@ -334,16 +332,14 @@ iri-string = { version = "0.4" }
 is-terminal = { version = "0.4", default-features = false }
 itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
-js-sys = { version = "0.3", default-features = false }
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4", default-features = false }
 jsonpath_lib = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["http-client", "macros", "server", "ws-client"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "http-helpers", "server", "soketto"] }
 jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
 jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
 jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
@@ -567,7 +563,6 @@ sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["pem", 
 secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
 semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
-send_wrapper = { version = "0.4", default-features = false }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-name = { version = "0.2", default-features = false }
 serde-reflection = { version = "0.3", default-features = false }
@@ -652,6 +647,7 @@ tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24", default-features = false, features = ["logging", "tls12"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
+tokio-tungstenite = { version = "0.18" }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
@@ -677,6 +673,7 @@ treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
 tui = { version = "0.17" }
+tungstenite = { version = "0.18", default-features = false, features = ["handshake"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2" }
 typenum = { version = "1", default-features = false }
@@ -703,6 +700,7 @@ unsigned-varint = { version = "0.7", default-features = false, features = ["std"
 untrusted = { version = "0.7", default-features = false }
 url = { version = "2", features = ["serde"] }
 urlencoding = { version = "2", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 vec_map = { version = "0.8", default-features = false }
@@ -713,9 +711,6 @@ wait-timeout = { version = "0.2", default-features = false }
 waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["AddEventListenerOptions", "BinaryType", "Blob", "CloseEvent", "CloseEventInit", "Document", "ErrorEvent", "FileReader", "History", "HtmlHeadElement", "Location", "MessageEvent", "ProgressEvent", "WebSocket", "Window"] }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots = { version = "0.22", default-features = false }
 whoami = { version = "1" }
@@ -785,6 +780,7 @@ asn1-rs-impl = { version = "0.1", default-features = false }
 assert_cmd = { version = "2", default-features = false }
 async-compression = { version = "0.3", features = ["brotli", "gzip", "tokio", "zlib"] }
 async-graphql = { version = "5" }
+async-graphql-axum = { version = "5", default-features = false }
 async-graphql-derive = { version = "5", default-features = false }
 async-graphql-parser = { version = "5", default-features = false }
 async-graphql-value = { version = "5", default-features = false }
@@ -819,7 +815,7 @@ aws-smithy-query = { version = "0.55", default-features = false }
 aws-smithy-types = { version = "0.55", default-features = false }
 aws-smithy-xml = { version = "0.55", default-features = false }
 aws-types = { version = "0.55", default-features = false }
-axum = { version = "0.6", default-features = false, features = ["form", "headers", "http1", "http2", "json", "matched-path", "original-uri", "query", "tokio"] }
+axum = { version = "0.6", features = ["headers", "http2", "ws"] }
 axum-core = { version = "0.3", default-features = false }
 axum-extra = { version = "0.4" }
 axum-server = { version = "0.4", default-features = false, features = ["tls-rustls"] }
@@ -861,7 +857,6 @@ brotli-decompressor = { version = "2", default-features = false, features = ["st
 bs58 = { version = "0.4", features = ["check"] }
 bstr = { version = "1" }
 bulletproofs = { version = "4" }
-bumpalo = { version = "3" }
 byte-slice-cast = { version = "1" }
 bytecode-interpreter-crypto = { path = "../../external-crates/move/move-prover/interpreter/crypto" }
 bytecount = { version = "0.6", default-features = false }
@@ -1027,7 +1022,7 @@ futures-lite = { version = "1" }
 futures-macro = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
-futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
+futures-timer = { version = "3", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
@@ -1039,9 +1034,6 @@ git-version-macro = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
 globset = { version = "0.4" }
 globwalk = { version = "0.8", default-features = false }
-gloo-net = { version = "0.2", default-features = false, features = ["json", "websocket"] }
-gloo-timers = { version = "0.2", features = ["futures"] }
-gloo-utils = { version = "0.1", default-features = false, features = ["serde"] }
 governor = { version = "0.5" }
 group-594e8ee84c453af0 = { package = "group", version = "0.13", default-features = false, features = ["alloc"] }
 group-5ef9efb8ec2df382 = { package = "group", version = "0.12", default-features = false }
@@ -1102,17 +1094,15 @@ is-terminal = { version = "0.4", default-features = false }
 itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
-js-sys = { version = "0.3", default-features = false }
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4", default-features = false }
 jsonpath_lib = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["http-client", "macros", "server", "ws-client"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "http-helpers", "server", "soketto"] }
 jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 jsonrpsee-proc-macros = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
 jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
 jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
 jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
@@ -1380,7 +1370,6 @@ secp256k1-sys = { version = "0.8", default-features = false, features = ["recove
 semver-a6292c17cd707f01 = { package = "semver", version = "0.11" }
 semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
 semver-parser = { version = "0.10", default-features = false }
-send_wrapper = { version = "0.4", default-features = false }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-name = { version = "0.2", default-features = false }
 serde-reflection = { version = "0.3", default-features = false }
@@ -1480,6 +1469,7 @@ tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24", default-features = false, features = ["logging", "tls12"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
+tokio-tungstenite = { version = "0.18" }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
@@ -1508,6 +1498,7 @@ treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
 tui = { version = "0.17" }
+tungstenite = { version = "0.18", default-features = false, features = ["handshake"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2" }
 typenum = { version = "1", default-features = false }
@@ -1537,6 +1528,7 @@ untrusted = { version = "0.7", default-features = false }
 unzip-n = { version = "0.1", default-features = false }
 url = { version = "2", features = ["serde"] }
 urlencoding = { version = "2", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 variant_count = { version = "1", default-features = false }
@@ -1550,13 +1542,6 @@ wait-timeout = { version = "0.2", default-features = false }
 waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-backend = { version = "0.2", default-features = false, features = ["spans"] }
-wasm-bindgen-futures = { version = "0.4", default-features = false }
-wasm-bindgen-macro = { version = "0.2", default-features = false, features = ["spans"] }
-wasm-bindgen-macro-support = { version = "0.2", default-features = false, features = ["spans"] }
-wasm-bindgen-shared = { version = "0.2", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["AddEventListenerOptions", "BinaryType", "Blob", "CloseEvent", "CloseEventInit", "Document", "ErrorEvent", "FileReader", "History", "HtmlHeadElement", "Location", "MessageEvent", "ProgressEvent", "WebSocket", "Window"] }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots = { version = "0.22", default-features = false }
 which = { version = "4", default-features = false }
@@ -1614,7 +1599,6 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1657,7 +1641,6 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1695,7 +1678,6 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1735,7 +1717,6 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 anstyle-wincon = { version = "1", default-features = false }
@@ -1754,7 +1735,6 @@ raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
@@ -1784,7 +1764,6 @@ schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 vcpkg = { version = "0.2", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }


### PR DESCRIPTION
## Description 
this is to support multiple iss in addition to google, the mapping key is (kid, iss) now. 

this is cherry picked out of the main pr for better review: https://github.com/MystenLabs/sui/pull/13124 however the underlying fastcrypto also changed so this won't compile till that is merged. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
