### PR TITLE
[narwhal] normalise proposer min_timeout timer

### DIFF
--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -730,6 +730,16 @@ impl Consensus {
                         // expected by primary.
                         let leader_commit_round = committed_certificates.iter().map(|c| c.round()).max().unwrap();
 
+                        for certificate in &committed_certificates {
+                            let authority: &Authority = self.committee.authority_safe(&certificate.origin());
+
+                            self
+                            .metrics
+                            .num_of_committed_certificates_per_authority
+                            .with_label_values(&["authority", authority.hostname()])
+                            .inc();
+                        }
+
                         self.tx_committed_certificates
                         .send((leader_commit_round, committed_certificates))
                         .await

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -736,7 +736,7 @@ impl Consensus {
                             self
                             .metrics
                             .num_of_committed_certificates_per_authority
-                            .with_label_values(&["authority", authority.hostname()])
+                            .with_label_values(&[authority.hostname()])
                             .inc();
                         }
 

--- a/narwhal/consensus/src/metrics.rs
+++ b/narwhal/consensus/src/metrics.rs
@@ -52,6 +52,8 @@ pub struct ConsensusMetrics {
     pub leader_commits: IntCounterVec,
     /// number of bad nodes in the committee
     pub num_of_bad_nodes: IntGauge,
+
+    pub num_of_committed_certificates_per_authority: IntCounterVec,
 }
 
 impl ConsensusMetrics {
@@ -118,6 +120,12 @@ impl ConsensusMetrics {
             num_of_bad_nodes: register_int_gauge_with_registry!(
                 "num_of_bad_nodes",
                 "The number of bad nodes in the new leader schedule",
+                registry
+            ).unwrap(),
+            num_of_committed_certificates_per_authority: register_int_counter_vec_with_registry!(
+               "num_of_committed_certificates_per_authority",
+                "Count the number of committed certificates per authority",
+                &["authority"],
                 registry
             ).unwrap(),
         }

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -328,6 +328,7 @@ pub struct PrimaryMetrics {
     pub header_max_parent_wait_ms: IntCounter,
     /// Counts when the GC loop in synchronizer times out waiting for consensus commit.
     pub synchronizer_gc_timeout: IntCounter,
+    pub proposal_counter_booster_diff: Histogram,
 }
 
 impl PrimaryMetrics {
@@ -511,6 +512,12 @@ impl PrimaryMetrics {
             synchronizer_gc_timeout: register_int_counter_with_registry!(
                 "synchronizer_gc_timeout",
                 "Counts when the GC loop in synchronizer times out waiting for consensus commit.",
+                registry
+            ).unwrap(),
+            proposal_counter_booster_diff: register_histogram_with_registry!(
+                "proposal_counter_booster_diff",
+                "Diff time for counter the even round booster",
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
         }

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -328,7 +328,7 @@ pub struct PrimaryMetrics {
     pub header_max_parent_wait_ms: IntCounter,
     /// Counts when the GC loop in synchronizer times out waiting for consensus commit.
     pub synchronizer_gc_timeout: IntCounter,
-    pub proposal_counter_booster_diff: Histogram,
+    pub proposal_reset_min_delay: Histogram,
 }
 
 impl PrimaryMetrics {
@@ -514,9 +514,9 @@ impl PrimaryMetrics {
                 "Counts when the GC loop in synchronizer times out waiting for consensus commit.",
                 registry
             ).unwrap(),
-            proposal_counter_booster_diff: register_histogram_with_registry!(
-                "proposal_counter_booster_diff",
-                "Diff time for counter the even round booster",
+            proposal_reset_min_delay: register_histogram_with_registry!(
+                "proposal_reset_min_delay",
+                "When there is a need to re-caliber the min delay",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -328,7 +328,7 @@ pub struct PrimaryMetrics {
     pub header_max_parent_wait_ms: IntCounter,
     /// Counts when the GC loop in synchronizer times out waiting for consensus commit.
     pub synchronizer_gc_timeout: IntCounter,
-    pub proposal_reset_min_delay: Histogram,
+    pub proposal_reset_min_delay: HistogramVec,
 }
 
 impl PrimaryMetrics {
@@ -514,9 +514,10 @@ impl PrimaryMetrics {
                 "Counts when the GC loop in synchronizer times out waiting for consensus commit.",
                 registry
             ).unwrap(),
-            proposal_reset_min_delay: register_histogram_with_registry!(
+            proposal_reset_min_delay: register_histogram_vec_with_registry!(
                 "proposal_reset_min_delay",
                 "When there is a need to re-caliber the min delay",
+                &["direction"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -749,7 +749,7 @@ impl Proposer {
         // Try to correct the proposal timeout based on the last proposed round's avg proposed header time.
         // If we detect that our remaining timeout value is greater than the calculated proposal remaining time,
         // then we reset to the one calculated from the proposal to align with the others.
-        let last_round_start_ts: TimestampMs = Self::calculate_round_start_avg(parents);
+        let last_round_start_ts: TimestampMs = Self::calculate_round_start_median(parents);
         let remaining_until_timeout: Duration = min_delay_timer_deadline.sub(Instant::now());
 
         let remaining_until_time_based_on_network = self.min_header_delay.saturating_sub(

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -348,8 +348,10 @@ impl Proposer {
         // the time the node proposed for the previous round. Then we'll use that to calculate the theoretical
         // remainder of time if the leader was supposed to wait for the full min delay timeout.
         if self.committee.size() > 1
-            && self.round % 2 == 0
-            && self.leader_schedule.leader(self.round).id() == self.authority_id
+            && ((self.round % 2 == 0
+                && self.leader_schedule.leader(self.round).id() == self.authority_id)
+                || (next_round % 2 != 0
+                    && self.committee.leader(next_round).id() == self.authority_id))
         {
             // calculate the round start (propose) of previous round by taking the max header (if not our proposal exists) creation time
             let last_proposal_timestamp: Option<TimestampMs> = if let Some(c) = last_parents
@@ -378,19 +380,6 @@ impl Proposer {
                 return delay.min(self.max_header_delay);
             }
         }
-
-        /*
-        // Give a boost on the odd rounds to a node by using the whole committee here, not just the
-        // nodes of the leader_schedule. By doing this we keep the proposal rate as high as possible
-        // which leads to higher round rate and also acting as a score booster to the less strong nodes
-        // as well.
-        if self.committee.size() > 1
-            && next_round % 2 != 0
-            && self.committee.leader(next_round).id() == self.authority_id
-        {
-            return Duration::ZERO;
-        }
-        */
 
         self.min_header_delay
     }

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -358,7 +358,7 @@ impl Proposer {
                 // we only take the timestamp into account if the earlier timestamp is of the previous round.
                 if self.round - round == 1 {
                     let diff = Duration::from_millis(current_time - ts);
-                    let delay = self.min_header_delay + (self.min_header_delay - diff);
+                    let delay = (2 * self.min_header_delay).saturating_sub(diff);
 
                     debug!(
                         "Setting min_delay to: {delay:?}, with diff: {diff:?} for round {}",

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -357,7 +357,7 @@ impl Proposer {
             if let Some((round, ts)) = last_proposal_timestamp {
                 // we only take the timestamp into account if the earlier timestamp is of the previous round.
                 if self.round - round == 1 {
-                    let diff = Duration::from_millis(ts - current_time);
+                    let diff = Duration::from_millis(current_time - ts);
                     let delay = self.min_header_delay + (self.min_header_delay - diff);
 
                     debug!(

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -803,7 +803,7 @@ impl Proposer {
         // if this node has somehow drifted a lot.
         if ((remaining_until_time_based_on_network + MIN_TIMEOUT_DRIFT) < remaining_until_timeout)
             || (remaining_until_timeout
-                < (remaining_until_time_based_on_network - MIN_TIMEOUT_DRIFT))
+                < (remaining_until_time_based_on_network.saturating_sub(MIN_TIMEOUT_DRIFT)))
         {
             debug!("Resetting min_delay to {remaining_until_time_based_on_network:?} vs {remaining_until_timeout:?}");
 

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -335,8 +335,10 @@ impl Proposer {
         // the next leader.
         let next_round = self.round + 1;
         if self.committee.size() > 1
-            && next_round % 2 == 0
-            && self.leader_schedule.leader(next_round).id() == self.authority_id
+            && ((next_round % 2 == 0
+                && self.leader_schedule.leader(next_round).id() == self.authority_id)
+                || (next_round % 2 != 0
+                    && self.committee.leader(next_round).id() == self.authority_id))
         {
             return Duration::ZERO;
         }
@@ -350,8 +352,8 @@ impl Proposer {
         if self.committee.size() > 1
             && ((self.round % 2 == 0
                 && self.leader_schedule.leader(self.round).id() == self.authority_id)
-                || (next_round % 2 != 0
-                    && self.committee.leader(next_round).id() == self.authority_id))
+                || (self.round % 2 != 0
+                    && self.committee.leader(self.round).id() == self.authority_id))
         {
             // calculate the round start (propose) of previous round by taking the max header (if not our proposal exists) creation time
             let last_proposal_timestamp: Option<TimestampMs> = if let Some(c) = last_parents

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -745,7 +745,7 @@ impl Proposer {
         // Try to correct the proposal timeout based on the last proposed round's avg proposed header time.
         // If we detect that our remaining timeout value is greater than the calculated proposal remaining time,
         // then we reset to the one calculated from the proposal to align with the others.
-        let last_round_start_ts: TimestampMs = Self::calculate_round_start_median(parents);
+        let last_round_start_ts: TimestampMs = Self::calculate_round_start_avg(parents);
         let remaining_until_timeout: Duration = min_delay_timer_deadline.sub(Instant::now());
 
         let remaining_until_time_based_on_network = self.min_header_delay.saturating_sub(
@@ -769,6 +769,7 @@ impl Proposer {
         None
     }
 
+    #[allow(dead_code)]
     fn calculate_round_start_median(round_certificates: &[Certificate]) -> TimestampMs {
         let mut start_timestamps: Vec<TimestampMs> = round_certificates
             .iter()
@@ -786,5 +787,14 @@ impl Proposer {
             let middle_right = start_timestamps[len / 2];
             (middle_left + middle_right) / 2
         }
+    }
+
+    #[allow(dead_code)]
+    fn calculate_round_start_avg(round_certificates: &[Certificate]) -> TimestampMs {
+        round_certificates
+            .iter()
+            .map(|c| *c.header().created_at())
+            .sum::<TimestampMs>()
+            / round_certificates.len() as u64
     }
 }


### PR DESCRIPTION
## Description 

This PR is attempting to normalise the min_timeout timer to ensure that a validator:
* **is not attempting to propose too soon** (unless they are the next round leader - in this case we want them to propose as soon as they receive a quorum of certificates)
* **is not attempting to propose too late**  (so they are practically proposing much later than others and eventually miss the round)

I've attempted various iterations, but the one presented lately is the one that gave the most stable results. From some private-testnet experiments I've managed to get similar performance we currently have in terms of latency and throughput, but now with much more stable score results:

**Benchmark tx rate: 5K tps**

<img width="1711" alt="Screenshot 2023-08-17 at 20 35 33" src="https://github.com/MystenLabs/sui/assets/17335598/9b48f9ce-d8fd-4409-8e48-f6d1d86dfa56">

<img width="1703" alt="Screenshot 2023-08-17 at 20 51 47" src="https://github.com/MystenLabs/sui/assets/17335598/68d012db-c88c-4faf-97aa-b5cef321f19c">

<img width="1700" alt="Screenshot 2023-08-18 at 14 22 48" src="https://github.com/MystenLabs/sui/assets/17335598/8a76f3b0-527d-47ac-853b-95ee9980c9b4">


validator scores and latency **before** the changes

<img width="1699" alt="Screenshot 2023-08-17 at 20 35 20" src="https://github.com/MystenLabs/sui/assets/17335598/37a33a76-014b-4e47-a105-469a325d43d3">

<img width="1702" alt="Screenshot 2023-08-17 at 20 51 31" src="https://github.com/MystenLabs/sui/assets/17335598/929a82d0-2da2-4a2e-9f6b-b0f172a537d3">

<img width="1704" alt="Screenshot 2023-08-18 at 14 21 44" src="https://github.com/MystenLabs/sui/assets/17335598/fcc0c686-d791-49f8-a813-c5e2cab2d056">


validator scores and latency **after** the changes

We can see that latencies don't differ much, but the p95 appears to be less stable when the changes applied. However, the scores are much more stable compared to before.

For what is worth, an experiment has been done by removing completely the rule that zeros the min delay to give a boost to the leader. We can see the scores here:

<img width="1703" alt="Screenshot 2023-08-18 at 14 11 32" src="https://github.com/MystenLabs/sui/assets/17335598/71309150-213e-4ea8-a69f-1f47819ba0dd">

<img width="1705" alt="Screenshot 2023-08-18 at 14 23 26" src="https://github.com/MystenLabs/sui/assets/17335598/1a4413ba-796f-48b2-a426-91ae746e5fbd">

<img width="1710" alt="Screenshot 2023-08-18 at 14 24 12" src="https://github.com/MystenLabs/sui/assets/17335598/a8ece0a8-5eb3-4ca9-84ec-14489178f9b8">



we can observe that the scores are formed even more "aggressively" as now no validator gets boosted, so they do their best based on their resources.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
