### PR TITLE
wallet-ext: onboarding qredo accounts

### DIFF
--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -161,8 +161,16 @@ export class UiConnection extends Connection {
 					),
 				);
 			} else if (isQredoConnectPayload(payload, 'acceptQredoConnection')) {
-				await acceptQredoConnection(payload.args);
-				this.send(createMessage({ type: 'done' }, id));
+				this.send(
+					createMessage<QredoConnectPayload<'acceptQredoConnectionResponse'>>(
+						{
+							type: 'qredo-connect',
+							method: 'acceptQredoConnectionResponse',
+							args: { accounts: await acceptQredoConnection(payload.args) },
+						},
+						id,
+					),
+				);
 			} else if (isQredoConnectPayload(payload, 'rejectQredoConnection')) {
 				await rejectQredoConnection(payload.args);
 				this.send(createMessage({ type: 'done' }, id));

--- a/apps/wallet/src/background/qredo/index.ts
+++ b/apps/wallet/src/background/qredo/index.ts
@@ -18,7 +18,7 @@ import { Window } from '../Window';
 import { getQredoAccountSource } from '../account-sources';
 import { QredoAccountSource } from '../account-sources/QredoAccountSource';
 import { addNewAccounts } from '../accounts';
-import { type QredoSerializedAccount } from '../accounts/QredoAccount';
+import { type QredoAccount, type QredoSerializedAccount } from '../accounts/QredoAccount';
 import { type ContentScriptConnection } from '../connections/ContentScriptConnection';
 import { type QredoConnectInput } from '_src/dapp-interface/WalletStandardInterface';
 import { type Message } from '_src/shared/messaging/messages';
@@ -61,7 +61,7 @@ export async function requestUserApproval(
 				url: qredoConnectUrl,
 				windowID: existingPendingRequest.windowID || undefined,
 				match: ({ url, inAppRedirectUrl }) => {
-					const urlMatch = `/dapp/qredo-connect/${existingPendingRequest.id}`;
+					const urlMatch = `/accounts/qredo-connect/${existingPendingRequest.id}`;
 					return (
 						url.includes(urlMatch) || (!!inAppRedirectUrl && inAppRedirectUrl.includes(urlMatch))
 					);
@@ -238,10 +238,11 @@ export async function acceptQredoConnection({
 			nickname: null,
 		});
 	}
-	await addNewAccounts(newQredoAccounts);
+	const connectedAccounts = (await addNewAccounts(newQredoAccounts)) as QredoAccount[];
 	await deletePendingRequest(pendingRequest);
 	qredoEvents.emit('onConnectionResponse', {
 		allowed: true,
 		request: pendingRequest,
 	});
+	return Promise.all(connectedAccounts.map(async (anAccount) => await anAccount.toUISerialized()));
 }

--- a/apps/wallet/src/background/qredo/utils.ts
+++ b/apps/wallet/src/background/qredo/utils.ts
@@ -11,7 +11,7 @@ import {
 import { type QredoConnectInput } from '_src/dapp-interface/WalletStandardInterface';
 
 export function qredoConnectPageUrl(requestID: string) {
-	return `${Browser.runtime.getURL('ui.html')}#/dapp/qredo-connect/${encodeURIComponent(
+	return `${Browser.runtime.getURL('ui.html')}#/accounts/qredo-connect/${encodeURIComponent(
 		requestID,
 	)}`;
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/QredoConnect.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/QredoConnect.ts
@@ -3,6 +3,7 @@
 
 import { type BasePayload, isBasePayload } from './BasePayload';
 import { type Payload } from './Payload';
+import { type QredoSerializedUiAccount } from '_src/background/accounts/QredoAccount';
 import { type UIQredoInfo, type UIQredoPendingRequest } from '_src/background/qredo/types';
 import { type QredoConnectInput } from '_src/dapp-interface/WalletStandardInterface';
 import { type Wallet } from '_src/shared/qredo-api';
@@ -22,6 +23,7 @@ type Methods = {
 		accounts: Wallet[];
 		password: string;
 	};
+	acceptQredoConnectionResponse: { accounts: QredoSerializedUiAccount[] };
 	rejectQredoConnection: {
 		qredoID: string;
 	};

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -392,7 +392,15 @@ export class BackgroundClient {
 					method: 'acceptQredoConnection',
 					args,
 				}),
-			).pipe(take(1)),
+			).pipe(
+				take(1),
+				map(({ payload }) => {
+					if (isQredoConnectPayload(payload, 'acceptQredoConnectionResponse')) {
+						return payload.args.accounts;
+					}
+					throw new Error('Error unknown response for accept qredo connection');
+				}),
+			),
 		);
 	}
 

--- a/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
+++ b/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
@@ -29,7 +29,7 @@ export function DAppInfoCard({
 	const appHostname = validDAppUrl?.hostname ?? url;
 
 	return (
-		<div className="bg-white p-6 flex flex-1 flex-col gap-5">
+		<div className="bg-white p-6 flex flex-col gap-5">
 			<div className="flex flex-row flex-nowrap items-center gap-3.75 py-3">
 				<div className="flex items-stretch h-15 w-15 overflow-hidden bg-steel/20 shrink-0 grow-0 rounded-2xl">
 					{iconUrl ? <img className="flex-1" src={iconUrl} alt={name} /> : null}
@@ -58,11 +58,13 @@ export function DAppInfoCard({
 					<AccountAddress copyable address={connectedAddress} />
 				</div>
 			) : null}
-			<SummaryCard
-				header="Permissions requested"
-				body={permissions ? <DAppPermissionsList permissions={permissions} /> : null}
-				boxShadow
-			/>
+			{permissions?.length ? (
+				<SummaryCard
+					header="Permissions requested"
+					body={<DAppPermissionsList permissions={permissions} />}
+					boxShadow
+				/>
+			) : null}
 		</div>
 	);
 }

--- a/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
@@ -11,6 +11,7 @@ import {
 	type SetStateAction,
 } from 'react';
 import { type ZkProvider } from '_src/background/accounts/zk/providers';
+import { type Wallet } from '_src/shared/qredo-api';
 
 export type AccountsFormValues =
 	| { type: 'zk'; provider: ZkProvider }
@@ -22,6 +23,7 @@ export type AccountsFormValues =
 			type: 'ledger';
 			accounts: { publicKey: string; derivationPath: string; address: string }[];
 	  }
+	| { type: 'qredo'; accounts: Wallet[]; qredoID: string }
 	| null;
 
 type AccountsFormContextType = [AccountsFormValues, Dispatch<SetStateAction<AccountsFormValues>>];

--- a/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
+++ b/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
@@ -35,6 +35,7 @@ const createTypeToAmpliAccount: Record<CreateType, AddedAccountsProperties['acco
 	'mnemonic-derived': 'Derived',
 	imported: 'Imported',
 	ledger: 'Ledger',
+	qredo: 'Qredo',
 };
 
 export function useCreateAccountsMutation() {
@@ -90,6 +91,15 @@ export function useCreateAccountsMutation() {
 			) {
 				createdAccounts = await backgroundClient.createAccounts({
 					type: 'ledger',
+					accounts: accountsFormValues.accounts,
+					password: password!,
+				});
+			} else if (
+				type === 'qredo' &&
+				validateAccountFormValues(type, accountsFormValues, password)
+			) {
+				createdAccounts = await backgroundClient.acceptQredoConnection({
+					qredoID: accountsFormValues.qredoID,
 					accounts: accountsFormValues.accounts,
 					password: password!,
 				});

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -3,7 +3,7 @@
 
 import { toB64 } from '@mysten/sui.js/utils';
 import { useEffect, useMemo } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom';
 
 import { useSuiLedgerClient } from './components/ledger/SuiLedgerClientProvider';
 import { useAccounts } from './hooks/useAccounts';
@@ -45,6 +45,7 @@ import { SelectQredoAccountsPage } from './pages/qredo-connect/SelectQredoAccoun
 import { RestrictedPage } from './pages/restricted';
 import SiteConnectPage from './pages/site-connect';
 import { AppType } from './redux/slices/app/AppType';
+import PageMainLayout from './shared/page-main-layout';
 import { Staking } from './staking/home';
 
 import { useAppDispatch, useAppSelector } from '_hooks';
@@ -160,6 +161,17 @@ const App = () => {
 				<Route path="manage" element={<ManageAccountsPage />} />
 				<Route path="protect-account" element={<ProtectAccountPage />} />
 				<Route path="backup/:accountSourceID" element={<BackupMnemonicPage />} />
+				<Route
+					path="qredo-connect/*"
+					element={
+						<PageMainLayout>
+							<Outlet />
+						</PageMainLayout>
+					}
+				>
+					<Route path=":requestID" element={<QredoConnectInfoPage />} />
+					<Route path=":id/select" element={<SelectQredoAccountsPage />} />
+				</Route>
 			</Route>
 			<Route path="/account">
 				<Route path="forgot-password" element={<ForgotPasswordPage />} />
@@ -167,8 +179,6 @@ const App = () => {
 			<Route path="/dapp/*" element={<HomePage disableNavigation />}>
 				<Route path="connect/:requestID" element={<SiteConnectPage />} />
 				<Route path="approve/:requestID" element={<ApprovalRequestPage />} />
-				<Route path="qredo-connect/:requestID" element={<QredoConnectInfoPage />} />
-				<Route path="qredo-connect/:id/select" element={<SelectQredoAccountsPage />} />
 			</Route>
 			{process.env.NODE_ENV === 'development' ? (
 				<Route path="/accounts-dev" element={<AccountsDev />} />

--- a/apps/wallet/src/ui/app/pages/accounts/ProtectAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/ProtectAccountPage.tsx
@@ -18,6 +18,7 @@ const allowedAccountTypes: CreateType[] = [
 	'mnemonic-derived',
 	'imported',
 	'ledger',
+	'qredo',
 ];
 
 type AllowedAccountTypes = (typeof allowedAccountTypes)[number];

--- a/apps/wallet/src/ui/app/pages/qredo-connect/SelectQredoAccountsPage.tsx
+++ b/apps/wallet/src/ui/app/pages/qredo-connect/SelectQredoAccountsPage.tsx
@@ -3,24 +3,19 @@
 
 import { ArrowRight16 } from '@mysten/icons';
 import { useEffect, useState } from 'react';
-import { toast } from 'react-hot-toast';
 import { useParams, useLocation, Navigate, useNavigate } from 'react-router-dom';
 
 import { SelectQredoAccountsSummaryCard } from './components/SelectQredoAccountsSummaryCard';
 import { useQredoUIPendingRequest } from './hooks';
-import { useBackgroundClient } from '../../hooks/useBackgroundClient';
+import { useAccountsFormContext } from '../../components/accounts/AccountsFormContext';
 import { Button } from '../../shared/ButtonUI';
-import { testPassNewAccounts } from '../AccountsDevPage';
 import Overlay from '_components/overlay';
-import { ampli } from '_src/shared/analytics/ampli';
 import { type Wallet } from '_src/shared/qredo-api';
-import { PasswordInputDialog } from '_src/ui/app/components/PasswordInputDialog';
 
 export function SelectQredoAccountsPage() {
 	const { id } = useParams();
 	const { state } = useLocation();
 	const navigate = useNavigate();
-	const backgroundService = useBackgroundClient();
 	const qredoRequestReviewed = !!state?.reviewed;
 	const { data: qredoPendingRequest, isLoading: isQredoRequestLoading } =
 		useQredoUIPendingRequest(id);
@@ -28,8 +23,8 @@ export function SelectQredoAccountsPage() {
 	const fetchAccountsEnabled =
 		!isQredoRequestLoading && (!qredoPendingRequest || qredoRequestReviewed);
 	const [selectedAccounts, setSelectedAccounts] = useState<Wallet[]>([]);
-	const [showPassword, setShowPassword] = useState(false);
 	const shouldCloseWindow = (!isQredoRequestLoading && !qredoPendingRequest) || !id;
+	const [, setAccountsFormValues] = useAccountsFormContext();
 	useEffect(() => {
 		if (shouldCloseWindow) {
 			window.close();
@@ -42,73 +37,36 @@ export function SelectQredoAccountsPage() {
 		return null;
 	}
 	return (
-		<>
-			{showPassword ? (
-				<div className="flex flex-1 pb-4">
-					<PasswordInputDialog
-						title="Import Accounts"
-						continueLabel="Import"
-						onBackClicked={() => setShowPassword(false)}
-						showBackButton
-						onPasswordVerified={async (password) => {
-							await backgroundService.acceptQredoConnection({
-								qredoID: id,
-								accounts: selectedAccounts,
-								password,
-							});
-
-							ampli.addedAccounts({
-								accountType: 'Qredo',
-								numberOfAccounts: selectedAccounts.length,
-							});
-							toast.success(`Qredo account${selectedAccounts.length > 1 ? 's' : ''} added`);
-							navigate('/tokens?menu=/accounts');
-						}}
-						background
-						spacing
+		<Overlay
+			showModal
+			title="Import Accounts"
+			closeOverlay={() => {
+				navigate(-1);
+			}}
+		>
+			<div className="flex flex-col flex-1 flex-nowrap align-top overflow-x-hidden overflow-y-auto gap-3">
+				<div className="flex flex-1 overflow-hidden">
+					<SelectQredoAccountsSummaryCard
+						fetchAccountsEnabled={fetchAccountsEnabled}
+						qredoID={id}
+						selectedAccounts={selectedAccounts}
+						onChange={setSelectedAccounts}
 					/>
 				</div>
-			) : (
-				<Overlay
-					showModal
-					title="Import Accounts"
-					closeOverlay={() => {
-						navigate(-1);
-					}}
-				>
-					<div className="flex flex-col flex-1 flex-nowrap align-top overflow-x-hidden overflow-y-auto gap-3">
-						<div className="flex flex-1 overflow-hidden">
-							<SelectQredoAccountsSummaryCard
-								fetchAccountsEnabled={fetchAccountsEnabled}
-								qredoID={id}
-								selectedAccounts={selectedAccounts}
-								onChange={setSelectedAccounts}
-							/>
-						</div>
-						<div>
-							<Button
-								size="tall"
-								variant="primary"
-								text="Continue"
-								after={<ArrowRight16 />}
-								disabled={!selectedAccounts?.length}
-								onClick={async () => {
-									// TODO: now it just stores the accounts with test password
-									// aka qredo is broken! fix it
-									await backgroundService.acceptQredoConnection({
-										qredoID: id,
-										accounts: selectedAccounts,
-										password: testPassNewAccounts,
-									});
-									toast.success(`Qredo account${selectedAccounts.length > 1 ? 's' : ''} added`);
-									window.close();
-									// setShowPassword(true);
-								}}
-							/>
-						</div>
-					</div>
-				</Overlay>
-			)}
-		</>
+				<div>
+					<Button
+						size="tall"
+						variant="primary"
+						text="Continue"
+						after={<ArrowRight16 />}
+						disabled={!selectedAccounts?.length}
+						onClick={async () => {
+							setAccountsFormValues({ type: 'qredo', accounts: selectedAccounts, qredoID: id });
+							navigate('/accounts/protect-account?accountType=qredo');
+						}}
+					/>
+				</div>
+			</div>
+		</Overlay>
 	);
 }


### PR DESCRIPTION
## Description 

* allow onboarding with qredo

https://github.com/MystenLabs/sui/assets/10210143/dc4f3fb4-de6e-4d30-90bf-1ddbd8fb2b6b


* includes a small fix for DAppInfoAppCard to hid permission if not provided (not required)

| before | after |
| -- | -- |
| <img width="367" alt="Screenshot 2023-09-04 at 18 45 42" src="https://github.com/MystenLabs/sui/assets/10210143/81720f06-6342-412b-b963-ce36244cfd28"> | <img width="367" alt="Screenshot 2023-09-04 at 18 45 56" src="https://github.com/MystenLabs/sui/assets/10210143/9720439d-4cfb-4d36-8104-906ac05b1c8a"> |

part of APPS-1501

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
