### PR TITLE
[fix] small refactoring to fix the usage of Network client in cluster tests

### DIFF
--- a/narwhal/primary/src/tests/rpc_tests.rs
+++ b/narwhal/primary/src/tests/rpc_tests.rs
@@ -17,7 +17,7 @@ async fn test_server_authorizations() {
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     let test_authority = test_cluster.authority(0);
-    let test_client = test_authority.client.clone();
+    let test_client = test_authority.client().await;
     let test_committee = test_cluster.committee.clone();
     let test_worker_cache = test_cluster.worker_cache.clone();
 

--- a/narwhal/primary/tests/nodes_bootstrapping_tests.rs
+++ b/narwhal/primary/tests/nodes_bootstrapping_tests.rs
@@ -104,6 +104,8 @@ async fn test_node_staggered_starts() {
 #[ignore]
 #[tokio::test]
 async fn test_full_outage_and_recovery() {
+    let _guard = setup_tracing();
+
     let stop_and_start_delay = Duration::from_secs(12);
     let node_advance_delay = Duration::from_secs(60);
 


### PR DESCRIPTION
## Description 

It seems after the merge of this PR https://github.com/MystenLabs/sui/pull/13328/files the narwhal nightly tests started failing https://github.com/MystenLabs/sui/actions/runs/5828472064/job/15806247384

This PR is refactoring the cluster struct so we always create a new network client and inject it to the primary/worker nodes to ensure that we don't deal with any internal state mutations after shutdown (which were preventing properly reusing the client on a new start).

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
