### PR TITLE
fix(wallet-kit): TypeError: walletEventUnsubscribe is not a function

### DIFF
--- a/sdk/wallet-kit/core/src/index.ts
+++ b/sdk/wallet-kit/core/src/index.ts
@@ -242,7 +242,7 @@ export function createWalletKitCore({
 			setState({ currentWallet });
 
 			if (currentWallet) {
-				if (walletEventUnsubscribe) {
+				if (typeof walletEventUnsubscribe === 'function') {
 					walletEventUnsubscribe();
 				}
 				walletEventUnsubscribe = currentWallet.features['standard:events'].on(


### PR DESCRIPTION
Make sure walletEventUnsubscribe is a function before invocation

## Description 

walletEventUnsubscribe is checked before invoked but it's not necessarily a function. This change will make sure it is.
The problem root cause is from OKX Wallet but I think we should be defensive from the wallet-kit end. 
![Screenshot from 2023-08-24 11-06-54](https://github.com/MystenLabs/sui/assets/1917947/5a519c62-9ced-412f-9052-65049e6c97fd)


## Test Plan 

- Install OKX Wallet.
- Try to connect('OKX Wallet') twice.
- The expected outcome after the fix should be no error thrown in the console.
