### PR TITLE
indexer: epoch move call view -> table

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
@@ -12,6 +12,7 @@ CREATE INDEX move_calls_transaction_digest ON move_calls (transaction_digest);
 CREATE INDEX move_calls_move_package ON move_calls (move_package);
 CREATE INDEX move_calls_move_module ON move_calls (move_module);
 CREATE INDEX move_calls_move_function ON move_calls (move_function);
+CREATE INDEX move_calls_epoch ON move_calls (epoch);
 
 CREATE TABLE recipients (
     id                          BIGSERIAL       PRIMARY KEY,

--- a/crates/sui-indexer/migrations/2023-03-20-041133_epoch/down.sql
+++ b/crates/sui-indexer/migrations/2023-03-20-041133_epoch/down.sql
@@ -1,3 +1,3 @@
 DROP TABLE IF EXISTS epochs;
 DROP MATERIALIZED VIEW epoch_network_metrics;
-DROP MATERIALIZED VIEW epoch_move_call_metrics;
+DROP TABLE IF EXISTS epoch_move_call_metrics;

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1207,7 +1207,13 @@ impl PgIndexerStore {
 
     fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError> {
         let metrics = read_only_blocking!(&self.blocking_cp, |conn| {
-            diesel::sql_query("SELECT * FROM epoch_move_call_metrics;")
+            diesel::sql_query("SELECT
+                day,
+                move_package,
+                move_module,
+                move_function,
+                count
+            FROM epoch_move_call_metrics WHERE epoch = (SELECT MAX(epoch) FROM epoch_move_call_metrics);")
                 .get_results::<DBMoveCallMetrics>(conn)
         })?;
 


### PR DESCRIPTION
## Description 

context is https://mysten-labs.slack.com/archives/C05PUKKGNRF/p1693190511602099

## Test Plan 

make DB ops with _test and verify that it returns the same result as the original view

```

defaultdb=> SELECT
defaultdb->                 day,
defaultdb->                 move_package,
defaultdb->                 move_module,
defaultdb->                 move_function,
defaultdb->                 count
defaultdb->             FROM epoch_move_call_metrics_test WHERE epoch = (SELECT MAX(epoch) FROM epoch_move_call_metrics_test);
 day |                            move_package                            |    move_module    |         move_function         |  count
-----+--------------------------------------------------------------------+-------------------+-------------------------------+----------
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      |  3802004
   3 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   |  2786428
   3 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           |  2786428
   3 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |   938898
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |   937334
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |   937334
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | decrease_position             |   699318
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | open_position                 |   667719
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | clear_closed_position         |   636425
   3 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |   583262
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      |  9029925
   7 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           |  6917701
   7 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   |  6917701
   7 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |  2178398
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |  2175714
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |  2175714
   7 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |  1450085
   7 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_y                  |  1284738
   7 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | decrease_position             |   942312
   7 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | open_position                 |   910861
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      | 38773912
  30 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           | 29945919
  30 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   | 29945919
  30 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |  8658141
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |  8607509
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |  8607507
  30 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |  6140055
  30 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_y                  |  5031812
  30 | 0x8378b3bd39931aa74a6aa3a820304c1109d327426e4275183ed0b797eb6660a8 | weather           | update                        |  3446004
  30 | 0x71bd3651e47a7590e607b976a332338e2230e995fa96de430703af537086b643 | cryptopedia       | mint_nft_to_address           |  3335673
(30 rows)

defaultdb=> select * from epoch_move_call_metrics;
 day |                            move_package                            |    move_module    |         move_function         |  count
-----+--------------------------------------------------------------------+-------------------+-------------------------------+----------
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      |  1441833
   3 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           |   991318
   3 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   |   991318
   3 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |   378915
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |   378036
   3 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |   378036
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | decrease_position             |   289541
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | open_position                 |   265437
   3 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | clear_closed_position         |   262953
   3 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |   215743
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      |  6613639
   7 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   |  5087325
   7 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           |  5087325
   7 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |  1591417
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |  1589434
   7 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |  1589434
   7 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |  1071009
   7 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_y                  |  1019387
   7 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | decrease_position             |   721706
   7 | 0xceab84acf6bf70f503c3b0627acaff6b3f84cee0f2d7ed53d00fa6c2a168d14f | market            | open_position                 |   713114
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | update_single_price_feed      | 36527560
  30 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | decimal_value     | new                           | 28114009
  30 | 0x51179c2df7466220b513901c52412258942a1e041fccb973e92a53c29e1a09ed | simple_oracle     | submit_data                   | 28114009
  30 | 0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a | vaa               | parse_and_verify              |  8157600
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | pyth              | create_price_infos_hot_potato |  8107287
  30 | 0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302 | hot_potato_vector | destroy                       |  8107285
  30 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_x                  |  5990548
  30 | 0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66 | spot_dex          | swap_token_y                  |  4903456
  30 | 0x8378b3bd39931aa74a6aa3a820304c1109d327426e4275183ed0b797eb6660a8 | weather           | update                        |  3335877
  30 | 0xa9e3193efd15564c33121e614c5e1a28ae9de560b87455b520e25613dfad2871 | releap_social     | like_post                     |  2728552
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
