### PR TITLE
wallet-ext: welcome page wait for creating zklogin to finish

### DIFF
--- a/apps/wallet/src/ui/app/hooks/useInitializedGuard.ts
+++ b/apps/wallet/src/ui/app/hooks/useInitializedGuard.ts
@@ -7,12 +7,12 @@ import { useNavigate } from 'react-router-dom';
 import { useAccounts } from './useAccounts';
 import { useRestrictedGuard } from './useRestrictedGuard';
 
-export default function useInitializedGuard(initializedRequired: boolean) {
+export default function useInitializedGuard(initializedRequired: boolean, enabled = true) {
 	const restricted = useRestrictedGuard();
 	const { data: allAccounts, isLoading } = useAccounts();
 	const isInitialized = !!allAccounts?.length;
 	const navigate = useNavigate();
-	const guardAct = !restricted && !isLoading && initializedRequired !== isInitialized;
+	const guardAct = !restricted && !isLoading && initializedRequired !== isInitialized && enabled;
 	useEffect(() => {
 		if (guardAct) {
 			navigate(isInitialized ? '/' : '/accounts/welcome', { replace: true });

--- a/apps/wallet/src/ui/app/pages/accounts/WelcomePage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/WelcomePage.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 import { useAccountsFormContext } from '../../components/accounts/AccountsFormContext';
 import { useCreateAccountsMutation } from '../../hooks/useCreateAccountMutation';
 import { SocialButton } from '../../shared/SocialButton';
@@ -28,12 +29,16 @@ const zkLoginProviders: {
 ];
 
 export function WelcomePage() {
-	const isFullscreenGuardLoading = useFullscreenGuard(true);
-	const isInitializedLoading = useInitializedGuard(false);
-	const [, setAccountsFormValues] = useAccountsFormContext();
 	const createAccountsMutation = useCreateAccountsMutation();
+	const isFullscreenGuardLoading = useFullscreenGuard(true);
+	const isInitializedLoading = useInitializedGuard(
+		false,
+		!(createAccountsMutation.isLoading || createAccountsMutation.isSuccess),
+	);
+	const [, setAccountsFormValues] = useAccountsFormContext();
 	const [createInProgressProvider, setCreateInProgressProvider] = useState<ZkProvider | null>(null);
 	const buttonsDisabled = createAccountsMutation.isLoading || createAccountsMutation.isSuccess;
+	const navigate = useNavigate();
 	return (
 		<Loading loading={isInitializedLoading || isFullscreenGuardLoading}>
 			<div className="rounded-20 bg-sui-lightest shadow-wallet-content flex flex-col items-center px-7 py-6 h-full overflow-auto">
@@ -74,6 +79,9 @@ export function WelcomePage() {
 												type: 'zk',
 											},
 											{
+												onSuccess: () => {
+													navigate('/tokens');
+												},
 												onError: (error) => {
 													toast.error(
 														(error as Error)?.message ||


### PR DESCRIPTION
## Description 

* wait to finish before navigating to tokens page
* this fixes an issue where the account is locked and the unlocked (now it wait for it to unlock)
* this adds an enabled flag to init guard since this was that was doing the redirect
* creating zklogin account time will be improved with APPS-1621

before


https://github.com/MystenLabs/sui/assets/10210143/fda96339-db92-4148-a8d5-b44f13d731b0


after


https://github.com/MystenLabs/sui/assets/10210143/6822b16b-d7fe-4a77-84f2-5b7e341e9ac6



closes APPS-1501

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
