### PR TITLE
Remove expensive clone on hot execution path

### DIFF
--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -322,7 +322,7 @@ impl<'backing> TemporaryStore<'backing> {
                 .map(|(id, metadata)| (id, metadata.version))
                 .collect(),
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
-            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.read().clone(),
+            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
         }
     }
 


### PR DESCRIPTION
Turned an unnecessary clone of a `BTreeMap` wrapped within an `RwLock` into a call to `into_inner()`. This change is valid since the `RwLock` is dropped afterwards anyways as part of the consumed `self` argument of this function. Since this clone was called every time within the `to_effects()` call of the `TemporaryStore` it is on the hot execution path for transaction processing. According to measurements performed by applying this change on the code base for the distributed execution research project (https://github.com/TonyZhangND/sui/tree/distributed-execution) it seems this change could improve tps by around 6% for sequential tx processing (specifically measured mainnet txs CP 0 through CP 500k).