### PR TITLE
Remove session

### DIFF
--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -16,6 +16,7 @@ use move_binary_format::access::ModuleAccess;
 use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::file_format::CompiledModule;
 use move_binary_format::normalized;
+use move_core_types::language_storage::ModuleId;
 use move_core_types::{
     account_address::AccountAddress,
     ident_str,
@@ -380,6 +381,19 @@ impl MovePackage {
             type_origin_table,
             linkage_table,
         )
+    }
+
+    // Retrieve the module with `ModuleId` in the given package.
+    // The module must be the `storage_id` or the call will return `None`.
+    // Check if the address of the module is the same of the package
+    // and return `None` if that is not the case.
+    // All modules in a package share the address with the package.
+    pub fn get_module(&self, storage_id: &ModuleId) -> Option<&Vec<u8>> {
+        if self.id != ObjectID::from(*storage_id.address()) {
+            None
+        } else {
+            self.module_map.get(&storage_id.name().to_string())
+        }
     }
 
     /// Return the size of the package in bytes

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -680,6 +680,10 @@ impl Object {
     }
 
     // Note: this will panic if `modules` is empty
+    pub fn new_from_package(package: MovePackage, previous_transaction: TransactionDigest) -> Self {
+        Self::new_package_from_data(Data::Package(package), previous_transaction)
+    }
+
     pub fn new_package<'p>(
         modules: &[CompiledModule],
         previous_transaction: TransactionDigest,

--- a/external-crates/move-execution/suivm/move-vm/runtime/src/lib.rs
+++ b/external-crates/move-execution/suivm/move-vm/runtime/src/lib.rs
@@ -17,7 +17,7 @@ pub mod logging;
 pub mod move_vm;
 pub mod native_extensions;
 pub mod native_functions;
-mod runtime;
+pub mod runtime;
 pub mod session;
 #[macro_use]
 mod tracing;

--- a/external-crates/move-execution/suivm/move-vm/runtime/src/move_vm.rs
+++ b/external-crates/move-execution/suivm/move-vm/runtime/src/move_vm.rs
@@ -101,4 +101,8 @@ impl MoveVM {
     pub fn get_module_metadata(&self, module: ModuleId, key: &[u8]) -> Option<Metadata> {
         self.runtime.loader().get_metadata(module, key)
     }
+
+    pub fn get_runtime(&self) -> &VMRuntime {
+        &self.runtime
+    }
 }

--- a/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
@@ -6,6 +6,7 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
     use std::{
+        borrow::Borrow,
         collections::{BTreeMap, HashMap},
         sync::Arc,
     };
@@ -13,22 +14,33 @@ mod checked {
     use crate::adapter::new_native_extensions;
     use crate::error::convert_vm_error;
     use crate::gas_charger::GasCharger;
-    use crate::programmable_transactions::linkage_view::{LinkageView, SavedLinkage};
+    use crate::programmable_transactions::linkage_view::LinkageView;
     use move_binary_format::{
-        errors::{Location, VMError, VMResult},
+        errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
         CompiledModule,
     };
+    use move_core_types::gas_algebra::NumBytes;
+    use move_core_types::resolver::ModuleResolver;
+    use move_core_types::value::MoveTypeLayout;
+    use move_core_types::vm_status::StatusCode;
     use move_core_types::{
         account_address::AccountAddress,
+        identifier::IdentStr,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
     #[cfg(debug_assertions)]
     use move_vm_profiler::GasProfiler;
-    use move_vm_runtime::{move_vm::MoveVM, session::Session};
+    use move_vm_runtime::native_extensions::NativeContextExtensions;
+    use move_vm_runtime::{
+        move_vm::MoveVM,
+        session::{LoadedFunctionInstantiation, SerializedReturnValues},
+    };
+    use move_vm_types::data_store::DataStore;
     #[cfg(debug_assertions)]
     use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
+    use move_vm_types::values::{GlobalValue, Value as VMValue};
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -47,7 +59,7 @@ mod checked {
         metrics::LimitsMetrics,
         move_package::MovePackage,
         object::{Data, MoveObject, Object, Owner},
-        storage::{BackingPackageStore, ChildObjectResolver},
+        storage::BackingPackageStore,
         transaction::{Argument, CallArg, ObjectArg},
         type_resolver::TypeTagResolver,
     };
@@ -66,6 +78,9 @@ mod checked {
         pub metrics: Arc<LimitsMetrics>,
         /// The MoveVM
         pub vm: &'vm MoveVM,
+        /// The LinkageView for this session
+        pub linkage_view: LinkageView<'state>,
+        pub native_extensions: NativeContextExtensions<'state>,
         /// The global state, used for resolving packages
         pub state_view: &'state dyn ExecutionState,
         /// A shared transaction context, contains transaction digest information and manages the
@@ -73,12 +88,10 @@ mod checked {
         pub tx_context: &'a mut TxContext,
         /// The gas charger used for metering
         pub gas_charger: &'a mut GasCharger,
-        /// The session used for interacting with Move types and calls
-        pub session: Session<'state, 'vm, LinkageView<'state>>,
         /// Additional transfers not from the Move runtime
         additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
         /// Newly published packages
-        new_packages: Vec<Object>,
+        new_packages: Vec<MovePackage>,
         /// User events are claimed after each Move call
         user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
         // runtime data
@@ -117,18 +130,7 @@ mod checked {
             gas_charger: &'a mut GasCharger,
             inputs: Vec<CallArg>,
         ) -> Result<Self, ExecutionError> {
-            // we need a new session just for loading types, which is sad
-            // TODO remove this
-            let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()));
-            let mut tmp_session = new_session(
-                vm,
-                linkage,
-                state_view.as_child_resolver(),
-                BTreeMap::new(),
-                !gas_charger.is_unmetered(),
-                protocol_config,
-                metrics.clone(),
-            );
+            let mut linkage_view = LinkageView::new(Box::new(state_view.as_sui_resolver()));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()
@@ -136,7 +138,8 @@ mod checked {
                     load_call_arg(
                         vm,
                         state_view,
-                        &mut tmp_session,
+                        &mut linkage_view,
+                        &[],
                         &mut input_object_map,
                         call_arg,
                     )
@@ -146,7 +149,8 @@ mod checked {
                 let mut gas = load_object(
                     vm,
                     state_view,
-                    &mut tmp_session,
+                    &mut linkage_view,
+                    &[],
                     &mut input_object_map,
                     /* imm override */ false,
                     gas_coin,
@@ -178,17 +182,7 @@ mod checked {
                     },
                 }
             };
-            // the session was just used for ability and layout metadata fetching, no changes should
-            // exist. Plus, Sui Move does not use these changes or events
-            let (res, linkage) = tmp_session.finish();
-            let (change_set, move_events) =
-                res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
-            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-            assert_invariant!(move_events.is_empty(), "Events must be empty");
-            // make the real session
-            let session = new_session(
-                vm,
-                linkage,
+            let native_extensions = new_native_extensions(
                 state_view.as_child_resolver(),
                 input_object_map,
                 !gas_charger.is_unmetered(),
@@ -216,10 +210,11 @@ mod checked {
                 protocol_config,
                 metrics,
                 vm,
+                linkage_view,
+                native_extensions,
                 state_view,
                 tx_context,
                 gas_charger,
-                session,
                 gas,
                 inputs,
                 results: vec![],
@@ -230,10 +225,14 @@ mod checked {
             })
         }
 
+        pub fn object_runtime(&mut self) -> &ObjectRuntime {
+            self.native_extensions.get()
+        }
+
         /// Create a new ID and update the state
         pub fn fresh_id(&mut self) -> Result<ObjectID, ExecutionError> {
             let object_id = self.tx_context.fresh_id();
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             object_runtime
                 .new_id(object_id)
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))?;
@@ -242,7 +241,7 @@ mod checked {
 
         /// Delete an ID and update the state
         pub fn delete_id(&mut self, object_id: ObjectID) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             object_runtime
                 .delete_id(object_id)
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
@@ -254,49 +253,38 @@ mod checked {
             &mut self,
             package_id: ObjectID,
         ) -> Result<AccountAddress, ExecutionError> {
-            let resolver = self.session.get_resolver();
-            if resolver.has_linkage(package_id) {
+            if self.linkage_view.has_linkage(package_id) {
                 // Setting same context again, can skip.
-                return Ok(resolver.original_package_id().unwrap_or(*package_id));
+                return Ok(self
+                    .linkage_view
+                    .original_package_id()
+                    .unwrap_or(*package_id));
             }
 
-            let package = package_for_linkage(&self.session, package_id)
+            let package = package_for_linkage(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            set_linkage(&mut self.session, &package)
-        }
-
-        /// Set the link context for the session from the linkage information in the `package`.  Returns
-        /// the runtime ID of the link context package on success.
-        pub fn set_linkage(
-            &mut self,
-            package: &MovePackage,
-        ) -> Result<AccountAddress, ExecutionError> {
-            set_linkage(&mut self.session, package)
-        }
-
-        /// Turn off linkage information, so that the next use of the session will need to set linkage
-        /// information to succeed.
-        pub fn reset_linkage(&mut self) {
-            reset_linkage(&mut self.session);
-        }
-
-        /// Reset the linkage context, and save it (if one exists)
-        pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
-            steal_linkage(&mut self.session)
-        }
-
-        /// Restore a previously stolen/saved link context.
-        pub fn restore_linkage(
-            &mut self,
-            saved: Option<SavedLinkage>,
-        ) -> Result<(), ExecutionError> {
-            restore_linkage(&mut self.session, saved)
+            self.linkage_view.set_linkage(&package)
         }
 
         /// Load a type using the context's current session.
         pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
-            load_type(&mut self.session, type_tag)
+            load_type(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                type_tag,
+            )
+        }
+
+        /// Load a type using the context's current session.
+        pub fn load_type_from_struct(&mut self, struct_tag: &StructTag) -> VMResult<Type> {
+            load_type_from_struct(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                struct_tag,
+            )
         }
 
         /// Takes the user events from the runtime and tags them with the Move module of the function
@@ -307,7 +295,7 @@ mod checked {
             function: FunctionDefinitionIndex,
             last_offset: CodeOffset,
         ) -> Result<(), ExecutionError> {
-            let object_runtime: &mut ObjectRuntime = self.session.get_native_extensions().get_mut();
+            let object_runtime: &mut ObjectRuntime = self.native_extensions.get_mut();
             let events = object_runtime.take_user_events();
             let num_events = self.user_events.len() + events.len();
             let max_events = self.protocol_config.max_num_event_emit();
@@ -321,7 +309,8 @@ mod checked {
                 .into_iter()
                 .map(|(ty, tag, value)| {
                     let layout = self
-                        .session
+                        .vm
+                        .get_runtime()
                         .type_to_type_layout(&ty)
                         .map_err(|e| self.convert_vm_error(e))?;
                     let Some(bytes) = value.simple_serialize(&layout) else {
@@ -474,7 +463,7 @@ mod checked {
             assert_invariant!(
                 was_mut_opt.is_some() && was_mut_opt.unwrap(),
                 "Should never restore a non-mut borrowed value. \
-            The take+restore is an implementation detail of mutable references"
+                The take+restore is an implementation detail of mutable references"
             );
             // restore is exclusively used for mut
             let Ok((_, value_opt)) = self.borrow_mut_impl(arg, None) else {
@@ -484,7 +473,7 @@ mod checked {
             assert_invariant!(
                 old_value.is_none() || old_value.unwrap().is_copyable(),
                 "Should never restore a non-taken value, unless it is copyable. \
-            The take+restore is an implementation detail of mutable references"
+                The take+restore is an implementation detail of mutable references"
             );
             Ok(())
         }
@@ -504,10 +493,9 @@ mod checked {
             &self,
             modules: &[CompiledModule],
             dependencies: impl IntoIterator<Item = &'p MovePackage>,
-        ) -> Result<Object, ExecutionError> {
-            Object::new_package(
+        ) -> Result<MovePackage, ExecutionError> {
+            MovePackage::new_initial(
                 modules,
-                self.tx_context.digest(),
                 self.protocol_config.max_move_package_size(),
                 dependencies,
             )
@@ -520,22 +508,26 @@ mod checked {
             previous_package: &MovePackage,
             new_modules: &[CompiledModule],
             dependencies: impl IntoIterator<Item = &'p MovePackage>,
-        ) -> Result<Object, ExecutionError> {
-            Object::new_upgraded_package(
-                previous_package,
+        ) -> Result<MovePackage, ExecutionError> {
+            previous_package.new_upgraded(
                 storage_id,
                 new_modules,
-                self.tx_context.digest(),
                 self.protocol_config,
                 dependencies,
             )
         }
 
         /// Add a newly created package to write as an effect of the transaction
-        pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
-            assert_invariant!(package.is_package(), "Must be a package");
+        pub fn write_package(&mut self, package: MovePackage) {
             self.new_packages.push(package);
-            Ok(())
+        }
+
+        /// Return the last pacakge pushed in `write_package`.
+        /// This function should be used in block of codes that push a pacakge, verify
+        /// it, run the init and in case of error will remove the package.
+        /// The package has to be pushed for the init to run correctly.
+        pub fn pop_package(&mut self) -> Option<MovePackage> {
+            self.new_packages.pop()
         }
 
         /// Finish a command: clearing the borrows and adding the results to the result vector
@@ -555,12 +547,11 @@ mod checked {
         pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
             let Self {
                 protocol_config,
-                metrics,
                 vm,
-                state_view,
+                linkage_view,
+                mut native_extensions,
                 tx_context,
                 gas_charger,
-                session,
                 additional_transfers,
                 new_packages,
                 gas,
@@ -635,7 +626,7 @@ mod checked {
                                 } else {
                                     let msg = if abilities.has_copy() {
                                         "The value has copy, but not drop. \
-                                    Its last usage must be by-value so it can be taken."
+                                        Its last usage must be by-value so it can be taken."
                                     } else {
                                         "Unused value without drop"
                                     };
@@ -662,17 +653,7 @@ mod checked {
                 refund_max_gas_budget(&mut additional_writes, gas_charger, gas_id)?;
             }
 
-            let (res, linkage) = session.finish_with_extensions();
-            let (change_set, events, mut native_context_extensions) =
-                res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-            // Sui Move programs should never touch global state, so resources should be empty
-            assert_invariant!(
-                change_set.resources().next().is_none(),
-                "Change set must be empty"
-            );
-            // Sui Move no longer uses Move's internal event system
-            assert_invariant!(events.is_empty(), "Events must be empty");
-            let object_runtime: ObjectRuntime = native_context_extensions.remove();
+            let object_runtime: ObjectRuntime = native_extensions.remove();
             let RuntimeResults {
                 writes,
                 user_events: remaining_events,
@@ -689,21 +670,11 @@ mod checked {
 
             let mut written_objects = BTreeMap::new();
             for package in new_packages {
-                let id = package.id();
+                let package_obj = Object::new_from_package(package, tx_digest);
+                let id = package_obj.id();
                 created_object_ids.insert(id, ());
-                written_objects.insert(id, package);
+                written_objects.insert(id, package_obj);
             }
-            // we need a new session just for deserializing and fetching abilities. Which is sad
-            // TODO remove this
-            let tmp_session = new_session(
-                vm,
-                linkage,
-                state_view.as_child_resolver(),
-                BTreeMap::new(),
-                !gas_charger.is_unmetered(),
-                protocol_config,
-                metrics,
-            );
             for (id, additional_write) in additional_writes {
                 let AdditionalWrite {
                     recipient,
@@ -715,7 +686,7 @@ mod checked {
                 let move_object = unsafe {
                     create_written_object(
                         vm,
-                        &tmp_session,
+                        &linkage_view,
                         protocol_config,
                         &loaded_runtime_objects,
                         id,
@@ -732,13 +703,15 @@ mod checked {
             }
 
             for (id, (recipient, ty, value)) in writes {
-                let abilities = tmp_session
+                let abilities = vm
+                    .get_runtime()
                     .get_type_abilities(&ty)
-                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                    .map_err(|e| convert_vm_error(e, vm, &linkage_view))?;
                 let has_public_transfer = abilities.has_store();
-                let layout = tmp_session
+                let layout = vm
+                    .get_runtime()
                     .type_to_type_layout(&ty)
-                    .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
+                    .map_err(|e| convert_vm_error(e, vm, &linkage_view))?;
                 let Some(bytes) = value.simple_serialize(&layout) else {
                     invariant_violation!("Failed to deserialize already serialized Move value");
                 };
@@ -746,7 +719,7 @@ mod checked {
                 let move_object = unsafe {
                     create_written_object(
                         vm,
-                        &tmp_session,
+                        &linkage_view,
                         protocol_config,
                         &loaded_runtime_objects,
                         id,
@@ -758,14 +731,6 @@ mod checked {
                 let object = Object::new_move(move_object, recipient, tx_digest);
                 written_objects.insert(id, object);
             }
-
-            let (res, linkage) = tmp_session.finish();
-            let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
-
-            // the session was just used for ability and layout metadata fetching, no changes should
-            // exist. Plus, Sui Move does not use these changes or events
-            assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
-            assert_invariant!(move_events.is_empty(), "Events must be empty");
 
             let user_events = user_events
                 .into_iter()
@@ -798,7 +763,7 @@ mod checked {
 
         /// Convert a VM Error to an execution one
         pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-            crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
+            crate::error::convert_vm_error(error, self.vm, &self.linkage_view)
         }
 
         /// Special case errors for type arguments to Move functions
@@ -855,8 +820,8 @@ mod checked {
                 Argument::GasCoin => (self.gas.object_metadata.as_ref(), &mut self.gas.inner),
                 Argument::Input(i) => {
                     let Some(input_value) = self.inputs.get_mut(i as usize) else {
-                    return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
-                };
+                        return Err(CommandArgumentError::IndexOutOfBounds { idx: i });
+                    };
                     (input_value.object_metadata.as_ref(), &mut input_value.inner)
                 }
                 Argument::Result(i) => {
@@ -886,80 +851,96 @@ mod checked {
             }
             Ok((metadata, &mut result_value.value))
         }
+
+        pub(crate) fn execute_function_bypass_visibility(
+            &mut self,
+            module: &ModuleId,
+            function_name: &IdentStr,
+            ty_args: Vec<Type>,
+            args: Vec<impl Borrow<[u8]>>,
+        ) -> VMResult<SerializedReturnValues> {
+            let gas_status = self.gas_charger.move_gas_status_mut();
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().execute_function_bypass_visibility(
+                module,
+                function_name,
+                ty_args,
+                args,
+                &mut data_store,
+                gas_status,
+                &mut self.native_extensions,
+            )
+        }
+
+        pub(crate) fn load_function(
+            &mut self,
+            module_id: &ModuleId,
+            function_name: &IdentStr,
+            type_arguments: &[Type],
+        ) -> VMResult<LoadedFunctionInstantiation> {
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().load_function(
+                module_id,
+                function_name,
+                type_arguments,
+                &mut data_store,
+            )
+        }
+
+        pub(crate) fn make_object_value(
+            &mut self,
+            type_: MoveObjectType,
+            has_public_transfer: bool,
+            used_in_non_entry_move_call: bool,
+            contents: &[u8],
+        ) -> Result<ObjectValue, ExecutionError> {
+            make_object_value(
+                self.vm,
+                &mut self.linkage_view,
+                &self.new_packages,
+                type_,
+                has_public_transfer,
+                used_in_non_entry_move_call,
+                contents,
+            )
+        }
+
+        pub fn publish_module_bundle(
+            &mut self,
+            modules: Vec<Vec<u8>>,
+            sender: AccountAddress,
+        ) -> VMResult<()> {
+            // TODO: publish_module_bundle() currently doesn't charge gas.
+            // Do we want to charge there?
+            let mut data_store = SuiDataStore::new(&self.linkage_view, &self.new_packages);
+            self.vm.get_runtime().publish_module_bundle(
+                modules,
+                sender,
+                &mut data_store,
+                self.gas_charger.move_gas_status_mut(),
+            )
+        }
     }
 
     impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
         fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
-            self.session
+            self.vm
+                .get_runtime()
                 .get_type_tag(type_)
                 .map_err(|e| self.convert_vm_error(e))
         }
     }
 
-    pub(crate) fn new_session<'state, 'vm>(
-        vm: &'vm MoveVM,
-        linkage: LinkageView<'state>,
-        child_resolver: &'state dyn ChildObjectResolver,
-        input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
-        is_metered: bool,
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<LimitsMetrics>,
-    ) -> Session<'state, 'vm, LinkageView<'state>> {
-        vm.new_session_with_extensions(
-            linkage,
-            new_native_extensions(
-                child_resolver,
-                input_objects,
-                is_metered,
-                protocol_config,
-                metrics,
-            ),
-        )
-    }
-
-    // Create a new Session suitable for resolving type and type operations rather than execution
-    pub(crate) fn new_session_for_linkage<'vm, 'state>(
-        vm: &'vm MoveVM,
-        linkage: LinkageView<'state>,
-    ) -> Session<'state, 'vm, LinkageView<'state>> {
-        vm.new_session(linkage)
-    }
-
-    /// Set the link context for the session from the linkage information in the `package`.
-    pub fn set_linkage(
-        session: &mut Session<LinkageView>,
-        linkage: &MovePackage,
-    ) -> Result<AccountAddress, ExecutionError> {
-        session.get_resolver_mut().set_linkage(linkage)
-    }
-
-    /// Turn off linkage information, so that the next use of the session will need to set linkage
-    /// information to succeed.
-    pub fn reset_linkage(session: &mut Session<LinkageView>) {
-        session.get_resolver_mut().reset_linkage();
-    }
-
-    pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
-        session.get_resolver_mut().steal_linkage()
-    }
-
-    pub fn restore_linkage(
-        session: &mut Session<LinkageView>,
-        saved: Option<SavedLinkage>,
-    ) -> Result<(), ExecutionError> {
-        session.get_resolver_mut().restore_linkage(saved)
-    }
-
     /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
     /// if the object at that ID does not exist, or is not a package.
     fn package_for_linkage(
-        session: &Session<LinkageView>,
+        linkage_view: &LinkageView,
         package_id: ObjectID,
     ) -> VMResult<MovePackage> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
-        match session.get_resolver().get_package(&package_id) {
+        match linkage_view.get_package(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
@@ -972,16 +953,75 @@ mod checked {
         }
     }
 
-    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
-    /// reset after this operation, because during the operation, it may change when loading a struct.
-    pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
-        use move_binary_format::errors::PartialVMError;
-        use move_core_types::vm_status::StatusCode;
-
+    pub fn load_type_from_struct(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
+        struct_tag: &StructTag,
+    ) -> VMResult<Type> {
         fn verification_error<T>(code: StatusCode) -> VMResult<T> {
             Err(PartialVMError::new(code).finish(Location::Undefined))
         }
 
+        let StructTag {
+            address,
+            module,
+            name,
+            type_params,
+        } = struct_tag;
+
+        // Load the package that the struct is defined in, in storage
+        let defining_id = ObjectID::from_address(*address);
+        let package = package_for_linkage(linkage_view, defining_id)?;
+
+        // Set the defining package as the link context while loading the
+        // struct
+        let original_address = linkage_view.set_linkage(&package).map_err(|e| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message(e.to_string())
+                .finish(Location::Undefined)
+        })?;
+
+        let runtime_id = ModuleId::new(original_address, module.clone());
+        let data_store = SuiDataStore::new(linkage_view, new_packages);
+        let res = vm.get_runtime().load_struct(&runtime_id, name, &data_store);
+        linkage_view.reset_linkage();
+        let (idx, struct_type) = res?;
+
+        // Recursively load type parameters, if necessary
+        let type_param_constraints = struct_type.type_param_constraints();
+        if type_param_constraints.len() != type_params.len() {
+            return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
+        }
+
+        if type_params.is_empty() {
+            Ok(Type::Struct(idx))
+        } else {
+            let loaded_type_params = type_params
+                .iter()
+                .map(|type_param| load_type(vm, linkage_view, new_packages, type_param))
+                .collect::<VMResult<Vec<_>>>()?;
+
+            // Verify that the type parameter constraints on the struct are met
+            for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
+                let abilities = vm.get_runtime().get_type_abilities(param)?;
+                if !constraint.is_subset(abilities) {
+                    return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
+                }
+            }
+
+            Ok(Type::StructInstantiation(idx, loaded_type_params))
+        }
+    }
+
+    /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
+    /// reset after this operation, because during the operation, it may change when loading a struct.
+    pub fn load_type(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
+        type_tag: &TypeTag,
+    ) -> VMResult<Type> {
         Ok(match type_tag {
             TypeTag::Bool => Type::Bool,
             TypeTag::U8 => Type::U8,
@@ -993,63 +1033,19 @@ mod checked {
             TypeTag::Address => Type::Address,
             TypeTag::Signer => Type::Signer,
 
-            TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
+            TypeTag::Vector(inner) => {
+                Type::Vector(Box::new(load_type(vm, linkage_view, new_packages, inner)?))
+            }
             TypeTag::Struct(struct_tag) => {
-                let StructTag {
-                    address,
-                    module,
-                    name,
-                    type_params,
-                } = struct_tag.as_ref();
-
-                // Load the package that the struct is defined in, in storage
-                let defining_id = ObjectID::from_address(*address);
-                let package = package_for_linkage(session, defining_id)?;
-
-                // Set the defining package as the link context on the session while loading the
-                // struct
-                let original_address = set_linkage(session, &package).map_err(|e| {
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(e.to_string())
-                        .finish(Location::Undefined)
-                })?;
-
-                let runtime_id = ModuleId::new(original_address, module.clone());
-                let res = session.load_struct(&runtime_id, name);
-                reset_linkage(session);
-                let (idx, struct_type) = res?;
-
-                // Recursively load type parameters, if necessary
-                let type_param_constraints = struct_type.type_param_constraints();
-                if type_param_constraints.len() != type_params.len() {
-                    return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
-                }
-
-                if type_params.is_empty() {
-                    Type::Struct(idx)
-                } else {
-                    let loaded_type_params = type_params
-                        .iter()
-                        .map(|type_param| load_type(session, type_param))
-                        .collect::<VMResult<Vec<_>>>()?;
-
-                    // Verify that the type parameter constraints on the struct are met
-                    for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
-                        let abilities = session.get_type_abilities(param)?;
-                        if !constraint.is_subset(abilities) {
-                            return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
-                        }
-                    }
-
-                    Type::StructInstantiation(idx, loaded_type_params)
-                }
+                return load_type_from_struct(vm, linkage_view, new_packages, struct_tag)
             }
         })
     }
 
-    pub(crate) fn make_object_value<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    pub(crate) fn make_object_value(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
         type_: MoveObjectType,
         has_public_transfer: bool,
         used_in_non_entry_move_call: bool,
@@ -1057,16 +1053,16 @@ mod checked {
     ) -> Result<ObjectValue, ExecutionError> {
         let contents = if type_.is_coin() {
             let Ok(coin) = Coin::from_bcs_bytes(contents) else {
-            invariant_violation!("Could not deserialize a coin")
-        };
+                invariant_violation!("Could not deserialize a coin")
+            };
             ObjectContents::Coin(coin)
         } else {
             ObjectContents::Raw(contents.to_vec())
         };
 
         let tag: StructTag = type_.into();
-        let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
-            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        let type_ = load_type_from_struct(vm, linkage_view, new_packages, &tag)
+            .map_err(|e| crate::error::convert_vm_error(e, vm, linkage_view))?;
         Ok(ObjectValue {
             type_,
             has_public_transfer,
@@ -1075,19 +1071,21 @@ mod checked {
         })
     }
 
-    pub(crate) fn value_from_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    pub(crate) fn value_from_object(
+        vm: &MoveVM,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
         object: &Object,
     ) -> Result<ObjectValue, ExecutionError> {
         let Object { data: Data::Move(object), .. } = object else {
-        invariant_violation!("Expected a Move object");
-    };
+            invariant_violation!("Expected a Move object");
+        };
 
         let used_in_non_entry_move_call = false;
         make_object_value(
             vm,
-            session,
+            linkage_view,
+            new_packages,
             object.type_().clone(),
             object.has_public_transfer(),
             used_in_non_entry_move_call,
@@ -1096,18 +1094,19 @@ mod checked {
     }
 
     /// Load an input object from the state_view
-    fn load_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_object(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         override_as_immutable: bool,
         id: ObjectID,
     ) -> Result<InputValue, ExecutionError> {
         let Some(obj) = state_view.read_object(&id) else {
-        // protected by transaction input checker
-        invariant_violation!("Object {} does not exist yet", id);
-    };
+            // protected by transaction input checker
+            invariant_violation!("Object {} does not exist yet", id);
+        };
         // override_as_immutable ==> Owner::Shared
         assert_invariant!(
             !override_as_immutable || matches!(obj.owner, Owner::Shared { .. }),
@@ -1131,12 +1130,12 @@ mod checked {
             version,
             digest: obj.digest(),
         };
-        let obj_value = value_from_object(vm, session, obj)?;
+        let obj_value = value_from_object(vm, linkage_view, new_packages, obj)?;
         let contained_uids = {
-            let fully_annotated_layout =
-                session
-                    .type_to_fully_annotated_layout(&obj_value.type_)
-                    .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+            let fully_annotated_layout = vm
+                .get_runtime()
+                .type_to_fully_annotated_layout(&obj_value.type_)
+                .map_err(|e| convert_vm_error(e, vm, linkage_view))?;
             let mut bytes = vec![];
             obj_value.write_bcs_bytes(&mut bytes);
             match get_all_uids(&fully_annotated_layout, &bytes) {
@@ -1158,26 +1157,33 @@ mod checked {
     }
 
     /// Load an a CallArg, either an object or a raw set of BCS bytes
-    fn load_call_arg<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_call_arg(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         call_arg: CallArg,
     ) -> Result<InputValue, ExecutionError> {
         Ok(match call_arg {
             CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
-            CallArg::Object(obj_arg) => {
-                load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
-            }
+            CallArg::Object(obj_arg) => load_object_arg(
+                vm,
+                state_view,
+                linkage_view,
+                new_packages,
+                input_object_map,
+                obj_arg,
+            )?,
         })
     }
 
     /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-    fn load_object_arg<'vm, 'state>(
-        vm: &'vm MoveVM,
-        state_view: &'state dyn ExecutionState,
-        session: &mut Session<'state, 'vm, LinkageView<'state>>,
+    fn load_object_arg(
+        vm: &MoveVM,
+        state_view: &dyn ExecutionState,
+        linkage_view: &mut LinkageView,
+        new_packages: &[MovePackage],
         input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
         obj_arg: ObjectArg,
     ) -> Result<InputValue, ExecutionError> {
@@ -1185,7 +1191,8 @@ mod checked {
             ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
                 vm,
                 state_view,
-                session,
+                linkage_view,
+                new_packages,
                 input_object_map,
                 /* imm override */ false,
                 id,
@@ -1193,7 +1200,8 @@ mod checked {
             ObjectArg::SharedObject { id, mutable, .. } => load_object(
                 vm,
                 state_view,
-                session,
+                linkage_view,
+                new_packages,
                 input_object_map,
                 /* imm override */ !mutable,
                 id,
@@ -1262,9 +1270,9 @@ mod checked {
     ///
     /// This function assumes proper generation of has_public_transfer, either from the abilities of
     /// the StructTag, or from the runtime correctly propagating from the inputs
-    unsafe fn create_written_object<'vm, 'state>(
-        vm: &'vm MoveVM,
-        session: &Session<'state, 'vm, LinkageView<'state>>,
+    unsafe fn create_written_object(
+        vm: &MoveVM,
+        linkage_view: &LinkageView,
         protocol_config: &ProtocolConfig,
         objects_modified_at: &BTreeMap<ObjectID, LoadedRuntimeObject>,
         id: ObjectID,
@@ -1280,9 +1288,10 @@ mod checked {
             .get(&id)
             .map(|obj: &LoadedRuntimeObject| obj.version);
 
-        let type_tag = session
+        let type_tag = vm
+            .get_runtime()
             .get_type_tag(&type_)
-            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
+            .map_err(|e| crate::error::convert_vm_error(e, vm, linkage_view))?;
 
         let struct_tag = match type_tag {
             TypeTag::Struct(inner) => *inner,
@@ -1295,5 +1304,120 @@ mod checked {
             contents,
             protocol_config,
         )
+    }
+
+    // Implementation of the `DataStore` trait for the Move VM.
+    // When used during execution it may have a list of new packages that have
+    // just been published in the current context. Thos are used for module/type
+    // resolution when executing module init.
+    // It may be created with an empty slice of packages either when no publish/upgrade
+    // are performed or when a type is requested not during execution.
+    pub(crate) struct SuiDataStore<'state, 'a> {
+        linkage_view: &'a LinkageView<'state>,
+        new_packages: &'a [MovePackage],
+    }
+
+    impl<'state, 'a> SuiDataStore<'state, 'a> {
+        pub(crate) fn new(
+            linkage_view: &'a LinkageView<'state>,
+            new_packages: &'a [MovePackage],
+        ) -> Self {
+            Self {
+                linkage_view,
+                new_packages,
+            }
+        }
+
+        fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
+            for package in self.new_packages {
+                let module = package.get_module(module_id);
+                if module.is_some() {
+                    return module;
+                }
+            }
+            None
+        }
+    }
+
+    // TODO: `DataStore` wil be reworked and this is likely to disappear.
+    //       Leaving this comment around until then as testament to better days to come...
+    impl<'state, 'a> DataStore for SuiDataStore<'state, 'a> {
+        fn link_context(&self) -> AccountAddress {
+            self.linkage_view.link_context()
+        }
+
+        fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
+            self.linkage_view.relocate(module_id).map_err(|err| {
+                PartialVMError::new(StatusCode::LINKER_ERROR)
+                    .with_message(format!("Error relocating {module_id}: {err:?}"))
+            })
+        }
+
+        fn defining_module(
+            &self,
+            runtime_id: &ModuleId,
+            struct_: &IdentStr,
+        ) -> PartialVMResult<ModuleId> {
+            self.linkage_view
+                .defining_module(runtime_id, struct_)
+                .map_err(|err| {
+                    PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
+                        "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
+                    ))
+                })
+        }
+
+        fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
+            if let Some(bytes) = self.get_module(module_id) {
+                return Ok(bytes.clone());
+            }
+            match self.linkage_view.get_module(module_id) {
+                Ok(Some(bytes)) => Ok(bytes),
+                Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                    .with_message(format!("Cannot find {:?} in data cache", module_id))
+                    .finish(Location::Undefined)),
+                Err(err) => {
+                    let msg = format!("Unexpected storage error: {:?}", err);
+                    Err(
+                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                            .with_message(msg)
+                            .finish(Location::Undefined),
+                    )
+                }
+            }
+        }
+
+        //
+        // TODO: later we will clean up the interface with the runtime and the functions below
+        //       will likely be exposed via extensions
+        //
+
+        fn load_resource(
+            &mut self,
+            _addr: AccountAddress,
+            _ty: &Type,
+        ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
+            panic!("load_resource should never be called for LinkageView")
+        }
+
+        fn emit_event(
+            &mut self,
+            _guid: Vec<u8>,
+            _seq_num: u64,
+            _ty: Type,
+            _val: VMValue,
+        ) -> PartialVMResult<()> {
+            panic!("emit_event should never be called for LinkageView")
+        }
+
+        fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, VMValue)> {
+            panic!("events should never be called for LinkageView")
+        }
+
+        fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
+            // we cannot panic here because during executon and publishing this is
+            // currently called from the publish flow in the Move runtime
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
## Description 

This is the first step in removing Session from the execution layer/adapter.
It's a replacement for #13000 as it creates a new version of the execution layer.
It also adds a couple of protocol config features around publishing, a change in charging and in the number of packages published per PTB.
Here we get rid of Session entirely. However there is a lot more we are doing in the VM (loader and more) and in the adapter traits. More coming.

I have the change for protocol config here, however I could remove it if we want to go in without the protocol change yet. Looking for feedback around how we want to push this.
We can enable this only for devnet (maybe testnet) if we wanted, or go to mainnet, or nowhere for now.

@tnowacki @amnn sorry for the churn but this should be what you reviewed already. As a side note I went back to have the published packages as a vector, given the new constraints. To be honest I feel that logic will change more as we integrate better with the Move VM, and that is coming soon. Not sure if that is a reason to keep this on the side, or to promote it sooner because of the new protocol changes

## Test Plan 

More tests added for new features

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
