### PR TITLE
sui-execution generate primitive results

### DIFF
--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -8,7 +8,7 @@ use crate::digests::{
 };
 use crate::effects::{TransactionEffects, TransactionEvents};
 use crate::error::SuiError;
-use crate::execution::LoadedChildObjectMetadata;
+use crate::execution::{ExecutionResults, LoadedChildObjectMetadata};
 use crate::message_envelope::Message;
 use crate::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, FullCheckpointContents, VerifiedCheckpoint,
@@ -19,7 +19,6 @@ use crate::transaction::{SenderSignedData, TransactionDataAPI, VerifiedTransacti
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::SuiResult,
-    event::Event,
     object::Object,
 };
 use itertools::Itertools;
@@ -125,12 +124,9 @@ pub trait ChildObjectResolver {
 pub trait Storage {
     fn reset(&mut self);
 
-    /// Record an event that happened during execution
-    fn log_event(&mut self, event: Event);
-
     fn read_object(&self, id: &ObjectID) -> Option<&Object>;
 
-    fn apply_object_changes(&mut self, changes: BTreeMap<ObjectID, ObjectChange>);
+    fn record_execution_results(&mut self, results: ExecutionResults);
 
     fn save_loaded_child_objects(
         &mut self,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -38,10 +38,8 @@ mod checked {
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},
-        event::Event,
         execution::{
-            CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue,
-            RawValueType, Value,
+            CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
         },
         id::{RESOLVED_SUI_ID, UID},
         metrics::LimitsMetrics,
@@ -106,21 +104,7 @@ mod checked {
         let finished = context.finish::<Mode>();
         // Save loaded objects for debug. We dont want to lose the info
         state_view.save_loaded_child_objects(loaded_child_objects);
-
-        let ExecutionResults {
-            object_changes,
-            user_events,
-        } = finished?;
-        state_view.apply_object_changes(object_changes);
-        for (module_id, tag, contents) in user_events {
-            state_view.log_event(Event::new(
-                module_id.address(),
-                module_id.name(),
-                tx_context.sender(),
-                tag,
-                contents,
-            ))
-        }
+        state_view.record_execution_results(finished?);
         Ok(mode_results)
     }
 

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -27,13 +27,14 @@ use sui_types::{
     id::UID,
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
-    storage::{ChildObjectResolver, DeleteKind, WriteKind},
+    storage::ChildObjectResolver,
     SUI_CLOCK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
 pub(crate) mod object_store;
 
 use object_store::ChildObjectStore;
+use sui_types::base_types::ObjectDigest;
 
 use self::object_store::{ChildObjectEffect, ObjectResult};
 
@@ -62,12 +63,19 @@ pub(crate) struct TestInventories {
     pub(crate) taken: BTreeMap<ObjectID, Owner>,
 }
 
+pub struct LoadedRuntimeObject {
+    pub version: SequenceNumber,
+    pub digest: ObjectDigest,
+    pub is_modified: bool,
+}
+
 pub struct RuntimeResults {
-    pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, Value)>,
-    pub deletions: LinkedHashMap<ObjectID, DeleteKind>,
+    pub writes: LinkedHashMap<ObjectID, (Owner, Type, Value)>,
     pub user_events: Vec<(Type, StructTag, Value)>,
-    // loaded child objects and their versions
-    pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+    // Loaded child objects, their loaded version/digest and whether they were modified.
+    pub loaded_child_objects: BTreeMap<ObjectID, LoadedRuntimeObject>,
+    pub created_object_ids: Set<ObjectID>,
+    pub deleted_object_ids: Set<ObjectID>,
 }
 
 #[derive(Default)]
@@ -259,10 +267,6 @@ impl<'a> ObjectRuntime<'a> {
         Ok(())
     }
 
-    pub fn new_ids(&self) -> &Set<ObjectID> {
-        &self.state.new_ids
-    }
-
     pub fn transfer(
         &mut self,
         owner: Owner,
@@ -382,18 +386,10 @@ impl<'a> ObjectRuntime<'a> {
         std::mem::take(&mut self.state)
     }
 
-    pub fn finish(
-        mut self,
-        by_value_inputs: BTreeSet<ObjectID>,
-        external_transfers: BTreeSet<ObjectID>,
-    ) -> Result<RuntimeResults, ExecutionError> {
-        let (loaded_child_objects, child_effects) = self.child_object_store.take_effects();
-        self.state.finish(
-            by_value_inputs,
-            external_transfers,
-            loaded_child_objects,
-            child_effects,
-        )
+    pub fn finish(mut self) -> Result<RuntimeResults, ExecutionError> {
+        let loaded_child_objects = self.loaded_child_objects();
+        let child_effects = self.child_object_store.take_effects();
+        self.state.finish(loaded_child_objects, child_effects)
     }
 
     pub(crate) fn all_active_child_objects(
@@ -442,26 +438,39 @@ impl ObjectRuntimeState {
     /// - Passes through user events
     pub(crate) fn finish(
         mut self,
-        by_value_inputs: BTreeSet<ObjectID>,
-        external_transfers: BTreeSet<ObjectID>,
-        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
         child_object_effects: BTreeMap<ObjectID, ChildObjectEffect>,
     ) -> Result<RuntimeResults, ExecutionError> {
-        let mut wrapped_children = BTreeSet::new();
+        let mut loaded_child_objects: BTreeMap<_, _> = loaded_child_objects
+            .into_iter()
+            .map(|(id, metadata)| {
+                (
+                    id,
+                    LoadedRuntimeObject {
+                        version: metadata.version,
+                        digest: metadata.digest,
+                        is_modified: false,
+                    },
+                )
+            })
+            .collect();
         for (child, child_object_effect) in child_object_effects {
             let ChildObjectEffect {
                 owner: parent,
-                loaded_version,
                 ty,
                 effect,
             } = child_object_effect;
+
+            if let Some(loaded_child) = loaded_child_objects.get_mut(&child) {
+                loaded_child.is_modified = true;
+            }
 
             match effect {
                 // was modified, so mark it as mutated and transferred
                 Op::Modify(v) => {
                     debug_assert!(!self.transfers.contains_key(&child));
                     debug_assert!(!self.new_ids.contains_key(&child));
-                    debug_assert!(loaded_version.is_some());
+                    debug_assert!(loaded_child_objects.contains_key(&child));
                     self.transfers
                         .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
@@ -471,27 +480,22 @@ impl ObjectRuntimeState {
                     self.transfers
                         .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
-                // was transferred so not actually deleted
-                Op::Delete if self.transfers.contains_key(&child) => {
-                    debug_assert!(!self.deleted_ids.contains_key(&child));
-                }
-                // ID was deleted too was deleted so mark as deleted
-                Op::Delete if self.deleted_ids.contains_key(&child) => {
-                    debug_assert!(!self.transfers.contains_key(&child));
-                    debug_assert!(!self.new_ids.contains_key(&child));
-                }
-                // was new so the object is transient and does not need to be marked as deleted
-                Op::Delete if self.new_ids.contains_key(&child) => {}
-                // child was transferred externally to the runtime
-                Op::Delete if external_transfers.contains(&child) => {}
-                // otherwise it must have been wrapped
+
                 Op::Delete => {
-                    wrapped_children.insert(child);
+                    // was transferred so not actually deleted
+                    if self.transfers.contains_key(&child) {
+                        debug_assert!(!self.deleted_ids.contains_key(&child));
+                    }
+                    // ID was deleted too was deleted so mark as deleted
+                    if self.deleted_ids.contains_key(&child) {
+                        debug_assert!(!self.transfers.contains_key(&child));
+                        debug_assert!(!self.new_ids.contains_key(&child));
+                    }
                 }
             }
         }
         let ObjectRuntimeState {
-            input_objects,
+            input_objects: _,
             new_ids,
             deleted_ids,
             transfers,
@@ -501,62 +505,22 @@ impl ObjectRuntimeState {
         // Check new owners from transfers, reports an error on cycles.
         // TODO can we have cycles in the new system?
         check_circular_ownership(transfers.iter().map(|(id, (owner, _, _))| (*id, *owner)))?;
-        // determine write kinds
-        let writes: LinkedHashMap<_, _> = transfers
+        let written_objects: LinkedHashMap<_, _> = transfers
             .into_iter()
             .map(|(id, (owner, type_, value))| {
-                let write_kind =
-                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
-                        debug_assert!(!new_ids.contains_key(&id));
-                        WriteKind::Mutate
-                    } else if id == SUI_SYSTEM_STATE_OBJECT_ID || new_ids.contains_key(&id) {
-                        // SUI_SYSTEM_STATE_OBJECT_ID is only transferred during genesis
-                        // TODO find a way to insert this in the new_ids during genesis transactions
-                        WriteKind::Create
-                    } else {
-                        WriteKind::Unwrap
-                    };
-                (id, (write_kind, owner, type_, value))
+                if let Some(loaded_child) = loaded_child_objects.get_mut(&id) {
+                    loaded_child.is_modified = true;
+                }
+                (id, (owner, type_, value))
             })
             .collect();
-        // determine delete kinds
-        let mut deletions: LinkedHashMap<_, _> = deleted_ids
-            .into_iter()
-            .map(|(id, ())| {
-                debug_assert!(!new_ids.contains_key(&id));
-                let delete_kind =
-                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
-                        DeleteKind::Normal
-                    } else {
-                        DeleteKind::UnwrapThenDelete
-                    };
-                (id, delete_kind)
-            })
-            .collect();
-        // remaining by value objects must be wrapped
-        let remaining_by_value_objects = by_value_inputs
-            .into_iter()
-            .filter(|id| {
-                !writes.contains_key(id)
-                    && !deletions.contains_key(id)
-                    && !external_transfers.contains(id)
-            })
-            .collect::<Vec<_>>();
-        for id in remaining_by_value_objects {
-            deletions.insert(id, DeleteKind::Wrap);
-        }
-        // children that weren't deleted or transferred must be wrapped
-        for id in wrapped_children {
-            deletions.insert(id, DeleteKind::Wrap);
-        }
 
-        debug_assert!(writes.keys().all(|id| !deletions.contains_key(id)));
-        debug_assert!(deletions.keys().all(|id| !writes.contains_key(id)));
         Ok(RuntimeResults {
-            writes,
-            deletions,
+            writes: written_objects,
             user_events,
             loaded_child_objects,
+            created_object_ids: new_ids,
+            deleted_object_ids: deleted_ids,
         })
     }
 

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -32,8 +32,6 @@ pub(super) struct ChildObject {
 #[derive(Debug)]
 pub(crate) struct ChildObjectEffect {
     pub(super) owner: ObjectID,
-    // none if it was an input object
-    pub(super) loaded_version: Option<SequenceNumber>,
     pub(super) ty: Type,
     pub(super) effect: Op<Value>,
 }
@@ -406,19 +404,8 @@ impl<'a> ChildObjectStore<'a> {
     }
 
     // retrieve the `Op` effects for the child objects
-    pub(super) fn take_effects(
-        &mut self,
-    ) -> (
-        BTreeMap<ObjectID, SequenceNumber>,
-        BTreeMap<ObjectID, ChildObjectEffect>,
-    ) {
-        let loaded_versions: BTreeMap<ObjectID, SequenceNumber> = self
-            .inner
-            .cached_objects
-            .iter()
-            .filter_map(|(id, obj_opt)| Some((*id, obj_opt.as_ref()?.version())))
-            .collect();
-        let child_object_effects = std::mem::take(&mut self.store)
+    pub(super) fn take_effects(&mut self) -> BTreeMap<ObjectID, ChildObjectEffect> {
+        std::mem::take(&mut self.store)
             .into_iter()
             .filter_map(|(id, child_object)| {
                 let ChildObject {
@@ -427,18 +414,11 @@ impl<'a> ChildObjectStore<'a> {
                     move_type: _,
                     value,
                 } = child_object;
-                let loaded_version = loaded_versions.get(&id).copied();
                 let effect = value.into_effect()?;
-                let child_effect = ChildObjectEffect {
-                    owner,
-                    loaded_version,
-                    ty,
-                    effect,
-                };
+                let child_effect = ChildObjectEffect { owner, ty, effect };
                 Some((id, child_effect))
             })
-            .collect();
-        (loaded_versions, child_object_effects)
+            .collect()
     }
 
     pub(super) fn all_active_objects(&self) -> impl Iterator<Item = (&ObjectID, &Type, Value)> {

--- a/sui-execution/suivm/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/suivm/sui-adapter/src/programmable_transactions/execution.rs
@@ -4,12 +4,6 @@
 pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    use std::{
-        collections::{BTreeMap, BTreeSet},
-        fmt,
-        sync::Arc,
-    };
-
     use crate::gas_charger::GasCharger;
     use move_binary_format::{
         access::ModuleAccess,
@@ -30,6 +24,11 @@ mod checked {
     };
     use move_vm_types::loaded_data::runtime_types::{StructType, Type};
     use serde::{de::DeserializeSeed, Deserialize};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fmt,
+        sync::Arc,
+    };
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::{
@@ -39,10 +38,8 @@ mod checked {
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},
-        event::Event,
         execution::{
-            CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue,
-            RawValueType, Value,
+            CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
         },
         id::{RESOLVED_SUI_ID, UID},
         metrics::LimitsMetrics,
@@ -107,21 +104,7 @@ mod checked {
         let finished = context.finish::<Mode>();
         // Save loaded objects for debug. We dont want to lose the info
         state_view.save_loaded_child_objects(loaded_child_objects);
-
-        let ExecutionResults {
-            object_changes,
-            user_events,
-        } = finished?;
-        state_view.apply_object_changes(object_changes);
-        for (module_id, tag, contents) in user_events {
-            state_view.log_event(Event::new(
-                module_id.address(),
-                module_id.name(),
-                tx_context.sender(),
-                tag,
-                contents,
-            ))
-        }
+        state_view.record_execution_results(finished?);
         Ok(mode_results)
     }
 

--- a/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
@@ -27,13 +27,14 @@ use sui_types::{
     id::UID,
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
-    storage::{ChildObjectResolver, DeleteKind, WriteKind},
+    storage::ChildObjectResolver,
     SUI_CLOCK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
 pub(crate) mod object_store;
 
 use object_store::ChildObjectStore;
+use sui_types::base_types::ObjectDigest;
 
 use self::object_store::{ChildObjectEffect, ObjectResult};
 
@@ -62,12 +63,19 @@ pub(crate) struct TestInventories {
     pub(crate) taken: BTreeMap<ObjectID, Owner>,
 }
 
+pub struct LoadedRuntimeObject {
+    pub version: SequenceNumber,
+    pub digest: ObjectDigest,
+    pub is_modified: bool,
+}
+
 pub struct RuntimeResults {
-    pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, Value)>,
-    pub deletions: LinkedHashMap<ObjectID, DeleteKind>,
+    pub writes: LinkedHashMap<ObjectID, (Owner, Type, Value)>,
     pub user_events: Vec<(Type, StructTag, Value)>,
-    // loaded child objects and their versions
-    pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+    // Loaded child objects, their loaded version/digest and whether they were modified.
+    pub loaded_child_objects: BTreeMap<ObjectID, LoadedRuntimeObject>,
+    pub created_object_ids: Set<ObjectID>,
+    pub deleted_object_ids: Set<ObjectID>,
 }
 
 #[derive(Default)]
@@ -259,10 +267,6 @@ impl<'a> ObjectRuntime<'a> {
         Ok(())
     }
 
-    pub fn new_ids(&self) -> &Set<ObjectID> {
-        &self.state.new_ids
-    }
-
     pub fn transfer(
         &mut self,
         owner: Owner,
@@ -382,18 +386,10 @@ impl<'a> ObjectRuntime<'a> {
         std::mem::take(&mut self.state)
     }
 
-    pub fn finish(
-        mut self,
-        by_value_inputs: BTreeSet<ObjectID>,
-        external_transfers: BTreeSet<ObjectID>,
-    ) -> Result<RuntimeResults, ExecutionError> {
-        let (loaded_child_objects, child_effects) = self.child_object_store.take_effects();
-        self.state.finish(
-            by_value_inputs,
-            external_transfers,
-            loaded_child_objects,
-            child_effects,
-        )
+    pub fn finish(mut self) -> Result<RuntimeResults, ExecutionError> {
+        let loaded_child_objects = self.loaded_child_objects();
+        let child_effects = self.child_object_store.take_effects();
+        self.state.finish(loaded_child_objects, child_effects)
     }
 
     pub(crate) fn all_active_child_objects(
@@ -442,26 +438,39 @@ impl ObjectRuntimeState {
     /// - Passes through user events
     pub(crate) fn finish(
         mut self,
-        by_value_inputs: BTreeSet<ObjectID>,
-        external_transfers: BTreeSet<ObjectID>,
-        loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
+        loaded_child_objects: BTreeMap<ObjectID, LoadedChildObjectMetadata>,
         child_object_effects: BTreeMap<ObjectID, ChildObjectEffect>,
     ) -> Result<RuntimeResults, ExecutionError> {
-        let mut wrapped_children = BTreeSet::new();
+        let mut loaded_child_objects: BTreeMap<_, _> = loaded_child_objects
+            .into_iter()
+            .map(|(id, metadata)| {
+                (
+                    id,
+                    LoadedRuntimeObject {
+                        version: metadata.version,
+                        digest: metadata.digest,
+                        is_modified: false,
+                    },
+                )
+            })
+            .collect();
         for (child, child_object_effect) in child_object_effects {
             let ChildObjectEffect {
                 owner: parent,
-                loaded_version,
                 ty,
                 effect,
             } = child_object_effect;
+
+            if let Some(loaded_child) = loaded_child_objects.get_mut(&child) {
+                loaded_child.is_modified = true;
+            }
 
             match effect {
                 // was modified, so mark it as mutated and transferred
                 Op::Modify(v) => {
                     debug_assert!(!self.transfers.contains_key(&child));
                     debug_assert!(!self.new_ids.contains_key(&child));
-                    debug_assert!(loaded_version.is_some());
+                    debug_assert!(loaded_child_objects.contains_key(&child));
                     self.transfers
                         .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
@@ -471,27 +480,22 @@ impl ObjectRuntimeState {
                     self.transfers
                         .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
-                // was transferred so not actually deleted
-                Op::Delete if self.transfers.contains_key(&child) => {
-                    debug_assert!(!self.deleted_ids.contains_key(&child));
-                }
-                // ID was deleted too was deleted so mark as deleted
-                Op::Delete if self.deleted_ids.contains_key(&child) => {
-                    debug_assert!(!self.transfers.contains_key(&child));
-                    debug_assert!(!self.new_ids.contains_key(&child));
-                }
-                // was new so the object is transient and does not need to be marked as deleted
-                Op::Delete if self.new_ids.contains_key(&child) => {}
-                // child was transferred externally to the runtime
-                Op::Delete if external_transfers.contains(&child) => {}
-                // otherwise it must have been wrapped
+
                 Op::Delete => {
-                    wrapped_children.insert(child);
+                    // was transferred so not actually deleted
+                    if self.transfers.contains_key(&child) {
+                        debug_assert!(!self.deleted_ids.contains_key(&child));
+                    }
+                    // ID was deleted too was deleted so mark as deleted
+                    if self.deleted_ids.contains_key(&child) {
+                        debug_assert!(!self.transfers.contains_key(&child));
+                        debug_assert!(!self.new_ids.contains_key(&child));
+                    }
                 }
             }
         }
         let ObjectRuntimeState {
-            input_objects,
+            input_objects: _,
             new_ids,
             deleted_ids,
             transfers,
@@ -501,62 +505,22 @@ impl ObjectRuntimeState {
         // Check new owners from transfers, reports an error on cycles.
         // TODO can we have cycles in the new system?
         check_circular_ownership(transfers.iter().map(|(id, (owner, _, _))| (*id, *owner)))?;
-        // determine write kinds
-        let writes: LinkedHashMap<_, _> = transfers
+        let written_objects: LinkedHashMap<_, _> = transfers
             .into_iter()
             .map(|(id, (owner, type_, value))| {
-                let write_kind =
-                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
-                        debug_assert!(!new_ids.contains_key(&id));
-                        WriteKind::Mutate
-                    } else if id == SUI_SYSTEM_STATE_OBJECT_ID || new_ids.contains_key(&id) {
-                        // SUI_SYSTEM_STATE_OBJECT_ID is only transferred during genesis
-                        // TODO find a way to insert this in the new_ids during genesis transactions
-                        WriteKind::Create
-                    } else {
-                        WriteKind::Unwrap
-                    };
-                (id, (write_kind, owner, type_, value))
+                if let Some(loaded_child) = loaded_child_objects.get_mut(&id) {
+                    loaded_child.is_modified = true;
+                }
+                (id, (owner, type_, value))
             })
             .collect();
-        // determine delete kinds
-        let mut deletions: LinkedHashMap<_, _> = deleted_ids
-            .into_iter()
-            .map(|(id, ())| {
-                debug_assert!(!new_ids.contains_key(&id));
-                let delete_kind =
-                    if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
-                        DeleteKind::Normal
-                    } else {
-                        DeleteKind::UnwrapThenDelete
-                    };
-                (id, delete_kind)
-            })
-            .collect();
-        // remaining by value objects must be wrapped
-        let remaining_by_value_objects = by_value_inputs
-            .into_iter()
-            .filter(|id| {
-                !writes.contains_key(id)
-                    && !deletions.contains_key(id)
-                    && !external_transfers.contains(id)
-            })
-            .collect::<Vec<_>>();
-        for id in remaining_by_value_objects {
-            deletions.insert(id, DeleteKind::Wrap);
-        }
-        // children that weren't deleted or transferred must be wrapped
-        for id in wrapped_children {
-            deletions.insert(id, DeleteKind::Wrap);
-        }
 
-        debug_assert!(writes.keys().all(|id| !deletions.contains_key(id)));
-        debug_assert!(deletions.keys().all(|id| !writes.contains_key(id)));
         Ok(RuntimeResults {
-            writes,
-            deletions,
+            writes: written_objects,
             user_events,
             loaded_child_objects,
+            created_object_ids: new_ids,
+            deleted_object_ids: deleted_ids,
         })
     }
 

--- a/sui-execution/suivm/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/suivm/sui-move-natives/src/object_runtime/object_store.rs
@@ -32,8 +32,6 @@ pub(super) struct ChildObject {
 #[derive(Debug)]
 pub(crate) struct ChildObjectEffect {
     pub(super) owner: ObjectID,
-    // none if it was an input object
-    pub(super) loaded_version: Option<SequenceNumber>,
     pub(super) ty: Type,
     pub(super) effect: Op<Value>,
 }
@@ -406,19 +404,8 @@ impl<'a> ChildObjectStore<'a> {
     }
 
     // retrieve the `Op` effects for the child objects
-    pub(super) fn take_effects(
-        &mut self,
-    ) -> (
-        BTreeMap<ObjectID, SequenceNumber>,
-        BTreeMap<ObjectID, ChildObjectEffect>,
-    ) {
-        let loaded_versions: BTreeMap<ObjectID, SequenceNumber> = self
-            .inner
-            .cached_objects
-            .iter()
-            .filter_map(|(id, obj_opt)| Some((*id, obj_opt.as_ref()?.version())))
-            .collect();
-        let child_object_effects = std::mem::take(&mut self.store)
+    pub(super) fn take_effects(&mut self) -> BTreeMap<ObjectID, ChildObjectEffect> {
+        std::mem::take(&mut self.store)
             .into_iter()
             .filter_map(|(id, child_object)| {
                 let ChildObject {
@@ -427,18 +414,11 @@ impl<'a> ChildObjectStore<'a> {
                     move_type: _,
                     value,
                 } = child_object;
-                let loaded_version = loaded_versions.get(&id).copied();
                 let effect = value.into_effect()?;
-                let child_effect = ChildObjectEffect {
-                    owner,
-                    loaded_version,
-                    ty,
-                    effect,
-                };
+                let child_effect = ChildObjectEffect { owner, ty, effect };
                 Some((id, child_effect))
             })
-            .collect();
-        (loaded_versions, child_object_effects)
+            .collect()
     }
 
     pub(super) fn all_active_objects(&self) -> impl Iterator<Item = (&ObjectID, &Type, Value)> {

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
@@ -41,10 +41,8 @@ mod checked {
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},
-        event::Event,
         execution::{
-            CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue,
-            RawValueType, Value,
+            CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
         },
         id::{RESOLVED_SUI_ID, UID},
         metrics::LimitsMetrics,
@@ -109,21 +107,7 @@ mod checked {
         let finished = context.finish::<Mode>();
         // Save loaded objects for debug. We dont want to lose the info
         state_view.save_loaded_child_objects(loaded_child_objects);
-
-        let ExecutionResults {
-            object_changes,
-            user_events,
-        } = finished?;
-        state_view.apply_object_changes(object_changes);
-        for (module_id, tag, contents) in user_events {
-            state_view.log_event(Event::new(
-                module_id.address(),
-                module_id.name(),
-                tx_context.sender(),
-                tag,
-                contents,
-            ))
-        }
+        state_view.record_execution_results(finished?);
         Ok(mode_results)
     }
 


### PR DESCRIPTION
## Description 

Refactor sui-execution latest to make it generate primitive execution results, which is compatible with both transaction effects v1 and v2.
The purpose of this change is to gradually introduce changes necessary for effects v2.
In this change, instead of figuring out write kinds and delete kinds in the runtime, we only generate primitive results in the runtime, and then in the end we derive all the write kinds and delete kinds from the primitive results to generate effects v1.
This is a non-functional change, and allows us to test the sui-execution refactoring using existing production data.
In the next PR I will refactor the rest of execution engine to also generate effects v2 compatible results.

## Test Plan 

CI.
Also ran fullnode locally and sync on mainnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
