### PR TITLE
indexer: fix move call metrics query

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-20-041133_epoch/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-20-041133_epoch/up.sql
@@ -69,7 +69,7 @@ BEGIN
                 attempts := attempts + 1;
                 REFRESH MATERIALIZED VIEW CONCURRENTLY epoch_network_metrics;
                 INSERT INTO epoch_move_call_metrics
-                  SELECT max(epoch), 3::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
+                  SELECT (SELECT MAX(epoch) FROM epochs) AS epoch, 3::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
                    FROM move_calls
                    WHERE epoch >=
                          (SELECT MIN(epoch)
@@ -79,7 +79,7 @@ BEGIN
                    ORDER BY count DESC
                    LIMIT 10;
                 INSERT INTO epoch_move_call_metrics
-                  SELECT max(epoch), 7::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
+                  SELECT (SELECT MAX(epoch) FROM epochs) AS epoch, 7::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
                    FROM move_calls
                    WHERE epoch >=
                          (SELECT MIN(epoch)
@@ -89,7 +89,7 @@ BEGIN
                    ORDER BY count DESC
                    LIMIT 10;
                 INSERT INTO epoch_move_call_metrics
-                  SELECT max(epoch), 30::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
+                  SELECT (SELECT MAX(epoch) FROM epochs) AS epoch, 30::BIGINT AS day, move_package, move_module, move_function, COUNT(*) AS count
                    FROM move_calls
                    WHERE epoch >=
                          (SELECT MIN(epoch)


### PR DESCRIPTION
## Description 

The previous query included rows from previous epochs, fixed that so that on the reading side we will always have 10 rows.

## Test Plan 

verify the query results and updated this query in mnt DB already.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
