### PR TITLE
Revert "[Narwhal] wait to cancel header proposal after higher round c…

### DIFF
--- a/narwhal/primary/src/certifier.rs
+++ b/narwhal/primary/src/certifier.rs
@@ -11,8 +11,6 @@ use futures::StreamExt;
 use mysten_metrics::metered_channel::Receiver;
 use mysten_metrics::{monitored_future, spawn_logged_monitored_task};
 use network::anemo_ext::NetworkExt;
-use parking_lot::Mutex;
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 use storage::CertificateStore;
@@ -26,7 +24,7 @@ use types::{
     ensure,
     error::{DagError, DagResult},
     Certificate, CertificateDigest, ConditionalBroadcastReceiver, Header, HeaderAPI,
-    PrimaryToPrimaryClient, RequestVoteRequest, Round, Vote, VoteAPI,
+    PrimaryToPrimaryClient, RequestVoteRequest, Vote, VoteAPI,
 };
 
 #[cfg(test)]
@@ -53,8 +51,9 @@ pub struct Certifier {
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Receives our newly created headers from the `Proposer`.
     rx_headers: Receiver<Header>,
-    /// Used to cancel vote requests for proposing header that are no longer needed.
-    cancel_proposing_headers: Arc<Mutex<VecDeque<(Round, oneshot::Sender<()>)>>>,
+    /// Used to cancel vote requests for a previously-proposed header that is being replaced
+    /// before a certificate could be formed.
+    cancel_proposed_header: Option<oneshot::Sender<()>>,
     /// Handle to propose_header task. Our target is to have only one task running always, thus
     /// we cancel the previously running before we spawn the next one. However, we don't wait for
     /// the previous to finish to spawn the new one, so we might temporarily have more that one
@@ -90,7 +89,7 @@ impl Certifier {
                     signature_service,
                     rx_shutdown,
                     rx_headers,
-                    cancel_proposing_headers: Default::default(),
+                    cancel_proposed_header: None,
                     propose_header_tasks: JoinSet::new(),
                     network: primary_network,
                     metrics,
@@ -243,7 +242,6 @@ impl Certifier {
         metrics: Arc<PrimaryMetrics>,
         network: anemo::Network,
         header: Header,
-        cancel_proposing_headers: Arc<Mutex<VecDeque<(Round, oneshot::Sender<()>)>>>,
         mut cancel: oneshot::Receiver<()>,
     ) -> DagResult<Certificate> {
         if header.epoch() != committee.epoch() {
@@ -332,15 +330,6 @@ impl Certifier {
         })?;
         debug!("Assembled {certificate:?}");
 
-        let mut cancel_proposing_headers = cancel_proposing_headers.lock();
-        while let Some(&(round, _)) = cancel_proposing_headers.front() {
-            if round > header.round() {
-                break;
-            }
-            let (_round, sender) = cancel_proposing_headers.pop_front().unwrap();
-            let _ = sender.send(());
-        }
-
         Ok(certificate)
     }
 
@@ -373,16 +362,10 @@ impl Certifier {
                 // TODO: move logic into Proposer.
                 Some(header) = self.rx_headers.recv() => {
                     let (tx_cancel, rx_cancel) = oneshot::channel();
-                    {
-                        let mut cancel_proposing_headers = self.cancel_proposing_headers.lock();
-                        cancel_proposing_headers.push_back((header.round(), tx_cancel));
-
-                        const MAX_PROPOSING_HEADERS: usize = 3;
-                        while cancel_proposing_headers.len() > MAX_PROPOSING_HEADERS {
-                            let (_round, sender) = cancel_proposing_headers.pop_front().unwrap();
-                            let _ = sender.send(());
-                        }
+                    if let Some(cancel) = self.cancel_proposed_header {
+                        let _ = cancel.send(());
                     }
+                    self.cancel_proposed_header = Some(tx_cancel);
 
                     let name = self.authority_id;
                     let committee = self.committee.clone();
@@ -390,7 +373,6 @@ impl Certifier {
                     let signature_service = self.signature_service.clone();
                     let metrics = self.metrics.clone();
                     let network = self.network.clone();
-                    let cancel_proposing_headers = self.cancel_proposing_headers.clone();
                     fail_point_async!("narwhal-delay");
                     self.propose_header_tasks.spawn(monitored_future!(Self::propose_header(
                         name,
@@ -400,7 +382,6 @@ impl Certifier {
                         metrics,
                         network,
                         header,
-                        cancel_proposing_headers,
                         rx_cancel,
                     )));
                     Ok(())

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -809,7 +809,7 @@ impl PrimaryReceiverHandler {
         // certificates to still have a chance to be included in the DAG while not wasting
         // resources on very old vote requests. This value affects performance but not correctness
         // of the algorithm.
-        const HEADER_AGE_LIMIT: Round = 5;
+        const HEADER_AGE_LIMIT: Round = 3;
 
         // Lock to ensure consistency between limit_round and where parent_digests are gc'ed.
         let mut parent_digests = self.parent_digests.lock();

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{rpc::Status, Network, Request, Response};
-use config::{AuthorityIdentifier, Committee, Epoch, Stake, WorkerCache};
+use config::{AuthorityIdentifier, Committee, Epoch, WorkerCache};
 use consensus::consensus::ConsensusRound;
 use crypto::NetworkPublicKey;
 use fastcrypto::hash::Hash as _;
@@ -361,37 +361,11 @@ impl Synchronizer {
         let inner_proposer = inner.clone();
         spawn_logged_monitored_task!(
             async move {
-                let highest_round_number = inner_proposer.certificate_store.highest_round_number();
-                let mut certificates = vec![];
-                // The last or last 2 rounds are sufficient for recovery.
-                for i in 0..2 {
-                    let round = highest_round_number - i;
-                    // Do not recover genesis certificates. They are initialized into certificate
-                    // aggregator already.
-                    if round == 0 {
-                        break;
-                    }
-                    let round_certs = inner_proposer
-                        .certificate_store
-                        .at_round(round)
-                        .expect("Failed recovering certificates in primary core");
-                    let stake: Stake = round_certs
-                        .iter()
-                        .map(|c: &Certificate| inner_proposer.committee.stake_by_id(c.origin()))
-                        .sum();
-                    certificates.extend(round_certs.into_iter());
-                    // If a round has a quorum of certificates, enough have recovered because
-                    // a header can be proposed with these parents.
-                    if stake >= inner_proposer.committee.quorum_threshold() {
-                        break;
-                    } else {
-                        // Only the last round can have less than a quorum of stake.
-                        assert_eq!(i, 0);
-                    }
-                }
-                // Unnecessary to append certificates in ascending round order, but it doesn't
-                // hurt either.
-                for certificate in certificates.into_iter().rev() {
+                let last_round_certificates = inner_proposer
+                    .certificate_store
+                    .last_two_rounds_certs()
+                    .expect("Failed recovering certificates in primary core");
+                for certificate in last_round_certificates {
                     if let Err(e) = inner_proposer
                         .append_certificate_in_aggregator(certificate)
                         .await
@@ -722,6 +696,20 @@ impl Synchronizer {
             .highest_received_round
             .with_label_values(&[certificate_source])
             .set(highest_received_round as i64);
+
+        // Let the proposer draw early conclusions from a certificate at this round and epoch, without its
+        // parents or payload (which we may not have yet).
+        //
+        // Since our certificate is well-signed, it shows a majority of honest signers stand at round r,
+        // so to make a successful proposal, our proposer must use parents at least at round r-1.
+        //
+        // This allows the proposer not to fire proposals at rounds strictly below the certificate we witnessed.
+        let minimal_round_for_parents = certificate.round().saturating_sub(1);
+        self.inner
+            .tx_parents
+            .send((vec![], minimal_round_for_parents, certificate.epoch()))
+            .await
+            .map_err(|_| DagError::ShuttingDown)?;
 
         // Instruct workers to download any missing batches referenced in this certificate.
         // Since this header got certified, we are sure that all the data it refers to (ie. its batches and its parents) are available.

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -534,10 +534,13 @@ impl<T: Cache> CertificateStore<T> {
     /// Retrieves all the certificates with round >= the provided round.
     /// The result is returned with certificates sorted in round asc order
     pub fn after_round(&self, round: Round) -> StoreResult<Vec<Certificate>> {
-        // Restrict the scan to at or after the requested round.
-        let iter = self
-            .certificate_id_by_round
-            .iter_with_bounds(Some((round, AuthorityIdentifier(0))), None);
+        // Skip to a row at or before the requested round.
+        // TODO: Add a more efficient seek method to typed store.
+        let mut iter = self.certificate_id_by_round.unbounded_iter();
+        if round > 0 {
+            iter = iter.skip_to(&(round - 1, AuthorityIdentifier::default()))?;
+        }
+
         let mut digests = Vec::new();
         for ((r, _), d) in iter {
             match r.cmp(&round) {
@@ -545,7 +548,7 @@ impl<T: Cache> CertificateStore<T> {
                     digests.push(d);
                 }
                 Ordering::Less => {
-                    unreachable!("Failed to specify start range. Round {}", round);
+                    continue;
                 }
             }
         }
@@ -587,41 +590,43 @@ impl<T: Cache> CertificateStore<T> {
         Ok(result)
     }
 
-    /// Retrieves the certificates at the specified round.
-    pub fn at_round(&self, round: Round) -> StoreResult<Vec<Certificate>> {
-        // Restrict the scan to at or after the requested round.
-        let iter = self.certificate_id_by_round.iter_with_bounds(
-            Some((round, AuthorityIdentifier(0))),
-            Some((round + 1, AuthorityIdentifier(0))),
-        );
-        let mut digests = Vec::new();
-        for ((r, _), d) in iter {
-            match r.cmp(&round) {
-                Ordering::Greater => {
-                    unreachable!("Failed to specify end range. Round {}", round);
-                }
-                Ordering::Equal => {
-                    digests.push(d);
-                }
-                Ordering::Less => {
-                    unreachable!("Failed to specify start range. Round {}", round);
-                }
+    /// Retrieves the certificates of the last round and the round before that
+    pub fn last_two_rounds_certs(&self) -> StoreResult<Vec<Certificate>> {
+        // starting from the last element - hence the last round - move backwards until
+        // we find certificates of different round.
+        let certificates_reverse = self
+            .certificate_id_by_round
+            .unbounded_iter()
+            .skip_to_last()
+            .reverse();
+
+        let mut round = 0;
+        let mut certificates = Vec::new();
+
+        for (key, digest) in certificates_reverse {
+            let (certificate_round, _certificate_origin) = key;
+
+            // We treat zero as special value (round unset) in order to
+            // capture the last certificate's round.
+            // We are now in a round less than the previous so we want to
+            // stop consuming
+            if round == 0 {
+                round = certificate_round;
+            } else if certificate_round < round - 1 {
+                break;
             }
+
+            let certificate = self.certificates_by_id.get(&digest)?.ok_or_else(|| {
+                RocksDBError(format!(
+                    "Certificate with id {} not found in main storage although it should",
+                    digest
+                ))
+            })?;
+
+            certificates.push(certificate);
         }
 
-        // Fetch all those certificates from main storage, return an error if any one is missing.
-        self.certificates_by_id
-            .multi_get(digests.clone())?
-            .into_iter()
-            .map(|opt_cert| {
-                opt_cert.ok_or_else(|| {
-                    RocksDBError(format!(
-                        "Certificate with some digests not found, CertificateStore invariant violation: {:?}",
-                        digests
-                    ))
-                })
-            })
-            .collect()
+        Ok(certificates)
     }
 
     /// Retrieves the last certificate of the given origin.
@@ -927,7 +932,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_last_round() {
+    async fn test_last_two_rounds() {
         // GIVEN
         let store = new_store(temp_dir());
 
@@ -939,7 +944,7 @@ mod test {
         store.write_all(certs).unwrap();
 
         // WHEN
-        let result = store.at_round(50).unwrap();
+        let result = store.last_two_rounds_certs().unwrap();
         let last_round_cert = store.last_round(origin).unwrap().unwrap();
         let last_round_number = store.last_round_number(origin).unwrap().unwrap();
         let last_round_number_not_exist =
@@ -947,12 +952,15 @@ mod test {
         let highest_round_number = store.highest_round_number();
 
         // THEN
-        assert_eq!(result.len(), 4);
+        assert_eq!(result.len(), 8);
         assert_eq!(last_round_cert.round(), 50);
         assert_eq!(last_round_number, 50);
         assert_eq!(highest_round_number, 50);
         for certificate in result {
-            assert_eq!(certificate.round(), last_round_number);
+            assert!(
+                (certificate.round() == last_round_number)
+                    || (certificate.round() == last_round_number - 1)
+            );
         }
         assert!(last_round_number_not_exist.is_none());
     }
@@ -963,7 +971,7 @@ mod test {
         let store = new_store(temp_dir());
 
         // WHEN
-        let result = store.at_round(1).unwrap();
+        let result = store.last_two_rounds_certs().unwrap();
         let last_round_cert = store.last_round(AuthorityIdentifier::default()).unwrap();
         let last_round_number = store
             .last_round_number(AuthorityIdentifier::default())


### PR DESCRIPTION
…ertificates have been created (#13002)"

This reverts commit 52a6e7b205b11456134e54980e6864a862ba0f0d.

## Description 

It seems this is causing increase in proposer batch latency and header resend rate:
<img width="1869" alt="Screenshot 2023-09-01 at 11 19 39 AM" src="https://github.com/MystenLabs/sui/assets/81660174/6da154a4-ee97-4305-8d8d-857b918d6a29">
<img width="1882" alt="Screenshot 2023-09-01 at 11 20 42 AM" src="https://github.com/MystenLabs/sui/assets/81660174/398d4680-dfd9-4e21-84c6-1e4c64e7ac2f">

The benefit to lower commit latency may not worth the potentially increased transaction latency at stragglers.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
