### PR TITLE
[explorer] fix the validator page crashing because we're checking the wrong field for wallet features

### DIFF
--- a/apps/explorer/src/components/validator/StakeButton.tsx
+++ b/apps/explorer/src/components/validator/StakeButton.tsx
@@ -25,7 +25,7 @@ export function StakeButton() {
 	if (!stakeButtonEnabled) return null;
 
 	const stakeSupportedWallets = wallets.filter((wallet) => {
-		if (!('wallet' in wallet)) {
+		if (!('wallet' in wallet) || !wallet.wallet) {
 			return false;
 		}
 

--- a/apps/explorer/src/components/validator/StakeButton.tsx
+++ b/apps/explorer/src/components/validator/StakeButton.tsx
@@ -24,15 +24,7 @@ export function StakeButton() {
 
 	if (!stakeButtonEnabled) return null;
 
-	const stakeSupportedWallets = wallets.filter((wallet) => {
-		if (!('wallet' in wallet) || !wallet.wallet) {
-			return false;
-		}
-
-		const standardWallet = wallet.wallet as StakeWallet;
-		return 'suiWallet:stake' in standardWallet.features;
-	});
-
+	const stakeSupportedWallets = wallets.filter((wallet) => 'suiWallet:stake' in wallet.features);
 	const currentWalletSupportsStake =
 		currentWallet && !!stakeSupportedWallets.find(({ name }) => currentWallet.name === name);
 


### PR DESCRIPTION
## Description 

The validator pages are broken on Sui Explorer because we're checking `wallet.wallet.features` and doing some type assertions to see what wallets supported the staking feature. With https://github.com/MystenLabs/sui/pull/13359, now we should just be checking `wallet.features` instead of `wallet.wallet.features`

Broken:
https://suiexplorer.com/validator/0x9062fc51d91056246dc31f2b818a4ddb113a044ec22c8dd0674616bbe56f7192

Fixt:
https://explorer-git-wrobertson-fixvalipage-mysten-labs.vercel.app/validator/0x4430b86069d8850d9bee199739e5fc90bb0f323a5a7735f431ec7a5fb5409e6b

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
