### PR TITLE
[example/swap] Port trusted_swap.move

### DIFF
--- a/examples/sui-move/trusted_swap/Move.toml
+++ b/examples/sui-move/trusted_swap/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "trusted_swap"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+trusted_swap = "0x0"

--- a/examples/sui-move/trusted_swap/sources/example.move
+++ b/examples/sui-move/trusted_swap/sources/example.move
@@ -1,0 +1,167 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module trusted_swap::example {
+    use sui::balance::{Self, Balance};
+    use sui::coin::{Self, Coin};
+    use sui::object::{Self, UID};
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Object has key, store {
+        id: UID,
+        scarcity: u8,
+        style: u8,
+    }
+
+    struct SwapRequest has key {
+        id: UID,
+        owner: address,
+        object: Object,
+        fee: Balance<SUI>,
+    }
+
+    // === Errors ===
+
+    /// Fee is too low for the service
+    const EFeeTooLow: u64 = 0;
+
+    /// The two swap requests are not compatible
+    const EBadSwap: u64 = 1;
+
+    // === Constants ===
+
+    const MIN_FEE: u64 = 1000;
+
+    // === Public Functions ===
+
+    public fun new(scarcity: u8, style: u8, ctx: &mut TxContext): Object {
+        Object { id: object::new(ctx), scarcity, style }
+    }
+
+    /// Anyone who owns an `Object` can make it available for swapping, which
+    /// sends a `SwapRequest` to a `service` responsible for matching swaps.
+    public fun request_swap(
+        object: Object,
+        fee: Coin<SUI>,
+        service: address,
+        ctx: &mut TxContext,
+    ) {
+        assert!(coin::value(&fee) >= MIN_FEE, EFeeTooLow);
+
+        let request = SwapRequest {
+            id: object::new(ctx),
+            owner: tx_context::sender(ctx),
+            object,
+            fee: coin::into_balance(fee),
+        };
+
+        transfer::transfer(request, service)
+    }
+
+    /// When the service has two swap requests, it can execute them, sending the
+    /// objects to the respective owners and taking its fee.
+    public fun execute_swap(s1: SwapRequest, s2: SwapRequest,): Balance<SUI> {
+        let SwapRequest {id: id1, owner: owner1, object: o1, fee: fee1} = s1;
+        let SwapRequest {id: id2, owner: owner2, object: o2, fee: fee2} = s2;
+
+        assert!(o1.scarcity == o2.scarcity, EBadSwap);
+        assert!(o1.style != o2.style, EBadSwap);
+
+        // Perform the swap
+        transfer::transfer(o1, owner2);
+        transfer::transfer(o2, owner1);
+
+        // Delete the wrappers
+        object::delete(id1);
+        object::delete(id2);
+
+        // Take the fee and return it
+        balance::join(&mut fee1, fee2);
+        fee1
+    }
+
+    // === Tests ===
+    use sui::test_scenario as ts;
+
+    #[test]
+    fun successful_swap() {
+        let ts = ts::begin(@0xA);
+        let o1 = new(1, 0, ts::ctx(&mut ts));
+        let i1 = object::id(&o1);
+        let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xB);
+        let o2 = new(1, 1, ts::ctx(&mut ts));
+        let i2 = object::id(&o2);
+        let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xC);
+        let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let fee = execute_swap(s1, s2);
+
+        ts::next_tx(&mut ts, @0x0);
+        assert!(ts::ids_for_address<Object>(@0xA) == vector[i2], 0);
+        assert!(ts::ids_for_address<Object>(@0xB) == vector[i1], 0);
+        assert!(balance::value(&fee) == MIN_FEE * 2, 0);
+
+        balance::destroy_for_testing(fee);
+        ts::end(ts);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EFeeTooLow)]
+    fun swap_too_cheap() {
+        let ts = ts::begin(@0xA);
+        let o1 = new(1, 0, ts::ctx(&mut ts));
+        let c1 = coin::mint_for_testing<SUI>(MIN_FEE - 1, ts::ctx(&mut ts));
+        request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EBadSwap)]
+    fun swap_different_scarcity() {
+        let ts = ts::begin(@0xA);
+        let o1 = new(1, 0, ts::ctx(&mut ts));
+        let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xB);
+        let o2 = new(0, 1, ts::ctx(&mut ts));
+        let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xC);
+
+        let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let _fee = execute_swap(s1, s2);
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EBadSwap)]
+    fun swap_same_style() {
+        let ts = ts::begin(@0xA);
+        let o1 = new(1, 0, ts::ctx(&mut ts));
+        let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xB);
+        let o2 = new(1, 0, ts::ctx(&mut ts));
+        let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
+        request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+
+        ts::next_tx(&mut ts, @0xC);
+
+        let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+        let _fee = execute_swap(s1, s2);
+        abort 1337
+    }
+}

--- a/examples/sui-move/trusted_swap/sources/example.move
+++ b/examples/sui-move/trusted_swap/sources/example.move
@@ -91,42 +91,45 @@ module trusted_swap::example {
     #[test]
     fun successful_swap() {
         let ts = ts::begin(@0x0);
+        let alice = @0xA;
+        let bob = @0xB;
+        let custodian = @0xC;
 
         let i1 = {
-            ts::next_tx(&mut ts, @0xA);
+            ts::next_tx(&mut ts, alice);
             let o1 = new(1, 0, ts::ctx(&mut ts));
             let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
             let i = object::id(&o1);
-            request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+            request_swap(o1, c1, custodian, ts::ctx(&mut ts));
             i
         };
 
         let i2 = {
-            ts::next_tx(&mut ts, @0xB);
+            ts::next_tx(&mut ts, bob);
             let o2 = new(1, 1, ts::ctx(&mut ts));
             let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
             let i = object::id(&o2);
-            request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+            request_swap(o2, c2, custodian, ts::ctx(&mut ts));
             i
         };
 
         {
-            ts::next_tx(&mut ts, @0xC);
+            ts::next_tx(&mut ts, custodian);
             let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
             let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
 
             let bal = execute_swap(s1, s2);
             let fee = coin::from_balance(bal, ts::ctx(&mut ts));
 
-            transfer::public_transfer(fee, @0xC);
+            transfer::public_transfer(fee, custodian);
         };
 
         {
-            ts::next_tx(&mut ts, @0xC);
+            ts::next_tx(&mut ts, custodian);
             let fee: Coin<SUI> = ts::take_from_sender(&ts);
 
-            assert!(ts::ids_for_address<Object>(@0xA) == vector[i2], 0);
-            assert!(ts::ids_for_address<Object>(@0xB) == vector[i1], 0);
+            assert!(ts::ids_for_address<Object>(alice) == vector[i2], 0);
+            assert!(ts::ids_for_address<Object>(bob) == vector[i1], 0);
             assert!(coin::value(&fee) == MIN_FEE * 2, 0);
 
             ts::return_to_sender(&ts, fee);
@@ -138,10 +141,13 @@ module trusted_swap::example {
     #[test]
     #[expected_failure(abort_code = EFeeTooLow)]
     fun swap_too_cheap() {
-        let ts = ts::begin(@0xA);
+        let alice = @0xA;
+        let custodian = @0xC;
+
+        let ts = ts::begin(alice);
         let o1 = new(1, 0, ts::ctx(&mut ts));
         let c1 = coin::mint_for_testing<SUI>(MIN_FEE - 1, ts::ctx(&mut ts));
-        request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+        request_swap(o1, c1, custodian, ts::ctx(&mut ts));
 
         abort 1337
     }
@@ -150,23 +156,26 @@ module trusted_swap::example {
     #[expected_failure(abort_code = EBadSwap)]
     fun swap_different_scarcity() {
         let ts = ts::begin(@0x0);
+        let alice = @0xA;
+        let bob = @0xB;
+        let custodian = @0xC;
 
         {
-            ts::next_tx(&mut ts, @0xA);
+            ts::next_tx(&mut ts, alice);
             let o1 = new(1, 0, ts::ctx(&mut ts));
             let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
-            request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+            request_swap(o1, c1, custodian, ts::ctx(&mut ts));
         };
 
         {
-            ts::next_tx(&mut ts, @0xB);
+            ts::next_tx(&mut ts, bob);
             let o2 = new(0, 1, ts::ctx(&mut ts));
             let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
-            request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+            request_swap(o2, c2, custodian, ts::ctx(&mut ts));
         };
 
         {
-            ts::next_tx(&mut ts, @0xC);
+            ts::next_tx(&mut ts, custodian);
             let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
             let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
             let _fee = execute_swap(s1, s2);
@@ -179,23 +188,26 @@ module trusted_swap::example {
     #[expected_failure(abort_code = EBadSwap)]
     fun swap_same_style() {
         let ts = ts::begin(@0x0);
+        let alice = @0xA;
+        let bob = @0xB;
+        let custodian = @0xC;
 
         {
-            ts::next_tx(&mut ts, @0xA);
+            ts::next_tx(&mut ts, alice);
             let o1 = new(1, 0, ts::ctx(&mut ts));
             let c1 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
-            request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+            request_swap(o1, c1, custodian, ts::ctx(&mut ts));
         };
 
         {
-            ts::next_tx(&mut ts, @0xB);
+            ts::next_tx(&mut ts, bob);
             let o2 = new(1, 0, ts::ctx(&mut ts));
             let c2 = coin::mint_for_testing<SUI>(MIN_FEE, ts::ctx(&mut ts));
-            request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
+            request_swap(o2, c2, custodian, ts::ctx(&mut ts));
         };
 
         {
-            ts::next_tx(&mut ts, @0xC);
+            ts::next_tx(&mut ts, custodian);
             let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
             let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
             let _fee = execute_swap(s1, s2);

--- a/examples/sui-move/trusted_swap/sources/example.move
+++ b/examples/sui-move/trusted_swap/sources/example.move
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Executing a swap of two objects via a third party, using object wrapping to
+/// hand ownership of the objects to swap to the third party without giving them
+/// the ability to modify those objects.
 module trusted_swap::example {
     use sui::balance::{Self, Balance};
     use sui::coin::{Self, Coin};
@@ -62,7 +65,7 @@ module trusted_swap::example {
 
     /// When the service has two swap requests, it can execute them, sending the
     /// objects to the respective owners and taking its fee.
-    public fun execute_swap(s1: SwapRequest, s2: SwapRequest,): Balance<SUI> {
+    public fun execute_swap(s1: SwapRequest, s2: SwapRequest): Balance<SUI> {
         let SwapRequest {id: id1, owner: owner1, object: o1, fee: fee1} = s1;
         let SwapRequest {id: id2, owner: owner2, object: o2, fee: fee2} = s2;
 
@@ -120,6 +123,7 @@ module trusted_swap::example {
         let o1 = new(1, 0, ts::ctx(&mut ts));
         let c1 = coin::mint_for_testing<SUI>(MIN_FEE - 1, ts::ctx(&mut ts));
         request_swap(o1, c1, @0xC, ts::ctx(&mut ts));
+
         abort 1337
     }
 
@@ -137,10 +141,10 @@ module trusted_swap::example {
         request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
 
         ts::next_tx(&mut ts, @0xC);
-
         let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
         let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
         let _fee = execute_swap(s1, s2);
+
         abort 1337
     }
 
@@ -158,10 +162,10 @@ module trusted_swap::example {
         request_swap(o2, c2, @0xC, ts::ctx(&mut ts));
 
         ts::next_tx(&mut ts, @0xC);
-
         let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
         let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
         let _fee = execute_swap(s1, s2);
+
         abort 1337
     }
 }


### PR DESCRIPTION
##  Description

Original: ./sui_programmability/examples/objects_tutorial/sources/trusted_swap.move

Porting and modernising example used in "object wrapping" documentation, with the following changes:

- Moved into an isolated move package.
- Remove use of `public entry`
- Avoid transfer-to-sender pattern where possible (e.g. creating a new object and returning the fee to the service).
- Use named error codes.
- Add unit tests that will get run during CI.
- Rename `ObjectWrapper` to `SwapRequest`.

## Test Plan

New unit tests:

```
sui move test trusted_swaps
```