### PR TITLE
Adding protocol change highlight to release notes script

### DIFF
--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -13,9 +13,10 @@ else
     new_branch=$2
 fi
 
+echo -e "Sui Protocol Version in this release: XX\n"
 for pr_number in $(git log --grep "\[x\]" --pretty=oneline --abbrev-commit origin/"${new_branch}"...origin/"${prev_branch}" -- crates dashboards doc docker external-crates kiosk narwhal nre sui-execution | grep -o '#[0-9]\+' | grep -o '[0-9]\+')
 do
     pr_body=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/MystenLabs/sui/pulls/"${pr_number}" --jq ".body")
     release_notes="${pr_body#*### Release notes}"
-    echo "https://github.com/MystenLabs/sui/pull/${pr_number}: ${release_notes}"
+    echo -e "\nhttps://github.com/MystenLabs/sui/pull/${pr_number}: ${release_notes}"
 done


### PR DESCRIPTION
## Description 
Adding protocol change highlight to release notes script

## Test Plan 
```
eugene@mac-studio ~/code/sui (eugene/add_protocol_highlight_to_release_notes) $ ./scripts/generate-release-notes.sh releases/sui-v1.7.0-release releases/sui-v1.8.0-release
Sui Protocol Version in this release: XX


https://github.com/MystenLabs/sui/pull/13124:
Add protocol config feature flags for zkLogin to enable testing in Devnet, use updated proof verification logics for zkLogin signature verification.

https://github.com/MystenLabs/sui/pull/13417:

When building Move code, there are now additional linter warnings related to comparing collections from Sui framework code (`Bag`, `Table`, and `TableVec`). Note that this comparison is not a structural one based on the collection content, which is what one might expect, so Sui now indicates this via a linter warning.

https://github.com/MystenLabs/sui/pull/12989:
All transaction execution errors from `execute_transaction_block` of `client-fault` now return a -32002 error code. If you encounter this error code, there is most likely an issue in your transaction inputs.
Previously, when executing a transaction failed on the RPC, you would receive a, "Transaction has non recoverable errors from at least 1/3 of validators" after the transaction failed to execute. You now receive an improved error message, "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: {errors}", where `{errors}` is a string list of actionable errors. After you resolve the errors indicated, your transaction should succeed.

https://github.com/MystenLabs/sui/pull/13194:

When building Move code, there are now additional linter warnings related to freezing an object containing (directly or indirectly) other (wrapped) object. Freezing such an object prevents unwrapping of inner objects.

https://github.com/MystenLabs/sui/pull/12575:

The details included in error messages returned during dependency graph construction might differ from the previous error messages, but they still include similar details and information.


https://github.com/MystenLabs/sui/pull/12933:
Error code designation is updated to support a more cohesive error reporting structure. Internal errors that arise while reading from authority return a `-32603` error code. Client-fault errors that arise while reading from authority return a `-32602` error code. Error strings are not modified.

https://github.com/MystenLabs/sui/pull/13312:

Removes the `--legacy-digest` flag from the `sui client upgrade` and `sui move build` CLI commands, as Sui networks no longer require package digests to be calculated using the legacy algorithm.
```