### PR TITLE
Avoid object digest recomputation

### DIFF
--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -272,10 +272,10 @@ pub(crate) fn try_construct_object(
         }
     };
 
-    Ok(Object {
+    Ok(Object::new(
         data,
-        owner: store_object.owner,
-        previous_transaction: store_object.previous_transaction,
-        storage_rebate: store_object.storage_rebate,
-    })
+        store_object.owner,
+        store_object.previous_transaction,
+        store_object.storage_rebate,
+    ))
 }

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -638,18 +638,17 @@ impl TryInto<Object> for SuiObjectData {
                 "BCS data is required to convert SuiObjectData to Object"
             ))?,
         };
-        Ok(Object {
+        Ok(Object::new(
             data,
-            owner: self
-                .owner
+            self.owner
                 .ok_or_else(|| anyhow!("Owner is required to convert SuiObjectData to Object"))?,
-            previous_transaction: self.previous_transaction.ok_or_else(|| {
+            self.previous_transaction.ok_or_else(|| {
                 anyhow!("previous_transaction is required to convert SuiObjectData to Object")
             })?,
-            storage_rebate: self.storage_rebate.ok_or_else(|| {
+            self.storage_rebate.ok_or_else(|| {
                 anyhow!("storage_rebate is required to convert SuiObjectData to Object")
             })?,
-        })
+        ))
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -466,12 +466,7 @@ mod checked {
                 for genesis_object in objects {
                     match genesis_object {
                         sui_types::transaction::GenesisObject::RawObject { data, owner } => {
-                            let object = Object {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
+                            let object = Object::new(data, owner, tx_ctx.digest(), 0);
                             temporary_store.write_object(object, WriteKind::Create);
                         }
                     }

--- a/sui-execution/suivm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/suivm/sui-adapter/src/execution_engine.rs
@@ -466,12 +466,7 @@ mod checked {
                 for genesis_object in objects {
                     match genesis_object {
                         sui_types::transaction::GenesisObject::RawObject { data, owner } => {
-                            let object = Object {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
+                            let object = Object::new(data, owner, tx_ctx.digest(), 0);
                             temporary_store.write_object(object, WriteKind::Create);
                         }
                     }

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -401,12 +401,7 @@ mod checked {
                 for genesis_object in objects {
                     match genesis_object {
                         sui_types::transaction::GenesisObject::RawObject { data, owner } => {
-                            let object = Object {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
+                            let object = Object::new(data, owner, tx_ctx.digest(), 0);
                             temporary_store.write_object(object, WriteKind::Create);
                         }
                     }


### PR DESCRIPTION
## Description 

Add a lazily initialized digest field in Object.
This allows us to call object.digest() without thinking too much about the performance implication.
After this PR, we can then rename compute_object_reference() to something simpler. There will also be quite some code that we can clean up because in quite a few places we purposely coded it in a way to avoid recomputation of object digest.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
