### PR TITLE
Extend Object to support partial data from fetching owned objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10267,6 +10267,7 @@ dependencies = [
  "sui-json-rpc",
  "sui-json-rpc-types",
  "sui-sdk",
+ "thiserror",
  "tokio",
  "tower",
  "workspace-hack",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -16,6 +16,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 serde.workspace = true
 tokio.workspace = true
+thiserror.workspace = true
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -1118,7 +1118,12 @@ type ObjectConnection {
 
 type ObjectEdge {
   cursor: String
-  node: Object!
+  node: ObjectPayload!
+}
+
+type ObjectPayload {
+  object: Object
+  errors: String
 }
 
 # Event

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -1,13 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{ErrorExtensionValues, Response, ServerError};
+use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, ServerError};
 use async_graphql_axum::GraphQLResponse;
 
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
+/// `<https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes>`
 pub mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
+    pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
 }
 
@@ -30,4 +32,37 @@ pub(crate) fn graphql_error(code: &str, message: String) -> GraphQLResponse {
     };
 
     Response::from_errors(error.into()).into()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("'before' and 'after' must not be used together")]
+    CursorNoBeforeAfter,
+    #[error("'first' and 'last' must not be used together")]
+    CursorNoFirstLast,
+    #[error("reverse pagination is not supported")]
+    CursorNoReversePagination,
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
+    #[error("Data has changed since cursor was generated: {0}")]
+    CursorConnectionFetchFailed(String),
+    #[error("Internal error occurred while processing request.")]
+    Internal(String),
+}
+
+impl ErrorExtensions for Error {
+    fn extend(&self) -> async_graphql::Error {
+        async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
+            Error::CursorNoBeforeAfter
+            | Error::CursorNoFirstLast
+            | Error::CursorNoReversePagination
+            | Error::InvalidCursor(_)
+            | Error::CursorConnectionFetchFailed(_) => {
+                e.set("code", code::BAD_USER_INPUT);
+            }
+            Error::Internal(_) => {
+                e.set("code", code::INTERNAL_SERVER_ERROR);
+            }
+        })
+    }
 }

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -8,7 +8,6 @@ use crate::types::address::Address;
 use crate::types::balance::Balance;
 use crate::types::base64::Base64;
 use crate::types::big_int::BigInt;
-use crate::types::error::CustomError;
 use crate::types::object::ObjectFilter;
 use crate::types::object::ObjectKind;
 use crate::types::protocol_config::ProtocolConfigAttr;
@@ -114,7 +113,10 @@ pub(crate) async fn fetch_owned_objs(
                     let cursor = g.object_id.to_string();
                     Ok(Edge::new(cursor, ObjectPayload::with_object(object)))
                 } else {
-                    Err(CustomError::Internal.extend())
+                    Err(Error::Internal(
+                        "Expected either data or error fields, received neither".to_string(),
+                    )
+                    .extend())
                 }
             })
             .collect::<Result<Vec<_>, _>>()?,

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -8,6 +8,7 @@ use crate::types::address::Address;
 use crate::types::balance::Balance;
 use crate::types::base64::Base64;
 use crate::types::big_int::BigInt;
+use crate::types::error::CustomError;
 use crate::types::object::ObjectFilter;
 use crate::types::object::ObjectKind;
 use crate::types::protocol_config::ProtocolConfigAttr;
@@ -96,22 +97,10 @@ pub(crate) async fn fetch_owned_objs(
         .await?;
 
     // TODO: support partial success/ failure responses
-    pg.data.iter().try_for_each(|n| {
         if n.error.is_some() {
             return Err(
                 Error::CursorConnectionFetchFailed(n.error.as_ref().unwrap().to_string()).extend(),
-            );
-        } else if n.data.is_none() {
-            return Err(Error::Internal(
-                "Expected either data or error fields, received neither".to_string(),
-            )
             .extend());
-        }
-        Ok(())
-    })?;
-    let mut connection = Connection::new(false, pg.has_next_page);
-
-    connection.edges.extend(pg.data.into_iter().map(|n| {
         let g = n.data.unwrap();
         let o = convert_obj(&g);
 

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -104,8 +104,7 @@ pub(crate) async fn fetch_owned_objs(
     connection.edges.extend(
         pg.data
             .into_iter()
-            .enumerate()
-            .map(|(idx, n)| {
+            .map(|n| {
                 if let Some(err) = &n.error {
                     let cursor = "error_cursor".to_string();
                     let errors = err.as_ref().to_string();
@@ -115,7 +114,7 @@ pub(crate) async fn fetch_owned_objs(
                     let cursor = g.object_id.to_string();
                     Ok(Edge::new(cursor, ObjectPayload::with_object(object)))
                 } else {
-                    Err(CustomError::ClientFetch("Unexpected".to_string()).extend())
+                    Err(CustomError::Internal.extend())
                 }
             })
             .collect::<Result<Vec<_>, _>>()?,

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -9,7 +9,7 @@ use super::{
     balance::{Balance, BalanceConnection},
     coin::CoinConnection,
     name_service::NameServiceConnection,
-    object::{Object, ObjectFilter},
+    object::{ObjectFilter, ObjectPayload},
     stake::StakeConnection,
     sui_address::SuiAddress,
     transaction_block::{TransactionBlockConnection, TransactionBlockFilter},
@@ -58,7 +58,7 @@ impl Address {
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, ObjectPayload>> {
         fetch_owned_objs(
             ctx.data_unchecked::<sui_sdk::SuiClient>(),
             &self.address,

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -22,9 +22,7 @@ impl ScalarType for Base64 {
                     InputValueError::custom(format!("Invalid Base64: {}", r))
                 })?))
             }
-            _ => Err(InputValueError::custom(
-                "Invalid Base64: Input must be String type",
-            )),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 

--- a/crates/sui-graphql-rpc/src/types/big_int.rs
+++ b/crates/sui-graphql-rpc/src/types/big_int.rs
@@ -27,10 +27,12 @@ impl ScalarType for BigInt {
                 } else if r.chars().all(|c| c.is_ascii_digit()) {
                     format!("{}{}", if signed { "-" } else { "" }, r)
                 } else {
-                    return Err(InputValueError::custom("Invalid BigInt"));
+                    return Err(InputValueError::custom(
+                        "Invalid BigInt value. All characters should be digits.",
+                    ));
                 }))
             }
-            _ => Err(InputValueError::custom("Invalid BigInt")),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 

--- a/crates/sui-graphql-rpc/src/types/error.rs
+++ b/crates/sui-graphql-rpc/src/types/error.rs
@@ -3,12 +3,15 @@
 
 use async_graphql::{Error, ErrorExtensions};
 
+#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 pub enum CustomError {
     #[error("{0}")]
     Input(String),
     #[error("{0}")]
     ClientFetch(String),
+    #[error("Internal error occurred")]
+    Internal,
 }
 
 impl ErrorExtensions for CustomError {
@@ -19,6 +22,9 @@ impl ErrorExtensions for CustomError {
             }
             CustomError::ClientFetch(_) => {
                 e.set("code", "CLIENT_FETCH_ERROR");
+            }
+            CustomError::Internal => {
+                e.set("code", "INTERNAL_ERROR");
             }
         })
     }

--- a/crates/sui-graphql-rpc/src/types/error.rs
+++ b/crates/sui-graphql-rpc/src/types/error.rs
@@ -6,18 +6,18 @@ use async_graphql::{Error, ErrorExtensions};
 #[derive(Debug, thiserror::Error)]
 pub enum CustomError {
     #[error("{0}")]
-    InputValueError(String),
+    Input(String),
     #[error("{0}")]
-    ClientFetchError(String),
+    ClientFetch(String),
 }
 
 impl ErrorExtensions for CustomError {
     fn extend(&self) -> Error {
         Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            CustomError::InputValueError(_) => {
-                e.set("code", "INVALID_INPUT_VALUE");
+            CustomError::Input(_) => {
+                e.set("code", "INVALID_INPUT");
             }
-            CustomError::ClientFetchError(_) => {
+            CustomError::ClientFetch(_) => {
                 e.set("code", "CLIENT_FETCH_ERROR");
             }
         })

--- a/crates/sui-graphql-rpc/src/types/error.rs
+++ b/crates/sui-graphql-rpc/src/types/error.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Error, ErrorExtensions};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CustomError {
+    #[error("{0}")]
+    InputValueError(String),
+    #[error("{0}")]
+    ClientFetchError(String),
+}
+
+impl ErrorExtensions for CustomError {
+    fn extend(&self) -> Error {
+        Error::new(format!("{}", self)).extend_with(|_err, e| match self {
+            CustomError::InputValueError(_) => {
+                e.set("code", "INVALID_INPUT_VALUE");
+            }
+            CustomError::ClientFetchError(_) => {
+                e.set("code", "CLIENT_FETCH_ERROR");
+            }
+        })
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -29,6 +29,27 @@ pub(crate) struct Object {
     pub kind: Option<ObjectKind>,
 }
 
+pub(crate) struct ObjectPayload {
+    pub object: Option<Object>,
+    pub errors: Option<String>,
+}
+
+impl ObjectPayload {
+    pub fn with_error(errors: String) -> Self {
+        Self {
+            object: None,
+            errors: Some(errors),
+        }
+    }
+
+    pub fn with_object(object: Object) -> Self {
+        Self {
+            object: Some(object),
+            errors: None,
+        }
+    }
+}
+
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum ObjectKind {
     Owned,
@@ -107,7 +128,7 @@ impl Object {
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, ObjectPayload>> {
         fetch_owned_objs(
             ctx.data_unchecked::<sui_sdk::SuiClient>(),
             &self.address,
@@ -172,5 +193,18 @@ impl Object {
         before: Option<String>,
     ) -> Option<NameServiceConnection> {
         unimplemented!()
+    }
+}
+
+#[allow(unreachable_code)]
+#[allow(unused_variables)]
+#[Object]
+impl ObjectPayload {
+    async fn object(&self) -> Option<&Object> {
+        self.object.as_ref()
+    }
+
+    async fn errors(&self) -> Option<&String> {
+        self.errors.as_ref()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -19,7 +19,7 @@ use super::address::Address;
     field(name = "location", type = "SuiAddress"),
     field(
         name = "object_connection",
-        type = "Option<Connection<String, Object>>",
+        type = "Option<Connection<String, ObjectPayload>>",
         arg(name = "first", type = "Option<u64>"),
         arg(name = "after", type = "Option<String>"),
         arg(name = "last", type = "Option<u64>"),
@@ -107,7 +107,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, ObjectPayload>> {
         fetch_owned_objs(
             ctx.data_unchecked::<sui_sdk::SuiClient>(),
             &self.address,

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -25,7 +25,8 @@ impl ScalarType for SuiAddress {
                 let bytes = hex::decode(s)?;
                 if bytes.len() != SUI_ADDRESS_LENGTH {
                     return Err(InputValueError::custom(format!(
-                        "Invalid SuiAddress length: {}",
+                        "Expected SuiAddress of length {}, received {}.",
+                        SUI_ADDRESS_LENGTH,
                         bytes.len()
                     )));
                 }
@@ -33,7 +34,7 @@ impl ScalarType for SuiAddress {
                 arr.copy_from_slice(&bytes);
                 Ok(SuiAddress(arr))
             }
-            _ => Err(InputValueError::custom("Invalid SuiAddress")),
+            _ => Err(InputValueError::expected_type(value)),
         }
     }
 


### PR DESCRIPTION
## Description 
Modify ObjectEdge's node to ObjectPayload, a result type of object: Object or errors: string, so we can return partially successful data. Also using this as an example of how we can embed errors in graphql schema more broadly in addition to using top-level errors field

![Capture-2023-08-14-141034](https://github.com/MystenLabs/sui/assets/127570466/4153d09d-60a0-4de6-8c32-4b202d2fd98d)

## Test Plan 

Manually
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
