### PR TITLE
[EffectsV2 1/n] Simplify inner temp store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1112,7 +1112,7 @@ impl AuthorityState {
         let output_keys: Vec<_> = inner_temporary_store
             .written
             .iter()
-            .map(|(_, ((id, seq, _), obj, _))| InputKey(*id, (!obj.is_package()).then_some(*seq)))
+            .map(|(id, obj)| InputKey(*id, (!obj.is_package()).then_some(obj.version())))
             .collect();
 
         self.commit_certificate(inner_temporary_store, certificate, effects, epoch_store)
@@ -1328,6 +1328,29 @@ impl AuthorityState {
         // Returning empty vector here because we recalculate changes in the rpc layer.
         let balance_changes = Vec::new();
 
+        let written_with_kind = effects
+            .created()
+            .into_iter()
+            .map(|(oref, _)| (oref, WriteKind::Create))
+            .chain(
+                effects
+                    .unwrapped()
+                    .into_iter()
+                    .map(|(oref, _)| (oref, WriteKind::Unwrap)),
+            )
+            .chain(
+                effects
+                    .mutated()
+                    .into_iter()
+                    .map(|(oref, _)| (oref, WriteKind::Mutate)),
+            )
+            .map(|(oref, kind)| {
+                let obj = inner_temp_store.written.get(&oref.0).unwrap();
+                // TODO: Avoid clones.
+                (oref.0, (oref, obj.clone(), kind))
+            })
+            .collect();
+
         Ok((
             DryRunTransactionBlockResponse {
                 input: SuiTransactionBlockData::try_from(transaction, &module_cache).map_err(
@@ -1348,7 +1371,7 @@ impl AuthorityState {
                 object_changes,
                 balance_changes,
             },
-            inner_temp_store.written,
+            written_with_kind,
             effects,
             mock_gas,
         ))
@@ -1572,10 +1595,9 @@ impl AuthorityState {
                     let new_object = written.get(id).unwrap_or_else(
                         || panic!("tx_digest={:?}, error processing object owner index, written does not contain object {:?}", tx_digest, id)
                     );
-                    assert_eq!(new_object.0.1, oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched version. Actual: {}, expected: {}", tx_digest, id, new_object.0.1, oref.1);
+                    assert_eq!(new_object.version(), oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched version. Actual: {}, expected: {}", tx_digest, id, new_object.version(), oref.1);
 
                     let type_ = new_object
-                        .1
                         .type_()
                         .map(|type_| ObjectType::Struct(type_.clone()))
                         .unwrap_or(ObjectType::Package);
@@ -1596,9 +1618,9 @@ impl AuthorityState {
                     let new_object = written.get(id).unwrap_or_else(
                         || panic!("tx_digest={:?}, error processing object owner index, written does not contain object {:?}", tx_digest, id)
                     );
-                    assert_eq!(new_object.0.1, oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched version. Actual: {}, expected: {}", tx_digest, id, new_object.0.1, oref.1);
+                    assert_eq!(new_object.version(), oref.1, "tx_digest={:?} error processing object owner index, object {:?} from written has mismatched version. Actual: {}, expected: {}", tx_digest, id, new_object.version(), oref.1);
 
-                    let Some(df_info) = self.try_create_dynamic_field_info(&new_object.1, written, module_resolver)
+                    let Some(df_info) = self.try_create_dynamic_field_info(new_object, written, module_resolver)
                         .expect("try_create_dynamic_field_info should not fail.") else {
                         // Skip indexing for non dynamic field objects.
                         continue;
@@ -1655,26 +1677,25 @@ impl AuthorityState {
                 // Find the actual object from storage using the object id obtained from the wrapper.
 
                 // Try to find the object in the written objects first.
-                let (version, digest, object_type) =
-                    if let Some((_, object, _)) = written.get(&object_id) {
-                        let version = object.version();
-                        let digest = object.digest();
-                        let object_type = object.data.type_().unwrap().clone();
-                        (version, digest, object_type)
-                    } else {
-                        // If not found, try to find it in the database.
-                        let object = self
-                            .database
-                            .get_object_by_key(&object_id, o.version())?
-                            .ok_or_else(|| UserInputError::ObjectNotFound {
-                                object_id,
-                                version: Some(o.version()),
-                            })?;
-                        let version = object.version();
-                        let digest = object.digest();
-                        let object_type = object.data.type_().unwrap().clone();
-                        (version, digest, object_type)
-                    };
+                let (version, digest, object_type) = if let Some(object) = written.get(&object_id) {
+                    let version = object.version();
+                    let digest = object.digest();
+                    let object_type = object.data.type_().unwrap().clone();
+                    (version, digest, object_type)
+                } else {
+                    // If not found, try to find it in the database.
+                    let object = self
+                        .database
+                        .get_object_by_key(&object_id, o.version())?
+                        .ok_or_else(|| UserInputError::ObjectNotFound {
+                            object_id,
+                            version: Some(o.version()),
+                        })?;
+                    let version = object.version();
+                    let digest = object.digest();
+                    let object_type = object.data.type_().unwrap().clone();
+                    (version, digest, object_type)
+                };
                 DynamicFieldInfo {
                     name,
                     bcs_name,
@@ -3306,13 +3327,13 @@ impl AuthorityState {
             .written
             .iter()
             .filter_map(|(k, v)| {
-                if v.1.is_coin() {
+                if v.is_coin() {
                     Some((*k, v.clone()))
                 } else {
                     None
                 }
             })
-            .collect::<WrittenObjects>();
+            .collect();
         let input_coin_objects = inner_temporary_store
             .objects
             .iter()

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1103,7 +1103,7 @@ impl AuthorityState {
         let _scope: Option<mysten_metrics::MonitoredScopeGuard> =
             monitored_scope("Execution::commit_cert_and_notify");
 
-        let input_object_count = inner_temporary_store.objects.len();
+        let input_object_count = inner_temporary_store.input_objects.len();
         let shared_object_count = effects.input_shared_objects().len();
         let digest = *certificate.digest();
 
@@ -3335,7 +3335,7 @@ impl AuthorityState {
             })
             .collect();
         let input_coin_objects = inner_temporary_store
-            .objects
+            .input_objects
             .iter()
             .filter_map(|(k, v)| {
                 if v.is_coin() {
@@ -4360,7 +4360,11 @@ impl NodeStateDump {
             modified_at_versions,
             runtime_reads,
             sender_signed_data: certificate.clone().into_message(),
-            input_objects: inner_temporary_store.objects.values().cloned().collect(),
+            input_objects: inner_temporary_store
+                .input_objects
+                .values()
+                .cloned()
+                .collect(),
             computed_effects: effects.clone(),
             expected_effects_digest,
         })

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1012,7 +1012,7 @@ impl AuthorityStore {
         _epoch_id: EpochId,
     ) -> SuiResult {
         let InnerTemporaryStore {
-            input_objects,
+            input_objects: _,
             mutable_inputs,
             written,
             events,
@@ -1026,12 +1026,8 @@ impl AuthorityStore {
 
         let owned_inputs: Vec<_> = mutable_inputs
             .into_iter()
-            .filter_map(|(id, (version, digest))| {
-                input_objects
-                    .get(&id)
-                    .unwrap()
-                    .is_address_owned()
-                    .then_some((id, version, digest))
+            .filter_map(|(id, ((version, digest), owner))| {
+                owner.is_address_owned().then_some((id, version, digest))
             })
             .collect();
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -23,7 +23,7 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module_by_id, BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey, ObjectStore,
+    get_module_by_id, BackingPackageStore, ChildObjectResolver, ObjectKey, ObjectStore,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -943,6 +943,7 @@ impl AuthorityStore {
         self.update_objects_and_locks(
             &mut write_batch,
             inner_temporary_store,
+            effects,
             transaction,
             epoch_id,
         )
@@ -991,8 +992,8 @@ impl AuthorityStore {
         // concurrent transaction executions produce independent ref count increments and don't corrupt the state
         let digests = inner_temporary_store
             .written
-            .iter()
-            .filter_map(|(_, (_, object, _))| {
+            .values()
+            .filter_map(|object| {
                 let StoreObjectPair(_, indirect_object) =
                     get_store_object_pair(object.clone(), self.indirect_objects_threshold);
                 indirect_object.map(|obj| obj.inner().digest())
@@ -1006,6 +1007,7 @@ impl AuthorityStore {
         &self,
         write_batch: &mut DBBatch,
         inner_temporary_store: InnerTemporaryStore,
+        effects: &TransactionEffects,
         _transaction: &VerifiedTransaction,
         _epoch_id: EpochId,
     ) -> SuiResult {
@@ -1013,14 +1015,13 @@ impl AuthorityStore {
             objects,
             mutable_inputs: active_inputs,
             written,
-            deleted,
             events,
             max_binary_format_version: _,
             loaded_child_objects: _,
             no_extraneous_module_bytes: _,
             runtime_packages_loaded_from_db: _,
         } = inner_temporary_store;
-        trace!(written =? written.values().map(|((obj_id, ver, _), _, _)| (obj_id, ver)).collect::<Vec<_>>(),
+        trace!(written =? written.iter().map(|(obj_id, obj)| (obj_id, obj.version())).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");
 
         let owned_inputs: Vec<_> = active_inputs
@@ -1034,27 +1035,35 @@ impl AuthorityStore {
             })
             .collect();
 
-        write_batch.insert_batch(
-            &self.perpetual_tables.objects,
-            deleted.iter().map(|(object_id, (version, kind))| {
-                let tombstone: StoreObjectWrapper = if *kind == DeleteKind::Wrap {
-                    StoreObject::Wrapped.into()
-                } else {
-                    StoreObject::Deleted.into()
-                };
-                (ObjectKey(*object_id, *version), tombstone)
-            }),
-        )?;
+        let tombstones = effects
+            .deleted()
+            .into_iter()
+            .chain(effects.unwrapped_then_deleted())
+            .map(|oref| (oref, StoreObject::Deleted))
+            .chain(
+                effects
+                    .wrapped()
+                    .into_iter()
+                    .map(|oref| (oref, StoreObject::Wrapped)),
+            )
+            .map(|(oref, store_object)| {
+                (
+                    ObjectKey::from(oref),
+                    StoreObjectWrapper::from(store_object),
+                )
+            });
+        write_batch.insert_batch(&self.perpetual_tables.objects, tombstones)?;
 
         // Insert each output object into the stores
         let (new_objects, new_indirect_move_objects): (Vec<_>, Vec<_>) = written
             .iter()
-            .map(|(_, (obj_ref, new_object, _))| {
-                debug!(?obj_ref, "writing object");
+            .map(|(id, new_object)| {
+                let version = new_object.version();
+                debug!(?id, ?version, "writing object");
                 let StoreObjectPair(store_object, indirect_object) =
                     get_store_object_pair(new_object.clone(), self.indirect_objects_threshold);
                 (
-                    (ObjectKey::from(obj_ref), store_object),
+                    (ObjectKey(*id, version), store_object),
                     indirect_object.map(|obj| (obj.inner().digest(), obj)),
                 )
             })
@@ -1098,10 +1107,10 @@ impl AuthorityStore {
         write_batch.insert_batch(&self.perpetual_tables.events, events)?;
 
         let new_locks_to_init: Vec<_> = written
-            .iter()
-            .filter_map(|(_, (object_ref, new_object, _kind))| {
+            .values()
+            .filter_map(|new_object| {
                 if new_object.is_address_owned() {
-                    Some(*object_ref)
+                    Some(new_object.compute_object_reference())
                 } else {
                     None
                 }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1012,8 +1012,8 @@ impl AuthorityStore {
         _epoch_id: EpochId,
     ) -> SuiResult {
         let InnerTemporaryStore {
-            objects,
-            mutable_inputs: active_inputs,
+            input_objects,
+            mutable_inputs,
             written,
             events,
             max_binary_format_version: _,
@@ -1024,10 +1024,10 @@ impl AuthorityStore {
         trace!(written =? written.iter().map(|(obj_id, obj)| (obj_id, obj.version())).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");
 
-        let owned_inputs: Vec<_> = active_inputs
+        let owned_inputs: Vec<_> = mutable_inputs
             .into_iter()
             .filter_map(|(id, (version, digest))| {
-                objects
+                input_objects
                     .get(&id)
                     .unwrap()
                     .is_address_owned()

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1024,9 +1024,14 @@ impl AuthorityStore {
                "batch_update_objects: temp store written");
 
         let owned_inputs: Vec<_> = active_inputs
-            .iter()
-            .filter(|(id, _, _)| objects.get(id).unwrap().is_address_owned())
-            .cloned()
+            .into_iter()
+            .filter_map(|(id, (version, digest))| {
+                objects
+                    .get(&id)
+                    .unwrap()
+                    .is_address_owned()
+                    .then_some((id, version, digest))
+            })
             .collect();
 
         write_batch.insert_batch(

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -27,7 +27,7 @@ use sui_types::crypto::{
     AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignInfoTrait,
     AuthoritySignature, DefaultHash, SuiAuthoritySignature,
 };
-use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiGasStatus;
 use sui_types::gas_coin::GasCoin;
@@ -848,16 +848,13 @@ fn create_genesis_transaction(
             );
         assert!(inner_temp_store.objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
-        assert!(inner_temp_store.deleted.is_empty());
+        assert!(effects.mutated().is_empty());
+        assert!(effects.unwrapped().is_empty());
+        assert!(effects.deleted().is_empty());
+        assert!(effects.wrapped().is_empty());
+        assert!(effects.unwrapped_then_deleted().is_empty());
 
-        let objects = inner_temp_store
-            .written
-            .into_iter()
-            .map(|(_, (_, o, kind))| {
-                assert_eq!(kind, sui_types::storage::WriteKind::Create);
-                o
-            })
-            .collect();
+        let objects = inner_temp_store.written.into_values().collect();
         (effects, inner_temp_store.events, objects)
     };
 

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -846,7 +846,7 @@ fn create_genesis_transaction(
                 signer,
                 genesis_digest,
             );
-        assert!(inner_temp_store.objects.is_empty());
+        assert!(inner_temp_store.input_objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
         assert!(effects.mutated().is_empty());
         assert!(effects.unwrapped().is_empty());

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -384,7 +384,7 @@ impl IndexStore {
         .iter()
         .filter_map(|((owner, obj_id), obj_info)| {
             // If it's in written_coins, then it's not a coin. Skip it.
-            let (_obj_ref, obj, _write_kind) = written_coins.get(obj_id)?;
+            let obj = written_coins.get(obj_id)?;
             let coin_type_tag = obj.coin_type_maybe().unwrap_or_else(|| {
                 panic!(
                     "object_id: {:?} in written_coins is not a coin type, written_coins: {:?}, tx_digest: {:?}",
@@ -1591,7 +1591,6 @@ mod tests {
     use sui_types::gas_coin::GAS;
     use sui_types::object;
     use sui_types::object::Owner;
-    use sui_types::storage::WriteKind;
 
     #[tokio::test]
     async fn test_index_cache() -> anyhow::Result<()> {
@@ -1622,10 +1621,7 @@ mod tests {
                 },
             ));
             object_map.insert(object.id(), object.clone());
-            written_objects.insert(
-                object.data.id(),
-                (object.compute_object_reference(), object, WriteKind::Mutate),
-            );
+            written_objects.insert(object.data.id(), object);
         }
         let object_index_changes = ObjectIndexChanges {
             deleted_owners: vec![],
@@ -1671,14 +1667,7 @@ mod tests {
         let mut deleted_objects = vec![];
         for (id, object) in object_map.iter().take(3) {
             deleted_objects.push((address, *id));
-            written_objects.insert(
-                object.data.id(),
-                (
-                    object.compute_object_reference(),
-                    object.clone(),
-                    WriteKind::Create,
-                ),
-            );
+            written_objects.insert(object.data.id(), object.clone());
         }
         let object_index_changes = ObjectIndexChanges {
             deleted_owners: deleted_objects,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -124,6 +124,8 @@ pub struct ObjectID(
     AccountAddress,
 );
 
+pub type VersionDigest = (SequenceNumber, ObjectDigest);
+
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
 pub fn random_object_ref() -> ObjectRef {

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -12,7 +12,7 @@ use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 
 use crate::{
-    base_types::{ObjectID, SequenceNumber, SuiAddress, VersionDigest},
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
     digests::ObjectDigest,
     error::{ExecutionError, ExecutionErrorKind, SuiError},

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -12,7 +12,7 @@ use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 
 use crate::{
-    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    base_types::{ObjectID, SequenceNumber, SuiAddress, VersionDigest},
     coin::Coin,
     digests::ObjectDigest,
     error::{ExecutionError, ExecutionErrorKind, SuiError},

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::VersionNumber;
+use crate::inner_temporary_store::WrittenObjects;
 use crate::storage::get_module_by_id;
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::{SuiError, SuiResult},
     object::{Object, Owner},
-    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync, WriteKind},
+    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
 };
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
@@ -180,8 +181,8 @@ impl InMemoryStorage {
         self.persistent
     }
 
-    pub fn finish(&mut self, written: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>) {
-        for (_id, (_, new_object, _)) in written {
+    pub fn finish(&mut self, written: WrittenObjects) {
+        for (_id, new_object) in written {
             debug_assert!(new_object.id() == _id);
             self.insert_object(new_object);
         }

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -22,7 +22,7 @@ pub type TxCoins = (ObjectMap, WrittenObjects);
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InnerTemporaryStore {
-    pub objects: ObjectMap,
+    pub input_objects: ObjectMap,
     pub mutable_inputs: BTreeMap<ObjectID, VersionDigest>,
     // All the written objects' sequence number should have been updated to the lamport version.
     pub written: WrittenObjects,

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base_types::VersionDigest;
 use crate::effects::TransactionEvents;
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
@@ -23,7 +24,7 @@ pub type TxCoins = (ObjectMap, WrittenObjects);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InnerTemporaryStore {
     pub objects: ObjectMap,
-    pub mutable_inputs: Vec<ObjectRef>,
+    pub mutable_inputs: BTreeMap<ObjectID, VersionDigest>,
     // All the written objects' sequence number should have been updated to the lamport version.
     pub written: WrittenObjects,
     // deleted or wrapped or unwrap-then-delete. The sequence number should have been updated to

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -5,7 +5,7 @@ use crate::base_types::VersionDigest;
 use crate::effects::TransactionEvents;
 use crate::{
     base_types::{ObjectID, SequenceNumber},
-    object::Object,
+    object::{Object, Owner},
 };
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
@@ -23,7 +23,7 @@ pub type TxCoins = (ObjectMap, WrittenObjects);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InnerTemporaryStore {
     pub input_objects: ObjectMap,
-    pub mutable_inputs: BTreeMap<ObjectID, VersionDigest>,
+    pub mutable_inputs: BTreeMap<ObjectID, (VersionDigest, Owner)>,
     // All the written objects' sequence number should have been updated to the lamport version.
     pub written: WrittenObjects,
     pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2386,7 +2386,7 @@ impl InputObjects {
             .collect()
     }
 
-    pub fn mutable_inputs(&self) -> BTreeMap<ObjectID, VersionDigest> {
+    pub fn mutable_inputs(&self) -> BTreeMap<ObjectID, (VersionDigest, Owner)> {
         self.objects
             .iter()
             .filter_map(|(kind, object)| match kind {
@@ -2395,13 +2395,13 @@ impl InputObjects {
                     if object.is_immutable() {
                         None
                     } else {
-                        Some((object_ref.0, (object_ref.1, object_ref.2)))
+                        Some((object_ref.0, ((object_ref.1, object_ref.2), object.owner)))
                     }
                 }
                 InputObjectKind::SharedMoveObject { mutable, .. } => {
                     if *mutable {
                         let oref = object.compute_object_reference();
-                        Some((oref.0, (oref.1, oref.2)))
+                        Some((oref.0, ((oref.1, oref.2), object.owner)))
                     } else {
                         None
                     }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2386,7 +2386,7 @@ impl InputObjects {
             .collect()
     }
 
-    pub fn mutable_inputs(&self) -> Vec<ObjectRef> {
+    pub fn mutable_inputs(&self) -> BTreeMap<ObjectID, VersionDigest> {
         self.objects
             .iter()
             .filter_map(|(kind, object)| match kind {
@@ -2395,12 +2395,13 @@ impl InputObjects {
                     if object.is_immutable() {
                         None
                     } else {
-                        Some(*object_ref)
+                        Some((object_ref.0, (object_ref.1, object_ref.2)))
                     }
                 }
                 InputObjectKind::SharedMoveObject { mutable, .. } => {
                     if *mutable {
-                        Some(object.compute_object_reference())
+                        let oref = object.compute_object_reference();
+                        Some((oref.0, (oref.1, oref.2)))
                     } else {
                         None
                     }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -235,6 +235,7 @@ mod checked {
             &mut gas_charger,
             pt,
         )?;
+        temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner())
     }
 

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -48,7 +48,7 @@ pub struct TemporaryStore<'backing> {
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
-    mutable_input_refs: BTreeMap<ObjectID, VersionDigest>, // Inputs that are mutable
+    mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
     // When an object is being written, we need to ensure that a few invariants hold.
     // It's critical that we always call write_object to update `written`, instead of writing
     // into written directly.

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -145,7 +145,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
     pub fn into_inner(self) -> InnerTemporaryStore {
         InnerTemporaryStore {
-            objects: self.input_objects,
+            input_objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
             written: self
                 .written

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -11,6 +11,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
+use sui_types::base_types::VersionDigest;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::execution::{ExecutionResults, LoadedChildObjectMetadata};
@@ -48,7 +49,7 @@ pub struct TemporaryStore<'backing> {
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
-    mutable_input_refs: Vec<ObjectRef>, // Inputs that are mutable
+    mutable_input_refs: BTreeMap<ObjectID, VersionDigest>, // Inputs that are mutable
     // When an object is being written, we need to ensure that a few invariants hold.
     // It's critical that we always call write_object to update `written`, instead of writing
     // into written directly.
@@ -76,7 +77,7 @@ impl<'backing> TemporaryStore<'backing> {
         tx_digest: TransactionDigest,
         protocol_config: &ProtocolConfig,
     ) -> Self {
-        let mutable_inputs = input_objects.mutable_inputs();
+        let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp();
         let objects = input_objects.into_object_map();
         Self {
@@ -84,7 +85,7 @@ impl<'backing> TemporaryStore<'backing> {
             tx_digest,
             input_objects: objects,
             lamport_timestamp,
-            mutable_input_refs: mutable_inputs,
+            mutable_input_refs,
             written: BTreeMap::new(),
             deleted: BTreeMap::new(),
             events: Vec::new(),
@@ -178,7 +179,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// sequence number. This is required to achieve safety.
     pub(crate) fn ensure_active_inputs_mutated(&mut self) {
         let mut to_be_updated = vec![];
-        for (id, _seq, _) in &self.mutable_input_refs {
+        for id in self.mutable_input_refs.keys() {
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
                 // We cannot update here but have to push to `to_be_updated` and update later
                 // because the for loop is holding a reference to `self`, and calling
@@ -309,9 +310,7 @@ impl<'backing> TemporaryStore<'backing> {
                 self.written.iter().all(|(elt, _)| used.insert(elt));
                 self.deleted.iter().all(|elt| used.insert(elt.0));
 
-                self.mutable_input_refs
-                    .iter()
-                    .all(|elt| !used.insert(&elt.0))
+                self.mutable_input_refs.keys().all(|elt| !used.insert(elt))
             },
             "Mutable input neither written nor deleted."
         );

--- a/sui-execution/suivm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/suivm/sui-adapter/src/execution_engine.rs
@@ -229,6 +229,7 @@ mod checked {
             &mut gas_charger,
             pt,
         )?;
+        temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner())
     }
 

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -48,7 +48,7 @@ pub struct TemporaryStore<'backing> {
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
-    mutable_input_refs: BTreeMap<ObjectID, VersionDigest>, // Inputs that are mutable
+    mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
     // When an object is being written, we need to ensure that a few invariants hold.
     // It's critical that we always call write_object to update `written`, instead of writing
     // into written directly.

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -145,7 +145,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
     pub fn into_inner(self) -> InnerTemporaryStore {
         InnerTemporaryStore {
-            objects: self.input_objects,
+            input_objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
             written: self
                 .written

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -11,6 +11,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
+use sui_types::base_types::VersionDigest;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::execution::{ExecutionResults, LoadedChildObjectMetadata};
@@ -48,7 +49,7 @@ pub struct TemporaryStore<'backing> {
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
-    mutable_input_refs: Vec<ObjectRef>, // Inputs that are mutable
+    mutable_input_refs: BTreeMap<ObjectID, VersionDigest>, // Inputs that are mutable
     // When an object is being written, we need to ensure that a few invariants hold.
     // It's critical that we always call write_object to update `written`, instead of writing
     // into written directly.
@@ -76,7 +77,7 @@ impl<'backing> TemporaryStore<'backing> {
         tx_digest: TransactionDigest,
         protocol_config: &ProtocolConfig,
     ) -> Self {
-        let mutable_inputs = input_objects.mutable_inputs();
+        let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp();
         let objects = input_objects.into_object_map();
         Self {
@@ -84,7 +85,7 @@ impl<'backing> TemporaryStore<'backing> {
             tx_digest,
             input_objects: objects,
             lamport_timestamp,
-            mutable_input_refs: mutable_inputs,
+            mutable_input_refs,
             written: BTreeMap::new(),
             deleted: BTreeMap::new(),
             events: Vec::new(),
@@ -178,7 +179,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// sequence number. This is required to achieve safety.
     pub(crate) fn ensure_active_inputs_mutated(&mut self) {
         let mut to_be_updated = vec![];
-        for (id, _seq, _) in &self.mutable_input_refs {
+        for id in self.mutable_input_refs.keys() {
             if !self.written.contains_key(id) && !self.deleted.contains_key(id) {
                 // We cannot update here but have to push to `to_be_updated` and update later
                 // because the for loop is holding a reference to `self`, and calling
@@ -309,9 +310,7 @@ impl<'backing> TemporaryStore<'backing> {
                 self.written.iter().all(|(elt, _)| used.insert(elt));
                 self.deleted.iter().all(|elt| used.insert(elt.0));
 
-                self.mutable_input_refs
-                    .iter()
-                    .all(|elt| !used.insert(&elt.0))
+                self.mutable_input_refs.keys().all(|elt| !used.insert(elt))
             },
             "Mutable input neither written nor deleted."
         );

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -229,6 +229,7 @@ mod checked {
             &mut gas_charger,
             pt,
         )?;
+        temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner())
     }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -48,7 +48,7 @@ pub struct TemporaryStore<'backing> {
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
-    mutable_input_refs: BTreeMap<ObjectID, VersionDigest>, // Inputs that are mutable
+    mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
     // When an object is being written, we need to ensure that a few invariants hold.
     // It's critical that we always call write_object to update `written`, instead of writing
     // into written directly.

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -145,7 +145,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
     pub fn into_inner(self) -> InnerTemporaryStore {
         InnerTemporaryStore {
-            objects: self.input_objects,
+            input_objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
             written: self
                 .written

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -31,8 +31,7 @@ use sui_types::{
     object::Owner,
     object::{Data, Object},
     storage::{
-        BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectChange, ParentSync, Storage,
-        WriteKind,
+        BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage, WriteKind,
     },
     transaction::InputObjects,
 };
@@ -100,17 +99,13 @@ impl<'backing> TemporaryStore<'backing> {
         &self.input_objects
     }
 
-    /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
-    pub fn into_inner(self) -> InnerTemporaryStore {
+    pub fn update_object_version_and_prev_tx(&mut self) {
         #[cfg(debug_assertions)]
         {
             self.check_invariants();
         }
 
-        let mut written = BTreeMap::new();
-        let mut deleted = BTreeMap::new();
-
-        for (id, (mut obj, kind)) in self.written {
+        for (id, (obj, kind)) in self.written.iter_mut() {
             // Update the version for the written object.
             match &mut obj.data {
                 Data::Move(obj) => {
@@ -122,7 +117,7 @@ impl<'backing> TemporaryStore<'backing> {
                     // Modified packages get their version incremented (this is a special case that
                     // only applies to system packages).  All other packages can only be created,
                     // and they are left alone.
-                    if kind == WriteKind::Mutate {
+                    if *kind == WriteKind::Mutate {
                         pkg.increment_version();
                     }
                 }
@@ -135,7 +130,7 @@ impl<'backing> TemporaryStore<'backing> {
                 initial_shared_version,
             } = &mut obj.owner
             {
-                if kind == WriteKind::Create {
+                if *kind == WriteKind::Create {
                     assert_eq!(
                         *initial_shared_version,
                         SequenceNumber::new(),
@@ -144,24 +139,19 @@ impl<'backing> TemporaryStore<'backing> {
                     *initial_shared_version = self.lamport_timestamp;
                 }
             }
-            written.insert(id, (obj.compute_object_reference(), obj, kind));
         }
+    }
 
-        for (id, kind) in self.deleted {
-            // Check invariant that version must increase.
-            if let Some(version) = kind.old_version() {
-                debug_assert!(version < self.lamport_timestamp);
-            }
-            deleted.insert(id, (self.lamport_timestamp, kind.to_delete_kind()));
-        }
-
-        // Combine object events with move events.
-
+    /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
+    pub fn into_inner(self) -> InnerTemporaryStore {
         InnerTemporaryStore {
             objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
-            written,
-            deleted,
+            written: self
+                .written
+                .into_iter()
+                .map(|(id, (obj, _))| (id, obj))
+                .collect(),
             events: TransactionEvents { data: self.events },
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_child_objects: self
@@ -218,16 +208,40 @@ impl<'backing> TemporaryStore<'backing> {
             }
         });
 
-        let protocol_version = self.protocol_config.version;
-        let inner = self.into_inner();
+        self.update_object_version_and_prev_tx();
+
+        let mut deleted = vec![];
+        let mut wrapped = vec![];
+        let mut unwrapped_then_deleted = vec![];
+        for (id, kind) in &self.deleted {
+            match kind {
+                DeleteKindWithOldVersion::Normal(_) => deleted.push((
+                    *id,
+                    self.lamport_timestamp,
+                    ObjectDigest::OBJECT_DIGEST_DELETED,
+                )),
+                DeleteKindWithOldVersion::UnwrapThenDelete
+                | DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(_) => unwrapped_then_deleted
+                    .push((
+                        *id,
+                        self.lamport_timestamp,
+                        ObjectDigest::OBJECT_DIGEST_DELETED,
+                    )),
+                DeleteKindWithOldVersion::Wrap(_) => wrapped.push((
+                    *id,
+                    self.lamport_timestamp,
+                    ObjectDigest::OBJECT_DIGEST_WRAPPED,
+                )),
+            }
+        }
 
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
         // Gas coins are guaranteed to be at least size 1 and if more than 1
         // the first coin is where all the others are merged.
         let updated_gas_object_info = if let Some(coin_id) = gas_charger.gas_coin() {
-            let (obj_ref, object, _kind) = &inner.written[&coin_id];
-            (*obj_ref, object.owner)
+            let (object, _kind) = &self.written[&coin_id];
+            (object.compute_object_reference(), object.owner)
         } else {
             (
                 (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
@@ -238,32 +252,17 @@ impl<'backing> TemporaryStore<'backing> {
         let mut mutated = vec![];
         let mut created = vec![];
         let mut unwrapped = vec![];
-        for (object_ref, object, kind) in inner.written.values() {
+        for (object, kind) in self.written.values() {
+            let object_ref = object.compute_object_reference();
             match kind {
-                WriteKind::Mutate => mutated.push((*object_ref, object.owner)),
-                WriteKind::Create => created.push((*object_ref, object.owner)),
-                WriteKind::Unwrap => unwrapped.push((*object_ref, object.owner)),
+                WriteKind::Mutate => mutated.push((object_ref, object.owner)),
+                WriteKind::Create => created.push((object_ref, object.owner)),
+                WriteKind::Unwrap => unwrapped.push((object_ref, object.owner)),
             }
         }
 
-        let mut deleted = vec![];
-        let mut wrapped = vec![];
-        let mut unwrapped_then_deleted = vec![];
-        for (id, (version, kind)) in &inner.deleted {
-            match kind {
-                DeleteKind::Normal => {
-                    deleted.push((*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED))
-                }
-                DeleteKind::UnwrapThenDelete => unwrapped_then_deleted.push((
-                    *id,
-                    *version,
-                    ObjectDigest::OBJECT_DIGEST_DELETED,
-                )),
-                DeleteKind::Wrap => {
-                    wrapped.push((*id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED))
-                }
-            }
-        }
+        let protocol_version = self.protocol_config.version;
+        let inner = self.into_inner();
 
         let effects = TransactionEffects::new_from_execution(
             protocol_version,


### PR DESCRIPTION
## Description 

This PR simplifies the fields of InnerTemporaryStore such that it's no longer dependent on the implementation details of effects.
Specifically, it gets rid of all the use of WriteKind and DeleteKind stuff. Instead it only has a map of all written objects.
To access to deleted objects, we could always refer to effects because we always have effects when we have the inner.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
