### PR TITLE
wallet-ext: consistent extension ids across dev builds

### DIFF
--- a/apps/wallet/configs/webpack/webpack.config.common.ts
+++ b/apps/wallet/configs/webpack/webpack.config.common.ts
@@ -186,6 +186,11 @@ const commonConfig: () => Promise<Configuration> = async () => {
 								...walletVersionDetails,
 								name: APP_NAME,
 								description: packageJson.description,
+								...(IS_DEV
+									? {
+											key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2HTQu/66edl64fM/SKDnHJmCz9SIYqM/QK7NM3vD1LTE2UNXzHX5Clj8geuoWAYS6HE/aFcd//qPnAh8TnPgqTS3IX+IbZsY/+kcokxIEWHly3eKEHWB32tQsGdJx6tgDzx8TRkFZEcCCdE4pFqQO68W3I/+8AQPosdd5fsIoF6OGKZ/i29mpGkYJSmMroCN5zYCQqvpjTBIkiTkI9TTjxmBid77pHyG4TsHz0wda4KxHV9ZtzZQXB4vexTku/Isczdtif7pDqFEDCAqEkpiGPyKoIuqrxc75IfpzIGFsIylycBr0fZellSsl2M6FM34R99/vUrGj5iWcjNmhYvZ8QIDAQAB',
+									  }
+									: undefined),
 							};
 							return JSON.stringify(manifestJson, null, 4);
 						},


### PR DESCRIPTION
## Description 

* every time wallet is built using NODE_ENV='development', manifest will use a specific public key to make the extension id be the same across devices/installs
* if we ever want to publish a dev build to chrome store we should make sure we remove this `key` field
* now id for dev should always be `iabmfhchcocfljednlcpgnijajedhecc`

NOTE: after this building the wallet in dev and installing it will create the above id, which is different than any existing one so it will be a fresh install

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
