### PR TITLE
[GraphQL] Limit TransactionBlockKind to system vs programmable

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -596,10 +596,8 @@ type TransactionBlock {
 }
 
 enum TransactionBlockKindInput {
-  CONSENSUS_COMMIT_PROLOGUE
-  GENESIS
-  CHANGE_EPOCH
-  PROGRAMMABLE
+  PROGRAMMABLE_TX
+  SYSTEM_TX
 }
 
 union TransactionBlockKind =

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -15,10 +15,8 @@ pub(crate) struct TransactionBlockConnection;
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum TransactionBlockKindInput {
-    ConsensusCommitPrologue,
-    Genesis,
-    ChangeEpoch,
-    Programmable,
+    ProgrammableTx,
+    SystemTx,
 }
 
 #[derive(InputObject)]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -213,10 +213,8 @@ input TransactionBlockFilter {
 }
 
 enum TransactionBlockKindInput {
-	CONSENSUS_COMMIT_PROLOGUE
-	GENESIS
-	CHANGE_EPOCH
-	PROGRAMMABLE
+	PROGRAMMABLE_TX
+	SYSTEM_TX
 }
 
 schema {


### PR DESCRIPTION
## Description

This reduces the size of the index needed to serve this kind of query while still satisfying the requirements on Explorer.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```