### PR TITLE
kvstore: add suport for writting tx to checkpoint to dynamodb

### DIFF
--- a/crates/sui-kvstore/src/client.rs
+++ b/crates/sui-kvstore/src/client.rs
@@ -19,6 +19,7 @@ pub enum KVTable {
     Events,
     CheckpointContent,
     CheckpointSummary,
+    TransactionToCheckpoint,
     State,
 }
 
@@ -86,6 +87,7 @@ impl DynamoDbClient {
             KVTable::State => "state",
             KVTable::CheckpointContent => "cc",
             KVTable::CheckpointSummary => "cs",
+            KVTable::TransactionToCheckpoint => "tx2c",
         }
         .to_string()
     }


### PR DESCRIPTION
temporary PR used for initial backfill