### PR TITLE
[cli] change display output for addresses and dynamic field in the Sui CLI client command

### DIFF
--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -83,6 +83,15 @@ pub enum DynamicFieldType {
     DynamicObject,
 }
 
+impl Display for DynamicFieldType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DynamicFieldType::DynamicField => write!(f, "DynamicField"),
+            DynamicFieldType::DynamicObject => write!(f, "DynamicObject"),
+        }
+    }
+}
+
 impl DynamicFieldInfo {
     pub fn is_dynamic_field(tag: &StructTag) -> bool {
         tag.address == SUI_FRAMEWORK_ADDRESS

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -127,8 +127,9 @@ async fn handle_command(
     // TODO: Completion data are keyed by strings, are there ways to make it more error proof?
     if let Ok(mut cache) = completion_cache.write() {
         match result {
-            SuiClientCommandResult::Addresses(ref addresses, _) => {
+            SuiClientCommandResult::Addresses(ref addresses) => {
                 let addresses = addresses
+                    .addresses
                     .iter()
                     .map(|addr| format!("{addr}"))
                     .collect::<Vec<_>>();


### PR DESCRIPTION
## Description 

This PR implements the structured output (table with header and rows) for two Sui CLI commands, `sui client addresses` and `sui client dynamic-field`. 

## Test Plan 

Manual tests by running the commands.

![Screenshot 2023-09-01 at 2 33 10 PM](https://github.com/MystenLabs/sui/assets/135084671/94b4f8cb-1b3b-4f10-9b63-684900ff9f7e)

![image](https://github.com/MystenLabs/sui/assets/135084671/15a13c2c-7738-42fb-88eb-143eb8fa45d3)



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR implements the structured output (table with header and rows) for two Sui CLI commands, `sui client addresses` and `sui client dynamic-field`.