### PR TITLE
Check system overload using txn age in queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10299,6 +10299,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "im",
+ "indexmap 1.9.3",
  "itertools",
  "lru 0.10.0",
  "more-asserts",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -159,6 +159,9 @@ pub struct NodeConfig {
 
     #[serde(default = "default_zklogin_oauth_providers")]
     pub zklogin_oauth_providers: BTreeMap<Chain, BTreeSet<String>>,
+
+    #[serde(default = "default_overload_threshold_config")]
+    pub overload_threshold_config: OverloadThresholdConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
@@ -669,6 +672,29 @@ pub struct TransactionKeyValueStoreWriteConfig {
     pub table_name: String,
     pub bucket_name: String,
     pub concurrency: usize,
+}
+
+/// Configuration for the threshold(s) at which we consider the system
+/// to be overloaded. When one of the threshold is passed, the node may
+/// stop processing new transactions and/or certificates until the congestion
+/// resolves.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OverloadThresholdConfig {
+    pub max_txn_age_in_queue: Duration,
+    // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
+    // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
+}
+
+impl Default for OverloadThresholdConfig {
+    fn default() -> Self {
+        Self {
+            max_txn_age_in_queue: Duration::from_secs(1), // 1 second
+        }
+    }
+}
+
+fn default_overload_threshold_config() -> OverloadThresholdConfig {
+    OverloadThresholdConfig::default()
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -19,6 +19,7 @@ enum_dispatch.workspace = true
 eyre.workspace = true
 futures.workspace = true
 im.workspace = true
+indexmap.workspace = true
 itertools.workspace = true
 lru.workspace = true
 num_cpus.workspace = true

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -5,8 +5,10 @@ use std::{
     cmp::max,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
+    time::{Duration, Instant},
 };
 
+use indexmap::IndexMap;
 use lru::LruCache;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
@@ -246,10 +248,10 @@ struct Inner {
     // Maps input objects to transactions waiting for locks on the object.
     lock_waiters: HashMap<InputKey, LockQueue>,
 
-    // Number of transactions that depend on each object ID. Should match exactly with total
-    // number of transactions per object ID prefix in the missing_inputs table.
+    // Stores age info for all transactions depending on each object.
     // Used for throttling signing and submitting transactions depending on hot objects.
-    input_objects: HashMap<ObjectID, usize>,
+    // An `IndexMap` is used to ensure that the insertion order is preserved.
+    input_objects: HashMap<ObjectID, IndexMap<TransactionDigest, Instant>>,
 
     // Maps object IDs to the highest observed sequence number of the object. When the value is
     // None, indicates that the object is immutable, corresponding to an InputKey with no sequence
@@ -312,7 +314,7 @@ impl Inner {
             return ready_certificates;
         }
 
-        let input_count = self
+        let input_txns = self
             .input_objects
             .get_mut(&input_key.id())
             .unwrap_or_else(|| {
@@ -321,8 +323,12 @@ impl Inner {
                     input_key.id()
                 )
             });
-        *input_count -= digests.len();
-        if *input_count == 0 {
+        for digest in digests.iter() {
+            // The digest of the transaction must be inside the map.
+            assert!(input_txns.shift_remove(digest).is_some());
+        }
+
+        if input_txns.is_empty() {
             self.input_objects.remove(&input_key.id());
         }
 
@@ -665,8 +671,8 @@ impl TransactionManager {
                 }
                 if acquire {
                     pending_cert.acquiring_locks.insert(key, lock_mode);
-                    let input_count = inner.input_objects.entry(key.id()).or_default();
-                    *input_count += 1;
+                    let input_txns = inner.input_objects.entry(key.id()).or_default();
+                    input_txns.insert(digest, Instant::now());
                 } else {
                     pending_cert.acquired_locks.insert(key, lock_mode);
                 }
@@ -836,14 +842,20 @@ impl TransactionManager {
             .map(|cert| cert.acquiring_locks.keys().cloned().collect())
     }
 
-    // Returns the number of transactions waiting on each object ID.
-    pub(crate) fn objects_queue_len(&self, keys: Vec<ObjectID>) -> Vec<(ObjectID, usize)> {
+    // Returns the number of transactions waiting on each object ID, as well as the age of the oldest transaction in the queue.
+    pub(crate) fn objects_queue_len_and_age(
+        &self,
+        keys: Vec<ObjectID>,
+    ) -> Vec<(ObjectID, usize, Option<Duration>)> {
         let inner = self.inner.read();
         keys.into_iter()
             .map(|key| {
+                let default_map = IndexMap::new();
+                let txns = inner.input_objects.get(&key).unwrap_or(&default_map);
                 (
                     key,
-                    inner.input_objects.get(&key).cloned().unwrap_or_default(),
+                    txns.len(),
+                    txns.first().map(|(_, time)| time.elapsed()),
                 )
             })
             .collect()
@@ -862,7 +874,11 @@ impl TransactionManager {
         *inner = Inner::new(new_epoch, self.metrics.clone());
     }
 
-    pub(crate) fn check_execution_overload(&self, tx_data: &SenderSignedData) -> SuiResult {
+    pub(crate) fn check_execution_overload(
+        &self,
+        txn_age_threshold: Duration,
+        tx_data: &SenderSignedData,
+    ) -> SuiResult {
         // Too many transactions are pending execution.
         let inflight_queue_len = self.inflight_queue_len();
         fp_ensure!(
@@ -873,7 +889,7 @@ impl TransactionManager {
             }
         );
 
-        for (object_id, queue_len) in self.objects_queue_len(
+        for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data
                 .transaction_data()
                 .input_objects()?
@@ -890,6 +906,17 @@ impl TransactionManager {
                     threshold: MAX_PER_OBJECT_QUEUE_LENGTH,
                 }
             );
+            if let Some(age) = txn_age {
+                // Check that we don't have a txn that has been waiting for a long time in the queue.
+                fp_ensure!(
+                    age < txn_age_threshold,
+                    SuiError::TooOldTransactionPendingOnObject {
+                        object_id,
+                        txn_age_sec: age.as_secs(),
+                        threshold: txn_age_threshold.as_secs(),
+                    }
+                );
+            }
         }
         Ok(())
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -580,6 +580,7 @@ impl SuiNode {
             config.certificate_deny_config.clone(),
             config.indirect_objects_threshold,
             config.state_debug_dump_config.clone(),
+            config.overload_threshold_config.clone(),
             archive_readers,
         )
         .await;

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -170,6 +170,7 @@ impl ValidatorConfigBuilder {
                 .map(|i| i.as_secs())
                 .unwrap_or(3600),
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
+            overload_threshold_config: Default::default(),
         }
     }
 
@@ -406,6 +407,7 @@ impl FullnodeConfigBuilder {
             // note: not used by fullnodes.
             jwk_fetch_interval_seconds: 3600,
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
+            overload_threshold_config: Default::default(),
         }
     }
 }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -109,6 +109,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -215,6 +219,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -321,6 +329,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -427,6 +439,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -533,6 +549,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -639,6 +659,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -745,6 +769,10 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
+    overload-threshold-config:
+      max_txn_age_in_queue:
+        secs: 1
+        nanos: 0
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -316,6 +316,13 @@ pub enum SuiError {
         threshold: usize,
     },
 
+    #[error("Input {object_id} has a transaction {txn_age_sec} seconds old pending, above threshold of {threshold} seconds")]
+    TooOldTransactionPendingOnObject {
+        object_id: ObjectID,
+        txn_age_sec: u64,
+        threshold: u64,
+    },
+
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },
@@ -735,6 +742,7 @@ impl SuiError {
             // Overload errors
             SuiError::TooManyTransactionsPendingExecution { .. } => (true, true),
             SuiError::TooManyTransactionsPendingOnObject { .. } => (true, true),
+            SuiError::TooOldTransactionPendingOnObject { .. } => (true, true),
             SuiError::TooManyTransactionsPendingConsensus => (true, true),
 
             // Non retryable error
@@ -769,6 +777,7 @@ impl SuiError {
             self,
             SuiError::TooManyTransactionsPendingExecution { .. }
                 | SuiError::TooManyTransactionsPendingOnObject { .. }
+                | SuiError::TooOldTransactionPendingOnObject { .. }
                 | SuiError::TooManyTransactionsPendingConsensus
         )
     }


### PR DESCRIPTION
## Description 

This PR enhances our current system overload detection to also include the scenario where the transactions depending on an object are not great in the count, but lengthy in execution. More precisely, we keep track of how long each transaction has been in the execution queue and use this age as a proxy for the hotness of the object when determining whether to reject a transaction or not. 

I also added a field in the node config to make this threshold configurable and easier to test. We can also move other similar numbers here as well.

## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Enhance our validators' protection mechanism against congestion to stop accepting transactions when one of the following happens:
- There are long-running transactions waiting for execution in a certain object's queue
- There are a large number of transactions waiting in a certain object's queue, or in general