### PR TITLE
[wallet-ext] - group / sort accounts list 

### DIFF
--- a/apps/wallet/src/background/account-sources/AccountSource.ts
+++ b/apps/wallet/src/background/account-sources/AccountSource.ts
@@ -51,6 +51,7 @@ export abstract class AccountSource<
 export interface AccountSourceSerialized {
 	readonly id: string;
 	readonly type: AccountSourceType;
+	readonly createdAt: number;
 }
 
 export type AccountSourceSerializedUI = {

--- a/apps/wallet/src/background/account-sources/MnemonicAccountSource.ts
+++ b/apps/wallet/src/background/account-sources/MnemonicAccountSource.ts
@@ -75,6 +75,7 @@ export class MnemonicAccountSource extends AccountSource<
 			type: 'mnemonic',
 			encryptedData: await encrypt(password, decryptedData),
 			sourceHash: bytesToHex(sha256(entropy)),
+			createdAt: Date.now(),
 		};
 		const allAccountSources = await getAccountSources();
 		for (const anAccountSource of allAccountSources) {

--- a/apps/wallet/src/background/account-sources/QredoAccountSource.ts
+++ b/apps/wallet/src/background/account-sources/QredoAccountSource.ts
@@ -68,6 +68,7 @@ export class QredoAccountSource extends AccountSource<QredoAccountSourceSerializ
 			service,
 			encrypted: await encrypt(password, decryptedData),
 			originFavIcon,
+			createdAt: Date.now(),
 		};
 		const allAccountSources = await getAccountSources();
 		for (const anAccountSource of allAccountSources) {

--- a/apps/wallet/src/background/account-sources/index.ts
+++ b/apps/wallet/src/background/account-sources/index.ts
@@ -33,9 +33,8 @@ export async function getAccountSources(filter?: { type: AccountSourceType }) {
 	const db = await getDB();
 	return (
 		await (filter?.type
-			? await db.accountSources.where('type').equals(filter.type)
-			: await db.accountSources
-		).toArray()
+			? await db.accountSources.where('type').equals(filter.type).sortBy('createdAt')
+			: await db.accountSources.toCollection().sortBy('createdAt'))
 	).map(toAccountSource);
 }
 

--- a/apps/wallet/src/background/accounts/Account.ts
+++ b/apps/wallet/src/background/accounts/Account.ts
@@ -128,6 +128,7 @@ export interface SerializedAccount {
 	 */
 	readonly selected: boolean;
 	readonly nickname: string | null;
+	readonly createdAt: number;
 }
 
 export interface SerializedUIAccount {

--- a/apps/wallet/src/background/accounts/ImportedAccount.ts
+++ b/apps/wallet/src/background/accounts/ImportedAccount.ts
@@ -55,6 +55,7 @@ export class ImportedAccount
 			lastUnlockedOn: null,
 			selected: false,
 			nickname: null,
+			createdAt: Date.now(),
 		};
 	}
 

--- a/apps/wallet/src/background/accounts/LedgerAccount.ts
+++ b/apps/wallet/src/background/accounts/LedgerAccount.ts
@@ -57,6 +57,7 @@ export class LedgerAccount
 			lastUnlockedOn: null,
 			selected: false,
 			nickname: null,
+			createdAt: Date.now(),
 		};
 	}
 

--- a/apps/wallet/src/background/accounts/MnemonicAccount.ts
+++ b/apps/wallet/src/background/accounts/MnemonicAccount.ts
@@ -63,6 +63,7 @@ export class MnemonicAccount
 			lastUnlockedOn: null,
 			selected: false,
 			nickname: null,
+			createdAt: Date.now(),
 		};
 	}
 

--- a/apps/wallet/src/background/accounts/index.ts
+++ b/apps/wallet/src/background/accounts/index.ts
@@ -45,11 +45,11 @@ export async function getAllAccounts(filter?: { sourceID: string }) {
 	const db = await getDB();
 	let accounts;
 	if (filter?.sourceID) {
-		accounts = await db.accounts.where('sourceID').equals(filter.sourceID);
+		accounts = await db.accounts.where('sourceID').equals(filter.sourceID).sortBy('createdAt');
 	} else {
-		accounts = db.accounts;
+		accounts = await db.accounts.toCollection().sortBy('createdAt');
 	}
-	return (await accounts.toArray()).map(toAccount);
+	return accounts.map(toAccount);
 }
 
 export async function getAccountByID(id: string) {

--- a/apps/wallet/src/background/accounts/zk/ZkAccount.ts
+++ b/apps/wallet/src/background/accounts/zk/ZkAccount.ts
@@ -133,6 +133,7 @@ export class ZkAccount
 			lastUnlockedOn: null,
 			selected: false,
 			nickname: claims.email || null,
+			createdAt: Date.now(),
 		};
 	}
 

--- a/apps/wallet/src/background/qredo/index.ts
+++ b/apps/wallet/src/background/qredo/index.ts
@@ -236,6 +236,7 @@ export async function acceptQredoConnection({
 			lastUnlockedOn: null,
 			selected: false,
 			nickname: null,
+			createdAt: Date.now(),
 		});
 	}
 	const connectedAccounts = (await addNewAccounts(newQredoAccounts)) as QredoAccount[];

--- a/apps/wallet/src/background/storage-migration.ts
+++ b/apps/wallet/src/background/storage-migration.ts
@@ -121,6 +121,7 @@ async function makeQredoAccounts(password: string) {
 				sourceID: aQredoSource.id,
 				selected: false,
 				nickname: null,
+				createdAt: Date.now(),
 			});
 		}
 	}

--- a/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
@@ -20,7 +20,7 @@ type AccountListItemProps = {
 export function AccountListItem({ account }: AccountListItemProps) {
 	const activeAccount = useActiveAccount();
 	const { data: domainName } = useResolveSuiNSName(account?.address);
-	const { unlockAccount, lockAccount, isLoading } = useUnlockAccount();
+	const { unlockAccount, lockAccount, isLoading, accountToUnlock } = useUnlockAccount();
 
 	return (
 		<AccountItem
@@ -32,7 +32,7 @@ export function AccountListItem({ account }: AccountListItemProps) {
 					<div className="flex items-center justify-center">
 						<LockUnlockButton
 							isLocked={account.isLocked}
-							isLoading={isLoading}
+							isLoading={isLoading && accountToUnlock?.id === account.id}
 							onClick={(e) => {
 								// prevent the account from being selected when clicking the lock button
 								e.stopPropagation();

--- a/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsList.tsx
@@ -6,22 +6,22 @@ import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import { useMemo } from 'react';
 import { AccountListItem } from './AccountListItem';
 import { FooterLink } from './FooterLink';
+import { useAccountGroups } from '../../hooks/useAccountGroups';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
 import { useBackgroundClient } from '../../hooks/useBackgroundClient';
 import { Heading } from '../../shared/heading';
 
 import { ampli } from '_src/shared/analytics/ampli';
-import { useAccounts } from '_src/ui/app/hooks/useAccounts';
 import { Collapsible } from '_src/ui/app/shared/collapse';
 
 export function AccountsList() {
-	const { data: accounts } = useAccounts();
+	const accountGroups = useAccountGroups();
+	const accounts = accountGroups.list();
 	const activeAccount = useActiveAccount();
 	const backgroundClient = useBackgroundClient();
 
-	// todo: these will be grouped by account type
 	const otherAccounts = useMemo(
-		() => accounts?.filter((a) => a.id !== activeAccount?.id) || [],
+		() => accounts.filter((a) => a.id !== activeAccount?.id) || [],
 		[accounts, activeAccount?.id],
 	);
 

--- a/apps/wallet/src/ui/app/components/accounts/FooterLink.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/FooterLink.tsx
@@ -1,12 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { forwardRef } from 'react';
 import { Link, type LinkProps } from '../../shared/Link';
 
-export function FooterLink({ icon, ...props }: LinkProps & { icon?: React.ReactNode }) {
+const FooterLink = forwardRef((props: LinkProps & { icon?: React.ReactNode }, forwardedRef) => {
 	return (
 		<div className="flex gap-1 uppercase bg-none rounded-sm  hover:bg-white/60 p-1 items-center justify-center">
-			<Link before={icon} weight="semibold" size="captionSmall" {...props} />
+			<Link before={props.icon} weight="semibold" size="captionSmall" {...props} />
 		</div>
 	);
-}
+});
+
+export { FooterLink };

--- a/apps/wallet/src/ui/app/helpers/sortAccounts.ts
+++ b/apps/wallet/src/ui/app/helpers/sortAccounts.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { type AccountType, type SerializedUIAccount } from '_src/background/accounts/Account';
+import { isMnemonicSerializedUiAccount } from '_src/background/accounts/MnemonicAccount';
+import { isZkAccountSerializedUI } from '_src/background/accounts/zk/ZkAccount';
+
+function getKey(account: SerializedUIAccount): string {
+	if (isMnemonicSerializedUiAccount(account)) return account.sourceID;
+	if (isZkAccountSerializedUI(account)) return account.provider;
+	return account.type;
+}
+
+export const defaultSortOrder: AccountType[] = [
+	'zk',
+	'mnemonic-derived',
+	'imported',
+	'ledger',
+	'qredo',
+];
+
+export function groupByType(accounts: SerializedUIAccount[]) {
+	return accounts.reduce(
+		(acc, account) => {
+			const byType = acc[account.type] || (acc[account.type] = {});
+			const key = getKey(account);
+			(byType[key] || (byType[key] = [])).push(account);
+			return acc;
+		},
+		defaultSortOrder.reduce(
+			(acc, type) => {
+				acc[type] = {};
+				return acc;
+			},
+			{} as Record<AccountType, Record<string, SerializedUIAccount[]>>,
+		),
+	);
+}

--- a/apps/wallet/src/ui/app/hooks/useAccountGroups.ts
+++ b/apps/wallet/src/ui/app/hooks/useAccountGroups.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+import { useAccounts } from './useAccounts';
+import { defaultSortOrder, groupByType } from '../helpers/sortAccounts';
+
+export function useAccountGroups() {
+	const { data: accounts } = useAccounts();
+
+	const sortedAndGroupedAccounts = useMemo(() => {
+		return groupByType(accounts ?? []);
+	}, [accounts]);
+
+	const list = () => {
+		return defaultSortOrder.flatMap((type) => {
+			const group = sortedAndGroupedAccounts[type];
+			return Object.values(group).flat();
+		});
+	};
+
+	return { ...sortedAndGroupedAccounts, list };
+}

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 import { ArrowBgFill16, Plus12 } from '@mysten/icons';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 import { useState } from 'react';
@@ -53,11 +52,12 @@ function AccountFooter({ accountID }: { accountID: string }) {
 	return (
 		<div className="flex flex-shrink-0 w-full">
 			<div className="flex gap-3 items-center">
-				<div className="w-4" />
+				<div className="w-1.5" />
 				<NicknameDialog accountID={accountID} trigger={<FooterLink>Edit Nickname</FooterLink>} />
-				<FooterLink to="/remove">
+				{/* TODO: Remove Account functionality */}
+				{/* <FooterLink to="/remove">
 					<div>Remove</div>
-				</FooterLink>
+				</FooterLink> */}
 			</div>
 		</div>
 	);

--- a/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
@@ -1,48 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
-import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AccountGroup } from './AccountGroup';
-
 import Overlay from '../../../components/overlay';
-import { useAccounts } from '../../../hooks/useAccounts';
-import { type AccountType, type SerializedUIAccount } from '_src/background/accounts/Account';
-import { isMnemonicSerializedUiAccount } from '_src/background/accounts/MnemonicAccount';
+import { type AccountType } from '_src/background/accounts/Account';
+import { useAccountGroups } from '_src/ui/app/hooks/useAccountGroups';
 
 export function ManageAccountsPage() {
-	const { data: accounts } = useAccounts();
-
 	const navigate = useNavigate();
-	const groupedAccounts = useMemo(() => {
-		return (accounts ?? []).reduce(
-			(acc, account) => {
-				if (!acc[account.type]) {
-					acc[account.type] = [];
-				}
-				acc[account.type].push(account);
-				return acc;
-			},
-			{} as Record<AccountType, SerializedUIAccount[]>,
-		);
-	}, [accounts]);
+	const groupedAccounts = useAccountGroups();
 
 	return (
 		<Overlay showModal title="Manage Accounts" closeOverlay={() => navigate('/home')}>
 			<div className="flex flex-col gap-4 flex-1">
-				{Object.entries(groupedAccounts).map(([type, accounts]) => {
-					let accountSource;
-					// todo: is there a better way???
-					if (isMnemonicSerializedUiAccount(accounts[0])) accountSource = accounts[0].sourceID;
-					return (
-						<AccountGroup
-							key={type}
-							accounts={accounts ?? []}
-							accountSource={accountSource}
-							type={type as AccountType}
-						/>
-					);
-				})}
+				{Object.entries(groupedAccounts).map(([type, accountGroups]) =>
+					Object.entries(accountGroups).map(([key, accounts]) => {
+						return (
+							<AccountGroup
+								key={`${type}-${key}`}
+								accounts={accounts}
+								accountSource={key}
+								type={type as AccountType}
+							/>
+						);
+					}),
+				)}
 			</div>
 		</Overlay>
 	);


### PR DESCRIPTION
## Description 

- adds some helper functions to group the accounts list by `type` and `sourceID` / `provider` / other for display on the Manage Accounts page. 
- sort accounts within a group
- add default sort for account groups: `zk -> mnemonic-derived -> imported -> ledger -> qredo`

notes:
-  might want to rename `useAccountGroups` to something else
- we should eventually update the UI to distinguish groups of the same type (Passphrase Derived in the video) cc: @mystie711 

https://github.com/MystenLabs/sui/assets/122397493/63dede7a-a0ef-4ec5-80ec-ee2a2d07a131


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
