### PR TITLE
move: field to watch upgraded objects in source service

### DIFF
--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.88"
 url = "2.3.1"
 
-sui-move.workspace = true
+sui-move = { workspace = true, features = ["all"] }
 sui-move-build.workspace = true
 sui-sdk.workspace = true
 sui-source-validation.workspace = true

--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -4,11 +4,11 @@ source = "Repository"
 repository = "https://github.com/mystenlabs/sui"
 branch = "framework/mainnet"
 network = "mainnet"
-paths = [
-    "crates/sui-framework/packages/deepbook",
-    "crates/sui-framework/packages/move-stdlib",
-    "crates/sui-framework/packages/sui-framework",
-    "crates/sui-framework/packages/sui-system",
+packages = [
+    { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },
+    { path = "crates/sui-framework/packages/move-stdlib", watch = "0x1" },
+    { path = "crates/sui-framework/packages/sui-framework", watch = "0x2" },
+    { path = "crates/sui-framework/packages/sui-system", watch = "0x3" },
 ]
 
 [[packages]]
@@ -17,9 +17,22 @@ source = "Repository"
 repository = "https://github.com/mystenlabs/sui"
 branch = "framework/testnet"
 network = "testnet"
-paths = [
-    "crates/sui-framework/packages/deepbook",
-    "crates/sui-framework/packages/move-stdlib",
-    "crates/sui-framework/packages/sui-framework",
-    "crates/sui-framework/packages/sui-system",
+packages = [
+    { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },
+    { path = "crates/sui-framework/packages/move-stdlib", watch = "0x1" },
+    { path = "crates/sui-framework/packages/sui-framework", watch = "0x2" },
+    { path = "crates/sui-framework/packages/sui-system", watch = "0x3" },
+]
+
+[[packages]]
+source = "Repository"
+[packages.values]
+repository = "https://github.com/mystenlabs/sui"
+branch = "framework/devnet"
+network = "devnet"
+packages = [
+    { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },
+    { path = "crates/sui-framework/packages/move-stdlib", watch = "0x1" },
+    { path = "crates/sui-framework/packages/sui-framework", watch = "0x2" },
+    { path = "crates/sui-framework/packages/sui-system", watch = "0x3" },
 ]

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -27,6 +27,7 @@ use move_package::BuildConfig as MoveBuildConfig;
 use move_symbol_pool::Symbol;
 use sui_move::build::resolve_lock_file_path;
 use sui_move_build::{BuildConfig, SuiPackageHooks};
+use sui_sdk::types::base_types::ObjectID;
 use sui_sdk::SuiClientBuilder;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
@@ -62,14 +63,22 @@ pub enum PackageSources {
 pub struct RepositorySource {
     pub repository: String,
     pub branch: String,
-    pub paths: Vec<String>,
+    pub packages: Vec<Package>,
     pub network: Option<Network>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct DirectorySource {
-    pub paths: Vec<String>,
+    pub packages: Vec<Package>,
     pub network: Option<Network>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Package {
+    pub path: String,
+    /// Optional object ID to watch for upgrades. For framework packages, this is an address like 0x2.
+    /// For non-framework packages this is an upgrade cap (possibly wrapped).
+    pub watch: Option<ObjectID>,
 }
 
 #[derive(Debug)]
@@ -225,7 +234,11 @@ impl CloneCommand {
             ostr!("set"),
             ostr!("--no-cone"),
         ];
-        let path_args: Vec<OsString> = p.paths.iter().map(OsString::from).collect();
+        let path_args: Vec<OsString> = p
+            .packages
+            .iter()
+            .map(|p| OsString::from(p.path.clone()))
+            .collect();
         cmd_args.extend_from_slice(&path_args);
         args.push(cmd_args);
 
@@ -298,8 +311,8 @@ pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<Netw
                 let repo_name = repo_name_from_url(&r.repository)?;
                 let network_name = r.network.clone().unwrap_or_default().to_string();
                 let packages_dir = dir.join(network_name).join(repo_name);
-                for p in &r.paths {
-                    let package_path = packages_dir.join(p).clone();
+                for p in &r.packages {
+                    let package_path = packages_dir.join(p.path.clone()).clone();
                     let network = r.network.clone().unwrap_or_default();
                     let t =
                         tokio::spawn(async move { verify_package(&network, package_path).await });
@@ -307,8 +320,8 @@ pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<Netw
                 }
             }
             PackageSources::Directory(packages_dir) => {
-                for p in &packages_dir.paths {
-                    let package_path = PathBuf::from(p);
+                for p in &packages_dir.packages {
+                    let package_path = PathBuf::from(p.path.clone());
                     let network = packages_dir.network.clone().unwrap_or_default();
                     let t =
                         tokio::spawn(async move { verify_package(&network, package_path).await });


### PR DESCRIPTION
## Description 

Adds ability to specify `watch = <Object ID>` to track on-chain upgrades. This PR is scaffolding and only adds the option to the config and the Rust types, no actual tracking of the `Object ID`. That happens in follow up PR: https://github.com/MystenLabs/sui/pull/13396.

## Test Plan 

Updated tests for config schema.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
