### PR TITLE
[graphql] change storage rebate to be of type BigInt

### DIFF
--- a/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
@@ -220,7 +220,7 @@ fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
     Object {
         version: s.version.into(),
         digest: s.digest.to_string(),
-        storage_rebate: s.storage_rebate,
+        storage_rebate: s.storage_rebate.map(BigInt::from),
         address: SuiAddress::from_array(**s.object_id),
         owner: s
             .owner

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -3,6 +3,7 @@
 
 use async_graphql::{connection::Connection, *};
 
+use super::big_int::BigInt;
 use super::name_service::NameService;
 use super::{
     balance::Balance, coin::Coin, owner::Owner, stake::Stake, sui_address::SuiAddress,
@@ -15,7 +16,7 @@ pub(crate) struct Object {
     pub address: SuiAddress,
     pub version: u64,
     pub digest: String,
-    pub storage_rebate: Option<u64>,
+    pub storage_rebate: Option<BigInt>,
     pub owner: Option<SuiAddress>,
     pub bcs: Option<Base64>,
     pub previous_transaction: Option<String>,
@@ -59,8 +60,8 @@ impl Object {
         self.digest.clone()
     }
 
-    async fn storage_rebate(&self) -> Option<u64> {
-        self.storage_rebate
+    async fn storage_rebate(&self) -> Option<BigInt> {
+        self.storage_rebate.clone()
     }
 
     async fn bcs(&self) -> Option<Base64> {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -161,7 +161,7 @@ type NameServiceEdge {
 type Object implements ObjectOwner {
 	version: Int!
 	digest: String!
-	storageRebate: Int
+	storageRebate: BigInt
 	bcs: Base64
 	previousTransactionBlock: TransactionBlock
 	kind: ObjectKind


### PR DESCRIPTION
## Description 

Change `storage_rebate` to be of type BigInt for the graphql `Object` struct implementation to ensure consistency across the `storage_rebate` fields from different structs. 

## Test Plan 

Compiling and running manual tests. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
