### PR TITLE
kv writer: backfill objects

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -9,6 +9,7 @@ use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
 use sui_types::digests::{TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::error::SuiError;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -16,8 +17,9 @@ use sui_types::messages_checkpoint::EndOfEpochData;
 use sui_types::messages_checkpoint::FullCheckpointContents;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::messages_checkpoint::VerifiedCheckpointContents;
-use sui_types::storage::ReadStore;
+use sui_types::object::Object;
 use sui_types::storage::WriteStore;
+use sui_types::storage::{ObjectKey, ReadStore};
 use sui_types::transaction::VerifiedTransaction;
 use typed_store::Map;
 
@@ -48,6 +50,10 @@ impl RocksDbStore {
             highest_verified_checkpoint: Arc::new(Mutex::new(None)),
             highest_synced_checkpoint: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub fn get_objects(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>, SuiError> {
+        self.authority_store.multi_get_object_by_key(object_keys)
     }
 }
 

--- a/crates/sui-kvstore/src/client.rs
+++ b/crates/sui-kvstore/src/client.rs
@@ -19,10 +19,11 @@ pub enum KVTable {
     Events,
     CheckpointContent,
     CheckpointSummary,
+    Objects,
     State,
 }
 
-const UPLOAD_PROGRESS_KEY: [u8; 1] = [0];
+const UPLOAD_PROGRESS_KEY: [u8; 6] = [111, 98, 106, 101, 99, 116];
 
 #[async_trait]
 pub trait KVWriteClient {
@@ -83,6 +84,7 @@ impl DynamoDbClient {
             KVTable::Transactions => "tx",
             KVTable::Effects => "fx",
             KVTable::Events => "ev",
+            KVTable::Objects => "ob",
             KVTable::State => "state",
             KVTable::CheckpointContent => "cc",
             KVTable::CheckpointSummary => "cs",


### PR DESCRIPTION
A temporary PR on top of 1.8.0 is being used for the initial backfill of the objects table to DynamoDB (all other backfills are disabled here). 
It will be manually deployed to a separate unpruned FN. Additionally, a different progress key is being used (`UPLOAD_PROGRESS_KEY = b'objects'`). 
Once the backfill is complete, the two flows will be merged, and the existing progress key will be used.