### PR TITLE
Enable clippy for `external-crates/move` in CI, with clippy changes in the code.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,5 +11,18 @@ xclippy = [
 xlint = "run --package x --bin x -- lint"
 xtest = "run --package x --bin x -- external-crates-tests"
 
+# Configuration specifically for running clippy on `external-crates/move/`.
+# Some of these allows are to avoid code churn; others are filed as issues on the `sui` repo now.
+move-clippy = [
+    "clippy", "--",
+    "-Wclippy::all",
+    "-Wclippy::disallowed_methods",
+    "-Aclippy::upper_case_acronyms",
+    "-Aclippy::type_complexity",
+    "-Aclippy::new_without_default",
+    "-Aclippy::box_default",
+    "-Aclippy::manual_slice_size_calculation",
+]
+
 [build]
 rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -38,7 +38,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isRust: ${{ steps.diff.outputs.isRust }} 
+      isRust: ${{ steps.diff.outputs.isRust }}
       isMove: ${{ steps.diff.outputs.isMove }}
     steps:
       - uses: actions/checkout@v3
@@ -147,6 +147,30 @@ jobs:
       # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo clippy
         run: cargo xclippy -D warnings
+
+  move-clippy:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: [ubuntu-ghcloud]
+    steps:
+      - uses: arduino/setup-protoc@v1
+        # this avoids rate-limiting
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: rustup component add clippy
+      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      #   with:
+      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
+
+      # See '.cargo/config' for list of enabled/disappled clippy lints
+      - name: cargo move-clippy
+        run: |
+          cd external-crates/move
+          cargo move-clippy -D warnings
 
   rustfmt:
     needs: diff

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -131,28 +131,6 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ubuntu-ghcloud]
     steps:
-      - uses: arduino/setup-protoc@v1
-        # this avoids rate-limiting
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - run: rustup component add clippy
-      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
-      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
-      # 'librocksdb-sys' src directory which is managed by cargo
-      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      #   with:
-      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
-
-      # See '.cargo/config' for list of enabled/disappled clippy lints
-      - name: cargo clippy
-        run: cargo xclippy -D warnings
-
-  move-clippy:
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ubuntu-ghcloud]
-    steps:
       - uses: actions/checkout@v3
       - run: rustup component add clippy
 

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -153,10 +153,6 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ubuntu-ghcloud]
     steps:
-      - uses: arduino/setup-protoc@v1
-        # this avoids rate-limiting
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - run: rustup component add clippy
       # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -155,12 +155,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup component add clippy
-      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
-      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
-      # 'librocksdb-sys' src directory which is managed by cargo
-      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      #   with:
-      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
 
       # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo move-clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -308,22 +308,6 @@ jobs:
       - name: cargo clippy
         run: cargo xclippy -D warnings
 
-  move-clippy:
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ubuntu-ghcloud]
-    steps:
-      - uses: arduino/setup-protoc@v1
-        # this avoids rate-limiting
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - run: rustup component add clippy
-      - name: cargo move-clippy
-        run: |
-          cd external-crates/move
-          cargo move-clippy -D warnings
-
   rustfmt:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -308,6 +308,22 @@ jobs:
       - name: cargo clippy
         run: cargo xclippy -D warnings
 
+  move-clippy:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: [ubuntu-ghcloud]
+    steps:
+      - uses: arduino/setup-protoc@v1
+        # this avoids rate-limiting
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: rustup component add clippy
+      - name: cargo move-clippy
+        run: |
+          cd external-crates/move
+          cargo move-clippy -D warnings
+
   rustfmt:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'

--- a/external-crates/move/move-binary-format/src/file_format.rs
+++ b/external-crates/move/move-binary-format/src/file_format.rs
@@ -434,8 +434,6 @@ impl Visibility {
     pub const DEPRECATED_SCRIPT: u8 = 0x2;
 }
 
-
-
 impl std::convert::TryFrom<u8> for Visibility {
     type Error = ();
 

--- a/external-crates/move/move-binary-format/src/file_format.rs
+++ b/external-crates/move/move-binary-format/src/file_format.rs
@@ -416,8 +416,10 @@ pub struct FieldDefinition {
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
+#[derive(Default)]
 pub enum Visibility {
     /// Accessible within its defining module only.
+    #[default]
     Private = 0x0,
     /// Accessible by any module or script outside of its declaring module.
     Public = 0x1,
@@ -432,11 +434,7 @@ impl Visibility {
     pub const DEPRECATED_SCRIPT: u8 = 0x2;
 }
 
-impl Default for Visibility {
-    fn default() -> Self {
-        Visibility::Private
-    }
-}
+
 
 impl std::convert::TryFrom<u8> for Visibility {
     type Error = ();

--- a/external-crates/move/move-binary-format/src/views.rs
+++ b/external-crates/move/move-binary-format/src/views.rs
@@ -441,7 +441,7 @@ impl<'a, T: ModuleAccess> LocalsSignatureView<'a, T> {
         let parameters = self.parameters();
         SignatureTokenView::new(
             self.function_def_view.module,
-            if (index as usize) < parameters.len() {
+            if index < parameters.len() {
                 &parameters[index]
             } else {
                 &self.additional_locals()[index - parameters.len()]

--- a/external-crates/move/move-bytecode-verifier/src/struct_defs.rs
+++ b/external-crates/move/move-bytecode-verifier/src/struct_defs.rs
@@ -104,7 +104,7 @@ impl<'a> StructDefGraphBuilder<'a> {
         token: &SignatureToken,
     ) -> PartialVMResult<()> {
         use SignatureToken as T;
-        Ok(match token {
+        match token {
             T::Bool
             | T::U8
             | T::U16
@@ -141,6 +141,7 @@ impl<'a> StructDefGraphBuilder<'a> {
                     self.add_signature_token(neighbors, cur_idx, t)?
                 }
             }
-        })
+        };
+        Ok(())
     }
 }

--- a/external-crates/move/move-command-line-common/src/types.rs
+++ b/external-crates/move/move-command-line-common/src/types.rs
@@ -47,7 +47,7 @@ pub enum ParsedType {
 }
 
 impl Display for TypeToken {
-    fn fmt<'f>(&self, formatter: &mut fmt::Formatter<'f>) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match *self {
             TypeToken::Whitespace => "[whitespace]",
             TypeToken::Ident => "[identifier]",

--- a/external-crates/move/move-command-line-common/src/values.rs
+++ b/external-crates/move/move-command-line-common/src/values.rs
@@ -117,7 +117,7 @@ impl ParsableValue for () {
 }
 
 impl Display for ValueToken {
-    fn fmt<'f>(&self, formatter: &mut fmt::Formatter<'f>) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match self {
             ValueToken::Number => "[num]",
             ValueToken::NumberTyped => "[num typed]",

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -110,7 +110,7 @@ impl<V: SimpleDomain> AbstractDomain for V {
         );
         let mut result = JoinResult::Unchanged;
         for (local, other_state) in other_locals {
-            match (self.locals().get(&local).unwrap(), other_state) {
+            match (self.locals().get(local).unwrap(), other_state) {
                 // both available, join the value
                 (L::Available(loc, v1), L::Available(_, v2)) => {
                     let loc = *loc;
@@ -390,7 +390,7 @@ pub trait SimpleAbsInt: Sized {
             E::ModuleCall(mcall) => {
                 let evalues = self.exp(context, state, &mcall.arguments);
                 if let Some(vs) =
-                    self.call_custom(context, state, eloc, &parent_e.ty, &mcall, evalues)
+                    self.call_custom(context, state, eloc, &parent_e.ty, mcall, evalues)
                 {
                     return vs;
                 }

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -391,7 +391,7 @@ impl WarningFilters {
     pub fn union(&mut self, other: &Self) {
         for (prefix, filters) in &other.0 {
             self.0
-                .entry(prefix.clone())
+                .entry(*prefix)
                 .or_insert_with(UnprefixedWarningFilters::new)
                 .union(filters);
         }
@@ -468,7 +468,7 @@ impl UnprefixedWarningFilters {
                 codes.extend(
                     other_codes
                         .iter()
-                        .filter(|((category, _), _)| !categories.contains_key(&category)),
+                        .filter(|((category, _), _)| !categories.contains_key(category)),
                 );
             }
         }
@@ -489,7 +489,7 @@ impl UnprefixedWarningFilters {
                     categories: BTreeMap::new(),
                     codes: BTreeMap::new(),
                 };
-                return self.add(filter_category, filter_code, filter_name);
+                self.add(filter_category, filter_code, filter_name)
             }
             Self::Specified { categories, .. } if categories.contains_key(&filter_category) => (),
             Self::Specified { categories, codes } => {
@@ -509,16 +509,16 @@ impl UnprefixedWarningFilters {
         let unused_fn_tparam_info = UnusedItem::FunTypeParam.into_info();
         let filtered_codes = BTreeMap::from([
             (
-                (unused_fun_info.category() as u8, unused_fun_info.code()),
+                (unused_fun_info.category(), unused_fun_info.code()),
                 Some(FILTER_UNUSED_FUNCTION),
             ),
             (
-                (unused_field_info.category() as u8, unused_field_info.code()),
+                (unused_field_info.category(), unused_field_info.code()),
                 Some(FILTER_UNUSED_STRUCT_FIELD),
             ),
             (
                 (
-                    unused_fn_tparam_info.category() as u8,
+                    unused_fn_tparam_info.category(),
                     unused_fn_tparam_info.code(),
                 ),
                 Some(FILTER_UNUSED_TYPE_PARAMETER),

--- a/external-crates/move/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/move-compiler/src/editions/mod.rs
@@ -29,7 +29,9 @@ pub struct Edition {
 pub enum FeatureGate {}
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Flavor {
+    #[default]
     GlobalStorage,
     Sui,
 }
@@ -74,9 +76,9 @@ impl Edition {
 
     // Intended only for implementing the lazy static (supported feature map) above
     fn prev(&self) -> Option<Self> {
-        match self {
-            &Self::LEGACY => None,
-            &Self::E2024_ALPHA => Some(Self::LEGACY),
+        match *self {
+            Self::LEGACY => None,
+            Self::E2024_ALPHA => Some(Self::LEGACY),
             _ => self.unknown_edition_panic(),
         }
     }
@@ -84,9 +86,9 @@ impl Edition {
     // Inefficient and should be called only to implement the lazy static
     // (supported feature map) above
     fn features(&self) -> BTreeSet<FeatureGate> {
-        match self {
-            &Self::LEGACY => BTreeSet::new(),
-            &Self::E2024_ALPHA => self.prev().unwrap().features(),
+        match *self {
+            Self::LEGACY => BTreeSet::new(),
+            Self::E2024_ALPHA => self.prev().unwrap().features(),
             _ => self.unknown_edition_panic(),
         }
     }
@@ -233,8 +235,4 @@ impl Default for Edition {
     }
 }
 
-impl Default for Flavor {
-    fn default() -> Self {
-        Flavor::GlobalStorage
-    }
-}
+

--- a/external-crates/move/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/move-compiler/src/editions/mod.rs
@@ -28,8 +28,7 @@ pub struct Edition {
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
 pub enum FeatureGate {}
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
-#[derive(Default)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
 pub enum Flavor {
     #[default]
     GlobalStorage,
@@ -234,5 +233,3 @@ impl Default for Edition {
         Edition::LEGACY
     }
 }
-
-

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -52,7 +52,7 @@ impl<'env, 'map> Context<'env, 'map> {
     ) -> Self {
         let mut all_filter_alls = WarningFilters::new();
         for allow in compilation_env.filter_attributes() {
-            for f in compilation_env.filter_from_str(FILTER_ALL, allow.clone()) {
+            for f in compilation_env.filter_from_str(FILTER_ALL, *allow) {
                 all_filter_alls.add(f);
             }
         }
@@ -804,7 +804,7 @@ fn warning_filter(
                     n
                 }
             };
-            let filters = context.env.filter_from_str(name_, allow.clone());
+            let filters = context.env.filter_from_str(name_, allow);
             if filters.is_empty() {
                 let msg = format!("Unknown warning filter '{name_}'");
                 context
@@ -2662,7 +2662,7 @@ fn check_valid_address_name_(
 
 fn check_valid_local_name(context: &mut Context, v: &Var) {
     fn is_valid(s: Symbol) -> bool {
-        s.starts_with('_') || s.starts_with(|c| matches!(c, 'a'..='z'))
+        s.starts_with('_') || s.starts_with(|c: char| c.is_ascii_lowercase())
     }
     if !is_valid(v.value()) {
         let msg = format!(
@@ -2822,7 +2822,7 @@ fn check_valid_module_member_name_impl(
 }
 
 pub fn is_valid_struct_constant_or_schema_name(s: &str) -> bool {
-    s.starts_with(|c| matches!(c, 'A'..='Z'))
+    s.starts_with(|c: char| c.is_ascii_uppercase())
 }
 
 // Checks for a restricted name in any decl case

--- a/external-crates/move/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/move-compiler/src/hlir/translate.rs
@@ -850,8 +850,8 @@ fn exp(
     Box::new(exp_(context, result, expected_type_opt, te))
 }
 
-fn exp_<'env>(
-    context: &mut Context<'env>,
+fn exp_(
+    context: &mut Context<'_>,
     result: &mut Block,
     initial_expected_type_opt: Option<&H::Type>,
     initial_e: T::Exp,

--- a/external-crates/move/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/move-compiler/src/naming/translate.rs
@@ -1645,7 +1645,7 @@ fn remove_unused_bindings_exp_dotted(
 }
 
 fn report_unused_local(context: &mut Context, sp!(loc, unused_): &N::Var) {
-    if !unused_.name.starts_with(|c| matches!(c, 'a'..='z')) {
+    if !unused_.name.starts_with(|c: char| c.is_ascii_lowercase()) {
         return;
     }
     let N::Var_ { name, id, color } = unused_;

--- a/external-crates/move/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/move-compiler/src/parser/lexer.rs
@@ -83,7 +83,7 @@ pub enum Tok {
 }
 
 impl fmt::Display for Tok {
-    fn fmt<'f>(&self, formatter: &mut fmt::Formatter<'f>) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         use Tok::*;
         let s = match *self {
             EOF => "[end-of-file]",

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -459,7 +459,8 @@ impl CompilationEnv {
     ) -> BTreeSet<WarningFilter> {
         self.known_filters
             .get(&KnownFilterInfo::new(name, attribute_name))
-            .cloned().unwrap_or_default()
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub fn filter_attributes(&self) -> &BTreeSet<E::AttributeName_> {

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -443,7 +443,7 @@ impl CompilationEnv {
             "TODO If triggered this TODO you might want to make this more efficient"
         );
         if let Some(cur_filter) = self.warning_filter.last() {
-            filter.union(&cur_filter)
+            filter.union(cur_filter)
         }
         self.warning_filter.push(filter)
     }
@@ -459,8 +459,7 @@ impl CompilationEnv {
     ) -> BTreeSet<WarningFilter> {
         self.known_filters
             .get(&KnownFilterInfo::new(name, attribute_name))
-            .cloned()
-            .unwrap_or_else(BTreeSet::new)
+            .cloned().unwrap_or_default()
     }
 
     pub fn filter_attributes(&self) -> &BTreeSet<E::AttributeName_> {

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -53,8 +53,7 @@ pub struct IDLeakVerifierAI<'a> {
     declared_abilities: &'a UniqueMap<StructName, AbilitySet>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[derive(Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Value {
     FreshID(Loc),
     NotFresh(Loc),
@@ -238,5 +237,3 @@ impl SimpleExecutionContext for ExecutionContext {
         self.diags.add(diag)
     }
 }
-
-

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -54,9 +54,11 @@ pub struct IDLeakVerifierAI<'a> {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Value {
     FreshID(Loc),
     NotFresh(Loc),
+    #[default]
     Other,
 }
 
@@ -144,7 +146,7 @@ impl<'a> SimpleAbsInt for IDLeakVerifierAI<'a> {
         let (f, _, first_e) = fields_iter.next().unwrap();
         let first_value = self.exp(context, state, first_e).pop().unwrap_or_default();
         if !matches!(first_value, Value::FreshID(_)) {
-            let msg = format!("Invalid object creation without a newly created UID.");
+            let msg = "Invalid object creation without a newly created UID.".to_string();
             let uid_msg = format!(
                 "The UID must come directly from {sui}::{object}::{new}. \
                 Or for tests, it can come from {sui}::{ts}::{ts_new}",
@@ -237,8 +239,4 @@ impl SimpleExecutionContext for ExecutionContext {
     }
 }
 
-impl Default for Value {
-    fn default() -> Self {
-        Value::Other
-    }
-}
+

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -490,7 +490,7 @@ fn entry_signature(
         Some((_, last_param_ty)) if tx_context_kind(last_param_ty) != TxContextKind::None => {
             &parameters[0..parameters.len() - 1]
         }
-        _ => &parameters,
+        _ => parameters,
     };
     entry_param(context, entry_loc, name, all_non_ctx_parameters);
     entry_return(context, entry_loc, name, return_type);

--- a/external-crates/move/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/move-compiler/src/to_bytecode/translate.rs
@@ -617,7 +617,9 @@ fn function(
     let v = visibility(v);
     let parameters = signature.parameters.clone();
     let signature = function_signature(context, signature);
-    let acquires = acquires.into_keys().map(|s| context.struct_definition_name(m.unwrap(), s))
+    let acquires = acquires
+        .into_keys()
+        .map(|s| context.struct_definition_name(m.unwrap(), s))
         .collect();
     let body = match body.value {
         G::FunctionBody_::Native => IR::FunctionBody::Native,

--- a/external-crates/move/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/move-compiler/src/to_bytecode/translate.rs
@@ -617,9 +617,7 @@ fn function(
     let v = visibility(v);
     let parameters = signature.parameters.clone();
     let signature = function_signature(context, signature);
-    let acquires = acquires
-        .into_iter()
-        .map(|(s, _)| context.struct_definition_name(m.unwrap(), s))
+    let acquires = acquires.into_keys().map(|s| context.struct_definition_name(m.unwrap(), s))
         .collect();
     let body = match body.value {
         G::FunctionBody_::Native => IR::FunctionBody::Native,

--- a/external-crates/move/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/move-compiler/src/unit_test/filter_test_members.rs
@@ -175,10 +175,10 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
 
     let leading_name_access = sp(
         mloc,
-        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME.into())),
+        P::LeadingNameAccess_::Name(sp(mloc, STDLIB_ADDRESS_NAME)),
     );
 
-    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME.into());
+    let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME);
     let mod_addr_name = sp(mloc, (leading_name_access, mod_name));
     let fn_name = sp(mloc, "create_signers_for_testing".into());
     let args_ = vec![sp(

--- a/external-crates/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -589,7 +589,7 @@ fn compile_friends(
 fn compile_imports(context: &mut Context, imports: Vec<ImportDefinition>) -> Result<()> {
     for import in imports {
         context.declare_import(import.ident, import.alias)?;
-    };
+    }
     Ok(())
 }
 

--- a/external-crates/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -587,9 +587,10 @@ fn compile_friends(
 }
 
 fn compile_imports(context: &mut Context, imports: Vec<ImportDefinition>) -> Result<()> {
-    Ok(for import in imports {
+    for import in imports {
         context.declare_import(import.ident, import.alias)?;
-    })
+    };
+    Ok(())
 }
 
 fn type_parameter_indexes<'a>(
@@ -1076,7 +1077,7 @@ fn compile_expression(
     exp: Exp,
 ) -> Result<()> {
     make_push_instr!(context, code);
-    Ok(match exp.value {
+    match exp.value {
         Exp_::Move(v) => {
             let loc_idx = function_frame.get_local(&v.value)?;
             let load_loc = Bytecode::MoveLoc(loc_idx);
@@ -1321,7 +1322,8 @@ fn compile_expression(
                 compile_expression(context, function_frame, code, e)?;
             }
         }
-    })
+    };
+    Ok(())
 }
 
 fn compile_call(
@@ -1331,7 +1333,7 @@ fn compile_call(
     call: FunctionCall,
 ) -> Result<()> {
     make_push_instr!(context, code);
-    Ok(match call.value {
+    match call.value {
         FunctionCall_::Builtin(function) => {
             match function {
                 Builtin::Exists(name, tys) => {
@@ -1545,7 +1547,8 @@ fn compile_call(
             // Return value of current function is pushed onto the stack.
             function_frame.push()?;
         }
-    })
+    };
+    Ok(())
 }
 
 fn compile_constant(_context: &mut Context, ty: Type, value: MoveValue) -> Result<Constant> {

--- a/external-crates/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/external-crates/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -403,7 +403,7 @@ impl<'input> Lexer<'input> {
 fn get_name_len(text: &str) -> usize {
     // If the first character is 0..=9 or EOF, then return a length of 0.
     let first_char = text.chars().next().unwrap_or('0');
-    if ('0'..='9').contains(&first_char) {
+    if first_char.is_ascii_digit() {
         return 0;
     }
     text.chars()

--- a/external-crates/move/move-model/src/builder/module_builder.rs
+++ b/external-crates/move/move-model/src/builder/module_builder.rs
@@ -939,7 +939,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         }
         let spec_fun_idx = spec_fun_id.as_usize();
         let body = if self.spec_funs[spec_fun_idx].body.is_some() {
-            std::mem::replace(&mut self.spec_funs[spec_fun_idx].body, None).unwrap()
+            self.spec_funs[spec_fun_idx].body.take().unwrap()
         } else {
             // If the function is native and contains no mutable references
             // as parameters, consider it pure.
@@ -2877,7 +2877,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         // the full self. Rust requires us to do so (at least the author doesn't know better yet),
         // but moving it should be not too expensive.
         let body = if self.spec_funs[fun_idx].body.is_some() {
-            std::mem::replace(&mut self.spec_funs[fun_idx].body, None).unwrap()
+            self.spec_funs[fun_idx].body.take().unwrap()
         } else {
             // No body: assume it is pure.
             return;
@@ -3204,7 +3204,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         fun_spec,
                     )))
                 } else {
-                    let funs = self.parent.fun_table.iter().map(|(k, _)| {
+                    let funs = self.parent.fun_table.keys().map(|k| {
                         format!("{}", k.display_full(self.symbol_pool()))
                     }).join(", ");
                     self.parent.error(

--- a/external-crates/move/move-model/src/model.rs
+++ b/external-crates/move/move-model/src/model.rs
@@ -2062,10 +2062,13 @@ impl<'env> ModuleEnv<'env> {
     /// Gets a FunctionEnv in this module by name.
     pub fn find_function(&self, name: Symbol) -> Option<FunctionEnv<'env>> {
         let id = FunId(name);
-        self.data.function_data.get(&id).map(move |data| FunctionEnv {
-            module_env: self.clone(),
-            data,
-        })
+        self.data
+            .function_data
+            .get(&id)
+            .map(move |data| FunctionEnv {
+                module_env: self.clone(),
+                data,
+            })
     }
 
     /// Gets a FunctionEnv by id.
@@ -2197,13 +2200,10 @@ impl<'env> ModuleEnv<'env> {
 
     /// Returns iterator over structs in this module.
     pub fn into_structs(self) -> impl Iterator<Item = StructEnv<'env>> {
-        self.data
-            .struct_data
-            .values()
-            .map(move |data| StructEnv {
-                module_env: self.clone(),
-                data,
-            })
+        self.data.struct_data.values().map(move |data| StructEnv {
+            module_env: self.clone(),
+            data,
+        })
     }
 
     /// Globalizes a signature local to this module.

--- a/external-crates/move/move-model/src/model.rs
+++ b/external-crates/move/move-model/src/model.rs
@@ -316,7 +316,7 @@ impl NodeId {
     }
 
     pub fn as_usize(self) -> usize {
-        self.0 as usize
+        self.0
     }
 }
 
@@ -2052,8 +2052,8 @@ impl<'env> ModuleEnv<'env> {
     pub fn into_named_constants(self) -> impl Iterator<Item = NamedConstantEnv<'env>> {
         self.data
             .named_constants
-            .iter()
-            .map(move |(_, data)| NamedConstantEnv {
+            .values()
+            .map(move |data| NamedConstantEnv {
                 module_env: self.clone(),
                 data,
             })
@@ -2062,7 +2062,7 @@ impl<'env> ModuleEnv<'env> {
     /// Gets a FunctionEnv in this module by name.
     pub fn find_function(&self, name: Symbol) -> Option<FunctionEnv<'env>> {
         let id = FunId(name);
-        self.data.function_data.get(&id).map(|data| FunctionEnv {
+        self.data.function_data.get(&id).map(move |data| FunctionEnv {
             module_env: self.clone(),
             data,
         })
@@ -2096,8 +2096,8 @@ impl<'env> ModuleEnv<'env> {
     pub fn into_functions(self) -> impl Iterator<Item = FunctionEnv<'env>> {
         self.data
             .function_data
-            .iter()
-            .map(move |(_, data)| FunctionEnv {
+            .values()
+            .map(move |data| FunctionEnv {
                 module_env: self.clone(),
                 data,
             })
@@ -2199,8 +2199,8 @@ impl<'env> ModuleEnv<'env> {
     pub fn into_structs(self) -> impl Iterator<Item = StructEnv<'env>> {
         self.data
             .struct_data
-            .iter()
-            .map(move |(_, data)| StructEnv {
+            .values()
+            .map(move |data| StructEnv {
                 module_env: self.clone(),
                 data,
             })
@@ -3472,7 +3472,7 @@ impl<'env> FunctionEnv<'env> {
     /// otherwise generate a unique name.
     pub fn get_local_name(&self, idx: usize) -> Symbol {
         if idx < self.data.arg_names.len() {
-            return self.data.arg_names[idx as usize];
+            return self.data.arg_names[idx];
         }
         // Try to obtain name from source map.
         if let Ok(fmap) = self

--- a/external-crates/move/move-model/src/simplifier/mod.rs
+++ b/external-crates/move/move-model/src/simplifier/mod.rs
@@ -58,7 +58,7 @@ impl SpecRewriterPipeline {
         for entry in pipeline {
             match entry {
                 SimplificationPass::Inline => {
-                    result.rewriters.push(Box::new(SpecPassInline::default()))
+                    result.rewriters.push(Box::<SpecPassInline>::default())
                 }
             }
         }

--- a/external-crates/move/move-model/src/ty.rs
+++ b/external-crates/move/move-model/src/ty.rs
@@ -439,7 +439,7 @@ impl Type {
                 } else {
                     Some(MType::Reference(Box::new(t.into_normalized_type(env).expect("Invariant violation: reference type contains incomplete, tuple, or spec type"))))
                 }
-            TypeParameter(idx) => Some(MType::TypeParameter(idx as u16)),
+            TypeParameter(idx) => Some(MType::TypeParameter(idx)),
             Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | Var(..) =>
                 None
         }

--- a/external-crates/move/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/external-crates/move/move-prover/bytecode/src/function_target_pipeline.rs
@@ -597,7 +597,7 @@ impl FunctionTargetPipeline {
         let dump = format!("{}\n", content.trim());
         let file_name = format!("{}_{}_{}.bytecode", base_name, step_count, suffix);
         debug!("dumping bytecode to `{}`", file_name);
-        fs::write(&file_name, &dump).expect("dumping bytecode");
+        fs::write(&file_name, dump).expect("dumping bytecode");
     }
 
     /// Generate dot files for control-flow graphs.

--- a/external-crates/move/move-prover/bytecode/src/loop_analysis.rs
+++ b/external-crates/move/move-prover/bytecode/src/loop_analysis.rs
@@ -192,7 +192,7 @@ impl LoopAnalysisProcessor {
                         let affected_variables: BTreeSet<_> = loop_info
                             .val_targets
                             .iter()
-                            .chain(loop_info.mut_targets.iter().map(|(idx, _)| idx))
+                            .chain(loop_info.mut_targets.keys())
                             .collect();
 
                         // Only emit this for user declared locals, not for ones introduced

--- a/external-crates/move/move-prover/bytecode/src/number_operation_analysis.rs
+++ b/external-crates/move/move-prover/bytecode/src/number_operation_analysis.rs
@@ -84,7 +84,7 @@ impl NumberOperationProcessor {
         }
     }
 
-    fn analyze_fun<'a>(&self, env: &'a GlobalEnv, target: FunctionTarget) {
+    fn analyze_fun(&self, env: &GlobalEnv, target: FunctionTarget) {
         if !target.func_env.is_native_or_intrinsic() {
             let cfg = StacklessControlFlowGraph::one_block(target.get_bytecode());
             let analyzer = NumberOperationAnalysis {

--- a/external-crates/move/move-prover/lab/src/z3log.rs
+++ b/external-crates/move/move-prover/lab/src/z3log.rs
@@ -98,8 +98,8 @@ pub fn plot_instantiations(
 
         chart
             .configure_series_labels()
-            .background_style(&WHITE.mix(0.8))
-            .border_style(&BLACK)
+            .background_style(WHITE.mix(0.8))
+            .border_style(BLACK)
             .position(SeriesLabelPosition::UpperLeft)
             .draw()?;
         Ok(())

--- a/external-crates/move/move-prover/src/cli.rs
+++ b/external-crates/move/move-prover/src/cli.rs
@@ -694,7 +694,7 @@ impl Options {
         }
         if let Some(m) = matches.get_many::<String>("simplification-pipeline") {
             for name in m {
-                let pass = SimplificationPass::from_str(&name)
+                let pass = SimplificationPass::from_str(name)
                     .map_err(|e| anyhow!("Unknown simplification pass: {}", e))?;
                 options.model_builder.simplification_pipeline.push(pass);
             }

--- a/external-crates/move/move-stdlib/src/main.rs
+++ b/external-crates/move/move-stdlib/src/main.rs
@@ -8,18 +8,18 @@ fn main() {
     // Generate documentation
     {
         time_it("Generating stdlib documentation", || {
-            std::fs::remove_dir_all(&move_stdlib::move_stdlib_docs_full_path()).unwrap_or(());
+            std::fs::remove_dir_all(move_stdlib::move_stdlib_docs_full_path()).unwrap_or(());
             //std::fs::create_dir_all(&move_stdlib::move_stdlib_docs_full_path()).unwrap();
             move_stdlib::build_stdlib_doc(&move_stdlib::move_stdlib_docs_full_path());
         });
 
         time_it("Generating nursery documentation", || {
-            std::fs::remove_dir_all(&move_stdlib::move_nursery_docs_full_path()).unwrap_or(());
+            std::fs::remove_dir_all(move_stdlib::move_nursery_docs_full_path()).unwrap_or(());
             move_stdlib::build_nursery_doc(&move_stdlib::move_nursery_docs_full_path());
         });
 
         time_it("Generating error explanations", || {
-            std::fs::remove_file(&move_stdlib::move_stdlib_errmap_full_path()).unwrap_or(());
+            std::fs::remove_file(move_stdlib::move_stdlib_errmap_full_path()).unwrap_or(());
             move_stdlib::build_error_code_map(&move_stdlib::move_stdlib_errmap_full_path());
         });
     }

--- a/external-crates/move/move-stdlib/src/natives/debug.rs
+++ b/external-crates/move/move-stdlib/src/natives/debug.rs
@@ -488,7 +488,7 @@ mod testing {
                 // If this is a vector<u8> we print it in hex (as most users would expect us to)
                 if is_non_empty_vector_u8(&vec) {
                     let bytes = MoveValue::vec_to_vec_u8(vec).map_err(to_vec_u8_type_err)?;
-                    write!(out, "0x{}", hex::encode(&bytes))
+                    write!(out, "0x{}", hex::encode(bytes))
                         .map_err(fmt_error_to_partial_vm_error)?;
                 } else {
                     let is_complex_inner_type =

--- a/external-crates/move/move-stdlib/src/tests.rs
+++ b/external-crates/move/move-stdlib/src/tests.rs
@@ -13,7 +13,7 @@ fn check_that_docs_are_updated() {
 
     crate::build_stdlib_doc(&temp_dir.path().to_string_lossy());
 
-    let res = check_dirs_not_diff(&temp_dir, &crate::move_stdlib_docs_full_path());
+    let res = check_dirs_not_diff(&temp_dir, crate::move_stdlib_docs_full_path());
     assert!(
         res.is_ok(),
         "Generated docs differ from the ones checked in. {}",

--- a/external-crates/move/move-vm/profiler/src/lib.rs
+++ b/external-crates/move/move-vm/profiler/src/lib.rs
@@ -158,7 +158,7 @@ impl GasProfiler {
             return;
         }
 
-        let frame_idx = self.add_frame(metadata.clone(), frame_name.clone(), metadata);
+        let frame_idx = self.add_frame(metadata.clone(), frame_name, metadata);
         let start = self.start_gas();
 
         self.profiles[0].events.push(Event {

--- a/external-crates/move/move-vm/runtime/src/data_cache.rs
+++ b/external-crates/move/move-vm/runtime/src/data_cache.rs
@@ -294,7 +294,8 @@ impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
         val: Value,
     ) -> PartialVMResult<()> {
         let ty_layout = self.loader.type_to_type_layout(&ty)?;
-        Ok(self.event_data.push((guid, seq_num, ty, ty_layout, val)))
+        self.event_data.push((guid, seq_num, ty, ty_layout, val));
+        Ok(())
     }
 
     fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)> {

--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -522,7 +522,7 @@ impl ModuleCache {
                     })
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
                 let struct_formula = self.calculate_depth_of_struct(&struct_type, depth_cache)?;
-                
+
                 struct_formula.subst(ty_arg_map)?
             }
         })

--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -347,7 +347,7 @@ impl ModuleCache {
 
         let mut depth_cache = BTreeMap::new();
         for struct_type in self.structs.binaries.iter().rev().take(field_types_len) {
-            self.calculate_depth_of_struct(&struct_type, &mut depth_cache)?;
+            self.calculate_depth_of_struct(struct_type, &mut depth_cache)?;
         }
 
         debug_assert!(depth_cache.len() == field_types_len);
@@ -522,8 +522,8 @@ impl ModuleCache {
                     })
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
                 let struct_formula = self.calculate_depth_of_struct(&struct_type, depth_cache)?;
-                let subst_struct_formula = struct_formula.subst(ty_arg_map)?;
-                subst_struct_formula
+                
+                struct_formula.subst(ty_arg_map)?
             }
         })
     }

--- a/external-crates/move/move-vm/runtime/src/runtime.rs
+++ b/external-crates/move/move-vm/runtime/src/runtime.rs
@@ -464,10 +464,7 @@ impl VMRuntime {
         #[cfg(debug_assertions)]
         {
             let rem = gas_meter.remaining_gas().into();
-            gas_meter.set_profiler(GasProfiler::init_default_cfg(
-                func.pretty_string(),
-                rem,
-            ));
+            gas_meter.set_profiler(GasProfiler::init_default_cfg(func.pretty_string(), rem));
         }
         // execute the function
         self.execute_function_impl(

--- a/external-crates/move/move-vm/runtime/src/runtime.rs
+++ b/external-crates/move/move-vm/runtime/src/runtime.rs
@@ -465,7 +465,7 @@ impl VMRuntime {
         {
             let rem = gas_meter.remaining_gas().into();
             gas_meter.set_profiler(GasProfiler::init_default_cfg(
-                func.pretty_string().to_owned(),
+                func.pretty_string(),
                 rem,
             ));
         }

--- a/external-crates/move/move-vm/runtime/src/session.rs
+++ b/external-crates/move/move-vm/runtime/src/session.rs
@@ -213,7 +213,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     }
 
     pub fn vm_config(&self) -> &move_vm_config::runtime::VMConfig {
-        &self.runtime.loader().vm_config()
+        self.runtime.loader().vm_config()
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.

--- a/external-crates/move/tools/move-bytecode-utils/src/module_cache.rs
+++ b/external-crates/move/tools/move-bytecode-utils/src/module_cache.rs
@@ -40,6 +40,7 @@ impl<R: ModuleResolver> ModuleCache<R> {
         self.cache.borrow_mut().insert(id, m);
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.cache.borrow().len()
     }
@@ -118,6 +119,7 @@ impl<R: ModuleResolver> SyncModuleCache<R> {
         self.cache.write().unwrap().insert(id, Arc::new(m));
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.cache.read().unwrap().len()
     }

--- a/external-crates/move/tools/move-cli/src/base/mod.rs
+++ b/external-crates/move/tools/move-cli/src/base/mod.rs
@@ -18,7 +18,7 @@ pub fn reroot_path(path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     let path = path.unwrap_or_else(|| PathBuf::from("."));
     // Always root ourselves to the package root, and then compile relative to that.
     let rooted_path = SourcePackageLayout::try_find_root(&path.canonicalize()?)?;
-    std::env::set_current_dir(&rooted_path).unwrap();
+    std::env::set_current_dir(rooted_path).unwrap();
 
     Ok(PathBuf::from("."))
 }

--- a/external-crates/move/tools/move-cli/src/base/test.rs
+++ b/external-crates/move/tools/move-cli/src/base/test.rs
@@ -253,7 +253,7 @@ pub fn run_move_unit_tests<CW: Write + Send, TW: Write + Send>(
     // Compute the coverage map. This will be used by other commands after this.
     if compute_coverage && !no_tests {
         let coverage_map = CoverageMap::from_trace_file(trace_path);
-        output_map_to_file(&coverage_map_path, &coverage_map).unwrap();
+        output_map_to_file(coverage_map_path, &coverage_map).unwrap();
     }
     Ok(UnitTestResult::Success)
 }

--- a/external-crates/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -320,7 +320,7 @@ impl OnDiskStateView {
             event_type,
             event_data,
         ));
-        Ok(fs::write(path, &bcs::to_bytes(&event_log)?)?)
+        Ok(fs::write(path, bcs::to_bytes(&event_log)?)?)
     }
 
     /// Save `module` on disk under the path `module.address()`/`module.name()`

--- a/external-crates/move/tools/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/tools/move-disassembler/src/disassembler.rs
@@ -415,7 +415,7 @@ impl<'a> Disassembler<'a> {
     ) -> Result<String> {
         let sig_tok = locals
             .0
-            .get(local_idx as usize)
+            .get(local_idx)
             .ok_or_else(|| format_err!("Unable to get type for local at index {}", local_idx))?;
         self.disassemble_sig_tok(sig_tok.clone(), &function_source_map.type_parameters)
     }
@@ -462,7 +462,7 @@ impl<'a> Disassembler<'a> {
 
     fn preview_const(slice: &[u8]) -> String {
         if slice.len() <= 4 {
-            format!("{}", hex::encode(slice))
+            hex::encode(slice)
         } else {
             format!("{}..", hex::encode(&slice[..4]))
         }

--- a/external-crates/move/tools/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/tools/move-package/src/lock_file/schema.rs
@@ -96,9 +96,10 @@ impl Packages {
 
 /// Read lock file header after verifying that the version of the lock is not newer than the version
 /// supported by this library.
+#[allow(clippy::ptr_arg)] // Allowed to avoid interface changes.
 pub fn read_header(contents: &String) -> Result<Header> {
     let Schema { move_: header } =
-        toml::de::from_str::<Schema<Header>>(&contents).context("Deserializing lock header")?;
+        toml::de::from_str::<Schema<Header>>(contents).context("Deserializing lock header")?;
 
     if header.version > VERSION {
         bail!(


### PR DESCRIPTION
## Description 

Enables clippy for `external-crates/move`, including fixes that clippy flagged (with a few ignores).

Hopefully this will avoid issues in the codebase in the future that clippy will flag automatically.

**Most of these changes were made automatically with `cargo clippy --fix` so special care should be taken in reviewing this diff.**

## Test Plan 

CI should work as expected, and now report signals for `move-clippy`, as I've called it. (I'm happy to bikeshed the name.)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
