### PR TITLE
[wallet-standard] fix broken documentation link for the wallet-standard SDK

### DIFF
--- a/.changeset/lovely-adults-heal.md
+++ b/.changeset/lovely-adults-heal.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-standard': patch
+---
+
+Fix broken documentation link for the wallet-standard SDK

--- a/sdk/wallet-standard/README.md
+++ b/sdk/wallet-standard/README.md
@@ -1,6 +1,6 @@
 # `@mysten/wallet-standard`
 
 A suite of standard utilities for implementing wallets and libraries based on the
-[Wallet Standard](https://github.com/wallet-standard/wallet-standard/).
+[Wallet Standard](https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard/).
 
-**Documentation:** https://sui-wallet-kit.vercel.app/advanced/wallet-standard
+**Documentation:** https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard

--- a/sdk/wallet-standard/README.md
+++ b/sdk/wallet-standard/README.md
@@ -3,4 +3,4 @@
 A suite of standard utilities for implementing wallets and libraries based on the
 [Wallet Standard](https://github.com/wallet-standard/wallet-standard/).
 
-**Documentation:** https://sui-typescript-docs.vercel.app/wallet-kit
+**Documentation:** https://sui-typescript-docs.vercel.app/wallet-kit/advanced/wallet-standard

--- a/sdk/wallet-standard/README.md
+++ b/sdk/wallet-standard/README.md
@@ -1,6 +1,6 @@
 # `@mysten/wallet-standard`
 
 A suite of standard utilities for implementing wallets and libraries based on the
-[Wallet Standard](https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard/).
+[Wallet Standard](https://github.com/wallet-standard/wallet-standard/).
 
 **Documentation:** https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard

--- a/sdk/wallet-standard/README.md
+++ b/sdk/wallet-standard/README.md
@@ -3,4 +3,4 @@
 A suite of standard utilities for implementing wallets and libraries based on the
 [Wallet Standard](https://github.com/wallet-standard/wallet-standard/).
 
-**Documentation:** https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard
+**Documentation:** https://sui-typescript-docs.vercel.app/wallet-kit


### PR DESCRIPTION
## Description 

Just a quick fix for a broken doc site link that I encountered while working on dapp-kit stuff. https://sui-wallet-kit.vercel.app/wallet-kit/advanced/wallet-standard is the correct URL for the wallet-standard documentation (the other URL gives a 404).

## Test Plan 
- 👁️ 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
