### PR TITLE
Linter native primitives only, tested for Defined functions for now

### DIFF
--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -7,7 +7,11 @@ use move_ir_types::location::Loc;
 pub mod coin_field;
 pub mod collection_equality;
 pub mod custom_state_change;
+<<<<<<< HEAD
 pub mod freeze_wrapped;
+=======
+pub mod native_primitives_only;
+>>>>>>> d8cdb2845 (First linter tweaks)
 pub mod self_transfer;
 pub mod share_owned;
 
@@ -55,8 +59,12 @@ pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
 pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
 pub const CUSTOM_STATE_CHANGE_FILTER_NAME: &str = "custom_state_change";
 pub const COIN_FIELD_FILTER_NAME: &str = "coin_field";
+<<<<<<< HEAD
 pub const FREEZE_WRAPPED_FILTER_NAME: &str = "freeze_wrapped";
 pub const COLLECTION_EQUALITY_FILTER_NAME: &str = "collection_equality";
+=======
+pub const NATIVE_PRIMITIVES_FILTER_NAME: &str = "native_primitives_only";
+>>>>>>> d8cdb2845 (First linter tweaks)
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
@@ -65,8 +73,12 @@ pub enum LinterDiagCategory {
     SelfTransfer,
     CustomStateChange,
     CoinField,
+<<<<<<< HEAD
     FreezeWrapped,
     CollectionEquality,
+=======
+    NativePrimitivesOnly,
+>>>>>>> d8cdb2845 (First linter tweaks)
 }
 
 /// A default code for each linter category (as long as only one code per category is used, no other
@@ -102,6 +114,7 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
                 LINTER_DEFAULT_DIAG_CODE,
                 Some(COIN_FIELD_FILTER_NAME),
             ),
+<<<<<<< HEAD
             WarningFilter::code(
                 Some(LINT_WARNING_PREFIX),
                 LinterDiagCategory::FreezeWrapped as u8,
@@ -113,6 +126,15 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
                 LinterDiagCategory::CollectionEquality as u8,
                 LINTER_DEFAULT_DIAG_CODE,
                 Some(COLLECTION_EQUALITY_FILTER_NAME),
+=======
+            WarningFilter::Code(
+                DiagnosticsID::new(
+                    LinterDiagCategory::NativePrimitivesOnly as u8,
+                    LINTER_DEFAULT_DIAG_CODE,
+                    Some(LINT_WARNING_PREFIX),
+                ),
+                Some(NATIVE_PRIMITIVES_FILTER_NAME),
+>>>>>>> d8cdb2845 (First linter tweaks)
             ),
         ],
     )

--- a/crates/sui-move-build/src/linters/mod.rs
+++ b/crates/sui-move-build/src/linters/mod.rs
@@ -7,11 +7,8 @@ use move_ir_types::location::Loc;
 pub mod coin_field;
 pub mod collection_equality;
 pub mod custom_state_change;
-<<<<<<< HEAD
 pub mod freeze_wrapped;
-=======
 pub mod native_primitives_only;
->>>>>>> d8cdb2845 (First linter tweaks)
 pub mod self_transfer;
 pub mod share_owned;
 
@@ -59,12 +56,9 @@ pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
 pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
 pub const CUSTOM_STATE_CHANGE_FILTER_NAME: &str = "custom_state_change";
 pub const COIN_FIELD_FILTER_NAME: &str = "coin_field";
-<<<<<<< HEAD
 pub const FREEZE_WRAPPED_FILTER_NAME: &str = "freeze_wrapped";
 pub const COLLECTION_EQUALITY_FILTER_NAME: &str = "collection_equality";
-=======
 pub const NATIVE_PRIMITIVES_FILTER_NAME: &str = "native_primitives_only";
->>>>>>> d8cdb2845 (First linter tweaks)
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
@@ -73,12 +67,9 @@ pub enum LinterDiagCategory {
     SelfTransfer,
     CustomStateChange,
     CoinField,
-<<<<<<< HEAD
     FreezeWrapped,
     CollectionEquality,
-=======
     NativePrimitivesOnly,
->>>>>>> d8cdb2845 (First linter tweaks)
 }
 
 /// A default code for each linter category (as long as only one code per category is used, no other
@@ -114,7 +105,6 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
                 LINTER_DEFAULT_DIAG_CODE,
                 Some(COIN_FIELD_FILTER_NAME),
             ),
-<<<<<<< HEAD
             WarningFilter::code(
                 Some(LINT_WARNING_PREFIX),
                 LinterDiagCategory::FreezeWrapped as u8,
@@ -126,15 +116,12 @@ pub fn known_filters() -> (E::AttributeName_, Vec<WarningFilter>) {
                 LinterDiagCategory::CollectionEquality as u8,
                 LINTER_DEFAULT_DIAG_CODE,
                 Some(COLLECTION_EQUALITY_FILTER_NAME),
-=======
-            WarningFilter::Code(
-                DiagnosticsID::new(
-                    LinterDiagCategory::NativePrimitivesOnly as u8,
-                    LINTER_DEFAULT_DIAG_CODE,
-                    Some(LINT_WARNING_PREFIX),
-                ),
+            ),
+            WarningFilter::code(
+                Some(LINT_WARNING_PREFIX),
+                LinterDiagCategory::NativePrimitivesOnly as u8,
+                LINTER_DEFAULT_DIAG_CODE,
                 Some(NATIVE_PRIMITIVES_FILTER_NAME),
->>>>>>> d8cdb2845 (First linter tweaks)
             ),
         ],
     )

--- a/crates/sui-move-build/src/linters/native_primitives_only.rs
+++ b/crates/sui-move-build/src/linters/native_primitives_only.rs
@@ -22,12 +22,12 @@ use super::{
     LINT_WARNING_PREFIX, SUI_PKG_NAME,
 };
 
-const COIN_FIELD_DIAG: DiagnosticInfo = custom(
+const NATIVE_PRIMITIVE_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
     Severity::Warning,
-    LinterDiagCategory::CoinField as u8,
+    LinterDiagCategory::NativePrimitivesOnly as u8,
     LINTER_DEFAULT_DIAG_CODE,
-    "sub-optimal 'sui::coin::Coin' field type",
+    "passing non-native types to native functions",
 );
 
 pub struct NativePrimitivesOnlyVisitor;
@@ -41,70 +41,75 @@ impl TypingVisitor for NativePrimitivesOnlyVisitor {
     ) {
         for (_, _, mdef) in program.modules.iter() {
             env.add_warning_filter_scope(mdef.warning_filter.clone());
-            let _x = mdef
-                .functions
+            mdef.functions
                 .iter()
-                .for_each(|(_sloc, fname, fun)| match fun.body.value {
-                    move_compiler::typing::ast::FunctionBody_::Defined(_) => {
-                        // println!("This is a defined function{:?}", fname);
-                        // println!("Its types are {:?}", fun.signature.type_parameters);
-                        // println!("Now for this one{:?}", fun.signature.parameters);
-                    }
-                    move_compiler::typing::ast::FunctionBody_::Native => {
-                        println!("This is a native function");
-                        //     println!("Its types are {:?}", fun.signature.type_parameters);
-                        //     println!("Now for this one{:?}", fun.signature.parameters);
-                    }
-                });
-            // mdef.structs
-            //     .iter()
-            //     .for_each(|(sloc, sname, sdef)| struct_def(env, *sname, sdef, sloc));
+                .for_each(|(sloc, fname, fun)| check_native(env, *fname, fun, sloc));
             env.pop_warning_filter_scope();
         }
     }
 }
 
-// fn struct_def(env: &mut CompilationEnv, sname: Symbol, sdef: &N::StructDefinition, sloc: Loc) {
-//     env.add_warning_filter_scope(sdef.warning_filter.clone());
-//
-//     if let N::StructFields::Defined(sfields) = &sdef.fields {
-//         for (floc, fname, (_, ftype)) in sfields.iter() {
-//             if is_field_coin_type(ftype) {
-//                 let msg = format!("The field '{fname}' of '{sname}' has type 'sui::coin::Coin'");
-//                 let uid_msg = "Storing 'sui::balance::Balance' in this field will typically be more space-efficient";
-//                 let d = diag!(COIN_FIELD_DIAG, (sloc, msg), (floc, uid_msg));
-//                 env.add_diag(d);
-//             }
-//         }
-//     }
-//
-//     env.pop_warning_filter_scope();
-// }
+fn check_native(env: &mut CompilationEnv, fname: Symbol, fun: &T::Function, sloc: Loc) {
+    match fun.body.value {
+        T::FunctionBody_::Defined(_) => {
+            let parameters = &fun.signature.parameters;
+            for (_var, data) in parameters.iter() {
+                if !is_native_or_ref(data.value.clone()) {
+                    //This is a non-native type, so we prepare the message
+                    let c = _var.value.name;
+                    let msg =
+                        format!("The parameter '{c}' of '{fname}' is not native or a reference");
+                    let uid_msg = "Only native types or references are allowed";
+                    let mut d = diag!(NATIVE_PRIMITIVE_DIAG, (sloc, msg),);
+                    d.add_note(uid_msg);
+                    env.add_diag(d);
 
-// fn is_field_coin_type(sp!(_, t): &N::Type) -> bool {
-//     use N::Type_ as T;
-//     match t {
-//         T::Ref(_, inner_t) => is_field_coin_type(inner_t),
-//         T::Apply(_, tname, _) => {
-//             let sp!(_, tname) = tname;
-//             if let N::TypeName_::ModuleType(mident, sname) = tname {
-//                 return is_mident_sui_coin(mident) || sname.value() == COIN_STRUCT_NAME.into();
-//             }
-//             false
-//         }
-//         T::Unit | T::Param(_) | T::Var(_) | T::Anything | T::UnresolvedError => false,
-//     }
-// }
-//
-// fn is_mident_sui_coin(sp!(_, mident): &E::ModuleIdent) -> bool {
-//     use E::Address as A;
-//     if mident.module.value() != COIN_MOD_NAME.into() {
-//         return false;
-//     }
-//     let sui_addr = NumericalAddress::new(AccountAddress::TWO.into_bytes(), NumberFormat::Hex);
-//     match mident.address {
-//         A::Numerical(_, addr) => addr.value == sui_addr,
-//         A::NamedUnassigned(n) => n.value == SUI_PKG_NAME.into(),
-//     }
-// }
-//
+                    println!("Object in definition, time to shoot");
+                }
+            }
+        }
+        T::FunctionBody_::Native => {
+            //Uncomment and comment the other piece of code to try it out
+            // let parameters = &fun.signature.parameters;
+            // for (_var, data) in parameters.iter() {
+            //     if !is_native_or_ref(data.value.clone()) {
+            //         //This is a non-native type, so we prepare the message
+            //         let c = _var.value.name;
+            //         let msg =
+            //             format!("The parameter '{c}' of '{fname}' is not native or a reference");
+            //         let uid_msg = "Only native types or references are allowed";
+            //         let mut d = diag!(NATIVE_PRIMITIVE_DIAG, (sloc, msg),);
+            //         d.add_note(uid_msg);
+            //         env.add_diag(d);
+            //
+            //         println!("Object in definition, time to shoot");
+            //     }
+            // }
+        }
+    }
+}
+fn is_native_or_ref(element: N::Type_) -> bool {
+    match element {
+        N::Type_::Apply(_option, typename, _stype) => match typename.value {
+            N::TypeName_::Builtin(_) => {
+                return true;
+            }
+            N::TypeName_::ModuleType(_mident, _sname) => {
+                //Flash out that a struct should not be here!
+                return false;
+            }
+            _ => {
+                return false;
+            }
+        },
+        N::Type_::Ref(_is_mutable, _referenced_element) => {
+            //I'm ok, it's a reference, I can't have && in move
+            return true;
+            // let el = referenced_element.as_ref().value.clone();
+            // is_native_or_ref(el);
+        }
+        _ => {}
+    }
+
+    false
+}

--- a/crates/sui-move-build/src/linters/native_primitives_only.rs
+++ b/crates/sui-move-build/src/linters/native_primitives_only.rs
@@ -38,7 +38,6 @@ impl TypingVisitor for NativePrimitivesOnlyVisitor {
             mdef.functions
                 .key_cloned_iter()
                 .for_each(|(fname, fdef)| check_native(env, fname.value(), fdef, fname.loc()));
-            // .for_each(|(sloc, fname, fun)| check_native(env, *fname, fun, sloc));
             env.pop_warning_filter_scope();
         }
     }

--- a/crates/sui-move-build/src/linters/native_primitives_only.rs
+++ b/crates/sui-move-build/src/linters/native_primitives_only.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This analysis flags uses of the sui::coin::Coin struct in fields of other structs. In most cases
+//! it's preferable to use sui::balance::Balance instead to save space.
+
+use move_command_line_common::{address::NumericalAddress, parser::NumberFormat};
+use move_compiler::{
+    diag,
+    diagnostics::codes::{custom, DiagnosticInfo, Severity},
+    expansion::ast as E,
+    naming::ast as N,
+    shared::{CompilationEnv, Identifier},
+    typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
+};
+use move_core_types::account_address::AccountAddress;
+use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
+
+use super::{
+    LinterDiagCategory, COIN_MOD_NAME, COIN_STRUCT_NAME, LINTER_DEFAULT_DIAG_CODE,
+    LINT_WARNING_PREFIX, SUI_PKG_NAME,
+};
+
+const COIN_FIELD_DIAG: DiagnosticInfo = custom(
+    LINT_WARNING_PREFIX,
+    Severity::Warning,
+    LinterDiagCategory::CoinField as u8,
+    LINTER_DEFAULT_DIAG_CODE,
+    "sub-optimal 'sui::coin::Coin' field type",
+);
+
+pub struct NativePrimitivesOnlyVisitor;
+
+impl TypingVisitor for NativePrimitivesOnlyVisitor {
+    fn visit(
+        &mut self,
+        env: &mut CompilationEnv,
+        _program_info: &ProgramInfo,
+        program: &mut T::Program,
+    ) {
+        for (_, _, mdef) in program.modules.iter() {
+            env.add_warning_filter_scope(mdef.warning_filter.clone());
+            let _x = mdef
+                .functions
+                .iter()
+                .for_each(|(_sloc, fname, fun)| match fun.body.value {
+                    move_compiler::typing::ast::FunctionBody_::Defined(_) => {
+                        // println!("This is a defined function{:?}", fname);
+                        // println!("Its types are {:?}", fun.signature.type_parameters);
+                        // println!("Now for this one{:?}", fun.signature.parameters);
+                    }
+                    move_compiler::typing::ast::FunctionBody_::Native => {
+                        println!("This is a native function");
+                        //     println!("Its types are {:?}", fun.signature.type_parameters);
+                        //     println!("Now for this one{:?}", fun.signature.parameters);
+                    }
+                });
+            // mdef.structs
+            //     .iter()
+            //     .for_each(|(sloc, sname, sdef)| struct_def(env, *sname, sdef, sloc));
+            env.pop_warning_filter_scope();
+        }
+    }
+}
+
+// fn struct_def(env: &mut CompilationEnv, sname: Symbol, sdef: &N::StructDefinition, sloc: Loc) {
+//     env.add_warning_filter_scope(sdef.warning_filter.clone());
+//
+//     if let N::StructFields::Defined(sfields) = &sdef.fields {
+//         for (floc, fname, (_, ftype)) in sfields.iter() {
+//             if is_field_coin_type(ftype) {
+//                 let msg = format!("The field '{fname}' of '{sname}' has type 'sui::coin::Coin'");
+//                 let uid_msg = "Storing 'sui::balance::Balance' in this field will typically be more space-efficient";
+//                 let d = diag!(COIN_FIELD_DIAG, (sloc, msg), (floc, uid_msg));
+//                 env.add_diag(d);
+//             }
+//         }
+//     }
+//
+//     env.pop_warning_filter_scope();
+// }
+
+// fn is_field_coin_type(sp!(_, t): &N::Type) -> bool {
+//     use N::Type_ as T;
+//     match t {
+//         T::Ref(_, inner_t) => is_field_coin_type(inner_t),
+//         T::Apply(_, tname, _) => {
+//             let sp!(_, tname) = tname;
+//             if let N::TypeName_::ModuleType(mident, sname) = tname {
+//                 return is_mident_sui_coin(mident) || sname.value() == COIN_STRUCT_NAME.into();
+//             }
+//             false
+//         }
+//         T::Unit | T::Param(_) | T::Var(_) | T::Anything | T::UnresolvedError => false,
+//     }
+// }
+//
+// fn is_mident_sui_coin(sp!(_, mident): &E::ModuleIdent) -> bool {
+//     use E::Address as A;
+//     if mident.module.value() != COIN_MOD_NAME.into() {
+//         return false;
+//     }
+//     let sui_addr = NumericalAddress::new(AccountAddress::TWO.into_bytes(), NumberFormat::Hex);
+//     match mident.address {
+//         A::Numerical(_, addr) => addr.value == sui_addr,
+//         A::NamedUnassigned(n) => n.value == SUI_PKG_NAME.into(),
+//     }
+// }
+//

--- a/crates/sui-move-build/src/linters/native_primitives_only.rs
+++ b/crates/sui-move-build/src/linters/native_primitives_only.rs
@@ -8,7 +8,7 @@ use move_compiler::{
     diag,
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
     naming::ast as N,
-    shared::CompilationEnv,
+    shared::{CompilationEnv, Identifier},
     typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
 };
 use move_ir_types::location::Loc;
@@ -36,8 +36,9 @@ impl TypingVisitor for NativePrimitivesOnlyVisitor {
         for (_, _, mdef) in &program.modules {
             env.add_warning_filter_scope(mdef.warning_filter.clone());
             mdef.functions
-                .iter()
-                .for_each(|(sloc, fname, fun)| check_native(env, *fname, fun, sloc));
+                .key_cloned_iter()
+                .for_each(|(fname, fdef)| check_native(env, fname.value(), fdef, fname.loc()));
+            // .for_each(|(sloc, fname, fun)| check_native(env, *fname, fun, sloc));
             env.pop_warning_filter_scope();
         }
     }

--- a/crates/sui-move-build/src/linters/native_primitives_only.rs
+++ b/crates/sui-move-build/src/linters/native_primitives_only.rs
@@ -4,23 +4,17 @@
 //! This analysis flags uses of the sui::coin::Coin struct in fields of other structs. In most cases
 //! it's preferable to use sui::balance::Balance instead to save space.
 
-use move_command_line_common::{address::NumericalAddress, parser::NumberFormat};
 use move_compiler::{
     diag,
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
-    expansion::ast as E,
     naming::ast as N,
-    shared::{CompilationEnv, Identifier},
+    shared::CompilationEnv,
     typing::{ast as T, core::ProgramInfo, visitor::TypingVisitor},
 };
-use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
-use super::{
-    LinterDiagCategory, COIN_MOD_NAME, COIN_STRUCT_NAME, LINTER_DEFAULT_DIAG_CODE,
-    LINT_WARNING_PREFIX, SUI_PKG_NAME,
-};
+use super::{LinterDiagCategory, LINTER_DEFAULT_DIAG_CODE, LINT_WARNING_PREFIX};
 
 const NATIVE_PRIMITIVE_DIAG: DiagnosticInfo = custom(
     LINT_WARNING_PREFIX,
@@ -39,7 +33,7 @@ impl TypingVisitor for NativePrimitivesOnlyVisitor {
         _program_info: &ProgramInfo,
         program: &mut T::Program,
     ) {
-        for (_, _, mdef) in program.modules.iter() {
+        for (_, _, mdef) in &program.modules {
             env.add_warning_filter_scope(mdef.warning_filter.clone());
             mdef.functions
                 .iter()
@@ -51,44 +45,27 @@ impl TypingVisitor for NativePrimitivesOnlyVisitor {
 
 fn check_native(env: &mut CompilationEnv, fname: Symbol, fun: &T::Function, sloc: Loc) {
     match fun.body.value {
-        T::FunctionBody_::Defined(_) => {
+        T::FunctionBody_::Defined(_) => {}
+        T::FunctionBody_::Native => {
             let parameters = &fun.signature.parameters;
-            for (_var, data) in parameters.iter() {
-                if !is_native_or_ref(data.value.clone()) {
+            for (var, type_) in parameters.iter() {
+                if !is_native_or_ref(&type_.value) {
                     //This is a non-native type, so we prepare the message
-                    let c = _var.value.name;
+                    let c = var.value.name;
                     let msg =
                         format!("The parameter '{c}' of '{fname}' is not native or a reference");
                     let uid_msg = "Only native types or references are allowed";
-                    let mut d = diag!(NATIVE_PRIMITIVE_DIAG, (sloc, msg),);
+                    let mut d = diag!(NATIVE_PRIMITIVE_DIAG, (sloc, msg));
                     d.add_note(uid_msg);
                     env.add_diag(d);
 
-                    println!("Object in definition, time to shoot");
+                    // println!("Object in definition, time to shoot");
                 }
             }
         }
-        T::FunctionBody_::Native => {
-            //Uncomment and comment the other piece of code to try it out
-            // let parameters = &fun.signature.parameters;
-            // for (_var, data) in parameters.iter() {
-            //     if !is_native_or_ref(data.value.clone()) {
-            //         //This is a non-native type, so we prepare the message
-            //         let c = _var.value.name;
-            //         let msg =
-            //             format!("The parameter '{c}' of '{fname}' is not native or a reference");
-            //         let uid_msg = "Only native types or references are allowed";
-            //         let mut d = diag!(NATIVE_PRIMITIVE_DIAG, (sloc, msg),);
-            //         d.add_note(uid_msg);
-            //         env.add_diag(d);
-            //
-            //         println!("Object in definition, time to shoot");
-            //     }
-            // }
-        }
     }
 }
-fn is_native_or_ref(element: N::Type_) -> bool {
+fn is_native_or_ref(element: &N::Type_) -> bool {
     match element {
         N::Type_::Apply(_option, typename, _stype) => match typename.value {
             N::TypeName_::Builtin(_) => {

--- a/crates/sui-move-build/tests/linter/native_primitives_only.exp
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.exp
@@ -1,0 +1,9 @@
+warning[Lint W06001]: passing non-native types to native functions
+   ┌─ tests/linter/native_primitives_only.move:14:9
+   │
+14 │     fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64){
+   │         ^^^^^^^^^^^^^^^^^ The parameter 'c' of 'returns_something' is not native or a reference
+   │
+   = Only native types or references are allowed
+   = This warning can be suppressed with '#[lint_allow(native_primitives_only)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/crates/sui-move-build/tests/linter/native_primitives_only.exp
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.exp
@@ -1,9 +1,20 @@
 warning[Lint W06001]: passing non-native types to native functions
-   ┌─ tests/linter/native_primitives_only.move:15:16
+   ┌─ tests/linter/native_primitives_only.move:12:47
    │
-15 │     native fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64);
-   │                ^^^^^^^^^^^^^^^^^ The parameter 'c' of 'returns_something' is not native or a reference
+12 │     native fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64);
+   │                -----------------              ^ The parameter 'c' of 'returns_something' is not native or a reference
+   │                │                               
+   │                - It is recommended when implementing native functions to only deal with primitives
    │
-   = Only native types or references are allowed
+   = This warning can be suppressed with '#[lint_allow(native_primitives_only)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W06001]: passing non-native types to native functions
+   ┌─ tests/linter/native_primitives_only.move:12:60
+   │
+12 │     native fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64);
+   │                -----------------                           ^ The parameter 'd' of 'returns_something' is not native or a reference
+   │                │                                            
+   │                - It is recommended when implementing native functions to only deal with primitives
+   │
    = This warning can be suppressed with '#[lint_allow(native_primitives_only)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/crates/sui-move-build/tests/linter/native_primitives_only.exp
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.exp
@@ -1,8 +1,8 @@
 warning[Lint W06001]: passing non-native types to native functions
-   ┌─ tests/linter/native_primitives_only.move:14:9
+   ┌─ tests/linter/native_primitives_only.move:15:16
    │
-14 │     fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64){
-   │         ^^^^^^^^^^^^^^^^^ The parameter 'c' of 'returns_something' is not native or a reference
+15 │     native fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64);
+   │                ^^^^^^^^^^^^^^^^^ The parameter 'c' of 'returns_something' is not native or a reference
    │
    = Only native types or references are allowed
    = This warning can be suppressed with '#[lint_allow(native_primitives_only)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module 0x42::test1 {
-    //has copy needed because it's a vector
 
-    struct S1 has copy{}
-    
     struct Coolstruct has copy ,drop {
         a: bool,
         b: u64,
@@ -17,4 +14,9 @@ module 0x42::test1 {
     public entry fun main(){
         let (_x,_y) = returns_something(true,42,Coolstruct{a:true,b:42},&Coolstruct{a:true,b:42});
     }
+}
+
+module 0x42::test2 {
+    #[allow(unused_function)]
+    native fun should_not_complain(a:u64, b:bool, c:bool) : bool;
 }

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -1,20 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_variable)]
-module 0x42::test1{
+module 0x42::test1 {
     //has copy needed because it's a vector
 
     struct S1 has copy{}
     
-    struct Coolstruct has copy,drop{
+    struct Coolstruct has copy ,drop {
         a: bool,
         b: u64,
     }
 
     #[allow(unused_function)]
-    fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64){
-        let x = b;
-        (a,x)
-    }
+    native fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64);
 
     public entry fun main(){
         let (_x,_y) = returns_something(true,42,Coolstruct{a:true,b:42},&Coolstruct{a:true,b:42});

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -1,6 +1,6 @@
 
+#[allow(unused_variable)]
 module 0x42::test1{
-    use std::vector;
     //has copy needed because it's a vector
 
     struct S1 has copy{}
@@ -10,10 +10,15 @@ module 0x42::test1{
         b: u64,
     }
 
+    #[allow(unused_function)]
+    fun returns_something(a:bool,b:u64,c:Coolstruct,d:&Coolstruct) : (bool,u64){
+        let x = b;
+        (a,x)
+    }
+
     public entry fun main(){
-        let v = vector::empty<Coolstruct>();
         //The linter should complain because push_back is native 
         //and S2 is not a primitive type
-        vector::push_back(&mut v, Coolstruct{a:true,b:42});
+        let (_cazzo,_palle) = returns_something(true,42,Coolstruct{a:true,b:42},&Coolstruct{a:true,b:42});
     }
 }

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -17,8 +17,6 @@ module 0x42::test1{
     }
 
     public entry fun main(){
-        //The linter should complain because push_back is native 
-        //and S2 is not a primitive type
-        let (_cazzo,_palle) = returns_something(true,42,Coolstruct{a:true,b:42},&Coolstruct{a:true,b:42});
+        let (_x,_y) = returns_something(true,42,Coolstruct{a:true,b:42},&Coolstruct{a:true,b:42});
     }
 }

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -18,5 +18,10 @@ module 0x42::test1 {
 
 module 0x42::test2 {
     #[allow(unused_function)]
-    native fun should_not_complain(a:u64, b:bool, c:bool) : bool;
+    native fun should_not_complain();
+}
+
+module 0x42::test3 {
+    #[allow(unused_function)]
+    native fun compare_numbers(a:u64,b:u64) : bool;
 }

--- a/crates/sui-move-build/tests/linter/native_primitives_only.move
+++ b/crates/sui-move-build/tests/linter/native_primitives_only.move
@@ -1,0 +1,19 @@
+
+module 0x42::test1{
+    use std::vector;
+    //has copy needed because it's a vector
+
+    struct S1 has copy{}
+    
+    struct Coolstruct has copy,drop{
+        a: bool,
+        b: u64,
+    }
+
+    public entry fun main(){
+        let v = vector::empty<Coolstruct>();
+        //The linter should complain because push_back is native 
+        //and S2 is not a primitive type
+        vector::push_back(&mut v, Coolstruct{a:true,b:42});
+    }
+}

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -19,16 +19,10 @@ use move_compiler::{
 };
 
 use sui_move_build::linters::{
-<<<<<<< HEAD
     coin_field::CoinFieldVisitor, collection_equality::CollectionEqualityVisitor,
     custom_state_change::CustomStateChangeVerifier, freeze_wrapped::FreezeWrappedVisitor,
-    known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
-    LINT_WARNING_PREFIX,
-=======
-    coin_field::CoinFieldVisitor, custom_state_change::CustomStateChangeVerifier, known_filters,
-    native_primitives_only::NativePrimitivesOnlyVisitor, self_transfer::SelfTransferVerifier,
-    share_owned::ShareOwnedVerifier, LINT_WARNING_PREFIX,
->>>>>>> d8cdb2845 (First linter tweaks)
+    known_filters, native_primitives_only::NativePrimitivesOnlyVisitor,
+    self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier, LINT_WARNING_PREFIX,
 };
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
@@ -75,12 +69,9 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         SelfTransferVerifier.visitor(),
         CustomStateChangeVerifier.visitor(),
         CoinFieldVisitor.visitor(),
-<<<<<<< HEAD
         FreezeWrappedVisitor::default().visitor(),
         CollectionEqualityVisitor.visitor(),
-=======
         NativePrimitivesOnlyVisitor.visitor(),
->>>>>>> d8cdb2845 (First linter tweaks)
     ];
     let (filter_attr_name, filters) = known_filters_for_test();
     let (files, comments_and_compiler_res) = Compiler::from_files(

--- a/crates/sui-move-build/tests/linter_tests.rs
+++ b/crates/sui-move-build/tests/linter_tests.rs
@@ -19,10 +19,16 @@ use move_compiler::{
 };
 
 use sui_move_build::linters::{
+<<<<<<< HEAD
     coin_field::CoinFieldVisitor, collection_equality::CollectionEqualityVisitor,
     custom_state_change::CustomStateChangeVerifier, freeze_wrapped::FreezeWrappedVisitor,
     known_filters, self_transfer::SelfTransferVerifier, share_owned::ShareOwnedVerifier,
     LINT_WARNING_PREFIX,
+=======
+    coin_field::CoinFieldVisitor, custom_state_change::CustomStateChangeVerifier, known_filters,
+    native_primitives_only::NativePrimitivesOnlyVisitor, self_transfer::SelfTransferVerifier,
+    share_owned::ShareOwnedVerifier, LINT_WARNING_PREFIX,
+>>>>>>> d8cdb2845 (First linter tweaks)
 };
 
 const SUI_FRAMEWORK_PATH: &str = "../sui-framework/packages/sui-framework";
@@ -69,8 +75,12 @@ fn run_tests(path: &Path) -> anyhow::Result<()> {
         SelfTransferVerifier.visitor(),
         CustomStateChangeVerifier.visitor(),
         CoinFieldVisitor.visitor(),
+<<<<<<< HEAD
         FreezeWrappedVisitor::default().visitor(),
         CollectionEqualityVisitor.visitor(),
+=======
+        NativePrimitivesOnlyVisitor.visitor(),
+>>>>>>> d8cdb2845 (First linter tweaks)
     ];
     let (filter_attr_name, filters) = known_filters_for_test();
     let (files, comments_and_compiler_res) = Compiler::from_files(


### PR DESCRIPTION
## Description 

This is my first implementation of the linter described [here.](https://github.com/MystenLabs/sui/issues/7197)
The linter in question is:
To check: native functions should only accept primitive types or references
Why: if you pass a Move struct into Rust code, there are no ability protections and it is easy to accidentally violate ability constraints. Also, it is very cumbersome to work with Move structs inside Rust.
Severity: High. Blast radius of a native function is much higher when you break this rule



## Test Plan 

I tried this linter on defined functions(because I can't create native ones), but by commenting the Defined and uncommenting the Native piece of code it should check for Native ones.

---

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
