### PR TITLE
CustomError enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10267,6 +10267,7 @@ dependencies = [
  "sui-json-rpc",
  "sui-json-rpc-types",
  "sui-sdk",
+ "thiserror",
  "tokio",
  "tower",
  "workspace-hack",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -16,6 +16,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 serde.workspace = true
 tokio.workspace = true
+thiserror.workspace = true
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -1,13 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{ErrorExtensionValues, Response, ServerError};
+use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, ServerError};
 use async_graphql_axum::GraphQLResponse;
 
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
+/// `<https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes>`
 pub mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
+    pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
 }
 
@@ -30,4 +32,37 @@ pub(crate) fn graphql_error(code: &str, message: String) -> GraphQLResponse {
     };
 
     Response::from_errors(error.into()).into()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("'before' and 'after' must not be used together")]
+    CursorNoBeforeAfter,
+    #[error("'first' and 'last' must not be used together")]
+    CursorNoFirstLast,
+    #[error("reverse pagination is not supported")]
+    CursorNoReversePagination,
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
+    #[error("Data has changed since cursor was generated: {0}")]
+    CursorConnectionFetchFailed(String),
+    #[error("Internal error occurred while processing request.")]
+    Internal(String),
+}
+
+impl ErrorExtensions for Error {
+    fn extend(&self) -> async_graphql::Error {
+        async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
+            Error::CursorNoBeforeAfter
+            | Error::CursorNoFirstLast
+            | Error::CursorNoReversePagination
+            | Error::InvalidCursor(_)
+            | Error::CursorConnectionFetchFailed(_) => {
+                e.set("code", code::BAD_USER_INPUT);
+            }
+            Error::Internal(_) => {
+                e.set("code", code::INTERNAL_SERVER_ERROR);
+            }
+        })
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -22,9 +22,7 @@ impl ScalarType for Base64 {
                     InputValueError::custom(format!("Invalid Base64: {}", r))
                 })?))
             }
-            _ => Err(InputValueError::custom(
-                "Invalid Base64: Input must be String type",
-            )),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 

--- a/crates/sui-graphql-rpc/src/types/big_int.rs
+++ b/crates/sui-graphql-rpc/src/types/big_int.rs
@@ -27,10 +27,12 @@ impl ScalarType for BigInt {
                 } else if r.chars().all(|c| c.is_ascii_digit()) {
                     format!("{}{}", if signed { "-" } else { "" }, r)
                 } else {
-                    return Err(InputValueError::custom("Invalid BigInt"));
+                    return Err(InputValueError::custom(
+                        "Invalid BigInt value. All characters should be digits.",
+                    ));
                 }))
             }
-            _ => Err(InputValueError::custom("Invalid BigInt")),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -25,7 +25,8 @@ impl ScalarType for SuiAddress {
                 let bytes = hex::decode(s)?;
                 if bytes.len() != SUI_ADDRESS_LENGTH {
                     return Err(InputValueError::custom(format!(
-                        "Invalid SuiAddress length: {}",
+                        "Expected SuiAddress of length {}, received {}.",
+                        SUI_ADDRESS_LENGTH,
                         bytes.len()
                     )));
                 }
@@ -33,7 +34,7 @@ impl ScalarType for SuiAddress {
                 arr.copy_from_slice(&bytes);
                 Ok(SuiAddress(arr))
             }
-            _ => Err(InputValueError::custom("Invalid SuiAddress")),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 


### PR DESCRIPTION
## Description 
1. Consolidate error strings to sui_graphql_rpc::Error enum.
2. Extend enum variants with machine-readable code using ErrorExtensions. Map code to default graphql codes as best as possible.
3. Use graphql::InputValueError::expected_type for parsing logic. 

Follow-up:
1. Error middleware to extend all errors with a machine-readable code. As an example, if we run into a validation issue of graphql::InputValueError, it would be missing errors[n].extensions.code
2. embedded error typing for queries like fetch_owned_objs

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
