### PR TITLE
Simplify sui-execution interface

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1183,8 +1183,6 @@ impl AuthorityState {
         self.check_owned_locks(&owned_object_refs).await?;
         let tx_digest = *certificate.digest();
         let protocol_config = epoch_store.protocol_config();
-        let shared_object_refs = input_objects.filter_shared_objects();
-        let transaction_dependencies = input_objects.transaction_dependencies();
         let transaction_data = &certificate.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (inner_temp_store, effects, execution_error_opt) =
@@ -1203,13 +1201,11 @@ impl AuthorityState {
                     .epoch_data()
                     .epoch_start_timestamp(),
                 input_objects,
-                shared_object_refs,
                 gas,
                 gas_status,
                 kind,
                 signer,
                 tx_digest,
-                transaction_dependencies,
             );
 
         Ok((inner_temp_store, effects, execution_error_opt.err()))
@@ -1279,10 +1275,7 @@ impl AuthorityState {
             )
         };
 
-        let shared_object_refs = input_objects.filter_shared_objects();
-
         let protocol_config = epoch_store.protocol_config();
-        let transaction_dependencies = input_objects.transaction_dependencies();
         let (kind, signer, _) = transaction.execution_parts();
 
         let silent = true;
@@ -1306,13 +1299,11 @@ impl AuthorityState {
                     .epoch_data()
                     .epoch_start_timestamp(),
                 input_objects,
-                shared_object_refs,
                 gas_object_refs,
                 gas_status,
                 kind,
                 signer,
                 transaction_digest,
-                transaction_dependencies,
             );
         let tx_digest = *effects.transaction_digest();
 
@@ -1396,7 +1387,6 @@ impl AuthorityState {
             gas_object,
         )
         .await?;
-        let shared_object_refs = input_objects.filter_shared_objects();
 
         let gas_budget = max_tx_gas;
         let data = TransactionData::new(
@@ -1408,7 +1398,6 @@ impl AuthorityState {
         );
         let transaction_digest = TransactionDigest::new(default_hash(&data));
         let transaction_kind = data.into_kind();
-        let transaction_dependencies = input_objects.transaction_dependencies();
         let silent = true;
         let executor = sui_execution::executor(
             protocol_config,
@@ -1430,13 +1419,11 @@ impl AuthorityState {
                 .epoch_data()
                 .epoch_start_timestamp(),
             input_objects,
-            shared_object_refs,
             vec![gas_object_ref],
             gas_status,
             transaction_kind,
             sender,
             transaction_digest,
-            transaction_dependencies,
         );
 
         let module_cache =

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -8,7 +8,7 @@ use fastcrypto::traits::KeyPair;
 use move_binary_format::CompiledModule;
 use move_core_types::ident_str;
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -815,10 +815,9 @@ fn create_genesis_transaction(
 
         let expensive_checks = false;
         let certificate_deny_set = HashSet::new();
-        let shared_object_refs = vec![];
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, _) = transaction_data.execution_parts();
-        let transaction_dependencies = BTreeSet::new();
+        let input_objects = InputObjects::new(vec![]);
         let (inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
                 InMemoryStorage::new(Vec::new()),
@@ -828,14 +827,12 @@ fn create_genesis_transaction(
                 &certificate_deny_set,
                 &epoch_data.epoch_id(),
                 epoch_data.epoch_start_timestamp(),
-                InputObjects::new(vec![]),
-                shared_object_refs,
+                input_objects,
                 vec![],
                 SuiGasStatus::new_unmetered(),
                 kind,
                 signer,
                 genesis_digest,
-                transaction_dependencies,
             );
         assert!(inner_temp_store.objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -355,7 +355,7 @@ mod tests {
 
 #[cfg(test)]
 mod test {
-    use std::collections::{BTreeSet, HashSet};
+    use std::collections::HashSet;
     use std::sync::Arc;
     use sui_config::genesis::Genesis;
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
@@ -402,10 +402,9 @@ mod test {
         let expensive_checks = false;
         let certificate_deny_set = HashSet::new();
         let epoch = EpochData::new_test();
-        let shared_object_refs = vec![];
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, _) = transaction_data.execution_parts();
-        let transaction_dependencies = BTreeSet::new();
+        let input_objects = InputObjects::new(vec![]);
 
         let (_inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
@@ -416,14 +415,12 @@ mod test {
                 &certificate_deny_set,
                 &epoch.epoch_id(),
                 epoch.epoch_start_timestamp(),
-                InputObjects::new(vec![]),
-                shared_object_refs,
+                input_objects,
                 vec![],
                 SuiGasStatus::new_unmetered(),
                 kind,
                 signer,
                 genesis_digest,
-                transaction_dependencies,
             );
 
         assert_eq!(&effects, genesis.effects());

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -94,36 +94,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    /// WARNING! Should only be used for dry run and dev inspect!
-    /// In dry run and dev inspect, you might load a dynamic field that is actually too new for
-    /// the transaction. Ideally, we would want to load the "correct" dynamic fields, but as that
-    /// is not easily determined, we instead set the lamport version MAX, which is a valid lamport
-    /// version for any object used in the transaction (preventing internal assertions or
-    /// invariant violations from being triggered)
-    pub fn new_for_mock_transaction(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
-        input_objects: InputObjects,
-        tx_digest: TransactionDigest,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        let mutable_inputs = input_objects.mutable_inputs();
-        let lamport_timestamp = SequenceNumber::MAX;
-        let objects = input_objects.into_object_map();
-        Self {
-            store,
-            tx_digest,
-            input_objects: objects,
-            lamport_timestamp,
-            mutable_input_refs: mutable_inputs,
-            written: BTreeMap::new(),
-            deleted: BTreeMap::new(),
-            events: Vec::new(),
-            protocol_config: protocol_config.clone(),
-            loaded_child_objects: BTreeMap::new(),
-            runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
-        }
-    }
-
     // Helpers to access private fields
     pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
         &self.input_objects

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::storage::BackingStore;
 use sui_types::{
@@ -37,7 +34,6 @@ pub trait Executor {
         epoch_timestamp_ms: u64,
         // Transaction Inputs
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         // Gas related
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -45,7 +41,6 @@ pub trait Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
@@ -65,7 +60,6 @@ pub trait Executor {
         epoch_timestamp_ms: u64,
         // Transaction Inputs
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         // Gas related
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -73,7 +67,6 @@ pub trait Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::VerifierConfig;
@@ -28,10 +25,9 @@ use move_vm_runtime_latest::move_vm::MoveVM;
 use sui_adapter_latest::adapter::{
     default_verifier_config, new_move_vm, run_metered_move_bytecode_verifier,
 };
-use sui_adapter_latest::execution_engine::execute_transaction_to_effects;
-use sui_adapter_latest::gas_charger::GasCharger;
-use sui_adapter_latest::programmable_transactions;
-use sui_adapter_latest::temporary_store::TemporaryStore;
+use sui_adapter_latest::execution_engine::{
+    execute_genesis_state_update, execute_transaction_to_effects,
+};
 use sui_adapter_latest::type_layout_resolver::TypeLayoutResolver;
 use sui_move_natives_latest::all_natives;
 use sui_types::storage::BackingStore;
@@ -89,30 +85,24 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
-        let temporary_store =
-            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
-        let mut gas_charger =
-            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
         execute_transaction_to_effects::<execution_mode::Normal>(
-            shared_object_refs,
-            temporary_store,
+            store,
+            input_objects,
+            gas_coins,
+            gas_status,
             transaction_kind,
             transaction_signer,
-            &mut gas_charger,
             transaction_digest,
-            transaction_dependencies,
             &self.0,
             epoch_id,
             epoch_timestamp_ms,
@@ -133,34 +123,24 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        let temporary_store = TemporaryStore::new_for_mock_transaction(
+        execute_transaction_to_effects::<execution_mode::DevInspect>(
             store,
             input_objects,
-            transaction_digest,
-            protocol_config,
-        );
-        let mut gas_charger =
-            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            shared_object_refs,
-            temporary_store,
+            gas_coins,
+            gas_status,
             transaction_kind,
             transaction_signer,
-            &mut gas_charger,
             transaction_digest,
-            transaction_dependencies,
             &self.0,
             epoch_id,
             epoch_timestamp_ms,
@@ -180,19 +160,15 @@ impl executor::Executor for Executor {
         input_objects: InputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
-        let mut temporary_store =
-            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
-        programmable_transactions::execution::execute::<execution_mode::Genesis>(
+        execute_genesis_state_update(
+            store,
             protocol_config,
             metrics,
             &self.0,
-            &mut temporary_store,
             tx_context,
-            &mut gas_charger,
+            input_objects,
             pt,
-        )?;
-        Ok(temporary_store.into_inner())
+        )
     }
 
     fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(

--- a/sui-execution/src/suivm.rs
+++ b/sui-execution/src/suivm.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::VerifierConfig;
@@ -29,10 +26,9 @@ use move_vm_runtime_suivm::move_vm::MoveVM;
 use sui_adapter_suivm::adapter::{
     default_verifier_config, new_move_vm, run_metered_move_bytecode_verifier,
 };
-use sui_adapter_suivm::execution_engine::execute_transaction_to_effects;
-use sui_adapter_suivm::gas_charger::GasCharger;
-use sui_adapter_suivm::programmable_transactions;
-use sui_adapter_suivm::temporary_store::TemporaryStore;
+use sui_adapter_suivm::execution_engine::{
+    execute_genesis_state_update, execute_transaction_to_effects,
+};
 use sui_adapter_suivm::type_layout_resolver::TypeLayoutResolver;
 use sui_move_natives_suivm::all_natives;
 use sui_verifier_suivm::meter::SuiVerifierMeter;
@@ -89,30 +85,24 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
-        let temporary_store =
-            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
-        let mut gas_charger =
-            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
         execute_transaction_to_effects::<execution_mode::Normal>(
-            shared_object_refs,
-            temporary_store,
+            store,
+            input_objects,
+            gas_coins,
+            gas_status,
             transaction_kind,
             transaction_signer,
-            &mut gas_charger,
             transaction_digest,
-            transaction_dependencies,
             &self.0,
             epoch_id,
             epoch_timestamp_ms,
@@ -133,34 +123,24 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: InputObjects,
-        shared_object_refs: Vec<ObjectRef>,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        let temporary_store = TemporaryStore::new_for_mock_transaction(
+        execute_transaction_to_effects::<execution_mode::DevInspect>(
             store,
             input_objects,
-            transaction_digest,
-            protocol_config,
-        );
-        let mut gas_charger =
-            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            shared_object_refs,
-            temporary_store,
+            gas_coins,
+            gas_status,
             transaction_kind,
             transaction_signer,
-            &mut gas_charger,
             transaction_digest,
-            transaction_dependencies,
             &self.0,
             epoch_id,
             epoch_timestamp_ms,
@@ -180,19 +160,15 @@ impl executor::Executor for Executor {
         input_objects: InputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
-        let mut temporary_store =
-            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
-        programmable_transactions::execution::execute::<execution_mode::Genesis>(
+        execute_genesis_state_update(
+            store,
             protocol_config,
             metrics,
             &self.0,
-            &mut temporary_store,
             tx_context,
-            &mut gas_charger,
+            input_objects,
             pt,
-        )?;
-        Ok(temporary_store.into_inner())
+        )
     }
 
     fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(

--- a/sui-execution/suivm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/suivm/sui-adapter/src/execution_engine.rs
@@ -9,10 +9,7 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_vm_runtime::move_vm::MoveVM;
     use once_cell::sync::Lazy;
-    use std::{
-        collections::{BTreeSet, HashSet},
-        sync::Arc,
-    };
+    use std::{collections::HashSet, sync::Arc};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
         BALANCE_MODULE_NAME,
@@ -35,12 +32,15 @@ mod checked {
     use sui_types::error::{ExecutionError, ExecutionErrorKind};
     use sui_types::execution_status::ExecutionStatus;
     use sui_types::gas::GasCostSummary;
+    use sui_types::gas::SuiGasStatus;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
     use sui_types::messages_consensus::ConsensusCommitPrologue;
+    use sui_types::storage::BackingStore;
     use sui_types::storage::WriteKind;
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
+    use sui_types::transaction::InputObjects;
     use sui_types::transaction::{
         Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
         TransactionKind,
@@ -85,14 +85,14 @@ mod checked {
     }
 
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
-        shared_object_refs: Vec<ObjectRef>,
-        mut temporary_store: TemporaryStore<'_>,
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode, 'backing>(
+        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        input_objects: InputObjects,
+        gas_coins: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
-        gas_charger: &mut GasCharger,
         transaction_digest: TransactionDigest,
-        mut transaction_dependencies: BTreeSet<TransactionDigest>,
         move_vm: &Arc<MoveVM>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
@@ -105,6 +105,13 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        let shared_object_refs = input_objects.filter_shared_objects();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
+        let mut gas_charger =
+            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
+
         let mut tx_ctx = TxContext::new_from_components(
             &transaction_signer,
             &transaction_digest,
@@ -118,7 +125,7 @@ mod checked {
         let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
             &mut temporary_store,
             transaction_kind,
-            gas_charger,
+            &mut gas_charger,
             &mut tx_ctx,
             move_vm,
             protocol_config,
@@ -185,7 +192,7 @@ mod checked {
 
         if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
             temporary_store
-                .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
+                .check_ownership_invariants(&transaction_signer, &mut gas_charger, is_epoch_change)
                 .unwrap()
         } // else, in dev inspect mode and anything goes--don't check
 
@@ -195,10 +202,34 @@ mod checked {
             transaction_dependencies.into_iter().collect(),
             gas_cost_summary,
             status,
-            gas_charger,
+            &mut gas_charger,
             *epoch_id,
         );
         (inner, effects, execution_result)
+    }
+
+    pub fn execute_genesis_state_update(
+        store: Arc<dyn BackingStore + Send + Sync>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        move_vm: &Arc<MoveVM>,
+        tx_context: &mut TxContext,
+        input_objects: InputObjects,
+        pt: ProgrammableTransaction,
+    ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
+        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
+        programmable_transactions::execution::execute::<execution_mode::Genesis>(
+            protocol_config,
+            metrics,
+            move_vm,
+            &mut temporary_store,
+            tx_context,
+            &mut gas_charger,
+            pt,
+        )?;
+        Ok(temporary_store.into_inner())
     }
 
     #[instrument(name = "tx_execute", level = "debug", skip_all)]

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -94,36 +94,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    /// WARNING! Should only be used for dry run and dev inspect!
-    /// In dry run and dev inspect, you might load a dynamic field that is actually too new for
-    /// the transaction. Ideally, we would want to load the "correct" dynamic fields, but as that
-    /// is not easily determined, we instead set the lamport version MAX, which is a valid lamport
-    /// version for any object used in the transaction (preventing internal assertions or
-    /// invariant violations from being triggered)
-    pub fn new_for_mock_transaction(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
-        input_objects: InputObjects,
-        tx_digest: TransactionDigest,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        let mutable_inputs = input_objects.mutable_inputs();
-        let lamport_timestamp = SequenceNumber::MAX;
-        let objects = input_objects.into_object_map();
-        Self {
-            store,
-            tx_digest,
-            input_objects: objects,
-            lamport_timestamp,
-            mutable_input_refs: mutable_inputs,
-            written: BTreeMap::new(),
-            deleted: BTreeMap::new(),
-            events: Vec::new(),
-            protocol_config: protocol_config.clone(),
-            loaded_child_objects: BTreeMap::new(),
-            runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
-        }
-    }
-
     // Helpers to access private fields
     pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
         &self.input_objects

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -14,10 +14,7 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_vm_runtime::move_vm::MoveVM;
     use once_cell::sync::Lazy;
-    use std::{
-        collections::{BTreeSet, HashSet},
-        sync::Arc,
-    };
+    use std::{collections::HashSet, sync::Arc};
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
@@ -30,16 +27,19 @@ mod checked {
     use sui_types::execution_mode::{self, ExecutionMode};
     use sui_types::execution_status::ExecutionStatus;
     use sui_types::gas::GasCostSummary;
+    use sui_types::gas::SuiGasStatus;
     use sui_types::gas_coin::GAS;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
     use sui_types::messages_consensus::ConsensusCommitPrologue;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::object::OBJECT_START_VERSION;
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+    use sui_types::storage::BackingStore;
     use sui_types::storage::WriteKind;
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
+    use sui_types::transaction::InputObjects;
     use sui_types::transaction::{
         Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
         TransactionKind,
@@ -85,14 +85,14 @@ mod checked {
     }
 
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
-        shared_object_refs: Vec<ObjectRef>,
-        mut temporary_store: TemporaryStore<'_>,
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode, 'backing>(
+        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        input_objects: InputObjects,
+        gas_coins: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
-        gas_charger: &mut GasCharger,
         transaction_digest: TransactionDigest,
-        mut transaction_dependencies: BTreeSet<TransactionDigest>,
         move_vm: &Arc<MoveVM>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
@@ -105,6 +105,13 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        let shared_object_refs = input_objects.filter_shared_objects();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, transaction_digest, protocol_config);
+        let mut gas_charger =
+            GasCharger::new(transaction_digest, gas_coins, gas_status, protocol_config);
+
         let mut tx_ctx = TxContext::new_from_components(
             &transaction_signer,
             &transaction_digest,
@@ -118,7 +125,7 @@ mod checked {
         let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
             &mut temporary_store,
             transaction_kind,
-            gas_charger,
+            &mut gas_charger,
             &mut tx_ctx,
             move_vm,
             protocol_config,
@@ -185,7 +192,7 @@ mod checked {
 
         if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
             temporary_store
-                .check_ownership_invariants(&transaction_signer, gas_charger, is_epoch_change)
+                .check_ownership_invariants(&transaction_signer, &mut gas_charger, is_epoch_change)
                 .unwrap()
         } // else, in dev inspect mode and anything goes--don't check
 
@@ -195,10 +202,34 @@ mod checked {
             transaction_dependencies.into_iter().collect(),
             gas_cost_summary,
             status,
-            gas_charger,
+            &mut gas_charger,
             *epoch_id,
         );
         (inner, effects, execution_result)
+    }
+
+    pub fn execute_genesis_state_update(
+        store: Arc<dyn BackingStore + Send + Sync>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        move_vm: &Arc<MoveVM>,
+        tx_context: &mut TxContext,
+        input_objects: InputObjects,
+        pt: ProgrammableTransaction,
+    ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let mut temporary_store =
+            TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
+        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
+        programmable_transactions::execution::execute::<execution_mode::Genesis>(
+            protocol_config,
+            metrics,
+            move_vm,
+            &mut temporary_store,
+            tx_context,
+            &mut gas_charger,
+            pt,
+        )?;
+        Ok(temporary_store.into_inner())
     }
 
     #[instrument(name = "tx_execute", level = "debug", skip_all)]

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -94,36 +94,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
     }
 
-    /// WARNING! Should only be used for dry run and dev inspect!
-    /// In dry run and dev inspect, you might load a dynamic field that is actually too new for
-    /// the transaction. Ideally, we would want to load the "correct" dynamic fields, but as that
-    /// is not easily determined, we instead set the lamport version MAX, which is a valid lamport
-    /// version for any object used in the transaction (preventing internal assertions or
-    /// invariant violations from being triggered)
-    pub fn new_for_mock_transaction(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
-        input_objects: InputObjects,
-        tx_digest: TransactionDigest,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        let mutable_inputs = input_objects.mutable_inputs();
-        let lamport_timestamp = SequenceNumber::MAX;
-        let objects = input_objects.into_object_map();
-        Self {
-            store,
-            tx_digest,
-            input_objects: objects,
-            lamport_timestamp,
-            mutable_input_refs: mutable_inputs,
-            written: BTreeMap::new(),
-            deleted: BTreeMap::new(),
-            events: Vec::new(),
-            protocol_config: protocol_config.clone(),
-            loaded_child_objects: BTreeMap::new(),
-            runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
-        }
-    }
-
     // Helpers to access private fields
     pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
         &self.input_objects


### PR DESCRIPTION
## Description 

Simplify sui-execution API and avoid too much logic in the dispatch functions.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
