### PR TITLE
wallet-ext: allow unlocking account before staking send nft or tokens

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/AccountLockStateSwitch.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountLockStateSwitch.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+import { type SerializedUIAccount } from '../../../../background/accounts/Account';
+import { useIsAccountReadLocked } from '../../hooks/useIsAccountReadLocked';
+
+export type AccountLockStateSwitchProps = {
+	account: SerializedUIAccount | null;
+	/** layout to show when the account is unlocked (write and read is allowed - executing transactions is possible) */
+	fullyUnlockedLayout?: ReactNode;
+	/** layout to show when the account is locked but read is allowed (was unlocked recently but for some reason the account keyPair was evicted from session storage) */
+	readOnlyLayout?: ReactNode;
+	/** layout to show when the account is unlocked at least for read (can be write unlocked as well)*/
+	readLayout?: ReactNode;
+	/** layout to show when the account is locked */
+	writeLockedLayout?: ReactNode;
+	/** layout to show when non of the provided states were applicable */
+	elseLayout?: ReactNode;
+};
+export function AccountLockedStateSwitch({
+	account,
+	fullyUnlockedLayout,
+	readOnlyLayout,
+	readLayout,
+	writeLockedLayout,
+	elseLayout,
+}: AccountLockStateSwitchProps) {
+	const isWriteLocked = !account || account.isLocked;
+	const isReadLocked = useIsAccountReadLocked(account);
+	if (!account) {
+		return null;
+	}
+	if (isWriteLocked && writeLockedLayout !== undefined) {
+		return writeLockedLayout;
+	}
+	if (isWriteLocked && !isReadLocked && readOnlyLayout !== undefined) {
+		return readOnlyLayout;
+	}
+	if (!isWriteLocked && !isReadLocked && fullyUnlockedLayout !== undefined) {
+		return fullyUnlockedLayout;
+	}
+	if (!isReadLocked && readLayout !== undefined) {
+		return readLayout;
+	}
+	return elseLayout || null;
+}

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -18,6 +18,7 @@ import { Text } from '_app/shared/text';
 import { AddressInput } from '_components/address-input';
 import { ampli } from '_src/shared/analytics/ampli';
 import { QredoActionIgnoredByUser } from '_src/ui/app/QredoSigner';
+import { UnlockAccountButton } from '_src/ui/app/components/accounts/UnlockAccountButton';
 import { getSignerOperationErrorMessage } from '_src/ui/app/helpers/errorMessages';
 import { useActiveAddress } from '_src/ui/app/hooks';
 import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
@@ -36,6 +37,7 @@ export function TransferNFTForm({
 	const suiNSEnabled = useSuiNSEnabled();
 	const validationSchema = createValidationSchema(rpc, suiNSEnabled, activeAddress || '', objectId);
 	const activeAccount = useActiveAccount();
+	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	const signer = useSigner(activeAccount);
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
@@ -107,7 +109,9 @@ export function TransferNFTForm({
 			}
 		},
 	});
-
+	if (!activeAccount) {
+		return null;
+	}
 	return (
 		<Formik
 			initialValues={{
@@ -138,15 +142,19 @@ export function TransferNFTForm({
 							</div>
 						</Content>
 						<Menu stuckClass="sendCoin-cta" className="w-full px-0 pb-0 mx-0 gap-2.5">
-							<Button
-								type="submit"
-								variant="primary"
-								loading={transferNFT.isLoading}
-								disabled={!isValid}
-								size="tall"
-								text="Send NFT Now"
-								after={<ArrowRight16 />}
-							/>
+							{isAccountWriteLocked ? (
+								<UnlockAccountButton account={activeAccount} />
+							) : (
+								<Button
+									type="submit"
+									variant="primary"
+									loading={transferNFT.isLoading}
+									disabled={!isValid}
+									size="tall"
+									text="Send NFT Now"
+									after={<ArrowRight16 />}
+								/>
+							)}
 						</Menu>
 					</BottomMenuLayout>
 					{notificationModal}

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -18,6 +18,7 @@ import { Text } from '_app/shared/text';
 import { AddressInput } from '_components/address-input';
 import { ampli } from '_src/shared/analytics/ampli';
 import { QredoActionIgnoredByUser } from '_src/ui/app/QredoSigner';
+import { AccountLockedStateSwitch } from '_src/ui/app/components/accounts/AccountLockStateSwitch';
 import { UnlockAccountButton } from '_src/ui/app/components/accounts/UnlockAccountButton';
 import { getSignerOperationErrorMessage } from '_src/ui/app/helpers/errorMessages';
 import { useActiveAddress } from '_src/ui/app/hooks';
@@ -37,7 +38,6 @@ export function TransferNFTForm({
 	const suiNSEnabled = useSuiNSEnabled();
 	const validationSchema = createValidationSchema(rpc, suiNSEnabled, activeAddress || '', objectId);
 	const activeAccount = useActiveAccount();
-	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	const signer = useSigner(activeAccount);
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
@@ -142,19 +142,21 @@ export function TransferNFTForm({
 							</div>
 						</Content>
 						<Menu stuckClass="sendCoin-cta" className="w-full px-0 pb-0 mx-0 gap-2.5">
-							{isAccountWriteLocked ? (
-								<UnlockAccountButton account={activeAccount} />
-							) : (
-								<Button
-									type="submit"
-									variant="primary"
-									loading={transferNFT.isLoading}
-									disabled={!isValid}
-									size="tall"
-									text="Send NFT Now"
-									after={<ArrowRight16 />}
-								/>
-							)}
+							<AccountLockedStateSwitch
+								account={activeAccount || null}
+								writeLockedLayout={<UnlockAccountButton account={activeAccount} />}
+								elseLayout={
+									<Button
+										type="submit"
+										variant="primary"
+										loading={transferNFT.isLoading}
+										disabled={!isValid}
+										size="tall"
+										text="Send NFT Now"
+										after={<ArrowRight16 />}
+									/>
+								}
+							/>
 						</Menu>
 					</BottomMenuLayout>
 					{notificationModal}

--- a/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
@@ -37,10 +37,10 @@ import { useAppSelector, useCoinsReFetchingConfig } from '_hooks';
 import { ampli } from '_src/shared/analytics/ampli';
 import { API_ENV } from '_src/shared/api-env';
 import { FEATURES } from '_src/shared/experimentation/features';
+import { AccountLockedStateSwitch } from '_src/ui/app/components/accounts/AccountLockStateSwitch';
 import { AccountsList } from '_src/ui/app/components/accounts/AccountsList';
 import { UnlockAccountButton } from '_src/ui/app/components/accounts/UnlockAccountButton';
 import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
-import { useIsAccountReadLocked } from '_src/ui/app/hooks/useIsAccountReadLocked';
 import { usePinnedCoinTypes } from '_src/ui/app/hooks/usePinnedCoinTypes';
 import { useRecognizedPackages } from '_src/ui/app/hooks/useRecognizedPackages';
 import PageTitle from '_src/ui/app/shared/PageTitle';
@@ -170,7 +170,6 @@ function TokenDetails({ coinType }: TokenDetailsProps) {
 	const activeCoinType = coinType || SUI_TYPE_ARG;
 	const activeAccount = useActiveAccount();
 	const activeAccountAddress = activeAccount?.address;
-	const isAccountLocked = useIsAccountReadLocked(activeAccount);
 	const { data: domainName } = useResolveSuiNSName(activeAccountAddress);
 	const { staleTime, refetchInterval } = useCoinsReFetchingConfig();
 	const {
@@ -269,85 +268,91 @@ function TokenDetails({ coinType }: TokenDetailsProps) {
 						<PortfolioName
 							name={activeAccount.nickname ?? domainName ?? formatAddress(activeAccountAddress)}
 						/>
-						{isAccountLocked ? null : (
-							<>
-								<div
-									data-testid="coin-balance"
-									className="bg-sui/10 rounded-2xl py-5 px-4 flex flex-col w-full gap-3 items-center mt-4"
-								>
-									{accountHasSui ? (
-										<CoinBalance amount={BigInt(tokenBalance)} type={activeCoinType} />
-									) : (
-										<div className="flex flex-col gap-5">
-											<div className="flex flex-col flex-nowrap justify-center items-center text-center px-2.5">
-												<SvgSuiTokensStack className="h-14 w-14 text-steel" />
-												<div className="flex flex-col gap-2 justify-center">
-													<Text variant="pBodySmall" color="gray-80" weight="normal">
-														To conduct transactions on the Sui network, you need SUI in your wallet.
-													</Text>
+						<AccountLockedStateSwitch
+							account={activeAccount}
+							readLayout={
+								<>
+									<div
+										data-testid="coin-balance"
+										className="bg-sui/10 rounded-2xl py-5 px-4 flex flex-col w-full gap-3 items-center mt-4"
+									>
+										{accountHasSui ? (
+											<CoinBalance amount={BigInt(tokenBalance)} type={activeCoinType} />
+										) : (
+											<div className="flex flex-col gap-5">
+												<div className="flex flex-col flex-nowrap justify-center items-center text-center px-2.5">
+													<SvgSuiTokensStack className="h-14 w-14 text-steel" />
+													<div className="flex flex-col gap-2 justify-center">
+														<Text variant="pBodySmall" color="gray-80" weight="normal">
+															To conduct transactions on the Sui network, you need SUI in your
+															wallet.
+														</Text>
+													</div>
 												</div>
+												<FaucetRequestButton />
 											</div>
-											<FaucetRequestButton />
-										</div>
-									)}
-									{isError ? (
-										<Alert>
-											<div>
-												<strong>Error updating balance</strong>
-											</div>
-										</Alert>
-									) : null}
-									<div className="grid grid-cols-3 gap-3 w-full">
-										<LargeButton
-											center
-											to="/onramp"
-											disabled={(coinType && coinType !== SUI_TYPE_ARG) || !providers?.length}
-											top={<WalletActionBuy24 />}
-										>
-											Buy
-										</LargeButton>
-
-										<LargeButton
-											center
-											data-testid="send-coin-button"
-											to={`/send${
-												coinBalance?.coinType
-													? `?${new URLSearchParams({
-															type: coinBalance.coinType,
-													  }).toString()}`
-													: ''
-											}`}
-											disabled={!tokenBalance}
-											top={<WalletActionSend24 />}
-										>
-											Send
-										</LargeButton>
-
-										<LargeButton center to="/" disabled top={<Swap16 />}>
-											Swap
-										</LargeButton>
-									</div>
-									<div className="w-full">
-										{activeCoinType === SUI_TYPE_ARG ? (
-											<TokenIconLink
-												disabled={!tokenBalance}
-												accountAddress={activeAccountAddress}
-											/>
+										)}
+										{isError ? (
+											<Alert>
+												<div>
+													<strong>Error updating balance</strong>
+												</div>
+											</Alert>
 										) : null}
+										<div className="grid grid-cols-3 gap-3 w-full">
+											<LargeButton
+												center
+												to="/onramp"
+												disabled={(coinType && coinType !== SUI_TYPE_ARG) || !providers?.length}
+												top={<WalletActionBuy24 />}
+											>
+												Buy
+											</LargeButton>
+
+											<LargeButton
+												center
+												data-testid="send-coin-button"
+												to={`/send${
+													coinBalance?.coinType
+														? `?${new URLSearchParams({
+																type: coinBalance.coinType,
+														  }).toString()}`
+														: ''
+												}`}
+												disabled={!tokenBalance}
+												top={<WalletActionSend24 />}
+											>
+												Send
+											</LargeButton>
+
+											<LargeButton center to="/" disabled top={<Swap16 />}>
+												Swap
+											</LargeButton>
+										</div>
+										<div className="w-full">
+											{activeCoinType === SUI_TYPE_ARG ? (
+												<TokenIconLink
+													disabled={!tokenBalance}
+													accountAddress={activeAccountAddress}
+												/>
+											) : null}
+										</div>
 									</div>
-								</div>
-							</>
-						)}
-					</div>
-					{isAccountLocked ? (
-						<UnlockAccountButton account={activeAccount} />
-					) : (
-						<MyTokens
-							coinBalances={coinBalances ?? []}
-							isLoading={coinBalancesLoading}
-							isFetched={coinBalancesFetched}
+								</>
+							}
 						/>
-					)}
+					</div>
+					<AccountLockedStateSwitch
+						account={activeAccount}
+						readLayout={
+							<MyTokens
+								coinBalances={coinBalances ?? []}
+								isLoading={coinBalancesLoading}
+								isFetched={coinBalancesFetched}
+							/>
+						}
+						elseLayout={<UnlockAccountButton account={activeAccount} />}
+					/>
 				</div>
 			</Loading>
 		</>

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
@@ -28,6 +28,8 @@ import Alert from '_components/alert';
 import Loading from '_components/loading';
 import { parseAmount } from '_helpers';
 import { useGetAllCoins } from '_hooks';
+import { UnlockAccountButton } from '_src/ui/app/components/accounts/UnlockAccountButton';
+import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
 import { GAS_SYMBOL } from '_src/ui/app/redux/slices/sui-objects/Coin';
 import { InputWithAction } from '_src/ui/app/shared/InputWithAction';
 
@@ -142,7 +144,9 @@ export function SendTokenForm({
 	initialTo = '',
 }: SendTokenFormProps) {
 	const client = useSuiClient();
-	const activeAddress = useActiveAddress();
+	const activeAccount = useActiveAccount();
+	const activeAddress = activeAccount?.address;
+	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	// Get all coins of the type
 	const { data: coinsData, isLoading: coinsIsLoading } = useGetAllCoins(coinType, activeAddress!);
 
@@ -174,7 +178,11 @@ export function SendTokenForm({
 	return (
 		<Loading
 			loading={
-				queryResult.isLoading || coinMetadata.isLoading || suiCoinsIsLoading || coinsIsLoading
+				queryResult.isLoading ||
+				coinMetadata.isLoading ||
+				suiCoinsIsLoading ||
+				coinsIsLoading ||
+				!activeAccount
 			}
 		>
 			<Formik
@@ -286,18 +294,22 @@ export function SendTokenForm({
 								</Form>
 							</Content>
 							<Menu stuckClass="sendCoin-cta" className="w-full px-0 pb-0 mx-0 gap-2.5">
-								<Button
-									type="submit"
-									onClick={submitForm}
-									variant="primary"
-									loading={isSubmitting}
-									disabled={
-										!isValid || isSubmitting || !hasEnoughBalance || values.gasBudgetEst === ''
-									}
-									size="tall"
-									text="Review"
-									after={<ArrowRight16 />}
-								/>
+								{isAccountWriteLocked ? (
+									<UnlockAccountButton account={activeAccount!} />
+								) : (
+									<Button
+										type="submit"
+										onClick={submitForm}
+										variant="primary"
+										loading={isSubmitting}
+										disabled={
+											!isValid || isSubmitting || !hasEnoughBalance || values.gasBudgetEst === ''
+										}
+										size="tall"
+										text="Review"
+										after={<ArrowRight16 />}
+									/>
+								)}
 							</Menu>
 						</BottomMenuLayout>
 					);

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
@@ -28,6 +28,7 @@ import Alert from '_components/alert';
 import Loading from '_components/loading';
 import { parseAmount } from '_helpers';
 import { useGetAllCoins } from '_hooks';
+import { AccountLockedStateSwitch } from '_src/ui/app/components/accounts/AccountLockStateSwitch';
 import { UnlockAccountButton } from '_src/ui/app/components/accounts/UnlockAccountButton';
 import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
 import { GAS_SYMBOL } from '_src/ui/app/redux/slices/sui-objects/Coin';
@@ -146,7 +147,6 @@ export function SendTokenForm({
 	const client = useSuiClient();
 	const activeAccount = useActiveAccount();
 	const activeAddress = activeAccount?.address;
-	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	// Get all coins of the type
 	const { data: coinsData, isLoading: coinsIsLoading } = useGetAllCoins(coinType, activeAddress!);
 
@@ -294,22 +294,24 @@ export function SendTokenForm({
 								</Form>
 							</Content>
 							<Menu stuckClass="sendCoin-cta" className="w-full px-0 pb-0 mx-0 gap-2.5">
-								{isAccountWriteLocked ? (
-									<UnlockAccountButton account={activeAccount!} />
-								) : (
-									<Button
-										type="submit"
-										onClick={submitForm}
-										variant="primary"
-										loading={isSubmitting}
-										disabled={
-											!isValid || isSubmitting || !hasEnoughBalance || values.gasBudgetEst === ''
-										}
-										size="tall"
-										text="Review"
-										after={<ArrowRight16 />}
-									/>
-								)}
+								<AccountLockedStateSwitch
+									account={activeAccount}
+									writeLockedLayout={<UnlockAccountButton account={activeAccount!} />}
+									elseLayout={
+										<Button
+											type="submit"
+											onClick={submitForm}
+											variant="primary"
+											loading={isSubmitting}
+											disabled={
+												!isValid || isSubmitting || !hasEnoughBalance || values.gasBudgetEst === ''
+											}
+											size="tall"
+											text="Review"
+											after={<ArrowRight16 />}
+										/>
+									}
+								/>
 							</Menu>
 						</BottomMenuLayout>
 					);

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -19,6 +19,7 @@ import { ValidatorFormDetail } from './ValidatorFormDetail';
 import { createStakeTransaction, createUnstakeTransaction } from './utils/transaction';
 import { createValidationSchema } from './utils/validation';
 import { QredoActionIgnoredByUser } from '../../QredoSigner';
+import { UnlockAccountButton } from '../../components/accounts/UnlockAccountButton';
 import Alert from '../../components/alert';
 import { getSignerOperationErrorMessage } from '../../helpers/errorMessages';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
@@ -52,6 +53,7 @@ function StakingCard() {
 	const coinType = SUI_TYPE_ARG;
 	const activeAccount = useActiveAccount();
 	const accountAddress = activeAccount?.address;
+	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	const { staleTime, refetchInterval } = useCoinsReFetchingConfig();
 	const { data: suiBalance, isLoading: loadingSuiBalances } = useBalance(
 		{ coinType: SUI_TYPE_ARG, owner: accountAddress! },
@@ -273,7 +275,7 @@ function StakingCard() {
 	}
 	return (
 		<div className="flex flex-col flex-nowrap flex-grow w-full">
-			<Loading loading={isLoading || validatorsIsloading || loadingSuiBalances}>
+			<Loading loading={isLoading || validatorsIsloading || loadingSuiBalances || !activeAccount}>
 				<Formik
 					initialValues={initialValues}
 					validationSchema={validationSchema}
@@ -324,22 +326,30 @@ function StakingCard() {
 							</Content>
 
 							<Menu stuckClass="staked-cta" className="w-full px-0 pb-0 mx-0">
-								<Button
-									size="tall"
-									variant="secondary"
-									to="/stake"
-									disabled={isSubmitting}
-									before={<ArrowLeft16 />}
-									text="Back"
-								/>
-								<Button
-									size="tall"
-									variant="primary"
-									onClick={submitForm}
-									disabled={!isValid || isSubmitting || (unstake && !delegationId)}
-									loading={isSubmitting}
-									text={unstake ? 'Unstake Now' : 'Stake Now'}
-								/>
+								{isAccountWriteLocked ? (
+									<div className="w-full mb-0.5">
+										<UnlockAccountButton account={activeAccount!} />
+									</div>
+								) : (
+									<>
+										<Button
+											size="tall"
+											variant="secondary"
+											to="/stake"
+											disabled={isSubmitting}
+											before={<ArrowLeft16 />}
+											text="Back"
+										/>
+										<Button
+											size="tall"
+											variant="primary"
+											onClick={submitForm}
+											disabled={!isValid || isSubmitting || (unstake && !delegationId)}
+											loading={isSubmitting}
+											text={unstake ? 'Unstake Now' : 'Stake Now'}
+										/>
+									</>
+								)}
 							</Menu>
 						</BottomMenuLayout>
 					)}

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -19,6 +19,7 @@ import { ValidatorFormDetail } from './ValidatorFormDetail';
 import { createStakeTransaction, createUnstakeTransaction } from './utils/transaction';
 import { createValidationSchema } from './utils/validation';
 import { QredoActionIgnoredByUser } from '../../QredoSigner';
+import { AccountLockedStateSwitch } from '../../components/accounts/AccountLockStateSwitch';
 import { UnlockAccountButton } from '../../components/accounts/UnlockAccountButton';
 import Alert from '../../components/alert';
 import { getSignerOperationErrorMessage } from '../../helpers/errorMessages';
@@ -53,7 +54,6 @@ function StakingCard() {
 	const coinType = SUI_TYPE_ARG;
 	const activeAccount = useActiveAccount();
 	const accountAddress = activeAccount?.address;
-	const isAccountWriteLocked = !activeAccount || activeAccount.isLocked;
 	const { staleTime, refetchInterval } = useCoinsReFetchingConfig();
 	const { data: suiBalance, isLoading: loadingSuiBalances } = useBalance(
 		{ coinType: SUI_TYPE_ARG, owner: accountAddress! },
@@ -326,30 +326,34 @@ function StakingCard() {
 							</Content>
 
 							<Menu stuckClass="staked-cta" className="w-full px-0 pb-0 mx-0">
-								{isAccountWriteLocked ? (
-									<div className="w-full mb-0.5">
-										<UnlockAccountButton account={activeAccount!} />
-									</div>
-								) : (
-									<>
-										<Button
-											size="tall"
-											variant="secondary"
-											to="/stake"
-											disabled={isSubmitting}
-											before={<ArrowLeft16 />}
-											text="Back"
-										/>
-										<Button
-											size="tall"
-											variant="primary"
-											onClick={submitForm}
-											disabled={!isValid || isSubmitting || (unstake && !delegationId)}
-											loading={isSubmitting}
-											text={unstake ? 'Unstake Now' : 'Stake Now'}
-										/>
-									</>
-								)}
+								<AccountLockedStateSwitch
+									account={activeAccount}
+									writeLockedLayout={
+										<div className="w-full mb-0.5">
+											<UnlockAccountButton account={activeAccount!} />
+										</div>
+									}
+									elseLayout={
+										<>
+											<Button
+												size="tall"
+												variant="secondary"
+												to="/stake"
+												disabled={isSubmitting}
+												before={<ArrowLeft16 />}
+												text="Back"
+											/>
+											<Button
+												size="tall"
+												variant="primary"
+												onClick={submitForm}
+												disabled={!isValid || isSubmitting || (unstake && !delegationId)}
+												loading={isSubmitting}
+												text={unstake ? 'Unstake Now' : 'Stake Now'}
+											/>
+										</>
+									}
+								/>
 							</Menu>
 						</BottomMenuLayout>
 					)}


### PR DESCRIPTION
## Description 

* an account can be locked for write/execute transaction but unlocked for read
* allow user to unlock the account before sending the transaction


https://github.com/MystenLabs/sui/assets/10210143/9878a0c1-f511-4b12-b6a4-342d77d55459


https://github.com/MystenLabs/sui/assets/10210143/291590a8-e05c-475c-b7fc-05ddd95d4a4b

<img width="1503" alt="Screenshot 2023-08-22 at 23 11 48" src="https://github.com/MystenLabs/sui/assets/10210143/232f36bc-0db7-4dc8-abd3-9f5a81eba94a">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
