### PR TITLE
wallet-ext: zklogin generate proofs only when required

### DIFF
--- a/.changeset/fuzzy-pumpkins-provide.md
+++ b/.changeset/fuzzy-pumpkins-provide.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zklogin': patch
+---
+
+update bcs AddressParams struct

--- a/apps/wallet/src/background/accounts/zk/ZkAccount.ts
+++ b/apps/wallet/src/background/accounts/zk/ZkAccount.ts
@@ -5,6 +5,7 @@ import {
 	type SerializedSignature,
 	type ExportedKeypair,
 	toSerializedSignature,
+	type PublicKey,
 } from '@mysten/sui.js/cryptography';
 import { computeZkAddress, getZkSignature } from '@mysten/zklogin';
 import { blake2b } from '@noble/hashes/blake2b';
@@ -29,13 +30,23 @@ import { type NetworkEnvType } from '_src/shared/api-env';
 import { deobfuscate, obfuscate } from '_src/shared/cryptography/keystore';
 import { fromExportedKeypair } from '_src/shared/utils/from-exported-keypair';
 
-type SessionStorageData = {
+type SerializedNetwork = `${NetworkEnvType['env']}_${NetworkEnvType['customRpcUrl']}`;
+
+function serializeNetwork(network: NetworkEnvType): SerializedNetwork {
+	return `${network.env}_${network.customRpcUrl}`;
+}
+
+type CredentialData = {
 	ephemeralKeyPair: ExportedKeypair;
-	proofs: PartialZkSignature;
+	proofs?: PartialZkSignature;
 	minEpoch: number;
 	maxEpoch: number;
 	network: NetworkEnvType;
+	randomness: string;
+	jwt: string;
 };
+
+type SessionStorageData = Partial<Record<SerializedNetwork, CredentialData>>;
 
 type JwtSerializedClaims = {
 	email: string;
@@ -145,54 +156,11 @@ export class ZkAccount
 	}
 
 	async isLocked(): Promise<boolean> {
-		const credentials = await this.getEphemeralValue();
-		if (!credentials) {
-			return true;
-		}
-		const { maxEpoch, network } = credentials;
-		const currentNetwork = await networkEnv.getActiveNetwork();
-		if (
-			currentNetwork.env !== network.env ||
-			currentNetwork.customRpcUrl !== network.customRpcUrl
-		) {
-			await this.lock(true);
-			return true;
-		}
-		return (await getCurrentEpoch()) > maxEpoch;
+		return !(await this.getEphemeralValue());
 	}
 
 	async unlock() {
-		const { provider, claims, salt: obfuscatedSalt } = await this.getStoredData();
-		const salt = await deobfuscate<string>(obfuscatedSalt);
-		const { email, sub, aud, iss } = await deobfuscate<JwtSerializedClaims>(claims);
-		const epoch = await getCurrentEpoch();
-		const { ephemeralKeyPair, nonce, randomness, maxEpoch } = prepareZKLogin(Number(epoch));
-		const jwt = await zkLogin({ provider, nonce, loginHint: sub });
-		const decodedJWT = decodeJwt(jwt);
-		if (
-			decodedJWT.aud !== aud ||
-			decodedJWT.email !== email ||
-			decodedJWT.sub !== sub ||
-			decodedJWT.iss !== iss
-		) {
-			throw new Error("Logged in account doesn't match with saved account");
-		}
-		const proofs = await createPartialZKSignature({
-			jwt,
-			ephemeralPublicKey: ephemeralKeyPair.getPublicKey(),
-			userSalt: BigInt(salt),
-			jwtRandomness: randomness,
-			keyClaimName: 'sub',
-			maxEpoch,
-		});
-		await this.setEphemeralValue({
-			ephemeralKeyPair: await ephemeralKeyPair.export(),
-			minEpoch: Number(epoch),
-			maxEpoch,
-			proofs,
-			network: await networkEnv.getActiveNetwork(),
-		});
-		await this.onUnlocked();
+		await this.#doLogin();
 	}
 
 	async toUISerialized(): Promise<ZkAccountSerializedUI> {
@@ -218,7 +186,6 @@ export class ZkAccount
 	async signData(data: Uint8Array): Promise<SerializedSignature> {
 		const digest = blake2b(data, { dkLen: 32 });
 		if (await this.isLocked()) {
-			// check is locked to handle cases of different network, current epoch higher than max epoch etc.
 			throw new Error('Account is locked');
 		}
 		const credentials = await this.getEphemeralValue();
@@ -226,9 +193,33 @@ export class ZkAccount
 			// checking the isLocked above should catch this but keep it just in case
 			throw new Error('Account is locked');
 		}
-		const { ephemeralKeyPair, proofs, maxEpoch } = credentials;
+		const activeNetwork = await networkEnv.getActiveNetwork();
+		let credentialsData = credentials[serializeNetwork(activeNetwork)];
+		const currentEpoch = await getCurrentEpoch();
+		// handle cases of different network, current epoch higher than max epoch etc.
+		if (!this.#areCredentialsValid(currentEpoch, activeNetwork, credentialsData)) {
+			credentialsData = await this.#doLogin();
+		}
+		const { ephemeralKeyPair, proofs: storedProofs, maxEpoch, jwt, randomness } = credentialsData;
 		const keyPair = fromExportedKeypair(ephemeralKeyPair);
-
+		let proofs = storedProofs;
+		if (!proofs) {
+			proofs = await this.#generateProofs(
+				jwt,
+				BigInt(randomness),
+				maxEpoch,
+				keyPair.getPublicKey(),
+			);
+			credentialsData.proofs = proofs;
+			// store the proofs to avoid creating them again
+			const newEphemeralValue = await this.getEphemeralValue();
+			if (!newEphemeralValue) {
+				// this should never happen
+				throw new Error('Missing data, account is locked');
+			}
+			newEphemeralValue[serializeNetwork(activeNetwork)] = credentialsData;
+			await this.setEphemeralValue(newEphemeralValue);
+		}
 		const userSignature = toSerializedSignature({
 			signature: await keyPair.sign(digest),
 			signatureScheme: keyPair.getKeyScheme(),
@@ -236,5 +227,65 @@ export class ZkAccount
 		});
 
 		return getZkSignature({ inputs: proofs, maxEpoch, userSignature });
+	}
+
+	#areCredentialsValid(
+		currentEpoch: number,
+		activeNetwork: NetworkEnvType,
+		credentials?: CredentialData,
+	): credentials is CredentialData {
+		if (!credentials) {
+			return false;
+		}
+		const { maxEpoch, network } = credentials;
+		return (
+			activeNetwork.env === network.env &&
+			activeNetwork.customRpcUrl === network.customRpcUrl &&
+			currentEpoch <= maxEpoch
+		);
+	}
+
+	async #doLogin() {
+		const { provider, claims } = await this.getStoredData();
+		const { sub, aud, iss } = await deobfuscate<JwtSerializedClaims>(claims);
+		const epoch = await getCurrentEpoch();
+		const { ephemeralKeyPair, nonce, randomness, maxEpoch } = prepareZKLogin(Number(epoch));
+		const jwt = await zkLogin({ provider, nonce, loginHint: sub });
+		const decodedJWT = decodeJwt(jwt);
+		if (decodedJWT.aud !== aud || decodedJWT.sub !== sub || decodedJWT.iss !== iss) {
+			throw new Error("Logged in account doesn't match with saved account");
+		}
+		const ephemeralValue = (await this.getEphemeralValue()) || {};
+		const activeNetwork = await networkEnv.getActiveNetwork();
+		const credentialsData: CredentialData = {
+			ephemeralKeyPair: ephemeralKeyPair.export(),
+			minEpoch: Number(epoch),
+			maxEpoch,
+			network: activeNetwork,
+			randomness: randomness.toString(),
+			jwt,
+		};
+		ephemeralValue[serializeNetwork(activeNetwork)] = credentialsData;
+		await this.setEphemeralValue(ephemeralValue);
+		await this.onUnlocked();
+		return credentialsData;
+	}
+
+	async #generateProofs(
+		jwt: string,
+		randomness: bigint,
+		maxEpoch: number,
+		ephemeralPublicKey: PublicKey,
+	) {
+		const { salt: obfuscatedSalt } = await this.getStoredData();
+		const salt = await deobfuscate<string>(obfuscatedSalt);
+		return await createPartialZKSignature({
+			jwt,
+			ephemeralPublicKey,
+			userSalt: BigInt(salt),
+			jwtRandomness: randomness,
+			keyClaimName: 'sub',
+			maxEpoch,
+		});
 	}
 }

--- a/apps/wallet/src/background/accounts/zk/ZkAccount.ts
+++ b/apps/wallet/src/background/accounts/zk/ZkAccount.ts
@@ -49,7 +49,7 @@ type CredentialData = {
 type SessionStorageData = Partial<Record<SerializedNetwork, CredentialData>>;
 
 type JwtSerializedClaims = {
-	email: string;
+	email: string | null;
 	fullName: string | null;
 	firstName: string | null;
 	lastName: string | null;
@@ -74,7 +74,7 @@ export interface ZkAccountSerialized extends SerializedAccount {
 
 export interface ZkAccountSerializedUI extends SerializedUIAccount {
 	type: 'zk';
-	email: string;
+	email: string | null;
 	picture: string | null;
 	provider: ZkProvider;
 }
@@ -100,13 +100,7 @@ export class ZkAccount
 		const jwt = await zkLogin({ provider, prompt: 'select_account' });
 		const salt = await fetchSalt(jwt);
 		const decodedJWT = decodeJwt(jwt);
-		if (
-			!decodedJWT.sub ||
-			!decodedJWT.iss ||
-			!decodedJWT.aud ||
-			!decodedJWT.email ||
-			typeof decodedJWT.email !== 'string'
-		) {
+		if (!decodedJWT.sub || !decodedJWT.iss || !decodedJWT.aud) {
 			throw new Error('Missing jwt data');
 		}
 		if (Array.isArray(decodedJWT.aud)) {
@@ -114,7 +108,7 @@ export class ZkAccount
 		}
 		const aud = decodedJWT.aud;
 		const claims: JwtSerializedClaims = {
-			email: decodedJWT.email,
+			email: String(decodedJWT.email || '') || null,
 			fullName: String(decodedJWT.name || '') || null,
 			firstName: String(decodedJWT.given_name || '') || null,
 			lastName: String(decodedJWT.family_name || '') || null,

--- a/apps/wallet/src/shared/cryptography/keystore.ts
+++ b/apps/wallet/src/shared/cryptography/keystore.ts
@@ -18,7 +18,7 @@ export type Serializable =
 	| number
 	| boolean
 	| null
-	| { [index: string]: Serializable }
+	| { [index: string]: Serializable | undefined }
 	| Serializable[];
 
 export async function encrypt(password: string, secrets: Serializable): Promise<string> {

--- a/sdk/zklogin/src/bcs.ts
+++ b/sdk/zklogin/src/bcs.ts
@@ -9,7 +9,6 @@ export const zkBcs = new BCS(bcs);
 
 zkBcs.registerStructType('AddressParams', {
 	iss: BCS.STRING,
-	aud: BCS.STRING,
 });
 
 zkBcs.registerStructType('ZkClaim', {


### PR DESCRIPTION
## Description 

* generate proofs only when required for signing
* keep ephemeral keys/logins in cache for each network to avoid always creating new one every time user switches
* this makes login-in pretty fast but adds about 3-5 seconds before executing a transaction (but only if proofs are not cached already)
* zklogin make email in claims optional
* zklogin-sdk: update AddressParams struct to not require aud since it was removed [here](https://github.com/MystenLabs/sui/pull/13617/files#diff-6b13a8f8558936c1cc76658631764d455f401ff65b40498c63e53908bcf0e4baR56)

closes APPS-1621

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
