### PR TITLE
kvstore: add support for reading/writing transaction to checkpoint metadata

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4077,6 +4077,15 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
 
         Ok((summaries, contents, summaries_by_digest, contents_by_digest))
     }
+
+    async fn deprecated_get_transaction_checkpoint(
+        &self,
+        digest: TransactionDigest,
+    ) -> SuiResult<Option<CheckpointSequenceNumber>> {
+        self.database
+            .deprecated_get_transaction_checkpoint(&digest)
+            .map(|maybe| maybe.map(|(_epoch, checkpoint)| checkpoint))
+    }
 }
 
 #[cfg(msim)]

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -444,6 +444,11 @@ mod tests {
                 checkpoint_summaries_by_digest: &[CheckpointDigest],
                 checkpoint_contents_by_digest: &[CheckpointContentsDigest],
             ) -> SuiResult<KVStoreCheckpointData>;
+
+            async fn deprecated_get_transaction_checkpoint(
+                &self,
+                digest: TransactionDigest,
+            ) -> SuiResult<Option<CheckpointSequenceNumber>>;
         }
     }
 

--- a/crates/sui-kvstore/src/client.rs
+++ b/crates/sui-kvstore/src/client.rs
@@ -19,6 +19,7 @@ pub enum KVTable {
     Events,
     CheckpointContent,
     CheckpointSummary,
+    TransactionToCheckpoint,
     State,
 }
 
@@ -86,6 +87,7 @@ impl DynamoDbClient {
             KVTable::State => "state",
             KVTable::CheckpointContent => "cc",
             KVTable::CheckpointSummary => "cs",
+            KVTable::TransactionToCheckpoint => "tx2c",
         }
         .to_string()
     }

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -52,6 +52,7 @@ struct MockTxStore {
     checkpoint_contents: HashMap<CheckpointSequenceNumber, CheckpointContents>,
     checkpoint_summaries_by_digest: HashMap<CheckpointDigest, CertifiedCheckpointSummary>,
     checkpoint_contents_by_digest: HashMap<CheckpointContentsDigest, CheckpointContents>,
+    tx_to_checkpoint: HashMap<TransactionDigest, CheckpointSequenceNumber>,
 
     next_seq_number: u64,
 }
@@ -207,6 +208,13 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         }
 
         Ok((summaries, contents, summaries_by_digest, contents_by_digest))
+    }
+
+    async fn deprecated_get_transaction_checkpoint(
+        &self,
+        digest: TransactionDigest,
+    ) -> SuiResult<Option<CheckpointSequenceNumber>> {
+        Ok(self.tx_to_checkpoint.get(&digest).cloned())
     }
 }
 


### PR DESCRIPTION
## Description 

Adds support for reading/writing transaction to checkpoint metadata to kvstore. Please check that i've properly covered all the necessary pieces since this is my first time modifying this system.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
