### PR TITLE
indexer: update address & active address info based on recipients instead

### DIFF
--- a/crates/sui-indexer/src/models/transaction_index.rs
+++ b/crates/sui-indexer/src/models/transaction_index.rs
@@ -28,9 +28,10 @@ pub struct MoveCall {
     pub move_function: String,
 }
 
-#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[derive(Queryable, Insertable, Debug, Clone, Default, QueryableByName)]
 #[diesel(table_name = recipients)]
 pub struct Recipient {
+    #[diesel(deserialize_as = i64)]
     pub id: Option<i64>,
     pub transaction_digest: String,
     pub checkpoint_sequence_number: i64,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -209,6 +209,10 @@ pub trait IndexerStore {
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError>;
+    async fn get_recipients_data_by_checkpoint(
+        &self,
+        seq: u64,
+    ) -> Result<Vec<Recipient>, IndexerError>;
 
     async fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
     async fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;


### PR DESCRIPTION
## Description 

see thread in https://mysten-labs.slack.com/archives/C0578KFD9D2/p1693095224772239?thread_ts=1692994121.678369&cid=C0578KFD9D2

## Test Plan 
<img width="714" alt="Screenshot 2023-08-27 at 12 34 42 PM" src="https://github.com/MystenLabs/sui/assets/106119108/082fc4ea-be60-4b9a-b270-f5ce5e272ddd">
tested on devnet and made sure that addr stats can be populated accordingly based on recipients table;
could not test on mainnet b/c old txns have been pruned


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
