### PR TITLE
[framework, chore] No more public entry, better style

### DIFF
--- a/crates/sui-framework/docs/coin.md
+++ b/crates/sui-framework/docs/coin.md
@@ -579,7 +579,7 @@ Consume the coin <code>c</code> and add its value to <code>self</code>.
 Aborts if <code>c.value + self.value &gt; U64_MAX</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -588,7 +588,7 @@ Aborts if <code>c.value + self.value &gt; U64_MAX</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;) {
     <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = c;
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.<a href="balance.md#0x2_balance">balance</a>, <a href="balance.md#0x2_balance">balance</a>);
@@ -918,7 +918,7 @@ Destroy the coin <code>c</code> and decrease the total supply in <code>cap</code
 accordingly.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -927,7 +927,7 @@ accordingly.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, c: <a href="coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;): u64 {
     <b>let</b> <a href="coin.md#0x2_coin_Coin">Coin</a> { id, <a href="balance.md#0x2_balance">balance</a> } = c;
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
     <a href="balance.md#0x2_balance_decrease_supply">balance::decrease_supply</a>(&<b>mut</b> cap.total_supply, <a href="balance.md#0x2_balance">balance</a>)
@@ -957,7 +957,7 @@ accordingly.
 Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code>recipient</code>. Invokes <code><a href="coin.md#0x2_coin_mint">mint</a>()</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -966,7 +966,7 @@ Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(
     c: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
 ) {
     <a href="transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(<a href="coin.md#0x2_coin_mint">mint</a>(c, amount, ctx), recipient)
@@ -984,7 +984,7 @@ Mint <code>amount</code> of <code><a href="coin.md#0x2_coin_Coin">Coin</a></code
 Update name of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, name: <a href="_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, name: <a href="_String">string::String</a>)
 </code></pre>
 
 
@@ -993,7 +993,7 @@ Update name of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMet
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(
     _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, name: <a href="_String">string::String</a>
 ) {
     metadata.name = name;
@@ -1011,7 +1011,7 @@ Update name of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMet
 Update the symbol of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, symbol: <a href="_String">ascii::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, symbol: <a href="_String">ascii::String</a>)
 </code></pre>
 
 
@@ -1020,7 +1020,7 @@ Update the symbol of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">C
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(
     _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, symbol: <a href="_String">ascii::String</a>
 ) {
     metadata.symbol = symbol;
@@ -1038,7 +1038,7 @@ Update the symbol of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">C
 Update the description of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, description: <a href="_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, description: <a href="_String">string::String</a>)
 </code></pre>
 
 
@@ -1047,7 +1047,7 @@ Update the description of the coin in <code><a href="coin.md#0x2_coin_CoinMetada
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(
     _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, description: <a href="_String">string::String</a>
 ) {
     metadata.description = description;
@@ -1065,7 +1065,7 @@ Update the description of the coin in <code><a href="coin.md#0x2_coin_CoinMetada
 Update the url of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>)
 </code></pre>
 
 
@@ -1074,7 +1074,7 @@ Update the url of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">Coin
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(
     _treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;, <a href="url.md#0x2_url">url</a>: <a href="_String">ascii::String</a>
 ) {
     metadata.icon_url = <a href="_some">option::some</a>(<a href="url.md#0x2_url_new_unsafe">url::new_unsafe</a>(<a href="url.md#0x2_url">url</a>));

--- a/crates/sui-framework/docs/display.md
+++ b/crates/sui-framework/docs/display.md
@@ -11,7 +11,7 @@ and keeping it separate from the ecosystem agreements.
 Each of the fields of the Display object should allow for pattern
 substitution and filling-in the pieces using the data from the object T.
 
-More entry functions might be added in the future depending on the use cases.
+More functions might be added in the future depending on the use cases.
 
 
 -  [Resource `Display`](#0x2_display_Display)
@@ -275,7 +275,7 @@ Create a new Display<T> object with a set of fields.
 Create a new empty Display<T> object and keep it.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &<a href="package.md#0x2_package_Publisher">package::Publisher</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &<a href="package.md#0x2_package_Publisher">package::Publisher</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -284,7 +284,7 @@ Create a new empty Display<T> object and keep it.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext) {
     <a href="transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(<a href="display.md#0x2_display_new">new</a>&lt;T&gt;(pub, ctx), sender(ctx))
 }
 </code></pre>
@@ -300,7 +300,7 @@ Create a new empty Display<T> object and keep it.
 Manually bump the version and emit an event with the updated version's contents.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_update_version">update_version</a>&lt;T: key&gt;(<a href="display.md#0x2_display">display</a>: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_update_version">update_version</a>&lt;T: key&gt;(<a href="display.md#0x2_display">display</a>: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -309,7 +309,7 @@ Manually bump the version and emit an event with the updated version's contents.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_update_version">update_version</a>&lt;T: key&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_update_version">update_version</a>&lt;T: key&gt;(
     <a href="display.md#0x2_display">display</a>: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;
 ) {
     <a href="display.md#0x2_display">display</a>.version = <a href="display.md#0x2_display">display</a>.version + 1;
@@ -332,7 +332,7 @@ Manually bump the version and emit an event with the updated version's contents.
 Sets a custom <code>name</code> field with the <code>value</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>, value: <a href="_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>, value: <a href="_String">string::String</a>)
 </code></pre>
 
 
@@ -341,7 +341,7 @@ Sets a custom <code>name</code> field with the <code>value</code>.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_add">add</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
     <a href="display.md#0x2_display_add_internal">add_internal</a>(self, name, value)
 }
 </code></pre>
@@ -357,7 +357,7 @@ Sets a custom <code>name</code> field with the <code>value</code>.
 Sets multiple <code>fields</code> with <code>values</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_add_multiple">add_multiple</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, fields: <a href="">vector</a>&lt;<a href="_String">string::String</a>&gt;, values: <a href="">vector</a>&lt;<a href="_String">string::String</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_add_multiple">add_multiple</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, fields: <a href="">vector</a>&lt;<a href="_String">string::String</a>&gt;, values: <a href="">vector</a>&lt;<a href="_String">string::String</a>&gt;)
 </code></pre>
 
 
@@ -366,7 +366,7 @@ Sets multiple <code>fields</code> with <code>values</code>.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_add_multiple">add_multiple</a>&lt;T: key&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_add_multiple">add_multiple</a>&lt;T: key&gt;(
     self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, fields: <a href="">vector</a>&lt;String&gt;, values: <a href="">vector</a>&lt;String&gt;
 ) {
     <b>let</b> len = <a href="_length">vector::length</a>(&fields);
@@ -389,10 +389,9 @@ Sets multiple <code>fields</code> with <code>values</code>.
 ## Function `edit`
 
 Change the value of the field.
-TODO (long run): version changes;
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_edit">edit</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>, value: <a href="_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_edit">edit</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>, value: <a href="_String">string::String</a>)
 </code></pre>
 
 
@@ -401,7 +400,7 @@ TODO (long run): version changes;
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_edit">edit</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_edit">edit</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
     <b>let</b> (_, _) = <a href="vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(&<b>mut</b> self.fields, &name);
     <a href="display.md#0x2_display_add_internal">add_internal</a>(self, name, value)
 }
@@ -418,7 +417,7 @@ TODO (long run): version changes;
 Remove the key from the Display.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="display.md#0x2_display_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">display::Display</a>&lt;T&gt;, name: <a href="_String">string::String</a>)
 </code></pre>
 
 
@@ -427,7 +426,7 @@ Remove the key from the Display.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>public</b> <b>fun</b> <a href="display.md#0x2_display_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String) {
+<pre><code><b>public</b> <b>fun</b> <a href="display.md#0x2_display_remove">remove</a>&lt;T: key&gt;(self: &<b>mut</b> <a href="display.md#0x2_display_Display">Display</a>&lt;T&gt;, name: String) {
     <a href="vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(&<b>mut</b> self.fields, &name);
 }
 </code></pre>

--- a/crates/sui-framework/docs/event.md
+++ b/crates/sui-framework/docs/event.md
@@ -22,7 +22,7 @@ use sui::event;
 struct ItemPurchased has copy, drop {
 item_id: ID, buyer: address
 }
-entry fun buy(/* .... */) {
+public fun buy(/* .... */) {
 /* ... */
 event::emit(ItemPurchased { item_id: ..., buyer: .... })
 }

--- a/crates/sui-framework/docs/hash.md
+++ b/crates/sui-framework/docs/hash.md
@@ -32,7 +32,7 @@ Hash the input bytes using Blake2b-256 and returns 32 bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x2_hash_blake2b256">blake2b256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="hash.md#0x2_hash_blake2b256">blake2b256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -69,7 +69,7 @@ Hash the input bytes using keccak256 and returns 32 bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x2_hash_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="hash.md#0x2_hash_keccak256">keccak256</a>(data: &<a href="">vector</a>&lt;u8&gt;): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -808,7 +808,7 @@ Restrict upgrades through this upgrade <code>cap</code> to just add code, or
 change dependencies.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_only_additive_upgrades">only_additive_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_only_additive_upgrades">only_additive_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
 </code></pre>
 
 
@@ -817,7 +817,7 @@ change dependencies.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_only_additive_upgrades">only_additive_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_only_additive_upgrades">only_additive_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
     <a href="package.md#0x2_package_restrict">restrict</a>(cap, <a href="package.md#0x2_package_ADDITIVE">ADDITIVE</a>)
 }
 </code></pre>
@@ -834,7 +834,7 @@ Restrict upgrades through this upgrade <code>cap</code> to just change
 dependencies.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_only_dep_upgrades">only_dep_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_only_dep_upgrades">only_dep_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
 </code></pre>
 
 
@@ -843,7 +843,7 @@ dependencies.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_only_dep_upgrades">only_dep_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_only_dep_upgrades">only_dep_upgrades</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
     <a href="package.md#0x2_package_restrict">restrict</a>(cap, <a href="package.md#0x2_package_DEP_ONLY">DEP_ONLY</a>)
 }
 </code></pre>
@@ -859,7 +859,7 @@ dependencies.
 Discard the <code><a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a></code> to make a package immutable.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_make_immutable">make_immutable</a>(cap: <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_make_immutable">make_immutable</a>(cap: <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>)
 </code></pre>
 
 
@@ -868,7 +868,7 @@ Discard the <code><a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a></co
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="package.md#0x2_package_make_immutable">make_immutable</a>(cap: <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_make_immutable">make_immutable</a>(cap: <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>) {
     <b>let</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a> { id, <a href="package.md#0x2_package">package</a>: _, version: _, policy: _ } = cap;
     <a href="object.md#0x2_object_delete">object::delete</a>(id);
 }

--- a/crates/sui-framework/docs/pay.md
+++ b/crates/sui-framework/docs/pay.md
@@ -72,7 +72,7 @@ Split coin <code>self</code> to two coins, one with balance <code>split_amount</
 and the remaining balance is left is <code>self</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -81,7 +81,7 @@ and the remaining balance is left is <code>self</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split">split</a>&lt;T&gt;(
     self: &<b>mut</b> Coin&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext
 ) {
     <a href="pay.md#0x2_pay_keep">keep</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(self, split_amount, ctx), ctx)
@@ -100,7 +100,7 @@ Split coin <code>self</code> into multiple coins, each with balance specified
 in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -109,7 +109,7 @@ in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(
     self: &<b>mut</b> Coin&lt;T&gt;, split_amounts: <a href="">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> TxContext
 ) {
     <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&split_amounts));
@@ -132,7 +132,7 @@ Send <code>amount</code> units of <code>c</code> to <code>recipient</code>
 Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal to <code>amount</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -141,7 +141,7 @@ Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(
     c: &<b>mut</b> Coin&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> TxContext
 ) {
     <a href="transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(<a href="coin.md#0x2_coin_split">coin::split</a>(c, amount, ctx), recipient)
@@ -160,7 +160,7 @@ Divide coin <code>self</code> into <code>n - 1</code> coins with equal balances.
 not evenly divisible by <code>n</code>, the remainder is left in <code>self</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -169,7 +169,7 @@ not evenly divisible by <code>n</code>, the remainder is left in <code>self</cod
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(
     self: &<b>mut</b> Coin&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext
 ) {
     <b>let</b> vec: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt; = <a href="coin.md#0x2_coin_divide_into_n">coin::divide_into_n</a>(self, n, ctx);
@@ -193,7 +193,7 @@ not evenly divisible by <code>n</code>, the remainder is left in <code>self</cod
 Join <code><a href="coin.md#0x2_coin">coin</a></code> into <code>self</code>. Re-exports <code><a href="coin.md#0x2_coin_join">coin::join</a></code> function.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -202,7 +202,7 @@ Join <code><a href="coin.md#0x2_coin">coin</a></code> into <code>self</code>. Re
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, <a href="coin.md#0x2_coin">coin</a>: Coin&lt;T&gt;) {
     <a href="coin.md#0x2_coin_join">coin::join</a>(self, <a href="coin.md#0x2_coin">coin</a>)
 }
 </code></pre>
@@ -218,7 +218,7 @@ Join <code><a href="coin.md#0x2_coin">coin</a></code> into <code>self</code>. Re
 Join everything in <code>coins</code> with <code>self</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;)
 </code></pre>
 
 
@@ -227,7 +227,7 @@ Join everything in <code>coins</code> with <code>self</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;) {
     <b>let</b> (i, len) = (0, <a href="_length">vector::length</a>(&coins));
     <b>while</b> (i &lt; len) {
         <b>let</b> <a href="coin.md#0x2_coin">coin</a> = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
@@ -250,7 +250,7 @@ Join everything in <code>coins</code> with <code>self</code>
 Join a vector of <code>Coin</code> into a single object and transfer it to <code>receiver</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, receiver: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;<a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, receiver: <b>address</b>)
 </code></pre>
 
 
@@ -259,7 +259,7 @@ Join a vector of <code>Coin</code> into a single object and transfer it to <code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;, receiver: <b>address</b>) {
+<pre><code><b>public</b> <b>fun</b> <a href="pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="">vector</a>&lt;Coin&lt;T&gt;&gt;, receiver: <b>address</b>) {
     <b>assert</b>!(<a href="_length">vector::length</a>(&coins) &gt; 0, <a href="pay.md#0x2_pay_ENoCoins">ENoCoins</a>);
 
     <b>let</b> self = <a href="_pop_back">vector::pop_back</a>(&<b>mut</b> coins);

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -153,9 +153,13 @@ This should be called only once during genesis creation.
 
 ## Function `transfer`
 
+The <code>Coin</code> type has <code>store</code> constraint which makes it freely transferable
+using the TransferObjects command in a Programmable Transaction Block.
+
+This function is not necessary and can be considered redundant.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -164,7 +168,7 @@ This should be called only once during genesis creation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
+<pre><code><b>public</b> <b>fun</b> <a href="transfer.md#0x2_transfer">transfer</a>(c: <a href="coin.md#0x2_coin_Coin">coin::Coin</a>&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
     <a href="transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(c, recipient)
 }
 </code></pre>

--- a/crates/sui-framework/packages/sui-framework/sources/coin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/coin.move
@@ -147,7 +147,7 @@ module sui::coin {
 
     /// Consume the coin `c` and add its value to `self`.
     /// Aborts if `c.value + self.value > U64_MAX`
-    public entry fun join<T>(self: &mut Coin<T>, c: Coin<T>) {
+    public fun join<T>(self: &mut Coin<T>, c: Coin<T>) {
         let Coin { id, balance } = c;
         object::delete(id);
         balance::join(&mut self.balance, balance);
@@ -302,7 +302,7 @@ module sui::coin {
 
     /// Destroy the coin `c` and decrease the total supply in `cap`
     /// accordingly.
-    public entry fun burn<T>(cap: &mut TreasuryCap<T>, c: Coin<T>): u64 {
+    public fun burn<T>(cap: &mut TreasuryCap<T>, c: Coin<T>): u64 {
         let Coin { id, balance } = c;
         object::delete(id);
         balance::decrease_supply(&mut cap.total_supply, balance)
@@ -326,7 +326,7 @@ module sui::coin {
     // === Entrypoints ===
 
     /// Mint `amount` of `Coin` and send it to `recipient`. Invokes `mint()`.
-    public entry fun mint_and_transfer<T>(
+    public fun mint_and_transfer<T>(
         c: &mut TreasuryCap<T>, amount: u64, recipient: address, ctx: &mut TxContext
     ) {
         transfer::public_transfer(mint(c, amount, ctx), recipient)
@@ -335,28 +335,28 @@ module sui::coin {
     // === Update coin metadata ===
 
     /// Update name of the coin in `CoinMetadata`
-    public entry fun update_name<T>(
+    public fun update_name<T>(
         _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, name: string::String
     ) {
         metadata.name = name;
     }
 
     /// Update the symbol of the coin in `CoinMetadata`
-    public entry fun update_symbol<T>(
+    public fun update_symbol<T>(
         _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, symbol: ascii::String
     ) {
         metadata.symbol = symbol;
     }
 
     /// Update the description of the coin in `CoinMetadata`
-    public entry fun update_description<T>(
+    public fun update_description<T>(
         _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, description: string::String
     ) {
         metadata.description = description;
     }
 
     /// Update the url of the coin in `CoinMetadata`
-    public entry fun update_icon_url<T>(
+    public fun update_icon_url<T>(
         _treasury: &TreasuryCap<T>, metadata: &mut CoinMetadata<T>, url: ascii::String
     ) {
         metadata.icon_url = option::some(url::new_unsafe(url));

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/bls12381.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/bls12381.move
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::bls12381 {
-
     /// @param signature: A 48-bytes signature that is a point on the G1 subgroup.
     /// @param public_key: A 96-bytes public key that is a point on the G2 subgroup.
     /// @param msg: The message that we test the signature against.

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/hash.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/hash.move
@@ -6,9 +6,9 @@
 module sui::hash {
     /// @param data: Arbitrary binary data to hash
     /// Hash the input bytes using Blake2b-256 and returns 32 bytes.
-    native public fun blake2b256(data: &vector<u8>): vector<u8>;
+    public native fun blake2b256(data: &vector<u8>): vector<u8>;
 
     /// @param data: Arbitrary binary data to hash
     /// Hash the input bytes using keccak256 and returns 32 bytes.
-    native public fun keccak256(data: &vector<u8>): vector<u8>;
+    public native fun keccak256(data: &vector<u8>): vector<u8>;
 }

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/hmac.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/hmac.move
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::hmac {
-
     /// @param key: HMAC key, arbitrary bytes.
     /// @param msg: message to sign, arbitrary bytes.
     /// Returns the 32 bytes digest of HMAC-SHA3-256(key, msg).
     public native fun hmac_sha3_256(key: &vector<u8>, msg: &vector<u8>): vector<u8>;
-
 }

--- a/crates/sui-framework/packages/sui-framework/sources/display.move
+++ b/crates/sui-framework/packages/sui-framework/sources/display.move
@@ -9,7 +9,7 @@
 /// Each of the fields of the Display object should allow for pattern
 /// substitution and filling-in the pieces using the data from the object T.
 ///
-/// More entry functions might be added in the future depending on the use cases.
+/// More functions might be added in the future depending on the use cases.
 module sui::display {
     use sui::package::{from_package, Publisher};
     use sui::tx_context::{sender, TxContext};
@@ -104,12 +104,12 @@ module sui::display {
 
     #[lint_allow(self_transfer)]
     /// Create a new empty Display<T> object and keep it.
-    entry public fun create_and_keep<T: key>(pub: &Publisher, ctx: &mut TxContext) {
+    public fun create_and_keep<T: key>(pub: &Publisher, ctx: &mut TxContext) {
         transfer::public_transfer(new<T>(pub, ctx), sender(ctx))
     }
 
     /// Manually bump the version and emit an event with the updated version's contents.
-    entry public fun update_version<T: key>(
+    public fun update_version<T: key>(
         display: &mut Display<T>
     ) {
         display.version = display.version + 1;
@@ -120,15 +120,15 @@ module sui::display {
         })
     }
 
-    // === Entry functions: Add/Modify fields ===
+    // === functions: Add/Modify fields ===
 
     /// Sets a custom `name` field with the `value`.
-    entry public fun add<T: key>(self: &mut Display<T>, name: String, value: String) {
+    public fun add<T: key>(self: &mut Display<T>, name: String, value: String) {
         add_internal(self, name, value)
     }
 
     /// Sets multiple `fields` with `values`.
-    entry public fun add_multiple<T: key>(
+    public fun add_multiple<T: key>(
         self: &mut Display<T>, fields: vector<String>, values: vector<String>
     ) {
         let len = vector::length(&fields);
@@ -142,14 +142,13 @@ module sui::display {
     }
 
     /// Change the value of the field.
-    /// TODO (long run): version changes;
-    entry public fun edit<T: key>(self: &mut Display<T>, name: String, value: String) {
+    public fun edit<T: key>(self: &mut Display<T>, name: String, value: String) {
         let (_, _) = vec_map::remove(&mut self.fields, &name);
         add_internal(self, name, value)
     }
 
     /// Remove the key from the Display.
-    entry public fun remove<T: key>(self: &mut Display<T>, name: String) {
+    public fun remove<T: key>(self: &mut Display<T>, name: String) {
         vec_map::remove(&mut self.fields, &name);
     }
 

--- a/crates/sui-framework/packages/sui-framework/sources/event.move
+++ b/crates/sui-framework/packages/sui-framework/sources/event.move
@@ -20,7 +20,7 @@
 ///    struct ItemPurchased has copy, drop {
 ///      item_id: ID, buyer: address
 ///    }
-///    entry fun buy(/* .... */) {
+///    public fun buy(/* .... */) {
 ///       /* ... */
 ///       event::emit(ItemPurchased { item_id: ..., buyer: .... })
 ///    }

--- a/crates/sui-framework/packages/sui-framework/sources/math.move
+++ b/crates/sui-framework/packages/sui-framework/sources/math.move
@@ -3,7 +3,6 @@
 
 /// Basic math for nicer programmability
 module sui::math {
-
     /// Return the larger of `x` and `y`
     public fun max(x: u64, y: u64): u64 {
         if (x > y) {

--- a/crates/sui-framework/packages/sui-framework/sources/package.move
+++ b/crates/sui-framework/packages/sui-framework/sources/package.move
@@ -208,18 +208,18 @@ module sui::package {
 
     /// Restrict upgrades through this upgrade `cap` to just add code, or
     /// change dependencies.
-    public entry fun only_additive_upgrades(cap: &mut UpgradeCap) {
+    public fun only_additive_upgrades(cap: &mut UpgradeCap) {
         restrict(cap, ADDITIVE)
     }
 
     /// Restrict upgrades through this upgrade `cap` to just change
     /// dependencies.
-    public entry fun only_dep_upgrades(cap: &mut UpgradeCap) {
+    public fun only_dep_upgrades(cap: &mut UpgradeCap) {
         restrict(cap, DEP_ONLY)
     }
 
     /// Discard the `UpgradeCap` to make a package immutable.
-    public entry fun make_immutable(cap: UpgradeCap) {
+    public fun make_immutable(cap: UpgradeCap) {
         let UpgradeCap { id, package: _, version: _, policy: _ } = cap;
         object::delete(id);
     }

--- a/crates/sui-framework/packages/sui-framework/sources/pay.move
+++ b/crates/sui-framework/packages/sui-framework/sources/pay.move
@@ -19,7 +19,7 @@ module sui::pay {
 
     /// Split coin `self` to two coins, one with balance `split_amount`,
     /// and the remaining balance is left is `self`.
-    public entry fun split<T>(
+    public fun split<T>(
         self: &mut Coin<T>, split_amount: u64, ctx: &mut TxContext
     ) {
         keep(coin::split(self, split_amount, ctx), ctx)
@@ -27,7 +27,7 @@ module sui::pay {
 
     /// Split coin `self` into multiple coins, each with balance specified
     /// in `split_amounts`. Remaining balance is left in `self`.
-    public entry fun split_vec<T>(
+    public fun split_vec<T>(
         self: &mut Coin<T>, split_amounts: vector<u64>, ctx: &mut TxContext
     ) {
         let (i, len) = (0, vector::length(&split_amounts));
@@ -39,7 +39,7 @@ module sui::pay {
 
     /// Send `amount` units of `c` to `recipient`
     /// Aborts with `EVALUE` if `amount` is greater than or equal to `amount`
-    public entry fun split_and_transfer<T>(
+    public fun split_and_transfer<T>(
         c: &mut Coin<T>, amount: u64, recipient: address, ctx: &mut TxContext
     ) {
         transfer::public_transfer(coin::split(c, amount, ctx), recipient)
@@ -49,7 +49,7 @@ module sui::pay {
     #[lint_allow(self_transfer)]
     /// Divide coin `self` into `n - 1` coins with equal balances. If the balance is
     /// not evenly divisible by `n`, the remainder is left in `self`.
-    public entry fun divide_and_keep<T>(
+    public fun divide_and_keep<T>(
         self: &mut Coin<T>, n: u64, ctx: &mut TxContext
     ) {
         let vec: vector<Coin<T>> = coin::divide_into_n(self, n, ctx);
@@ -62,12 +62,12 @@ module sui::pay {
     }
 
     /// Join `coin` into `self`. Re-exports `coin::join` function.
-    public entry fun join<T>(self: &mut Coin<T>, coin: Coin<T>) {
+    public fun join<T>(self: &mut Coin<T>, coin: Coin<T>) {
         coin::join(self, coin)
     }
 
     /// Join everything in `coins` with `self`
-    public entry fun join_vec<T>(self: &mut Coin<T>, coins: vector<Coin<T>>) {
+    public fun join_vec<T>(self: &mut Coin<T>, coins: vector<Coin<T>>) {
         let (i, len) = (0, vector::length(&coins));
         while (i < len) {
             let coin = vector::pop_back(&mut coins);
@@ -79,7 +79,7 @@ module sui::pay {
     }
 
     /// Join a vector of `Coin` into a single object and transfer it to `receiver`.
-    public entry fun join_vec_and_transfer<T>(coins: vector<Coin<T>>, receiver: address) {
+    public fun join_vec_and_transfer<T>(coins: vector<Coin<T>>, receiver: address) {
         assert!(vector::length(&coins) > 0, ENoCoins);
 
         let self = vector::pop_back(&mut coins);

--- a/crates/sui-framework/packages/sui-framework/sources/sui.move
+++ b/crates/sui-framework/packages/sui-framework/sources/sui.move
@@ -53,7 +53,11 @@ module sui::sui {
         total_sui
     }
 
-    public entry fun transfer(c: coin::Coin<SUI>, recipient: address) {
+    /// The `Coin` type has `store` constraint which makes it freely transferable
+    /// using the TransferObjects command in a Programmable Transaction Block.
+    ///
+    /// This function is not necessary and can be considered redundant.
+    public fun transfer(c: coin::Coin<SUI>, recipient: address) {
         transfer::public_transfer(c, recipient)
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -14,7 +14,7 @@ module sui::pay_tests {
     const TEST_SENDER_ADDR: address = @0xA11CE;
 
     #[test]
-    public entry fun test_coin_split_n() {
+    fun test_coin_split_n() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -45,7 +45,7 @@ module sui::pay_tests {
     }
 
     #[test]
-    public entry fun test_coin_split_n_to_vec() {
+    fun test_coin_split_n_to_vec() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -69,7 +69,7 @@ module sui::pay_tests {
     }
 
     #[test]
-    public entry fun test_split_vec() {
+    fun test_split_vec() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -96,7 +96,7 @@ module sui::pay_tests {
     }
 
     #[test]
-    public entry fun test_split_and_transfer() {
+    fun test_split_and_transfer() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -118,7 +118,7 @@ module sui::pay_tests {
 
     #[test]
     #[expected_failure(abort_code = balance::ENotEnough)]
-    public entry fun test_split_and_transfer_fail() {
+    fun test_split_and_transfer_fail() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -137,7 +137,7 @@ module sui::pay_tests {
     }
 
     #[test]
-    public entry fun test_join_vec_and_transfer() {
+    fun test_join_vec_and_transfer() {
         let scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);


### PR DESCRIPTION
## Description 

As we're on a mission to fight the use of `public entry`, Sui Framework is a great start. This PR removes all occurrences of `public entry` in framework and slightly patches styles / spacings in other places.

## Test Plan 

No new code introduced.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
