### PR TITLE
[explorer]: auto expand transaction cards

### DIFF
--- a/apps/explorer/src/pages/transaction-result/programmable-transaction-view/TransactionsCard.tsx
+++ b/apps/explorer/src/pages/transaction-result/programmable-transaction-view/TransactionsCard.tsx
@@ -14,8 +14,6 @@ interface TransactionsCardProps {
 }
 
 export function TransactionsCard({ transactions }: TransactionsCardProps) {
-	const defaultOpen = transactions.length < DEFAULT_ITEMS_TO_SHOW;
-
 	if (!transactions?.length) {
 		return null;
 	}
@@ -24,7 +22,7 @@ export function TransactionsCard({ transactions }: TransactionsCardProps) {
 		const [[type, data]] = Object.entries(transaction);
 
 		return (
-			<TransactionBlockCardSection key={index} title={type} defaultOpen={defaultOpen}>
+			<TransactionBlockCardSection defaultOpen key={index} title={type}>
 				<div data-testid="transactions-card-content">
 					<Transaction key={index} type={type} data={data} />
 				</div>
@@ -39,7 +37,7 @@ export function TransactionsCard({ transactions }: TransactionsCardProps) {
 			itemsLabel={transactions.length > 1 ? 'Transactions' : 'Transaction'}
 			count={transactions.length}
 			defaultItemsToShow={DEFAULT_ITEMS_TO_SHOW}
-			noExpandableList={defaultOpen}
+			noExpandableList={transactions.length < DEFAULT_ITEMS_TO_SHOW}
 		/>
 	);
 }


### PR DESCRIPTION
## Description 

- @mystie711 requested to auto-expand the txn card on txn block page when opening

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
