### PR TITLE
[Faucet] Adding 2 consumer queues for locking

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -52,6 +52,8 @@ pub struct SimpleFaucet {
     active_address: SuiAddress,
     producer: Mutex<Sender<ObjectID>>,
     consumer: Mutex<Receiver<ObjectID>>,
+    batch_producer: Mutex<Sender<ObjectID>>,
+    batch_consumer: Mutex<Receiver<ObjectID>>,
     pub metrics: FaucetMetrics,
     pub wal: Mutex<WriteAheadLog>,
     request_producer: Sender<(Uuid, SuiAddress, Vec<u64>)>,
@@ -120,9 +122,15 @@ impl SimpleFaucet {
         let mut pending = vec![];
 
         let (producer, consumer) = mpsc::channel(coins.len());
+        let (batch_producer, batch_consumer) = mpsc::channel(coins.len());
+
         let (sender, mut receiver) =
             mpsc::channel::<(Uuid, SuiAddress, Vec<u64>)>(config.max_request_queue_length as usize);
 
+        let split_point = coins.len() / 2;
+        let mut coins_processed = 0;
+
+        // Put half of the coins in the old faucet impl queue, and put half in the other queue for batch coins.
         for coin in &coins {
             let coin_id = *coin.id();
             if let Some(write_ahead_log::Entry {
@@ -137,16 +145,31 @@ impl SimpleFaucet {
                 info!(?uuid, ?recipient, ?coin_id, "Retrying txn from WAL.");
                 pending.push((uuid, recipient, coin_id, tx));
             } else {
-                producer
-                    .send(coin_id)
-                    .await
-                    .tap_ok(|_| {
-                        info!(?coin_id, "Adding coin to gas pool");
-                        metrics.total_available_coins.inc();
-                    })
-                    .tap_err(|e| error!(?coin_id, "Failed to add coin to gas pools: {e:?}"))
-                    .unwrap();
+                if coins_processed < split_point {
+                    producer
+                        .send(coin_id)
+                        .await
+                        .tap_ok(|_| {
+                            info!(?coin_id, "Adding coin to gas pool");
+                            metrics.total_available_coins.inc();
+                        })
+                        .tap_err(|e| error!(?coin_id, "Failed to add coin to gas pools: {e:?}"))
+                        .unwrap();
+                } else {
+                    batch_producer
+                        .send(coin_id)
+                        .await
+                        .tap_ok(|_| {
+                            info!(?coin_id, "Adding coin to batch gas pool");
+                            metrics.total_available_coins.inc();
+                        })
+                        .tap_err(|e| {
+                            error!(?coin_id, "Failed to add coin to batch gas pools: {e:?}")
+                        })
+                        .unwrap();
+                }
             }
+            coins_processed += 1;
         }
         let (batch_transfer_shutdown, mut rx_batch_transfer_shutdown) = oneshot::channel();
 
@@ -155,6 +178,8 @@ impl SimpleFaucet {
             active_address,
             producer: Mutex::new(producer),
             consumer: Mutex::new(consumer),
+            batch_producer: Mutex::new(batch_producer),
+            batch_consumer: Mutex::new(batch_consumer),
             metrics,
             wal: Mutex::new(wal),
             request_producer: sender,
@@ -200,7 +225,7 @@ impl SimpleFaucet {
         // values -- if the executions failed, the pending coins will simply remain in the WAL, and
         // not recycled.
         futures::future::join_all(pending.into_iter().map(|(uuid, recipient, coin_id, tx)| {
-            arc_faucet.sign_and_execute_txn(uuid, recipient, coin_id, tx)
+            arc_faucet.sign_and_execute_txn(uuid, recipient, coin_id, tx, false)
         }))
         .await;
 
@@ -232,10 +257,46 @@ impl SimpleFaucet {
         Some(coin)
     }
 
+    /// Take the consumer lock and pull a Coin ID from the queue, without checking whether it is
+    /// valid or not.
+    async fn pop_gas_coin_for_batch(&self, uuid: Uuid) -> Option<ObjectID> {
+        // If the gas candidate queue is exhausted, the request will be suspended indefinitely until
+        // a producer puts in more candidate gas objects. At the same time, other requests will be
+        // blocked by the lock acquisition as well.
+        let Ok(mut batch_consumer) = tokio::time::timeout(LOCK_TIMEOUT, self.batch_consumer.lock()).await else {
+            error!(?uuid, "Timeout when getting consumer lock");
+            return None;
+        };
+
+        info!(?uuid, "Got consumer lock, pulling coins.");
+        let Ok(coin) = tokio::time::timeout(RECV_TIMEOUT, batch_consumer.recv()).await else {
+            error!(?uuid, "Timeout when getting gas coin from the queue");
+            return None;
+        };
+
+        let Some(coin) = coin else {
+            unreachable!("channel is closed");
+        };
+
+        self.metrics.total_available_coins.dec();
+        Some(coin)
+    }
+
     /// Pulls a coin from the queue and makes sure it is fit for use (belongs to the faucet, has
     /// sufficient balance).
-    async fn prepare_gas_coin(&self, total_amount: u64, uuid: Uuid) -> GasCoinResponse {
-        let Some(coin_id) = self.pop_gas_coin(uuid).await else {
+    async fn prepare_gas_coin(
+        &self,
+        total_amount: u64,
+        uuid: Uuid,
+        for_batch: bool,
+    ) -> GasCoinResponse {
+        let coin_id = if for_batch {
+            self.pop_gas_coin(uuid).await
+        } else {
+            self.pop_gas_coin_for_batch(uuid).await
+        };
+
+        let Some(coin_id) = coin_id else {
             warn!("Failed getting gas coin, try later!");
             return GasCoinResponse::NoGasCoinAvailable;
         };
@@ -328,7 +389,7 @@ impl SimpleFaucet {
         drop(wal);
 
         futures::future::join_all(pending.into_iter().map(|(uuid, recipient, coin_id, tx)| {
-            self.sign_and_execute_txn(uuid, recipient, coin_id, tx)
+            self.sign_and_execute_txn(uuid, recipient, coin_id, tx, false)
         }))
         .await;
 
@@ -343,6 +404,7 @@ impl SimpleFaucet {
         recipient: SuiAddress,
         coin_id: ObjectID,
         tx_data: TransactionData,
+        for_batch: bool,
     ) -> Result<SuiTransactionBlockResponse, FaucetError> {
         let signature = self
             .wallet
@@ -405,7 +467,11 @@ impl SimpleFaucet {
                 if self.wal.lock().await.commit(coin_id).is_err() {
                     error!(?coin_id, "Failed to remove coin from WAL");
                 }
-                self.recycle_gas_coin(coin_id, uuid).await;
+                if for_batch {
+                    self.recycle_gas_coin_for_batch(coin_id, uuid).await;
+                } else {
+                    self.recycle_gas_coin(coin_id, uuid).await;
+                }
                 Ok(result)
             }
         }
@@ -422,7 +488,9 @@ impl SimpleFaucet {
         let total_amount: u64 = amounts.iter().sum();
         let gas_cost = self.get_gas_cost().await?;
 
-        let gas_coin_response = self.prepare_gas_coin(total_amount + gas_cost, uuid).await;
+        let gas_coin_response = self
+            .prepare_gas_coin(total_amount + gas_cost, uuid, false)
+            .await;
         match gas_coin_response {
             GasCoinResponse::ValidGasCoin(coin_id) => {
                 let tx_data = self
@@ -439,7 +507,7 @@ impl SimpleFaucet {
                         .map_err(FaucetError::internal)?;
                 }
                 let response = self
-                    .sign_and_execute_txn(uuid, recipient, coin_id, tx_data)
+                    .sign_and_execute_txn(uuid, recipient, coin_id, tx_data, false)
                     .await?;
                 self.metrics.total_coin_requests_succeeded.inc();
                 self.check_and_map_transfer_gas_result(response, number_of_coins, recipient)
@@ -477,6 +545,19 @@ impl SimpleFaucet {
         let producer = self.producer.lock().await;
         info!(?uuid, ?coin_id, "Got producer lock and recycling coin");
         producer
+            .try_send(coin_id)
+            .expect("unexpected - queue is large enough to hold all coins");
+        self.metrics.total_available_coins.inc();
+        info!(?uuid, ?coin_id, "Recycled coin");
+    }
+
+    async fn recycle_gas_coin_for_batch(&self, coin_id: ObjectID, uuid: Uuid) {
+        // Once transactions are done, in despite of success or failure,
+        // we put back the coins. The producer should never wait indefinitely,
+        // in that the channel is initialized with big enough capacity.
+        let batch_producer = self.batch_producer.lock().await;
+        info!(?uuid, ?coin_id, "Got producer lock and recycling coin");
+        batch_producer
             .try_send(coin_id)
             .expect("unexpected - queue is large enough to hold all coins");
         self.metrics.total_available_coins.inc();
@@ -925,7 +1006,7 @@ pub async fn batch_transfer_gases(
     // This loop is utilized to grab a coin that is large enough for the request
     loop {
         let gas_coin_response = faucet
-            .prepare_gas_coin(total_sui_needed + gas_cost, uuid)
+            .prepare_gas_coin(total_sui_needed + gas_cost, uuid, true)
             .await;
 
         match gas_coin_response {
@@ -952,7 +1033,7 @@ pub async fn batch_transfer_gases(
                         .map_err(FaucetError::internal)?;
                 }
                 let response = faucet
-                    .sign_and_execute_txn(uuid, recipient, coin_id, tx_data)
+                    .sign_and_execute_txn(uuid, recipient, coin_id, tx_data, true)
                     .await?;
 
                 faucet
@@ -1343,7 +1424,7 @@ mod tests {
         let faucet_address = faucet.active_address;
         let uuid = Uuid::new_v4();
 
-        let GasCoinResponse::ValidGasCoin(coin_id) = faucet.prepare_gas_coin(100, uuid).await else {
+        let GasCoinResponse::ValidGasCoin(coin_id) = faucet.prepare_gas_coin(100, uuid, false).await else {
             panic!("prepare_gas_coin did not give a valid coin.")
         };
 
@@ -1626,7 +1707,7 @@ mod tests {
         let faucet_address = faucet.active_address;
         let uuid = Uuid::new_v4();
 
-        let GasCoinResponse::ValidGasCoin(coin_id) = faucet.prepare_gas_coin(100, uuid).await else {
+        let GasCoinResponse::ValidGasCoin(coin_id) = faucet.prepare_gas_coin(100, uuid, false).await else {
             panic!("prepare_gas_coin did not give a valid coin.")
         };
 

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -128,10 +128,9 @@ impl SimpleFaucet {
             mpsc::channel::<(Uuid, SuiAddress, Vec<u64>)>(config.max_request_queue_length as usize);
 
         let split_point = coins.len() / 2;
-        let mut coins_processed = 0;
 
         // Put half of the coins in the old faucet impl queue, and put half in the other queue for batch coins.
-        for coin in &coins {
+        for (coins_processed, coin) in coins.iter().enumerate() {
             let coin_id = *coin.id();
             if let Some(write_ahead_log::Entry {
                 uuid,
@@ -169,7 +168,6 @@ impl SimpleFaucet {
                         .unwrap();
                 }
             }
-            coins_processed += 1;
         }
         let (batch_transfer_shutdown, mut rx_batch_transfer_shutdown) = oneshot::channel();
 


### PR DESCRIPTION
Separating out queues so that batch and normal transfers don't try to use the same gas coin

## Description 

Currently there is a race condition where the 2 API calls `batch_gas` and `gas` try to use the same coin. This is a PR to implement a different queue so that they don't contest each other

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
