### PR TITLE
[1/2] Move TempStore and GasCharger to execution layer

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -90,7 +90,7 @@ use sui_types::effects::{
 use sui_types::error::{ExecutionError, UserInputError};
 use sui_types::event::{Event, EventID};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::gas::{GasCharger, GasCostSummary, SuiGasStatus};
+use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents, CheckpointContentsDigest,
@@ -1181,7 +1181,6 @@ impl AuthorityState {
         let transaction_dependencies = input_objects.transaction_dependencies();
         let transaction_data = &certificate.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
-        let mut gas_charger = GasCharger::new(tx_digest, gas, gas_status, protocol_config);
         let (inner_temp_store, effects, execution_error_opt) =
             epoch_store.executor().execute_transaction_to_effects(
                 self.database.clone(),
@@ -1199,7 +1198,8 @@ impl AuthorityState {
                     .epoch_start_timestamp(),
                 input_objects,
                 shared_object_refs,
-                &mut gas_charger,
+                gas,
+                gas_status,
                 kind,
                 signer,
                 tx_digest,
@@ -1305,12 +1305,8 @@ impl AuthorityState {
                     .epoch_start_timestamp(),
                 input_objects,
                 shared_object_refs,
-                &mut GasCharger::new(
-                    transaction_digest,
-                    gas_object_refs,
-                    gas_status,
-                    protocol_config,
-                ),
+                gas_object_refs,
+                gas_status,
                 kind,
                 signer,
                 transaction_digest,
@@ -1433,12 +1429,8 @@ impl AuthorityState {
                 .epoch_start_timestamp(),
             input_objects,
             shared_object_refs,
-            &mut GasCharger::new(
-                transaction_digest,
-                vec![gas_object_ref],
-                gas_status,
-                protocol_config,
-            ),
+            vec![gas_object_ref],
+            gas_status,
             transaction_kind,
             sender,
             transaction_digest,

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -41,7 +41,7 @@ use sui_types::metrics::LimitsMetrics;
 use sui_types::object::{Object, Owner};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState, SuiSystemStateTrait};
-use sui_types::temporary_store::{InnerTemporaryStore, TemporaryStore};
+use sui_types::temporary_store::InnerTemporaryStore;
 use sui_types::transaction::{CallArg, Command, InputObjectKind, InputObjects, Transaction};
 use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS};
 use tracing::trace;
@@ -808,13 +808,6 @@ fn create_genesis_transaction(
     let genesis_digest = *genesis_transaction.digest();
     // execute txn to effects
     let (effects, events, objects) = {
-        let temporary_store = TemporaryStore::new(
-            InMemoryStorage::new(Vec::new()),
-            InputObjects::new(vec![]),
-            genesis_digest,
-            protocol_config,
-        );
-
         let silent = true;
         let paranoid_checks = false;
         let executor = sui_execution::executor(protocol_config, paranoid_checks, silent)
@@ -828,13 +821,14 @@ fn create_genesis_transaction(
         let transaction_dependencies = BTreeSet::new();
         let (inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
+                InMemoryStorage::new(Vec::new()),
                 protocol_config,
                 metrics,
                 expensive_checks,
                 &certificate_deny_set,
                 &epoch_data.epoch_id(),
                 epoch_data.epoch_start_timestamp(),
-                temporary_store,
+                InputObjects::new(vec![]),
                 shared_object_refs,
                 &mut GasCharger::new_unmetered(genesis_digest),
                 kind,
@@ -960,12 +954,6 @@ fn process_package(
         .collect();
 
     let genesis_digest = ctx.digest();
-    let mut temporary_store = TemporaryStore::new(
-        store.clone(),
-        InputObjects::new(loaded_dependencies),
-        genesis_digest,
-        protocol_config,
-    );
     let module_bytes = modules
         .iter()
         .map(|m| {
@@ -980,18 +968,17 @@ fn process_package(
         builder.command(Command::Publish(module_bytes, dependencies));
         builder.finish()
     };
-    executor.update_genesis_state(
-        protocol_config,
-        metrics,
-        &mut temporary_store,
-        ctx,
-        &mut GasCharger::new_unmetered(genesis_digest),
-        pt,
-    )?;
-
     let InnerTemporaryStore {
         written, deleted, ..
-    } = temporary_store.into_inner();
+    } = executor.update_genesis_state(
+        store.clone(),
+        protocol_config,
+        metrics,
+        ctx,
+        &mut GasCharger::new_unmetered(genesis_digest),
+        InputObjects::new(loaded_dependencies),
+        pt,
+    )?;
 
     let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written, deleted);
@@ -1015,12 +1002,6 @@ pub fn generate_genesis_system_object(
     let protocol_config = ProtocolConfig::get_for_version(
         ProtocolVersion::new(genesis_chain_parameters.protocol_version),
         sui_protocol_config::Chain::Unknown,
-    );
-    let mut temporary_store = TemporaryStore::new(
-        store.clone(),
-        InputObjects::new(vec![]),
-        genesis_digest,
-        &protocol_config,
     );
 
     let pt = {
@@ -1075,18 +1056,17 @@ pub fn generate_genesis_system_object(
         builder.finish()
     };
 
-    executor.update_genesis_state(
-        &protocol_config,
-        metrics,
-        &mut temporary_store,
-        genesis_ctx,
-        &mut GasCharger::new_unmetered(genesis_digest),
-        pt,
-    )?;
-
     let InnerTemporaryStore {
         written, deleted, ..
-    } = temporary_store.into_inner();
+    } = executor.update_genesis_state(
+        store.clone(),
+        &protocol_config,
+        metrics,
+        genesis_ctx,
+        &mut GasCharger::new_unmetered(genesis_digest),
+        InputObjects::new(vec![]),
+        pt,
+    )?;
 
     let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written, deleted);

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -29,7 +29,7 @@ use sui_types::crypto::{
 };
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::epoch_data::EpochData;
-use sui_types::gas::GasCharger;
+use sui_types::gas::SuiGasStatus;
 use sui_types::gas_coin::GasCoin;
 use sui_types::governance::StakedSui;
 use sui_types::in_memory_storage::InMemoryStorage;
@@ -830,7 +830,8 @@ fn create_genesis_transaction(
                 epoch_data.epoch_start_timestamp(),
                 InputObjects::new(vec![]),
                 shared_object_refs,
-                &mut GasCharger::new_unmetered(genesis_digest),
+                vec![],
+                SuiGasStatus::new_unmetered(),
                 kind,
                 signer,
                 genesis_digest,
@@ -953,7 +954,6 @@ fn process_package(
         })
         .collect();
 
-    let genesis_digest = ctx.digest();
     let module_bytes = modules
         .iter()
         .map(|m| {
@@ -975,7 +975,6 @@ fn process_package(
         protocol_config,
         metrics,
         ctx,
-        &mut GasCharger::new_unmetered(genesis_digest),
         InputObjects::new(loaded_dependencies),
         pt,
     )?;
@@ -995,7 +994,6 @@ pub fn generate_genesis_system_object(
     token_distribution_schedule: &TokenDistributionSchedule,
     metrics: Arc<LimitsMetrics>,
 ) -> anyhow::Result<()> {
-    let genesis_digest = genesis_ctx.digest();
     // We don't know the chain ID here since we haven't yet created the genesis checkpoint.
     // However since we know there are no chain specific protocol config options in genesis,
     // we use Chain::Unknown here.
@@ -1063,7 +1061,6 @@ pub fn generate_genesis_system_object(
         &protocol_config,
         metrics,
         genesis_ctx,
-        &mut GasCharger::new_unmetered(genesis_digest),
         InputObjects::new(vec![]),
         pt,
     )?;

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -12,12 +12,15 @@ use move_unit_test::{extensions::set_extension_hook, UnitTestingConfig};
 use move_vm_runtime::native_extensions::NativeContextExtensions;
 use once_cell::sync::Lazy;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
-use sui_core::authority::TemporaryStore;
 use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    digests::TransactionDigest, gas_model::tables::initial_cost_schedule_for_unit_tests,
-    in_memory_storage::InMemoryStorage, metrics::LimitsMetrics, transaction::InputObjects,
+    base_types::{ObjectID, SequenceNumber},
+    error::SuiResult,
+    gas_model::tables::initial_cost_schedule_for_unit_tests,
+    metrics::LimitsMetrics,
+    object::Object,
+    storage::ChildObjectResolver,
 };
 
 // Move unit tests will halt after executing this many steps. This is a protection to avoid divergence
@@ -65,14 +68,20 @@ impl Test {
     }
 }
 
-static TEST_STORE: Lazy<TemporaryStore> = Lazy::new(|| {
-    TemporaryStore::new(
-        InMemoryStorage::new(vec![]),
-        InputObjects::new(vec![]),
-        TransactionDigest::random(),
-        &ProtocolConfig::get_for_min_version(),
-    )
-});
+struct DummyChildObjectStore {}
+
+impl ChildObjectResolver for DummyChildObjectStore {
+    fn read_child_object(
+        &self,
+        _parent: &ObjectID,
+        _child: &ObjectID,
+        _child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        Ok(None)
+    }
+}
+
+static TEST_STORE: Lazy<DummyChildObjectStore> = Lazy::new(|| DummyChildObjectStore {});
 
 static SET_EXTENSION_HOOK: Lazy<()> =
     Lazy::new(|| set_extension_hook(Box::new(new_testing_object_and_natives_cost_runtime)));

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -44,7 +44,7 @@ use sui_types::digests::TransactionDigest;
 use sui_types::error::ExecutionError;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::gas::{GasCharger, SuiGasStatus};
+use sui_types::gas::SuiGasStatus;
 use sui_types::metrics::LimitsMetrics;
 use sui_types::object::{Data, Object, Owner};
 use sui_types::storage::get_module_by_id;
@@ -732,7 +732,8 @@ impl LocalExec {
                 epoch_start_timestamp,
                 InputObjects::new(input_objects),
                 tx_info.shared_object_refs.clone(),
-                &mut GasCharger::new(*tx_digest, tx_info.gas.clone(), gas_status, protocol_config),
+                tx_info.gas.clone(),
+                gas_status,
                 override_transaction_kind.unwrap_or(tx_info.kind.clone()),
                 tx_info.sender,
                 *tx_digest,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -26,7 +26,6 @@ use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
 use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_core::authority::AuthorityState;
 use sui_core::authority::NodeStateDump;
-use sui_core::authority::TemporaryStore;
 use sui_core::epoch::epoch_metrics::EpochMetrics;
 use sui_core::module_cache_metrics::ResolverMetrics;
 use sui_core::signature_verifier::SignatureVerifierMetrics;
@@ -373,7 +372,7 @@ impl LocalExec {
                 }
             }
         }
-        error!("No more configs to attempt. Try specifing Full Node RPC URL directly or provide a config file with a valid URL");
+        error!("No more configs to attempt. Try specifying Full Node RPC URL directly or provide a config file with a valid URL");
         Err(ReplayEngineError::UnableToExecuteWithNetworkConfigs { cfgs: cfg })
     }
 
@@ -464,18 +463,6 @@ impl LocalExec {
             executor_version_override: None,
             protocol_version_override: None,
         })
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_temporary_store(
-        &mut self,
-        tx_digest: &TransactionDigest,
-        input_objects: InputObjects,
-        protocol_config: &ProtocolConfig,
-    ) -> TemporaryStore {
-        // Wrap `&mut self` in an `Arc` because of `TemporaryStore`'s interface, not because it will
-        // be shared across multiple threads
-        TemporaryStore::new(Arc::new(self), input_objects, *tx_digest, protocol_config)
     }
 
     pub async fn multi_download_and_store(
@@ -675,6 +662,13 @@ impl LocalExec {
         Ok((succeeded, num as u64))
     }
 
+    // TODO: Could we get rid of this strange self move?
+    #[allow(clippy::wrong_self_convention, clippy::redundant_allocation)]
+    fn to_backing_store(&mut self) -> Arc<&mut LocalExec> {
+        // Execution interface requires Arc for the store.
+        Arc::new(self)
+    }
+
     pub async fn execution_engine_execute_with_tx_info_impl(
         &mut self,
         tx_info: &OnChainTransactionInfo,
@@ -718,27 +712,25 @@ impl LocalExec {
 
         let ov = self.executor_version_override;
 
-        // Temp store for data
-        let temporary_store =
-            self.to_temporary_store(tx_digest, InputObjects::new(input_objects), protocol_config);
-
         // We could probably cache the executor per protocol config
         let executor = get_executor(ov, protocol_config, expensive_safety_check_config);
 
         // All prep done
         let expensive_checks = true;
         let certificate_deny_set = HashSet::new();
+        let store = self.to_backing_store();
         let res = if let Ok(gas_status) =
             SuiGasStatus::new(tx_info.gas_budget, tx_info.gas_price, rgp, protocol_config)
         {
             executor.execute_transaction_to_effects(
+                store,
                 protocol_config,
                 metrics,
                 expensive_checks,
                 &certificate_deny_set,
                 &tx_info.executed_epoch,
                 epoch_start_timestamp,
-                temporary_store,
+                InputObjects::new(input_objects),
                 tx_info.shared_object_refs.clone(),
                 &mut GasCharger::new(*tx_digest, tx_info.gas.clone(), gas_status, protocol_config),
                 override_transaction_kind.unwrap_or(tx_info.kind.clone()),

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -364,7 +364,6 @@ mod test {
     use sui_types::in_memory_storage::InMemoryStorage;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::sui_system_state::SuiSystemStateTrait;
-    use sui_types::temporary_store::TemporaryStore;
     use sui_types::transaction::InputObjects;
 
     #[test]
@@ -391,12 +390,6 @@ mod test {
         let genesis_transaction = genesis.transaction().clone();
 
         let genesis_digest = *genesis_transaction.digest();
-        let temporary_store = TemporaryStore::new(
-            InMemoryStorage::new(Vec::new()),
-            InputObjects::new(vec![]),
-            genesis_digest,
-            &protocol_config,
-        );
 
         let silent = true;
         let paranoid_checks = false;
@@ -416,13 +409,14 @@ mod test {
 
         let (_inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
+                InMemoryStorage::new(Vec::new()),
                 &protocol_config,
                 metrics,
                 expensive_checks,
                 &certificate_deny_set,
                 &epoch.epoch_id(),
                 epoch.epoch_start_timestamp(),
-                temporary_store,
+                InputObjects::new(vec![]),
                 shared_object_refs,
                 &mut GasCharger::new_unmetered(genesis_digest),
                 kind,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -360,7 +360,7 @@ mod test {
     use sui_config::genesis::Genesis;
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::epoch_data::EpochData;
-    use sui_types::gas::GasCharger;
+    use sui_types::gas::SuiGasStatus;
     use sui_types::in_memory_storage::InMemoryStorage;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::sui_system_state::SuiSystemStateTrait;
@@ -418,7 +418,8 @@ mod test {
                 epoch.epoch_start_timestamp(),
                 InputObjects::new(vec![]),
                 shared_object_refs,
-                &mut GasCharger::new_unmetered(genesis_digest),
+                vec![],
+                SuiGasStatus::new_unmetered(),
                 kind,
                 signer,
                 genesis_digest,

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -15,7 +15,7 @@ use sui_types::{
     error::ExecutionError,
     execution::TypeLayoutStore,
     execution_mode::ExecutionResult,
-    gas::GasCharger,
+    gas::SuiGasStatus,
     metrics::LimitsMetrics,
     temporary_store::{BackingStore, InnerTemporaryStore},
     transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
@@ -38,7 +38,9 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
-        gas_charger: &mut GasCharger,
+        // Gas related
+        gas_coins: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
         // Transaction
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
@@ -64,7 +66,9 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
-        gas_charger: &mut GasCharger,
+        // Gas related
+        gas_coins: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
         // Transaction
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
@@ -84,7 +88,6 @@ pub trait Executor {
         metrics: Arc<LimitsMetrics>,
         // Genesis State
         tx_context: &mut TxContext,
-        gas_charger: &mut GasCharger,
         // Transaction
         input_objects: InputObjects,
         pt: ProgrammableTransaction,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -15,12 +15,12 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionState, TypeLayoutStore},
+    execution::TypeLayoutStore,
     execution_mode::{self, ExecutionResult},
     gas::GasCharger,
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    temporary_store::{InnerTemporaryStore, TemporaryStore},
-    transaction::{ProgrammableTransaction, TransactionKind},
+    temporary_store::{BackingStore, InnerTemporaryStore, TemporaryStore},
+    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -76,15 +76,16 @@ impl<'m> Verifier<'m> {
 }
 
 impl executor::Executor for Executor {
-    fn execute_transaction_to_effects(
+    fn execute_transaction_to_effects<'backing>(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        temporary_store: TemporaryStore,
+        input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
         gas_charger: &mut GasCharger,
         transaction_kind: TransactionKind,
@@ -96,6 +97,8 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
+        let temporary_store =
+            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
         execute_transaction_to_effects::<execution_mode::Normal>(
             shared_object_refs,
             temporary_store,
@@ -116,13 +119,14 @@ impl executor::Executor for Executor {
 
     fn dev_inspect_transaction(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        temporary_store: TemporaryStore,
+        input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
         gas_charger: &mut GasCharger,
         transaction_kind: TransactionKind,
@@ -134,6 +138,12 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
+        let temporary_store = TemporaryStore::new_for_mock_transaction(
+            store,
+            input_objects,
+            transaction_digest,
+            protocol_config,
+        );
         execute_transaction_to_effects::<execution_mode::DevInspect>(
             shared_object_refs,
             temporary_store,
@@ -154,22 +164,26 @@ impl executor::Executor for Executor {
 
     fn update_genesis_state(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-        state_view: &mut dyn ExecutionState,
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
+        input_objects: InputObjects,
         pt: ProgrammableTransaction,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,
             &self.0,
-            state_view,
+            &mut temporary_store,
             tx_context,
             gas_charger,
             pt,
-        )
+        )?;
+        Ok(temporary_store.into_inner())
     }
 
     fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,12 +15,12 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionState, TypeLayoutStore},
+    execution::TypeLayoutStore,
     execution_mode::{self, ExecutionResult},
     gas::GasCharger,
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    temporary_store::{InnerTemporaryStore, TemporaryStore},
-    transaction::{ProgrammableTransaction, TransactionKind},
+    temporary_store::{BackingStore, InnerTemporaryStore, TemporaryStore},
+    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -76,15 +76,16 @@ impl<'m> Verifier<'m> {
 }
 
 impl executor::Executor for Executor {
-    fn execute_transaction_to_effects(
+    fn execute_transaction_to_effects<'backing>(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        temporary_store: TemporaryStore,
+        input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
         gas_charger: &mut GasCharger,
         transaction_kind: TransactionKind,
@@ -96,6 +97,8 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
+        let temporary_store =
+            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
         execute_transaction_to_effects::<execution_mode::Normal>(
             shared_object_refs,
             temporary_store,
@@ -116,13 +119,14 @@ impl executor::Executor for Executor {
 
     fn dev_inspect_transaction(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        temporary_store: TemporaryStore,
+        input_objects: InputObjects,
         shared_object_refs: Vec<ObjectRef>,
         gas_charger: &mut GasCharger,
         transaction_kind: TransactionKind,
@@ -134,6 +138,12 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
+        let temporary_store = TemporaryStore::new_for_mock_transaction(
+            store,
+            input_objects,
+            transaction_digest,
+            protocol_config,
+        );
         execute_transaction_to_effects::<execution_mode::DevInspect>(
             shared_object_refs,
             temporary_store,
@@ -154,22 +164,26 @@ impl executor::Executor for Executor {
 
     fn update_genesis_state(
         &self,
+        store: Arc<dyn BackingStore + Send + Sync>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-        state_view: &mut dyn ExecutionState,
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
+        input_objects: InputObjects,
         pt: ProgrammableTransaction,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,
             &self.0,
-            state_view,
+            &mut temporary_store,
             tx_context,
             gas_charger,
             pt,
-        )
+        )?;
+        Ok(temporary_store.into_inner())
     }
 
     fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(


### PR DESCRIPTION
## Description 

This PR makes it such that we always construct TempStore and GasCharger inside execution layer, and there is no more access to either of these two types outside of execution. This sets up the code in the right shape for step 2 of actually moving them.

## Test Plan 

Non functional change, CI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
