### PR TITLE
Add adapter tests for repeat dynamic field add/removal

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.exp
@@ -1,0 +1,34 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 11-45:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7638000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 47-47:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 49-49:
+created: object(3,0), object(3,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5950800,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+
+task 4 'run'. lines 51-51:
+mutated: object(0,0), object(2,0), object(3,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3496000,  storage_rebate: 5891292, non_refundable_storage_fee: 59508
+
+task 5 'run'. lines 53-53:
+created: object(3,0), object(5,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5950800,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+
+task 6 'run'. lines 55-55:
+mutated: object(0,0), object(2,0)
+deleted: object(3,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 5891292, non_refundable_storage_fee: 59508

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test attempts to remove a child, add it back, remove it again, and then transfer/delete it.
+// This is an interesting test case because when child objects are removed, added back and removed again,
+// they won't show up in the child_object_effects in the object runtiem. We must look at either transfers
+// or deleted_object_ids to figure them out.
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Object has key, store {
+        id: UID,
+    }
+
+    public entry fun create(ctx: &mut TxContext) {
+        let o = Object { id: object::new(ctx) };
+        transfer::public_transfer(o, tx_context::sender(ctx))
+    }
+
+    public entry fun add_child(parent: &mut Object, ctx: &mut TxContext) {
+        let child = Object { id: object::new(ctx) };
+        sui::dynamic_object_field::add(&mut parent.id, 0, child);
+    }
+
+    public fun transfer_child(parent: &mut Object, ctx: &TxContext) {
+        let child: Object = sui::dynamic_object_field::remove(&mut parent.id, 0);
+        sui::dynamic_object_field::add(&mut parent.id, 1, child);
+        let child: Object = sui::dynamic_object_field::remove(&mut parent.id, 1);
+        transfer::public_transfer(child, tx_context::sender(ctx))
+    }
+
+    public fun delete_child(parent: &mut Object) {
+        let child: Object = sui::dynamic_object_field::remove(&mut parent.id, 0);
+        sui::dynamic_object_field::add(&mut parent.id, 1, child);
+        let child: Object = sui::dynamic_object_field::remove(&mut parent.id, 1);
+        let Object { id } = child;
+        object::delete(id);
+    }
+}
+
+//# run test::m1::create --sender A
+
+//# run test::m1::add_child --args object(2,0) --sender A
+
+//# run test::m1::transfer_child --args object(2,0) --sender A
+
+//# run test::m1::add_child --args object(2,0) --sender A
+
+//# run test::m1::delete_child --args object(2,0) --sender A


### PR DESCRIPTION
## Description 

There seems to be an implementation inconsistency in the object runtime.
If we remove a dynamic object field and transfer it, such removal will show up in child object effects which is expected: https://github.com/MystenLabs/sui/blob/ebf24400925047e868971ddac2a3b24bbec0c467/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs#L442, and hence processing child object effects is sufficient to figure out all child object changes.
However, if we remove a field, add it back, remove it again, and then transfer it, such change won't show up in child object effects, hence we have to consult the transfers to figure it out (similar for deletes).

Add a test to expose such case and makes sure we always get it right.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
