### PR TITLE
Stop depending on tombstones

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1898,7 +1898,10 @@ impl ChildObjectResolver for AuthorityStore {
 }
 
 impl ParentSync for AuthorityStore {
-    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
         self.get_latest_object_ref_or_tombstone(object_id)
     }
 }

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -968,9 +968,7 @@ fn process_package(
         builder.command(Command::Publish(module_bytes, dependencies));
         builder.finish()
     };
-    let InnerTemporaryStore {
-        written, deleted, ..
-    } = executor.update_genesis_state(
+    let InnerTemporaryStore { written, .. } = executor.update_genesis_state(
         store.clone(),
         protocol_config,
         metrics,
@@ -980,7 +978,7 @@ fn process_package(
     )?;
 
     let store = Arc::get_mut(store).expect("only one reference to store");
-    store.finish(written, deleted);
+    store.finish(written);
 
     Ok(())
 }
@@ -1054,9 +1052,7 @@ pub fn generate_genesis_system_object(
         builder.finish()
     };
 
-    let InnerTemporaryStore {
-        written, deleted, ..
-    } = executor.update_genesis_state(
+    let InnerTemporaryStore { written, .. } = executor.update_genesis_state(
         store.clone(),
         &protocol_config,
         metrics,
@@ -1066,7 +1062,7 @@ pub fn generate_genesis_system_object(
     )?;
 
     let store = Arc::get_mut(store).expect("only one reference to store");
-    store.finish(written, deleted);
+    store.finish(written);
 
     Ok(())
 }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1715,7 +1715,10 @@ impl ChildObjectResolver for LocalExec {
 impl ParentSync for LocalExec {
     /// The objects here much already exist in the store because we downloaded them earlier
     /// No download from network
-    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
         fn inner(self_: &LocalExec, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
             if let Some(v) = self_.storage.live_objects_store.get(&object_id) {
                 return Ok(Some(v.compute_object_reference()));

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1125,8 +1125,11 @@ impl<'backing> ResourceResolver for TemporaryStore<'backing> {
 }
 
 impl<'backing> ParentSync for TemporaryStore<'backing> {
-    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
-        self.store.get_latest_parent_entry_ref(object_id)
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        _object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
+        unreachable!("Never called in newer protocol versions")
     }
 }
 

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -1125,8 +1125,11 @@ impl<'backing> ResourceResolver for TemporaryStore<'backing> {
 }
 
 impl<'backing> ParentSync for TemporaryStore<'backing> {
-    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
-        self.store.get_latest_parent_entry_ref(object_id)
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        _object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
+        unreachable!("Never called in newer protocol versions")
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -807,7 +807,9 @@ mod checked {
                         if protocol_config.simplified_unwrap_then_delete() {
                             DeleteKindWithOldVersion::UnwrapThenDelete
                         } else {
-                            let old_version = match state_view.get_latest_parent_entry_ref(id) {
+                            let old_version = match state_view
+                                .get_latest_parent_entry_ref_deprecated(id)
+                            {
                                 Ok(Some((_, previous_version, _))) => previous_version,
                                 // This object was not created this transaction but has never existed in
                                 // storage, skip it.

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -1090,8 +1090,11 @@ impl<'backing> ResourceResolver for TemporaryStore<'backing> {
 }
 
 impl<'backing> ParentSync for TemporaryStore<'backing> {
-    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
-        self.store.get_latest_parent_entry_ref(object_id)
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
+        self.store.get_latest_parent_entry_ref_deprecated(object_id)
     }
 }
 


### PR DESCRIPTION
## Description 

The ParentSync trait has an explicit dependency to tombstones as it also returns the tombstone as the result if it's the latest entry. Depending on this trait will make it impossible to prune tombstones.
Currently only sui-execution v0 still depends on it, and no other places should continue to depend on it.
This PR gets rid of such dependency except in sui-execution v0.
One thing I changed here which requires a close review is in the shared object lock assignment path, where I believe we shouldn't need to use parent sync.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
