### PR TITLE
Gas cleanup and test fixes

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -31,7 +31,6 @@ use sui_types::crypto::{AuthorityKeyPair, Signer};
 use sui_types::effects::{SignedTransactionEffects, TransactionEffects};
 use sui_types::error::SuiError;
 use sui_types::transaction::ObjectArg;
-use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS;
 use sui_types::transaction::{
     CallArg, SignedTransaction, Transaction, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
@@ -369,6 +368,7 @@ pub fn make_transfer_object_move_transaction(
     object_ref: ObjectRef,
     framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
+    gas_budget_in_units: u64,
     gas_price: u64,
 ) -> Transaction {
     let args = vec![
@@ -385,7 +385,7 @@ pub fn make_transfer_object_move_transaction(
             Vec::new(),
             gas_object_ref,
             args,
-            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * gas_price,
+            gas_budget_in_units * gas_price,
             gas_price,
         )
         .unwrap(),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -88,7 +88,7 @@ pub fn create_object_move_transaction(
             Vec::new(),
             gas_object_ref,
             arguments,
-            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * gas_price,
+            TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * gas_price,
             gas_price,
         )
         .unwrap(),

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -23,7 +23,9 @@ use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiResult;
 use sui_types::object::{Object, Owner};
-use sui_types::transaction::{Transaction, VerifiedCertificate};
+use sui_types::transaction::{
+    Transaction, VerifiedCertificate, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{sleep, timeout};
 
@@ -363,6 +365,7 @@ async fn test_execution_with_dependencies() {
             owned_object_ref,
             package,
             gas_ref,
+            TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
             rgp,
         );
         let (cert, effects) = execute_owned_on_first_three_authorities(

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -130,8 +130,12 @@ where
     F: FnOnce(&GasCostSummary, u64, u64) -> SuiResult,
 {
     // initial system with given gas coins
-    const GAS_AMOUNT: u64 = 10_000_000_000;
-    let gas_coins = make_gas_coins(sender, GAS_AMOUNT, coin_num);
+    let gas_amount: u64 = if budget < 10_000_000_000 {
+        10_000_000_000
+    } else {
+        budget
+    };
+    let gas_coins = make_gas_coins(sender, gas_amount, coin_num);
     let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
     let authority_state = TestAuthorityBuilder::new().build().await;
     for obj in gas_coins {
@@ -139,7 +143,7 @@ where
     }
 
     let gas_object_id = ObjectID::random();
-    let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, GAS_AMOUNT);
+    let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_amount);
     authority_state.insert_genesis_object(gas_coin).await;
     // touch gas coins so that `storage_rebate` is set (not 0 as in genesis)
     touch_gas_coins(
@@ -216,7 +220,7 @@ where
     let summary = effects.gas_cost_summary();
 
     // call checker
-    checker(summary, GAS_AMOUNT, final_value)
+    checker(summary, gas_amount, final_value)
 }
 
 // make a `coin_num` coins distributing `gas_amount` across them
@@ -279,19 +283,17 @@ async fn touch_gas_coins(
 }
 
 // - OOG computation, storage ok
-#[ignore]
 #[tokio::test]
-async fn test_oog_computation_storage_ok() -> SuiResult {
-    const MAX_BUDGET: u64 = 10_000_000;
-    const GAS_PRICE: u64 = 30;
-    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
+async fn test_oog_computation_storage_ok_one_coin() -> SuiResult {
+    const GAS_PRICE: u64 = 1_000;
+    let budget: u64 = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
     let (sender, sender_key) = get_key_pair();
     check_oog_transaction(
         sender,
         sender_key,
         "loopy",
         vec![],
-        BUDGET,
+        budget,
         GAS_PRICE,
         1,
         |summary, initial_value, final_value| {
@@ -310,13 +312,9 @@ async fn test_oog_computation_storage_ok() -> SuiResult {
 }
 
 // OOG for computation, OOG for minimal storage (e.g. computation is entire budget)
-#[ignore]
 #[tokio::test]
-async fn test_oog_computation_oog_storage() -> SuiResult {
-    const GAS_PRICE: u64 = 30;
-    // WARNING: this value is taken from gas_v2.rs::MAX_BUCKET_COST and when
-    // that value changes this test will break!
-    // TODO: when buckets move to ProtocolConfig change this value to use ProtocolConfig
+async fn test_oog_computation_oog_storage_final() -> SuiResult {
+    const GAS_PRICE: u64 = 1000;
     const MAX_UNIT_BUDGET: u64 = 5_000_000;
     const BUDGET: u64 = MAX_UNIT_BUDGET * GAS_PRICE;
     let (sender, sender_key) = get_key_pair();
@@ -376,7 +374,7 @@ async fn test_computation_ok_oog_storage_minimal_ok() -> SuiResult {
 
 // - computation ok, OOG for storage, OOG for minimal storage (e.g. computation is entire budget)
 #[tokio::test]
-async fn test_computation_ok_oog_storage() -> SuiResult {
+async fn test_computation_ok_oog_storage_final() -> SuiResult {
     const GAS_PRICE: u64 = 1001;
     const BUDGET: u64 = 1_002_000;
     let (sender, sender_key) = get_key_pair();
@@ -405,19 +403,17 @@ async fn test_computation_ok_oog_storage() -> SuiResult {
     .await
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_oog_computation_storage_ok_multi_coins() -> SuiResult {
-    const MAX_BUDGET: u64 = 4_000_000;
-    const GAS_PRICE: u64 = 30;
-    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
+    const GAS_PRICE: u64 = 1_000;
+    let budget: u64 = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
     let (sender, sender_key) = get_key_pair();
     check_oog_transaction(
         sender,
         sender_key,
         "loopy",
         vec![],
-        BUDGET,
+        budget,
         GAS_PRICE,
         5,
         |summary, initial_value, final_value| {

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -770,6 +770,7 @@ async fn test_entry_point_vector_empty() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
 
     let package = build_and_publish_test_package(
         &authority,
@@ -802,7 +803,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -831,7 +832,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -861,7 +862,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();
@@ -891,7 +892,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();
@@ -2281,6 +2282,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
             vec![vec, n],
         );
     }
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
     // empty
     let mut builder = ProgrammableTransactionBuilder::new();
     make_and_drop(&mut builder, package_id, &t, vec![]);
@@ -2291,7 +2293,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2313,7 +2315,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2338,7 +2340,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2368,7 +2370,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2405,7 +2407,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2534,6 +2536,8 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
     t: TypeTag,
     value: T,
 ) {
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
     // single without a type argument
     let mut builder = ProgrammableTransactionBuilder::new();
     let arg = builder.pure(value.clone()).unwrap();
@@ -2545,7 +2549,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2574,7 +2578,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2605,7 +2609,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2718,6 +2722,7 @@ async fn test_make_move_vec_empty() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
     let mut builder = ProgrammableTransactionBuilder::new();
     builder.command(Command::MakeMoveVec(None, vec![]));
     let pt = builder.finish();
@@ -2727,7 +2732,7 @@ async fn test_make_move_vec_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -103,6 +103,7 @@ struct UpgradeStateRunner {
     pub authority_state: Arc<AuthorityState>,
     pub package: ObjectRef,
     pub upgrade_cap: ObjectRef,
+    pub rgp: u64,
 }
 
 impl UpgradeStateRunner {
@@ -117,6 +118,7 @@ impl UpgradeStateRunner {
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
         let authority_state = TestAuthorityBuilder::new().build().await;
         authority_state.insert_genesis_object(gas_object).await;
+        let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
         let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(
             &authority_state,
@@ -135,6 +137,7 @@ impl UpgradeStateRunner {
             authority_state,
             package,
             upgrade_cap,
+            rgp,
         }
     }
 
@@ -213,7 +216,7 @@ impl UpgradeStateRunner {
             &self.sender,
             &self.sender_key,
             pt,
-            TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+            self.rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         )
         .await
         .unwrap();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -71,7 +71,7 @@
             },
             {
               "name": "tx_bytes",
-              "value": "AAACACBnxtMcbJcOVn8D72fYEaT4Q2ZbjePygvpIs+AQO6m77QEAagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbECAAAAAAAAACDoQ3EipycU+/EOvBcDPFtMkZiSbdzWAw3CwdmQCAtBWAEBAQEBAAEAAC9cVD1xauQ9RT3rOxmbva8bxwMMdoL4dwPc5DEkj+3gASxDgF0Nb1QCp60Npb3sVJx83qBrxKHTOaIlIe6pM7iJAgAAAAAAAAAgnvsgc1pPauyCE27/c+aBnHN3fSsxRAWdEJYzYFOryNAvXFQ9cWrkPUU96zsZm72vG8cDDHaC+HcD3OQxJI/t4AoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACBnxtMcbJcOVn8D72fYEaT4Q2ZbjePygvpIs+AQO6m77QEAagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbECAAAAAAAAACDoQ3EipycU+/EOvBcDPFtMkZiSbdzWAw3CwdmQCAtBWAEBAQEBAAEAAC9cVD1xauQ9RT3rOxmbva8bxwMMdoL4dwPc5DEkj+3gASxDgF0Nb1QCp60Npb3sVJx83qBrxKHTOaIlIe6pM7iJAgAAAAAAAAAgnvsgc1pPauyCE27/c+aBnHN3fSsxRAWdEJYzYFOryNAvXFQ9cWrkPUU96zsZm72vG8cDDHaC+HcD3OQxJI/t4AoAAAAAAAAAoIYBAAAAAAAA"
             },
             {
               "name": "gas_price",
@@ -168,13 +168,13 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgoAAAAAAAAAoIYBAAAAAAAA"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
-              "digest": "Gm54bTY5F9KjiCw3kfKpkXPaEE3kx8ToJkYqTsuQDZ7q",
+              "digest": "DNtx7EmGqSywGbnSC1CKoqmBFEXGvApXpRVt6bU855xP",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -220,14 +220,14 @@
                     ],
                     "owner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "AGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
+                  "AG+AHZMT7BZWQVagaGfENXyiFQ2nYRkG4XdnwqwToeJEmZ4J1IxKw0xKzTATGiUzFedY/nxKVuHikFibNlZ3wg9Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YABAE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAgsQwARuKTwIzsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/8BAQEBAQABAABh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgHo2MfOhj8xPaPb2SqD7ybRKLiP5mvybg4NCc2vcn0dhAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlYfu1tPNCpAvb+H/kqUa5440Yz4/8ewAAuXUXXHtqlXYKAAAAAAAAAAAtMQEAAAAAAAFhAGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ==",
+              "rawTransaction": "AQAAAAAAAgAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YABAE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAgsQwARuKTwIzsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/8BAQEBAQABAABh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgHo2MfOhj8xPaPb2SqD7ybRKLiP5mvybg4NCc2vcn0dhAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlYfu1tPNCpAvb+H/kqUa5440Yz4/8ewAAuXUXXHtqlXYKAAAAAAAAAKCGAQAAAAAAAAFhAG+AHZMT7BZWQVagaGfENXyiFQ2nYRkG4XdnwqwToeJEmZ4J1IxKw0xKzTATGiUzFedY/nxKVuHikFibNlZ3wg9Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -349,12 +349,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACBqEB6aOvXIBwES+Ahkizbvv43uihqC3kbZUE6WoRCKFwEAjvdvVsOZYzousxC8qRJOXy84znOeqsu2YAaIgE4HhEgCAAAAAAAAACB9w3+ufZMpihJFwxtCBojBaGy00TVtFxgN2C6TpIPFqwEBAQEBAAEAAAS0l6kWtGVmCaf6gnoJGE1vR2gdO6dM4NejbGSysfiHAZ+Q9/hmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTAgAAAAAAAAAgjleHL0UiRGjh/BfIFHCJ3EMY/dQA22c2TvNQyVJnbYUEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACBqEB6aOvXIBwES+Ahkizbvv43uihqC3kbZUE6WoRCKFwEAjvdvVsOZYzousxC8qRJOXy84znOeqsu2YAaIgE4HhEgCAAAAAAAAACB9w3+ufZMpihJFwxtCBojBaGy00TVtFxgN2C6TpIPFqwEBAQEBAAEAAAS0l6kWtGVmCaf6gnoJGE1vR2gdO6dM4NejbGSysfiHAZ+Q9/hmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTAgAAAAAAAAAgjleHL0UiRGjh/BfIFHCJ3EMY/dQA22c2TvNQyVJnbYUEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwoAAAAAAAAAoIYBAAAAAAAA"
             },
             {
               "name": "signatures",
               "value": [
-                "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
+                "AKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
               ]
             },
             {
@@ -376,7 +376,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "BgSFSEFYbCrVUJJtHFeoLmLJi8jDf1CpC2o8S33HjeDJ",
+              "digest": "Gx7V6EteEAqSsptc1kbi1nUEMP7mhr4qV2cYS7JjzbBd",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -422,14 +422,14 @@
                     ],
                     "owner": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
+                  "AKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAgahAemjr1yAcBEvgIZIs277+N7ooagt5G2VBOlqEQihcBAI73b1bDmWM6LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAQEBAQABAAAEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwGfkPf4Zswp37HaY3POlPnZXcpaQPThdpkY7r+fuuAL0wIAAAAAAAAAII5Xhy9FIkRo4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FBLSXqRa0ZWYJp/qCegkYTW9HaB07p0zg16NsZLKx+IcKAAAAAAAAAAAtMQEAAAAAAAFhAEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w==",
+              "rawTransaction": "AQAAAAAAAgAgahAemjr1yAcBEvgIZIs277+N7ooagt5G2VBOlqEQihcBAI73b1bDmWM6LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAQEBAQABAAAEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwGfkPf4Zswp37HaY3POlPnZXcpaQPThdpkY7r+fuuAL0wIAAAAAAAAAII5Xhy9FIkRo4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FBLSXqRa0ZWYJp/qCegkYTW9HaB07p0zg16NsZLKx+IcKAAAAAAAAAKCGAQAAAAAAAAFhAKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -1923,7 +1923,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "oKtFZjL99EZ2K3TLPRarpZN8gz9xReMkiNf4Tjja2no"
+              "value": "Hay2tj3GcDYcE3AMHrej5WDsHGPVAYsegcubixLUvXUF"
             },
             {
               "name": "options",
@@ -1940,7 +1940,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "oKtFZjL99EZ2K3TLPRarpZN8gz9xReMkiNf4Tjja2no",
+              "digest": "Hay2tj3GcDYcE3AMHrej5WDsHGPVAYsegcubixLUvXUF",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -1986,14 +1986,14 @@
                     ],
                     "owner": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "ABTTP4JUSxqOQTlysdS30HzkMc3DOwJqlBJstqn2EwW0SKtvoGIoxFEbmTqIS+UYSemveVGJ+S6BijQQVS97cwxtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA=="
+                  "AMU7cJTEsJ5WoVlKZ2zsVuGMk9linDuNqLV9eGIIrqarP2x4R9riuvmmMgXfdxMm7jTzYxbHrsDNMwlxpTbbFghtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAggZbQSLem0EyO3IlXnYb9P8kMUvmhTGuBK5T+YTxbzrsBAF7rHUSeJRYWbVfXH96xVNDcns23swBX0KkyaEysNSzcAgAAAAAAAAAg43+UGkUe+CCaD7+/G1SbK7Jrjq7giJUUbfJ7w88mEMEBAQEBAQABAACCF5xX1Ylbq/tlXNYujohqUzNLXnvpvmWOt1nMNeP8ZgEaPomAKdAk7sHUTGr14vrN7YTQO1NzUU8W49ZuAAgQUQIAAAAAAAAAIGS7c6HtWLLBiwy/N3eS4gbmuA1NXupk4ucFY7FYkCbEghecV9WJW6v7ZVzWLo6IalMzS1576b5ljrdZzDXj/GYKAAAAAAAAAAAtMQEAAAAAAAFhABTTP4JUSxqOQTlysdS30HzkMc3DOwJqlBJstqn2EwW0SKtvoGIoxFEbmTqIS+UYSemveVGJ+S6BijQQVS97cwxtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA==",
+              "rawTransaction": "AQAAAAAAAgAggZbQSLem0EyO3IlXnYb9P8kMUvmhTGuBK5T+YTxbzrsBAF7rHUSeJRYWbVfXH96xVNDcns23swBX0KkyaEysNSzcAgAAAAAAAAAg43+UGkUe+CCaD7+/G1SbK7Jrjq7giJUUbfJ7w88mEMEBAQEBAQABAACCF5xX1Ylbq/tlXNYujohqUzNLXnvpvmWOt1nMNeP8ZgEaPomAKdAk7sHUTGr14vrN7YTQO1NzUU8W49ZuAAgQUQIAAAAAAAAAIGS7c6HtWLLBiwy/N3eS4gbmuA1NXupk4ucFY7FYkCbEghecV9WJW6v7ZVzWLo6IalMzS1576b5ljrdZzDXj/GYKAAAAAAAAAKCGAQAAAAAAAAFhAMU7cJTEsJ5WoVlKZ2zsVuGMk9linDuNqLV9eGIIrqarP2x4R9riuvmmMgXfdxMm7jTzYxbHrsDNMwlxpTbbFghtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -2297,9 +2297,9 @@
             {
               "name": "digests",
               "value": [
-                "Gd2vRA1pRwWu8j7KQe6fzHS4mMChq1JHJpi9KGnVJMtV",
-                "73FjSYzymaz1UWPu4bMW191cyxSxziKXJm2MyTQMjeur",
-                "7TxdfBqwTPYgG4hztwiQdeQcdWgeqpZKF7EJpyjDojFd"
+                "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
+                "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
+                "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7"
               ]
             },
             {
@@ -2318,7 +2318,7 @@
             "name": "Result",
             "value": [
               {
-                "digest": "Gd2vRA1pRwWu8j7KQe6fzHS4mMChq1JHJpi9KGnVJMtV",
+                "digest": "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2364,14 +2364,14 @@
                       ],
                       "owner": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ABWZkYviOekutE6mrOgoq7d2q5fx3xlmo0qWTyQSa+jDFzePlm+RPZm1zkOedq3TlQcYiMKaw+jqNYIYerHujAg34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ=="
+                    "AFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5fD5PhGooIBAHVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jL6wacOIOAgAAAAAAAAAgDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyL8J2rqpzwBAQEBAQABAAAKP1esHudBRjvJd0QFDxr01XDYuNDyA7Z9Cc2C/bIeEwEUb7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAbvavygo7gIAAAAAAAAAIJyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8DQItueIaCj9XrB7nQUY7yXdEBQ8a9NVw2LjQ8gO2fQnNgv2yHhMKAAAAAAAAAAAtMQEAAAAAAAFhABWZkYviOekutE6mrOgoq7d2q5fx3xlmo0qWTyQSa+jDFzePlm+RPZm1zkOedq3TlQcYiMKaw+jqNYIYerHujAg34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ==",
+                "rawTransaction": "AQAAAAAAAgAgCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5fD5PhGooIBAHVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jL6wacOIOAgAAAAAAAAAgDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyL8J2rqpzwBAQEBAQABAAAKP1esHudBRjvJd0QFDxr01XDYuNDyA7Z9Cc2C/bIeEwEUb7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAbvavygo7gIAAAAAAAAAIJyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8DQItueIaCj9XrB7nQUY7yXdEBQ8a9NVw2LjQ8gO2fQnNgv2yHhMKAAAAAAAAAKCGAQAAAAAAAAFhAFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2434,7 +2434,7 @@
                 ]
               },
               {
-                "digest": "73FjSYzymaz1UWPu4bMW191cyxSxziKXJm2MyTQMjeur",
+                "digest": "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2480,14 +2480,14 @@
                       ],
                       "owner": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ANFMDxz+6lExShcHA/qG/j2jZk6y9+5k65x6u8JGJP/dyxkfrihDdFxtOt3fvaoJ/OvEZ4eo123n/momyGQuFgahtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg=="
+                    "ABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEDiMKN3VkBAHeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutyCCnW1dCAgAAAAAAAAAgVlPau21sld3X01pC0x86m+u7aD22booGcGhVRnLhN7UBAQEBAQABAAACjWNudIYpke1SHcycbLerhgtEnj9Pe4UgtYIyW82k9gEkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXNgCS0s5pwIAAAAAAAAAIP7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEeeRW/wE/Ao1jbnSGKZHtUh3MnGy3q4YLRJ4/T3uFILWCMlvNpPYKAAAAAAAAAAAtMQEAAAAAAAFhANFMDxz+6lExShcHA/qG/j2jZk6y9+5k65x6u8JGJP/dyxkfrihDdFxtOt3fvaoJ/OvEZ4eo123n/momyGQuFgahtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg==",
+                "rawTransaction": "AQAAAAAAAgAgLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEDiMKN3VkBAHeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutyCCnW1dCAgAAAAAAAAAgVlPau21sld3X01pC0x86m+u7aD22booGcGhVRnLhN7UBAQEBAQABAAACjWNudIYpke1SHcycbLerhgtEnj9Pe4UgtYIyW82k9gEkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXNgCS0s5pwIAAAAAAAAAIP7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEeeRW/wE/Ao1jbnSGKZHtUh3MnGy3q4YLRJ4/T3uFILWCMlvNpPYKAAAAAAAAAKCGAQAAAAAAAAFhABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2550,7 +2550,7 @@
                 ]
               },
               {
-                "digest": "7TxdfBqwTPYgG4hztwiQdeQcdWgeqpZKF7EJpyjDojFd",
+                "digest": "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2596,14 +2596,14 @@
                       ],
                       "owner": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "AKM1jt3XaQUsZ9Pe77tb2tGgmJvI8GLE2P3kdaQ1I4oglYnu9TrBds27Zbm0KP0tayMvhoDRBQc2a3mdbfPsVA/WnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw=="
+                    "APXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAg3MhbraSnKdZQ93YiJkMhKXgJJ4OLBtsDRoCP+wZ2CZ0BAOBAizF1n1e2nFLglBCmb5ojw0vpkTtml6XoPgLioPx0AgAAAAAAAAAg5IK3WMI5kDnbvt1dskOF6TTWgrL9ZzRGkavQ78dxlBsBAQEBAQABAACzD91z21LE6wZ1S9tQ/sPqDhmnhR8jg9dk/LPW63+MggFwV7oJAeTZseBN516iaZpEEyFWElgeulfr5+WUuAnMzgIAAAAAAAAAIOwr5NrG/2lF1Js+zAQ9BJYR9s/RC8pNUX6UUq1Uhtaesw/dc9tSxOsGdUvbUP7D6g4Zp4UfI4PXZPyz1ut/jIIKAAAAAAAAAAAtMQEAAAAAAAFhAKM1jt3XaQUsZ9Pe77tb2tGgmJvI8GLE2P3kdaQ1I4oglYnu9TrBds27Zbm0KP0tayMvhoDRBQc2a3mdbfPsVA/WnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw==",
+                "rawTransaction": "AQAAAAAAAgAg3MhbraSnKdZQ93YiJkMhKXgJJ4OLBtsDRoCP+wZ2CZ0BAOBAizF1n1e2nFLglBCmb5ojw0vpkTtml6XoPgLioPx0AgAAAAAAAAAg5IK3WMI5kDnbvt1dskOF6TTWgrL9ZzRGkavQ78dxlBsBAQEBAQABAACzD91z21LE6wZ1S9tQ/sPqDhmnhR8jg9dk/LPW63+MggFwV7oJAeTZseBN516iaZpEEyFWElgeulfr5+WUuAnMzgIAAAAAAAAAIOwr5NrG/2lF1Js+zAQ9BJYR9s/RC8pNUX6UUq1Uhtaesw/dc9tSxOsGdUvbUP7D6g4Zp4UfI4PXZPyz1ut/jIIKAAAAAAAAAKCGAQAAAAAAAAFhAPXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -31,8 +31,8 @@ use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::transaction::{
     CallArg, InputObjectKind, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
     TransactionDataAPI, TransactionKind, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
-    TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN, TEST_ONLY_GAS_UNIT_FOR_STAKING,
-    TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,
+    TEST_ONLY_GAS_UNIT_FOR_STAKING, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use test_cluster::TestClusterBuilder;
 
@@ -162,7 +162,7 @@ async fn test_publish_and_move_call() {
         sender,
         pt,
         vec![],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
         rgp,
         false,
     )

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -20,7 +20,8 @@ use sui_types::signature::GenericSignature;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::transaction::{
     CallArg, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
-    DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::{TypeTag, SUI_SYSTEM_PACKAGE_ID};
 
@@ -230,7 +231,7 @@ impl TestTransactionBuilder {
                 data.type_args,
                 self.gas_object,
                 data.args,
-                self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+                self.gas_price * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
                 self.gas_price,
             )
             .unwrap(),
@@ -261,7 +262,7 @@ impl TestTransactionBuilder {
                     self.gas_object,
                     all_module_bytes,
                     dependencies,
-                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
                     self.gas_price,
                 )
             }

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -273,7 +273,7 @@ pub mod checked {
             }
 
             // compute and collect storage charges
-            temporary_store.ensure_gas_and_input_mutated(self);
+            temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
@@ -308,7 +308,7 @@ pub mod checked {
             if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                 self.reset(temporary_store);
                 self.gas_status.adjust_computation_on_out_of_gas();
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_rebate(self);
                 if execution_result.is_ok() {
                     *execution_result = Err(err);
@@ -325,14 +325,14 @@ pub mod checked {
                 // we run out of gas charging storage, reset and try charging for storage again.
                 // Input objects are touched and so they have a storage cost
                 self.reset(temporary_store);
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_storage_and_rebate(self);
                 if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                     // we run out of gas attempting to charge for the input objects exclusively,
                     // deal with this edge case by not charging for storage
                     self.reset(temporary_store);
                     self.gas_status.adjust_computation_on_out_of_gas();
-                    temporary_store.ensure_gas_and_input_mutated(self);
+                    temporary_store.ensure_active_inputs_mutated();
                     temporary_store.collect_rebate(self);
                     if execution_result.is_ok() {
                         *execution_result = Err(err);

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -286,7 +286,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
     /// mutated during the transaction execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
-    fn ensure_active_inputs_mutated(&mut self) {
+    pub fn ensure_active_inputs_mutated(&mut self) {
         let mut to_be_updated = vec![];
         for (id, _seq, _) in &self.mutable_input_refs {
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
@@ -767,19 +767,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    pub(crate) fn ensure_gas_and_input_mutated(&mut self, gas_charger: &mut GasCharger) {
-        if let Some(gas_object_id) = gas_charger.gas_coin() {
-            let gas_object = self
-                .read_object(&gas_object_id)
-                .expect("We constructed the object map so it should always have the gas object id")
-                .clone();
-            self.written
-                .entry(gas_object_id)
-                .or_insert_with(|| (gas_object, WriteKind::Mutate));
-        }
-        self.ensure_active_inputs_mutated();
-    }
-
     /// Track storage gas for each mutable input object (including the gas coin)
     /// and each created object. Compute storage refunds for each deleted object.
     /// Will *not* charge anything, gas status keeps track of storage cost and rebate.
@@ -787,7 +774,6 @@ impl<'backing> TemporaryStore<'backing> {
     /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
     /// overall storage rebate and cost.
     pub(crate) fn collect_storage_and_rebate(&mut self, gas_charger: &mut GasCharger) {
-        let mut objects_to_update = vec![];
         for (object_id, (object, write_kind)) in &mut self.written {
             // get the object storage_rebate in input for mutated objects
             let old_storage_rebate = match write_kind {
@@ -815,18 +801,9 @@ impl<'backing> TemporaryStore<'backing> {
             let new_storage_rebate =
                 gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
             object.storage_rebate = new_storage_rebate;
-            if !object.is_immutable() {
-                objects_to_update.push((object.clone(), *write_kind));
-            }
         }
 
         self.collect_rebate(gas_charger);
-
-        // Write all objects at the end only if all previous gas charges succeeded.
-        // This avoids polluting the temporary store state if this function failed.
-        for (object, write_kind) in objects_to_update {
-            self.write_object(object, write_kind);
-        }
     }
 
     pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
@@ -937,100 +914,124 @@ impl<'backing> TemporaryStore<'backing> {
 
     /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes
     /// except the epoch change tx, which mints staking rewards equal to the gas fees burned in the
-    /// previous epoch.  Specifically, this checks two key invariants about storage fees and storage
-    /// rebate:
+    /// previous epoch.  Specifically, this checks two key invariants about storage
+    /// fees and storage rebate:
     ///
     /// 1. all SUI in storage rebate fields of input objects should flow either to the transaction
     ///    storage rebate, or the transaction non-refundable storage rebate
     /// 2. all SUI charged for storage should flow into the storage rebate field of some output
     ///    object
     ///
-    /// If `do_expensive_checks` is true, this will also check a third invariant:
+    /// This function is intended to be called *after* we have charged for
+    /// gas + applied the storage rebate to the gas object, but *before* we
+    /// have updated object versions.
+    pub fn check_sui_conserved(&self, gas_summary: &GasCostSummary) -> Result<(), ExecutionError> {
+        // total amount of SUI in storage rebate of input objects
+        let mut total_input_rebate = 0;
+        // total amount of SUI in storage rebate of output objects
+        let mut total_output_rebate = 0;
+        for (_, input, output) in self.get_modified_objects() {
+            if let Some((_, storage_rebate)) = input {
+                total_input_rebate += storage_rebate;
+            }
+            if let Some(object) = output {
+                total_output_rebate += object.storage_rebate;
+            }
+        }
+
+        if gas_summary.storage_cost == 0
+            && gas_summary.storage_rebate == 0
+            && gas_summary.non_refundable_storage_fee == 0
+        {
+            // this condition is usually true when the transaction went OOG and no
+            // gas is left for storage charges.
+            // However if the storage charges are all 0 and if there is any object touched
+            // the value in input and output for the storage rebate must be equal
+            if total_input_rebate != total_output_rebate {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- no storage charges in gas summary \
+                        and total storage input rebate {} not equal  \
+                        to total storage output rebate {}",
+                    total_input_rebate, total_output_rebate,
+                )));
+            }
+        } else {
+            // all SUI in storage rebate fields of input objects should flow either to
+            // the transaction storage rebate, or the non-refundable storage rebate pool
+            if total_input_rebate
+                != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
+            {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI in storage rebate field of input objects, \
+                        {} SUI in tx storage rebate or tx non-refundable storage rebate",
+                    total_input_rebate, gas_summary.non_refundable_storage_fee,
+                )));
+            }
+
+            // all SUI charged for storage should flow into the storage rebate field
+            // of some output object
+            if gas_summary.storage_cost != total_output_rebate {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI charged for storage, \
+                        {} SUI in storage rebate field of output objects",
+                    gas_summary.storage_cost, total_output_rebate
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Check that this transaction neither creates nor destroys SUI.
+    /// This more expensive check will check a third invariant on top of the 2 performed
+    /// by `check_sui_conserved` above:
     ///
-    /// 3. all SUI in input objects (including coins etc in the Move part of an object) should flow
+    /// * all SUI in input objects (including coins etc in the Move part of an object) should flow
     ///    either to an output object, or be burned as part of computation fees or non-refundable
     ///    storage rebate
     ///
-    /// This function is intended to be called *after* we have charged for gas + applied the storage
-    /// rebate to the gas object, but *before* we have updated object versions.  If
-    /// `do_expensive_checks` is false, this function will only check conservation of object storage
-    /// rea `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.  The
+    /// This function is intended to be called *after* we have charged for gas + applied the
+    /// storage rebate to the gas object, but *before* we have updated object versions. The
     /// advance epoch transaction would mint `epoch_fees` amount of SUI, and burn `epoch_rebates`
-    /// amount of SUI. We need these information for conservation check.
-    pub fn check_sui_conserved(
+    /// amount of SUI. We need these information for this check.
+    pub fn check_sui_conserved_expensive(
         &self,
         gas_summary: &GasCostSummary,
         advance_epoch_gas_summary: Option<(u64, u64)>,
         layout_resolver: &mut impl LayoutResolver,
-        do_expensive_checks: bool,
     ) -> Result<(), ExecutionError> {
         // total amount of SUI in input objects, including both coins and storage rebates
         let mut total_input_sui = 0;
         // total amount of SUI in output objects, including both coins and storage rebates
         let mut total_output_sui = 0;
-        // total amount of SUI in storage rebate of input objects
-        let mut total_input_rebate = 0;
-        // total amount of SUI in storage rebate of output objects
-        let mut total_output_rebate = 0;
         for (id, input, output) in self.get_modified_objects() {
-            if let Some((version, storage_rebate)) = input {
-                total_input_rebate += storage_rebate;
-                if do_expensive_checks {
-                    total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
-                }
+            if let Some((version, _)) = input {
+                total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
             }
             if let Some(object) = output {
-                total_output_rebate += object.storage_rebate;
-                if do_expensive_checks {
-                    total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
-                        make_invariant_violation!(
-                            "Failed looking up output SUI in SUI conservation checking for \
-                             mutated type {:?}: {e:#?}",
-                            object.struct_tag(),
-                        )
-                    })?;
-                }
+                total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
+                    make_invariant_violation!(
+                        "Failed looking up output SUI in SUI conservation checking for \
+                         mutated type {:?}: {e:#?}",
+                        object.struct_tag(),
+                    )
+                })?;
             }
         }
-        if do_expensive_checks {
-            // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
-            // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
-            // both computation costs and storage rebate inflow are
-            total_output_sui +=
-                gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
-            if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
-                total_input_sui += epoch_fees;
-                total_output_sui += epoch_rebates;
-            }
-            if total_input_sui != total_output_sui {
-                return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed: input={}, output={}, this transaction either mints or burns SUI",
-                total_input_sui,
-                total_output_sui))
-            );
-            }
+        // note: storage_cost flows into the storage_rebate field of the output objects, which is
+        // why it is not accounted for here.
+        // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow
+        // gets credited to the gas coin both computation costs and storage rebate inflow are
+        total_output_sui += gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
+        if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
+            total_input_sui += epoch_fees;
+            total_output_sui += epoch_rebates;
         }
-
-        // all SUI in storage rebate fields of input objects should flow either to the transaction storage rebate, or the non-refundable
-        // storage rebate pool
-        if total_input_rebate != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
-        {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI in storage rebate field of input objects, {} SUI in tx storage rebate or tx non-refundable storage rebate",
-                total_input_rebate,
-                gas_summary.non_refundable_storage_fee))
-            );*/
-        }
-
-        // all SUI charged for storage should flow into the storage rebate field of some output object
-        if gas_summary.storage_cost != total_output_rebate {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI charged for storage, {} SUI in storage rebate field of output objects",
-                gas_summary.storage_cost,
-                total_output_rebate))
-            );*/
+        if total_input_sui != total_output_sui {
+            return Err(ExecutionError::invariant_violation(format!(
+                "SUI conservation failed: input={}, output={}, \
+                    this transaction either mints or burns SUI",
+                total_input_sui, total_output_sui,
+            )));
         }
         Ok(())
     }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -42,15 +42,17 @@ use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use tap::Pipe;
 use tracing::trace;
 
-// TODO: The following constants appear to be very large.
-// We should revisit them.
-pub const TEST_ONLY_GAS_UNIT_FOR_TRANSFER: u64 = 2_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS: u64 = 10_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_PUBLISH: u64 = 25_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_STAKING: u64 = 10_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_GENERIC: u64 = 5_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_VALIDATOR: u64 = 25_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN: u64 = 1_000_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_TRANSFER: u64 = 10_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_PUBLISH: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_STAKING: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_GENERIC: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN: u64 = 10_000;
+// For some transactions we may either perform heavy operations or touch
+// objects that are storage expensive. That may happen (and often is the case)
+// because the object touched are set up in genesis and carry no storage cost
+// (and thus rebate) on first usage.
+pub const TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE: u64 = 5_000_000;
 
 pub const GAS_PRICE_FOR_SYSTEM_TX: u64 = 1;
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1140,7 +1140,7 @@ fn test_move_input_objects() {
         SuiAddress::random_for_testing_only(),
         vec![gas_object_ref],
         builder.finish(),
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        1_000_000, // any random number the transaction is not run
         1,
     );
     let mut input_objects = data.input_objects().unwrap();

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -315,14 +315,22 @@ mod checked {
         if !is_genesis_tx && !Mode::allow_arbitrary_values() {
             // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
             let conservation_result = {
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                )
+                temporary_store
+                    .check_sui_conserved(cost_summary)
+                    .and_then(|()| {
+                        if enable_expensive_checks {
+                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                            let mut layout_resolver =
+                                TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                            temporary_store.check_sui_conserved_expensive(
+                                cost_summary,
+                                advance_epoch_gas_summary,
+                                &mut layout_resolver,
+                            )
+                        } else {
+                            Ok(())
+                        }
+                    })
             };
             if let Err(conservation_err) = conservation_result {
                 // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
@@ -331,14 +339,24 @@ mod checked {
                 gas_charger.reset(temporary_store);
                 gas_charger.charge_gas(temporary_store, &mut result);
                 // check conservation once more more
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                ) {
+                if let Err(recovery_err) = {
+                    temporary_store
+                        .check_sui_conserved(cost_summary)
+                        .and_then(|()| {
+                            if enable_expensive_checks {
+                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                                let mut layout_resolver =
+                                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                                temporary_store.check_sui_conserved_expensive(
+                                    cost_summary,
+                                    advance_epoch_gas_summary,
+                                    &mut layout_resolver,
+                                )
+                            } else {
+                                Ok(())
+                            }
+                        })
+                } {
                     // if we still fail, it's a problem with gas
                     // charging that happens even in the "aborted" case--no other option but panic.
                     // we will create or destroy SUI otherwise

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -330,14 +330,22 @@ mod checked {
         if !is_genesis_tx && !Mode::allow_arbitrary_values() {
             // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
             let conservation_result = {
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                temporary_store.check_sui_conserved(
-                    &cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                )
+                temporary_store
+                    .check_sui_conserved(&cost_summary)
+                    .and_then(|()| {
+                        if enable_expensive_checks {
+                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                            let mut layout_resolver =
+                                TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                            temporary_store.check_sui_conserved_expensive(
+                                &cost_summary,
+                                advance_epoch_gas_summary,
+                                &mut layout_resolver,
+                            )
+                        } else {
+                            Ok(())
+                        }
+                    })
             };
             if let Err(conservation_err) = conservation_result {
                 // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
@@ -346,14 +354,24 @@ mod checked {
                 gas_charger.reset(temporary_store);
                 gas_charger.charge_gas(temporary_store, &mut result);
                 // check conservation once more more
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                    &cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                ) {
+                if let Err(recovery_err) = {
+                    temporary_store
+                        .check_sui_conserved(&cost_summary)
+                        .and_then(|()| {
+                            if enable_expensive_checks {
+                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                                let mut layout_resolver =
+                                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                                temporary_store.check_sui_conserved_expensive(
+                                    &cost_summary,
+                                    advance_epoch_gas_summary,
+                                    &mut layout_resolver,
+                                )
+                            } else {
+                                Ok(())
+                            }
+                        })
+                } {
                     // if we still fail, it's a problem with gas
                     // charging that happens even in the "aborted" case--no other option but panic.
                     // we will create or destroy SUI otherwise


### PR DESCRIPTION
## Description 

Re-enabled some gas tests and changed some gas constant to be more in line with a proper usage.
We still have one big value that seems inevitable (though maybe code could be organized better).
Removed some redundant code and some cleanup as highlighted by @lxfind, thanks!
I wanted to make more changes to the testing framework but I am not sure anymore, I may open an issue for that to discuss. The idea was to expand the `TestAuthorityBuilder` API (like adding the "concept" of `insert_genesis_object`) and removing the excess of functions that build an authority, as seen in `authority_test.rs`. Also "genesis added objects" have this annoying missing storage rebate which makes guessing (or dry_run requests) for transaction charges very difficult (the value changes after first execution as the storage rebate goes from 0 to the correct one)
However I am not sure any longer that it is a true cleanup and I have to look/think into that more. If anybody got feelings please comment

## Test Plan 

Existing tests and enable some that were disabled (ignored)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
