### PR TITLE
wallet-ext: don't allow aud to be array

### DIFF
--- a/apps/wallet/src/background/accounts/zk/ZkAccount.ts
+++ b/apps/wallet/src/background/accounts/zk/ZkAccount.ts
@@ -101,9 +101,10 @@ export class ZkAccount
 		) {
 			throw new Error('Missing jwt data');
 		}
-		// based on jose typings aud can be an array
-		// we expect it to be string so here just doing a join if necessary
-		const aud = Array.isArray(decodedJWT.aud) ? decodedJWT.aud.join(' ') : decodedJWT.aud;
+		if (Array.isArray(decodedJWT.aud)) {
+			throw new Error('Not supported aud. Aud is an array, string was expected.');
+		}
+		const aud = decodedJWT.aud;
 		const claims: JwtSerializedClaims = {
 			email: decodedJWT.email,
 			fullName: String(decodedJWT.name || '') || null,


### PR DESCRIPTION
## Description 

* currently only aud of type string is supported
* throw an error if for some reason aud is an array

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
