### PR TITLE
Limit number of pacakges/upgrades in a single transaction block

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1718,6 +1718,7 @@
                 "max_programmable_tx_commands": {
                   "u32": "1024"
                 },
+                "max_publish_or_upgrade_per_ptb": null,
                 "max_pure_argument_size": {
                   "u32": "16384"
                 },

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
@@ -41,6 +41,7 @@ max_programmable_tx_commands: 1024
 move_binary_format_version: 6
 max_move_object_size: 256000
 max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_23.snap
@@ -46,6 +46,7 @@ max_programmable_tx_commands: 1024
 move_binary_format_version: 6
 max_move_object_size: 256000
 max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_23.snap
@@ -47,6 +47,7 @@ max_programmable_tx_commands: 1024
 move_binary_format_version: 6
 max_move_object_size: 256000
 max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -238,6 +238,13 @@ pub enum UserInputError {
         object_id
     )]
     InaccessibleSystemObject { object_id: ObjectID },
+    #[error(
+        "{max_publish_commands} max publish/upgrade commands allowed, {publish_count} provided"
+    )]
+    MaxPublishCountExceeded {
+        max_publish_commands: u64,
+        publish_count: u64,
+    },
 }
 
 #[derive(

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -658,8 +658,22 @@ impl ProgrammableTransaction {
         for input in inputs {
             input.validity_check(config)?
         }
+        let mut publish_count = 0u64;
         for command in commands {
-            command.validity_check(config)?
+            command.validity_check(config)?;
+            match command {
+                Command::Publish(_, _) | Command::Upgrade(_, _, _, _) => publish_count += 1,
+                _ => (),
+            }
+        }
+        if let Some(max_publish_commands) = config.max_publish_or_upgrade_per_ptb_as_option() {
+            fp_ensure!(
+                publish_count <= max_publish_commands,
+                UserInputError::MaxPublishCountExceeded {
+                    max_publish_commands,
+                    publish_count,
+                }
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
## Description 

There is no point in having a significant number of publish/upgrade in a single transaction block.
Cost will be higher after a relatively low number because of memory compound effects and tracking upgrade caps/packages will be harder.
So we are adding a protocol config controllable cap to the number of publish/upgrades per PTB

## Test Plan 

New tests added for publish, upgrade and mixed

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
