### PR TITLE
[kiosk] Adds marketplace adapter

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -289,4 +289,22 @@ module sui::transfer_policy {
 
     /// Get the `from` field of the `TransferRequest`.
     public fun from<T>(self: &TransferRequest<T>): ID { self.from }
+
+    // === Testing ===
+
+    #[test_only]
+    /// Create a new TransferPolicy and TransferPolicyCap for testing purposes.
+    /// Simplifies things in testing process due to `Publisher` being hard to
+    /// create and use in test environment.
+    public fun new_for_testing<T>(
+        ctx: &mut TxContext
+    ): (TransferPolicy<T>, TransferPolicyCap<T>) {
+        let id = object::new(ctx);
+        let policy_id = object::uid_to_inner(&id);
+
+        (
+            TransferPolicy { id, rules: vec_set::empty(), balance: balance::zero() },
+            TransferPolicyCap { id: object::new(ctx), policy_id }
+        )
+    }
 }

--- a/kiosk/examples/collectible.move
+++ b/kiosk/examples/collectible.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
 /// The module which defines the `Collectible` type. It is an all-in-one
 /// package to create a `Display`, a `Publisher` and a `TransferPolicy` to
 /// enable `Kiosk` trading from the start.

--- a/kiosk/examples/collectible.move
+++ b/kiosk/examples/collectible.move
@@ -76,6 +76,7 @@ module kiosk::collectible {
     /// OTW to initialize the Registry and the base type.
     struct COLLECTIBLE has drop {}
 
+    #[allow(unused_function)]
     /// Create the centralized Registry of Collectibles to provide access
     /// to the Publisher functionality of the Collectible.
     fun init(otw: COLLECTIBLE, ctx: &mut TxContext) {
@@ -85,6 +86,7 @@ module kiosk::collectible {
         })
     }
 
+    #[lint_allow(self_transfer)]
     /// Called in the external module initializer. Sends a `CollectionTicket`
     /// to the transaction sender which then enables them to initialize the
     /// Collection.
@@ -105,6 +107,7 @@ module kiosk::collectible {
         }, sender(ctx));
     }
 
+    #[lint_allow(share_owned)]
     /// Use the `CollectionTicket` to start a new collection and receive a
     /// `CollectionCap`.
     public fun create_collection<T: store>(
@@ -159,6 +162,7 @@ module kiosk::collectible {
         }
     }
 
+    #[lint_allow(self_transfer)]
     /// Batch mint a vector of Collectibles specifying the fields. Lengths of
     /// the optional fields must match the length of the `image_urls` vector.
     /// Metadata vector is also optional, which

--- a/kiosk/examples/marketplace.move
+++ b/kiosk/examples/marketplace.move
@@ -12,7 +12,7 @@ module kiosk::marketplace_example {
     use sui::transfer_policy as policy;
     use sui::transfer;
 
-    /// The One-Time-Witness for the Marketplace.
+    /// The One-Time-Witness for the module.
     struct MARKETPLACE_EXAMPLE has drop {}
 
     /// A type identifying the Marketplace.

--- a/kiosk/examples/marketplace.move
+++ b/kiosk/examples/marketplace.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// An example of a Marketplace. In Kiosk terms, a Marketplace is an entity similar
+/// to Creator - it owns and manages a `TransferPolicy` special to the marketplace
+/// and when a marketplace deal happens (eg via the `marketplace_adapter`), the
+/// marketplace enforces its own rules on the deal.
+///
+/// For reference, see the `marketplace_adapter` module.
+module kiosk::marketplace_example {
+    use sui::tx_context::{sender, TxContext};
+    use sui::transfer_policy as policy;
+    use sui::transfer;
+
+    /// The One-Time-Witness for the Marketplace.
+    struct MARKETPLACE_EXAMPLE has drop {}
+
+    /// A type identifying the Marketplace.
+    struct Walmart has drop {}
+
+    /// As easy as creating a Publisher; for simplicity's sake we also create
+    /// the `TransferPolicy` but this action can be performed offline in a PTB.
+    fun init(otw: MARKETPLACE_EXAMPLE, ctx: &mut TxContext) {
+        let publisher = sui::package::claim(otw, ctx);
+        let (policy, policy_cap) = policy::new<Walmart>(&publisher, ctx);
+
+        transfer::public_share_object(policy);
+        transfer::public_transfer(policy_cap, sender(ctx));
+        transfer::public_transfer(publisher, sender(ctx));
+    }
+}

--- a/kiosk/examples/marketplace.move
+++ b/kiosk/examples/marketplace.move
@@ -18,6 +18,8 @@ module kiosk::marketplace_example {
     /// A type identifying the Marketplace.
     struct MyMarket has drop {}
 
+    #[allow(unused_function)]
+    #[lint_allow(share_owned)]
     /// As easy as creating a Publisher; for simplicity's sake we also create
     /// the `TransferPolicy` but this action can be performed offline in a PTB.
     fun init(otw: MARKETPLACE_EXAMPLE, ctx: &mut TxContext) {

--- a/kiosk/examples/marketplace.move
+++ b/kiosk/examples/marketplace.move
@@ -16,13 +16,13 @@ module kiosk::marketplace_example {
     struct MARKETPLACE_EXAMPLE has drop {}
 
     /// A type identifying the Marketplace.
-    struct Walmart has drop {}
+    struct MyMarket has drop {}
 
     /// As easy as creating a Publisher; for simplicity's sake we also create
     /// the `TransferPolicy` but this action can be performed offline in a PTB.
     fun init(otw: MARKETPLACE_EXAMPLE, ctx: &mut TxContext) {
         let publisher = sui::package::claim(otw, ctx);
-        let (policy, policy_cap) = policy::new<Walmart>(&publisher, ctx);
+        let (policy, policy_cap) = policy::new<MyMarket>(&publisher, ctx);
 
         transfer::public_share_object(policy);
         transfer::public_transfer(policy_cap, sender(ctx));

--- a/kiosk/examples/template.move
+++ b/kiosk/examples/template.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
 /// Template bytecode to use when working with (de)serialized bytecode.
 module kiosk::template {
     use std::option::{some, none};

--- a/kiosk/examples/template.move
+++ b/kiosk/examples/template.move
@@ -12,6 +12,7 @@ module kiosk::template {
 
     const TOTAL_SUPPLY: u32 = 10;
 
+    #[allow(unused_function)]
     fun init(otw: TEMPLATE, ctx: &mut TxContext) {
         let supply = if (TOTAL_SUPPLY == 0) {
             none()

--- a/kiosk/examples/unlock.move
+++ b/kiosk/examples/unlock.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[test_only]
 /// This module contains a simple `unlocker` module which enables creators to
 /// `unlock` (as opposed to `lock`) assets without fulfilling the default set
 /// of requirements (rules / policies).

--- a/kiosk/sources/extensions/collection_bidding_ext.move
+++ b/kiosk/sources/extensions/collection_bidding_ext.move
@@ -52,7 +52,6 @@ module kiosk::collection_bidding_ext {
     /// An event that is emitted when a new bid is placed.
     struct NewBid<phantom T, phantom Market> has copy, drop {
         kiosk_id: ID,
-        count: u64,
         bids: vector<u64>,
         kiosk_owner: Option<address>,
     }
@@ -106,7 +105,6 @@ module kiosk::collection_bidding_ext {
 
         event::emit(NewBid<T, Market> {
             kiosk_id: object::id(self),
-            count: count,
             bids: amounts,
             kiosk_owner: personal_kiosk::try_owner(self)
         });

--- a/kiosk/sources/extensions/collection_bidding_ext.move
+++ b/kiosk/sources/extensions/collection_bidding_ext.move
@@ -1,0 +1,178 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Implements Collection Bidding.
+///
+/// It is important that the bidder chooses the Marketplace, not the buyer.
+module kiosk::collection_bidding_ext {
+    use std::type_name;
+
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap, PurchaseCap};
+    use sui::kiosk_extension as ext;
+    use sui::tx_context::TxContext;
+    use sui::coin::{Self, Coin};
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferRequest,
+    };
+    use sui::sui::SUI;
+    use sui::vec_set;
+    use sui::object::{Self, ID};
+    use sui::event;
+    use sui::bag;
+
+    use kiosk::kiosk_lock_rule::Rule as LockRule;
+    use kiosk::marketplace_adapter::{Self as mkt, MarketPurchaseCap, NoMarket};
+
+    /// Trying to perform an action in another user's Kiosk.
+    const ENotAuthorized: u64 = 0;
+    /// Trying to accept the bid in a disabled extension.
+    const EExtensionDisabled: u64 = 1;
+    /// A `PurchaseCap` was created in a different Kiosk.
+    const EIncorrectKiosk: u64 = 2;
+    /// The bid amount is less than the minimum price.
+    const EIncorrectAmount: u64 = 3;
+    /// Trying to accept a bid using a wrong function.
+    const EIncorrectMarketArg: u64 = 4;
+
+    /// Extension permissions - `place` and `lock`.
+    const PERMISSIONS: u128 = 3;
+
+    /// The Extension witness.
+    struct Extension has drop {}
+
+    /// A key for Extension storage - a single bid on an item of type `T` on a `Market`.
+    struct Bid<phantom T, phantom Market> has copy, store, drop {}
+
+    // === Events ===
+
+    /// An event that is emitted when a new bid is placed.
+    struct NewBid<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+        bid: u64,
+    }
+
+    /// An event that is emitted when a bid is accepted.
+    struct BidAccepted<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+        item_id: ID,
+    }
+
+    /// An event that is emitted when a bid is canceled.
+    struct BidCanceled<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+    }
+
+    // === Extension ===
+
+    /// Install the extension into the Kiosk.
+    public fun add(self: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext) {
+        ext::add(Extension {}, self, cap, PERMISSIONS, ctx)
+    }
+
+    // === Bidding logic ===
+
+    /// Place a bid on any item in a collection (`T`).
+    public fun bid<T: key + store, Market>(
+        self: &mut Kiosk, cap: &KioskOwnerCap, bid: Coin<SUI>, _ctx: &mut TxContext
+    ) {
+        event::emit(NewBid<T, Market> {
+            kiosk_id: object::id(self),
+            bid: coin::value(&bid),
+        });
+
+        assert!(kiosk::has_access(self, cap), ENotAuthorized);
+        bag::add(ext::storage_mut(Extension {}, self), Bid<T, Market> {}, bid);
+    }
+
+    /// Cancel a bid, return the funds to the owner.
+    public fun cancel<T: key + store, Market>(
+        self: &mut Kiosk, cap: &KioskOwnerCap, _ctx: &mut TxContext
+    ): Coin<SUI> {
+        event::emit(BidCanceled<T, Market> {
+            kiosk_id: object::id(self),
+        });
+
+        assert!(kiosk::has_access(self, cap), ENotAuthorized);
+        bag::remove(ext::storage_mut(Extension {}, self), Bid<T, Market> {})
+    }
+
+    /// Accept a bid on any item in a collection (`T`).
+    ///
+    /// To do so, the selling party needs to create a `PurchaseCap<T>` with the
+    /// value of the bid (or lower) and call the `accept` function.
+    ///
+    /// Internally, the item will be purchased from the seller's Kiosk for the
+    /// value of the bid, and then placed into the buyer's Kiosk using the ext
+    /// permissions (`lock` or `place` - depending on the `TransferPolicy`).
+    public fun accept<T: key + store>(
+        destination: &mut Kiosk,
+        source: &mut Kiosk,
+        purchase_cap: PurchaseCap<T>,
+        policy: &TransferPolicy<T>,
+
+        // consider removing this parameter and always follow optimistic approach:
+        // if the policy does not contain `kiosk_lock_rule` - do `place`. For now
+        // keeping it in case we discover a case when we need to do `lock`, and
+        // the function signature won't need to change.
+        _lock: bool,
+        _ctx: &mut TxContext
+    ): TransferRequest<T> {
+        let bid: Coin<SUI> = bag::remove(ext::storage_mut(Extension {}, destination), Bid<T, NoMarket> {});
+        let should_lock = vec_set::contains(policy::rules(policy), &type_name::get<LockRule>());
+
+        assert!(ext::is_enabled<Extension>(destination), EExtensionDisabled);
+        assert!(kiosk::purchase_cap_kiosk(&purchase_cap) == object::id(source), EIncorrectKiosk);
+        assert!(kiosk::purchase_cap_min_price(&purchase_cap) <= coin::value(&bid), EIncorrectAmount);
+
+        let (item, request) = kiosk::purchase_with_cap(source, purchase_cap, bid);
+
+        event::emit(BidAccepted<T, NoMarket> {
+            kiosk_id: object::id(destination),
+            item_id: object::id(&item),
+        });
+
+        if (should_lock) {
+            ext::lock(Extension {}, destination, item, policy)
+        } else {
+            ext::place(Extension {}, destination, item, policy);
+        };
+
+        request
+    }
+
+    /// Follows the same flow as the `accept` function but also returns the TransferRequest<Market>.
+    public fun accept_market<T: key + store, Market>(
+        destination: &mut Kiosk,
+        source: &mut Kiosk,
+        purchase_cap: MarketPurchaseCap<T, Market>,
+        policy: &TransferPolicy<T>,
+
+        _lock: bool,
+        _ctx: &mut TxContext
+    ): (TransferRequest<T>, TransferRequest<Market>) {
+        let bid: Coin<SUI> = bag::remove(ext::storage_mut(Extension {}, destination), Bid<T, Market> {});
+        let should_lock = vec_set::contains(policy::rules(policy), &type_name::get<LockRule>());
+
+        assert!(ext::is_enabled<Extension>(destination), EExtensionDisabled);
+        assert!(mkt::kiosk(&purchase_cap) == object::id(source), EIncorrectKiosk);
+        assert!(mkt::min_price(&purchase_cap) <= coin::value(&bid), EIncorrectAmount);
+        assert!(type_name::get<Market>() != type_name::get<NoMarket>(), EIncorrectMarketArg);
+
+        let (item, request, market_request) = mkt::purchase(source, purchase_cap, bid);
+
+        event::emit(BidAccepted<T, Market> {
+            kiosk_id: object::id(destination),
+            item_id: object::id(&item),
+        });
+
+        if (should_lock) {
+            ext::lock(Extension {}, destination, item, policy)
+        } else {
+            ext::place(Extension {}, destination, item, policy);
+        };
+
+        (request, market_request)
+    }
+}

--- a/kiosk/sources/extensions/collection_bidding_ext.move
+++ b/kiosk/sources/extensions/collection_bidding_ext.move
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Implements Collection Bidding.
+/// Implements Collection Bidding. Currently it's a Marketplace-only functionality.
 ///
 /// It is important that the bidder chooses the Marketplace, not the buyer.
 module kiosk::collection_bidding_ext {
     use std::type_name;
+    use std::vector;
 
-    use sui::kiosk::{Self, Kiosk, KioskOwnerCap, PurchaseCap};
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
     use sui::kiosk_extension as ext;
     use sui::tx_context::TxContext;
     use sui::coin::{Self, Coin};
@@ -20,6 +21,7 @@ module kiosk::collection_bidding_ext {
     use sui::vec_set;
     use sui::object::{Self, ID};
     use sui::event;
+    use sui::pay;
     use sui::bag;
 
     use kiosk::kiosk_lock_rule::Rule as LockRule;
@@ -35,12 +37,10 @@ module kiosk::collection_bidding_ext {
     const EIncorrectAmount: u64 = 3;
     /// Trying to accept a bid using a wrong function.
     const EIncorrectMarketArg: u64 = 4;
-
-    /// Extension permissions - `place` and `lock`.
-    const PERMISSIONS: u128 = 3;
-
-    /// The Extension witness.
-    struct Extension has drop {}
+    /// Trying to accept a bid that does not exist.
+    const EBidNotFound: u64 = 5;
+    /// Trying to place a bid with no coins.
+    const ENoCoinsPassed: u64 = 6;
 
     /// A key for Extension storage - a single bid on an item of type `T` on a `Market`.
     struct Bid<phantom T, phantom Market> has copy, store, drop {}
@@ -50,6 +50,7 @@ module kiosk::collection_bidding_ext {
     /// An event that is emitted when a new bid is placed.
     struct NewBid<phantom T, phantom Market> has copy, drop {
         kiosk_id: ID,
+        count: u64,
         bid: u64,
     }
 
@@ -66,6 +67,12 @@ module kiosk::collection_bidding_ext {
 
     // === Extension ===
 
+    /// Extension permissions - `place` and `lock`.
+    const PERMISSIONS: u128 = 3;
+
+    /// The Extension witness.
+    struct Extension has drop {}
+
     /// Install the extension into the Kiosk.
     public fun add(self: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext) {
         ext::add(Extension {}, self, cap, PERMISSIONS, ctx)
@@ -73,106 +80,130 @@ module kiosk::collection_bidding_ext {
 
     // === Bidding logic ===
 
-    /// Place a bid on any item in a collection (`T`).
-    public fun bid<T: key + store, Market>(
-        self: &mut Kiosk, cap: &KioskOwnerCap, bid: Coin<SUI>, _ctx: &mut TxContext
+    /// Place a bid on any item in a collection (`T`). We do not assert that all
+    /// the values in the `place_bids` are identical.
+    public fun place_bids<T: key + store, Market>(
+        self: &mut Kiosk, cap: &KioskOwnerCap, bids: vector<Coin<SUI>>, _ctx: &mut TxContext
     ) {
+        assert!(vector::length(&bids) > 0, ENoCoinsPassed);
+        assert!(kiosk::has_access(self, cap), ENotAuthorized);
+
+        let expected_amount = coin::value(vector::borrow(&bids, 0));
+        let (i, count) = (0, vector::length(&bids));
+        while (i < count) {
+            assert!(coin::value(vector::borrow(&bids, i)) == expected_amount, EIncorrectAmount);
+            i = i + 1;
+        };
+
         event::emit(NewBid<T, Market> {
             kiosk_id: object::id(self),
-            bid: coin::value(&bid),
+            bid: expected_amount,
+            count: count,
         });
 
-        assert!(kiosk::has_access(self, cap), ENotAuthorized);
-        bag::add(ext::storage_mut(Extension {}, self), Bid<T, Market> {}, bid);
+        bag::add(ext::storage_mut(Extension {}, self), Bid<T, Market> {}, bids);
     }
 
-    /// Cancel a bid, return the funds to the owner.
-    public fun cancel<T: key + store, Market>(
-        self: &mut Kiosk, cap: &KioskOwnerCap, _ctx: &mut TxContext
+    /// Cancel all bids, return the funds to the owner.
+    public fun cancel_all<T: key + store, Market>(
+        self: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext
     ): Coin<SUI> {
+        assert!(kiosk::has_access(self, cap), ENotAuthorized);
+
         event::emit(BidCanceled<T, Market> {
             kiosk_id: object::id(self),
         });
 
-        assert!(kiosk::has_access(self, cap), ENotAuthorized);
-        bag::remove(ext::storage_mut(Extension {}, self), Bid<T, Market> {})
+        let coins = bag::remove(ext::storage_mut(Extension {}, self), Bid<T, Market> {});
+        let total = coin::zero(ctx);
+        pay::join_vec(&mut total, coins);
+        total
     }
 
-    /// Accept a bid on any item in a collection (`T`).
+    /// Accept the bid and make a purchase on in the `Kiosk`.
     ///
-    /// To do so, the selling party needs to create a `PurchaseCap<T>` with the
-    /// value of the bid (or lower) and call the `accept` function.
+    /// 1. The seller creates a `MarketPurchaseCap` using the Marketplace adapter,
+    /// and passes the Cap to this function.
     ///
-    /// Internally, the item will be purchased from the seller's Kiosk for the
-    /// value of the bid, and then placed into the buyer's Kiosk using the ext
-    /// permissions (`lock` or `place` - depending on the `TransferPolicy`).
-    public fun accept<T: key + store>(
+    /// 2. The `bid` is taken from the extension storage and is used to purchase
+    /// the item with the `MarketPurchaseCap`. Proceeds go to the seller's Kiosk.
+    ///
+    /// 3. The item is placed in the seller's Kiosk using the `place` or `lock`
+    /// functions (see `PERMISSIONS`).
+    public fun accept_market_bid<T: key + store, Market>(
         destination: &mut Kiosk,
         source: &mut Kiosk,
-        purchase_cap: PurchaseCap<T>,
+        mkt_cap: MarketPurchaseCap<T, Market>,
         policy: &TransferPolicy<T>,
-
-        // consider removing this parameter and always follow optimistic approach:
-        // if the policy does not contain `kiosk_lock_rule` - do `place`. For now
-        // keeping it in case we discover a case when we need to do `lock`, and
-        // the function signature won't need to change.
+        // keeping these arguments for extendability
         _lock: bool,
-        _ctx: &mut TxContext
-    ): TransferRequest<T> {
-        let bid: Coin<SUI> = bag::remove(ext::storage_mut(Extension {}, destination), Bid<T, NoMarket> {});
-        let should_lock = vec_set::contains(policy::rules(policy), &type_name::get<LockRule>());
+        ctx: &mut TxContext
+    ): (TransferRequest<T>, TransferRequest<Market>) {
+        let storage = ext::storage_mut(Extension {}, destination);
+        assert!(bag::contains(storage, Bid<T, Market> {}), EBidNotFound);
 
-        assert!(ext::is_enabled<Extension>(destination), EExtensionDisabled);
-        assert!(kiosk::purchase_cap_kiosk(&purchase_cap) == object::id(source), EIncorrectKiosk);
-        assert!(kiosk::purchase_cap_min_price(&purchase_cap) <= coin::value(&bid), EIncorrectAmount);
+        // Take 1 Coin from the bag - this is our bid (bids can't be empty, we make sure of it).
+        let bid = vector::pop_back(bag::borrow_mut(storage, Bid<T, Market> {}));
 
-        let (item, request) = kiosk::purchase_with_cap(source, purchase_cap, bid);
-
-        event::emit(BidAccepted<T, NoMarket> {
-            kiosk_id: object::id(destination),
-            item_id: object::id(&item),
-        });
-
-        if (should_lock) {
-            ext::lock(Extension {}, destination, item, policy)
-        } else {
-            ext::place(Extension {}, destination, item, policy);
+        // If there are no bids left, remove the bag and the key from the storage.
+        if (bid_count<T, Market>(destination) == 0) {
+            vector::destroy_empty<Coin<SUI>>(
+                bag::remove(
+                    ext::storage_mut(Extension {}, destination),
+                    Bid<T, Market> {}
+                )
+            );
         };
 
-        request
-    }
-
-    /// Follows the same flow as the `accept` function but also returns the TransferRequest<Market>.
-    public fun accept_market<T: key + store, Market>(
-        destination: &mut Kiosk,
-        source: &mut Kiosk,
-        purchase_cap: MarketPurchaseCap<T, Market>,
-        policy: &TransferPolicy<T>,
-
-        _lock: bool,
-        _ctx: &mut TxContext
-    ): (TransferRequest<T>, TransferRequest<Market>) {
-        let bid: Coin<SUI> = bag::remove(ext::storage_mut(Extension {}, destination), Bid<T, Market> {});
-        let should_lock = vec_set::contains(policy::rules(policy), &type_name::get<LockRule>());
-
         assert!(ext::is_enabled<Extension>(destination), EExtensionDisabled);
-        assert!(mkt::kiosk(&purchase_cap) == object::id(source), EIncorrectKiosk);
-        assert!(mkt::min_price(&purchase_cap) <= coin::value(&bid), EIncorrectAmount);
+        assert!(mkt::kiosk(&mkt_cap) == object::id(source), EIncorrectKiosk);
+        assert!(mkt::min_price(&mkt_cap) <= coin::value(&bid), EIncorrectAmount);
         assert!(type_name::get<Market>() != type_name::get<NoMarket>(), EIncorrectMarketArg);
 
-        let (item, request, market_request) = mkt::purchase(source, purchase_cap, bid);
+        // Perform the purchase operation in the seller's Kiosk using the `Bid`.
+        let (item, request, market_request) = mkt::purchase(source, mkt_cap, bid, ctx);
 
         event::emit(BidAccepted<T, Market> {
             kiosk_id: object::id(destination),
             item_id: object::id(&item),
         });
 
-        if (should_lock) {
-            ext::lock(Extension {}, destination, item, policy)
-        } else {
-            ext::place(Extension {}, destination, item, policy);
-        };
+        // Place of lock the item in the Buyer's Kiosk.
+        place_or_lock(destination, item, policy);
 
         (request, market_request)
+    }
+
+    // === Getters ===
+
+    /// Number of currently active bids.
+    public fun offers_count(self: &Kiosk): u64 {
+        bag::length(ext::storage(Extension {}, self))
+    }
+
+    /// Number of bids on an item of type `T` on a `Market` in a `Kiosk`.
+    public fun bid_count<T: key + store, Market>(self: &Kiosk): u64 {
+        let coins = bag::borrow(ext::storage(Extension {}, self), Bid<T, Market> {});
+        vector::length<Coin<SUI>>(coins)
+    }
+
+    /// Returns the amount of the bid on an item of type `T` on a `Market`.
+    /// The `NoMarket` generic can be used to check an item listed off the market.
+    public fun bid_amount<T: key + store, Market>(self: &Kiosk): u64 {
+        let coins = bag::borrow(ext::storage(Extension {}, self), Bid<T, Market> {});
+        coin::value(vector::borrow<Coin<SUI>>(coins, 0))
+    }
+
+    // === Internal ===
+
+    /// A helper function which either places or locks an item in the Kiosk depending
+    /// on the Rules set in the `TransferPolicy`.
+    fun place_or_lock<T: key + store>(kiosk: &mut Kiosk, item: T, policy: &TransferPolicy<T>) {
+        let should_lock = vec_set::contains(policy::rules(policy), &type_name::get<LockRule>());
+        if (should_lock) {
+            ext::lock(Extension {}, kiosk, item, policy)
+        } else {
+            ext::place(Extension {}, kiosk, item, policy)
+        };
     }
 }

--- a/kiosk/sources/extensions/collection_bidding_ext.move
+++ b/kiosk/sources/extensions/collection_bidding_ext.move
@@ -59,7 +59,7 @@ module kiosk::collection_bidding_ext {
     struct NewBid<phantom T, phantom Market> has copy, drop {
         kiosk_id: ID,
         bids: vector<u64>,
-        kiosk_owner: Option<address>,
+        is_personal: bool,
     }
 
     /// An event that is emitted when a bid is accepted.
@@ -114,7 +114,7 @@ module kiosk::collection_bidding_ext {
         event::emit(NewBid<T, Market> {
             kiosk_id: object::id(self),
             bids: amounts,
-            kiosk_owner: personal_kiosk::try_owner(self)
+            is_personal: personal_kiosk::is_personal(self)
         });
 
         bag::add(ext::storage_mut(Extension {}, self), Bid<T, Market> {}, bids);

--- a/kiosk/sources/extensions/collection_bidding_ext.move
+++ b/kiosk/sources/extensions/collection_bidding_ext.move
@@ -148,7 +148,7 @@ module kiosk::collection_bidding_ext {
     ///
     /// 2. The `bid` is taken from the `source` Kiosk's extension storage and is
     /// used to purchase the item with the `MarketPurchaseCap`. Proceeds go to
-    /// the seller's Kiosk.
+    /// the `destination` Kiosk, as this Kiosk offers the `T`.
     ///
     /// 3. The item is placed in the `destination` Kiosk using the `place` or `lock`
     /// functions (see `PERMISSIONS`). The extension must be installed and enabled

--- a/kiosk/sources/extensions/list_purchase_ext.move
+++ b/kiosk/sources/extensions/list_purchase_ext.move
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This extension implements the default list-purchase flow but for a specific
+/// market (using the Marketplace Adapter).
+///
+/// Consists of 3 functions:
+/// - list
+/// - delist
+/// - purchase
+module kiosk::fixed_price_ext {
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+    use sui::transfer_policy::TransferRequest;
+    use sui::kiosk_extension as ext;
+    use sui::tx_context::TxContext;
+    use sui::object::{Self, ID};
+    use sui::coin::Coin;
+    use sui::sui::SUI;
+    use sui::event;
+    use sui::bag;
+
+    use kiosk::marketplace_adapter as mkt;
+
+    /// For when the caller is not the owner of the Kiosk.
+    const ENotOwner: u64 = 0;
+
+    /// The Extension Witness
+    struct Extension has drop {}
+
+    /// This Extension does not require any permissions.
+    const PERMISSIONS: u128 = 0;
+
+    struct ItemListed<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+        item_id: ID,
+        price: u64
+    }
+
+    struct ItemDelisted<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+        item_id: ID
+    }
+
+    struct ItemPurchased<phantom T, phantom Market> has copy, drop {
+        kiosk_id: ID,
+        item_id: ID,
+    }
+
+    /// Adds the Extension
+    public fun add(kiosk: &mut Kiosk, cap: &KioskOwnerCap, ctx: &mut TxContext) {
+        ext::add(Extension {}, kiosk, cap, PERMISSIONS, ctx)
+    }
+
+    /// List an item on a specified Marketplace.
+    public fun list<T: key + store, Market>(
+        self: &mut Kiosk,
+        cap: &KioskOwnerCap,
+        item_id: ID,
+        price: u64,
+        ctx: &mut TxContext
+    ) {
+        assert!(kiosk::has_access(self, cap), ENotOwner);
+
+        let mkt_cap = mkt::new<T, Market>(self, cap, item_id, price, ctx);
+        bag::add(ext::storage_mut(Extension {}, self), item_id, mkt_cap);
+
+        event::emit(ItemListed<T, Market> {
+            kiosk_id: object::id(self),
+            item_id,
+            price
+        });
+    }
+
+    /// Delist an item from a specified Marketplace.
+    public fun delist<T: key + store, Market>(
+        self: &mut Kiosk,
+        cap: &KioskOwnerCap,
+        item_id: ID,
+        _ctx: &mut TxContext
+    ) {
+        assert!(kiosk::has_access(self, cap), ENotOwner);
+
+        let mkt_cap = bag::remove(ext::storage_mut(Extension {}, self), item_id);
+        mkt::return_cap<T, Market>(self, mkt_cap);
+
+        event::emit(ItemDelisted<T, Market> {
+            kiosk_id: object::id(self),
+            item_id
+        });
+    }
+
+    public fun purchase<T: key + store, Market>(
+        self: &mut Kiosk,
+        item_id: ID,
+        payment: Coin<SUI>,
+        _ctx: &mut TxContext
+    ): (T, TransferRequest<T>, TransferRequest<Market>) {
+        let mkt_cap = bag::remove(ext::storage_mut(Extension {}, self), item_id);
+
+        event::emit(ItemPurchased<T, Market> {
+            kiosk_id: object::id(self),
+            item_id
+        });
+
+        mkt::purchase(self, mkt_cap, payment)
+    }
+}

--- a/kiosk/sources/extensions/marketplace_adapter.move
+++ b/kiosk/sources/extensions/marketplace_adapter.move
@@ -35,8 +35,7 @@ module kiosk::marketplace_adapter {
         purchase_cap: PurchaseCap<T>
     }
 
-    /// The `MarketKioskOwnerCap` wraps the `KioskOwnerCap` and forces the
-    /// unlocking with a TransferRequest.
+    /// Create a new `PurchaseCap` and wrap it into the `MarketPurchaseCap`.
     public fun new<T: key + store, Market>(
         kiosk: &mut Kiosk,
         cap: &KioskOwnerCap,
@@ -51,8 +50,8 @@ module kiosk::marketplace_adapter {
         }
     }
 
-    /// The `MarketKioskOwnerCap` wraps the `KioskOwnerCap` and forces the
-    /// unlocking with a TransferRequest.
+    /// Return the `MarketPurchaseCap` to the `Kiosk`. Similar to how a PurchaseCap
+    /// can be returned at any moment.
     public fun return_cap<T: key  + store, Market>(
         kiosk: &mut Kiosk,
         cap: MarketPurchaseCap<T, Market>

--- a/kiosk/sources/extensions/marketplace_adapter.move
+++ b/kiosk/sources/extensions/marketplace_adapter.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The best practical approach to trading on marketplaces and favoring their
+/// fees and conditions is issuing an additional `TransferRequest` which requires
+/// resolution in the marketplace. However, issuing another `TransferRequest`
+/// is not always possible because it must be copied from TransferRequest<Item>,
+/// mostly because the price of the sale is not known to the very moment of the
+/// sale. And if there's already a TransferRequest<Item>, how do we enforce the
+/// creation of an extra request?
+///
+/// To address this problem and also solve the extension interoperability issue,
+/// we created a `marketplace_adapter` - simple utility which wraps the
+/// `PurchaseCap` and handles the last step of the purchase flow in the Kiosk.
+///
+/// Unlike `PurchaseCap` purpose of which was to be "free", `MarketPurchaseCap`
+/// - the wrapper - only comes with a `store` to reduce the amount of scenarios
+/// when it is transferred by accident or sent to an address / object.
+module kiosk::marketplace_adapter {
+    use sui::transfer_policy::{Self as policy, TransferRequest};
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap, PurchaseCap};
+    use sui::tx_context::TxContext;
+    use sui::object::ID;
+    use sui::coin::Coin;
+    use sui::sui::SUI;
+
+    /// The `NoMarket` type is used to provide a default `Market` type parameter
+    /// for a scenario when the `MarketplaceAdapter` is not used and extensions
+    /// maintain uniformity of emitted events. NoMarket = no marketplace.
+    struct NoMarket {}
+
+    /// The `MarketPurchaseCap` wraps the `PurchaseCap` and forces the unlocking
+    /// party to satisfy the `TransferPolicy<Market>` requirements.
+    struct MarketPurchaseCap<phantom T: key + store, phantom Market> has store {
+        purchase_cap: PurchaseCap<T>
+    }
+
+    /// The `MarketKioskOwnerCap` wraps the `KioskOwnerCap` and forces the
+    /// unlocking with a TransferRequest.
+    public fun new<T: key + store, Market>(
+        kiosk: &mut Kiosk,
+        cap: &KioskOwnerCap,
+        item_id: ID,
+        min_price: u64,
+        ctx: &mut TxContext
+    ): MarketPurchaseCap<T, Market> {
+        MarketPurchaseCap<T, Market> {
+            purchase_cap: kiosk::list_with_purchase_cap(
+                kiosk, cap, item_id, min_price, ctx
+            )
+        }
+    }
+
+    /// The `MarketKioskOwnerCap` wraps the `KioskOwnerCap` and forces the
+    /// unlocking with a TransferRequest.
+    public fun return_cap<T: key  + store, Market>(
+        kiosk: &mut Kiosk,
+        cap: MarketPurchaseCap<T, Market>
+    ) {
+        let MarketPurchaseCap { purchase_cap } = cap;
+        kiosk::return_purchase_cap(kiosk, purchase_cap);
+    }
+
+    /// Use the `MarketPurchaseCap` to purchase an item from the `Kiosk`. Unlike
+    /// the default flow, this function adds a `TransferRequest<Market>` which
+    /// forces the unlocking party to satisfy the `TransferPolicy<Market>`
+    public fun purchase<T: key + store, Market>(
+        kiosk: &mut Kiosk,
+        cap: MarketPurchaseCap<T, Market>,
+        coin: Coin<SUI>
+    ): (T, TransferRequest<T>, TransferRequest<Market>) {
+        let MarketPurchaseCap { purchase_cap } = cap;
+        let (item, request) = kiosk::purchase_with_cap(kiosk, purchase_cap, coin);
+        let market_request = policy::new_request(
+            policy::item(&request),
+            policy::paid(&request),
+            policy::from(&request),
+        );
+
+        (item, request, market_request)
+    }
+
+    /// Handy wrapper to read the `kiosk` field of the inner `PurchaseCap`
+    public fun kiosk<T: key + store, Market>(self: &MarketPurchaseCap<T, Market>): ID {
+        kiosk::purchase_cap_kiosk(&self.purchase_cap)
+    }
+
+    /// Handy wrapper to read the `item` field of the inner `PurchaseCap`
+    public fun item<T: key + store, Market>(self: &MarketPurchaseCap<T, Market>): ID {
+        kiosk::purchase_cap_item(&self.purchase_cap)
+    }
+
+    /// Handy wrapper to read the `min_price` field of the inner `PurchaseCap`
+    public fun min_price<T: key + store, Market>(self: &MarketPurchaseCap<T, Market>): u64 {
+        kiosk::purchase_cap_min_price(&self.purchase_cap)
+    }
+}

--- a/kiosk/sources/extensions/marketplace_adapter.move
+++ b/kiosk/sources/extensions/marketplace_adapter.move
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// The best practical approach to trading on marketplaces and favoring their
-/// fees and conditions is issuing an additional `TransferRequest` which requires
-/// resolution in the marketplace. However, issuing another `TransferRequest`
-/// is not always possible because it must be copied from TransferRequest<Item>,
-/// mostly because the price of the sale is not known to the very moment of the
-/// sale. And if there's already a TransferRequest<Item>, how do we enforce the
-/// creation of an extra request?
+/// fees and conditions is issuing an additional `TransferRequest` (eg `Market`).
+/// However, doing so is not always possible because it must be copied from
+/// TransferRequest<Item>. Mainly because the price of the sale is not known to
+/// the very moment of the sale. And if there's already a TransferRequest<Item>,
+/// how do we enforce the creation of an extra request? That means that sale has
+/// already happened.
 ///
 /// To address this problem and also solve the extension interoperability issue,
 /// we created a `marketplace_adapter` - simple utility which wraps the

--- a/kiosk/sources/extensions/personal_kiosk.move
+++ b/kiosk/sources/extensions/personal_kiosk.move
@@ -115,6 +115,16 @@ module kiosk::personal_kiosk {
         *df::borrow(kiosk::uid(kiosk), OwnerMarker {})
     }
 
+    /// Try to get the owner of the Kiosk if the Kiosk is "personal". Returns
+    /// None otherwise.
+    public fun try_owner(kiosk: &Kiosk): Option<address> {
+        if (is_personal(kiosk)) {
+            option::some(owner(kiosk))
+        } else {
+            option::none()
+        }
+    }
+
     /// Transfer the `PersonalKioskCap` to the transaction sender.
     public fun transfer_to_sender(self: PersonalKioskCap, ctx: &mut TxContext) {
         transfer::transfer(self, sender(ctx));

--- a/kiosk/sources/extensions/personal_kiosk.move
+++ b/kiosk/sources/extensions/personal_kiosk.move
@@ -133,6 +133,7 @@ module kiosk::personal_kiosk {
         }
     }
 
+    #[lint_allow(self_transfer)]
     /// Transfer the `PersonalKioskCap` to the transaction sender.
     public fun transfer_to_sender(self: PersonalKioskCap, ctx: &mut TxContext) {
         transfer::transfer(self, sender(ctx));

--- a/kiosk/sources/extensions/personal_kiosk.move
+++ b/kiosk/sources/extensions/personal_kiosk.move
@@ -36,6 +36,10 @@ module kiosk::personal_kiosk {
     /// checks through the Kiosk).
     struct OwnerMarker has copy, store, drop {}
 
+    /// Event that is emitted when a new PersonalKioskCap is created. The sender
+    /// of the transaction is always the new Kiosk Owner.
+    struct NewPersonalKiosk has copy, drop { kiosk_id: ID }
+
     /// The default setup for the PersonalKioskCap.
     entry fun default(kiosk: &mut Kiosk, cap: KioskOwnerCap, ctx: &mut TxContext) {
         transfer_to_sender(new(kiosk, cap, ctx), ctx);
@@ -61,6 +65,10 @@ module kiosk::personal_kiosk {
             OwnerMarker {},
             owner
         );
+
+        sui::event::emit(NewPersonalKiosk {
+            kiosk_id: object::id(kiosk)
+        });
 
         // wrap the Cap in the `PersonalKioskCap`
         PersonalKioskCap {

--- a/kiosk/tests/extensions/marketplace_adapter_tests.move
+++ b/kiosk/tests/extensions/marketplace_adapter_tests.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Tests for the marketplace adapter.
+module kiosk::marketplace_adapter_tests {
+    use sui::coin;
+    use sui::kiosk;
+    use sui::object;
+    use sui::sui::SUI;
+    use sui::transfer_policy as policy;
+    use sui::kiosk_test_utils::{Self as test, Asset};
+
+    use kiosk::marketplace_adapter as mkt;
+
+
+    /// The Marketplace witness.
+    struct MyMarket has drop {}
+
+    /// The witness to use in tests.
+    struct OTW has drop {}
+
+    // Performs a test of the `new` and `return_cap` functions. Not supposed to
+    // abort, and there's only so many scenarios where it can fail due to strict
+    // type requirements.
+    #[test] fun test_new_return_flow() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
+        let (asset, asset_id) = test::get_asset(ctx);
+
+        kiosk::place(&mut kiosk, &kiosk_cap, asset);
+
+        let mkt_cap = mkt::new<Asset, MyMarket>(
+            &mut kiosk, &kiosk_cap, asset_id, 100000, ctx
+        );
+
+        assert!(mkt::item(&mkt_cap) == asset_id, 0);
+        assert!(mkt::min_price(&mkt_cap) == 100000, 1);
+        assert!(mkt::kiosk(&mkt_cap) == object::id(&kiosk), 2);
+
+        mkt::return_cap(&mut kiosk, mkt_cap, ctx);
+
+        let asset = kiosk::take(&mut kiosk, &kiosk_cap, asset_id);
+        test::return_kiosk(kiosk, kiosk_cap, ctx);
+        test::return_assets(vector[ asset ]);
+    }
+
+    // Perform a `purchase` using the `MarketPurchaseCap`. Type constraints make
+    // it impossible to cheat and pass another Cap. So the number of potential
+    // fail scenarios is limited and already covered by the base Kiosk
+    #[test] fun test_new_purchase_flow() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
+        let (asset, asset_id) = test::get_asset(ctx);
+
+        kiosk::place(&mut kiosk, &kiosk_cap, asset);
+
+        // Lock an item in the Marketplace
+        let mkt_cap = mkt::new<Asset, MyMarket>(
+            &mut kiosk, &kiosk_cap, asset_id, 100000, ctx
+        );
+
+        // Mint a Coin and make a purchase
+        let coin = coin::mint_for_testing<SUI>(100000, ctx);
+        let (item, req, mkt_req) = mkt::purchase<Asset, MyMarket>(
+            &mut kiosk, mkt_cap, coin, ctx
+        );
+
+        // Get Policy for the Asset, use it and clean up.
+        let (policy, policy_cap) = test::get_policy(ctx);
+        policy::confirm_request(&policy, req);
+        test::return_policy(policy, policy_cap, ctx);
+
+        // Get Policy for the Marketplace, use it and clean up.
+        let (policy, policy_cap) = policy::new_for_testing<MyMarket>(ctx);
+        policy::confirm_request(&policy, mkt_req);
+        let proceeds = policy::destroy_and_withdraw(policy, policy_cap, ctx);
+        coin::destroy_zero<SUI>(proceeds);
+
+        // Now deal with the item and with the Kiosk.
+        test::return_assets(vector[ item ]);
+        test::return_kiosk(kiosk, kiosk_cap, ctx);
+    }
+}

--- a/kiosk/tests/extensions/marketplace_trading_ext.move
+++ b/kiosk/tests/extensions/marketplace_trading_ext.move
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Tests for the marketplace `marketplace_trading_ext`.
+module kiosk::marketplace_trading_ext_tests {
+    use sui::coin;
+    use sui::object::ID;
+    use sui::kiosk_extension;
+    use sui::tx_context::TxContext;
+    use sui::transfer_policy as policy;
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+    use sui::kiosk_test_utils::{Self as test, Asset};
+    use kiosk::marketplace_trading_ext as ext;
+
+    const PRICE: u64 = 100_000;
+
+    /// Marketplace type.
+    struct MyMarket has drop {}
+
+    #[test] fun test_list_and_delist() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap, asset_id) = prepare(ctx);
+
+        ext::list<Asset, MyMarket>(&mut kiosk, &kiosk_cap, asset_id, PRICE, ctx);
+
+        assert!(ext::is_listed<Asset, MyMarket>(&kiosk, asset_id), 0);
+        assert!(ext::price<Asset, MyMarket>(&kiosk, asset_id) == PRICE, 1);
+
+        ext::delist<Asset, MyMarket>(&mut kiosk, &kiosk_cap, asset_id, ctx);
+
+        let asset = kiosk::take(&mut kiosk, &kiosk_cap, asset_id);
+        test::return_assets(vector[ asset ]);
+        wrapup(kiosk, kiosk_cap, ctx);
+    }
+
+    #[test] fun test_list_and_purchase() {
+        let ctx = &mut test::ctx();
+        let (kiosk, kiosk_cap, asset_id) = prepare(ctx);
+
+        ext::list<Asset, MyMarket>(&mut kiosk, &kiosk_cap, asset_id, PRICE, ctx);
+
+        let coin = test::get_sui(PRICE, ctx);
+        let (item, req, mkt_req) = ext::purchase<Asset, MyMarket>(
+            &mut kiosk, asset_id, coin, ctx
+        );
+
+        // Resolve creator's Policy
+        let (policy, policy_cap) = test::get_policy(ctx);
+        policy::confirm_request(&policy, req);
+        test::return_policy(policy, policy_cap, ctx);
+
+        // Resolve marketplace's Policy
+        let (policy, policy_cap) = policy::new_for_testing<MyMarket>(ctx);
+        policy::confirm_request(&policy, mkt_req);
+        let proceeds = policy::destroy_and_withdraw(policy, policy_cap, ctx);
+        coin::destroy_zero(proceeds);
+
+        // Deal with the Asset + Kiosk, KioskOwnerCap
+        test::return_assets(vector[ item ]);
+        wrapup(kiosk, kiosk_cap, ctx);
+    }
+
+    /// Prepare a Kiosk with:
+    /// - extension installed
+    /// - an asset inside
+    fun prepare(ctx: &mut TxContext): (Kiosk, KioskOwnerCap, ID) {
+        let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
+        let (asset, asset_id) = test::get_asset(ctx);
+
+        kiosk::place(&mut kiosk, &kiosk_cap, asset);
+        ext::add(&mut kiosk, &kiosk_cap, ctx);
+        (kiosk, kiosk_cap, asset_id)
+    }
+
+    /// Wrap everything up; remove the extension and the asset.
+    fun wrapup(kiosk: Kiosk, cap: KioskOwnerCap, ctx: &mut TxContext) {
+        kiosk_extension::remove<ext::Extension>(&mut kiosk, &cap);
+        test::return_kiosk(kiosk, cap, ctx);
+    }
+}

--- a/kiosk/tests/extensions/personal_kiosk_tests.move
+++ b/kiosk/tests/extensions/personal_kiosk_tests.move
@@ -11,6 +11,7 @@ module kiosk::personal_kiosk_tests {
     use kiosk::personal_kiosk;
 
     #[test]
+    #[lint_allow(share_owned)]
     fun new_and_transfer() {
         let ctx = &mut test::ctx();
         let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
@@ -20,6 +21,7 @@ module kiosk::personal_kiosk_tests {
     }
 
     #[test]
+    #[lint_allow(share_owned)]
     fun new_borrow() {
         let ctx = &mut test::ctx();
         let (kiosk, kiosk_cap) = test::get_kiosk(ctx);
@@ -38,7 +40,7 @@ module kiosk::personal_kiosk_tests {
         let (kiosk_cap, borrow) = personal_kiosk::borrow_val(&mut p_cap);
 
         assert!(kiosk::has_access(&mut kiosk, &kiosk_cap), 0);
-        assert!(kiosk::has_access(&mut kiosk, &mut kiosk_cap), 0);
+        assert!(kiosk::has_access(&mut kiosk, &kiosk_cap), 0);
 
         personal_kiosk::return_val(&mut p_cap, kiosk_cap, borrow);
         personal_kiosk::transfer_to_sender(p_cap, ctx);

--- a/kiosk/tests/rules/floor_price_rule_tests.move
+++ b/kiosk/tests/rules/floor_price_rule_tests.move
@@ -20,7 +20,7 @@ module kiosk::floor_price_rule_tests {
         let request = policy::new_request(test::fresh_id(ctx), 1_000_000_000, test::fresh_id(ctx));
 
         floor_price_rule::prove(&mut policy, &mut request);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         test::wrapup(policy, cap, ctx);
     }
@@ -36,7 +36,7 @@ module kiosk::floor_price_rule_tests {
         let request = policy::new_request(test::fresh_id(ctx), 100_000_000_000, test::fresh_id(ctx));
 
         floor_price_rule::prove(&mut policy, &mut request);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         test::wrapup(policy, cap, ctx);
     }
@@ -54,7 +54,7 @@ module kiosk::floor_price_rule_tests {
         let request = policy::new_request(test::fresh_id(ctx), 999_999_999, test::fresh_id(ctx));
 
         floor_price_rule::prove(&mut policy, &mut request);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         test::wrapup(policy, cap, ctx);
     }

--- a/kiosk/tests/rules/kiosk_lock_rule_tests.move
+++ b/kiosk/tests/rules/kiosk_lock_rule_tests.move
@@ -36,7 +36,7 @@ module kiosk::kiosk_lock_rule_tests {
         kiosk::lock(&mut bob_kiosk, &bob_kiosk_cap, &policy, item);
 
         // The difference!
-        kiosk_lock::prove(&mut request, &mut bob_kiosk);
+        kiosk_lock::prove(&mut request, &bob_kiosk);
         policy::confirm_request(&policy, request);
 
         // Carl the Cleaner;

--- a/kiosk/tests/rules/royalty_rule_tests.move
+++ b/kiosk/tests/rules/royalty_rule_tests.move
@@ -23,7 +23,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(0, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         let profits = test::wrapup(policy, cap, ctx);
         assert!(profits == 0, 1);
@@ -42,7 +42,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(10, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         let profits = test::wrapup(policy, cap, ctx);
         assert!(profits == 0, 1);
@@ -60,7 +60,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(1000, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         let profits = test::wrapup(policy, cap, ctx);
         assert!(profits == 1000, 1);
@@ -78,7 +78,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(100_000, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
 
         let profits = test::wrapup(policy, cap, ctx);
         assert!(profits == 100_000, 1);
@@ -96,7 +96,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(10_000, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
         assert!(test::wrapup(policy, cap, ctx) == 10_000, 1);
     }
 
@@ -112,7 +112,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(10_000, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
         assert!(test::wrapup(policy, cap, ctx) == 10_000, 1);
     }
 
@@ -128,7 +128,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(20_000, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
         assert!(test::wrapup(policy, cap, ctx) == 20_000, 1);
     }
 
@@ -156,7 +156,7 @@ module kiosk::royalty_rule_tests {
         let payment = coin::mint_for_testing<SUI>(999, ctx);
 
         royalty_rule::pay(&mut policy, &mut request, payment);
-        policy::confirm_request(&mut policy, request);
+        policy::confirm_request(&policy, request);
         test::wrapup(policy, cap, ctx);
     }
 }


### PR DESCRIPTION
## Description 

This PR adds new functionality to the Mysten Kiosk package. More specifically:

- Marketplace Adapter - "I want to use Auction but on a Marketplace X"
- FixedPrice Extension for Marketplaces - "I sell this Capy for 10 SUI"
- Collection Bidding Extension - "I want any Capy for 10 SUI"

## Test Plan 

To be

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
