### PR TITLE
[move-compiler] Use default implementations for custom visitors in SimpleAbsInt

### DIFF
--- a/crates/sui-move-build/src/linters/custom_state_change.rs
+++ b/crates/sui-move-build/src/linters/custom_state_change.rs
@@ -25,8 +25,7 @@ use move_compiler::{
         Diagnostic, Diagnostics,
     },
     hlir::ast::{
-        BaseType_, Command, Exp, LValue, Label, ModuleCall, SingleType, SingleType_, Type,
-        TypeName_, Type_, Var,
+        BaseType_, Label, ModuleCall, SingleType, SingleType_, Type, TypeName_, Type_, Var,
     },
     parser::ast::Ability_,
     shared::{CompilationEnv, Identifier},
@@ -123,15 +122,6 @@ impl SimpleAbsInt for CustomStateChangeVerifierAI {
         diags
     }
 
-    fn exp_custom(
-        &self,
-        _context: &mut ExecutionContext,
-        _state: &mut State,
-        _e: &Exp,
-    ) -> Option<Vec<Value>> {
-        None
-    }
-
     fn call_custom(
         &self,
         context: &mut ExecutionContext,
@@ -182,20 +172,6 @@ impl SimpleAbsInt for CustomStateChangeVerifierAI {
             Type_::Single(_) => vec![Value::Other],
             Type_::Multiple(types) => vec![Value::Other; types.len()],
         })
-    }
-
-    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
-        false
-    }
-
-    fn lvalue_custom(
-        &self,
-        _context: &mut ExecutionContext,
-        _state: &mut State,
-        _l: &LValue,
-        _value: &Value,
-    ) -> bool {
-        false
     }
 }
 

--- a/crates/sui-move-build/src/linters/self_transfer.rs
+++ b/crates/sui-move-build/src/linters/self_transfer.rs
@@ -20,7 +20,7 @@ use move_compiler::{
         codes::{custom, DiagnosticInfo, Severity},
         Diagnostic, Diagnostics,
     },
-    hlir::ast::{Command, Exp, LValue, Label, ModuleCall, Type, Type_, Var},
+    hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     shared::CompilationEnv,
 };
 use move_symbol_pool::Symbol;
@@ -125,15 +125,6 @@ impl SimpleAbsInt for SelfTransferVerifierAI {
         diags
     }
 
-    fn exp_custom(
-        &self,
-        _context: &mut ExecutionContext,
-        _state: &mut State,
-        _e: &Exp,
-    ) -> Option<Vec<Value>> {
-        None
-    }
-
     fn call_custom(
         &self,
         context: &mut ExecutionContext,
@@ -174,20 +165,6 @@ impl SimpleAbsInt for SelfTransferVerifierAI {
             Type_::Single(_) => vec![Value::Other],
             Type_::Multiple(types) => vec![Value::Other; types.len()],
         })
-    }
-
-    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
-        false
-    }
-
-    fn lvalue_custom(
-        &self,
-        _context: &mut ExecutionContext,
-        _state: &mut State,
-        _l: &LValue,
-        _value: &Value,
-    ) -> bool {
-        false
     }
 }
 

--- a/crates/sui-move-build/src/linters/share_owned.rs
+++ b/crates/sui-move-build/src/linters/share_owned.rs
@@ -22,8 +22,8 @@ use move_compiler::{
         Diagnostic, Diagnostics,
     },
     hlir::ast::{
-        BaseType_, Command, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_, Type,
-        Type_, Var,
+        BaseType_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_, Type, Type_,
+        Var,
     },
     parser::ast::Ability_,
     shared::{CompilationEnv, Identifier},
@@ -178,10 +178,6 @@ impl SimpleAbsInt for ShareOwnedVerifierAI {
                 })
                 .collect(),
         })
-    }
-
-    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
-        false
     }
 
     fn lvalue_custom(

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -226,10 +226,12 @@ pub trait SimpleAbsInt: Sized {
     /// custom visit for a command. It will skip `command` if `command_custom` returns true.
     fn command_custom(
         &self,
-        context: &mut Self::ExecutionContext,
-        state: &mut Self::State,
-        cmd: &Command,
-    ) -> bool;
+        _context: &mut Self::ExecutionContext,
+        _state: &mut Self::State,
+        _cmd: &Command,
+    ) -> bool {
+        false
+    }
     fn command(
         &self,
         context: &mut Self::ExecutionContext,
@@ -280,11 +282,13 @@ pub trait SimpleAbsInt: Sized {
     /// custom visit for an lvalue. It will skip `lvalue` if `lvalue_custom` returns true.
     fn lvalue_custom(
         &self,
-        context: &mut Self::ExecutionContext,
-        state: &mut Self::State,
-        l: &LValue,
-        value: &<Self::State as SimpleDomain>::Value,
-    ) -> bool;
+        _context: &mut Self::ExecutionContext,
+        _state: &mut Self::State,
+        _l: &LValue,
+        _value: &<Self::State as SimpleDomain>::Value,
+    ) -> bool {
+        false
+    }
     fn lvalue(
         &self,
         context: &mut Self::ExecutionContext,
@@ -315,19 +319,23 @@ pub trait SimpleAbsInt: Sized {
     /// custom visit for an exp. It will skip `exp` and `call_custom` if `exp_custom` returns Some.
     fn exp_custom(
         &self,
-        context: &mut Self::ExecutionContext,
-        state: &mut Self::State,
-        parent_e: &Exp,
-    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>>;
+        _context: &mut Self::ExecutionContext,
+        _state: &mut Self::State,
+        _parent_e: &Exp,
+    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>> {
+        None
+    }
     fn call_custom(
         &self,
-        context: &mut Self::ExecutionContext,
-        state: &mut Self::State,
-        loc: &Loc,
-        return_ty: &Type,
-        f: &ModuleCall,
-        args: Vec<<Self::State as SimpleDomain>::Value>,
-    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>>;
+        _context: &mut Self::ExecutionContext,
+        _state: &mut Self::State,
+        _loc: &Loc,
+        _return_ty: &Type,
+        _f: &ModuleCall,
+        _args: Vec<<Self::State as SimpleDomain>::Value>,
+    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>> {
+        None
+    }
     fn exp(
         &self,
         context: &mut Self::ExecutionContext,

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -17,7 +17,7 @@ use crate::{
     diagnostics::{Diagnostic, Diagnostics},
     editions::Flavor,
     expansion::ast::AbilitySet,
-    hlir::ast::{Command, Exp, LValue, Label, ModuleCall, SingleType, Type, Type_, Var},
+    hlir::ast::{Exp, Label, ModuleCall, SingleType, Type, Type_, Var},
     parser::ast::{Ability_, StructName},
     shared::{unique_map::UniqueMap, CompilationEnv, Identifier},
     sui_mode::{OBJECT_NEW, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT},
@@ -188,20 +188,6 @@ impl<'a> SimpleAbsInt for IDLeakVerifierAI<'a> {
             Type_::Single(t) => vec![value_for_ty(loc, t)],
             Type_::Multiple(ts) => ts.iter().map(|t| value_for_ty(loc, t)).collect(),
         })
-    }
-
-    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
-        false
-    }
-
-    fn lvalue_custom(
-        &self,
-        _: &mut ExecutionContext,
-        _: &mut State,
-        _: &LValue,
-        _: &Value,
-    ) -> bool {
-        false
     }
 }
 


### PR DESCRIPTION
## Description 

- Added defaults for custom functions in absint visitor

## Test Plan 

- cargo check

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
