### PR TITLE
indexer: on conflict do nothing for cp metrics processor

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-06-182806_checkpoint_metrics/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-06-182806_checkpoint_metrics/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE checkpoint_metrics
 (
-    checkpoint                                     BIGINT PRIMARY KEY,
+    checkpoint                                          BIGINT PRIMARY KEY,
     epoch                                               BIGINT NOT NULL,   
     real_time_tps                                       FLOAT8 NOT NULL,
     peak_tps_30d                                        FLOAT8 NOT NULL, 

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1795,6 +1795,7 @@ impl PgIndexerStore {
         transactional_blocking!(&self.blocking_cp, |conn| {
             diesel::insert_into(checkpoint_metrics::dsl::checkpoint_metrics)
                 .values(checkpoint_metrics)
+                .on_conflict_do_nothing()
                 .execute(conn)
         })
         .context("Failed persisting checkpoint metrics to PostgresDB")?;


### PR DESCRIPTION
## Description 

Saw this error on indexer 0
```
`Failed persisting checkpoint metrics to PostgresDB`: `Indexer failed to commit changes to PostgresDB with error: `duplicate key value violates unique constraint "checkpoint_metrics_pkey"``
```

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
