### PR TITLE
[Fullnode] more cleanups on local execution

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1875,35 +1875,6 @@ impl AuthorityState {
         })
     }
 
-    pub fn load_fastpath_input_objects(
-        &self,
-        effects: &TransactionEffects,
-    ) -> SuiResult<Vec<Object>> {
-        // Note: any future addition to the returned object list needs cautions
-        // to make sure not to mess up object pruning.
-
-        let clock_ref = effects
-            .input_shared_objects()
-            .into_iter()
-            .find(|(obj_ref, _)| obj_ref.0.is_clock())
-            .map(|(obj_ref, _)| obj_ref);
-
-        if let Some((id, version, digest)) = clock_ref {
-            let clock_obj = self.database.get_object_by_key(&id, version)?;
-            debug_assert!(clock_obj.is_some());
-            debug_assert_eq!(
-                clock_obj.as_ref().unwrap().compute_object_reference().2,
-                digest
-            );
-            Ok(clock_obj
-                .tap_none(|| error!("Clock object not found: {:?}", clock_ref))
-                .into_iter()
-                .collect())
-        } else {
-            Ok(vec![])
-        }
-    }
-
     fn check_protocol_version(
         supported_protocol_versions: SupportedProtocolVersions,
         current_version: ProtocolVersion,

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -148,7 +148,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
             return Ok(HandleCertificateResponseV2 {
                 signed_effects: response.signed_effects,
                 events: response.events,
-                fastpath_input_objects: vec![],
+                fastpath_input_objects: vec![], // fastpath is unused for now
             });
         }
         response.map_err(Into::into)

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -190,11 +190,11 @@ impl LocalAuthorityClient {
                 error: "Mock error after handle_confirmation_transaction".to_owned(),
             });
         }
-        let fastpath_input_objects = state.load_fastpath_input_objects(&signed_effects)?;
+
         Ok(HandleCertificateResponseV2 {
             signed_effects,
             events,
-            fastpath_input_objects,
+            fastpath_input_objects: vec![],
         })
     }
 }


### PR DESCRIPTION
## Description 

- Reenable local execution for transactions with shared input objects.
- Remove unused code for input object fast path.

## Test Plan 

CI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
