### PR TITLE
[graphql] Add data provider for the GasInput type

### DIFF
--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,14 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{address::Address, base64::Base64, sui_address::SuiAddress};
+use super::{
+    address::Address,
+    base64::Base64,
+    gas::{GasEffects, GasInput},
+    sui_address::SuiAddress,
+};
 use async_graphql::*;
 
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 pub(crate) struct TransactionBlock {
     pub digest: String,
+    pub effects: Option<TransactionBlockEffects>,
     pub sender: Option<Address>,
     pub bcs: Option<Base64>,
+    pub gas_input: Option<GasInput>,
+}
+
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+pub(crate) struct TransactionBlockEffects {
+    pub digest: String,
+    pub gas_effects: GasEffects,
 }
 
 pub(crate) struct TransactionBlockConnection;

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -40,6 +40,25 @@ type CoinConnection {
 }
 
 
+type GasCostSummary {
+	computationCost: BigInt
+	storageCost: BigInt
+	storageRebate: BigInt
+	nonRefundableStorageFee: BigInt
+}
+
+type GasEffects {
+	gasObject: Object
+	gasSummary: GasCostSummary
+}
+
+type GasInput {
+	gasSponsor: Address
+	gasPayment: [Object!]
+	gasPrice: BigInt
+	gasBudget: BigInt
+}
+
 
 
 type NameServiceConnection {
@@ -195,12 +214,19 @@ scalar SuiAddress
 
 type TransactionBlock {
 	digest: String!
+	effects: TransactionBlockEffects
 	sender: Address
 	bcs: Base64
+	gasInput: GasInput
 }
 
 type TransactionBlockConnection {
 	unimplemented: Boolean!
+}
+
+type TransactionBlockEffects {
+	digest: String!
+	gasEffects: GasEffects!
 }
 
 input TransactionBlockFilter {


### PR DESCRIPTION
## Description 

Add data provider for the GasInput graphql type. 

![image](https://github.com/MystenLabs/sui/assets/135084671/587f9917-872d-4b12-813e-88f41e8c5654)



## Test Plan 

Manually checked the output for now. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
