### PR TITLE
[graphql/rpc] fix cmd clobber with help short cmd

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -25,7 +25,7 @@ pub enum Command {
         #[clap(short, long, default_value = "8000")]
         port: u16,
         /// Host to bind the server to
-        #[clap(short, long, default_value = "127.0.0.1")]
+        #[clap(long, default_value = "127.0.0.1")]
         host: String,
     },
 }


### PR DESCRIPTION
## Description 

`main` fails because `help` short form of `h` conflicts with `host` short form.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
