### PR TITLE
[move-compiler][sui-mode] Added struct declaration, private generics, and global storage checks

### DIFF
--- a/external-crates/move/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/move-compiler/src/expansion/ast.rs
@@ -666,6 +666,14 @@ impl AbilitySet {
         self.0.contains_(&a)
     }
 
+    pub fn ability_loc(&self, sp!(_, a_): &Ability) -> Option<Loc> {
+        self.0.get_loc_(a_).copied()
+    }
+
+    pub fn ability_loc_(&self, a: Ability_) -> Option<Loc> {
+        self.0.get_loc_(&a).copied()
+    }
+
     // intersection of two sets. Keeps the loc of the first set
     pub fn intersect(&self, other: &Self) -> Self {
         Self(self.0.intersect(&other.0))

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -9,6 +9,7 @@ pub mod id_leak;
 pub mod typing;
 
 pub const INIT_FUNCTION_NAME: Symbol = symbol!("init");
+pub const ID_FIELD_NAME: Symbol = symbol!("id");
 
 pub const STD_ADDR_NAME: Symbol = symbol!("std");
 pub const OPTION_MODULE_NAME: Symbol = symbol!("option");
@@ -40,6 +41,20 @@ pub const SUI_CLOCK_CREATE: Symbol = symbol!("create");
 pub const AUTHENTICATOR_STATE_MODULE_NAME: Symbol = symbol!("authenticator_state");
 pub const AUTHENTICATOR_STATE_TYPE_NAME: Symbol = symbol!("AuthenticatorState");
 pub const AUTHENTICATOR_STATE_CREATE: Symbol = symbol!("create");
+
+pub const EVENT_MODULE_NAME: Symbol = symbol!("event");
+pub const EVENT_FUNCTION_NAME: Symbol = symbol!("emit");
+
+pub const TRANSFER_MODULE_NAME: Symbol = symbol!("transfer");
+pub const TRANSFER_FUNCTION_NAME: Symbol = symbol!("transfer");
+pub const FREEZE_FUNCTION_NAME: Symbol = symbol!("freeze_object");
+pub const SHARE_FUNCTION_NAME: Symbol = symbol!("share_object");
+
+pub const PRIVATE_TRANSFER_FUNCTIONS: &[Symbol] = &[
+    TRANSFER_FUNCTION_NAME,
+    FREEZE_FUNCTION_NAME,
+    SHARE_FUNCTION_NAME,
+];
 
 //**************************************************************************************************
 // Diagnostics
@@ -100,4 +115,32 @@ pub const INIT_CALL_DIAG: DiagnosticInfo = custom(
     /* category */ TYPING,
     /* code */ 6,
     "invalid 'init' call",
+);
+pub const OBJECT_DECL_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 7,
+    "invalid object declaration",
+);
+pub const EVENT_EMIT_CALL_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 8,
+    "invalid event",
+);
+pub const PRIVATE_TRANSFER_CALL_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 9,
+    "invalid private transfer call",
+);
+pub const GLOBAL_STORAGE_DIAG: DiagnosticInfo = custom(
+    SUI_DIAG_PREFIX,
+    Severity::NonblockingError,
+    /* category */ TYPING,
+    /* code */ 9,
+    "invalid global storage usage",
 );

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -142,5 +142,5 @@ pub const GLOBAL_STORAGE_DIAG: DiagnosticInfo = custom(
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 9,
-    "invalid global storage usage",
+    "global storage is not supported in Sui",
 );

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -9,21 +9,17 @@ use crate::{
     diagnostics::WarningFilters,
     editions::Flavor,
     expansion::ast::{AbilitySet, AttributeName_, Fields, ModuleIdent, Visibility},
-    naming::ast::{self as N, BuiltinTypeName_, FunctionSignature, Type, TypeName_, Type_, Var},
+    naming::ast::{
+        self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
+    },
     parser::ast::{Ability_, FunctionName, StructName},
     shared::{
         known_attributes::{KnownAttribute, TestingAttribute},
         CompilationEnv, Identifier,
     },
-    sui_mode::{
-        ASCII_MODULE_NAME, ASCII_TYPE_NAME, CLOCK_MODULE_NAME, CLOCK_TYPE_NAME,
-        ENTRY_FUN_SIGNATURE_DIAG, ID_TYPE_NAME, INIT_CALL_DIAG, INIT_FUN_DIAG, OBJECT_MODULE_NAME,
-        OPTION_MODULE_NAME, OPTION_TYPE_NAME, OTW_DECL_DIAG, OTW_USAGE_DIAG, SCRIPT_DIAG,
-        STD_ADDR_NAME, SUI_ADDR_NAME, SUI_MODULE_NAME, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_TYPE_NAME, UTF_MODULE_NAME, UTF_TYPE_NAME,
-    },
+    sui_mode::*,
     typing::{
-        ast as T,
+        ast::{self as T, ModuleCall},
         core::{ability_not_satisfied_tips, error_format, error_format_, Subst, TypingProgramInfo},
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
@@ -54,27 +50,34 @@ impl TypingVisitorConstructor for SuiTypeChecks {
 pub struct Context<'a> {
     env: &'a mut CompilationEnv,
     info: &'a TypingProgramInfo,
+    sui_transfer_ident: Option<ModuleIdent>,
     current_module: Option<ModuleIdent>,
-    upper_module: Option<Symbol>,
+    otw_name: Option<Symbol>,
     one_time_witness: Option<Result<StructName, ()>>,
     in_test: bool,
 }
 
 impl<'a> Context<'a> {
     fn new(env: &'a mut CompilationEnv, info: &'a TypingProgramInfo) -> Self {
+        let sui_module_ident = info
+            .modules
+            .key_cloned_iter()
+            .find(|(m, _)| m.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME))
+            .map(|(m, _)| m);
         Context {
             env,
-            current_module: None,
-            upper_module: None,
-            one_time_witness: None,
             info,
+            sui_transfer_ident: sui_module_ident,
+            current_module: None,
+            otw_name: None,
+            one_time_witness: None,
             in_test: false,
         }
     }
 
     fn set_module(&mut self, current_module: ModuleIdent) {
         self.current_module = Some(current_module);
-        self.upper_module = Some(Symbol::from(
+        self.otw_name = Some(Symbol::from(
             current_module.value.module.0.value.as_str().to_uppercase(),
         ));
         self.one_time_witness = None;
@@ -84,8 +87,8 @@ impl<'a> Context<'a> {
         self.current_module.as_ref().unwrap()
     }
 
-    fn upper_module(&self) -> Symbol {
-        self.upper_module.unwrap()
+    fn otw_name(&self) -> Symbol {
+        self.otw_name.unwrap()
     }
 }
 
@@ -94,6 +97,9 @@ const OTW_NOTE: &str = "One-time witness types are structs with the following re
                         they have no fields (or a single boolean field), \
                         they have no type parameters, \
                         and they have only the 'drop' ability.";
+const GLOBAL_NOTE: &str = "Global storage is not used in Sui. \
+                        Instead objects (structs with the 'key' ability) are used with \
+                        programmable transaction blocks and the 'sui::transfer' functions.";
 
 //**************************************************************************************************
 // Entry
@@ -139,23 +145,27 @@ impl<'a> TypingVisitorContext for Context<'a> {
                 AttributeName_::Known(KnownAttribute::Testing(TestingAttribute::TestOnly))
             )
         });
-        if let Some(sdef) = mdef.structs.get_(&self.upper_module()) {
+        if let Some(sdef) = mdef.structs.get_(&self.otw_name()) {
             let valid_fields = if let N::StructFields::Defined(fields) = &sdef.fields {
                 invalid_otw_field_loc(fields).is_none()
             } else {
                 true
             };
             if valid_fields {
-                let name = mdef.structs.get_full_key_(&self.upper_module()).unwrap();
+                let name = mdef.structs.get_full_key_(&self.otw_name()).unwrap();
                 check_otw_type(self, name, sdef, None)
             }
         }
 
-        if let Some(fdef) = mdef.functions.get_(&symbol!("init")) {
-            let name = mdef.functions.get_full_key_(&symbol!("init")).unwrap();
+        if let Some(fdef) = mdef.functions.get_(&INIT_FUNCTION_NAME) {
+            let name = mdef.functions.get_full_key_(&INIT_FUNCTION_NAME).unwrap();
             init_signature(self, name, &fdef.signature)
         }
-        self.in_test = false;
+
+        for (name, sdef) in mdef.structs.key_cloned_iter() {
+            struct_def(self, name, sdef)
+        }
+
         // do not skip module
         false
     }
@@ -179,7 +189,82 @@ impl<'a> TypingVisitorContext for Context<'a> {
     }
 }
 
-//**********************************************************************************************
+//**************************************************************************************************
+// Structs
+//**************************************************************************************************
+
+fn struct_def(context: &mut Context, name: StructName, sdef: &N::StructDefinition) {
+    const KEY_MSG: &str = "The 'key' ability is used to declare objects in Sui";
+    let N::StructDefinition {
+        warning_filter: _,
+        index: _,
+        attributes: _,
+        abilities,
+        type_parameters: _,
+        fields,
+    } = sdef;
+    let Some(key_loc) = abilities.ability_loc_(Ability_::Key) else {
+        // not an object, no extra rules
+        return;
+    };
+
+    let StructFields::Defined(fields) = fields else { return };
+    let invalid_first_field = if fields.is_empty() {
+        // no fields
+        Some(name.loc())
+    } else {
+        let (first_field_loc, first_field_name, _) =
+            fields.iter().find(|(_, _, (idx, _))| *idx == 0).unwrap();
+        if *first_field_name != ID_FIELD_NAME {
+            Some(first_field_loc)
+        } else {
+            None
+        }
+    };
+    if let Some(loc) = invalid_first_field {
+        // no fields or an invalid 'id' field
+        let msg = format!(
+            "Invalid object '{}'. \
+            Structs with the '{}' ability must have '{}: {}::{}::{}' as their first field",
+            name,
+            Ability_::Key,
+            ID_FIELD_NAME,
+            SUI_ADDR_NAME,
+            OBJECT_MODULE_NAME,
+            UID_TYPE_NAME
+        );
+        context
+            .env
+            .add_diag(diag!(OBJECT_DECL_DIAG, (loc, msg), (key_loc, KEY_MSG)));
+    };
+
+    let Some((_, id_field_type)) = fields.get_(&ID_FIELD_NAME) else {
+        // no id field, but that case is already indirectly covered above
+        return
+    };
+    let id_field_loc = fields.get_loc_(&ID_FIELD_NAME).unwrap();
+    if !id_field_type
+        .value
+        .is(SUI_ADDR_NAME, OBJECT_MODULE_NAME, UID_TYPE_NAME)
+    {
+        let expected = format!(
+            "Invalid object. Expected the '{}' field to have type '{}::{}::{}'",
+            ID_FIELD_NAME, SUI_ADDR_NAME, OBJECT_MODULE_NAME, UID_TYPE_NAME
+        );
+        let actual = format!(
+            "But found type: {}",
+            error_format(id_field_type, &Subst::empty())
+        );
+        context.env.add_diag(diag!(
+            OBJECT_DECL_DIAG,
+            (*id_field_loc, expected),
+            (id_field_type.loc, actual),
+            (key_loc, KEY_MSG.to_string()),
+        ));
+    }
+}
+
+//**************************************************************************************************
 // Functions
 //**********************************************************************************************
 
@@ -187,7 +272,7 @@ fn function(context: &mut Context, name: FunctionName, fdef: &mut T::Function) {
     let T::Function {
         visibility,
         signature,
-        acquires: _,
+        acquires,
         body,
         warning_filter: _,
         index: _,
@@ -205,7 +290,14 @@ fn function(context: &mut Context, name: FunctionName, fdef: &mut T::Function) {
     }) {
         context.in_test = true;
     }
-    if name.0.value == symbol!("init") {
+    if let Some(acquire_loc) = acquires.values().next() {
+        global_storage_error(
+            context,
+            *acquire_loc,
+            format!("Invalid usage of global storage acquires"),
+        )
+    }
+    if name.0.value == INIT_FUNCTION_NAME {
         init_visibility(context, name, *visibility, *entry);
     }
     if let Some(entry_loc) = entry {
@@ -291,7 +383,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
             (last_loc, msg),
         ))
     }
-    let upper_module: Symbol = context.upper_module();
+    let upper_module: Symbol = context.otw_name();
     if parameters.len() == 1 && context.one_time_witness.is_some() {
         // if there is 1 parameter, and a OTW, this is an error since the OTW must be used
         let msg = format!(
@@ -786,7 +878,27 @@ fn exp(context: &mut Context, e: &T::Exp) {
                 );
                 context.env.add_diag(diag)
             }
+            if module.value.is(SUI_ADDR_NAME, EVENT_MODULE_NAME)
+                && name.value() == EVENT_FUNCTION_NAME
+            {
+                check_event_emit(context, e.exp.loc, &mcall)
+            }
+            let is_transfer_module = module.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME);
+            if is_transfer_module && PRIVATE_TRANSFER_FUNCTIONS.contains(&name.value()) {
+                check_private_transfer(context, e.exp.loc, &mcall)
+            }
         }
+        T::UnannotatedExp_::Builtin(b, _) => match &b.value {
+            T::BuiltinFunction_::MoveTo(_)
+            | T::BuiltinFunction_::MoveFrom(_)
+            | T::BuiltinFunction_::BorrowGlobal(_, _)
+            | T::BuiltinFunction_::Exists(_) => global_storage_error(
+                context,
+                e.exp.loc,
+                format!("Invalid usage of global storage primitive '{}'", b),
+            ),
+            T::BuiltinFunction_::Freeze(_) | T::BuiltinFunction_::Assert(_) => (),
+        },
         T::UnannotatedExp_::Pack(m, s, _, _) => {
             if !context.in_test
                 && !context
@@ -807,4 +919,125 @@ fn exp(context: &mut Context, e: &T::Exp) {
         }
         _ => (),
     }
+}
+
+fn check_event_emit(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
+    let current_module = context.current_module();
+    let ModuleCall {
+        module,
+        name,
+        type_arguments,
+        ..
+    } = mcall;
+    let Some(first_ty) = type_arguments.first() else {
+        // invalid arity
+        debug_assert!(false, "ICE arity should have been expanded for errors");
+        return;
+    };
+    let is_defined_in_current_module = matches!(first_ty.value.type_name(), Some(sp!(_, TypeName_::ModuleType(m, _))) if m == current_module);
+    if !is_defined_in_current_module {
+        let msg = format!(
+            "Invalid event. The function '{}::{}' must be called with a type defined in the current module, '{}'",
+            module, name, current_module
+        );
+        let ty_msg = format!(
+            "The type {} is not declared in the current module, '{}'",
+            error_format(first_ty, &Subst::empty()),
+            current_module
+        );
+        context.env.add_diag(diag!(
+            EVENT_EMIT_CALL_DIAG,
+            (loc, msg),
+            (first_ty.loc, ty_msg)
+        ));
+    }
+}
+
+fn check_private_transfer(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
+    let ModuleCall {
+        module,
+        name,
+        type_arguments,
+        ..
+    } = mcall;
+    let current_module = context.current_module();
+    if current_module
+        .value
+        .is(SUI_ADDR_NAME, TRANSFER_FUNCTION_NAME)
+    {
+        // inside the transfer module, so no private transfer rules
+        return;
+    }
+    let Some(first_ty) = type_arguments.first() else {
+        // invalid arity
+        debug_assert!(false, "ICE arity should have been expanded for errors");
+        return;
+    };
+    let (in_current_module, first_ty_tn) = match first_ty.value.type_name() {
+        Some(sp!(_, TypeName_::Multiple(_))) | Some(sp!(_, TypeName_::Builtin(_))) | None => {
+            (false, None)
+        }
+        Some(sp!(_, TypeName_::ModuleType(m, n))) => (m == current_module, Some((m, n))),
+    };
+    if !in_current_module {
+        let mut msg = format!(
+            "Invalid private transfer. \
+            The function '{}::{}' is restricted to being called in the object's module",
+            module, name,
+        );
+        if let Some((first_ty_module, _)) = &first_ty_tn {
+            msg = format!("{}, '{}'", msg, first_ty_module);
+        };
+        let ty_msg = format!(
+            "The type {} is not declared in the current module, '{}'",
+            error_format(first_ty, &Subst::empty()),
+            current_module
+        );
+        let mut diag = diag!(
+            PRIVATE_TRANSFER_CALL_DIAG,
+            (loc, msg),
+            (first_ty.loc, ty_msg)
+        );
+        if first_ty
+            .value
+            .has_ability_(Ability_::Store)
+            .is_some_and(|b| b)
+        {
+            let store_loc = if let Some((first_ty_module, first_ty_name)) = &first_ty_tn {
+                let abilities = context
+                    .info
+                    .struct_declared_abilities(first_ty_module, first_ty_name);
+                abilities.ability_loc_(Ability_::Store).unwrap()
+            } else {
+                first_ty
+                    .value
+                    .abilities(first_ty.loc)
+                    .unwrap()
+                    .ability_loc_(Ability_::Store)
+                    .unwrap()
+            };
+            let store_msg = format!(
+                "The object has '{}' so '{}::public_{}' can be called instead",
+                Ability_::Store,
+                module,
+                name
+            );
+            diag.add_secondary_label((store_loc, store_msg))
+        }
+        context.env.add_diag(diag)
+    }
+}
+
+fn global_storage_error(context: &mut Context, loc: Loc, msg: String) {
+    let mut diag = diag!(GLOBAL_STORAGE_DIAG, (loc, msg),);
+    let sui_transfer_loc = context
+        .sui_transfer_ident
+        .as_ref()
+        .map(|m| *context.info.modules.get_loc(m).unwrap());
+    if let Some(tloc) = sui_transfer_loc {
+        diag.add_secondary_label((tloc, GLOBAL_NOTE.to_string()))
+    } else {
+        diag.add_note(GLOBAL_NOTE)
+    }
+    context.env.add_diag(diag)
 }

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -287,7 +287,7 @@ fn function(context: &mut Context, name: FunctionName, fdef: &mut T::Function) {
         global_storage_error(
             context,
             *acquire_loc,
-            format!("Global storage acquires are not supported in Sui"),
+            "Global storage acquires are not supported in Sui",
         )
     }
     if name.0.value == INIT_FUNCTION_NAME {
@@ -874,11 +874,11 @@ fn exp(context: &mut Context, e: &T::Exp) {
             if module.value.is(SUI_ADDR_NAME, EVENT_MODULE_NAME)
                 && name.value() == EVENT_FUNCTION_NAME
             {
-                check_event_emit(context, e.exp.loc, &mcall)
+                check_event_emit(context, e.exp.loc, mcall)
             }
             let is_transfer_module = module.value.is(SUI_ADDR_NAME, TRANSFER_MODULE_NAME);
             if is_transfer_module && PRIVATE_TRANSFER_FUNCTIONS.contains(&name.value()) {
-                check_private_transfer(context, e.exp.loc, &mcall)
+                check_private_transfer(context, e.exp.loc, mcall)
             }
         }
         T::UnannotatedExp_::Builtin(b, _) => match &b.value {
@@ -1019,8 +1019,8 @@ fn check_private_transfer(context: &mut Context, loc: Loc, mcall: &ModuleCall) {
     }
 }
 
-fn global_storage_error(context: &mut Context, loc: Loc, msg: String) {
-    let mut diag = diag!(GLOBAL_STORAGE_DIAG, (loc, msg),);
+fn global_storage_error(context: &mut Context, loc: Loc, msg: impl ToString) {
+    let mut diag = diag!(GLOBAL_STORAGE_DIAG, (loc, msg));
     let sui_transfer_loc = context
         .sui_transfer_ident
         .as_ref()

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -58,7 +58,9 @@ pub struct ModuleInfo {
     pub constants: UniqueMap<ConstantName, ConstantInfo>,
 }
 
-pub struct ProgramInfo<const AFTER_TYPING: bool>(UniqueMap<ModuleIdent, ModuleInfo>);
+pub struct ProgramInfo<const AFTER_TYPING: bool> {
+    pub modules: UniqueMap<ModuleIdent, ModuleInfo>,
+}
 pub type NamingProgramInfo = ProgramInfo<false>;
 pub type TypingProgramInfo = ProgramInfo<true>;
 
@@ -122,7 +124,7 @@ macro_rules! program_info {
             (mident, minfo)
         }))
         .unwrap();
-        ProgramInfo(modules)
+        ProgramInfo { modules }
     }};
 }
 
@@ -140,7 +142,9 @@ impl NamingProgramInfo {
 
 impl<const AFTER_TYPING: bool> ProgramInfo<AFTER_TYPING> {
     pub fn module(&self, m: &ModuleIdent) -> &ModuleInfo {
-        self.0.get(m).expect("ICE should have failed in naming")
+        self.modules
+            .get(m)
+            .expect("ICE should have failed in naming")
     }
 
     pub fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.exp
@@ -1,98 +1,98 @@
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:8:76
    │
  8 │     public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
-   │                                                                            ^ Invalid usage of global storage acquires
+   │                                                                            ^ Global storage acquires are not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:9:13
    │
  9 │         _ = exists<R>(addr);
-   │             ^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │             ^^^^^^^^^^^^^^^ Global storage primitive 'exists' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:10:13
    │
 10 │         _ = exists<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │             ^^^^^^^^^^^^^^^^^^ Global storage primitive 'exists' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:11:13
    │
 11 │         _ = borrow_global<R>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:12:13
    │
 12 │         _ = borrow_global<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:13:13
    │
 13 │         _ = borrow_global_mut<R>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global_mut' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:14:13
    │
 14 │         _ = borrow_global_mut<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global_mut' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:15:20
    │
 15 │         consume<R>(move_from<R>(addr));
-   │                    ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │                    ^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_from' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:16:23
    │
 16 │         consume<G<T>>(move_from<G<T>>(addr));
-   │                       ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_from' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:17:9
    │
 17 │         move_to<R>(s, r);
-   │         ^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │         ^^^^^^^^^^^^^^^^ Global storage primitive 'move_to' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all.move:18:9
    │
 18 │         move_to<G<T>>(s, g);
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │         ^^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_to' is not supported in Sui
    ·
 33 │ module sui::transfer {
    │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.exp
@@ -1,0 +1,99 @@
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:8:76
+   │
+ 8 │     public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
+   │                                                                            ^ Invalid usage of global storage acquires
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:9:13
+   │
+ 9 │         _ = exists<R>(addr);
+   │             ^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:10:13
+   │
+10 │         _ = exists<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:11:13
+   │
+11 │         _ = borrow_global<R>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:12:13
+   │
+12 │         _ = borrow_global<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:13:13
+   │
+13 │         _ = borrow_global_mut<R>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:14:13
+   │
+14 │         _ = borrow_global_mut<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:15:20
+   │
+15 │         consume<R>(move_from<R>(addr));
+   │                    ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:16:23
+   │
+16 │         consume<G<T>>(move_from<G<T>>(addr));
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:17:9
+   │
+17 │         move_to<R>(s, r);
+   │         ^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all.move:18:9
+   │
+18 │         move_to<G<T>>(s, g);
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   ·
+33 │ module sui::transfer {
+   │             -------- Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all.move
@@ -1,0 +1,34 @@
+// tests all global storage operations are banned
+// tests acquires is banned
+module a::m {
+    use sui::object;
+    struct R has key { id: object::UID }
+    struct G<phantom T> has key { id: object::UID }
+
+    public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
+        _ = exists<R>(addr);
+        _ = exists<G<T>>(addr);
+        _ = borrow_global<R>(addr);
+        _ = borrow_global<G<T>>(addr);
+        _ = borrow_global_mut<R>(addr);
+        _ = borrow_global_mut<G<T>>(addr);
+        consume<R>(move_from<R>(addr));
+        consume<G<T>>(move_from<G<T>>(addr));
+        move_to<R>(s, r);
+        move_to<G<T>>(s, g);
+    }
+
+    fun consume<T>(_: T) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.exp
@@ -1,0 +1,88 @@
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:11:76
+   │
+11 │     public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
+   │                                                                            ^ Invalid usage of global storage acquires
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:12:13
+   │
+12 │         _ = exists<R>(addr);
+   │             ^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:13:13
+   │
+13 │         _ = exists<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:14:13
+   │
+14 │         _ = borrow_global<R>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:15:13
+   │
+15 │         _ = borrow_global<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:16:13
+   │
+16 │         _ = borrow_global_mut<R>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:17:13
+   │
+17 │         _ = borrow_global_mut<G<T>>(addr);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:18:20
+   │
+18 │         consume<R>(move_from<R>(addr));
+   │                    ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:19:23
+   │
+19 │         consume<G<T>>(move_from<G<T>>(addr));
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:20:9
+   │
+20 │         move_to<R>(s, r);
+   │         ^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+
+error[Sui E02009]: invalid global storage usage
+   ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:21:9
+   │
+21 │         move_to<G<T>>(s, g);
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │
+   = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.exp
@@ -1,88 +1,88 @@
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:11:76
    │
 11 │     public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
-   │                                                                            ^ Invalid usage of global storage acquires
+   │                                                                            ^ Global storage acquires are not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:12:13
    │
 12 │         _ = exists<R>(addr);
-   │             ^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │             ^^^^^^^^^^^^^^^ Global storage primitive 'exists' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:13:13
    │
 13 │         _ = exists<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'exists'
+   │             ^^^^^^^^^^^^^^^^^^ Global storage primitive 'exists' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:14:13
    │
 14 │         _ = borrow_global<R>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:15:13
    │
 15 │         _ = borrow_global<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:16:13
    │
 16 │         _ = borrow_global_mut<R>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global_mut' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:17:13
    │
 17 │         _ = borrow_global_mut<G<T>>(addr);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'borrow_global_mut'
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'borrow_global_mut' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:18:20
    │
 18 │         consume<R>(move_from<R>(addr));
-   │                    ^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │                    ^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_from' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:19:23
    │
 19 │         consume<G<T>>(move_from<G<T>>(addr));
-   │                       ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_from'
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_from' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:20:9
    │
 20 │         move_to<R>(s, r);
-   │         ^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │         ^^^^^^^^^^^^^^^^ Global storage primitive 'move_to' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 
-error[Sui E02009]: invalid global storage usage
+error[Sui E02009]: global storage is not supported in Sui
    ┌─ tests/sui_mode/global_storage_access/all_without_sui_transfer.move:21:9
    │
 21 │         move_to<G<T>>(s, g);
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of global storage primitive 'move_to'
+   │         ^^^^^^^^^^^^^^^^^^^ Global storage primitive 'move_to' is not supported in Sui
    │
    = Global storage is not used in Sui. Instead objects (structs with the 'key' ability) are used with programmable transaction blocks and the 'sui::transfer' functions.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/global_storage_access/all_without_sui_transfer.move
@@ -1,0 +1,34 @@
+// tests all global storage operations are banned
+// tests acquires is banned
+
+// compiled with sui::transfer missing
+
+module a::m {
+    use sui::object;
+    struct R has key { id: object::UID }
+    struct G<phantom T> has key { id: object::UID }
+
+    public fun no<T>(s: &signer, addr: address, r: R, g: G<T>) acquires R, G {
+        _ = exists<R>(addr);
+        _ = exists<G<T>>(addr);
+        _ = borrow_global<R>(addr);
+        _ = borrow_global<G<T>>(addr);
+        _ = borrow_global_mut<R>(addr);
+        _ = borrow_global_mut<G<T>>(addr);
+        consume<R>(move_from<R>(addr));
+        consume<G<T>>(move_from<G<T>>(addr));
+        move_to<R>(s, r);
+        move_to<G<T>>(s, g);
+    }
+
+    fun consume<T>(_: T) {
+        abort 0
+    }
+
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
@@ -2,7 +2,7 @@ error[Sui E02009]: invalid private transfer call
   ┌─ tests/sui_mode/private_generics/no_public_transfer.move:8:9
   │
 7 │     public fun t1(s: other::S) {
-  │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+  │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
 8 │         transfer::transfer(s, @0x100);
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module, '(a=0x42)::other'
 
@@ -10,7 +10,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer.move:12:9
    │
 11 │     public fun t2(s: other::S) {
-   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
 12 │         transfer::freeze_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module, '(a=0x42)::other'
 
@@ -18,7 +18,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer.move:16:9
    │
 15 │     public fun t3(s: other::S) {
-   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
 16 │         transfer::share_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module, '(a=0x42)::other'
 

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
@@ -1,0 +1,24 @@
+error[Sui E02009]: invalid private transfer call
+  ┌─ tests/sui_mode/private_generics/no_public_transfer.move:8:9
+  │
+7 │     public fun t1(s: other::S) {
+  │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+8 │         transfer::transfer(s, @0x100);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module, '(a=0x42)::other'
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer.move:12:9
+   │
+11 │     public fun t2(s: other::S) {
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+12 │         transfer::freeze_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module, '(a=0x42)::other'
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer.move:16:9
+   │
+15 │     public fun t3(s: other::S) {
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+16 │         transfer::share_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module, '(a=0x42)::other'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer.move
@@ -1,0 +1,56 @@
+// tests modules cannot use transfer internal functions outside of the defining module
+
+module a::m {
+    use sui::transfer;
+    use a::other;
+
+    public fun t1(s: other::S) {
+        transfer::transfer(s, @0x100);
+    }
+
+    public fun t2(s: other::S) {
+        transfer::freeze_object(s);
+    }
+
+    public fun t3(s: other::S) {
+        transfer::share_object(s);
+    }
+}
+
+module a::other {
+    struct S has key {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.exp
@@ -1,0 +1,24 @@
+error[Sui E02009]: invalid private transfer call
+  ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:9:9
+  │
+8 │     public fun t1<T: key>(s: T) {
+  │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+9 │         transfer::transfer(s, @0x100);
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:13:9
+   │
+12 │     public fun t2<T: key>(s: T) {
+   │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+13 │         transfer::freeze_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:17:9
+   │
+16 │     public fun t3<T: key>(s: T) {
+   │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+17 │         transfer::share_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module
+

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.exp
@@ -2,7 +2,7 @@ error[Sui E02009]: invalid private transfer call
   ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:9:9
   │
 8 │     public fun t1<T: key>(s: T) {
-  │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+  │                              - The type 'T' is not declared in the current module
 9 │         transfer::transfer(s, @0x100);
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module
 
@@ -10,7 +10,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:13:9
    │
 12 │     public fun t2<T: key>(s: T) {
-   │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                              - The type 'T' is not declared in the current module
 13 │         transfer::freeze_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module
 
@@ -18,7 +18,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_generic.move:17:9
    │
 16 │     public fun t3<T: key>(s: T) {
-   │                              - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                              - The type 'T' is not declared in the current module
 17 │         transfer::share_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module
 

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_generic.move
@@ -1,0 +1,51 @@
+// tests modules cannot use transfer internal functions outside of the defining module
+// Note: it is not possible to make a generic type `T<...> has key, store`
+// where a given instantiation`T<...>` has key but does _not_ have store
+
+module a::m {
+    use sui::transfer;
+
+    public fun t1<T: key>(s: T) {
+        transfer::transfer(s, @0x100);
+    }
+
+    public fun t2<T: key>(s: T) {
+        transfer::freeze_object(s);
+    }
+
+    public fun t3<T: key>(s: T) {
+        transfer::share_object(s);
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.exp
@@ -1,0 +1,33 @@
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:9:9
+   │
+ 8 │     public fun t1(s: other::S) {
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+ 9 │         transfer::transfer(s, @0x100);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module, '(a=0x42)::other'
+   ·
+22 │     struct S has key, store {
+   │                       ----- The object has 'store' so '(sui=0x2)::transfer::public_transfer' can be called instead
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:13:9
+   │
+12 │     public fun t2(s: other::S) {
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+13 │         transfer::freeze_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module, '(a=0x42)::other'
+   ·
+22 │     struct S has key, store {
+   │                       ----- The object has 'store' so '(sui=0x2)::transfer::public_freeze_object' can be called instead
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:17:9
+   │
+16 │     public fun t3(s: other::S) {
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+17 │         transfer::share_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module, '(a=0x42)::other'
+   ·
+22 │     struct S has key, store {
+   │                       ----- The object has 'store' so '(sui=0x2)::transfer::public_share_object' can be called instead
+

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.exp
@@ -2,7 +2,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:9:9
    │
  8 │     public fun t1(s: other::S) {
-   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
  9 │         transfer::transfer(s, @0x100);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module, '(a=0x42)::other'
    ·
@@ -13,7 +13,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:13:9
    │
 12 │     public fun t2(s: other::S) {
-   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
 13 │         transfer::freeze_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module, '(a=0x42)::other'
    ·
@@ -24,7 +24,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store.move:17:9
    │
 16 │     public fun t3(s: other::S) {
-   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module, '(a=0x42)::m'
+   │                      -------- The type '(a=0x42)::other::S' is not declared in the current module
 17 │         transfer::share_object(s);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module, '(a=0x42)::other'
    ·

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store.move
@@ -1,0 +1,57 @@
+// tests modules cannot use transfer internal functions outside of the defining module
+// even if it has store
+
+module a::m {
+    use sui::transfer;
+    use a::other;
+
+    public fun t1(s: other::S) {
+        transfer::transfer(s, @0x100);
+    }
+
+    public fun t2(s: other::S) {
+        transfer::freeze_object(s);
+    }
+
+    public fun t3(s: other::S) {
+        transfer::share_object(s);
+    }
+}
+
+module a::other {
+    struct S has key, store {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.exp
@@ -2,7 +2,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:10:9
    │
  9 │     public fun t1<T: key + store>(s: T) {
-   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            -----     - The type 'T' is not declared in the current module
    │                            │          
    │                            The object has 'store' so '(sui=0x2)::transfer::public_transfer' can be called instead
 10 │         transfer::transfer(s, @0x100);
@@ -12,7 +12,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:14:9
    │
 13 │     public fun t2<T: key + store>(s: T) {
-   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            -----     - The type 'T' is not declared in the current module
    │                            │          
    │                            The object has 'store' so '(sui=0x2)::transfer::public_freeze_object' can be called instead
 14 │         transfer::freeze_object(s);
@@ -22,7 +22,7 @@ error[Sui E02009]: invalid private transfer call
    ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:18:9
    │
 17 │     public fun t3<T: key + store>(s: T) {
-   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            -----     - The type 'T' is not declared in the current module
    │                            │          
    │                            The object has 'store' so '(sui=0x2)::transfer::public_share_object' can be called instead
 18 │         transfer::share_object(s);

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.exp
@@ -1,0 +1,30 @@
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:10:9
+   │
+ 9 │     public fun t1<T: key + store>(s: T) {
+   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            │          
+   │                            The object has 'store' so '(sui=0x2)::transfer::public_transfer' can be called instead
+10 │         transfer::transfer(s, @0x100);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::transfer' is restricted to being called in the object's module
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:14:9
+   │
+13 │     public fun t2<T: key + store>(s: T) {
+   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            │          
+   │                            The object has 'store' so '(sui=0x2)::transfer::public_freeze_object' can be called instead
+14 │         transfer::freeze_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::freeze_object' is restricted to being called in the object's module
+
+error[Sui E02009]: invalid private transfer call
+   ┌─ tests/sui_mode/private_generics/no_public_transfer_store_generic.move:18:9
+   │
+17 │     public fun t3<T: key + store>(s: T) {
+   │                            -----     - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                            │          
+   │                            The object has 'store' so '(sui=0x2)::transfer::public_share_object' can be called instead
+18 │         transfer::share_object(s);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function '(sui=0x2)::transfer::share_object' is restricted to being called in the object's module
+

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/no_public_transfer_store_generic.move
@@ -1,0 +1,52 @@
+// tests modules cannot use transfer internal functions outside of the defining module
+// even if it has store
+// Note: it is not possible to make a generic type `T<...> has key, store`
+// where a given instantiation`T<...>` has key but does _not_ have store
+
+module a::m {
+    use sui::transfer;
+
+    public fun t1<T: key + store>(s: T) {
+        transfer::transfer(s, @0x100);
+    }
+
+    public fun t2<T: key + store>(s: T) {
+        transfer::freeze_object(s);
+    }
+
+    public fun t3<T: key + store>(s: T) {
+        transfer::share_object(s);
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.exp
@@ -2,31 +2,31 @@ error[Sui E02008]: invalid event
   ┌─ tests/sui_mode/private_generics/private_event_emit.move:8:9
   │
 7 │     public fun t(s: a::other::Event) {
-  │                     --------------- The type '(a=0x42)::other::Event' is not declared in the current module, '(a=0x42)::m'
+  │                     --------------- The type '(a=0x42)::other::Event' is not declared in the current module
 8 │         event::emit(s)
-  │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+  │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module
 
 error[Sui E02008]: invalid event
    ┌─ tests/sui_mode/private_generics/private_event_emit.move:12:9
    │
 11 │     public fun gen<T: copy + drop>(x: T) {
-   │                                       - The type 'T' is not declared in the current module, '(a=0x42)::m'
+   │                                       - The type 'T' is not declared in the current module
 12 │         event::emit(move x)
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module
 
 error[Sui E02008]: invalid event
    ┌─ tests/sui_mode/private_generics/private_event_emit.move:16:9
    │
 15 │     public fun prim(x: u64) {
-   │                        --- The type 'u64' is not declared in the current module, '(a=0x42)::m'
+   │                        --- The type 'u64' is not declared in the current module
 16 │         event::emit(x)
-   │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+   │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module
 
 error[Sui E02008]: invalid event
    ┌─ tests/sui_mode/private_generics/private_event_emit.move:20:9
    │
 19 │     public fun vec(x: vector<X>) {
-   │                       --------- The type 'vector<(a=0x42)::m::X>' is not declared in the current module, '(a=0x42)::m'
+   │                       --------- The type 'vector<(a=0x42)::m::X>' is not declared in the current module
 20 │         event::emit(move x)
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module
 

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.exp
@@ -1,0 +1,32 @@
+error[Sui E02008]: invalid event
+  ┌─ tests/sui_mode/private_generics/private_event_emit.move:8:9
+  │
+7 │     public fun t(s: a::other::Event) {
+  │                     --------------- The type '(a=0x42)::other::Event' is not declared in the current module, '(a=0x42)::m'
+8 │         event::emit(s)
+  │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+
+error[Sui E02008]: invalid event
+   ┌─ tests/sui_mode/private_generics/private_event_emit.move:12:9
+   │
+11 │     public fun gen<T: copy + drop>(x: T) {
+   │                                       - The type 'T' is not declared in the current module, '(a=0x42)::m'
+12 │         event::emit(move x)
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+
+error[Sui E02008]: invalid event
+   ┌─ tests/sui_mode/private_generics/private_event_emit.move:16:9
+   │
+15 │     public fun prim(x: u64) {
+   │                        --- The type 'u64' is not declared in the current module, '(a=0x42)::m'
+16 │         event::emit(x)
+   │         ^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+
+error[Sui E02008]: invalid event
+   ┌─ tests/sui_mode/private_generics/private_event_emit.move:20:9
+   │
+19 │     public fun vec(x: vector<X>) {
+   │                       --------- The type 'vector<(a=0x42)::m::X>' is not declared in the current module, '(a=0x42)::m'
+20 │         event::emit(move x)
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid event. The function '(sui=0x2)::event::emit' must be called with a type defined in the current module, '(a=0x42)::m'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/private_event_emit.move
@@ -1,0 +1,30 @@
+// tests modules cannot emit events for types not defined in the current module
+module a::m {
+    use sui::event;
+
+    struct X has copy, drop {}
+
+    public fun t(s: a::other::Event) {
+        event::emit(s)
+    }
+
+    public fun gen<T: copy + drop>(x: T) {
+        event::emit(move x)
+    }
+
+    public fun prim(x: u64) {
+        event::emit(x)
+    }
+
+    public fun vec(x: vector<X>) {
+        event::emit(move x)
+    }
+}
+
+module a::other {
+    struct Event has copy, drop {}
+}
+
+module sui::event {
+    public fun emit<T: copy + drop>(_: T) { abort 0 }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/public_transfer_with_store.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/public_transfer_with_store.move
@@ -1,0 +1,56 @@
+// tests modules can use transfer functions outside of the defining module, if the type
+// has store
+module a::m {
+    use sui::transfer;
+    use a::other;
+
+    public fun t(s: other::S) {
+        transfer::public_transfer(s, @0x100)
+    }
+
+    public fun f(s: other::S) {
+        transfer::public_freeze_object(s)
+    }
+
+    public fun s(s: other::S) {
+        transfer::public_share_object(s)
+    }
+}
+
+module a::other {
+    struct S has key, store {
+        id: sui::object::UID,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/private_generics/public_transfer_with_store_generic.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/private_generics/public_transfer_with_store_generic.move
@@ -1,0 +1,67 @@
+// tests modules can use transfer functions outside of the defining module, if the type
+// has store.
+
+module a::m {
+    use sui::transfer;
+    use a::other;
+
+    public fun t<T: store>(s: other::S<T>) {
+        transfer::public_transfer(s, @0x100)
+    }
+    public fun t_gen<T: key + store>(s: T) {
+        transfer::public_transfer(s, @0x100)
+    }
+
+    public fun f<T: store>(s: other::S<T>) {
+        transfer::public_freeze_object(s)
+    }
+    public fun f_gen<T: key + store>(s: T) {
+        transfer::public_freeze_object(s)
+    }
+
+    public fun s<T: store>(s: other::S<T>) {
+        transfer::public_share_object(s)
+    }
+    public fun s_gen<T: key + store>(s: T) {
+        transfer::public_share_object(s)
+    }
+}
+
+module a::other {
+    struct S<T> has key, store {
+        id: sui::object::UID,
+        value: T,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}
+
+module sui::transfer {
+    public fun transfer<T: key>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun public_transfer<T: key + store>(_: T, _: address) {
+        abort 0
+    }
+
+    public fun freeze_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_freeze_object<T: key + store>(_: T) {
+        abort 0
+    }
+
+    public fun share_object<T: key>(_: T) {
+        abort 0
+    }
+
+    public fun public_share_object<T: key + store>(_: T) {
+        abort 0
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.exp
@@ -1,0 +1,8 @@
+error[Sui E02007]: invalid object declaration
+  ┌─ tests/sui_mode/struct_with_key/key_struct_first_field_not_id.move:4:9
+  │
+3 │     struct S has key {
+  │                  --- The 'key' ability is used to declare objects in Sui
+4 │         flag: bool
+  │         ^^^^ Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.move
@@ -1,0 +1,6 @@
+// invalid, first field of an ojbect must be sui::object::UID
+module a::m {
+    struct S has key {
+        flag: bool
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
@@ -6,7 +6,7 @@ error[Sui E02007]: invalid object declaration
 5 │         id: UID
   │         ^^  --- But found type: '(a=0x42)::object::UID'
   │         │    
-  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+  │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 
 error[Sui E02007]: invalid object declaration
    ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move:13:9
@@ -16,5 +16,5 @@ error[Sui E02007]: invalid object declaration
 13 │         id: UID
    │         ^^  --- But found type: '0x2::object::UID'
    │         │    
-   │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+   │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
@@ -1,0 +1,20 @@
+error[Sui E02007]: invalid object declaration
+  ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move:5:9
+  │
+4 │     struct S has key {
+  │                  --- The 'key' ability is used to declare objects in Sui
+5 │         id: UID
+  │         ^^  --- But found type: '(a=0x42)::object::UID'
+  │         │    
+  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+
+error[Sui E02007]: invalid object declaration
+   ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move:13:9
+   │
+12 │     struct S has key {
+   │                  --- The 'key' ability is used to declare objects in Sui
+13 │         id: UID
+   │         ^^  --- But found type: '0x2::object::UID'
+   │         │    
+   │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_address.move
@@ -1,0 +1,15 @@
+// invalid, the object has a UID field, but not the sui::object::UID
+module a::object {
+    struct UID has store { flag: bool }
+    struct S has key {
+        id: UID
+    }
+}
+
+// TODO we might want to support this
+module 0x2::object {
+    struct UID has store { flag: bool }
+    struct S has key {
+        id: UID
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
@@ -1,0 +1,10 @@
+error[Sui E02007]: invalid object declaration
+  ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.move:5:9
+  │
+4 │     struct S has key {
+  │                  --- The 'key' ability is used to declare objects in Sui
+5 │         id: object::ID
+  │         ^^  ---------- But found type: '(sui=0x2)::object::ID'
+  │         │    
+  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
@@ -6,5 +6,5 @@ error[Sui E02007]: invalid object declaration
 5 │         id: object::ID
   │         ^^  ---------- But found type: '(sui=0x2)::object::ID'
   │         │    
-  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+  │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_struct_name.move
@@ -1,0 +1,13 @@
+// invalid, objects need UID not ID
+module a::m {
+    use sui::object;
+    struct S has key {
+        id: object::ID
+    }
+}
+
+module sui::object {
+    struct ID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.exp
@@ -1,0 +1,10 @@
+error[Sui E02007]: invalid object declaration
+  ┌─ tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.move:4:9
+  │
+3 │     struct S has key {
+  │                  --- The 'key' ability is used to declare objects in Sui
+4 │         id: bool
+  │         ^^  ---- But found type: 'bool'
+  │         │    
+  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.exp
@@ -6,5 +6,5 @@ error[Sui E02007]: invalid object declaration
 4 │         id: bool
   │         ^^  ---- But found type: 'bool'
   │         │    
-  │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+  │         Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_incorrect_type.move
@@ -1,0 +1,6 @@
+// invalid, id field must have type UID
+module a::m {
+    struct S has key {
+        id: bool
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_valid.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_id_field_valid.move
@@ -1,0 +1,13 @@
+// valid
+module a::m {
+    use sui::object;
+    struct S has key {
+        id: object::UID
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.exp
@@ -1,0 +1,27 @@
+error[Sui E02007]: invalid object declaration
+  ┌─ tests/sui_mode/struct_with_key/key_struct_second_field_id.move:6:9
+  │
+5 │     struct S has key {
+  │                  --- The 'key' ability is used to declare objects in Sui
+6 │         flag: bool,
+  │         ^^^^ Invalid object 'S'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
+
+error[Sui E02007]: invalid object declaration
+   ┌─ tests/sui_mode/struct_with_key/key_struct_second_field_id.move:11:9
+   │
+10 │     struct R has key {
+   │                  --- The 'key' ability is used to declare objects in Sui
+11 │         flag: bool,
+   │         ^^^^ Invalid object 'R'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
+
+error[Sui E02007]: invalid object declaration
+   ┌─ tests/sui_mode/struct_with_key/key_struct_second_field_id.move:12:9
+   │
+10 │     struct R has key {
+   │                  --- The 'key' ability is used to declare objects in Sui
+11 │         flag: bool,
+12 │         id: address,
+   │         ^^  ------- But found type: 'address'
+   │         │    
+   │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.exp
@@ -14,14 +14,3 @@ error[Sui E02007]: invalid object declaration
 11 │         flag: bool,
    │         ^^^^ Invalid object 'R'. Structs with the 'key' ability must have 'id: sui::object::UID' as their first field
 
-error[Sui E02007]: invalid object declaration
-   ┌─ tests/sui_mode/struct_with_key/key_struct_second_field_id.move:12:9
-   │
-10 │     struct R has key {
-   │                  --- The 'key' ability is used to declare objects in Sui
-11 │         flag: bool,
-12 │         id: address,
-   │         ^^  ------- But found type: 'address'
-   │         │    
-   │         Invalid object. Expected the 'id' field to have type 'sui::object::UID'
-

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_second_field_id.move
@@ -1,0 +1,20 @@
+// invalid, object must have UID as first field not some other field
+
+module a::m {
+    use sui::object;
+    struct S has key {
+        flag: bool,
+        id: object::UID,
+    }
+
+    struct R has key {
+        flag: bool,
+        id: address,
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_with_drop.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_with_drop.exp
@@ -1,0 +1,12 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/sui_mode/struct_with_key/key_struct_with_drop.move:6:13
+   │
+ 6 │         id: object::UID,
+   │             ^^^^^^^^^^^
+   │             │
+   │             Invalid field type. The struct was declared with the ability 'drop' so all fields require the ability 'drop'
+   │             The type '(sui=0x2)::object::UID' does not have the ability 'drop'
+   ·
+12 │     struct UID has store {
+   │            --- To satisfy the constraint, the 'drop' ability would need to be added here
+

--- a/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_with_drop.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/struct_with_key/key_struct_with_drop.move
@@ -1,0 +1,15 @@
+// invalid, object cannot have drop since UID does not have drop
+
+module a::m {
+    use sui::object;
+    struct S has key, drop {
+        id: object::UID,
+        flag: bool
+    }
+}
+
+module sui::object {
+    struct UID has store {
+        id: address,
+    }
+}

--- a/external-crates/move/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/move-symbol-pool/src/lib.rs
@@ -70,8 +70,17 @@ static_symbols!(
     "TxContext",
     "ID",
     "SUI",
+<<<<<<< HEAD
     "authenticator_state",
     "AuthenticatorState",
+=======
+    "id",
+    "transfer",
+    "freeze_object",
+    "share_object",
+    "event",
+    "emit",
+>>>>>>> 01016866de ([move-compiler][sui-mode] Added struct declaration, private generics, and global storage checks)
 );
 
 /// The global, unique cache of strings.

--- a/external-crates/move/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/move-symbol-pool/src/lib.rs
@@ -70,17 +70,14 @@ static_symbols!(
     "TxContext",
     "ID",
     "SUI",
-<<<<<<< HEAD
     "authenticator_state",
     "AuthenticatorState",
-=======
     "id",
     "transfer",
     "freeze_object",
     "share_object",
     "event",
     "emit",
->>>>>>> 01016866de ([move-compiler][sui-mode] Added struct declaration, private generics, and global storage checks)
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

- Added checks for structs with key (id field naming+type)
- Added checks for private generics in sui::transfer and sui::event
- Added checks banning global storage operations

## Test Plan 

- Migrated tests 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Move now provides errors for all custom rules present in Sui
