### PR TITLE
[move-compiler] Added the collection equality check linter

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -55,9 +55,9 @@ use sui_types::{
 use sui_verifier::verifier as sui_bytecode_verifier;
 
 use crate::linters::{
-    coin_field::CoinFieldVisitor, custom_state_change::CustomStateChangeVerifier,
-    freeze_wrapped::FreezeWrappedVisitor, known_filters, self_transfer::SelfTransferVerifier,
-    share_owned::ShareOwnedVerifier,
+    coin_field::CoinFieldVisitor, collection_equality::CollectionEqualityVisitor,
+    custom_state_change::CustomStateChangeVerifier, freeze_wrapped::FreezeWrappedVisitor,
+    known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
 };
 
 #[cfg(test)]
@@ -143,6 +143,7 @@ impl BuildConfig {
                     CustomStateChangeVerifier.visitor(),
                     CoinFieldVisitor.visitor(),
                     FreezeWrappedVisitor::default().visitor(),
+                    CollectionEqualityVisitor.visitor(),
                 ];
                 let (filter_attr_name, filters) = known_filters();
                 compiler

--- a/crates/sui-move-build/src/linters/collection_equality.rs
+++ b/crates/sui-move-build/src/linters/collection_equality.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This analysis flags situations when instances of a sui::table::Table or sui::table_vec::TableVec
+//! or sui::bag::Bag are being compared for (in)equality at this type of comparison is not very
+//! useful and DOES NOT take into consideration structural (in)equality.
+
+use move_compiler::{
+    diag,
+    diagnostics::codes::{custom, DiagnosticInfo, Severity},
+    naming::ast as N,
+    parser::ast as P,
+    shared::{CompilationEnv, Identifier},
+    typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
+};
+
+use super::{
+    base_type, LinterDiagCategory, BAG_MOD_NAME, BAG_STRUCT_NAME, LINTER_DEFAULT_DIAG_CODE,
+    LINT_WARNING_PREFIX, SUI_PKG_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME,
+    TABLE_VEC_STRUCT_NAME,
+};
+
+const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
+    LINT_WARNING_PREFIX,
+    Severity::Warning,
+    LinterDiagCategory::CollectionEquality as u8,
+    LINTER_DEFAULT_DIAG_CODE,
+    "possibly useless collections compare",
+);
+
+const COLLECTION_TYPES: &[(&str, &str, &str)] = &[
+    (SUI_PKG_NAME, BAG_MOD_NAME, BAG_STRUCT_NAME),
+    (SUI_PKG_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME),
+    (SUI_PKG_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME),
+];
+
+pub struct CollectionEqualityVisitor;
+
+impl TypingVisitor for CollectionEqualityVisitor {
+    fn visit_exp_custom(
+        &mut self,
+        exp: &T::Exp,
+        env: &mut CompilationEnv,
+        _program_info: &ProgramInfo,
+        _program: &T::Program,
+    ) -> bool {
+        use T::UnannotatedExp_ as E;
+        if let E::BinopExp(_, op, t, _) = &exp.exp.value {
+            if op.value != P::BinOp_::Eq && op.value != P::BinOp_::Neq {
+                // not a comparison
+                return false;
+            }
+            let Some(bt) = base_type(t) else {
+                return false;
+            };
+            let N::Type_::Apply(_, tname, _) = &bt.value else {
+                return false;
+            };
+            let N::TypeName_::ModuleType(mident, sname) = tname.value else {
+                return false;
+            };
+
+            if let Some((caddr, cmodule, cname)) =
+                COLLECTION_TYPES.iter().find(|(caddr, cmodule, cname)| {
+                    mident.value.is(*caddr, *cmodule) && sname.value().as_str() == *cname
+                })
+            {
+                let msg = format!(
+                    "Comparing collections of type '{caddr}::{cmodule}::{cname}' may yield unexpected result."
+                );
+                let note_msg =
+                    "Equality for collections IS NOT a structural check based on content";
+                let mut d = diag!(COLLECTIONS_EQUALITY_DIAG, (op.loc, msg),);
+                d.add_note(note_msg);
+                env.add_diag(d);
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/crates/sui-move-build/src/linters/freeze_wrapped.rs
+++ b/crates/sui-move-build/src/linters/freeze_wrapped.rs
@@ -20,7 +20,7 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 
 use super::{
-    LinterDiagCategory, FREEZE_FUN, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
+    base_type, LinterDiagCategory, FREEZE_FUN, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX,
     PUBLIC_FREEZE_FUN, SUI_PKG_NAME, TRANSFER_MOD_NAME,
 };
 
@@ -358,13 +358,4 @@ fn add_diag(
         d.add_secondary_label((wrapped_tloc, "Indirectly wrapped object is of this type"));
     }
     env.add_diag(d);
-}
-
-fn base_type(t: &N::Type) -> Option<&N::Type> {
-    use N::Type_ as T;
-    match &t.value {
-        T::Ref(_, inner_t) => base_type(inner_t),
-        T::Apply(_, _, _) | T::Param(_) => Some(t),
-        T::Unit | T::Var(_) | T::Anything | T::UnresolvedError => None,
-    }
 }

--- a/crates/sui-move-build/src/linters/freeze_wrapped.rs
+++ b/crates/sui-move-build/src/linters/freeze_wrapped.rs
@@ -105,152 +105,55 @@ pub struct FreezeWrappedVisitor {
 }
 
 impl TypingVisitor for FreezeWrappedVisitor {
-    fn visit(
+    fn visit_exp_custom(
         &mut self,
+        exp: &T::Exp,
         env: &mut CompilationEnv,
         _program_info: &ProgramInfo,
-        program: &mut T::Program,
-    ) {
-        for (_, _, mdef) in program.modules.iter() {
-            env.add_warning_filter_scope(mdef.warning_filter.clone());
-
-            for (_, _, fdef) in mdef.functions.iter() {
-                env.add_warning_filter_scope(fdef.warning_filter.clone());
-
-                if let T::FunctionBody_::Defined(seq) = &fdef.body.value {
-                    self.visit_seq(seq, env, &program.modules);
+        program: &T::Program,
+    ) -> bool {
+        use T::UnannotatedExp_ as E;
+        if let E::ModuleCall(fun) = &exp.exp.value {
+            if FREEZE_FUNCTIONS.iter().any(|(addr, module, fname)| {
+                fun.module.value.is(*addr, *module) && &fun.name.value().as_str() == fname
+            }) {
+                let Some(bt) = base_type(&fun.type_arguments[0]) else {
+                        // not an (potentially dereferenced) N::Type_::Apply nor N::Type_::Param
+                        return true;
+                    };
+                let N::Type_::Apply(_,tname, _) = &bt.value else {
+                        // not a struct type
+                        return true;
+                    };
+                let N::TypeName_::ModuleType(mident, sname) = tname.value else {
+                        // struct with a given name not found
+                        return true;
+                    };
+                if let Some(wrapping_field_info) = self.find_wrapping_field_loc(
+                    &program.modules,
+                    mident,
+                    sname,
+                    /* outer_field_info */ None,
+                    /* field_depth  */ 0,
+                ) {
+                    add_diag(
+                        env,
+                        fun.arguments.exp.loc,
+                        sname.value(),
+                        wrapping_field_info.fname(),
+                        wrapping_field_info.ftype_loc(),
+                        wrapping_field_info.wrapped_type_loc(),
+                        wrapping_field_info.direct(),
+                    );
                 }
-
-                env.pop_warning_filter_scope();
             }
-
-            env.pop_warning_filter_scope();
+            return true;
         }
+        false
     }
 }
 
 impl FreezeWrappedVisitor {
-    fn visit_seq_item(
-        &mut self,
-        sp!(_, seq_item): &T::SequenceItem,
-        env: &mut CompilationEnv,
-        modules: &UniqueMap<E::ModuleIdent, T::ModuleDefinition>,
-    ) {
-        use T::SequenceItem_ as SI;
-        match seq_item {
-            SI::Seq(e) => self.visit_exp(e, env, modules),
-            SI::Declare(_) => (),
-            SI::Bind(_, _, e) => self.visit_exp(e, env, modules),
-        }
-    }
-
-    fn visit_exp(
-        &mut self,
-        exp: &T::Exp,
-        env: &mut CompilationEnv,
-        modules: &UniqueMap<E::ModuleIdent, T::ModuleDefinition>,
-    ) {
-        use T::UnannotatedExp_ as E;
-        let sp!(_, uexp) = &exp.exp;
-        match uexp {
-            E::ModuleCall(fun) => {
-                if FREEZE_FUNCTIONS.iter().any(|(addr, module, fname)| {
-                    fun.module.value.is(*addr, *module) && &fun.name.value().as_str() == fname
-                }) {
-                    let Some(bt) = base_type(&fun.type_arguments[0]) else {
-                        // not an (potentially dereferenced) N::Type_::Apply nor N::Type_::Param
-                        return;
-                    };
-                    let N::Type_::Apply(_,tname, _) = &bt.value else {
-                        // not a struct type
-                        return;
-                    };
-                    let N::TypeName_::ModuleType(mident, sname) = tname.value else {
-                        // struct with a given name not found
-                        return;
-                    };
-                    if let Some(wrapping_field_info) = self.find_wrapping_field_loc(
-                        modules, mident, sname, /* outer_field_info */ None,
-                        /* field_depth  */ 0,
-                    ) {
-                        add_diag(
-                            env,
-                            fun.arguments.exp.loc,
-                            sname.value(),
-                            wrapping_field_info.fname(),
-                            wrapping_field_info.ftype_loc(),
-                            wrapping_field_info.wrapped_type_loc(),
-                            wrapping_field_info.direct(),
-                        );
-                    }
-                }
-            }
-            E::Builtin(_, e) => self.visit_exp(e, env, modules),
-            E::Vector(_, _, _, e) => self.visit_exp(e, env, modules),
-            E::IfElse(e1, e2, e3) => {
-                self.visit_exp(e1, env, modules);
-                self.visit_exp(e2, env, modules);
-                self.visit_exp(e3, env, modules);
-            }
-            E::While(e1, e2) => {
-                self.visit_exp(e1, env, modules);
-                self.visit_exp(e2, env, modules);
-            }
-            E::Loop { has_break: _, body } => self.visit_exp(body, env, modules),
-            E::Block(seq) => self.visit_seq(seq, env, modules),
-            E::Assign(_, _, e) => self.visit_exp(e, env, modules),
-            E::Mutate(e1, e2) => {
-                self.visit_exp(e1, env, modules);
-                self.visit_exp(e2, env, modules);
-            }
-            E::Return(e) => self.visit_exp(e, env, modules),
-            E::Abort(e) => self.visit_exp(e, env, modules),
-            E::Dereference(e) => self.visit_exp(e, env, modules),
-            E::UnaryExp(_, e) => self.visit_exp(e, env, modules),
-            E::BinopExp(e1, _, _, e2) => {
-                self.visit_exp(e1, env, modules);
-                self.visit_exp(e2, env, modules);
-            }
-            E::Pack(_, _, _, fields) => fields
-                .iter()
-                .for_each(|(_, _, (_, (_, e)))| self.visit_exp(e, env, modules)),
-            E::ExpList(list) => {
-                for l in list {
-                    match l {
-                        T::ExpListItem::Single(e, _) => self.visit_exp(e, env, modules),
-                        T::ExpListItem::Splat(_, e, _) => self.visit_exp(e, env, modules),
-                    }
-                }
-            }
-            E::Borrow(_, e, _) => self.visit_exp(e, env, modules),
-            E::TempBorrow(_, e) => self.visit_exp(e, env, modules),
-            E::Cast(e, _) => self.visit_exp(e, env, modules),
-            E::Annotate(e, _) => self.visit_exp(e, env, modules),
-            E::Unit { .. }
-            | E::Value(_)
-            | E::Move { .. }
-            | E::Copy { .. }
-            | E::Use(_)
-            | E::Constant(..)
-            | E::Break
-            | E::Continue
-            | E::BorrowLocal(..)
-            | E::Spec(..)
-            | E::UnresolvedError => (),
-        }
-    }
-
-    fn visit_seq(
-        &mut self,
-        seq: &T::Sequence,
-        env: &mut CompilationEnv,
-        modules: &UniqueMap<E::ModuleIdent, T::ModuleDefinition>,
-    ) {
-        for s in seq {
-            self.visit_seq_item(s, env, modules);
-        }
-    }
-
     fn struct_fields<'a>(
         &mut self,
         sname: &P::StructName,

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_compiler::{diagnostics::codes::WarningFilter, expansion::ast as E};
+use move_compiler::{diagnostics::codes::WarningFilter, expansion::ast as E, naming::ast as N};
 use move_ir_types::location::Loc;
 
 pub mod coin_field;
+pub mod collection_equality;
 pub mod custom_state_change;
 pub mod freeze_wrapped;
 pub mod self_transfer;
@@ -23,6 +24,15 @@ pub const PUBLIC_FREEZE_FUN: &str = "public_freeze_object";
 pub const COIN_MOD_NAME: &str = "coin";
 pub const COIN_STRUCT_NAME: &str = "Coin";
 
+pub const BAG_MOD_NAME: &str = "bag";
+pub const BAG_STRUCT_NAME: &str = "Bag";
+
+pub const TABLE_MOD_NAME: &str = "table";
+pub const TABLE_STRUCT_NAME: &str = "Table";
+
+pub const TABLE_VEC_MOD_NAME: &str = "table_vec";
+pub const TABLE_VEC_STRUCT_NAME: &str = "TableVec";
+
 pub const ALLOW_ATTR_NAME: &str = "lint_allow";
 pub const LINT_WARNING_PREFIX: &str = "Lint ";
 
@@ -31,6 +41,7 @@ pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
 pub const CUSTOM_STATE_CHANGE_FILTER_NAME: &str = "custom_state_change";
 pub const COIN_FIELD_FILTER_NAME: &str = "coin_field";
 pub const FREEZE_WRAPPED_FILTER_NAME: &str = "freeze_wrapped";
+pub const COLLECTION_EQUALITY_FILTER_NAME: &str = "collection_equality";
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
@@ -40,6 +51,7 @@ pub enum LinterDiagCategory {
     CustomStateChange,
     CoinField,
     FreezeWrapped,
+    CollectionEquality,
 }
 
 /// A default code for each linter category (as long as only one code per category is used, no other
@@ -81,6 +93,21 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
                 LINTER_DEFAULT_DIAG_CODE,
                 Some(FREEZE_WRAPPED_FILTER_NAME),
             ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::CollectionEquality as u8,
+                LINTER_DEFAULT_DIAG_CODE,
+                Some(COLLECTION_EQUALITY_FILTER_NAME),
+            ),
         ],
     )
+}
+
+pub fn base_type(t: &N::Type) -> Option<&N::Type> {
+    use N::Type_ as T;
+    match &t.value {
+        T::Ref(_, inner_t) => base_type(inner_t),
+        T::Apply(_, _, _) | T::Param(_) => Some(t),
+        T::Unit | T::Var(_) | T::Anything | T::UnresolvedError => None,
+    }
 }

--- a/crates/sui-move-build/tests/linter/collection_equality.exp
+++ b/crates/sui-move-build/tests/linter/collection_equality.exp
@@ -1,0 +1,27 @@
+warning[Lint W05001]: possibly useless collections compare
+   ┌─ tests/linter/collection_equality.move:12:14
+   │
+12 │         bag1 == bag2
+   │              ^^ Comparing collections of type 'sui::bag::Bag' may yield unexpected result.
+   │
+   = Equality for collections IS NOT a structural check based on content
+   = This warning can be suppressed with '#[lint_allow(collection_equality)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W05001]: possibly useless collections compare
+   ┌─ tests/linter/collection_equality.move:16:16
+   │
+16 │         table1 != table2
+   │                ^^ Comparing collections of type 'sui::table::Table' may yield unexpected result.
+   │
+   = Equality for collections IS NOT a structural check based on content
+   = This warning can be suppressed with '#[lint_allow(collection_equality)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W05001]: possibly useless collections compare
+   ┌─ tests/linter/collection_equality.move:20:16
+   │
+20 │         table1 == table2
+   │                ^^ Comparing collections of type 'sui::table_vec::TableVec' may yield unexpected result.
+   │
+   = Equality for collections IS NOT a structural check based on content
+   = This warning can be suppressed with '#[lint_allow(collection_equality)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/crates/sui-move-build/tests/linter/collection_equality.move
+++ b/crates/sui-move-build/tests/linter/collection_equality.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module 0x42::test {
+    use sui::bag::Bag;
+    use sui::table::Table;
+    use sui::table_vec::TableVec;
+
+
+
+    public fun bag_neq(bag1: &Bag, bag2: &Bag): bool {
+        bag1 == bag2
+    }
+
+    public fun table_neq(table1: &Table<u64, u64>, table2: &Table<u64, u64>): bool {
+        table1 != table2
+    }
+
+    public fun table_vec_eq(table1: &TableVec<u64>, table2: &TableVec<u64>): bool {
+        table1 == table2
+    }
+
+
+}

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -19,9 +19,10 @@ use move_compiler::{
 };
 
 use sui_move_build::linters::{
-    coin_field::CoinFieldVisitor, custom_state_change::CustomStateChangeVerifier,
-    freeze_wrapped::FreezeWrappedVisitor, known_filters, self_transfer::SelfTransferVerifier,
-    share_owned::ShareOwnedVerifier, LINT_WARNING_PREFIX,
+    coin_field::CoinFieldVisitor, collection_equality::CollectionEqualityVisitor,
+    custom_state_change::CustomStateChangeVerifier, freeze_wrapped::FreezeWrappedVisitor,
+    known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
+    LINT_WARNING_PREFIX,
 };
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
@@ -69,6 +70,7 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         CustomStateChangeVerifier.visitor(),
         CoinFieldVisitor.visitor(),
         FreezeWrappedVisitor::default().visitor(),
+        CollectionEqualityVisitor.visitor(),
     ];
     let (filter_attr_name, filters) = known_filters_for_test();
     let (files, comments_and_compiler_res) = Compiler::from_files(

--- a/external-crates/move/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/move-compiler/src/typing/visitor.rs
@@ -8,18 +8,148 @@ use crate::typing::{ast as T, core::ProgramInfo};
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
 
 pub trait TypingVisitor {
-    fn visit(
-        &mut self,
-        env: &mut CompilationEnv,
-        program_info: &ProgramInfo,
-        program: &mut T::Program,
-    );
-
     fn visitor(self) -> Visitor
     where
         Self: 'static + Sized,
     {
         Visitor::TypingVisitor(Box::new(self))
+    }
+
+    /// By default, the visitor will visit all all expressions in all functions in all modules. A
+    /// custom version should of this function should be created if different type of analysis is
+    /// required.
+    fn visit(
+        &mut self,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &mut T::Program,
+    ) {
+        for (_, _, mdef) in program.modules.iter() {
+            env.add_warning_filter_scope(mdef.warning_filter.clone());
+
+            for (_, _, fdef) in mdef.functions.iter() {
+                env.add_warning_filter_scope(fdef.warning_filter.clone());
+
+                if let T::FunctionBody_::Defined(seq) = &fdef.body.value {
+                    self.visit_seq(seq, env, program_info, program);
+                }
+
+                env.pop_warning_filter_scope();
+            }
+
+            env.pop_warning_filter_scope();
+        }
+    }
+
+    fn visit_seq(
+        &mut self,
+        seq: &T::Sequence,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &T::Program,
+    ) {
+        for s in seq {
+            self.visit_seq_item(s, env, program_info, program);
+        }
+    }
+
+    fn visit_seq_item(
+        &mut self,
+        sp!(_, seq_item): &T::SequenceItem,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &T::Program,
+    ) {
+        use T::SequenceItem_ as SI;
+        match seq_item {
+            SI::Seq(e) => self.visit_exp(e, env, program_info, program),
+            SI::Declare(_) => (),
+            SI::Bind(_, _, e) => self.visit_exp(e, env, program_info, program),
+        }
+    }
+
+    /// Custom visit for an expression. It will skip `visit_exp` if `visit_exp_custom` returns true.
+    fn visit_exp_custom(
+        &mut self,
+        _exp: &T::Exp,
+        _env: &mut CompilationEnv,
+        _program_info: &ProgramInfo,
+        _program: &T::Program,
+    ) -> bool {
+        false
+    }
+
+    fn visit_exp(
+        &mut self,
+        exp: &T::Exp,
+        env: &mut CompilationEnv,
+        program_info: &ProgramInfo,
+        program: &T::Program,
+    ) {
+        use T::UnannotatedExp_ as E;
+        if self.visit_exp_custom(exp, env, program_info, program) {
+            return;
+        }
+        let sp!(_, uexp) = &exp.exp;
+        match uexp {
+            E::Builtin(_, e) => self.visit_exp(e, env, program_info, program),
+            E::Vector(_, _, _, e) => self.visit_exp(e, env, program_info, program),
+            E::IfElse(e1, e2, e3) => {
+                self.visit_exp(e1, env, program_info, program);
+                self.visit_exp(e2, env, program_info, program);
+                self.visit_exp(e3, env, program_info, program);
+            }
+            E::While(e1, e2) => {
+                self.visit_exp(e1, env, program_info, program);
+                self.visit_exp(e2, env, program_info, program);
+            }
+            E::Loop { has_break: _, body } => self.visit_exp(body, env, program_info, program),
+            E::Block(seq) => self.visit_seq(seq, env, program_info, program),
+            E::Assign(_, _, e) => self.visit_exp(e, env, program_info, program),
+            E::Mutate(e1, e2) => {
+                self.visit_exp(e1, env, program_info, program);
+                self.visit_exp(e2, env, program_info, program);
+            }
+            E::Return(e) => self.visit_exp(e, env, program_info, program),
+            E::Abort(e) => self.visit_exp(e, env, program_info, program),
+            E::Dereference(e) => self.visit_exp(e, env, program_info, program),
+            E::UnaryExp(_, e) => self.visit_exp(e, env, program_info, program),
+            E::BinopExp(e1, _, _, e2) => {
+                self.visit_exp(e1, env, program_info, program);
+                self.visit_exp(e2, env, program_info, program);
+            }
+            E::Pack(_, _, _, fields) => fields
+                .iter()
+                .for_each(|(_, _, (_, (_, e)))| self.visit_exp(e, env, program_info, program)),
+            E::ExpList(list) => {
+                for l in list {
+                    match l {
+                        T::ExpListItem::Single(e, _) => {
+                            self.visit_exp(e, env, program_info, program)
+                        }
+                        T::ExpListItem::Splat(_, e, _) => {
+                            self.visit_exp(e, env, program_info, program)
+                        }
+                    }
+                }
+            }
+            E::Borrow(_, e, _) => self.visit_exp(e, env, program_info, program),
+            E::TempBorrow(_, e) => self.visit_exp(e, env, program_info, program),
+            E::Cast(e, _) => self.visit_exp(e, env, program_info, program),
+            E::Annotate(e, _) => self.visit_exp(e, env, program_info, program),
+            E::Unit { .. }
+            | E::Value(_)
+            | E::Move { .. }
+            | E::Copy { .. }
+            | E::Use(_)
+            | E::Constant(..)
+            | E::ModuleCall(_)
+            | E::Break
+            | E::Continue
+            | E::BorrowLocal(..)
+            | E::Spec(..)
+            | E::UnresolvedError => (),
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

Added a linter to signal a potentially useless comparison of two collections which the developer may expect to be based on comparing the collection content, but which is not implemented this way.

## Test Plan 

A new test has been added.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

When building Move code, there are now additional linter warnings related to comparing collections from Sui framework code (`Bag`, `Table` and `TableVec`). The comparison IS NOT a structural one based on the collection content which is what the developers may be expecting so we now signal it to them via a linter warning.