### PR TITLE
move: source service tracks recent release branches

### DIFF
--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -2,7 +2,7 @@
 source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
-branch = "framework/mainnet"
+branch = "mainnet"
 network = "mainnet"
 packages = [
     { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },
@@ -15,7 +15,7 @@ packages = [
 source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
-branch = "framework/testnet"
+branch = "testnet"
 network = "testnet"
 packages = [
     { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },
@@ -28,7 +28,7 @@ packages = [
 source = "Repository"
 [packages.values]
 repository = "https://github.com/mystenlabs/sui"
-branch = "framework/devnet"
+branch = "devnet"
 network = "devnet"
 packages = [
     { path = "crates/sui-framework/packages/deepbook", watch = "0xdee9" },


### PR DESCRIPTION
## Description 

I'm finding that `framework/*` branches diverge from on-chain bytecode when the on-chain code upgrades, but we haven't synced to `framework/*` branches yet. Specifically we have [hourly monitors](https://github.com/MystenLabs/sui-operations/blob/main/.github/workflows/sui-protocol-monitor.yml) for `framework/testnet` and `framework/mainnet` for syncing, meaning there's a potential time gap when it's not up to date. If there is a divergence, (a) the service won't start currently, (b) monitoring on-chain changes means that syncing from repositories won't succeed for some time gap (which could be up to an hour based on our monitors).

Because of this I want to change the default config to track and monitor latest `testnet` and `mainnet` for framework code. It should effectively addresses (a) and (b) because on-chain changes ought to be up to date with `testnet` and `mainnet` branches immediately.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
