### PR TITLE
[graphql] data provider trait to support swapping out providers for snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10254,6 +10254,7 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
+ "async-trait",
  "axum",
  "bcs",
  "clap 3.2.23",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 async-graphql.workspace = true
 async-graphql-axum = { version = "5.0.10" }
+async-trait.workspace = true
 axum.workspace = true
 clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -1,256 +1,34 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// For testing, use existing RPC as data source
-
-use crate::error::Error;
-use crate::types::address::Address;
 use crate::types::balance::Balance;
-use crate::types::base64::Base64;
-use crate::types::big_int::BigInt;
 use crate::types::object::ObjectFilter;
-use crate::types::object::ObjectKind;
-use crate::types::protocol_config::ProtocolConfigAttr;
-use crate::types::protocol_config::ProtocolConfigFeatureFlag;
 use crate::types::protocol_config::ProtocolConfigs;
 use crate::types::transaction_block::TransactionBlock;
 use crate::types::{object::Object, sui_address::SuiAddress};
-use async_graphql::connection::{Connection, Edge};
+use async_graphql::connection::Connection;
 use async_graphql::*;
-use std::str::FromStr;
-use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiPastObjectResponse, SuiRawData,
-    SuiTransactionBlockDataAPI, SuiTransactionBlockResponseOptions,
-};
-use sui_sdk::{
-    types::{
-        base_types::{ObjectID as NativeObjectID, SuiAddress as NativeSuiAddress},
-        digests::TransactionDigest,
-        object::Owner as NativeOwner,
-    },
-    SuiClient,
-};
+use async_trait::async_trait;
 
-pub(crate) async fn fetch_obj(
-    cl: &SuiClient,
-    address: SuiAddress,
-    version: Option<u64>,
-) -> Result<Option<Object>> {
-    let oid: NativeObjectID = address.into_array().as_slice().try_into()?;
-    let opts = SuiObjectDataOptions::full_content();
+#[async_trait]
+pub(crate) trait DataProvider: Send + Sync {
+    async fn fetch_obj(&self, address: SuiAddress, version: Option<u64>) -> Result<Option<Object>>;
 
-    let g = match version {
-        Some(v) => match cl
-            .read_api()
-            .try_get_parsed_past_object(oid, v.into(), opts)
-            .await?
-        {
-            SuiPastObjectResponse::VersionFound(x) => x,
-            _ => return Ok(None),
-        },
-        None => {
-            let val = cl.read_api().get_object_with_options(oid, opts).await?;
-            if val.error.is_some() || val.data.is_none() {
-                return Ok(None);
-            }
-            val.data.unwrap()
-        }
-    };
-    Ok(Some(convert_obj(&g)))
-}
+    async fn fetch_owned_objs(
+        &self,
+        owner: &SuiAddress,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        _filter: Option<ObjectFilter>,
+    ) -> Result<Connection<String, Object>>;
 
-pub(crate) async fn fetch_owned_objs(
-    cl: &SuiClient,
-    owner: &SuiAddress,
-    first: Option<u64>,
-    after: Option<String>,
-    last: Option<u64>,
-    before: Option<String>,
-    _filter: Option<ObjectFilter>,
-) -> Result<Connection<String, Object>> {
-    if before.is_some() && after.is_some() {
-        return Err(Error::CursorNoBeforeAfter.extend());
-    }
-    if first.is_some() && last.is_some() {
-        return Err(Error::CursorNoFirstLast.extend());
-    }
-    if before.is_some() || last.is_some() {
-        return Err(Error::CursorNoReversePagination.extend());
-    }
+    async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance>;
 
-    let count = first.map(|q| q as usize);
-    let native_owner = NativeSuiAddress::from(owner);
-    let query = SuiObjectResponseQuery::new_with_options(SuiObjectDataOptions::full_content());
+    async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>>;
 
-    let cursor = match after {
-        Some(q) => Some(
-            NativeObjectID::from_hex_literal(&q)
-                .map_err(|w| Error::InvalidCursor(w.to_string()).extend())?,
-        ),
-        None => None,
-    };
+    async fn fetch_chain_id(&self) -> Result<String>;
 
-    let pg = cl
-        .read_api()
-        .get_owned_objects(native_owner, Some(query), cursor, count)
-        .await?;
-
-    // TODO: support partial success/ failure responses
-    pg.data.iter().try_for_each(|n| {
-        if n.error.is_some() {
-            return Err(
-                Error::CursorConnectionFetchFailed(n.error.as_ref().unwrap().to_string()).extend(),
-            );
-        } else if n.data.is_none() {
-            return Err(Error::Internal(
-                "Expected either data or error fields, received neither".to_string(),
-            )
-            .extend());
-        }
-        Ok(())
-    })?;
-    let mut connection = Connection::new(false, pg.has_next_page);
-
-    connection.edges.extend(pg.data.into_iter().map(|n| {
-        let g = n.data.unwrap();
-        let o = convert_obj(&g);
-
-        Edge::new(g.object_id.to_string(), o)
-    }));
-    Ok(connection)
-}
-
-pub(crate) async fn fetch_balance(
-    cl: &SuiClient,
-    address: &SuiAddress,
-    type_: Option<String>,
-) -> Result<Balance> {
-    let b = cl
-        .coin_read_api()
-        .get_balance(address.into(), type_)
-        .await?;
-    Ok(convert_bal(b))
-}
-
-fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
-    Object {
-        version: s.version.into(),
-        digest: s.digest.to_string(),
-        storage_rebate: s.storage_rebate,
-        address: SuiAddress::from_array(**s.object_id),
-        owner: s
-            .owner
-            .unwrap()
-            .get_owner_address()
-            .map(|x| SuiAddress::from_array(x.to_inner()))
-            .ok(),
-        bcs: s.bcs.as_ref().map(|raw| match raw {
-            SuiRawData::Package(raw_package) => Base64::from(bcs::to_bytes(raw_package).unwrap()),
-            SuiRawData::MoveObject(raw_object) => Base64::from(&raw_object.bcs_bytes),
-        }),
-        previous_transaction: Some(s.previous_transaction.unwrap().to_string()),
-        kind: Some(match s.owner.unwrap() {
-            NativeOwner::AddressOwner(_) => ObjectKind::Owned,
-            NativeOwner::ObjectOwner(_) => ObjectKind::Child,
-            NativeOwner::Shared {
-                initial_shared_version: _,
-            } => ObjectKind::Shared,
-            NativeOwner::Immutable => ObjectKind::Immutable,
-        }),
-    }
-}
-
-pub(crate) async fn fetch_tx(cl: &SuiClient, digest: &String) -> Result<Option<TransactionBlock>> {
-    let tx_digest = TransactionDigest::from_str(digest)?;
-    let tx = cl
-        .read_api()
-        .get_transaction_with_options(
-            tx_digest,
-            SuiTransactionBlockResponseOptions::full_content(),
-        )
-        .await?;
-    let sender = *tx.transaction.unwrap().data.sender();
-    Ok(Some(TransactionBlock {
-        digest: digest.to_string(),
-        sender: Some(Address {
-            address: SuiAddress::from_array(sender.to_inner()),
-        }),
-        bcs: Some(Base64::from(&tx.raw_transaction)),
-    }))
-}
-
-pub(crate) async fn fetch_chain_id(cl: &SuiClient) -> Result<String> {
-    Ok(cl.read_api().get_chain_identifier().await?)
-}
-
-pub(crate) async fn fetch_protocol_config(
-    cl: &SuiClient,
-    version: Option<u64>,
-) -> Result<ProtocolConfigs> {
-    let cfg = cl
-        .read_api()
-        .get_protocol_config(version.map(|x| x.into()))
-        .await?;
-
-    Ok(ProtocolConfigs {
-        configs: cfg
-            .attributes
-            .into_iter()
-            .map(|(k, v)| ProtocolConfigAttr {
-                key: k,
-                // TODO:  what to return when value is None? nothing?
-                // TODO: do we want to return type info separately?
-                value: match v {
-                    Some(q) => format!("{:?}", q),
-                    None => "".to_string(),
-                },
-            })
-            .collect(),
-        feature_flags: cfg
-            .feature_flags
-            .into_iter()
-            .map(|x| ProtocolConfigFeatureFlag {
-                key: x.0,
-                value: x.1,
-            })
-            .collect(),
-        protocol_version: cfg.protocol_version.as_u64(),
-    })
-}
-
-fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
-    Balance {
-        coin_object_count: b.coin_object_count as u64,
-        total_balance: BigInt::from_str(&format!("{}", b.total_balance)).unwrap(),
-    }
-}
-
-impl From<Address> for SuiAddress {
-    fn from(a: Address) -> Self {
-        a.address
-    }
-}
-
-impl From<SuiAddress> for Address {
-    fn from(a: SuiAddress) -> Self {
-        Address { address: a }
-    }
-}
-
-impl From<NativeSuiAddress> for SuiAddress {
-    fn from(a: NativeSuiAddress) -> Self {
-        SuiAddress::from_array(a.to_inner())
-    }
-}
-
-impl From<SuiAddress> for NativeSuiAddress {
-    fn from(a: SuiAddress) -> Self {
-        NativeSuiAddress::try_from(a.as_slice()).unwrap()
-    }
-}
-
-impl From<&SuiAddress> for NativeSuiAddress {
-    fn from(a: &SuiAddress) -> Self {
-        NativeSuiAddress::try_from(a.as_slice()).unwrap()
-    }
+    async fn fetch_protocol_config(&self, version: Option<u64>) -> Result<ProtocolConfigs>;
 }

--- a/crates/sui-graphql-rpc/src/server/json_rpc_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/json_rpc_data_provider.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// For testing, use existing RPC as data source
+
+use crate::error::Error;
+use crate::types::address::Address;
+use crate::types::balance::Balance;
+use crate::types::base64::Base64;
+use crate::types::big_int::BigInt;
+use crate::types::object::ObjectFilter;
+use crate::types::object::ObjectKind;
+use crate::types::protocol_config::ProtocolConfigAttr;
+use crate::types::protocol_config::ProtocolConfigFeatureFlag;
+use crate::types::protocol_config::ProtocolConfigs;
+use crate::types::transaction_block::TransactionBlock;
+use crate::types::{object::Object, sui_address::SuiAddress};
+use async_graphql::connection::{Connection, Edge};
+use async_graphql::*;
+use async_trait::async_trait;
+use std::str::FromStr;
+use sui_json_rpc_types::{
+    SuiObjectDataOptions, SuiObjectResponseQuery, SuiPastObjectResponse, SuiRawData,
+    SuiTransactionBlockDataAPI, SuiTransactionBlockResponseOptions,
+};
+use sui_sdk::{
+    types::{
+        base_types::{ObjectID as NativeObjectID, SuiAddress as NativeSuiAddress},
+        digests::TransactionDigest,
+        object::Owner as NativeOwner,
+    },
+    SuiClient,
+};
+
+use crate::server::data_provider::DataProvider;
+
+pub struct JsonRpcDataProvider {
+    cl: SuiClient,
+}
+
+impl JsonRpcDataProvider {
+    pub fn new(cl: SuiClient) -> Self {
+        Self { cl }
+    }
+}
+
+#[async_trait]
+impl DataProvider for JsonRpcDataProvider {
+    async fn fetch_obj(&self, address: SuiAddress, version: Option<u64>) -> Result<Option<Object>> {
+        let oid: NativeObjectID = address.into_array().as_slice().try_into()?;
+        let opts = SuiObjectDataOptions::full_content();
+
+        let g = match version {
+            Some(v) => match self
+                .cl
+                .read_api()
+                .try_get_parsed_past_object(oid, v.into(), opts)
+                .await?
+            {
+                SuiPastObjectResponse::VersionFound(x) => x,
+                _ => return Ok(None),
+            },
+            None => {
+                let val = self
+                    .cl
+                    .read_api()
+                    .get_object_with_options(oid, opts)
+                    .await?;
+                if val.error.is_some() || val.data.is_none() {
+                    return Ok(None);
+                }
+                val.data.unwrap()
+            }
+        };
+        Ok(Some(convert_obj(&g)))
+    }
+
+    async fn fetch_owned_objs(
+        &self,
+        owner: &SuiAddress,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        _filter: Option<ObjectFilter>,
+    ) -> Result<Connection<String, Object>> {
+        if before.is_some() && after.is_some() {
+            return Err(Error::CursorNoBeforeAfter.extend());
+        }
+        if first.is_some() && last.is_some() {
+            return Err(Error::CursorNoFirstLast.extend());
+        }
+        if before.is_some() || last.is_some() {
+            return Err(Error::CursorNoReversePagination.extend());
+        }
+
+        let count = first.map(|q| q as usize);
+        let native_owner = NativeSuiAddress::from(owner);
+        let query = SuiObjectResponseQuery::new_with_options(SuiObjectDataOptions::full_content());
+
+        let cursor = match after {
+            Some(q) => Some(
+                NativeObjectID::from_hex_literal(&q)
+                    .map_err(|w| Error::InvalidCursor(w.to_string()).extend())?,
+            ),
+            None => None,
+        };
+
+        let pg = self
+            .cl
+            .read_api()
+            .get_owned_objects(native_owner, Some(query), cursor, count)
+            .await?;
+
+        // TODO: support partial success/ failure responses
+        pg.data.iter().try_for_each(|n| {
+            if n.error.is_some() {
+                return Err(Error::CursorConnectionFetchFailed(
+                    n.error.as_ref().unwrap().to_string(),
+                )
+                .extend());
+            } else if n.data.is_none() {
+                return Err(Error::Internal(
+                    "Expected either data or error fields, received neither".to_string(),
+                )
+                .extend());
+            }
+            Ok(())
+        })?;
+        let mut connection = Connection::new(false, pg.has_next_page);
+
+        connection.edges.extend(pg.data.into_iter().map(|n| {
+            let g = n.data.unwrap();
+            let o = convert_obj(&g);
+
+            Edge::new(g.object_id.to_string(), o)
+        }));
+        Ok(connection)
+    }
+
+    async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance> {
+        let b = self
+            .cl
+            .coin_read_api()
+            .get_balance(address.into(), type_)
+            .await?;
+        Ok(convert_bal(b))
+    }
+
+    async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>> {
+        let tx_digest = TransactionDigest::from_str(digest)?;
+        let tx = self
+            .cl
+            .read_api()
+            .get_transaction_with_options(
+                tx_digest,
+                SuiTransactionBlockResponseOptions::full_content(),
+            )
+            .await?;
+        let sender = *tx.transaction.unwrap().data.sender();
+        Ok(Some(TransactionBlock {
+            digest: digest.to_string(),
+            sender: Some(Address {
+                address: SuiAddress::from_array(sender.to_inner()),
+            }),
+            bcs: Some(Base64::from(&tx.raw_transaction)),
+        }))
+    }
+
+    async fn fetch_chain_id(&self) -> Result<String> {
+        Ok(self.cl.read_api().get_chain_identifier().await?)
+    }
+
+    async fn fetch_protocol_config(&self, version: Option<u64>) -> Result<ProtocolConfigs> {
+        let cfg = self
+            .cl
+            .read_api()
+            .get_protocol_config(version.map(|x| x.into()))
+            .await?;
+
+        Ok(ProtocolConfigs {
+            configs: cfg
+                .attributes
+                .into_iter()
+                .map(|(k, v)| ProtocolConfigAttr {
+                    key: k,
+                    // TODO:  what to return when value is None? nothing?
+                    // TODO: do we want to return type info separately?
+                    value: match v {
+                        Some(q) => format!("{:?}", q),
+                        None => "".to_string(),
+                    },
+                })
+                .collect(),
+            feature_flags: cfg
+                .feature_flags
+                .into_iter()
+                .map(|x| ProtocolConfigFeatureFlag {
+                    key: x.0,
+                    value: x.1,
+                })
+                .collect(),
+            protocol_version: cfg.protocol_version.as_u64(),
+        })
+    }
+}
+
+fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
+    Object {
+        version: s.version.into(),
+        digest: s.digest.to_string(),
+        storage_rebate: s.storage_rebate,
+        address: SuiAddress::from_array(**s.object_id),
+        owner: s
+            .owner
+            .unwrap()
+            .get_owner_address()
+            .map(|x| SuiAddress::from_array(x.to_inner()))
+            .ok(),
+        bcs: s.bcs.as_ref().map(|raw| match raw {
+            SuiRawData::Package(raw_package) => Base64::from(bcs::to_bytes(raw_package).unwrap()),
+            SuiRawData::MoveObject(raw_object) => Base64::from(&raw_object.bcs_bytes),
+        }),
+        previous_transaction: Some(s.previous_transaction.unwrap().to_string()),
+        kind: Some(match s.owner.unwrap() {
+            NativeOwner::AddressOwner(_) => ObjectKind::Owned,
+            NativeOwner::ObjectOwner(_) => ObjectKind::Child,
+            NativeOwner::Shared {
+                initial_shared_version: _,
+            } => ObjectKind::Shared,
+            NativeOwner::Immutable => ObjectKind::Immutable,
+        }),
+    }
+}
+
+fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
+    Balance {
+        coin_object_count: b.coin_object_count as u64,
+        total_balance: BigInt::from_str(&format!("{}", b.total_balance)).unwrap(),
+    }
+}
+
+impl From<Address> for SuiAddress {
+    fn from(a: Address) -> Self {
+        a.address
+    }
+}
+
+impl From<SuiAddress> for Address {
+    fn from(a: SuiAddress) -> Self {
+        Address { address: a }
+    }
+}
+
+impl From<NativeSuiAddress> for SuiAddress {
+    fn from(a: NativeSuiAddress) -> Self {
+        SuiAddress::from_array(a.to_inner())
+    }
+}
+
+impl From<SuiAddress> for NativeSuiAddress {
+    fn from(a: SuiAddress) -> Self {
+        NativeSuiAddress::try_from(a.as_slice()).unwrap()
+    }
+}
+
+impl From<&SuiAddress> for NativeSuiAddress {
+    fn from(a: &SuiAddress) -> Self {
+        NativeSuiAddress::try_from(a.as_slice()).unwrap()
+    }
+}

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod data_provider;
+pub mod json_rpc_data_provider;
 pub mod simple_server;
 mod version;

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    server::version::{check_version_middleware, set_version_middleware},
+    server::{
+        data_provider::DataProvider,
+        json_rpc_data_provider::JsonRpcDataProvider,
+        version::{check_version_middleware, set_version_middleware},
+    },
     types::query::{Query, SuiGraphQLSchema},
 };
 use async_graphql::{EmptyMutation, EmptySubscription};
@@ -64,8 +68,11 @@ pub async fn start_example_server(config: Option<ServerConfig>) {
         .await
         .expect("Failed to create SuiClient");
 
+    let data_provider: Box<dyn DataProvider> =
+        Box::new(JsonRpcDataProvider::new(sui_sdk_client_v0));
+
     let schema = async_graphql::Schema::build(Query, EmptyMutation, EmptySubscription)
-        .data(sui_sdk_client_v0)
+        .data(data_provider)
         .finish();
 
     let app = axum::Router::new()

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::{connection::Connection, *};
 
-use crate::server::data_provider::{fetch_balance, fetch_owned_objs};
+use crate::server::data_provider::DataProvider;
 
 use super::{
     balance::{Balance, BalanceConnection},
@@ -59,25 +59,15 @@ impl Address {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        fetch_owned_objs(
-            ctx.data_unchecked::<sui_sdk::SuiClient>(),
-            &self.address,
-            first,
-            after,
-            last,
-            before,
-            filter,
-        )
-        .await
+        let data_provider = ctx.data_unchecked::<Box<dyn DataProvider>>();
+        data_provider
+            .fetch_owned_objs(&self.address, first, after, last, before, filter)
+            .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
-        fetch_balance(
-            ctx.data_unchecked::<sui_sdk::SuiClient>(),
-            &self.address,
-            type_,
-        )
-        .await
+        let data_provider = ctx.data_unchecked::<Box<dyn DataProvider>>();
+        data_provider.fetch_balance(&self.address, type_).await
     }
 
     pub async fn balance_connection(

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::server::data_provider::fetch_balance;
-use crate::server::data_provider::fetch_owned_objs;
+use crate::server::data_provider::DataProvider;
 use crate::types::balance::*;
 use crate::types::coin::*;
 use crate::types::name_service::*;
@@ -108,25 +107,15 @@ impl Owner {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        fetch_owned_objs(
-            ctx.data_unchecked::<sui_sdk::SuiClient>(),
-            &self.address,
-            first,
-            after,
-            last,
-            before,
-            filter,
-        )
-        .await
+        ctx.data_unchecked::<Box<dyn DataProvider>>()
+            .fetch_owned_objs(&self.address, first, after, last, before, filter)
+            .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
-        fetch_balance(
-            ctx.data_unchecked::<sui_sdk::SuiClient>(),
-            &self.address,
-            type_,
-        )
-        .await
+        ctx.data_unchecked::<Box<dyn DataProvider>>()
+            .fetch_balance(&self.address, type_)
+            .await
     }
 
     pub async fn balance_connection(

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::*;
 
-use crate::server::data_provider::fetch_protocol_config;
+use crate::server::data_provider::DataProvider;
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct ProtocolConfigAttr {
@@ -30,7 +30,8 @@ pub(crate) struct ProtocolConfigs {
 impl ProtocolConfigs {
     async fn configs(&self, ctx: &Context<'_>) -> Result<Option<Vec<ProtocolConfigAttr>>> {
         Ok(Some(
-            fetch_protocol_config(ctx.data_unchecked::<sui_sdk::SuiClient>(), None)
+            ctx.data_unchecked::<Box<dyn DataProvider>>()
+                .fetch_protocol_config(None)
                 .await?
                 .configs,
         ))
@@ -41,18 +42,19 @@ impl ProtocolConfigs {
         ctx: &Context<'_>,
     ) -> Result<Option<Vec<ProtocolConfigFeatureFlag>>> {
         Ok(Some(
-            fetch_protocol_config(ctx.data_unchecked::<sui_sdk::SuiClient>(), None)
+            ctx.data_unchecked::<Box<dyn DataProvider>>()
+                .fetch_protocol_config(None)
                 .await?
                 .feature_flags,
         ))
     }
 
     async fn protocol_version(&self, ctx: &Context<'_>) -> Result<u64> {
-        Ok(
-            fetch_protocol_config(ctx.data_unchecked::<sui_sdk::SuiClient>(), None)
-                .await?
-                .protocol_version,
-        )
+        Ok(ctx
+            .data_unchecked::<Box<dyn DataProvider>>()
+            .fetch_protocol_config(None)
+            .await?
+            .protocol_version)
     }
 
     async fn config(&self, ctx: &Context<'_>, key: String) -> Result<Option<ProtocolConfigAttr>> {


### PR DESCRIPTION
## Description 

DataProvider trait + pass Box<dyn DataProvider> to graphql objects

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
