### PR TITLE
[explorer] lowercase SuiNS domain names when performing searches

### DIFF
--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -62,7 +62,7 @@ const getResultsForCheckpoint = async (client: SuiClient, query: string) => {
 
 const getResultsForAddress = async (client: SuiClient, query: string, suiNSEnabled: boolean) => {
 	if (suiNSEnabled && isSuiNSName(query)) {
-		const resolved = await client.resolveNameServiceAddress({ name: query });
+		const resolved = await client.resolveNameServiceAddress({ name: query.toLowerCase() });
 		if (!resolved) return null;
 		return [
 			{


### PR DESCRIPTION
## Description 

All SuiNS domain names are lowercase, so we should lowercase the query when doing the domain look-up from Sui Explorer.

## Test Plan 
- Manual testing (Scam.sui returns results now)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
