### PR TITLE
Assume simplified_unwrap_then_delete in sui-execution latest

### DIFF
--- a/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
+++ b/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
@@ -20,6 +20,8 @@ mod sim_only_tests {
     async fn test_simplified_unwrap_then_delete_protocol_upgrade() {
         let mut _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_simplified_unwrap_then_delete(false);
+            // sui-execution v1 assumes simplified_unwrap_then_delete is set.
+            config.set_execution_version_for_testing(0);
             config
         });
 


### PR DESCRIPTION
## Description 

simplified_unwrap_then_delete is enabled in v16, sui-execution latest is enabled in v18.
So we could always assume simplified_unwrap_then_delete in sui-execution latest without having to check it.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
