### PR TITLE
[EffectsV2 3/n] Refactor TemporaryStore to be ready for effects V2

### DIFF
--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -1,12 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use crate::base_types::{random_object_ref, ExecutionDigests, ObjectID, ObjectRef, SequenceNumber};
 use crate::committee::EpochId;
 use crate::crypto::{
     default_hash, AuthoritySignInfo, AuthorityStrongQuorumSignInfo, EmptySignInfo,
 };
-use crate::digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest};
+use crate::digests::{
+    ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
+};
 use crate::error::{SuiError, SuiResult};
 use crate::event::Event;
 use crate::execution_status::ExecutionStatus;
@@ -19,11 +23,15 @@ use crate::storage::WriteKind;
 use crate::transaction::{SenderSignedData, TransactionDataAPI, VersionedProtocolMessage};
 use effects_v1::TransactionEffectsV1;
 use enum_dispatch::enum_dispatch;
+pub use object_change::EffectsObjectChange;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
 
+use self::object_change::{IDOperation, ObjectIn, ObjectOut};
+
 mod effects_v1;
+mod object_change;
 
 // Since `std::mem::size_of` may not be stable across platforms, we use rough constants
 // We need these for estimating effects sizes
@@ -108,7 +116,7 @@ pub enum ObjectRemoveKind {
 impl TransactionEffects {
     /// Creates a TransactionEffects message from the results of execution, choosing the correct
     /// format for the current protocol version.
-    pub fn new_from_execution(
+    pub fn new_from_execution_v1(
         _protocol_version: ProtocolVersion,
         status: ExecutionStatus,
         executed_epoch: EpochId,
@@ -126,8 +134,115 @@ impl TransactionEffects {
         events_digest: Option<TransactionEventsDigest>,
         dependencies: Vec<TransactionDigest>,
     ) -> Self {
-        // TODO: when there are multiple versions, use protocol_version to construct the
-        // appropriate one.
+        Self::V1(TransactionEffectsV1::new(
+            status,
+            executed_epoch,
+            gas_used,
+            modified_at_versions,
+            shared_objects,
+            transaction_digest,
+            created,
+            mutated,
+            unwrapped,
+            deleted,
+            unwrapped_then_deleted,
+            wrapped,
+            gas_object,
+            events_digest,
+            dependencies,
+        ))
+    }
+
+    /// Creates a TransactionEffects message from the results of execution, choosing the correct
+    /// format for the current protocol version.
+    pub fn new_from_execution_v2(
+        _protocol_version: ProtocolVersion,
+        status: ExecutionStatus,
+        executed_epoch: EpochId,
+        gas_used: GasCostSummary,
+        shared_objects: Vec<ObjectRef>,
+        transaction_digest: TransactionDigest,
+        lamport_version: SequenceNumber,
+        object_changes: BTreeMap<ObjectID, EffectsObjectChange>,
+        gas_object: (ObjectRef, Owner),
+        events_digest: Option<TransactionEventsDigest>,
+        dependencies: Vec<TransactionDigest>,
+    ) -> Self {
+        let mut created = vec![];
+        let mut mutated = vec![];
+        let mut unwrapped = vec![];
+        let mut deleted = vec![];
+        let mut unwrapped_then_deleted = vec![];
+        let mut wrapped = vec![];
+        // It is important that we constructs `modified_at_versions` and `deleted_at_versions`
+        // separately, and merge them latter to achieve the exact same order as in v1.
+        let mut modified_at_versions = vec![];
+        let mut deleted_at_versions = vec![];
+        for (id, change) in object_changes {
+            match change.input_state {
+                ObjectIn::Exist(((old_version, _), _)) => {
+                    match (change.output_state, change.id_operation) {
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::None) => {
+                            mutated.push(((id, lamport_version, new_digest), new_owner));
+                            modified_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::PackageWrite((new_version, new_digest)), IDOperation::None) => {
+                            mutated.push(((id, new_version, new_digest), Owner::Immutable));
+                            modified_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Deleted) => {
+                            deleted.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_DELETED,
+                            ));
+                            deleted_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::NotExist, IDOperation::None) => {
+                            wrapped.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_WRAPPED,
+                            ));
+                            deleted_at_versions.push((id, old_version));
+                        }
+                        _ => {
+                            unreachable!("Impossible combination of output state and id operation");
+                        }
+                    }
+                }
+                ObjectIn::NotExist => {
+                    match (change.output_state, change.id_operation) {
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::Created) => {
+                            created.push(((id, lamport_version, new_digest), new_owner));
+                        }
+                        (
+                            ObjectOut::PackageWrite((new_version, new_digest)),
+                            IDOperation::Created,
+                        ) => {
+                            created.push(((id, new_version, new_digest), Owner::Immutable));
+                        }
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::None) => {
+                            unwrapped.push(((id, lamport_version, new_digest), new_owner));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Deleted) => {
+                            unwrapped_then_deleted.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_DELETED,
+                            ));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Created) => {
+                            // Created then wrapped.
+                        }
+                        _ => {
+                            unreachable!("Impossible combination of output state and id operation");
+                        }
+                    }
+                }
+            }
+        }
+        modified_at_versions.extend(deleted_at_versions);
 
         Self::V1(TransactionEffectsV1::new(
             status,

--- a/crates/sui-types/src/effects/object_change.rs
+++ b/crates/sui-types/src/effects/object_change.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    base_types::VersionDigest,
+    digests::ObjectDigest,
+    object::{Object, Owner},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct EffectsObjectChange {
+    // input_state and output_state are the core fields that's required by
+    // the protocol as it tells how an object changes on-chain.
+    /// State of the object in the store prior to this transaction.
+    pub(crate) input_state: ObjectIn,
+    /// State of the object in the store after this transaction.
+    pub(crate) output_state: ObjectOut,
+
+    /// Whether this object ID is created or deleted in this transaction.
+    /// This information isn't required by the protocol but is useful for providing more detailed
+    /// semantics on object changes.
+    pub(crate) id_operation: IDOperation,
+}
+
+impl EffectsObjectChange {
+    pub fn new(
+        modified_at: Option<(VersionDigest, Owner)>,
+        written: Option<&Object>,
+        id_created: bool,
+        id_deleted: bool,
+    ) -> Self {
+        debug_assert!(
+            !id_created || !id_deleted,
+            "Object ID can't be created and deleted at the same time."
+        );
+        Self {
+            input_state: modified_at.map_or(ObjectIn::NotExist, ObjectIn::Exist),
+            output_state: written.map_or(ObjectOut::NotExist, |o| {
+                if o.is_package() {
+                    ObjectOut::PackageWrite((o.version(), o.digest()))
+                } else {
+                    ObjectOut::ObjectWrite((o.digest(), o.owner))
+                }
+            }),
+            id_operation: if id_created {
+                IDOperation::Created
+            } else if id_deleted {
+                IDOperation::Deleted
+            } else {
+                IDOperation::None
+            },
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum IDOperation {
+    None,
+    Created,
+    Deleted,
+}
+
+/// If an object exists (at root-level) in the store prior to this transaction,
+/// it should be Exist, otherwise it's NonExist, e.g. wrapped objects should be
+/// NonExist.
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum ObjectIn {
+    NotExist,
+    /// The old version, digest and owner.
+    Exist((VersionDigest, Owner)),
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum ObjectOut {
+    /// Same definition as in ObjectIn.
+    NotExist,
+    /// Any written object, including all of mutated, created, unwrapped today.
+    ObjectWrite((ObjectDigest, Owner)),
+    /// Packages writes need to be tracked separately with version because
+    /// we don't use lamport version for package publish and upgrades.
+    PackageWrite(VersionDigest),
+}

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -1,8 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-
+use crate::{
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    coin::Coin,
+    digests::{ObjectDigest, TransactionDigest},
+    error::{ExecutionError, ExecutionErrorKind, SuiError},
+    event::Event,
+    execution_status::CommandArgumentError,
+    object::{Data, Object, Owner},
+    storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, StorageView},
+    transfer::Receiving,
+};
 use move_binary_format::file_format::AbilitySet;
 use move_core_types::{
     identifier::IdentStr,
@@ -11,18 +20,7 @@ use move_core_types::{
 use move_vm_types::loaded_data::runtime_types::Type;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-
-use crate::{
-    base_types::{ObjectID, SequenceNumber, SuiAddress},
-    coin::Coin,
-    digests::{ObjectDigest, TransactionDigest},
-    error::{ExecutionError, ExecutionErrorKind, SuiError},
-    event::Event,
-    execution_status::CommandArgumentError,
-    object::{Object, Owner},
-    storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, StorageView},
-    transfer::Receiving,
-};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 pub trait SuiResolver:
     ResourceResolver<Error = SuiError> + ModuleResolver<Error = SuiError> + BackingPackageStore
@@ -85,7 +83,7 @@ pub struct ExecutionResultsV1 {
 /// Used by sui-execution v1 and above, to capture the execution results from Move.
 /// The results represent the primitive information that can then be used to construct
 /// both transaction effects V1 and V2.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ExecutionResultsV2 {
     /// All objects written regardless of whether they were mutated, created, or unwrapped.
     pub written_objects: BTreeMap<ObjectID, Object>,
@@ -99,6 +97,72 @@ pub struct ExecutionResultsV2 {
     pub deleted_object_ids: BTreeSet<ObjectID>,
     /// All Move events emitted in this transaction.
     pub user_events: Vec<Event>,
+}
+
+impl ExecutionResultsV2 {
+    pub fn drop_writes(&mut self) {
+        self.written_objects.clear();
+        self.modified_objects.clear();
+        self.created_object_ids.clear();
+        self.deleted_object_ids.clear();
+        self.user_events.clear();
+    }
+
+    pub fn merge_results(&mut self, new_results: Self) {
+        self.written_objects.extend(new_results.written_objects);
+        self.modified_objects.extend(new_results.modified_objects);
+        self.created_object_ids
+            .extend(new_results.created_object_ids);
+        self.deleted_object_ids
+            .extend(new_results.deleted_object_ids);
+        self.user_events.extend(new_results.user_events);
+    }
+
+    pub fn update_version_and_previous_tx(
+        &mut self,
+        lamport_version: SequenceNumber,
+        prev_tx: TransactionDigest,
+    ) {
+        for (id, mut obj) in self.written_objects.iter_mut() {
+            // TODO: All of the following is no longer necessary and can be simplified.
+
+            // Update the version for the written object.
+            match &mut obj.data {
+                Data::Move(obj) => {
+                    // Move objects all get the transaction's lamport timestamp
+                    obj.increment_version_to(lamport_version);
+                }
+
+                Data::Package(pkg) => {
+                    // Modified packages get their version incremented (this is a special case that
+                    // only applies to system packages).  All other packages can only be created,
+                    // and they are left alone.
+                    if self.modified_objects.contains(id) {
+                        pkg.increment_version();
+                    }
+                }
+            }
+
+            // Record the version that the shared object was created at in its owner field.  Note,
+            // this only works because shared objects must be created as shared (not created as
+            // owned in one transaction and later converted to shared in another).
+            if let Owner::Shared {
+                initial_shared_version,
+            } = &mut obj.owner
+            {
+                if self.created_object_ids.contains(id) {
+                    assert_eq!(
+                        *initial_shared_version,
+                        SequenceNumber::new(),
+                        "Initial version should be blank before this point for {id:?}",
+                    );
+                    *initial_shared_version = lamport_version;
+                }
+            }
+
+            obj.previous_transaction = prev_tx;
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -73,16 +73,20 @@ impl SuiSystemStateWrapper {
         }
     }
 
+    /// Advances epoch in safe mode natively in Rust, without involking Move.
+    /// This ensures that there cannot be any failure from Move and is guaranteed to succeed.
+    /// Returns the old and new inner system state object.
     pub fn advance_epoch_safe_mode(
         &self,
         params: &AdvanceEpochParams,
         object_store: &dyn ObjectStore,
         protocol_config: &ProtocolConfig,
-    ) -> Object {
+    ) -> (Object, Object) {
         let id = self.id.id.bytes;
-        let mut field_object = get_dynamic_field_object_from_store(object_store, id, &self.version)
+        let old_field_object = get_dynamic_field_object_from_store(object_store, id, &self.version)
             .expect("Dynamic field object of wrapper should always be present in the object store");
-        let move_object = field_object
+        let mut new_field_object = old_field_object.clone();
+        let move_object = new_field_object
             .data
             .try_as_move_mut()
             .expect("Dynamic field object must be a Move object");
@@ -127,7 +131,7 @@ impl SuiSystemStateWrapper {
             }
             _ => unreachable!(),
         }
-        field_object
+        (old_field_object, new_field_object)
     }
 
     fn advance_epoch_safe_mode_impl<T>(

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -21,7 +21,6 @@ pub mod checked {
         gas_model::tables::GasStatus,
         is_system_package,
         object::Data,
-        storage::{DeleteKindWithOldVersion, WriteKind},
     };
     use tracing::trace;
 
@@ -174,9 +173,9 @@ pub mod checked {
                 })
                 .clone();
             // delete all gas objects except the primary_gas_object
-            for (id, version, _digest) in &self.gas_coins[1..] {
+            for (id, _version, _digest) in &self.gas_coins[1..] {
                 debug_assert_ne!(*id, primary_gas_object.id());
-                temporary_store.delete_object(id, DeleteKindWithOldVersion::Normal(*version));
+                temporary_store.delete_input_object(id);
             }
             primary_gas_object
                 .data
@@ -189,7 +188,7 @@ pub mod checked {
                     )
                 })
                 .set_coin_value_unsafe(new_balance);
-            temporary_store.write_object(primary_gas_object, WriteKind::Mutate);
+            temporary_store.mutate_input_object(primary_gas_object);
         }
 
         //
@@ -298,7 +297,7 @@ pub mod checked {
                 #[skip_checked_arithmetic]
                 trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
 
-                temporary_store.write_object(gas_object, WriteKind::Mutate);
+                temporary_store.mutate_input_object(gas_object);
                 cost_summary
             } else {
                 GasCostSummary::default()

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -259,7 +259,7 @@ impl<'backing> TemporaryStore<'backing> {
         let protocol_version = self.protocol_config.version;
         let inner = self.into_inner();
 
-        let effects = TransactionEffects::new_from_execution(
+        let effects = TransactionEffects::new_from_execution_v1(
             protocol_version,
             status,
             epoch,
@@ -742,7 +742,7 @@ impl<'backing> TemporaryStore<'backing> {
     ) {
         let wrapper = get_sui_system_state_wrapper(self.store.as_object_store())
             .expect("System state wrapper object must exist");
-        let new_object =
+        let (new_object, _) =
             wrapper.advance_epoch_safe_mode(params, self.store.as_object_store(), protocol_config);
         self.write_object(new_object, WriteKind::Mutate);
     }

--- a/sui-execution/vm-rework/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/gas_charger.rs
@@ -21,7 +21,6 @@ pub mod checked {
         gas_model::tables::GasStatus,
         is_system_package,
         object::Data,
-        storage::{DeleteKindWithOldVersion, WriteKind},
     };
     use tracing::trace;
 
@@ -174,9 +173,9 @@ pub mod checked {
                 })
                 .clone();
             // delete all gas objects except the primary_gas_object
-            for (id, version, _digest) in &self.gas_coins[1..] {
+            for (id, _version, _digest) in &self.gas_coins[1..] {
                 debug_assert_ne!(*id, primary_gas_object.id());
-                temporary_store.delete_object(id, DeleteKindWithOldVersion::Normal(*version));
+                temporary_store.delete_input_object(id);
             }
             primary_gas_object
                 .data
@@ -189,7 +188,7 @@ pub mod checked {
                     )
                 })
                 .set_coin_value_unsafe(new_balance);
-            temporary_store.write_object(primary_gas_object, WriteKind::Mutate);
+            temporary_store.mutate_input_object(primary_gas_object);
         }
 
         //
@@ -298,7 +297,7 @@ pub mod checked {
                 #[skip_checked_arithmetic]
                 trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
 
-                temporary_store.write_object(gas_object, WriteKind::Mutate);
+                temporary_store.mutate_input_object(gas_object);
                 cost_summary
             } else {
                 GasCostSummary::default()


### PR DESCRIPTION
## Description 

This PR refactors TemporaryStore so that it could emit both effects v1 and v2.
Previously, TemporaryStore contains a `written` field and a `deleted` field that contains all the writes and deletions, tailored for effects v1.
This PR changes the output field of TemporaryStore to use ExecutionResultsV2 directly. ExecutionResultsV2 contains all the primitive data of the execution output.
In order to maintain all the primitive results properly, this PR replaced the `write_object` and `delete_object` function with a list of more specific APIs such as `mutate_input_object`, `mutate_child_object`, `delete_input_object`, `create_object`, `update_system_package` and etc.
At the end, when we emit effects, we generate the object changes based on the primitive results, and convert back to what effects V1 needed.

## Test Plan 

CI.
Also replay from genesis on mainnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
