### PR TITLE
[GraphQL] Interface for Object multi-get

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -206,8 +206,13 @@ input ObjectFilter {
   type: String
 
   owner: SuiAddress
-  objectId: SuiAddress
-  version: Int
+  objectIds: [SuiAddress!]
+  objectKeys: [ObjectKey!]
+}
+
+input ObjectKey {
+  objectId: SuiAddress!
+  version: Int!
 }
 
 input EventFilter {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -44,8 +44,14 @@ pub(crate) struct ObjectFilter {
     ty: Option<String>,
 
     owner: Option<SuiAddress>,
-    object_id: Option<SuiAddress>,
-    version: Option<u64>,
+    object_ids: Option<Vec<SuiAddress>>,
+    object_keys: Option<Vec<ObjectKey>>,
+}
+
+#[derive(InputObject)]
+pub(crate) struct ObjectKey {
+    object_id: SuiAddress,
+    version: u64,
 }
 
 #[allow(unreachable_code)]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -98,8 +98,13 @@ input ObjectFilter {
 	module: String
 	ty: String
 	owner: SuiAddress
-	objectId: SuiAddress
-	version: Int
+	objectIds: [SuiAddress!]
+	objectKeys: [ObjectKey!]
+}
+
+input ObjectKey {
+	objectId: SuiAddress!
+	version: Int!
 }
 
 enum ObjectKind {


### PR DESCRIPTION
## Description

Replace the `objectId` and `version` fields in `ObjectFilter` with `objectIds: [SuiAddress!]` and `objectKeys: [ObjectKey]`, so that `objectConnection` can be used to multi-get objects.

## Test Plan

Schema generation:

```
sui-graphql-rpc$ cargo insta test
```