### PR TITLE
[wallet-ext] - update copy / explorer link UI for accounts

### DIFF
--- a/apps/wallet/src/ui/app/components/IconButton.tsx
+++ b/apps/wallet/src/ui/app/components/IconButton.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type VariantProps, cva } from 'class-variance-authority';
+import { ButtonOrLink, type ButtonOrLinkProps } from '../shared/utils/ButtonOrLink';
+
+interface IconButtonProps extends ButtonOrLinkProps, VariantProps<typeof buttonStyles> {
+	icon: JSX.Element;
+}
+
+const buttonStyles = cva(
+	[
+		'flex items-center rounded-sm bg-transparent border-0 p-0 text-steel-dark hover:text-hero cursor-pointer',
+	],
+	{
+		variants: {
+			variant: {
+				transparent: '',
+				subtle: 'hover:bg-hero-darkest/10',
+			},
+		},
+		defaultVariants: {
+			variant: 'subtle',
+		},
+	},
+);
+
+export function IconButton({ onClick, icon, variant, ...buttonOrLinkProps }: IconButtonProps) {
+	return (
+		<ButtonOrLink
+			onClick={onClick}
+			className={buttonStyles({ variant })}
+			children={icon}
+			{...buttonOrLinkProps}
+		/>
+	);
+}

--- a/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
@@ -26,7 +26,7 @@ export function AccountListItem({ account }: AccountListItemProps) {
 		<AccountItem
 			icon={<AccountIcon account={account} />}
 			name={account.nickname || domainName || formatAddress(account.address)}
-			selected={account.address === activeAccount?.address}
+			isActiveAccount={account.address === activeAccount?.address}
 			after={
 				<div className="ml-auto">
 					<div className="flex items-center justify-center">

--- a/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
@@ -21,7 +21,6 @@ export function AccountMultiSelectItem({ account, state }: AccountMultiSelectIte
 		<ToggleGroup.Item asChild value={account.id}>
 			<AccountItem
 				name={account.nickname ?? domainName ?? formatAddress(account.address)}
-				/* todo: implement account icon */
 				address={account.address}
 				disabled={state === 'disabled'}
 				selected={state === 'selected'}

--- a/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
@@ -38,7 +38,7 @@ export function AccountsList() {
 	if (!accounts || !activeAccount) return null;
 
 	return (
-		<div className="bg-gradients-graph-cards flex flex-col rounded-xl p-4 gap-5 border border-solid border-hero/10 w-full">
+		<div className="bg-gradients-graph-cards flex flex-col rounded-xl p-4 gap-5 border border-solid border-hero/10 w-full select-none">
 			<Heading variant="heading5" weight="semibold" color="steel-darker">
 				Accounts
 			</Heading>

--- a/apps/wallet/src/ui/app/hooks/useExplorerLink.ts
+++ b/apps/wallet/src/ui/app/hooks/useExplorerLink.ts
@@ -16,7 +16,7 @@ import { ExplorerLinkType } from '../components/explorer-link/ExplorerLinkType';
 export type ExplorerLinkConfig =
 	| {
 			type: ExplorerLinkType.address;
-			address: string;
+			address?: string;
 			useActiveAddress?: false;
 	  }
 	| {
@@ -48,6 +48,7 @@ export function useExplorerLink(linkConfig: ExplorerLinkConfig) {
 	// fallback to localhost if customRPC is not set
 	const customRPCUrl = customRPC || 'http://localhost:3000/';
 	return useMemo(() => {
+		if (!address) return null;
 		switch (type) {
 			case ExplorerLinkType.address:
 				return address && getAddressUrl(address, selectedApiEnv, customRPCUrl);

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -67,8 +67,8 @@ export function AccountGroup({
 	const createAccountMutation = useCreateAccountsMutation();
 	const showCreateNewButton = type === 'mnemonic-derived';
 	return (
-		<CollapsiblePrimitive.Root defaultOpen={true} asChild>
-			<div className="flex flex-col gap-4 h-full w-full ">
+		<CollapsiblePrimitive.Root defaultOpen asChild>
+			<div className="flex flex-col gap-4 w-full">
 				<CollapsiblePrimitive.Trigger asChild>
 					<div className="flex gap-2 w-full items-center justify-center cursor-pointer flex-shrink-0 group [&>*]:select-none">
 						<ArrowBgFill16 className="h-4 w-4 group-data-[state=open]:rotate-90 text-hero-darkest/20" />


### PR DESCRIPTION
## Description 

Updates the accounts list UI to match the latest designs for copying to clipboard and links out to Explorer.



https://github.com/MystenLabs/sui/assets/122397493/cc61ca84-0338-480c-abdc-1bd8b529804e





## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
