### PR TITLE
[GraphQL/RFC] Add a "CHILD" ObjectKind

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -340,6 +340,7 @@ enum AddressTransactionBlockRelationship {
 
 enum ObjectKind {
   OWNED
+  CHILD
   SHARED
   IMMUTABLE
 }

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -131,7 +131,8 @@ fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
         bcs: Some(Base64::from(&bcs::to_bytes(&s.bcs).unwrap())), // TODO: is this correct?
         previous_transaction: Some(s.previous_transaction.unwrap().to_string()),
         kind: Some(match s.owner.unwrap() {
-            NativeOwner::AddressOwner(_) | NativeOwner::ObjectOwner(_) => ObjectKind::Owned,
+            NativeOwner::AddressOwner(_) => ObjectKind::Owned,
+            NativeOwner::ObjectOwner(_) => ObjectKind::Child,
             NativeOwner::Shared {
                 initial_shared_version: _,
             } => ObjectKind::Shared,

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -31,6 +31,7 @@ pub(crate) struct Object {
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum ObjectKind {
     Owned,
+    Child,
     Shared,
     Immutable,
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -107,6 +107,7 @@ input ObjectFilter {
 
 enum ObjectKind {
 	OWNED
+	CHILD
 	SHARED
 	IMMUTABLE
 }


### PR DESCRIPTION
## Description

As spotted during the review of #13379 -- we need a different kind for objects that are owned by other objects via a dynamic field (as opposed to being transfered to another object).

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```