### PR TITLE
[Sui] Roll forward parallelizing spawning tasks to execute transactions

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -44,7 +44,7 @@ use sui_config::NodeConfig;
 use sui_types::execution::DynamicallyLoadedObjectMetadata;
 use tap::{TapFallible, TapOptional};
 use tokio::sync::mpsc::unbounded_channel;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Semaphore};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, error, info, instrument, trace, warn, Instrument};
 
@@ -133,7 +133,7 @@ use crate::checkpoints::checkpoint_executor::CheckpointExecutor;
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_adapter::ConsensusAdapter;
 use crate::epoch::committee_store::CommitteeStore;
-use crate::execution_driver::execution_process;
+use crate::execution_driver::{execution_process, ExecutionDispatcher};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::{StateAccumulator, WrappedObject};
@@ -2017,10 +2017,16 @@ impl AuthorityState {
 
         let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
         let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+        let execution_limit = Arc::new(Semaphore::new(num_cpus::get() * 2));
+        let execution_dispatcher = Arc::new(ExecutionDispatcher::new(
+            tx_ready_certificates,
+            execution_limit.clone(),
+            metrics.clone(),
+        ));
         let transaction_manager = Arc::new(TransactionManager::new(
             store.clone(),
             &epoch_store,
-            tx_ready_certificates,
+            execution_dispatcher.clone(),
             metrics.clone(),
         ));
         let (tx_execution_shutdown, rx_execution_shutdown) = oneshot::channel();
@@ -2060,10 +2066,12 @@ impl AuthorityState {
 
         // Start a task to execute ready certificates.
         let authority_state = Arc::downgrade(&state);
+        execution_dispatcher.set_authority(authority_state.clone());
         spawn_monitored_task!(execution_process(
             authority_state,
             rx_ready_certificates,
-            rx_execution_shutdown
+            rx_execution_shutdown,
+            execution_limit
         ));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
@@ -4210,6 +4218,9 @@ impl AuthorityState {
             .unwrap()
             .send(())
             .unwrap();
+        self.transaction_manager
+            .execution_dispatcher
+            .shutdown_execution_for_test();
     }
 }
 


### PR DESCRIPTION
## Description 

https://github.com/MystenLabs/sui/pull/11269 by @andll was rolled back because of drop in throughput. At that time anemo was using very small udp buffer, where any operation increasing transaction latency causes throughput drop (e.g. batching writes in consensus handler). Now the anemo issue has been fixed, so rolling the change forward.

## Test Plan 

`cargo run --release --bin sui-single-node-benchmark -- --component with-tx-manager no-move`
shows increase from 20k -> 26k TPS.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
