### PR TITLE
Use flag to report an OOG while charging basic storage fee

### DIFF
--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -837,6 +837,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// have updated object versions.
     pub fn check_sui_conserved(
         &self,
+        oog_on_storage_charges: bool,
         simple_conservation_checks: bool,
         gas_summary: &GasCostSummary,
     ) -> Result<(), ExecutionError> {
@@ -856,18 +857,19 @@ impl<'backing> TemporaryStore<'backing> {
             }
         }
 
-        if gas_summary.storage_cost == 0 {
-            // this condition is usually true when the transaction went OOG and no
+        if oog_on_storage_charges {
+            // this condition is true when the transaction went OOG and no
             // gas is left for storage charges.
-            // The storage cost has to be there at least for the gas coin which
+            // Normally the storage cost has to be there at least for the gas coin which
             // will not be deleted even when going to 0.
             // However if the storage cost is 0 and if there is any object touched
             // or deleted the value in input must be equal to the output plus rebate and
             // non refundable.
             // Rebate and non refundable will be positive when there are object deleted
             // (gas smashing being the primary and possibly only example).
-            // A more typical condition is for all storage charges in summary to be 0 and
+            // A typical condition is for all storage charges in summary to be 0 and
             // then input and output must be the same value
+            assert!(gas_summary.storage_cost == 0);
             if total_input_rebate
                 != total_output_rebate
                     + gas_summary.storage_rebate


### PR DESCRIPTION
## Description 

This PR adds a flag to signal OOG while charging for basic storage. In that case storage cost will be 0. That is then used in conservation checks to special case the simple check.
I do not particularly like this solution and I'd be inclined not to check it in.
However I am curious about what others think and I know @lxfind wanted to see how this looked.
I am more inclined to review this story at a later point in time and maybe find a better way to reorganize that code/checks so they are closer to each other and/or better encapsulated.
I do not like that the flag is traveling too much and it is not clear to see the relationship. I think it would make the code more brittle.
Thoughts and comments welcome

## Test Plan 

Existing tests already check for this condition

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
