### PR TITLE
[graphql] Data provider trait followup

### DIFF
--- a/crates/sui-graphql-rpc/src/server/context_ext.rs
+++ b/crates/sui-graphql-rpc/src/server/context_ext.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::server::data_provider::DataProvider;
+use async_graphql::Context;
+
+pub(crate) trait DataProviderContextExt {
+    fn data_provider(&self) -> &dyn DataProvider;
+}
+
+impl DataProviderContextExt for Context<'_> {
+    fn data_provider(&self) -> &dyn DataProvider {
+        &**self.data_unchecked::<Box<dyn DataProvider>>()
+    }
+}

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod context_ext;
 pub mod data_provider;
-pub mod json_rpc_data_provider;
 pub mod simple_server;
+pub mod sui_sdk_data_provider;
 mod version;

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -4,7 +4,6 @@
 use crate::{
     server::{
         data_provider::DataProvider,
-        json_rpc_data_provider::JsonRpcDataProvider,
         version::{check_version_middleware, set_version_middleware},
     },
     types::query::{Query, SuiGraphQLSchema},
@@ -68,8 +67,7 @@ pub async fn start_example_server(config: Option<ServerConfig>) {
         .await
         .expect("Failed to create SuiClient");
 
-    let data_provider: Box<dyn DataProvider> =
-        Box::new(JsonRpcDataProvider::new(sui_sdk_client_v0));
+    let data_provider: Box<dyn DataProvider> = Box::new(sui_sdk_client_v0);
 
     let schema = async_graphql::Schema::build(Query, EmptyMutation, EmptySubscription)
         .data(data_provider)

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::{connection::Connection, *};
 
-use crate::server::data_provider::DataProvider;
+use crate::server::context_ext::DataProviderContextExt;
 
 use super::{
     balance::{Balance, BalanceConnection},
@@ -59,15 +59,15 @@ impl Address {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        let data_provider = ctx.data_unchecked::<Box<dyn DataProvider>>();
-        data_provider
+        ctx.data_provider()
             .fetch_owned_objs(&self.address, first, after, last, before, filter)
             .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
-        let data_provider = ctx.data_unchecked::<Box<dyn DataProvider>>();
-        data_provider.fetch_balance(&self.address, type_).await
+        ctx.data_provider()
+            .fetch_balance(&self.address, type_)
+            .await
     }
 
     pub async fn balance_connection(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -12,7 +12,7 @@ use super::{
     sui_address::SuiAddress,
     transaction_block::TransactionBlock,
 };
-use crate::{server::data_provider::DataProvider, types::base64::Base64};
+use crate::{server::context_ext::DataProviderContextExt, types::base64::Base64};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct Object {
@@ -76,9 +76,7 @@ impl Object {
         ctx: &Context<'_>,
     ) -> Result<Option<TransactionBlock>> {
         if let Some(tx) = &self.previous_transaction {
-            ctx.data_unchecked::<Box<dyn DataProvider>>()
-                .fetch_tx(tx)
-                .await
+            ctx.data_provider().fetch_tx(tx).await
         } else {
             Ok(None)
         }
@@ -107,13 +105,13 @@ impl Object {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        ctx.data_unchecked::<Box<dyn DataProvider>>()
+        ctx.data_provider()
             .fetch_owned_objs(&self.address, first, after, last, before, filter)
             .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
-        ctx.data_unchecked::<Box<dyn DataProvider>>()
+        ctx.data_provider()
             .fetch_balance(&self.address, type_)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::server::data_provider::DataProvider;
+use crate::server::context_ext::DataProviderContextExt;
 use crate::types::balance::*;
 use crate::types::coin::*;
 use crate::types::name_service::*;
@@ -107,13 +107,13 @@ impl Owner {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
-        ctx.data_unchecked::<Box<dyn DataProvider>>()
+        ctx.data_provider()
             .fetch_owned_objs(&self.address, first, after, last, before, filter)
             .await
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
-        ctx.data_unchecked::<Box<dyn DataProvider>>()
+        ctx.data_provider()
             .fetch_balance(&self.address, type_)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::*;
 
-use crate::server::data_provider::DataProvider;
+use crate::server::context_ext::DataProviderContextExt;
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct ProtocolConfigAttr {
@@ -30,7 +30,7 @@ pub(crate) struct ProtocolConfigs {
 impl ProtocolConfigs {
     async fn configs(&self, ctx: &Context<'_>) -> Result<Option<Vec<ProtocolConfigAttr>>> {
         Ok(Some(
-            ctx.data_unchecked::<Box<dyn DataProvider>>()
+            ctx.data_provider()
                 .fetch_protocol_config(None)
                 .await?
                 .configs,
@@ -42,7 +42,7 @@ impl ProtocolConfigs {
         ctx: &Context<'_>,
     ) -> Result<Option<Vec<ProtocolConfigFeatureFlag>>> {
         Ok(Some(
-            ctx.data_unchecked::<Box<dyn DataProvider>>()
+            ctx.data_provider()
                 .fetch_protocol_config(None)
                 .await?
                 .feature_flags,
@@ -51,7 +51,7 @@ impl ProtocolConfigs {
 
     async fn protocol_version(&self, ctx: &Context<'_>) -> Result<u64> {
         Ok(ctx
-            .data_unchecked::<Box<dyn DataProvider>>()
+            .data_provider()
             .fetch_protocol_config(None)
             .await?
             .protocol_version)


### PR DESCRIPTION
## Description 

1. Implement DataProvider trait directly on sui_sdk
2. Extend Context struct so we can avoid having to write ctx.data_unchecked everywhere
3. Caught a potential bug where we were erroneously still expecting sui_sdk

## Test Plan 

Verified that the following query returns an expected result:
<img width="1412" alt="Screenshot 2023-08-17 at 2 15 10 PM" src="https://github.com/MystenLabs/sui/assets/127570466/8e447705-601f-4c7c-803c-0fddef0a8ebe">

```
query:
{
  address(
    address: "0xefa434f1441f5d61bfb5f3d9a26e494e8fcaef87a69cd9ce639d6b648cc8a512"
  ) {
    balance {
      totalBalance
    }
    objectConnection(first:10) {
      edges {
        node {
          version, digest, kind
        }
      }
    }
  }
  object(address:"0x0000b4e82142db2a8b933ea453f37c26ba6144d6d4a670f22153e9a4a9ef0142") {
    version, previousTransactionBlock {
      bcs
    }, objectConnection(first: 10) {
      edges {
        node {
          version
        }
      }
    }
  }
  protocolConfig {
    	protocolVersion
  }
  chainIdentifier
}
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
