### PR TITLE
[graphql/rpc] object connection pagination support with rpc 1.0 backing

### DIFF
--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -3,19 +3,22 @@
 
 // For testing, use existing RPC as data source
 
-use std::str::FromStr;
-
 use crate::types::address::Address;
 use crate::types::balance::Balance;
 use crate::types::base64::Base64;
 use crate::types::big_int::BigInt;
+use crate::types::object::ObjectFilter;
 use crate::types::transaction_block::TransactionBlock;
 use crate::types::{object::Object, sui_address::SuiAddress};
+use async_graphql::connection::{Connection, Edge};
 use async_graphql::*;
+use std::str::FromStr;
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiPastObjectResponse, SuiTransactionBlockResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponseQuery, SuiPastObjectResponse,
+    SuiTransactionBlockResponseOptions,
 };
-use sui_sdk::types::base_types::ObjectID;
+use sui_sdk::types::base_types::ObjectID as NaiveObjectID;
+use sui_sdk::types::base_types::SuiAddress as NativeSuiAddress;
 use sui_sdk::types::digests::TransactionDigest;
 use sui_sdk::SuiClient;
 
@@ -24,7 +27,7 @@ pub(crate) async fn fetch_obj(
     address: SuiAddress,
     version: Option<u64>,
 ) -> Result<Option<Object>> {
-    let oid: ObjectID = address.to_array().as_slice().try_into()?;
+    let oid: NaiveObjectID = address.to_array().as_slice().try_into()?;
     let opts = SuiObjectDataOptions::full_content();
 
     let g = match version {
@@ -44,7 +47,60 @@ pub(crate) async fn fetch_obj(
             val.data.unwrap()
         }
     };
-    Ok(Some(convert_obj(g)))
+    Ok(Some(convert_obj(&g)))
+}
+
+pub(crate) async fn fetch_owned_objs(
+    cl: &SuiClient,
+    owner: &SuiAddress,
+    first: Option<u64>,
+    after: Option<String>,
+    last: Option<u64>,
+    before: Option<String>,
+    _filter: Option<ObjectFilter>,
+) -> Result<Connection<String, Object>> {
+    if before.is_some() && after.is_some() {
+        return Err(Error::new("before and after must not be used together"));
+    }
+    if first.is_some() && last.is_some() {
+        return Err(Error::new("first and last must not be used together"));
+    }
+    if before.is_some() || last.is_some() {
+        return Err(Error::new("reverse pagination is not supported"));
+    }
+
+    let count = first.map(|q| q as usize);
+    let native_owner = NativeSuiAddress::from(owner);
+    let query = SuiObjectResponseQuery::new_with_options(SuiObjectDataOptions::full_content());
+
+    let cursor = match after {
+        Some(q) => Some(
+            NaiveObjectID::from_hex_literal(&q)
+                .map_err(|w| Error::new(format!("invalid object id: {}", w)))?,
+        ),
+        None => None,
+    };
+
+    let pg = cl
+        .read_api()
+        .get_owned_objects(native_owner, Some(query), cursor, count)
+        .await?;
+
+    pg.data.iter().try_for_each(|n| {
+        if n.error.is_some() || n.data.is_none() {
+            return Err(Error::new("error"));
+        }
+        Ok(())
+    })?;
+    let mut connection = Connection::new(false, pg.has_next_page);
+
+    connection.edges.extend(pg.data.into_iter().map(|n| {
+        let g = n.data.unwrap();
+        let o = convert_obj(&g);
+
+        Edge::new(g.object_id.to_string(), o)
+    }));
+    Ok::<_, async_graphql::Error>(connection)
 }
 
 pub(crate) async fn fetch_balance(
@@ -54,26 +110,9 @@ pub(crate) async fn fetch_balance(
 ) -> Result<Balance> {
     let b = cl
         .coin_read_api()
-        .get_balance(address.to_array().as_slice().try_into()?, type_)
+        .get_balance(address.into(), type_)
         .await?;
     Ok(convert_bal(b))
-}
-
-fn convert_obj(s: sui_json_rpc_types::SuiObjectData) -> Object {
-    Object {
-        version: s.version.into(),
-        digest: s.digest.to_string(),
-        storage_rebate: s.storage_rebate,
-        address: SuiAddress::from_array(**s.object_id),
-        owner: s
-            .owner
-            .unwrap()
-            .get_owner_address()
-            .map(|x| SuiAddress::from_array(x.to_inner()))
-            .ok(),
-        bcs: Some(Base64::from(&bcs::to_bytes(&s.bcs).unwrap())), // TODO: is this correct?
-        previous_transaction: Some(s.previous_transaction.unwrap().to_string()),
-    }
 }
 
 pub(crate) async fn fetch_tx(cl: &SuiClient, digest: &String) -> Result<Option<TransactionBlock>> {
@@ -97,9 +136,60 @@ pub(crate) async fn fetch_tx(cl: &SuiClient, digest: &String) -> Result<Option<T
     }))
 }
 
+pub(crate) async fn fetch_chain_id(cl: &SuiClient) -> Result<String> {
+    Ok(cl.read_api().get_chain_identifier().await?)
+}
+
+fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
+    Object {
+        version: s.version.into(),
+        digest: s.digest.to_string(),
+        storage_rebate: s.storage_rebate,
+        address: SuiAddress::from_array(**s.object_id),
+        owner: s
+            .owner
+            .unwrap()
+            .get_owner_address()
+            .map(|x| SuiAddress::from_array(x.to_inner()))
+            .ok(),
+        bcs: Some(Base64::from(&bcs::to_bytes(&s.bcs).unwrap())), // TODO: is this correct?
+        previous_transaction: Some(s.previous_transaction.unwrap().to_string()),
+    }
+}
+
 fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
     Balance {
         coin_object_count: b.coin_object_count as u64,
         total_balance: BigInt::from_str(&format!("{}", b.total_balance)).unwrap(),
+    }
+}
+
+impl From<Address> for SuiAddress {
+    fn from(a: Address) -> Self {
+        a.address
+    }
+}
+
+impl From<SuiAddress> for Address {
+    fn from(a: SuiAddress) -> Self {
+        Address { address: a }
+    }
+}
+
+impl From<NativeSuiAddress> for SuiAddress {
+    fn from(a: NativeSuiAddress) -> Self {
+        SuiAddress::from_array(a.to_inner())
+    }
+}
+
+impl From<SuiAddress> for NativeSuiAddress {
+    fn from(a: SuiAddress) -> Self {
+        NativeSuiAddress::try_from(a.as_slice()).unwrap()
+    }
+}
+
+impl From<&SuiAddress> for NativeSuiAddress {
+    fn from(a: &SuiAddress) -> Self {
+        NativeSuiAddress::try_from(a.as_slice()).unwrap()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::*;
+use async_graphql::{connection::Connection, *};
 
-use crate::server::data_provider::fetch_balance;
+use crate::server::data_provider::{fetch_balance, fetch_owned_objs};
 
 use super::{
     balance::{Balance, BalanceConnection},
     coin::CoinConnection,
     name_service::NameServiceConnection,
-    object::{ObjectConnection, ObjectFilter},
+    object::{Object, ObjectFilter},
     stake::StakeConnection,
     sui_address::SuiAddress,
     transaction_block::{TransactionBlockConnection, TransactionBlockFilter},
@@ -52,13 +52,23 @@ impl Address {
 
     pub async fn object_connection(
         &self,
+        ctx: &Context<'_>,
         first: Option<u64>,
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
-    ) -> Option<ObjectConnection> {
-        unimplemented!()
+    ) -> Result<Connection<String, Object>> {
+        fetch_owned_objs(
+            ctx.data_unchecked::<sui_sdk::SuiClient>(),
+            &self.address,
+            first,
+            after,
+            last,
+            before,
+            filter,
+        )
+        .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{*, connection::Connection};
+use async_graphql::{connection::Connection, *};
 
 use super::{
     balance::{Balance, BalanceConnection},

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::*;
+use async_graphql::{*, connection::Connection};
 
 use super::{
     balance::{Balance, BalanceConnection},
@@ -12,7 +12,7 @@ use super::{
     transaction_block::TransactionBlock,
 };
 use crate::{
-    server::data_provider::{fetch_balance, fetch_tx},
+    server::data_provider::{fetch_balance, fetch_owned_objs, fetch_tx},
     types::base64::Base64,
 };
 
@@ -25,8 +25,6 @@ pub(crate) struct Object {
     pub bcs: Option<Base64>,
     pub previous_transaction: Option<String>,
 }
-
-pub(crate) struct ObjectConnection;
 
 #[derive(InputObject)]
 pub(crate) struct ObjectFilter {
@@ -78,13 +76,23 @@ impl Object {
 
     pub async fn object_connection(
         &self,
+        ctx: &Context<'_>,
         first: Option<u64>,
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
-    ) -> Option<ObjectConnection> {
-        unimplemented!()
+    ) -> Result<Connection<String, Object>> {
+        fetch_owned_objs(
+            ctx.data_unchecked::<sui_sdk::SuiClient>(),
+            &self.address,
+            first,
+            after,
+            last,
+            before,
+            filter,
+        )
+        .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
@@ -138,15 +146,6 @@ impl Object {
         last: Option<u64>,
         before: Option<String>,
     ) -> Option<NameServiceConnection> {
-        unimplemented!()
-    }
-}
-
-#[allow(unreachable_code)]
-#[allow(unused_variables)]
-#[Object]
-impl ObjectConnection {
-    async fn unimplemented(&self) -> bool {
         unimplemented!()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -3,8 +3,8 @@
 
 use async_graphql::*;
 
-use crate::server::data_provider::fetch_chain_id;
 use super::{address::Address, object::Object, owner::Owner, sui_address::SuiAddress};
+use crate::server::data_provider::fetch_chain_id;
 
 pub(crate) struct Query;
 pub(crate) type SuiGraphQLSchema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -3,6 +3,7 @@
 
 use async_graphql::*;
 
+use crate::server::data_provider::fetch_chain_id;
 use super::{address::Address, object::Object, owner::Owner, sui_address::SuiAddress};
 
 pub(crate) struct Query;
@@ -12,8 +13,8 @@ pub(crate) type SuiGraphQLSchema = async_graphql::Schema<Query, EmptyMutation, E
 #[allow(unused_variables)]
 #[Object]
 impl Query {
-    async fn chain_identifier(&self) -> String {
-        "0000".to_string()
+    async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String> {
+        fetch_chain_id(ctx.data_unchecked::<sui_sdk::SuiClient>()).await
     }
 
     async fn owner(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<Owner>> {

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -50,4 +50,8 @@ impl SuiAddress {
     pub fn from_array(arr: [u8; SUI_ADDRESS_LENGTH]) -> Self {
         SuiAddress(arr)
     }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -5,7 +5,7 @@ expression: sdl
 type Address implements Owner {
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter): TransactionBlockConnection
 	location: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance!
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
@@ -23,7 +23,7 @@ enum AddressTransactionBlockRelationship {
 
 type AmbiguousOwner implements Owner {
 	location: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance!
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
@@ -67,7 +67,7 @@ type Object implements Owner {
 	bcs: Base64
 	previousTransactionBlock: TransactionBlock
 	location: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance!
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
@@ -77,7 +77,32 @@ type Object implements Owner {
 }
 
 type ObjectConnection {
-	unimplemented: Boolean!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ObjectEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Object!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ObjectEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Object!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 input ObjectFilter {
@@ -98,6 +123,28 @@ interface Owner {
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
 	nameServiceConnection(first: Int, after: String, last: Int, before: String): NameServiceConnection
+}
+
+"""
+Information about pagination in a connection
+"""
+type PageInfo {
+	"""
+	When paginating backwards, are there more items?
+	"""
+	hasPreviousPage: Boolean!
+	"""
+	When paginating forwards, are there more items?
+	"""
+	hasNextPage: Boolean!
+	"""
+	When paginating backwards, the cursor to continue.
+	"""
+	startCursor: String
+	"""
+	When paginating forwards, the cursor to continue.
+	"""
+	endCursor: String
 }
 
 type Query {


### PR DESCRIPTION
## Description 

Adds
* Chain identifier with rpc 1.0 data source
* Basic `Object` pagination/connection impl with rpc 1.0 data source

Sample output below

<img width="1155" alt="req" src="https://github.com/MystenLabs/sui/assets/93547199/8dd0a705-31a5-41be-924d-456f71198411">



## Test Plan 
Manual


How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
