### PR TITLE
[move-compiler] A fix to the freeze wrapped linter

### DIFF
--- a/crates/sui-move-build/src/linters/freeze_wrapped.rs
+++ b/crates/sui-move-build/src/linters/freeze_wrapped.rs
@@ -119,11 +119,11 @@ impl TypingVisitor for FreezeWrappedVisitor {
             }) {
                 let Some(bt) = base_type(&fun.type_arguments[0]) else {
                         // not an (potentially dereferenced) N::Type_::Apply nor N::Type_::Param
-                        return true;
+                        return false;
                     };
                 let N::Type_::Apply(_,tname, _) = &bt.value else {
                         // not a struct type
-                        return true;
+                        return false;
                     };
                 let N::TypeName_::ModuleType(mident, sname) = tname.value else {
                         // struct with a given name not found
@@ -147,8 +147,8 @@ impl TypingVisitor for FreezeWrappedVisitor {
                     );
                 }
             }
-            return true;
         }
+        // always return false to process arguments of the call
         false
     }
 }

--- a/crates/sui-move-build/tests/linter/freeze_wrapped.exp
+++ b/crates/sui-move-build/tests/linter/freeze_wrapped.exp
@@ -59,3 +59,25 @@ warning[Lint W04001]: attempting to freeze wrapped objects
    │
    = This warning can be suppressed with '#[lint_allow(freeze_wrapped)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+warning[Lint W04001]: attempting to freeze wrapped objects
+   ┌─ tests/linter/freeze_wrapped.move:64:40
+   │
+15 │         inner: Inner,
+   │                ----- The field of this type is a wrapped object
+   ·
+64 │         transfer::public_freeze_object({ transfer::public_freeze_object(w1) ; w2});
+   │                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
+   │
+   = This warning can be suppressed with '#[lint_allow(freeze_wrapped)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04001]: attempting to freeze wrapped objects
+   ┌─ tests/linter/freeze_wrapped.move:64:73
+   │
+15 │         inner: Inner,
+   │                ----- The field of this type is a wrapped object
+   ·
+64 │         transfer::public_freeze_object({ transfer::public_freeze_object(w1) ; w2});
+   │                                                                         ^^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
+   │
+   = This warning can be suppressed with '#[lint_allow(freeze_wrapped)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/crates/sui-move-build/tests/linter/freeze_wrapped.move
+++ b/crates/sui-move-build/tests/linter/freeze_wrapped.move
@@ -59,4 +59,9 @@ module 0x42::test {
     public fun freeze_indirect_gen<T: key + store>(w: IndirectGenWrapper<T>) {
         transfer::public_freeze_object(w);
     }
+
+    public fun freeze_arg(w1: Wrapper, w2: Wrapper) {
+        transfer::public_freeze_object({ transfer::public_freeze_object(w1) ; w2});
+    }
+
 }


### PR DESCRIPTION
## Description 

The original implementation of the freeze wrapped linter (https://github.com/MystenLabs/sui/pull/13194) had a bug - arguments to the transfer function were not processed to look for other cases where the linter warning should kick in. The case would have to look similarly to the example below, which makes it pretty unlikely, but still...

```
    public fun freeze_arg(w1: Wrapper, w2: Wrapper) {
        transfer::public_freeze_object({ transfer::public_freeze_object(w1) ; w2});
    }
```

## Test Plan 

Added a test capturing the missing bit (same as example above)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
