### PR TITLE
Update on gas tests and conservation rules

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -31,7 +31,6 @@ use sui_types::crypto::{AuthorityKeyPair, Signer};
 use sui_types::effects::{SignedTransactionEffects, TransactionEffects};
 use sui_types::error::SuiError;
 use sui_types::transaction::ObjectArg;
-use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS;
 use sui_types::transaction::{
     CallArg, SignedTransaction, Transaction, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
@@ -369,6 +368,7 @@ pub fn make_transfer_object_move_transaction(
     object_ref: ObjectRef,
     framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
+    gas_budget_in_units: u64,
     gas_price: u64,
 ) -> Transaction {
     let args = vec![
@@ -385,7 +385,7 @@ pub fn make_transfer_object_move_transaction(
             Vec::new(),
             gas_object_ref,
             args,
-            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * gas_price,
+            gas_budget_in_units * gas_price,
             gas_price,
         )
         .unwrap(),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -88,7 +88,7 @@ pub fn create_object_move_transaction(
             Vec::new(),
             gas_object_ref,
             arguments,
-            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * gas_price,
+            TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * gas_price,
             gas_price,
         )
         .unwrap(),

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -23,7 +23,9 @@ use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiResult;
 use sui_types::object::{Object, Owner};
-use sui_types::transaction::{Transaction, VerifiedCertificate};
+use sui_types::transaction::{
+    Transaction, VerifiedCertificate, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{sleep, timeout};
 
@@ -363,6 +365,7 @@ async fn test_execution_with_dependencies() {
             owned_object_ref,
             package,
             gas_ref,
+            TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
             rgp,
         );
         let (cert, effects) = execute_owned_on_first_three_authorities(

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -130,8 +130,12 @@ where
     F: FnOnce(&GasCostSummary, u64, u64) -> SuiResult,
 {
     // initial system with given gas coins
-    const GAS_AMOUNT: u64 = 10_000_000_000;
-    let gas_coins = make_gas_coins(sender, GAS_AMOUNT, coin_num);
+    let gas_amount: u64 = if budget < 10_000_000_000 {
+        10_000_000_000
+    } else {
+        budget
+    };
+    let gas_coins = make_gas_coins(sender, gas_amount, coin_num);
     let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
     let authority_state = TestAuthorityBuilder::new().build().await;
     for obj in gas_coins {
@@ -139,7 +143,7 @@ where
     }
 
     let gas_object_id = ObjectID::random();
-    let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, GAS_AMOUNT);
+    let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_amount);
     authority_state.insert_genesis_object(gas_coin).await;
     // touch gas coins so that `storage_rebate` is set (not 0 as in genesis)
     touch_gas_coins(
@@ -216,7 +220,7 @@ where
     let summary = effects.gas_cost_summary();
 
     // call checker
-    checker(summary, GAS_AMOUNT, final_value)
+    checker(summary, gas_amount, final_value)
 }
 
 // make a `coin_num` coins distributing `gas_amount` across them
@@ -279,19 +283,17 @@ async fn touch_gas_coins(
 }
 
 // - OOG computation, storage ok
-#[ignore]
 #[tokio::test]
-async fn test_oog_computation_storage_ok() -> SuiResult {
-    const MAX_BUDGET: u64 = 10_000_000;
-    const GAS_PRICE: u64 = 30;
-    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
+async fn test_oog_computation_storage_ok_one_coin() -> SuiResult {
+    const GAS_PRICE: u64 = 1_000;
+    let budget: u64 = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
     let (sender, sender_key) = get_key_pair();
     check_oog_transaction(
         sender,
         sender_key,
         "loopy",
         vec![],
-        BUDGET,
+        budget,
         GAS_PRICE,
         1,
         |summary, initial_value, final_value| {
@@ -309,14 +311,38 @@ async fn test_oog_computation_storage_ok() -> SuiResult {
     .await
 }
 
-// OOG for computation, OOG for minimal storage (e.g. computation is entire budget)
-#[ignore]
 #[tokio::test]
-async fn test_oog_computation_oog_storage() -> SuiResult {
-    const GAS_PRICE: u64 = 30;
-    // WARNING: this value is taken from gas_v2.rs::MAX_BUCKET_COST and when
-    // that value changes this test will break!
-    // TODO: when buckets move to ProtocolConfig change this value to use ProtocolConfig
+async fn test_oog_computation_storage_ok_multi_coins() -> SuiResult {
+    const GAS_PRICE: u64 = 1_000;
+    let budget: u64 = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "loopy",
+        vec![],
+        budget,
+        GAS_PRICE,
+        5,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(
+                summary.computation_cost > 0
+                    && summary.storage_cost > 0
+                    && summary.storage_rebate > 0
+                    && summary.non_refundable_storage_fee > 0
+            );
+            assert!(initial_value - gas_used == final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
+// OOG for computation, OOG for minimal storage (e.g. computation is entire budget)
+#[tokio::test]
+async fn test_oog_computation_oog_storage_final_one_coin() -> SuiResult {
+    const GAS_PRICE: u64 = 1000;
     const MAX_UNIT_BUDGET: u64 = 5_000_000;
     const BUDGET: u64 = MAX_UNIT_BUDGET * GAS_PRICE;
     let (sender, sender_key) = get_key_pair();
@@ -344,7 +370,7 @@ async fn test_oog_computation_oog_storage() -> SuiResult {
 
 // - computation ok, OOG for storage, minimal storage ok
 #[tokio::test]
-async fn test_computation_ok_oog_storage_minimal_ok() -> SuiResult {
+async fn test_computation_ok_oog_storage_minimal_ok_one_coin() -> SuiResult {
     const GAS_PRICE: u64 = 1001;
     const BUDGET: u64 = 1_100_000;
     let (sender, sender_key) = get_key_pair();
@@ -374,9 +400,41 @@ async fn test_computation_ok_oog_storage_minimal_ok() -> SuiResult {
     .await
 }
 
+// - computation ok, OOG for storage, minimal storage ok
+#[tokio::test]
+async fn test_computation_ok_oog_storage_minimal_ok_multi_coins() -> SuiResult {
+    const GAS_PRICE: u64 = 1001;
+    const BUDGET: u64 = 1_100_000;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&(100_u64)).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        BUDGET,
+        GAS_PRICE,
+        5,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage();
+            assert!(
+                summary.computation_cost > 0
+                    && summary.storage_cost > 0
+                    && summary.storage_rebate > 0
+                    && summary.non_refundable_storage_fee > 0
+            );
+            assert_eq!(initial_value as i64 - gas_used, final_value as i64);
+            Ok(())
+        },
+    )
+    .await
+}
+
 // - computation ok, OOG for storage, OOG for minimal storage (e.g. computation is entire budget)
 #[tokio::test]
-async fn test_computation_ok_oog_storage() -> SuiResult {
+async fn test_computation_ok_oog_storage_final_one_coin() -> SuiResult {
     const GAS_PRICE: u64 = 1001;
     const BUDGET: u64 = 1_002_000;
     let (sender, sender_key) = get_key_pair();
@@ -399,36 +457,6 @@ async fn test_computation_ok_oog_storage() -> SuiResult {
             assert_eq!(summary.storage_rebate, 0);
             assert_eq!(summary.non_refundable_storage_fee, 0);
             assert_eq!(initial_value - gas_used, final_value);
-            Ok(())
-        },
-    )
-    .await
-}
-
-#[ignore]
-#[tokio::test]
-async fn test_oog_computation_storage_ok_multi_coins() -> SuiResult {
-    const MAX_BUDGET: u64 = 4_000_000;
-    const GAS_PRICE: u64 = 30;
-    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
-    let (sender, sender_key) = get_key_pair();
-    check_oog_transaction(
-        sender,
-        sender_key,
-        "loopy",
-        vec![],
-        BUDGET,
-        GAS_PRICE,
-        5,
-        |summary, initial_value, final_value| {
-            let gas_used = summary.net_gas_usage() as u64;
-            assert!(
-                summary.computation_cost > 0
-                    && summary.storage_cost > 0
-                    && summary.storage_rebate > 0
-                    && summary.non_refundable_storage_fee > 0
-            );
-            assert!(initial_value - gas_used == final_value);
             Ok(())
         },
     )

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -770,6 +770,7 @@ async fn test_entry_point_vector_empty() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
 
     let package = build_and_publish_test_package(
         &authority,
@@ -802,7 +803,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -831,7 +832,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -861,7 +862,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();
@@ -891,7 +892,7 @@ async fn test_entry_point_vector_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();
@@ -2281,6 +2282,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
             vec![vec, n],
         );
     }
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
     // empty
     let mut builder = ProgrammableTransactionBuilder::new();
     make_and_drop(&mut builder, package_id, &t, vec![]);
@@ -2291,7 +2293,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2313,7 +2315,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2338,7 +2340,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2368,7 +2370,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2405,7 +2407,7 @@ async fn test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2534,6 +2536,8 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
     t: TypeTag,
     value: T,
 ) {
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
     // single without a type argument
     let mut builder = ProgrammableTransactionBuilder::new();
     let arg = builder.pure(value.clone()).unwrap();
@@ -2545,7 +2549,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2574,7 +2578,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2605,7 +2609,7 @@ async fn error_test_make_move_vec_for_type<T: Clone + Serialize>(
         sender,
         sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap();
@@ -2718,6 +2722,7 @@ async fn test_make_move_vec_empty() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
     let mut builder = ProgrammableTransactionBuilder::new();
     builder.command(Command::MakeMoveVec(None, vec![]));
     let pt = builder.finish();
@@ -2727,7 +2732,7 @@ async fn test_make_move_vec_empty() {
         &sender,
         &sender_key,
         pt,
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
     )
     .await
     .unwrap_err();

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -103,6 +103,7 @@ struct UpgradeStateRunner {
     pub authority_state: Arc<AuthorityState>,
     pub package: ObjectRef,
     pub upgrade_cap: ObjectRef,
+    pub rgp: u64,
 }
 
 impl UpgradeStateRunner {
@@ -117,6 +118,7 @@ impl UpgradeStateRunner {
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
         let authority_state = TestAuthorityBuilder::new().build().await;
         authority_state.insert_genesis_object(gas_object).await;
+        let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
         let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(
             &authority_state,
@@ -135,6 +137,7 @@ impl UpgradeStateRunner {
             authority_state,
             package,
             upgrade_cap,
+            rgp,
         }
     }
 
@@ -213,7 +216,7 @@ impl UpgradeStateRunner {
             &self.sender,
             &self.sender_key,
             pt,
-            TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+            self.rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         )
         .await
         .unwrap();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -71,7 +71,7 @@
             },
             {
               "name": "tx_bytes",
-              "value": "AAACACBnxtMcbJcOVn8D72fYEaT4Q2ZbjePygvpIs+AQO6m77QEAagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbECAAAAAAAAACDoQ3EipycU+/EOvBcDPFtMkZiSbdzWAw3CwdmQCAtBWAEBAQEBAAEAAC9cVD1xauQ9RT3rOxmbva8bxwMMdoL4dwPc5DEkj+3gASxDgF0Nb1QCp60Npb3sVJx83qBrxKHTOaIlIe6pM7iJAgAAAAAAAAAgnvsgc1pPauyCE27/c+aBnHN3fSsxRAWdEJYzYFOryNAvXFQ9cWrkPUU96zsZm72vG8cDDHaC+HcD3OQxJI/t4AoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACBnxtMcbJcOVn8D72fYEaT4Q2ZbjePygvpIs+AQO6m77QEAagYVO5/EhuEB8OnicDrIZm0GrsxN3355JqNhlwxlpbECAAAAAAAAACDoQ3EipycU+/EOvBcDPFtMkZiSbdzWAw3CwdmQCAtBWAEBAQEBAAEAAC9cVD1xauQ9RT3rOxmbva8bxwMMdoL4dwPc5DEkj+3gASxDgF0Nb1QCp60Npb3sVJx83qBrxKHTOaIlIe6pM7iJAgAAAAAAAAAgnvsgc1pPauyCE27/c+aBnHN3fSsxRAWdEJYzYFOryNAvXFQ9cWrkPUU96zsZm72vG8cDDHaC+HcD3OQxJI/t4AoAAAAAAAAAoIYBAAAAAAAA"
             },
             {
               "name": "gas_price",
@@ -168,13 +168,13 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgoAAAAAAAAAoIYBAAAAAAAA"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
-              "digest": "Gm54bTY5F9KjiCw3kfKpkXPaEE3kx8ToJkYqTsuQDZ7q",
+              "digest": "DNtx7EmGqSywGbnSC1CKoqmBFEXGvApXpRVt6bU855xP",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -220,14 +220,14 @@
                     ],
                     "owner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "AGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
+                  "AG+AHZMT7BZWQVagaGfENXyiFQ2nYRkG4XdnwqwToeJEmZ4J1IxKw0xKzTATGiUzFedY/nxKVuHikFibNlZ3wg9Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YABAE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAgsQwARuKTwIzsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/8BAQEBAQABAABh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgHo2MfOhj8xPaPb2SqD7ybRKLiP5mvybg4NCc2vcn0dhAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlYfu1tPNCpAvb+H/kqUa5440Yz4/8ewAAuXUXXHtqlXYKAAAAAAAAAAAtMQEAAAAAAAFhAGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ==",
+              "rawTransaction": "AQAAAAAAAgAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YABAE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAgsQwARuKTwIzsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/8BAQEBAQABAABh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgHo2MfOhj8xPaPb2SqD7ybRKLiP5mvybg4NCc2vcn0dhAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlYfu1tPNCpAvb+H/kqUa5440Yz4/8ewAAuXUXXHtqlXYKAAAAAAAAAKCGAQAAAAAAAAFhAG+AHZMT7BZWQVagaGfENXyiFQ2nYRkG4XdnwqwToeJEmZ4J1IxKw0xKzTATGiUzFedY/nxKVuHikFibNlZ3wg9Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -349,12 +349,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACBqEB6aOvXIBwES+Ahkizbvv43uihqC3kbZUE6WoRCKFwEAjvdvVsOZYzousxC8qRJOXy84znOeqsu2YAaIgE4HhEgCAAAAAAAAACB9w3+ufZMpihJFwxtCBojBaGy00TVtFxgN2C6TpIPFqwEBAQEBAAEAAAS0l6kWtGVmCaf6gnoJGE1vR2gdO6dM4NejbGSysfiHAZ+Q9/hmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTAgAAAAAAAAAgjleHL0UiRGjh/BfIFHCJ3EMY/dQA22c2TvNQyVJnbYUEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACBqEB6aOvXIBwES+Ahkizbvv43uihqC3kbZUE6WoRCKFwEAjvdvVsOZYzousxC8qRJOXy84znOeqsu2YAaIgE4HhEgCAAAAAAAAACB9w3+ufZMpihJFwxtCBojBaGy00TVtFxgN2C6TpIPFqwEBAQEBAAEAAAS0l6kWtGVmCaf6gnoJGE1vR2gdO6dM4NejbGSysfiHAZ+Q9/hmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTAgAAAAAAAAAgjleHL0UiRGjh/BfIFHCJ3EMY/dQA22c2TvNQyVJnbYUEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwoAAAAAAAAAoIYBAAAAAAAA"
             },
             {
               "name": "signatures",
               "value": [
-                "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
+                "AKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
               ]
             },
             {
@@ -376,7 +376,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "BgSFSEFYbCrVUJJtHFeoLmLJi8jDf1CpC2o8S33HjeDJ",
+              "digest": "Gx7V6EteEAqSsptc1kbi1nUEMP7mhr4qV2cYS7JjzbBd",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -422,14 +422,14 @@
                     ],
                     "owner": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
+                  "AKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAgahAemjr1yAcBEvgIZIs277+N7ooagt5G2VBOlqEQihcBAI73b1bDmWM6LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAQEBAQABAAAEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwGfkPf4Zswp37HaY3POlPnZXcpaQPThdpkY7r+fuuAL0wIAAAAAAAAAII5Xhy9FIkRo4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FBLSXqRa0ZWYJp/qCegkYTW9HaB07p0zg16NsZLKx+IcKAAAAAAAAAAAtMQEAAAAAAAFhAEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w==",
+              "rawTransaction": "AQAAAAAAAgAgahAemjr1yAcBEvgIZIs277+N7ooagt5G2VBOlqEQihcBAI73b1bDmWM6LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAQEBAQABAAAEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwGfkPf4Zswp37HaY3POlPnZXcpaQPThdpkY7r+fuuAL0wIAAAAAAAAAII5Xhy9FIkRo4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FBLSXqRa0ZWYJp/qCegkYTW9HaB07p0zg16NsZLKx+IcKAAAAAAAAAKCGAQAAAAAAAAFhAKD4XdltkCyBi1Heb4EJJ3lzuV3F4u7+CYeaE+Fd7qXpaT17yd4tHWjMf4CWq3TuXBLxTpkc2MV39P6p7eMV8QnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "22",
+              "maxSupportedProtocolVersion": "23",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,
@@ -1368,6 +1368,7 @@
                 "package_digest_hash_module": false,
                 "package_upgrades": true,
                 "scoring_decision_with_validity_cutoff": true,
+                "simple_conservation_checks": false,
                 "simplified_unwrap_then_delete": false,
                 "txn_base_cost_as_multiplier": false,
                 "upgraded_multisig_supported": false,
@@ -1926,7 +1927,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "oKtFZjL99EZ2K3TLPRarpZN8gz9xReMkiNf4Tjja2no"
+              "value": "Hay2tj3GcDYcE3AMHrej5WDsHGPVAYsegcubixLUvXUF"
             },
             {
               "name": "options",
@@ -1943,7 +1944,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "oKtFZjL99EZ2K3TLPRarpZN8gz9xReMkiNf4Tjja2no",
+              "digest": "Hay2tj3GcDYcE3AMHrej5WDsHGPVAYsegcubixLUvXUF",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -1989,14 +1990,14 @@
                     ],
                     "owner": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66",
                     "price": "10",
-                    "budget": "20000000"
+                    "budget": "100000"
                   }
                 },
                 "txSignatures": [
-                  "ABTTP4JUSxqOQTlysdS30HzkMc3DOwJqlBJstqn2EwW0SKtvoGIoxFEbmTqIS+UYSemveVGJ+S6BijQQVS97cwxtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA=="
+                  "AMU7cJTEsJ5WoVlKZ2zsVuGMk9linDuNqLV9eGIIrqarP2x4R9riuvmmMgXfdxMm7jTzYxbHrsDNMwlxpTbbFghtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAggZbQSLem0EyO3IlXnYb9P8kMUvmhTGuBK5T+YTxbzrsBAF7rHUSeJRYWbVfXH96xVNDcns23swBX0KkyaEysNSzcAgAAAAAAAAAg43+UGkUe+CCaD7+/G1SbK7Jrjq7giJUUbfJ7w88mEMEBAQEBAQABAACCF5xX1Ylbq/tlXNYujohqUzNLXnvpvmWOt1nMNeP8ZgEaPomAKdAk7sHUTGr14vrN7YTQO1NzUU8W49ZuAAgQUQIAAAAAAAAAIGS7c6HtWLLBiwy/N3eS4gbmuA1NXupk4ucFY7FYkCbEghecV9WJW6v7ZVzWLo6IalMzS1576b5ljrdZzDXj/GYKAAAAAAAAAAAtMQEAAAAAAAFhABTTP4JUSxqOQTlysdS30HzkMc3DOwJqlBJstqn2EwW0SKtvoGIoxFEbmTqIS+UYSemveVGJ+S6BijQQVS97cwxtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA==",
+              "rawTransaction": "AQAAAAAAAgAggZbQSLem0EyO3IlXnYb9P8kMUvmhTGuBK5T+YTxbzrsBAF7rHUSeJRYWbVfXH96xVNDcns23swBX0KkyaEysNSzcAgAAAAAAAAAg43+UGkUe+CCaD7+/G1SbK7Jrjq7giJUUbfJ7w88mEMEBAQEBAQABAACCF5xX1Ylbq/tlXNYujohqUzNLXnvpvmWOt1nMNeP8ZgEaPomAKdAk7sHUTGr14vrN7YTQO1NzUU8W49ZuAAgQUQIAAAAAAAAAIGS7c6HtWLLBiwy/N3eS4gbmuA1NXupk4ucFY7FYkCbEghecV9WJW6v7ZVzWLo6IalMzS1576b5ljrdZzDXj/GYKAAAAAAAAAKCGAQAAAAAAAAFhAMU7cJTEsJ5WoVlKZ2zsVuGMk9linDuNqLV9eGIIrqarP2x4R9riuvmmMgXfdxMm7jTzYxbHrsDNMwlxpTbbFghtCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -2300,9 +2301,9 @@
             {
               "name": "digests",
               "value": [
-                "Gd2vRA1pRwWu8j7KQe6fzHS4mMChq1JHJpi9KGnVJMtV",
-                "73FjSYzymaz1UWPu4bMW191cyxSxziKXJm2MyTQMjeur",
-                "7TxdfBqwTPYgG4hztwiQdeQcdWgeqpZKF7EJpyjDojFd"
+                "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
+                "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
+                "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7"
               ]
             },
             {
@@ -2321,7 +2322,7 @@
             "name": "Result",
             "value": [
               {
-                "digest": "Gd2vRA1pRwWu8j7KQe6fzHS4mMChq1JHJpi9KGnVJMtV",
+                "digest": "61GhydW9kTXNU6LXktceLKM5svzLcDwW1eRU2UdQ9wov",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2367,14 +2368,14 @@
                       ],
                       "owner": "0x0a3f57ac1ee741463bc97744050f1af4d570d8b8d0f203b67d09cd82fdb21e13",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ABWZkYviOekutE6mrOgoq7d2q5fx3xlmo0qWTyQSa+jDFzePlm+RPZm1zkOedq3TlQcYiMKaw+jqNYIYerHujAg34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ=="
+                    "AFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5fD5PhGooIBAHVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jL6wacOIOAgAAAAAAAAAgDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyL8J2rqpzwBAQEBAQABAAAKP1esHudBRjvJd0QFDxr01XDYuNDyA7Z9Cc2C/bIeEwEUb7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAbvavygo7gIAAAAAAAAAIJyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8DQItueIaCj9XrB7nQUY7yXdEBQ8a9NVw2LjQ8gO2fQnNgv2yHhMKAAAAAAAAAAAtMQEAAAAAAAFhABWZkYviOekutE6mrOgoq7d2q5fx3xlmo0qWTyQSa+jDFzePlm+RPZm1zkOedq3TlQcYiMKaw+jqNYIYerHujAg34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ==",
+                "rawTransaction": "AQAAAAAAAgAgCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5fD5PhGooIBAHVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jL6wacOIOAgAAAAAAAAAgDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyL8J2rqpzwBAQEBAQABAAAKP1esHudBRjvJd0QFDxr01XDYuNDyA7Z9Cc2C/bIeEwEUb7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAbvavygo7gIAAAAAAAAAIJyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8DQItueIaCj9XrB7nQUY7yXdEBQ8a9NVw2LjQ8gO2fQnNgv2yHhMKAAAAAAAAAKCGAQAAAAAAAAFhAFj3Uat/4CHwGMzZZgO6PXosHI9nErbfC8uFgiuvowKZKdMd1UVHez5YjNabMgZ98bC+I9C2Hud4/EjoXsamYAI34HWK6fGd/e11nJeO7UMQFVm4jiZjwDYb8XNiqcCJOQ==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2437,7 +2438,7 @@
                 ]
               },
               {
-                "digest": "73FjSYzymaz1UWPu4bMW191cyxSxziKXJm2MyTQMjeur",
+                "digest": "4TU9wToRuiYvPZZAtMzq3gfQEBuv91Nt5pkgWbVL8mR9",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2483,14 +2484,14 @@
                       ],
                       "owner": "0x028d636e74862991ed521dcc9c6cb7ab860b449e3f4f7b8520b582325bcda4f6",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ANFMDxz+6lExShcHA/qG/j2jZk6y9+5k65x6u8JGJP/dyxkfrihDdFxtOt3fvaoJ/OvEZ4eo123n/momyGQuFgahtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg=="
+                    "ABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEDiMKN3VkBAHeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutyCCnW1dCAgAAAAAAAAAgVlPau21sld3X01pC0x86m+u7aD22booGcGhVRnLhN7UBAQEBAQABAAACjWNudIYpke1SHcycbLerhgtEnj9Pe4UgtYIyW82k9gEkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXNgCS0s5pwIAAAAAAAAAIP7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEeeRW/wE/Ao1jbnSGKZHtUh3MnGy3q4YLRJ4/T3uFILWCMlvNpPYKAAAAAAAAAAAtMQEAAAAAAAFhANFMDxz+6lExShcHA/qG/j2jZk6y9+5k65x6u8JGJP/dyxkfrihDdFxtOt3fvaoJ/OvEZ4eo123n/momyGQuFgahtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg==",
+                "rawTransaction": "AQAAAAAAAgAgLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEDiMKN3VkBAHeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutyCCnW1dCAgAAAAAAAAAgVlPau21sld3X01pC0x86m+u7aD22booGcGhVRnLhN7UBAQEBAQABAAACjWNudIYpke1SHcycbLerhgtEnj9Pe4UgtYIyW82k9gEkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXNgCS0s5pwIAAAAAAAAAIP7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEeeRW/wE/Ao1jbnSGKZHtUh3MnGy3q4YLRJ4/T3uFILWCMlvNpPYKAAAAAAAAAKCGAQAAAAAAAAFhABBKl/c5PQ8vYVTfmqIhpmKaw5h87g3803RmvzBsvCs+7W4+X7UaGhrNMuHa1mgxEIaujlBa/b6tPZaZxuhfmwWhtxyxD8zwVSmWjSVhhtf+UKhpW2mTgOA1Wn2xxsedmg==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2553,7 +2554,7 @@
                 ]
               },
               {
-                "digest": "7TxdfBqwTPYgG4hztwiQdeQcdWgeqpZKF7EJpyjDojFd",
+                "digest": "HiWguwCqK3mWzhv5Qefb6pfhKdocWZo7gbToHED5Pzp7",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2599,14 +2600,14 @@
                       ],
                       "owner": "0xb30fdd73db52c4eb06754bdb50fec3ea0e19a7851f2383d764fcb3d6eb7f8c82",
                       "price": "10",
-                      "budget": "20000000"
+                      "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "AKM1jt3XaQUsZ9Pe77tb2tGgmJvI8GLE2P3kdaQ1I4oglYnu9TrBds27Zbm0KP0tayMvhoDRBQc2a3mdbfPsVA/WnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw=="
+                    "APXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAg3MhbraSnKdZQ93YiJkMhKXgJJ4OLBtsDRoCP+wZ2CZ0BAOBAizF1n1e2nFLglBCmb5ojw0vpkTtml6XoPgLioPx0AgAAAAAAAAAg5IK3WMI5kDnbvt1dskOF6TTWgrL9ZzRGkavQ78dxlBsBAQEBAQABAACzD91z21LE6wZ1S9tQ/sPqDhmnhR8jg9dk/LPW63+MggFwV7oJAeTZseBN516iaZpEEyFWElgeulfr5+WUuAnMzgIAAAAAAAAAIOwr5NrG/2lF1Js+zAQ9BJYR9s/RC8pNUX6UUq1Uhtaesw/dc9tSxOsGdUvbUP7D6g4Zp4UfI4PXZPyz1ut/jIIKAAAAAAAAAAAtMQEAAAAAAAFhAKM1jt3XaQUsZ9Pe77tb2tGgmJvI8GLE2P3kdaQ1I4oglYnu9TrBds27Zbm0KP0tayMvhoDRBQc2a3mdbfPsVA/WnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw==",
+                "rawTransaction": "AQAAAAAAAgAg3MhbraSnKdZQ93YiJkMhKXgJJ4OLBtsDRoCP+wZ2CZ0BAOBAizF1n1e2nFLglBCmb5ojw0vpkTtml6XoPgLioPx0AgAAAAAAAAAg5IK3WMI5kDnbvt1dskOF6TTWgrL9ZzRGkavQ78dxlBsBAQEBAQABAACzD91z21LE6wZ1S9tQ/sPqDhmnhR8jg9dk/LPW63+MggFwV7oJAeTZseBN516iaZpEEyFWElgeulfr5+WUuAnMzgIAAAAAAAAAIOwr5NrG/2lF1Js+zAQ9BJYR9s/RC8pNUX6UUq1Uhtaesw/dc9tSxOsGdUvbUP7D6g4Zp4UfI4PXZPyz1ut/jIIKAAAAAAAAAKCGAQAAAAAAAAFhAPXV3tMi3dDUyb0PGKcI4/2kDw7W++XWyRWZTLK4jZKo/V0qseed7rngZsrNg6fgmXIbJlHBxvzK50I4K208TwnWnfBR88qs+c/GcHXhsNtHEECK8vIjfFKQvXV+9IXwAw==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
@@ -1,0 +1,191 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 23
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  loaded_child_object_format: true
+  simple_conservation_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
@@ -1,0 +1,197 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 23
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
+  zklogin_supported_providers:
+    - Facebook
+    - Google
+    - Twitch
+  loaded_child_object_format: true
+  simple_conservation_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
@@ -1,0 +1,198 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 23
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
+  zklogin_supported_providers:
+    - Facebook
+    - Google
+    - Twitch
+  loaded_child_object_format: true
+  simple_conservation_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -31,8 +31,8 @@ use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::transaction::{
     CallArg, InputObjectKind, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
     TransactionDataAPI, TransactionKind, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
-    TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN, TEST_ONLY_GAS_UNIT_FOR_STAKING,
-    TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,
+    TEST_ONLY_GAS_UNIT_FOR_STAKING, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use test_cluster::TestClusterBuilder;
 
@@ -162,7 +162,7 @@ async fn test_publish_and_move_call() {
         sender,
         pt,
         vec![],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
         rgp,
         false,
     )

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 22
+  protocol_version: 23
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 22
+protocol_version: 23
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x0d3bd666957283976f138919527692165d0a97cdef4a14859f55396394dfaec1"
+            id: "0x694190a4f78a48a7dc1b3c76191ed45e7c07c201a6e278405c9ecc11b53f3818"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x734da6b02732262e378f5582a50f930f1ff0e709ee1c180c76ef5aff332f91e6"
+      operation_cap_id: "0x7f516808a7c4211db2dba5f5716f28e0776cb11e71a29b81b9ee48b5a8d3e181"
       gas_price: 1000
       staking_pool:
-        id: "0xef5f2665905b39a44d34f5a97fb9d10b0d211858d9dbe549d235352fb182ca6b"
+        id: "0x941ad42f274abeb0cc5633fe091d89b65657a049f27e8c8a76159e97fedd4207"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xf98ebe76616fc6f804506539e49ba0c8af53168d572b894bb23df2b044e5b779"
+          id: "0x33fac5111da07307fe6fef71a1e8da82ec4aca35baafbb15ee6b4da59a798b7b"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xe60e2e2904b3456d3f6db1a5156e04395c8dbfdb39b62a2d8d56ea0764970432"
+            id: "0x764a21d68bdb5eee22abd7d69a35845a9101fa03a68983d4e48833c463a338ca"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x30082a55162efe04c8c4137d2739ef4ac62faefe7345858169de4422f24798a2"
+          id: "0x1c0fb2941570de426c12e792c3cb52bdcb7ec75b0764db8b72caedf2b861fe5e"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x63a685d959e6e64080ecb897daa29c6036f723f51ff3e1f395ad945eeff0cc84"
+      id: "0x5d4cc243188129e9e446b7ab38222d5f092b2af7a906c3ad5cc9dd5a742a90d8"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xbc8eff66712ef94c8f8627ac3e77d071e75175d214ed40131168f917ef08def9"
+    id: "0xfbd0e039e81411a54e602686230192310c5677dc2e8724c6f1ac0ec021f77b0e"
     size: 1
   inactive_validators:
-    id: "0xc80fe5c3bda593b140036a74607e55923fee11706d303f9d992cf256853c6ff4"
+    id: "0x5442d61ea3cbdd7f896ed55639bb0ca3737ad28fac1a4bd412bd6ed4fa9ac61a"
     size: 0
   validator_candidates:
-    id: "0x1fb1ff9f347cbcb52232b56dcd6c62978d0b6a9684210245aa494547546856f2"
+    id: "0xbd8f202026c4bd333e589d356c79a1ebf838f7b2de1f58e19edcfec39af54462"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xf532e45b5044b64ec78c2cb907d0f9d9c92cc3241080a75bb88242ea01d54da1"
+      id: "0x76e0d78f3fe1cf71ce6bd0fc52a48c1195a42b4b124cad8f0456f9d5b86639cd"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x2928818c1ee5fdc3778e6b292e652ef24bd09a661519a28679b04bd60f0d15c6"
+      id: "0x87001f0afc74ec8bd32d69ae971d0299fac4a1586a7ae66c2e1f976c48b38e20"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x2bb5ef13bea428e7cdf7d338c1d4256ee1648e9ecf9861cb78adcf349e0b0c62"
+      id: "0x7ab62ea4e05c0dd2691153996c483c5df5811fcbe0a728ed8ba5af91a1c5dfae"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x8480b925bae23acf6ba677fb8561dd0fcfd06d19f8748b2d0f481169b36d2783"
+    id: "0x03c5d50edbd6dc220820ab7e8a5aaaa942144f14c7f67ef2fecd94661798ec83"
   size: 0
 

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -20,7 +20,8 @@ use sui_types::signature::GenericSignature;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::transaction::{
     CallArg, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
-    DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::{TypeTag, SUI_SYSTEM_PACKAGE_ID};
 
@@ -230,7 +231,7 @@ impl TestTransactionBuilder {
                 data.type_args,
                 self.gas_object,
                 data.args,
-                self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+                self.gas_price * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
                 self.gas_price,
             )
             .unwrap(),
@@ -261,7 +262,7 @@ impl TestTransactionBuilder {
                     self.gas_object,
                     all_module_bytes,
                     dependencies,
-                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
                     self.gas_price,
                 )
             }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -44,15 +44,17 @@ use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use tap::Pipe;
 use tracing::trace;
 
-// TODO: The following constants appear to be very large.
-// We should revisit them.
-pub const TEST_ONLY_GAS_UNIT_FOR_TRANSFER: u64 = 2_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS: u64 = 10_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_PUBLISH: u64 = 25_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_STAKING: u64 = 10_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_GENERIC: u64 = 5_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_VALIDATOR: u64 = 25_000_000;
-pub const TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN: u64 = 1_000_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_TRANSFER: u64 = 10_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_PUBLISH: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_STAKING: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_GENERIC: u64 = 50_000;
+pub const TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN: u64 = 10_000;
+// For some transactions we may either perform heavy operations or touch
+// objects that are storage expensive. That may happen (and often is the case)
+// because the object touched are set up in genesis and carry no storage cost
+// (and thus rebate) on first usage.
+pub const TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE: u64 = 5_000_000;
 
 pub const GAS_PRICE_FOR_SYSTEM_TX: u64 = 1;
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1140,7 +1140,7 @@ fn test_move_input_objects() {
         SuiAddress::random_for_testing_only(),
         vec![gas_object_ref],
         builder.finish(),
-        TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        1_000_000, // any random number the transaction is not run
         1,
     );
     let mut input_objects = data.input_objects().unwrap();

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -288,6 +288,7 @@ mod checked {
             gas_charger,
             tx_ctx,
             move_vm,
+            protocol_config.simple_conservation_checks(),
             enable_expensive_checks,
             &cost_summary,
             is_genesis_tx,
@@ -306,6 +307,7 @@ mod checked {
         gas_charger: &mut GasCharger,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
+        simple_conservation_checks: bool,
         enable_expensive_checks: bool,
         cost_summary: &GasCostSummary,
         is_genesis_tx: bool,
@@ -315,14 +317,22 @@ mod checked {
         if !is_genesis_tx && !Mode::allow_arbitrary_values() {
             // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
             let conservation_result = {
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                )
+                temporary_store
+                    .check_sui_conserved(simple_conservation_checks, cost_summary)
+                    .and_then(|()| {
+                        if enable_expensive_checks {
+                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                            let mut layout_resolver =
+                                TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                            temporary_store.check_sui_conserved_expensive(
+                                cost_summary,
+                                advance_epoch_gas_summary,
+                                &mut layout_resolver,
+                            )
+                        } else {
+                            Ok(())
+                        }
+                    })
             };
             if let Err(conservation_err) = conservation_result {
                 // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
@@ -331,14 +341,24 @@ mod checked {
                 gas_charger.reset(temporary_store);
                 gas_charger.charge_gas(temporary_store, &mut result);
                 // check conservation once more more
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                ) {
+                if let Err(recovery_err) = {
+                    temporary_store
+                        .check_sui_conserved(simple_conservation_checks, cost_summary)
+                        .and_then(|()| {
+                            if enable_expensive_checks {
+                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                                let mut layout_resolver =
+                                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                                temporary_store.check_sui_conserved_expensive(
+                                    cost_summary,
+                                    advance_epoch_gas_summary,
+                                    &mut layout_resolver,
+                                )
+                            } else {
+                                Ok(())
+                            }
+                        })
+                } {
                     // if we still fail, it's a problem with gas
                     // charging that happens even in the "aborted" case--no other option but panic.
                     // we will create or destroy SUI otherwise

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -268,7 +268,7 @@ pub mod checked {
             }
 
             // compute and collect storage charges
-            temporary_store.ensure_gas_and_input_mutated(self);
+            temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
@@ -303,7 +303,7 @@ pub mod checked {
             if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                 self.reset(temporary_store);
                 self.gas_status.adjust_computation_on_out_of_gas();
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_rebate(self);
                 if execution_result.is_ok() {
                     *execution_result = Err(err);
@@ -320,14 +320,14 @@ pub mod checked {
                 // we run out of gas charging storage, reset and try charging for storage again.
                 // Input objects are touched and so they have a storage cost
                 self.reset(temporary_store);
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_storage_and_rebate(self);
                 if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                     // we run out of gas attempting to charge for the input objects exclusively,
                     // deal with this edge case by not charging for storage
                     self.reset(temporary_store);
                     self.gas_status.adjust_computation_on_out_of_gas();
-                    temporary_store.ensure_gas_and_input_mutated(self);
+                    temporary_store.ensure_active_inputs_mutated();
                     temporary_store.collect_rebate(self);
                     if execution_result.is_ok() {
                         *execution_result = Err(err);

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -206,7 +206,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
     /// mutated during the transaction execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
-    fn ensure_active_inputs_mutated(&mut self) {
+    pub(crate) fn ensure_active_inputs_mutated(&mut self) {
         let mut to_be_updated = vec![];
         for (id, _seq, _) in &self.mutable_input_refs {
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
@@ -687,19 +687,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    pub(crate) fn ensure_gas_and_input_mutated(&mut self, gas_charger: &mut GasCharger) {
-        if let Some(gas_object_id) = gas_charger.gas_coin() {
-            let gas_object = self
-                .read_object(&gas_object_id)
-                .expect("We constructed the object map so it should always have the gas object id")
-                .clone();
-            self.written
-                .entry(gas_object_id)
-                .or_insert_with(|| (gas_object, WriteKind::Mutate));
-        }
-        self.ensure_active_inputs_mutated();
-    }
-
     /// Track storage gas for each mutable input object (including the gas coin)
     /// and each created object. Compute storage refunds for each deleted object.
     /// Will *not* charge anything, gas status keeps track of storage cost and rebate.
@@ -707,49 +694,26 @@ impl<'backing> TemporaryStore<'backing> {
     /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
     /// overall storage rebate and cost.
     pub(crate) fn collect_storage_and_rebate(&mut self, gas_charger: &mut GasCharger) {
-        let mut objects_to_update = vec![];
-        for (object_id, (object, write_kind)) in &mut self.written {
-            // get the object storage_rebate in input for mutated objects
-            let old_storage_rebate = match write_kind {
+        // Use two loops because we cannot mut iterate written while calling get_input_storage_rebate.
+        let old_storage_rebates: Vec<_> = self
+            .written
+            .iter()
+            .map(|(object_id, (object, write_kind))| match write_kind {
                 WriteKind::Create | WriteKind::Unwrap => 0,
-                WriteKind::Mutate => {
-                    if let Some(old_obj) = self.input_objects.get(object_id) {
-                        old_obj.storage_rebate
-                    } else {
-                        // else, this is a dynamic field, not an input object
-                        let expected_version = object.version();
-                        if let Ok(Some(old_obj)) =
-                            self.store.get_object_by_key(object_id, expected_version)
-                        {
-                            old_obj.storage_rebate
-                        } else {
-                            // not a lot we can do safely and under this condition everything is broken
-                            panic!(
-                                "Looking up storage rebate of mutated object {:?} should not fail",
-                                (object_id, expected_version)
-                            );
-                        }
-                    }
-                }
-            };
+                WriteKind::Mutate => self.get_input_storage_rebate(object_id, object.version()),
+            })
+            .collect();
+        for ((object, _), old_storage_rebate) in self.written.values_mut().zip(old_storage_rebates)
+        {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate =
                 gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
             object.storage_rebate = new_storage_rebate;
-            if !object.is_immutable() {
-                objects_to_update.push((object.clone(), *write_kind));
-            }
         }
 
         self.collect_rebate(gas_charger);
-
-        // Write all objects at the end only if all previous gas charges succeeded.
-        // This avoids polluting the temporary store state if this function failed.
-        for (object, write_kind) in objects_to_update {
-            self.write_object(object, write_kind);
-        }
     }
 
     pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
@@ -860,100 +824,139 @@ impl<'backing> TemporaryStore<'backing> {
 
     /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes
     /// except the epoch change tx, which mints staking rewards equal to the gas fees burned in the
-    /// previous epoch.  Specifically, this checks two key invariants about storage fees and storage
-    /// rebate:
+    /// previous epoch.  Specifically, this checks two key invariants about storage
+    /// fees and storage rebate:
     ///
     /// 1. all SUI in storage rebate fields of input objects should flow either to the transaction
     ///    storage rebate, or the transaction non-refundable storage rebate
     /// 2. all SUI charged for storage should flow into the storage rebate field of some output
     ///    object
     ///
-    /// If `do_expensive_checks` is true, this will also check a third invariant:
+    /// This function is intended to be called *after* we have charged for
+    /// gas + applied the storage rebate to the gas object, but *before* we
+    /// have updated object versions.
+    pub fn check_sui_conserved(
+        &self,
+        simple_conservation_checks: bool,
+        gas_summary: &GasCostSummary,
+    ) -> Result<(), ExecutionError> {
+        if !simple_conservation_checks {
+            return Ok(());
+        }
+        // total amount of SUI in storage rebate of input objects
+        let mut total_input_rebate = 0;
+        // total amount of SUI in storage rebate of output objects
+        let mut total_output_rebate = 0;
+        for (_, input, output) in self.get_modified_objects() {
+            if let Some((_, storage_rebate)) = input {
+                total_input_rebate += storage_rebate;
+            }
+            if let Some(object) = output {
+                total_output_rebate += object.storage_rebate;
+            }
+        }
+
+        if gas_summary.storage_cost == 0 {
+            // this condition is usually true when the transaction went OOG and no
+            // gas is left for storage charges.
+            // The storage cost has to be there at least for the gas coin which
+            // will not be deleted even when going to 0.
+            // However if the storage cost is 0 and if there is any object touched
+            // or deleted the value in input must be equal to the output plus rebate and
+            // non refundable.
+            // Rebate and non refundable will be positive when there are object deleted
+            // (gas smashing being the primary and possibly only example).
+            // A more typical condition is for all storage charges in summary to be 0 and
+            // then input and output must be the same value
+            if total_input_rebate
+                != total_output_rebate
+                    + gas_summary.storage_rebate
+                    + gas_summary.non_refundable_storage_fee
+            {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- no storage charges in gas summary \
+                        and total storage input rebate {} not equal  \
+                        to total storage output rebate {}",
+                    total_input_rebate, total_output_rebate,
+                )));
+            }
+        } else {
+            // all SUI in storage rebate fields of input objects should flow either to
+            // the transaction storage rebate, or the non-refundable storage rebate pool
+            if total_input_rebate
+                != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
+            {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI in storage rebate field of input objects, \
+                        {} SUI in tx storage rebate or tx non-refundable storage rebate",
+                    total_input_rebate, gas_summary.non_refundable_storage_fee,
+                )));
+            }
+
+            // all SUI charged for storage should flow into the storage rebate field
+            // of some output object
+            if gas_summary.storage_cost != total_output_rebate {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI charged for storage, \
+                        {} SUI in storage rebate field of output objects",
+                    gas_summary.storage_cost, total_output_rebate
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Check that this transaction neither creates nor destroys SUI.
+    /// This more expensive check will check a third invariant on top of the 2 performed
+    /// by `check_sui_conserved` above:
     ///
-    /// 3. all SUI in input objects (including coins etc in the Move part of an object) should flow
+    /// * all SUI in input objects (including coins etc in the Move part of an object) should flow
     ///    either to an output object, or be burned as part of computation fees or non-refundable
     ///    storage rebate
     ///
-    /// This function is intended to be called *after* we have charged for gas + applied the storage
-    /// rebate to the gas object, but *before* we have updated object versions.  If
-    /// `do_expensive_checks` is false, this function will only check conservation of object storage
-    /// rea `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.  The
+    /// This function is intended to be called *after* we have charged for gas + applied the
+    /// storage rebate to the gas object, but *before* we have updated object versions. The
     /// advance epoch transaction would mint `epoch_fees` amount of SUI, and burn `epoch_rebates`
-    /// amount of SUI. We need these information for conservation check.
-    pub fn check_sui_conserved(
+    /// amount of SUI. We need these information for this check.
+    pub fn check_sui_conserved_expensive(
         &self,
         gas_summary: &GasCostSummary,
         advance_epoch_gas_summary: Option<(u64, u64)>,
         layout_resolver: &mut impl LayoutResolver,
-        do_expensive_checks: bool,
     ) -> Result<(), ExecutionError> {
         // total amount of SUI in input objects, including both coins and storage rebates
         let mut total_input_sui = 0;
         // total amount of SUI in output objects, including both coins and storage rebates
         let mut total_output_sui = 0;
-        // total amount of SUI in storage rebate of input objects
-        let mut total_input_rebate = 0;
-        // total amount of SUI in storage rebate of output objects
-        let mut total_output_rebate = 0;
         for (id, input, output) in self.get_modified_objects() {
-            if let Some((version, storage_rebate)) = input {
-                total_input_rebate += storage_rebate;
-                if do_expensive_checks {
-                    total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
-                }
+            if let Some((version, _)) = input {
+                total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
             }
             if let Some(object) = output {
-                total_output_rebate += object.storage_rebate;
-                if do_expensive_checks {
-                    total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
-                        make_invariant_violation!(
-                            "Failed looking up output SUI in SUI conservation checking for \
-                             mutated type {:?}: {e:#?}",
-                            object.struct_tag(),
-                        )
-                    })?;
-                }
+                total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
+                    make_invariant_violation!(
+                        "Failed looking up output SUI in SUI conservation checking for \
+                         mutated type {:?}: {e:#?}",
+                        object.struct_tag(),
+                    )
+                })?;
             }
         }
-        if do_expensive_checks {
-            // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
-            // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
-            // both computation costs and storage rebate inflow are
-            total_output_sui +=
-                gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
-            if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
-                total_input_sui += epoch_fees;
-                total_output_sui += epoch_rebates;
-            }
-            if total_input_sui != total_output_sui {
-                return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed: input={}, output={}, this transaction either mints or burns SUI",
-                total_input_sui,
-                total_output_sui))
-            );
-            }
+        // note: storage_cost flows into the storage_rebate field of the output objects, which is
+        // why it is not accounted for here.
+        // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow
+        // gets credited to the gas coin both computation costs and storage rebate inflow are
+        total_output_sui += gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
+        if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
+            total_input_sui += epoch_fees;
+            total_output_sui += epoch_rebates;
         }
-
-        // all SUI in storage rebate fields of input objects should flow either to the transaction storage rebate, or the non-refundable
-        // storage rebate pool
-        if total_input_rebate != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
-        {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI in storage rebate field of input objects, {} SUI in tx storage rebate or tx non-refundable storage rebate",
-                total_input_rebate,
-                gas_summary.non_refundable_storage_fee))
-            );*/
-        }
-
-        // all SUI charged for storage should flow into the storage rebate field of some output object
-        if gas_summary.storage_cost != total_output_rebate {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI charged for storage, {} SUI in storage rebate field of output objects",
-                gas_summary.storage_cost,
-                total_output_rebate))
-            );*/
+        if total_input_sui != total_output_sui {
+            return Err(ExecutionError::invariant_violation(format!(
+                "SUI conservation failed: input={}, output={}, \
+                    this transaction either mints or burns SUI",
+                total_input_sui, total_output_sui,
+            )));
         }
         Ok(())
     }

--- a/sui-execution/suivm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/suivm/sui-adapter/src/execution_engine.rs
@@ -288,6 +288,7 @@ mod checked {
             gas_charger,
             tx_ctx,
             move_vm,
+            protocol_config.simple_conservation_checks(),
             enable_expensive_checks,
             &cost_summary,
             is_genesis_tx,
@@ -306,6 +307,7 @@ mod checked {
         gas_charger: &mut GasCharger,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
+        simple_conservation_checks: bool,
         enable_expensive_checks: bool,
         cost_summary: &GasCostSummary,
         is_genesis_tx: bool,
@@ -315,14 +317,22 @@ mod checked {
         if !is_genesis_tx && !Mode::allow_arbitrary_values() {
             // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
             let conservation_result = {
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                )
+                temporary_store
+                    .check_sui_conserved(simple_conservation_checks, cost_summary)
+                    .and_then(|()| {
+                        if enable_expensive_checks {
+                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                            let mut layout_resolver =
+                                TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                            temporary_store.check_sui_conserved_expensive(
+                                cost_summary,
+                                advance_epoch_gas_summary,
+                                &mut layout_resolver,
+                            )
+                        } else {
+                            Ok(())
+                        }
+                    })
             };
             if let Err(conservation_err) = conservation_result {
                 // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
@@ -331,14 +341,24 @@ mod checked {
                 gas_charger.reset(temporary_store);
                 gas_charger.charge_gas(temporary_store, &mut result);
                 // check conservation once more more
-                let mut layout_resolver =
-                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
-                if let Err(recovery_err) = temporary_store.check_sui_conserved(
-                    cost_summary,
-                    advance_epoch_gas_summary,
-                    &mut layout_resolver,
-                    enable_expensive_checks,
-                ) {
+                if let Err(recovery_err) = {
+                    temporary_store
+                        .check_sui_conserved(simple_conservation_checks, cost_summary)
+                        .and_then(|()| {
+                            if enable_expensive_checks {
+                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
+                                let mut layout_resolver =
+                                    TypeLayoutResolver::new(move_vm, Box::new(&*temporary_store));
+                                temporary_store.check_sui_conserved_expensive(
+                                    cost_summary,
+                                    advance_epoch_gas_summary,
+                                    &mut layout_resolver,
+                                )
+                            } else {
+                                Ok(())
+                            }
+                        })
+                } {
                     // if we still fail, it's a problem with gas
                     // charging that happens even in the "aborted" case--no other option but panic.
                     // we will create or destroy SUI otherwise

--- a/sui-execution/suivm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/suivm/sui-adapter/src/gas_charger.rs
@@ -268,7 +268,7 @@ pub mod checked {
             }
 
             // compute and collect storage charges
-            temporary_store.ensure_gas_and_input_mutated(self);
+            temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
@@ -303,7 +303,7 @@ pub mod checked {
             if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                 self.reset(temporary_store);
                 self.gas_status.adjust_computation_on_out_of_gas();
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_rebate(self);
                 if execution_result.is_ok() {
                     *execution_result = Err(err);
@@ -320,14 +320,14 @@ pub mod checked {
                 // we run out of gas charging storage, reset and try charging for storage again.
                 // Input objects are touched and so they have a storage cost
                 self.reset(temporary_store);
-                temporary_store.ensure_gas_and_input_mutated(self);
+                temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_storage_and_rebate(self);
                 if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                     // we run out of gas attempting to charge for the input objects exclusively,
                     // deal with this edge case by not charging for storage
                     self.reset(temporary_store);
                     self.gas_status.adjust_computation_on_out_of_gas();
-                    temporary_store.ensure_gas_and_input_mutated(self);
+                    temporary_store.ensure_active_inputs_mutated();
                     temporary_store.collect_rebate(self);
                     if execution_result.is_ok() {
                         *execution_result = Err(err);

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -206,7 +206,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
     /// mutated during the transaction execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
-    fn ensure_active_inputs_mutated(&mut self) {
+    pub(crate) fn ensure_active_inputs_mutated(&mut self) {
         let mut to_be_updated = vec![];
         for (id, _seq, _) in &self.mutable_input_refs {
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
@@ -687,19 +687,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    pub(crate) fn ensure_gas_and_input_mutated(&mut self, gas_charger: &mut GasCharger) {
-        if let Some(gas_object_id) = gas_charger.gas_coin() {
-            let gas_object = self
-                .read_object(&gas_object_id)
-                .expect("We constructed the object map so it should always have the gas object id")
-                .clone();
-            self.written
-                .entry(gas_object_id)
-                .or_insert_with(|| (gas_object, WriteKind::Mutate));
-        }
-        self.ensure_active_inputs_mutated();
-    }
-
     /// Track storage gas for each mutable input object (including the gas coin)
     /// and each created object. Compute storage refunds for each deleted object.
     /// Will *not* charge anything, gas status keeps track of storage cost and rebate.
@@ -707,49 +694,26 @@ impl<'backing> TemporaryStore<'backing> {
     /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
     /// overall storage rebate and cost.
     pub(crate) fn collect_storage_and_rebate(&mut self, gas_charger: &mut GasCharger) {
-        let mut objects_to_update = vec![];
-        for (object_id, (object, write_kind)) in &mut self.written {
-            // get the object storage_rebate in input for mutated objects
-            let old_storage_rebate = match write_kind {
+        // Use two loops because we cannot mut iterate written while calling get_input_storage_rebate.
+        let old_storage_rebates: Vec<_> = self
+            .written
+            .iter()
+            .map(|(object_id, (object, write_kind))| match write_kind {
                 WriteKind::Create | WriteKind::Unwrap => 0,
-                WriteKind::Mutate => {
-                    if let Some(old_obj) = self.input_objects.get(object_id) {
-                        old_obj.storage_rebate
-                    } else {
-                        // else, this is a dynamic field, not an input object
-                        let expected_version = object.version();
-                        if let Ok(Some(old_obj)) =
-                            self.store.get_object_by_key(object_id, expected_version)
-                        {
-                            old_obj.storage_rebate
-                        } else {
-                            // not a lot we can do safely and under this condition everything is broken
-                            panic!(
-                                "Looking up storage rebate of mutated object {:?} should not fail",
-                                (object_id, expected_version)
-                            );
-                        }
-                    }
-                }
-            };
+                WriteKind::Mutate => self.get_input_storage_rebate(object_id, object.version()),
+            })
+            .collect();
+        for ((object, _), old_storage_rebate) in self.written.values_mut().zip(old_storage_rebates)
+        {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate =
                 gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
             object.storage_rebate = new_storage_rebate;
-            if !object.is_immutable() {
-                objects_to_update.push((object.clone(), *write_kind));
-            }
         }
 
         self.collect_rebate(gas_charger);
-
-        // Write all objects at the end only if all previous gas charges succeeded.
-        // This avoids polluting the temporary store state if this function failed.
-        for (object, write_kind) in objects_to_update {
-            self.write_object(object, write_kind);
-        }
     }
 
     pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
@@ -860,100 +824,139 @@ impl<'backing> TemporaryStore<'backing> {
 
     /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes
     /// except the epoch change tx, which mints staking rewards equal to the gas fees burned in the
-    /// previous epoch.  Specifically, this checks two key invariants about storage fees and storage
-    /// rebate:
+    /// previous epoch.  Specifically, this checks two key invariants about storage
+    /// fees and storage rebate:
     ///
     /// 1. all SUI in storage rebate fields of input objects should flow either to the transaction
     ///    storage rebate, or the transaction non-refundable storage rebate
     /// 2. all SUI charged for storage should flow into the storage rebate field of some output
     ///    object
     ///
-    /// If `do_expensive_checks` is true, this will also check a third invariant:
+    /// This function is intended to be called *after* we have charged for
+    /// gas + applied the storage rebate to the gas object, but *before* we
+    /// have updated object versions.
+    pub fn check_sui_conserved(
+        &self,
+        simple_conservation_checks: bool,
+        gas_summary: &GasCostSummary,
+    ) -> Result<(), ExecutionError> {
+        if !simple_conservation_checks {
+            return Ok(());
+        }
+        // total amount of SUI in storage rebate of input objects
+        let mut total_input_rebate = 0;
+        // total amount of SUI in storage rebate of output objects
+        let mut total_output_rebate = 0;
+        for (_, input, output) in self.get_modified_objects() {
+            if let Some((_, storage_rebate)) = input {
+                total_input_rebate += storage_rebate;
+            }
+            if let Some(object) = output {
+                total_output_rebate += object.storage_rebate;
+            }
+        }
+
+        if gas_summary.storage_cost == 0 {
+            // this condition is usually true when the transaction went OOG and no
+            // gas is left for storage charges.
+            // The storage cost has to be there at least for the gas coin which
+            // will not be deleted even when going to 0.
+            // However if the storage cost is 0 and if there is any object touched
+            // or deleted the value in input must be equal to the output plus rebate and
+            // non refundable.
+            // Rebate and non refundable will be positive when there are object deleted
+            // (gas smashing being the primary and possibly only example).
+            // A more typical condition is for all storage charges in summary to be 0 and
+            // then input and output must be the same value
+            if total_input_rebate
+                != total_output_rebate
+                    + gas_summary.storage_rebate
+                    + gas_summary.non_refundable_storage_fee
+            {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- no storage charges in gas summary \
+                        and total storage input rebate {} not equal  \
+                        to total storage output rebate {}",
+                    total_input_rebate, total_output_rebate,
+                )));
+            }
+        } else {
+            // all SUI in storage rebate fields of input objects should flow either to
+            // the transaction storage rebate, or the non-refundable storage rebate pool
+            if total_input_rebate
+                != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
+            {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI in storage rebate field of input objects, \
+                        {} SUI in tx storage rebate or tx non-refundable storage rebate",
+                    total_input_rebate, gas_summary.non_refundable_storage_fee,
+                )));
+            }
+
+            // all SUI charged for storage should flow into the storage rebate field
+            // of some output object
+            if gas_summary.storage_cost != total_output_rebate {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "SUI conservation failed -- {} SUI charged for storage, \
+                        {} SUI in storage rebate field of output objects",
+                    gas_summary.storage_cost, total_output_rebate
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Check that this transaction neither creates nor destroys SUI.
+    /// This more expensive check will check a third invariant on top of the 2 performed
+    /// by `check_sui_conserved` above:
     ///
-    /// 3. all SUI in input objects (including coins etc in the Move part of an object) should flow
+    /// * all SUI in input objects (including coins etc in the Move part of an object) should flow
     ///    either to an output object, or be burned as part of computation fees or non-refundable
     ///    storage rebate
     ///
-    /// This function is intended to be called *after* we have charged for gas + applied the storage
-    /// rebate to the gas object, but *before* we have updated object versions.  If
-    /// `do_expensive_checks` is false, this function will only check conservation of object storage
-    /// rea `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.  The
+    /// This function is intended to be called *after* we have charged for gas + applied the
+    /// storage rebate to the gas object, but *before* we have updated object versions. The
     /// advance epoch transaction would mint `epoch_fees` amount of SUI, and burn `epoch_rebates`
-    /// amount of SUI. We need these information for conservation check.
-    pub fn check_sui_conserved(
+    /// amount of SUI. We need these information for this check.
+    pub fn check_sui_conserved_expensive(
         &self,
         gas_summary: &GasCostSummary,
         advance_epoch_gas_summary: Option<(u64, u64)>,
         layout_resolver: &mut impl LayoutResolver,
-        do_expensive_checks: bool,
     ) -> Result<(), ExecutionError> {
         // total amount of SUI in input objects, including both coins and storage rebates
         let mut total_input_sui = 0;
         // total amount of SUI in output objects, including both coins and storage rebates
         let mut total_output_sui = 0;
-        // total amount of SUI in storage rebate of input objects
-        let mut total_input_rebate = 0;
-        // total amount of SUI in storage rebate of output objects
-        let mut total_output_rebate = 0;
         for (id, input, output) in self.get_modified_objects() {
-            if let Some((version, storage_rebate)) = input {
-                total_input_rebate += storage_rebate;
-                if do_expensive_checks {
-                    total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
-                }
+            if let Some((version, _)) = input {
+                total_input_sui += self.get_input_sui(&id, version, layout_resolver)?;
             }
             if let Some(object) = output {
-                total_output_rebate += object.storage_rebate;
-                if do_expensive_checks {
-                    total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
-                        make_invariant_violation!(
-                            "Failed looking up output SUI in SUI conservation checking for \
-                             mutated type {:?}: {e:#?}",
-                            object.struct_tag(),
-                        )
-                    })?;
-                }
+                total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
+                    make_invariant_violation!(
+                        "Failed looking up output SUI in SUI conservation checking for \
+                         mutated type {:?}: {e:#?}",
+                        object.struct_tag(),
+                    )
+                })?;
             }
         }
-        if do_expensive_checks {
-            // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
-            // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
-            // both computation costs and storage rebate inflow are
-            total_output_sui +=
-                gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
-            if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
-                total_input_sui += epoch_fees;
-                total_output_sui += epoch_rebates;
-            }
-            if total_input_sui != total_output_sui {
-                return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed: input={}, output={}, this transaction either mints or burns SUI",
-                total_input_sui,
-                total_output_sui))
-            );
-            }
+        // note: storage_cost flows into the storage_rebate field of the output objects, which is
+        // why it is not accounted for here.
+        // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow
+        // gets credited to the gas coin both computation costs and storage rebate inflow are
+        total_output_sui += gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
+        if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
+            total_input_sui += epoch_fees;
+            total_output_sui += epoch_rebates;
         }
-
-        // all SUI in storage rebate fields of input objects should flow either to the transaction storage rebate, or the non-refundable
-        // storage rebate pool
-        if total_input_rebate != gas_summary.storage_rebate + gas_summary.non_refundable_storage_fee
-        {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI in storage rebate field of input objects, {} SUI in tx storage rebate or tx non-refundable storage rebate",
-                total_input_rebate,
-                gas_summary.non_refundable_storage_fee))
-            );*/
-        }
-
-        // all SUI charged for storage should flow into the storage rebate field of some output object
-        if gas_summary.storage_cost != total_output_rebate {
-            // TODO: re-enable once we fix the edge case with OOG, gas smashing, and storage rebate
-            /*return Err(ExecutionError::invariant_violation(
-                format!("SUI conservation failed--{} SUI charged for storage, {} SUI in storage rebate field of output objects",
-                gas_summary.storage_cost,
-                total_output_rebate))
-            );*/
+        if total_input_sui != total_output_sui {
+            return Err(ExecutionError::invariant_violation(format!(
+                "SUI conservation failed: input={}, output={}, \
+                    this transaction either mints or burns SUI",
+                total_input_sui, total_output_sui,
+            )));
         }
         Ok(())
     }


### PR DESCRIPTION
## Description 

This is a PR that supersedes #13387 . It is applied only to `latest` and `suivm` given the latest changes that brought `TemporaryStore` and `GasCharger` into the execution layer.

Re-enabled some gas tests and changed some gas constants to be more in line with a proper usage.
We still have one big value that seems inevitable (though maybe code could be organized better).
Removed some redundant code and some cleanup as highlighted by @lxfind, thanks!

@lxfind @sblackshear please read below...
We made changes to the conservation checks. Specifically we broke them into 2 parts and re-enabled some tests that were commented because of OOG logic. We now have 2 conservation check functions: a simple one and the expensive one. The expensive one is the same, the simple one has been lifted into its own function and changed to take into account the OOG scenario. The new logic seems sound to me. It basically claims that if no storage charges/rebates are performed (as defined in the `GasSummary`) the total input and output rebate (gas cost) has to be the same. 
That passes all tests including those that run OOG in all scenarios (computation, all storage, storage after OOG).
I am going to run that code on a fullnode syncing for a while and see what happens.
Also I'd be fine to put the new logic under protocol config version if we thought that was a better thing. Please advice.

I wanted to make more changes to the testing framework but I am not sure anymore, I may open an issue for that to discuss. The idea was to expand the `TestAuthorityBuilder` API (like adding the "concept" of insert_genesis_object) and removing the excess of functions that build an authority, as seen in `authority_test.rs`. Also "genesis added objects" have this annoying missing storage rebate which makes guessing (or dry_run requests) for transaction charges very difficult (the value changes after first execution as the storage rebate goes from 0 to the correct one)
However I am not sure any longer that it is a true cleanup and I have to look/think into that more. If anybody got feelings please comment

## Test Plan 

Existing tests and re-enabled some OOG important tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
