### PR TITLE
[wallet-ext] fix the browser extension having a width of 25px when used on Brave and sometimes Chrome

### DIFF
--- a/apps/wallet/src/ui/app/pages/layout/index.tsx
+++ b/apps/wallet/src/ui/app/pages/layout/index.tsx
@@ -27,7 +27,6 @@ function PageLayout({ forceFullscreen = false, children, className }: PageLayout
 			<div
 				className={cl('w-popup-width h-popup-height', st.container, className, {
 					[st.navHidden]: !isNavVisible,
-					'h-popup-height': true,
 				})}
 			>
 				{children}

--- a/apps/wallet/src/ui/styles/global.scss
+++ b/apps/wallet/src/ui/styles/global.scss
@@ -58,7 +58,6 @@ body {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	flex-flow: column nowrap;
 }
 
 * {


### PR DESCRIPTION
## Description 

I have no clue why this issue started happening out of the blue, but changing the flex-direction to `row` makes div respect its child's width/height properly. Some folks mentioned that it happened after they updated their browser, but I'm using the latest version of Chrome and couldn't get a repro 🤷🏼‍♂️ 

Before:
<img width="1092" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/047335f6-eceb-40f8-954e-a87532c47216">

After:
<img width="772" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/39432cbf-b9cc-4175-b4f4-fca56bac031c">

Chrome fullscreen:
<img width="919" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/00e80473-ce19-422d-86e0-86c13e5911d1">

Chrome popup:
<img width="426" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/c463ffc7-9f46-4430-8ba6-290a0db20117">

## Test Plan 
- Played around with the wallet in Chrome/Brave in popup mode and fullscreen mode and it seems to work fine

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
