### PR TITLE
rest: fix bug when getting events when requesting a full checkpoint

### DIFF
--- a/crates/sui-rest-api/src/checkpoints.rs
+++ b/crates/sui-rest-api/src/checkpoints.rs
@@ -72,7 +72,7 @@ pub async fn get_full_checkpoint(
         .map(|maybe_event| maybe_event.ok_or_else(|| anyhow::anyhow!("missing event")))
         .collect::<Result<Vec<_>>>()?;
 
-    let mut events = event_digests
+    let events = event_digests
         .into_iter()
         .zip(events)
         .collect::<HashMap<_, _>>();
@@ -94,7 +94,8 @@ pub async fn get_full_checkpoint(
     for (tx, fx) in transactions.into_iter().zip(effects) {
         let events = fx.events_digest().map(|event_digest| {
             events
-                .remove(event_digest)
+                .get(event_digest)
+                .cloned()
                 .expect("event was already checked to be present")
         });
 


### PR DESCRIPTION
Fix a bug when getting events when requesting a full checkpoint due to the fact that events are not unique. It is possible that two transactions both have identical events emitted, leading them to have the same emitted events digests.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
