### PR TITLE
[docs/entry] Runnable examples for entry function docs

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -3,7 +3,7 @@
 
 use move_cli::base::test::UnitTestResult;
 use move_unit_test::UnitTestingConfig;
-use std::path::PathBuf;
+use std::{path::PathBuf, io, fs};
 use sui_move::unit_test::run_move_unit_tests;
 use sui_move_build::BuildConfig;
 
@@ -56,6 +56,25 @@ fn run_examples_move_unit_tests() {
             buf
         });
     }
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn run_docs_examples_move_unit_tests() -> io::Result<()> {
+    let examples = {
+        let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        buf.extend(["..", "..", "examples", "sui-move"]);
+        buf
+    };
+
+    for entry in fs::read_dir(examples)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            check_move_unit_tests(entry.path());
+        }
+    }
+
+    Ok(())
 }
 
 #[test]

--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -3,7 +3,7 @@
 
 use move_cli::base::test::UnitTestResult;
 use move_unit_test::UnitTestingConfig;
-use std::{path::PathBuf, io, fs};
+use std::{fs, io, path::PathBuf};
 use sui_move::unit_test::run_move_unit_tests;
 use sui_move_build::BuildConfig;
 

--- a/examples/sui-move/entry_functions/Move.toml
+++ b/examples/sui-move/entry_functions/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "entry_functions"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+entry_functions = "0x0"

--- a/examples/sui-move/entry_functions/sources/example.move
+++ b/examples/sui-move/entry_functions/sources/example.move
@@ -1,0 +1,37 @@
+module entry_functions::example {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Foo has key {
+        id: UID,
+        bar: u64,
+    }
+
+    /// Entry functions can accept a reference to the `TxContext`
+    /// (mutable or immutable) as their last parameter.
+    entry fun share(bar: u64, ctx: &mut TxContext) {
+        transfer::share_object(Foo {
+            id: object::new(ctx),
+            bar,
+        })
+    }
+
+    /// Parameters passed to entry functions called in a programmable
+    /// transaction block (like `foo`, below) must be inputs to the
+    /// transaction block, and not results of previous transactions.
+    entry fun update(foo: &mut Foo, ctx: &TxContext) {
+        foo.bar = tx_context::epoch(ctx);
+    }
+
+    /// Entry functions can return types that have `drop`.
+    entry fun bar(foo: &Foo): u64 {
+        foo.bar
+    }
+
+    /// This function cannot be `entry` because it returns a value
+    /// that does not have `drop`.
+    public fun foo(ctx: &mut TxContext): Foo {
+        Foo { id: object::new(ctx), bar: 0 }
+    }
+}

--- a/examples/sui-move/entry_functions/sources/example.move
+++ b/examples/sui-move/entry_functions/sources/example.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module entry_functions::example {
     use sui::object::{Self, UID};
     use sui::transfer;


### PR DESCRIPTION
## Description

Some examples of functions that are and are not entry functions, to be used as part of Sui docs.

This PR also introduces a new home for sui-move examples (i.e. to port examples from `sui_programmability`).

## Test Plan

```
sui$ cargo build --bin sui
sui$ ~/sui/target/debug/sui move build -p ~/sui/examples/sui-move/entry_function
sui-framework-test$ cargo nextest run
```