### PR TITLE
[Doc] Update `--serialize-output` to `--serialize-unsigned-transaction`

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -65,7 +65,7 @@ macro_rules! serialize_or_execute {
     ($tx_data:expr, $serialize_unsigned:expr, $serialize_signed:expr, $context:expr, $result_variant:ident) => {{
         assert!(
             !$serialize_unsigned || !$serialize_signed,
-            "Cannot specify both --serialize-unsigned and --serialize-signed"
+            "Cannot specify both --serialize-unsigned-transaction and --serialize-signed-transaction"
         );
         if $serialize_unsigned {
             SuiClientCommandResult::SerializedUnsignedTransaction($tx_data)

--- a/doc/src/build/dev_cheat_sheet.md
+++ b/doc/src/build/dev_cheat_sheet.md
@@ -43,5 +43,5 @@ Quick reference on best practices for Sui Network developers.
 # Signing
 
 - **Never** sign two concurrent transactions that are touching the same owned object. Either use independent owned objects, or wait for one transaction to conclude before sending the next one. Violating this rule might lead to client [equivocation](https://docs.sui.io/learn/sui-glossary#equivocation), which locks up the owned objects involved in the two transactions until the end of the current epoch.
-- Any `sui client` command that crafts a transaction (e.g., `sui client publish`, `sui client call`) can accept the `--serialize-output` flag to output a base64 transaction to be signed.
+- Any `sui client` command that crafts a transaction (e.g., `sui client publish`, `sui client call`) can accept the `--serialize-unsigned-transaction` flag to output a base64 transaction to be signed.
 - Sui supports several [signature schemes](https://docs.sui.io/learn/cryptography/sui-offline-signing) for transaction signing, including native [multisig](https://docs.sui.io/learn/cryptography/sui-multisig).

--- a/doc/src/learn/cryptography/sui-offline-signing.md
+++ b/doc/src/learn/cryptography/sui-offline-signing.md
@@ -14,12 +14,12 @@ You must serialize transaction data following [Binary Canonical Serialization](h
 
 The following example demonstrates how to serialize data for a transfer using the Sui CLI. This returns serialized transaction data in Base64. Submit the raw transaction to execute as `tx_bytes`.
 ```shell
-$SUI_BINARY client transfer-sui --to $ADDRESS --sui-coin-object-id $OBJECT_ID --gas-budget 1000 --serialize-output
+$SUI_BINARY client transfer-sui --to $ADDRESS --sui-coin-object-id $OBJECT_ID --gas-budget 1000 --serialize-unsigned-transaction
 
 Raw tx_bytes to execute: $TX_BYTES
 ```
 
-**Note:** All other CLI commands that craft a transaction (e.g., `sui client publish`, `sui client call`) also accept the `--serialize-output` flag and you can use them in the same way.
+**Note:** All other CLI commands that craft a transaction (e.g., `sui client publish`, `sui client call`) also accept the `--serialize-unsigned-transaction` flag and you can use them in the same way.
 
 ## Sign the serialized data
 


### PR DESCRIPTION
## Description 

It seems the flag name has been updated.

## Test Plan 

CI
Ran command with the new flag name.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
