### PR TITLE
[graphql] add epoch's timestamp fields

### DIFF
--- a/crates/sui-graphql-rpc/src/types/date_time.rs
+++ b/crates/sui-graphql-rpc/src/types/date_time.rs
@@ -5,13 +5,14 @@ use std::str::FromStr;
 
 use async_graphql::*;
 use chrono::{
-    prelude::{DateTime as ChronoDateTime, Utc as ChronoUtc},
+    prelude::{DateTime as ChronoDateTime, TimeZone, Utc as ChronoUtc},
     ParseError as ChronoParseError,
 };
 
 // ISO-8601 Date and Time: RFC3339 in UTC
 // YYYY-MM-DDTHH:MM:SS.mmmZ
-struct DateTime(ChronoDateTime<ChronoUtc>);
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DateTime(ChronoDateTime<ChronoUtc>);
 
 #[Scalar]
 impl ScalarType for DateTime {
@@ -26,6 +27,15 @@ impl ScalarType for DateTime {
     fn to_value(&self) -> Value {
         // Debug format for chrono::DateTime is YYYY-MM-DDTHH:MM:SS.mmmZ
         Value::String(format!("{:?}", self.0))
+    }
+}
+
+impl DateTime {
+    pub fn from_ms(timestamp_ms: i64) -> Option<Self> {
+        ChronoUtc
+            .timestamp_millis_opt(timestamp_ms)
+            .single()
+            .map(Self)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::big_int::BigInt;
+use super::date_time::DateTime;
 use super::protocol_config::ProtocolConfigs;
 use super::safe_mode::SafeMode;
 use super::stake_subsidy::StakeSubsidy;
@@ -21,6 +22,6 @@ pub(crate) struct Epoch {
     pub validator_set: Option<ValidatorSet>,
     pub storage_fund: Option<StorageFund>,
     pub safe_mode: Option<SafeMode>,
-    // start_timestamp: todo!(),
-    // end_timestamp: todo!(),
+    pub start_timestamp: Option<DateTime>,
+    // pub end_timestamp: Option<DateTime>, //TODO decide if we want this data exposed or not
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -139,6 +139,8 @@ type CommitteeMember {
 	stakeUnit: Int
 }
 
+scalar DateTime
+
 type EndOfEpochData {
 	newCommittee: [CommitteeMember!]
 	nextProtocolVersion: Int
@@ -154,6 +156,7 @@ type Epoch {
 	validatorSet: ValidatorSet
 	storageFund: StorageFund
 	safeMode: SafeMode
+	startTimestamp: DateTime
 }
 
 enum ExecutionStatus {


### PR DESCRIPTION
## Description 

Add epoch's timestamp fields.

## Test Plan 

Manually. 

![image](https://github.com/MystenLabs/sui/assets/135084671/7ebd1a18-71a7-41f4-860b-022e489a2e3e)


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
