### PR TITLE
wallet-ext: add accounts functionality

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
@@ -3,12 +3,13 @@
 
 import { type ExportedKeypair } from '@mysten/sui.js/cryptography';
 import {
-	type Dispatch,
 	type ReactNode,
 	createContext,
 	useContext,
-	useState,
-	type SetStateAction,
+	useRef,
+	useCallback,
+	useMemo,
+	type MutableRefObject,
 } from 'react';
 import { type ZkProvider } from '_src/background/accounts/zk/providers';
 import { type Wallet } from '_src/shared/qredo-api';
@@ -26,12 +27,19 @@ export type AccountsFormValues =
 	| { type: 'qredo'; accounts: Wallet[]; qredoID: string }
 	| null;
 
-type AccountsFormContextType = [AccountsFormValues, Dispatch<SetStateAction<AccountsFormValues>>];
+type AccountsFormContextType = [
+	MutableRefObject<AccountsFormValues>,
+	(values: AccountsFormValues) => void,
+];
 
 const AccountsFormContext = createContext<AccountsFormContextType | null>(null);
 
 export const AccountsFormProvider = ({ children }: { children: ReactNode }) => {
-	const value = useState<AccountsFormValues>(null);
+	const valuesRef = useRef<AccountsFormValues>(null);
+	const setter = useCallback((values: AccountsFormValues) => {
+		valuesRef.current = values;
+	}, []);
+	const value = useMemo(() => [valuesRef, setter] as AccountsFormContextType, [setter]);
 	return <AccountsFormContext.Provider value={value}>{children}</AccountsFormContext.Provider>;
 };
 

--- a/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cx } from 'class-variance-authority';
+import { useState } from 'react';
+import { useCountAccountsByType } from '../../hooks/useCountAccountByType';
+import { SocialButton } from '../../shared/SocialButton';
+import { type ZkProvider } from '_src/background/accounts/zk/providers';
+import { ampli, type ClickedSocialSignInButtonProperties } from '_src/shared/analytics/ampli';
+
+const zkLoginProviders: {
+	provider: ZkProvider;
+	disabled?: boolean;
+	hidden?: boolean;
+	tooltip?: string;
+}[] = [
+	{ provider: 'google' },
+	{ provider: 'twitch', disabled: true, tooltip: 'Coming soon' },
+	{ provider: 'facebook', disabled: true, tooltip: 'Coming soon' },
+	{ provider: 'microsoft', disabled: true, hidden: true },
+];
+
+const providerToAmpli: Record<ZkProvider, ClickedSocialSignInButtonProperties['signInProvider']> = {
+	google: 'Google',
+	twitch: 'Twitch',
+	facebook: 'Facebook',
+	microsoft: 'Microsoft',
+};
+
+export type ZkLoginButtonsProps = {
+	layout: 'column' | 'row';
+	showLabel?: boolean;
+	buttonsDisabled?: boolean;
+	onButtonClick?: (provider: ZkProvider) => Promise<void> | void;
+	sourceFlow: string;
+	forcedZkLoginProvider?: ZkProvider | null;
+};
+
+export function ZkLoginButtons({
+	layout,
+	showLabel = false,
+	onButtonClick,
+	buttonsDisabled,
+	sourceFlow,
+	forcedZkLoginProvider,
+}: ZkLoginButtonsProps) {
+	const [createInProgressProvider, setCreateInProgressProvider] = useState<ZkProvider | null>(null);
+	const { data: accountsTotalByType, isLoading } = useCountAccountsByType();
+	return (
+		<div
+			className={cx('flex w-full', {
+				'flex-col gap-3': layout === 'column',
+				'flex-row gap-2': layout === 'row',
+			})}
+		>
+			{zkLoginProviders
+				.filter(({ hidden }) => !hidden)
+				.map(({ provider, disabled, tooltip }) => (
+					<div key={provider} className="flex-1">
+						<SocialButton
+							title={accountsTotalByType?.zk?.extra?.[provider] ? 'Already signed-in' : tooltip}
+							provider={provider}
+							onClick={async () => {
+								ampli.clickedSocialSignInButton({
+									signInProvider: providerToAmpli[provider],
+									sourceFlow,
+								});
+								setCreateInProgressProvider(provider);
+								try {
+									if (onButtonClick) {
+										await onButtonClick(provider);
+									}
+								} finally {
+									setCreateInProgressProvider(null);
+								}
+							}}
+							disabled={
+								disabled ||
+								buttonsDisabled ||
+								createInProgressProvider !== null ||
+								isLoading ||
+								!!accountsTotalByType?.zk?.extra?.[provider] ||
+								!!forcedZkLoginProvider
+							}
+							loading={createInProgressProvider === provider || forcedZkLoginProvider === provider}
+							showLabel={showLabel}
+						/>
+					</div>
+				))}
+		</div>
+	);
+}

--- a/apps/wallet/src/ui/app/hooks/useCountAccountByType.ts
+++ b/apps/wallet/src/ui/app/hooks/useCountAccountByType.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+import { useAccounts } from './useAccounts';
+import { type AccountType } from '_src/background/accounts/Account';
+import { isZkAccountSerializedUI } from '_src/background/accounts/zk/ZkAccount';
+import { type ZkProvider } from '_src/background/accounts/zk/providers';
+
+export function useCountAccountsByType() {
+	const { data: accounts, isLoading } = useAccounts();
+	const countPerType = useMemo(
+		() =>
+			accounts?.reduce<
+				Partial<Record<AccountType, { total: number; extra?: Record<ZkProvider, number> }>>
+			>((acc, anAccount) => {
+				acc[anAccount.type] = acc[anAccount.type] || { total: 0 };
+				acc[anAccount.type]!.total++;
+				if (isZkAccountSerializedUI(anAccount)) {
+					acc[anAccount.type]!.extra =
+						acc[anAccount.type]!.extra || ({} as Record<ZkProvider, number>);
+					acc[anAccount.type]!.extra![anAccount.provider] =
+						acc[anAccount.type]!.extra![anAccount.provider] || 0;
+					acc[anAccount.type]!.extra![anAccount.provider]++;
+				}
+				return acc;
+			}, {}) || {},
+		[accounts],
+	);
+	return { data: countPerType, isLoading };
+}

--- a/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
+++ b/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
@@ -40,11 +40,12 @@ const createTypeToAmpliAccount: Record<CreateType, AddedAccountsProperties['acco
 
 export function useCreateAccountsMutation() {
 	const backgroundClient = useBackgroundClient();
-	const [accountsFormValues, setAccountFormValues] = useAccountsFormContext();
+	const [accountsFormValuesRef, setAccountFormValues] = useAccountsFormContext();
 	return useMutation({
 		mutationKey: ['create accounts'],
 		mutationFn: async ({ type, password }: { type: CreateType; password?: string }) => {
 			let createdAccounts;
+			const accountsFormValues = accountsFormValuesRef.current;
 			if (type === 'zk' && validateAccountFormValues(type, accountsFormValues)) {
 				createdAccounts = await backgroundClient.createAccounts(accountsFormValues);
 			} else if (

--- a/apps/wallet/src/ui/app/pages/accounts/AddAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/AddAccountPage.tsx
@@ -2,86 +2,113 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LedgerLogo17 as LedgerLogo } from '@mysten/icons';
-import { useState, type ReactNode } from 'react';
+import { useState, type ReactNode, useEffect, useRef, useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
 import { useAccountsFormContext } from '../../components/accounts/AccountsFormContext';
+import { ZkLoginButtons } from '../../components/accounts/ZkLoginButtons';
 import { ConnectLedgerModal } from '../../components/ledger/ConnectLedgerModal';
 import { getLedgerConnectionErrorMessage } from '../../helpers/errorMessages';
 import { useAppSelector } from '../../hooks';
+import { useCountAccountsByType } from '../../hooks/useCountAccountByType';
+import { useCreateAccountsMutation } from '../../hooks/useCreateAccountMutation';
 import { AppType } from '../../redux/slices/app/AppType';
-import { SocialButton } from '../../shared/SocialButton';
 import { Button } from '_app/shared/ButtonUI';
 import { Text } from '_app/shared/text';
 import Overlay from '_components/overlay';
+import { type ZkProvider, zkProviderDataMap } from '_src/background/accounts/zk/providers';
 import { ampli } from '_src/shared/analytics/ampli';
 
+async function openTabWithSearchParam(searchParam: string, searchParamValue: string) {
+	const currentURL = new URL(window.location.href);
+	const [currentHash, currentHashSearch] = currentURL.hash.split('?');
+	const urlSearchParams = new URLSearchParams(currentHashSearch);
+	urlSearchParams.set(searchParam, searchParamValue);
+	currentURL.hash = `${currentHash}?${urlSearchParams.toString()}`;
+	currentURL.searchParams.delete('type');
+	await Browser.tabs.create({
+		url: currentURL.href,
+	});
+}
+
 export function AddAccountPage() {
-	const [searchParams] = useSearchParams();
+	const [searchParams, setSearchParams] = useSearchParams();
 	const navigate = useNavigate();
 	const sourceFlow = searchParams.get('sourceFlow') || 'Unknown';
 	const showSocialSignInOptions = sourceFlow !== 'Onboarding';
 	const forceShowLedger =
 		searchParams.has('showLedger') && searchParams.get('showLedger') !== 'false';
-	const [, setAccountFormValues] = useAccountsFormContext();
+	const [, setAccountsFormValues] = useAccountsFormContext();
 	const isPopup = useAppSelector((state) => state.app.appType === AppType.popup);
 	const [isConnectLedgerModalOpen, setConnectLedgerModalOpen] = useState(forceShowLedger);
+	const createAccountsMutation = useCreateAccountsMutation();
+	const createZkLoginAccount = useCallback(
+		async (provider: ZkProvider) => {
+			await setAccountsFormValues({ type: 'zk', provider });
+			await createAccountsMutation.mutateAsync(
+				{
+					type: 'zk',
+				},
+				{
+					onSuccess: () => {
+						navigate('/tokens');
+					},
+					onError: (error) => {
+						toast.error((error as Error)?.message || 'Failed to create account. (Unknown error)');
+					},
+				},
+			);
+		},
+		[setAccountsFormValues, createAccountsMutation, navigate],
+	);
+	const [forcedZkLoginProvider, setForcedZkLoginProvider] = useState<ZkProvider | null>(null);
+	const forceZkLoginWithProviderRef = useRef(searchParams.get('forceZkLoginProvider'));
+	const forcedLoginHandledRef = useRef(false);
+	const { data: accountsTotalByType, isLoading: isAccountsCountLoading } = useCountAccountsByType();
+	useEffect(() => {
+		if (isAccountsCountLoading) {
+			return;
+		}
+		const zkLoginProvider = forceZkLoginWithProviderRef.current as ZkProvider;
+		if (zkLoginProvider && zkProviderDataMap[zkLoginProvider] && !forcedLoginHandledRef.current) {
+			const totalProviderAccounts = accountsTotalByType?.zk?.extra?.[zkLoginProvider] || 0;
+			if (totalProviderAccounts === 0) {
+				setForcedZkLoginProvider(zkLoginProvider);
+				createZkLoginAccount(zkLoginProvider).finally(() => setForcedZkLoginProvider(null));
+			}
+			const newURLSearchParams = new URLSearchParams(searchParams.toString());
+			newURLSearchParams.delete('forceZkLoginProvider');
+			setSearchParams(newURLSearchParams.toString());
+			forcedLoginHandledRef.current = true;
+		}
+	}, [
+		setSearchParams,
+		accountsTotalByType,
+		searchParams,
+		createZkLoginAccount,
+		isAccountsCountLoading,
+	]);
 	return (
 		<Overlay showModal title="Add Account" closeOverlay={() => navigate('/')}>
 			<div className="w-full flex flex-col gap-8">
 				<div className="flex flex-col gap-3">
 					{showSocialSignInOptions && (
-						<>
-							<SocialButton
-								provider="google"
-								showLabel
-								onClick={() => {
-									// eslint-disable-next-line no-console
-									console.log('TODO: Open OAuth flow');
-									ampli.clickedSocialSignInButton({
-										signInProvider: 'Google',
-										sourceFlow,
-									});
-								}}
-							/>
-							<SocialButton
-								provider="twitch"
-								showLabel
-								onClick={() => {
-									// eslint-disable-next-line no-console
-									console.log('TODO: Open OAuth flow');
-									ampli.clickedSocialSignInButton({
-										signInProvider: 'Twitch',
-										sourceFlow,
-									});
-								}}
-							/>
-							<SocialButton
-								provider="facebook"
-								showLabel
-								onClick={() => {
-									// eslint-disable-next-line no-console
-									console.log('TODO: Open OAuth flow');
-									ampli.clickedSocialSignInButton({
-										signInProvider: 'Facebook',
-										sourceFlow,
-									});
-								}}
-							/>
-							<SocialButton
-								provider="microsoft"
-								showLabel
-								onClick={() => {
-									// eslint-disable-next-line no-console
-									console.log('TODO: Open OAuth flow');
-									ampli.clickedSocialSignInButton({
-										signInProvider: 'Microsoft',
-										sourceFlow,
-									});
-								}}
-							/>
-						</>
+						<ZkLoginButtons
+							layout="column"
+							showLabel
+							sourceFlow={sourceFlow}
+							forcedZkLoginProvider={forcedZkLoginProvider}
+							onButtonClick={async (provider) => {
+								if (isPopup) {
+									await openTabWithSearchParam('forceZkLoginProvider', provider);
+									window.close();
+									return;
+								} else {
+									return createZkLoginAccount(provider);
+								}
+							}}
+						/>
 					)}
 					<Button
 						variant="outline"
@@ -91,17 +118,13 @@ export function AddAccountPage() {
 						onClick={async () => {
 							ampli.openedConnectLedgerFlow({ sourceFlow });
 							if (isPopup) {
-								const { origin, pathname, hash } = window.location;
-								await Browser.tabs.create({
-									url: `${origin}${pathname}${hash}${
-										hash.includes('showLedger') ? '' : `${hash.includes('?') ? '&' : '?'}showLedger`
-									}`,
-								});
+								await openTabWithSearchParam('showLedger', 'true');
 								window.close();
 							} else {
 								setConnectLedgerModalOpen(true);
 							}
 						}}
+						disabled={createAccountsMutation.isLoading}
 					/>
 				</div>
 				<Section title="Create New">
@@ -111,9 +134,10 @@ export function AddAccountPage() {
 						text="Create a new Passphrase Account"
 						to="/accounts/protect-account?accountType=new-mnemonic"
 						onClick={() => {
-							setAccountFormValues({ type: 'new-mnemonic' });
+							setAccountsFormValues({ type: 'new-mnemonic' });
 							ampli.clickedCreateNewAccount({ sourceFlow });
 						}}
+						disabled={createAccountsMutation.isLoading}
 					/>
 				</Section>
 				<Section title="Import Existing Accounts">
@@ -125,6 +149,7 @@ export function AddAccountPage() {
 						onClick={() => {
 							ampli.clickedImportPassphrase({ sourceFlow });
 						}}
+						disabled={createAccountsMutation.isLoading}
 					/>
 					<Button
 						variant="outline"
@@ -134,6 +159,7 @@ export function AddAccountPage() {
 						onClick={() => {
 							ampli.clickedImportPrivateKey({ sourceFlow });
 						}}
+						disabled={createAccountsMutation.isLoading}
 					/>
 				</Section>
 			</div>

--- a/apps/wallet/src/ui/app/pages/accounts/ProtectAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/ProtectAccountPage.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ProtectAccountForm } from '../../components/accounts/ProtectAccountForm';
+import { VerifyPasswordModal } from '../../components/accounts/VerifyPasswordModal';
+import Loading from '../../components/loading';
 import { useAccounts } from '../../hooks/useAccounts';
 import { type CreateType, useCreateAccountsMutation } from '../../hooks/useCreateAccountMutation';
 import { Heading } from '../../shared/heading';
@@ -34,59 +36,74 @@ export function ProtectAccountPage() {
 	const navigate = useNavigate();
 	const { data: accounts } = useAccounts();
 	const createMutation = useCreateAccountsMutation();
+	const hasPasswordAccounts = useMemo(
+		() => accounts && accounts.some(({ isPasswordUnlockable }) => isPasswordUnlockable),
+		[accounts],
+	);
+	const [showVerifyPasswordView, setShowVerifyPasswordView] = useState<boolean | null>(null);
 	useEffect(() => {
-		// don't show this page if other password accounts exist (we should show the verify password instead)
 		if (
-			accounts?.length &&
-			accounts.some(({ isPasswordUnlockable }) => isPasswordUnlockable) &&
-			!createMutation.isLoading &&
-			!createMutation.isSuccess
+			typeof hasPasswordAccounts !== 'undefined' &&
+			!(createMutation.isSuccess || createMutation.isLoading)
 		) {
-			navigate('/', { replace: true });
+			setShowVerifyPasswordView(hasPasswordAccounts);
 		}
-	}, [accounts, navigate, createMutation.isSuccess, createMutation.isLoading]);
+	}, [hasPasswordAccounts, createMutation.isSuccess, createMutation.isLoading]);
+	const createAccountCallback = useCallback(
+		async (password: string, type: CreateType) => {
+			try {
+				const createdAccounts = await createMutation.mutateAsync({
+					type,
+					password,
+				});
+				if (type === 'new-mnemonic' && isMnemonicSerializedUiAccount(createdAccounts[0])) {
+					navigate(`/accounts/backup/${createdAccounts[0].sourceID}`, {
+						replace: true,
+						state: {
+							onboarding: true,
+						},
+					});
+				} else {
+					navigate(successRedirect, { replace: true });
+				}
+			} catch (e) {
+				toast.error((e as Error).message ?? 'Failed to create account');
+			}
+		},
+		[createMutation, navigate, successRedirect],
+	);
 	if (!isAllowedAccountType(accountType)) {
 		return <Navigate to="/" replace />;
 	}
 	return (
-		<div className="rounded-20 bg-sui-lightest shadow-wallet-content flex flex-col items-center px-6 py-10 h-full overflow-auto">
-			<Text variant="caption" color="steel-dark" weight="semibold">
-				Wallet Setup
-			</Text>
-			<div className="text-center mt-2.5">
-				<Heading variant="heading1" color="gray-90" as="h1" weight="bold">
-					Protect Account with a Password Lock
-				</Heading>
-			</div>
-			<div className="mt-6 w-full grow">
-				<ProtectAccountForm
-					cancelButtonText="Back"
-					submitButtonText="Create Wallet"
-					onSubmit={async (formValues) => {
-						try {
-							const createdAccounts = await createMutation.mutateAsync({
-								type: accountType,
-								password: formValues.password.input,
-							});
-							if (
-								accountType === 'new-mnemonic' &&
-								isMnemonicSerializedUiAccount(createdAccounts[0])
-							) {
-								navigate(`/accounts/backup/${createdAccounts[0].sourceID}`, {
-									replace: true,
-									state: {
-										onboarding: true,
-									},
-								});
-							} else {
-								navigate(successRedirect, { replace: true });
-							}
-						} catch (e) {
-							toast.error((e as Error).message ?? 'Failed to create account');
-						}
-					}}
-				/>
-			</div>
+		<div className="rounded-20 bg-sui-lightest shadow-wallet-content flex flex-col items-center px-6 py-10 overflow-auto w-popup-width h-popup-height">
+			<Loading loading={showVerifyPasswordView === null}>
+				{showVerifyPasswordView ? (
+					<VerifyPasswordModal
+						open
+						onClose={() => navigate(-1)}
+						onVerify={(password) => createAccountCallback(password, accountType)}
+					/>
+				) : (
+					<>
+						<Text variant="caption" color="steel-dark" weight="semibold">
+							Wallet Setup
+						</Text>
+						<div className="text-center mt-2.5">
+							<Heading variant="heading1" color="gray-90" as="h1" weight="bold">
+								Protect Account with a Password Lock
+							</Heading>
+						</div>
+						<div className="mt-6 w-full grow">
+							<ProtectAccountForm
+								cancelButtonText="Back"
+								submitButtonText="Create Wallet"
+								onSubmit={({ password }) => createAccountCallback(password.input, accountType)}
+							/>
+						</div>
+					</>
+				)}
+			</Loading>
 		</div>
 	);
 }

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -134,9 +134,9 @@ export function AccountGroup({
 				<VerifyPasswordModal
 					open
 					onVerify={async (password) => {
-						if (accountsFormValues && accountsFormValues.type !== 'zk') {
+						if (accountsFormValues.current && accountsFormValues.current.type !== 'zk') {
 							await createAccountMutation.mutateAsync({
-								type: accountsFormValues.type,
+								type: accountsFormValues.current.type,
 								password,
 							});
 						}

--- a/apps/wallet/src/ui/app/shared/tooltip/index.tsx
+++ b/apps/wallet/src/ui/app/shared/tooltip/index.tsx
@@ -37,8 +37,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
 	const {
 		x,
 		y,
-		reference,
-		floating,
+		refs,
 		strategy,
 		context,
 		middlewareData,
@@ -86,7 +85,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
 
 	return (
 		<>
-			<div tabIndex={0} className="w-fit" {...getReferenceProps({ ref: reference })}>
+			<div tabIndex={0} className="w-full" {...getReferenceProps({ ref: refs.setReference })}>
 				{children}
 			</div>
 			<FloatingPortal>
@@ -120,7 +119,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
 								width: 'max-content',
 								maxWidth: '200px',
 							}}
-							{...getFloatingProps({ ref: floating })}
+							{...getFloatingProps({ ref: refs.setFloating })}
 						>
 							<div className="flex flex-col flex-nowrap gap-px rounded-md bg-gray-100 p-2">
 								{tip}

--- a/apps/wallet/src/ui/app/shared/utils/ButtonOrLink.tsx
+++ b/apps/wallet/src/ui/app/shared/utils/ButtonOrLink.tsx
@@ -1,18 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ComponentProps, forwardRef, type Ref } from 'react';
+import { type ComponentProps, forwardRef, type Ref, type ReactNode } from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 
 import LoadingIndicator from '../../components/loading/LoadingIndicator';
+import { Tooltip } from '../tooltip';
+
+type WithTooltipProps = {
+	title?: ReactNode;
+	children: ReactNode;
+};
+function WithTooltip({ title, children }: WithTooltipProps) {
+	if (title) {
+		return <Tooltip tip={title}>{children}</Tooltip>;
+	}
+	return children;
+}
 
 export interface ButtonOrLinkProps
 	extends Omit<Partial<LinkProps> & ComponentProps<'a'> & ComponentProps<'button'>, 'ref'> {
 	loading?: boolean;
 }
-
 export const ButtonOrLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonOrLinkProps>(
-	({ href, to, disabled = false, loading = false, children, ...props }, ref) => {
+	({ href, to, disabled = false, loading = false, children, title, ...props }, ref) => {
 		const isDisabled = disabled || loading;
 		const content = loading ? (
 			<>
@@ -31,36 +42,42 @@ export const ButtonOrLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, Bu
 		// External link:
 		if (href && !isDisabled) {
 			return (
-				<a
-					ref={ref as Ref<HTMLAnchorElement>}
-					target="_blank"
-					rel="noreferrer noopener"
-					href={href}
-					{...props}
-					style={styles}
-				>
-					{content}
-				</a>
+				<WithTooltip title={title}>
+					<a
+						ref={ref as Ref<HTMLAnchorElement>}
+						target="_blank"
+						rel="noreferrer noopener"
+						href={href}
+						{...props}
+						style={styles}
+					>
+						{content}
+					</a>
+				</WithTooltip>
 			);
 		}
 		// Internal router link:
 		if (to && !isDisabled) {
 			return (
-				<Link to={to} ref={ref as Ref<HTMLAnchorElement>} {...props} style={styles}>
-					{content}
-				</Link>
+				<WithTooltip title={title}>
+					<Link to={to} ref={ref as Ref<HTMLAnchorElement>} {...props} style={styles}>
+						{content}
+					</Link>
+				</WithTooltip>
 			);
 		}
 		return (
-			<button
-				{...props}
-				type={props.type || 'button'}
-				ref={ref as Ref<HTMLButtonElement>}
-				disabled={isDisabled}
-				style={styles}
-			>
-				{content}
-			</button>
+			<WithTooltip title={title}>
+				<button
+					{...props}
+					type={props.type || 'button'}
+					ref={ref as Ref<HTMLButtonElement>}
+					disabled={isDisabled}
+					style={styles}
+				>
+					{content}
+				</button>
+			</WithTooltip>
 		);
 	},
 );


### PR DESCRIPTION
## Description 

* add accounts page support for zk login accounts
  * allow only one zklogin account for each provider
  * show a tooltip why a zklogin button is disabled
  * force doing the zklogin creation flow in a tab to avoid having the popup closed during the process
  * changes the accounts form values to context to avoid having issues with outdated values
  * tittle prop for ButtonOrLink now renders a tooltip
  
  

https://github.com/MystenLabs/sui/assets/10210143/40a95458-d42b-4e98-9df5-5da9e19be7de


https://github.com/MystenLabs/sui/assets/10210143/2386b3b7-5cf6-4d9d-8a87-f3a45b77eec1


  
* adding accounts shows password verification when password accounts exist


https://github.com/MystenLabs/sui/assets/10210143/fdf3f55b-7707-47b3-9140-38c6eb80eca5



closes APPS-1496

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
