### PR TITLE
[ts-sdk] rename generated TransactionBlock type to avoid naming conflicts

### DIFF
--- a/.changeset/four-meals-clean.md
+++ b/.changeset/four-meals-clean.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': minor
+---
+
+Rename TransactionBlock generated type in @mysten/sui.js/client to SuiTransactionBlock to avoid conflicting names in exports

--- a/sdk/typescript/scripts/generate.ts
+++ b/sdk/typescript/scripts/generate.ts
@@ -80,6 +80,7 @@ const options: {
 		SuiCoinMetadata: { alias: 'CoinMetadata' },
 		SuiProgrammableMoveCall: { alias: 'MoveCallSuiTransaction' },
 		Supply: { alias: 'CoinSupply' },
+		TransactionBlock: { alias: 'SuiTransactionBlock' },
 		TransactionBlockEffects: { alias: 'TransactionEffects' },
 		TransactionBlockKind: { alias: 'SuiTransactionBlockKind' },
 		TransactionBlockResponse: { alias: 'SuiTransactionBlockResponse' },

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1185,7 +1185,7 @@ export interface SuiValidatorSummary {
 export interface CoinSupply {
 	value: string;
 }
-export interface TransactionBlock {
+export interface SuiTransactionBlock {
 	data: TransactionBlockData;
 	txSignatures: string[];
 }
@@ -1306,7 +1306,7 @@ export interface SuiTransactionBlockResponse {
 	rawTransaction?: string;
 	timestampMs?: string | null;
 	/** Transaction input data */
-	transaction?: TransactionBlock | null;
+	transaction?: SuiTransactionBlock | null;
 }
 export interface SuiTransactionBlockResponseOptions {
 	/** Whether to show balance_changes. Default to be False */


### PR DESCRIPTION
## Description 

I think this type got overlooked because it wasn't used anywhere in the Sui repo, but having 2 things called `TransactionBlock` may cause some confusion.  This aligns this types name more closely with other generated types

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
