### PR TITLE
[DO NOT MERGE] WIP for a Merkle Tree for Objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,6 +4927,7 @@ dependencies = [
 name = "merkle"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,6 +4924,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkle"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,8 +4927,20 @@ dependencies = [
 name = "merkle"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bcs",
+ "eyre",
+ "fastcrypto",
+ "itertools",
  "proptest",
+ "rocksdb",
  "serde",
+ "sui-storage",
+ "sui-types",
+ "tempfile",
+ "tokio",
+ "typed-store",
+ "typed-store-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ exclude = [
 
 members = [
     "crates/anemo-benchmark",
+    "crates/merkle",
     "crates/mysten-common",
     "crates/mysten-metrics",
     "crates/mysten-network",

--- a/crates/merkle/Cargo.toml
+++ b/crates/merkle/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 serde.workspace = true
+proptest.workspace = true

--- a/crates/merkle/Cargo.toml
+++ b/crates/merkle/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "merkle"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde.workspace = true

--- a/crates/merkle/Cargo.toml
+++ b/crates/merkle/Cargo.toml
@@ -6,5 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
+fastcrypto.workspace = true
 serde.workspace = true
 proptest.workspace = true
+sui-types.workspace = true
+bcs.workspace = true
+
+
+typed-store.workspace = true
+typed-store-derive.workspace = true
+rocksdb.workspace = true
+eyre.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+sui-storage.workspace = true
+itertools.workspace = true

--- a/crates/merkle/src/lib.rs
+++ b/crates/merkle/src/lib.rs
@@ -1,2 +1,4 @@
-mod nibble;
+#![allow(unused)] //TODO remove
 
+pub mod nibble;
+pub mod tree;

--- a/crates/merkle/src/lib.rs
+++ b/crates/merkle/src/lib.rs
@@ -1,0 +1,2 @@
+mod nibble;
+

--- a/crates/merkle/src/main.rs
+++ b/crates/merkle/src/main.rs
@@ -1,0 +1,210 @@
+use std::{path::Path, sync::Arc, time::Duration};
+
+use anyhow::Result;
+
+use sui_storage::http_key_value_store::HttpKVStore;
+use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
+use sui_types::digests::TransactionDigest;
+use sui_types::effects::TransactionEffects;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::messages_checkpoint::{
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
+};
+use typed_store::traits::{Map, TableSummary, TypedStoreDebug};
+use typed_store::{
+    metrics::SamplingInterval,
+    rocks::{
+        default_db_options, read_size_from_env, DBBatch, DBMap, DBOptions, MetricConf,
+        ReadWriteOptions,
+    },
+};
+use typed_store_derive::DBMapUtils;
+
+use itertools::Itertools;
+use merkle::tree::{MerkleDigest, MerkleTree, MerkleTreeBuilder};
+use merkle::tree::{Node, TreeStore};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("hello");
+
+    let chain_data = Arc::new(ChainData::open("chaindata"));
+
+    let http_store = HttpKVStore::new_kv(
+        "https://transactions.sui.io/mainnet",
+        KeyValueStoreMetrics::new_for_tests(),
+    )?;
+
+    let last_downloaded = chain_data
+        .checkpoints
+        .unbounded_iter()
+        .skip_prior_to(&u64::MAX)?
+        .next();
+
+    let next = last_downloaded.map(|(i, _)| i + 1).unwrap_or(0);
+
+    for chunk in &(next..60_000).chunks(100) {
+        let n = chunk.collect_vec();
+        let summaries = http_store.multi_get_checkpoints_summaries(&n).await?;
+
+        let m = summaries
+            .iter()
+            .map(|c| c.as_ref().unwrap().content_digest)
+            .collect_vec();
+
+        let contents = http_store
+            .multi_get_checkpoints_contents_by_digest(&m)
+            .await?;
+
+        let tx_digests = contents
+            .iter()
+            .flat_map(|c| c.as_ref().unwrap().iter())
+            .map(|digests| digests.transaction)
+            .collect_vec();
+
+        let fxs = http_store.multi_get_fx_by_tx_digest(&tx_digests).await?;
+
+        let mut batch = chain_data.checkpoints.batch();
+
+        batch.insert_batch(
+            &chain_data.checkpoints,
+            n.clone()
+                .into_iter()
+                .zip(summaries.into_iter().map(Option::unwrap)),
+        )?;
+
+        batch.insert_batch(
+            &chain_data.checkpoint_contents,
+            n.clone()
+                .into_iter()
+                .zip(contents.into_iter().map(Option::unwrap)),
+        )?;
+
+        batch.insert_batch(
+            &chain_data.fx,
+            tx_digests
+                .clone()
+                .into_iter()
+                .zip(fxs.into_iter().map(Option::unwrap)),
+        )?;
+        batch.write()?;
+
+        println!("found and wrote: {:?}", n);
+    }
+
+    let merkledb = Arc::new(MerkleData::open("merkledb"));
+
+    let last_computed = merkledb
+        .state_root
+        .unbounded_iter()
+        .skip_prior_to(&u64::MAX)?
+        .next();
+    let next = last_computed.map(|(i, _)| i + 1).unwrap_or(0);
+
+    for (checkpoint, contents) in chain_data
+        .checkpoint_contents
+        .unbounded_iter()
+        .skip_prior_to(&next)?
+    {
+        let digests = contents
+            .iter()
+            .map(|digests| digests.transaction)
+            .collect_vec();
+        let fxs = chain_data
+            .fx
+            .multi_get(digests)?
+            .into_iter()
+            .map(|f| f.unwrap())
+            .collect_vec();
+
+        let mut builder = {
+            if checkpoint == 0 {
+                MerkleTree::new(ArcMerkleData(merkledb.clone())).into_builder()
+            } else {
+                let digest = merkledb.state_root.get(&(checkpoint - 1))?.unwrap();
+                MerkleTree::with_root(ArcMerkleData(merkledb.clone()), digest)?.into_builder()
+            }
+        };
+
+        for fx in fxs {
+            // inserts
+            for object_ref in fx.all_changed_objects() {
+                builder.insert(object_ref.0)?;
+            }
+            // removals
+            for id in fx.all_removed_objects() {
+                builder.remove(id.0 .0)?;
+            }
+        }
+
+        let tree = builder.build()?;
+        merkledb
+            .state_root
+            .insert(&checkpoint, &tree.root().digest())?;
+        println!(
+            "done: {checkpoint}, object count: {}",
+            tree.root().leaf_count()
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(DBMapUtils)]
+pub struct ChainData {
+    pub(crate) checkpoints: DBMap<CheckpointSequenceNumber, CertifiedCheckpointSummary>,
+    pub(crate) checkpoint_contents: DBMap<CheckpointSequenceNumber, CheckpointContents>,
+    pub(crate) fx: DBMap<TransactionDigest, TransactionEffects>,
+}
+
+#[derive(DBMapUtils)]
+pub struct MerkleData {
+    pub(crate) state_root: DBMap<CheckpointSequenceNumber, MerkleDigest>,
+    pub(crate) merkle_nodes: DBMap<MerkleDigest, Node>,
+}
+
+impl ChainData {
+    pub fn open<T: AsRef<Path>>(path: T) -> Self {
+        Self::open_tables_read_write(
+            path.as_ref().into(),
+            MetricConf::with_sampling(SamplingInterval::new(Duration::from_secs(60), 0)),
+            None,
+            None,
+        )
+    }
+}
+
+impl MerkleData {
+    pub fn open<T: AsRef<Path>>(path: T) -> Self {
+        Self::open_tables_read_write(
+            path.as_ref().into(),
+            MetricConf::with_sampling(SamplingInterval::new(Duration::from_secs(60), 0)),
+            None,
+            None,
+        )
+    }
+}
+
+struct ArcMerkleData(Arc<MerkleData>);
+
+impl TreeStore for &MerkleData {
+    fn get_node(&self, digest: MerkleDigest) -> anyhow::Result<Option<Node>> {
+        self.merkle_nodes.get(&digest).map_err(Into::into)
+    }
+
+    fn write_node(&mut self, node: Node) -> anyhow::Result<()> {
+        self.merkle_nodes
+            .insert(&node.digest(), &node)
+            .map_err(Into::into)
+    }
+}
+
+impl TreeStore for ArcMerkleData {
+    fn get_node(&self, digest: MerkleDigest) -> anyhow::Result<Option<Node>> {
+        self.0.as_ref().get_node(digest)
+    }
+
+    fn write_node(&mut self, node: Node) -> anyhow::Result<()> {
+        self.0.as_ref().write_node(node)
+    }
+}

--- a/crates/merkle/src/nibble.rs
+++ b/crates/merkle/src/nibble.rs
@@ -1,0 +1,388 @@
+//! `Nibble` represents a four-bit unsigned integer.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// /// The hardcoded maximum height of a state merkle tree in nibbles.
+// pub const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct Nibble(u8);
+
+impl From<u8> for Nibble {
+    fn from(nibble: u8) -> Self {
+        assert!(nibble < 16, "Nibble out of range: {}", nibble);
+        Self(nibble)
+    }
+}
+
+impl From<Nibble> for u8 {
+    fn from(nibble: Nibble) -> Self {
+        nibble.0
+    }
+}
+
+impl fmt::LowerHex for Nibble {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", self.0)
+    }
+}
+
+/// NibblePath defines a path in a Merkle tree in the unit of nibble (4 bits).
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct NibblePath {
+    /// Indicates the total number of nibbles in bytes. Either `bytes.len() * 2 - 1` or
+    /// `bytes.len() * 2`.
+    // Guarantees intended ordering based on the top-to-bottom declaration order of the struct's
+    // members.
+    len: u8,
+    /// The underlying bytes that stores the path, 2 nibbles per byte. If the number of nibbles is
+    /// odd, the second half of the last byte must be 0.
+    bytes: [u8; Self::MAX_BYTE_PATH_LENGTH],
+    // invariant num_nibbles <= ROOT_NIBBLE_HEIGHT
+}
+
+/// Supports debug format by concatenating nibbles literally. For example, [0x12, 0xa0] with 3
+/// nibbles will be printed as "12a".
+impl fmt::Debug for NibblePath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.nibbles().try_for_each(|x| write!(f, "{:x}", x))
+    }
+}
+
+/// Convert a vector of bytes into `NibblePath` using the lower 4 bits of each byte as nibble.
+impl FromIterator<Nibble> for NibblePath {
+    fn from_iter<I: IntoIterator<Item = Nibble>>(iter: I) -> Self {
+        let mut nibble_path = NibblePath::new_even(vec![]);
+        for nibble in iter {
+            nibble_path.push(nibble);
+        }
+        nibble_path
+    }
+}
+
+impl NibblePath {
+    const MAX_BYTE_PATH_LENGTH: usize = 32;
+    const MAX_NIBBLE_PATH_LENGTH: usize = Self::MAX_BYTE_PATH_LENGTH * 2;
+
+    /// Creates a new `NibblePath` from a vector of bytes assuming each byte has 2 nibbles.
+    pub fn new_even<T: AsRef<[u8]>>(bytes: T) -> Self {
+        let bytes = bytes.as_ref();
+        assert!(bytes.len() <= Self::MAX_BYTE_PATH_LENGTH);
+        let num_nibbles = bytes.len() * 2;
+
+        let mut buf = [0; Self::MAX_BYTE_PATH_LENGTH];
+        buf[..bytes.len()].copy_from_slice(bytes);
+
+        Self {
+            len: num_nibbles.try_into().unwrap(),
+            bytes: buf,
+        }
+    }
+
+    /// Similar to `new()` but asserts that the bytes have one less nibble.
+    pub fn new_odd<T: AsRef<[u8]>>(bytes: T) -> Self {
+        let bytes = bytes.as_ref();
+
+        assert!(bytes.len() <= Self::MAX_BYTE_PATH_LENGTH);
+        assert_eq!(bytes.last().unwrap() & 0x0F, 0, "Last nibble must be 0.");
+
+        let num_nibbles = bytes.len() * 2 - 1;
+
+        let mut buf = [0; Self::MAX_BYTE_PATH_LENGTH];
+        buf[..bytes.len()].copy_from_slice(bytes);
+
+        Self {
+            len: num_nibbles.try_into().unwrap(),
+            bytes: buf,
+        }
+    }
+
+    /// Explicitly grab the number of nibbles from `bytes`, if num_nibbles is odd then the final
+    /// nibble is zero'd out for the user
+    fn new_from_byte_array(bytes: &[u8], num_nibbles: usize) -> Self {
+        assert!(num_nibbles <= Self::MAX_NIBBLE_PATH_LENGTH);
+
+        if num_nibbles % 2 == 1 {
+            // Rounded up number of bytes to be considered
+            let num_bytes = (num_nibbles + 1) / 2;
+            assert!(bytes.len() >= num_bytes);
+
+            let mut buf = [0; Self::MAX_BYTE_PATH_LENGTH];
+            buf[..num_bytes].copy_from_slice(bytes);
+            // make sure to pad the last nibble with 0s.
+            let last_byte_padded = bytes[num_bytes - 1] & 0xF0;
+            buf[num_bytes - 1] = last_byte_padded;
+
+            Self {
+                len: num_nibbles.try_into().unwrap(),
+                bytes: buf,
+            }
+        } else {
+            assert!(bytes.len() >= num_nibbles / 2);
+            NibblePath::new_even(&bytes[..num_nibbles / 2])
+        }
+    }
+
+    /// Get the total number of nibbles stored.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    ///  Returns `true` if the nibbles contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Adds a nibble to the end of the nibble path.
+    pub fn push(&mut self, nibble: Nibble) {
+        assert!(Self::MAX_NIBBLE_PATH_LENGTH > self.len());
+
+        self.set_internal(nibble, self.len());
+        self.len += 1;
+    }
+
+    fn set_internal(&mut self, nibble: Nibble, nibble_idx: usize) {
+        let current_byte = self.bytes[nibble_idx / 2];
+
+        let is_high_bits = nibble_idx % 2 == 0;
+
+        // If we are setting high bits then we want to preserve the lower bits and clear out the
+        // higher ones, otherwise we need to do the opposite
+        let byte = current_byte & (if is_high_bits { 0x0F } else { 0xF0 })
+            | u8::from(nibble) << (if is_high_bits { 4 } else { 0 });
+
+        self.bytes[nibble_idx / 2] = byte;
+    }
+
+    fn get_internal(&self, nibble_idx: usize) -> Nibble {
+        Nibble::from(
+            (self.bytes[nibble_idx / 2] >> (if nibble_idx % 2 == 0 { 4 } else { 0 })) & 0xF,
+        )
+    }
+
+    /// Get the i-th nibble.
+    pub fn get_nibble(&self, i: usize) -> Nibble {
+        assert!(i < self.len());
+        self.get_internal(i)
+    }
+
+    /// Pops a nibble from the end of the nibble path.
+    pub fn pop(&mut self) -> Option<Nibble> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let nibble = self.get_nibble(self.len() - 1);
+        self.set_internal(Nibble::from(0), self.len() - 1);
+        self.len -= 1;
+
+        Some(nibble)
+    }
+
+    /// Returns the last nibble.
+    pub fn last(&self) -> Option<Nibble> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let nibble = self.get_nibble(self.len() - 1);
+        Some(nibble)
+    }
+
+    /// Get the i-th bit.
+    fn get_bit(&self, i: usize) -> bool {
+        assert!(i < self.num_nibbles * 4);
+        let pos = i / 8;
+        let bit = 7 - i % 8;
+        ((self.bytes[pos] >> bit) & 1) != 0
+    }
+
+    /// Get a bit iterator iterates over the whole nibble path.
+    pub fn bits(&self) -> BitIterator {
+        BitIterator {
+            nibble_path: self,
+            pos: (0..self.num_nibbles * 4),
+        }
+    }
+
+    /// Get a nibble iterator iterates over the whole nibble path.
+    pub fn nibbles(&self) -> NibbleIterator {
+        NibbleIterator::new(self, 0, self.num_nibbles)
+    }
+
+    /// Get the underlying bytes storing nibbles.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        assert!(len <= self.num_nibbles);
+        self.num_nibbles = len;
+        self.bytes.truncate((len + 1) / 2);
+        if len % 2 != 0 {
+            *self.bytes.last_mut().expect("must exist.") &= 0xF0;
+        }
+    }
+
+    // Returns the shard_id of the NibblePath, or None if it is root.
+    pub fn get_shard_id(&self) -> Option<u8> {
+        if self.num_nibbles() > 0 {
+            Some(u8::from(self.get_nibble(0)))
+        } else {
+            None
+        }
+    }
+}
+
+pub trait Peekable: Iterator {
+    /// Returns the `next()` value without advancing the iterator.
+    fn peek(&self) -> Option<Self::Item>;
+}
+
+/// BitIterator iterates a nibble path by bit.
+pub struct BitIterator<'a> {
+    nibble_path: &'a NibblePath,
+    pos: std::ops::Range<usize>,
+}
+
+impl<'a> Peekable for BitIterator<'a> {
+    /// Returns the `next()` value without advancing the iterator.
+    fn peek(&self) -> Option<Self::Item> {
+        if self.pos.start < self.pos.end {
+            Some(self.nibble_path.get_bit(self.pos.start))
+        } else {
+            None
+        }
+    }
+}
+
+/// BitIterator spits out a boolean each time. True/false denotes 1/0.
+impl<'a> Iterator for BitIterator<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pos.next().map(|i| self.nibble_path.get_bit(i))
+    }
+}
+
+/// Support iterating bits in reversed order.
+impl<'a> DoubleEndedIterator for BitIterator<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.pos.next_back().map(|i| self.nibble_path.get_bit(i))
+    }
+}
+
+/// NibbleIterator iterates a nibble path by nibble.
+#[derive(Debug)]
+pub struct NibbleIterator<'a> {
+    /// The underlying nibble path that stores the nibbles
+    nibble_path: &'a NibblePath,
+
+    /// The current index, `pos.start`, will bump by 1 after calling `next()` until `pos.start ==
+    /// pos.end`.
+    pos: std::ops::Range<usize>,
+
+    /// The start index of the iterator. At the beginning, `pos.start == start`. [start, pos.end)
+    /// defines the range of `nibble_path` this iterator iterates over. `nibble_path` refers to
+    /// the entire underlying buffer but the range may only be partial.
+    start: usize,
+    // invariant self.start <= self.pos.start;
+    // invariant self.pos.start <= self.pos.end;
+    // invariant self.pos.end <= ROOT_NIBBLE_HEIGHT;
+}
+
+/// NibbleIterator spits out a byte each time. Each byte must be in range [0, 16).
+impl<'a> Iterator for NibbleIterator<'a> {
+    type Item = Nibble;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pos.next().map(|i| self.nibble_path.get_nibble(i))
+    }
+}
+
+impl<'a> Peekable for NibbleIterator<'a> {
+    /// Returns the `next()` value without advancing the iterator.
+    fn peek(&self) -> Option<Self::Item> {
+        if self.pos.start < self.pos.end {
+            Some(self.nibble_path.get_nibble(self.pos.start))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> NibbleIterator<'a> {
+    fn new(nibble_path: &'a NibblePath, start: usize, end: usize) -> Self {
+        assert!(start <= end);
+        assert!(start <= ROOT_NIBBLE_HEIGHT);
+        assert!(end <= ROOT_NIBBLE_HEIGHT);
+        Self {
+            nibble_path,
+            pos: (start..end),
+            start,
+        }
+    }
+
+    /// Returns a nibble iterator that iterates all visited nibbles.
+    pub fn visited_nibbles(&self) -> NibbleIterator<'a> {
+        Self::new(self.nibble_path, self.start, self.pos.start)
+    }
+
+    /// Returns a nibble iterator that iterates all remaining nibbles.
+    pub fn remaining_nibbles(&self) -> NibbleIterator<'a> {
+        Self::new(self.nibble_path, self.pos.start, self.pos.end)
+    }
+
+    /// Turn it into a `BitIterator`.
+    pub fn bits(&self) -> BitIterator<'a> {
+        BitIterator {
+            nibble_path: self.nibble_path,
+            pos: (self.pos.start * 4..self.pos.end * 4),
+        }
+    }
+
+    /// Cut and return the range of the underlying `nibble_path` that this iterator is iterating
+    /// over as a new `NibblePath`
+    pub fn get_nibble_path(&self) -> NibblePath {
+        self.visited_nibbles()
+            .chain(self.remaining_nibbles())
+            .collect()
+    }
+
+    /// Get the number of nibbles that this iterator covers.
+    pub fn num_nibbles(&self) -> usize {
+        assert!(self.start <= self.pos.end); // invariant
+        self.pos.end - self.start
+    }
+
+    /// Return `true` if the iteration is over.
+    pub fn is_finished(&self) -> bool {
+        self.peek().is_none()
+    }
+}
+
+/// Advance both iterators if their next nibbles are the same until either reaches the end or
+/// the find a mismatch. Return the number of matched nibbles.
+pub fn skip_common_prefix<I1, I2>(x: &mut I1, y: &mut I2) -> usize
+where
+    I1: Iterator + Peekable,
+    I2: Iterator + Peekable,
+    <I1 as Iterator>::Item: std::cmp::PartialEq<<I2 as Iterator>::Item>,
+{
+    let mut count = 0;
+    loop {
+        let x_peek = x.peek();
+        let y_peek = y.peek();
+        if x_peek.is_none()
+            || y_peek.is_none()
+            || x_peek.expect("cannot be none") != y_peek.expect("cannot be none")
+        {
+            break;
+        }
+        count += 1;
+        x.next();
+        y.next();
+    }
+    count
+}

--- a/crates/merkle/src/tree.rs
+++ b/crates/merkle/src/tree.rs
@@ -31,6 +31,11 @@ pub enum Child {
     Leaf {
         object_ref: ObjectRef,
     },
+    // InternalWithCommonPath {
+    //     path: NibblePath,
+    //     digest: MerkleDigest,
+    //     leaf_count: usize,
+    // },
     // TODO maybe have a collapsed node that has the common nibble path this could help situations
     // for leading zero ids 0x1,0x2, 0x5, etc although this may not help due to 0xdee9?
 }
@@ -108,6 +113,13 @@ impl Node {
         self.children.iter().all(Child::is_none)
     }
 
+    pub fn child_count(&self) -> usize {
+        self.children
+            .iter()
+            .map(|c| if c.is_none() { 0 } else { 1 })
+            .sum()
+    }
+
     pub fn leaf_count(&self) -> usize {
         self.children.iter().map(Child::leaf_count).sum()
     }
@@ -172,7 +184,15 @@ pub trait TreeStore {
 
 #[derive(Debug)]
 pub struct InMemoryStore {
-    inner: HashMap<MerkleDigest, Node>,
+    pub inner: HashMap<MerkleDigest, Node>,
+}
+
+impl InMemoryStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
 }
 
 impl TreeStore for InMemoryStore {

--- a/crates/merkle/src/tree.rs
+++ b/crates/merkle/src/tree.rs
@@ -1,0 +1,613 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+use anyhow::{anyhow, Result};
+use fastcrypto::encoding::{Base58, Encoding};
+use fastcrypto::hash::HashFunction;
+use serde::{Deserialize, Serialize};
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    crypto::DefaultHash,
+    digests::Digest,
+};
+
+use crate::nibble::{self, Nibble, NibblePath};
+
+const CHILDREN_PER_NODE: usize = 16;
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    children: [Child; CHILDREN_PER_NODE],
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub enum Child {
+    #[default]
+    None,
+    Internal {
+        digest: MerkleDigest,
+        leaf_count: usize,
+    },
+    Leaf {
+        object_ref: ObjectRef,
+    },
+    // TODO maybe have a collapsed node that has the common nibble path this could help situations
+    // for leading zero ids 0x1,0x2, 0x5, etc although this may not help due to 0xdee9?
+}
+
+impl Child {
+    fn is_none(&self) -> bool {
+        match self {
+            Child::None => true,
+            Child::Internal { .. } | Child::Leaf { .. } => false,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
+pub struct MerkleDigest(Digest);
+
+impl MerkleDigest {
+    pub const ZERO: Self = Self(Digest::ZERO);
+
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+
+    pub fn random() -> Self {
+        Self(Digest::random())
+    }
+
+    pub fn into_inner(self) -> [u8; 32] {
+        self.0.into_inner()
+    }
+}
+
+impl fmt::Debug for MerkleDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("MerkleDigest").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for MerkleDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<[u8]> for MerkleDigest {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<[u8; 32]> for MerkleDigest {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
+
+impl std::str::FromStr for MerkleDigest {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut result = [0; 32];
+        result.copy_from_slice(&Base58::decode(s).map_err(|e| anyhow::anyhow!(e))?);
+        Ok(Self::new(result))
+    }
+}
+
+impl Node {
+    pub fn empty() -> Self {
+        Self {
+            children: Default::default(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.children.iter().all(Child::is_none)
+    }
+
+    pub fn leaf_count(&self) -> usize {
+        self.children.iter().map(Child::leaf_count).sum()
+    }
+
+    fn first_child(&self) -> Child {
+        self.children
+            .iter()
+            .find(|child| !child.is_none())
+            .cloned()
+            .unwrap()
+    }
+
+    //TODO have crypto audit this
+    pub fn digest(&self) -> MerkleDigest {
+        let mut digest = DefaultHash::default();
+        bcs::serialize_into(&mut digest, self).expect("serialization should not fail");
+        let hash = digest.finalize();
+        MerkleDigest::new(hash.into())
+    }
+
+    pub fn into_iter(self) -> NodeIntoIter {
+        NodeIntoIter {
+            node: self,
+            position: 0,
+        }
+    }
+}
+
+pub struct NodeIntoIter {
+    node: Node,
+    position: usize,
+}
+
+impl Iterator for NodeIntoIter {
+    type Item = Child;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.position < CHILDREN_PER_NODE {
+            let ret = self.node.children[self.position].clone();
+            self.position += 1;
+            Some(ret)
+        } else {
+            None
+        }
+    }
+}
+
+impl Child {
+    pub fn leaf_count(&self) -> usize {
+        match self {
+            Child::None => 0,
+            Child::Internal { leaf_count, .. } => *leaf_count,
+            Child::Leaf { .. } => 1,
+        }
+    }
+}
+
+pub trait TreeStore {
+    fn get_node(&self, digest: MerkleDigest) -> anyhow::Result<Option<Node>>;
+    fn write_node(&mut self, node: Node) -> anyhow::Result<()>;
+}
+
+#[derive(Debug)]
+pub struct InMemoryStore {
+    inner: HashMap<MerkleDigest, Node>,
+}
+
+impl TreeStore for InMemoryStore {
+    fn get_node(&self, digest: MerkleDigest) -> anyhow::Result<Option<Node>> {
+        Ok(self.inner.get(&digest).cloned())
+    }
+
+    fn write_node(&mut self, node: Node) -> anyhow::Result<()> {
+        self.inner.insert(node.digest(), node);
+        Ok(())
+    }
+}
+
+pub struct MerkleTree<S> {
+    store: S,
+    root: Node,
+}
+
+impl<S: TreeStore> MerkleTree<S> {
+    pub fn new(store: S) -> Self {
+        Self {
+            store,
+            root: Node::empty(),
+        }
+    }
+
+    pub fn with_root(store: S, root: MerkleDigest) -> Result<Self> {
+        let root = store
+            .get_node(root)?
+            .ok_or_else(|| anyhow::anyhow!("missing {root}"))?;
+
+        Ok(Self { store, root })
+    }
+
+    pub fn into_builder(self) -> MerkleTreeBuilder<S> {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            NibblePath::empty(),
+            NodeBuilder::from_node(self.root.clone()),
+        );
+
+        MerkleTreeBuilder {
+            store: self.store,
+            nodes,
+        }
+    }
+
+    pub fn root(&self) -> &Node {
+        &self.root
+    }
+
+    pub fn into_iter(self) -> ObjectRefIter<S> {
+        ObjectRefIter::new(self.store, self.root)
+    }
+}
+
+// struct NodeIter<S> {
+//     store: S,
+//     current: Option<NodeIntoIter>,
+//     stack: Vec<NodeIntoIter>,
+// }
+
+pub struct ObjectRefIter<S> {
+    store: S,
+    current: Option<NodeIntoIter>,
+    stack: Vec<NodeIntoIter>,
+}
+
+impl<S> ObjectRefIter<S> {
+    fn new(store: S, root: Node) -> Self {
+        Self {
+            store,
+            current: Some(root.into_iter()),
+            stack: vec![],
+        }
+    }
+}
+
+impl<S: TreeStore> Iterator for ObjectRefIter<S> {
+    type Item = Result<ObjectRef>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(current) = &mut self.current {
+                match current.next() {
+                    Some(Child::None) => continue,
+                    Some(Child::Internal { digest, .. }) => {
+                        let node = match self.store.get_node(digest) {
+                            Ok(Some(node)) => node,
+                            Ok(None) => return Some(Err(anyhow!("missing data"))),
+                            Err(e) => return Some(Err(e)),
+                        };
+                        let prev = self.current.replace(node.into_iter());
+                        self.stack.push(prev.unwrap());
+                    }
+                    Some(Child::Leaf { object_ref }) => return Some(Ok(object_ref)),
+                    None => {
+                        self.current = self.stack.pop();
+                    }
+                }
+            } else {
+                return None;
+            }
+        }
+    }
+}
+
+pub struct MerkleTreeBuilder<S> {
+    store: S,
+    nodes: BTreeMap<NibblePath, NodeBuilder>,
+}
+
+#[derive(Clone)]
+struct NodeBuilder {
+    children: [Option<Child>; 16],
+}
+
+impl NodeBuilder {
+    fn new() -> Self {
+        Self::from_node(Node::empty())
+    }
+
+    fn from_node(node: Node) -> Self {
+        let children = node.children.map(Some);
+        Self { children }
+    }
+}
+
+impl<S: TreeStore> MerkleTreeBuilder<S> {
+    pub fn insert(&mut self, object_ref: ObjectRef) -> Result<()> {
+        let path = NibblePath::new_even(object_ref.0);
+        let mut iter = path.nibbles();
+        let mut traversed_path = NibblePath::empty();
+
+        loop {
+            let curr = self.nodes.get_mut(&traversed_path).unwrap();
+            let nibble = iter.next().unwrap();
+            traversed_path.push(nibble);
+            let child = &mut curr.children[nibble.inner() as usize];
+            match child {
+                Some(Child::None) => {
+                    *child = Some(Child::Leaf { object_ref });
+                    break;
+                }
+                Some(Child::Leaf {
+                    object_ref: child_object_ref,
+                }) => {
+                    if object_ref.0 == child_object_ref.0 {
+                        assert!(object_ref.1 > child_object_ref.1);
+                        *child = Some(Child::Leaf { object_ref });
+                        break;
+                    }
+
+                    let mut next = NodeBuilder::new();
+
+                    let mut traversed_iter = traversed_path.nibbles();
+                    let child_path = NibblePath::new_even(child_object_ref.0);
+                    let mut child_iter = child_path.nibbles();
+                    nibble::skip_common_prefix(&mut traversed_iter, &mut child_iter);
+                    let next_child_nibble = child_iter.next().unwrap();
+                    next.children[next_child_nibble.inner() as usize] = child.clone();
+
+                    *child = None;
+                    assert!(self.nodes.insert(traversed_path.clone(), next).is_none());
+                }
+                Some(Child::Internal { digest, .. }) => {
+                    let next = NodeBuilder::from_node(
+                        self.store.get_node(*digest)?.expect("missing node"),
+                    );
+
+                    *child = None;
+                    assert!(self.nodes.insert(traversed_path.clone(), next).is_none());
+                }
+                None => continue,
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn remove(&mut self, object_id: ObjectID) -> Result<()> {
+        let path = NibblePath::new_even(object_id);
+        let mut iter = path.nibbles();
+        let mut traversed_path = NibblePath::empty();
+
+        loop {
+            let curr = self.nodes.get_mut(&traversed_path).unwrap();
+            let nibble = iter.next().unwrap();
+            traversed_path.push(nibble);
+            let child = &mut curr.children[nibble.inner() as usize];
+            match child {
+                Some(Child::None) => {
+                    break;
+                }
+                Some(Child::Leaf {
+                    object_ref: child_object_ref,
+                }) => {
+                    if object_id == child_object_ref.0 {
+                        *child = Some(Child::None);
+                    }
+
+                    break;
+                }
+                Some(Child::Internal { digest, .. }) => {
+                    let next = NodeBuilder::from_node(
+                        self.store.get_node(*digest)?.expect("missing node"),
+                    );
+
+                    *child = None;
+                    assert!(self.nodes.insert(traversed_path.clone(), next).is_none());
+                }
+                None => continue,
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn build(mut self) -> Result<MerkleTree<S>> {
+        let mut complete: HashMap<NibblePath, Node> = HashMap::new();
+        for (path, node_builder) in self.nodes.into_iter().rev() {
+            let mut node = Node::empty();
+
+            for (i, child) in node_builder.children.into_iter().enumerate() {
+                let child = match child {
+                    Some(child) => child,
+                    None => {
+                        let nibble = Nibble::from(i as u8);
+                        let mut path = path.clone();
+                        path.push(nibble);
+                        let node = complete.get(&path).unwrap();
+                        if node.is_empty() {
+                            complete.remove(&path);
+                            Child::None
+                        } else {
+                            let leaf_count = node.leaf_count();
+                            if leaf_count == 1 {
+                                let child = node.first_child();
+                                complete.remove(&path);
+                                child
+                            } else {
+                                let digest = node.digest();
+                                Child::Internal { digest, leaf_count }
+                            }
+                        }
+                    }
+                };
+                node.children[i] = child;
+            }
+            complete.insert(path, node);
+        }
+
+        let root = complete.get(&NibblePath::empty()).cloned().unwrap();
+        for node in complete.into_values() {
+            self.store.write_node(node)?;
+        }
+
+        Ok(MerkleTree {
+            store: self.store,
+            root,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_types::{base_types::SequenceNumber, digests::ObjectDigest};
+
+    use super::*;
+
+    #[test]
+    fn insert() {
+        let store = InMemoryStore {
+            inner: Default::default(),
+        };
+
+        let mut ids = BTreeMap::new();
+        let mut builder = MerkleTree::new(store).into_builder();
+
+        for _ in 0..10000 {
+            let object_ref = sui_types::base_types::random_object_ref();
+            builder.insert(object_ref);
+            ids.insert(object_ref.0, object_ref);
+        }
+
+        let tree = builder.build().unwrap();
+
+        assert_eq!(tree.root.leaf_count(), ids.len());
+
+        for (actual, expected) in tree.into_iter().zip(ids.into_values()) {
+            let actual = actual.unwrap();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn remove() {
+        let store = InMemoryStore {
+            inner: Default::default(),
+        };
+
+        let mut ids = BTreeMap::new();
+        let mut builder = MerkleTree::new(store).into_builder();
+
+        for _ in 0..10000 {
+            let object_ref = sui_types::base_types::random_object_ref();
+            builder.insert(object_ref);
+            ids.insert(object_ref.0, object_ref);
+        }
+
+        let tree = builder.build().unwrap();
+
+        let mut builder = tree.into_builder();
+
+        let mut to_remove = BTreeMap::new();
+        let mut to_keep = BTreeMap::new();
+
+        for (i, (k, v)) in ids.into_iter().enumerate() {
+            if i % 2 == 0 {
+                to_remove.insert(k, v);
+            } else {
+                to_keep.insert(k, v);
+            }
+        }
+
+        for id in to_remove.keys() {
+            builder.remove(*id);
+        }
+
+        let tree = builder.build().unwrap();
+
+        assert_eq!(tree.root.leaf_count(), to_keep.len());
+
+        for (actual, expected) in tree.into_iter().zip(to_keep.into_values()) {
+            let actual = actual.unwrap();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn add_and_remove() {
+        let store = InMemoryStore {
+            inner: Default::default(),
+        };
+
+        let mut ids = BTreeMap::new();
+        let mut builder = MerkleTree::new(store).into_builder();
+
+        for _ in 0..10000 {
+            let object_ref = sui_types::base_types::random_object_ref();
+            builder.insert(object_ref);
+            ids.insert(object_ref.0, object_ref);
+        }
+
+        let tree = builder.build().unwrap();
+
+        let mut builder = tree.into_builder();
+
+        let mut to_remove = BTreeMap::new();
+        let mut to_keep = BTreeMap::new();
+
+        for (i, (k, v)) in ids.into_iter().enumerate() {
+            if i % 2 == 0 {
+                to_remove.insert(k, v);
+            } else {
+                to_keep.insert(k, v);
+            }
+        }
+
+        for id in to_keep.values_mut() {
+            id.1.increment();
+            builder.insert(*id);
+        }
+
+        for id in to_remove.keys() {
+            builder.remove(*id);
+        }
+
+        for _ in 0..10000 {
+            let object_ref = sui_types::base_types::random_object_ref();
+            builder.insert(object_ref);
+            to_keep.insert(object_ref.0, object_ref);
+        }
+
+        let tree = builder.build().unwrap();
+
+        assert_eq!(tree.root.leaf_count(), to_keep.len());
+
+        for (actual, expected) in tree.into_iter().zip(to_keep.into_values()) {
+            let actual = actual.unwrap();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn long_branch() {
+        let store = InMemoryStore {
+            inner: Default::default(),
+        };
+
+        let mut builder = MerkleTree::new(store).into_builder();
+
+        let o1 = (
+            ObjectID::ZERO,
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        );
+
+        let o2 = (
+            {
+                let mut bytes = ObjectID::ZERO.into_bytes();
+                bytes[31] = 1;
+                ObjectID::new(bytes)
+            },
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        );
+        builder.insert(o1);
+        builder.insert(o2);
+
+        let tree = builder.build().unwrap();
+
+        println!("{}", tree.store.inner.len());
+        println!("{:#?}", tree.store);
+
+        let mut builder = tree.into_builder();
+
+        builder.remove(o1.0);
+        let tree = builder.build().unwrap();
+        println!("{:#?}", tree.root);
+
+        let mut builder = tree.into_builder();
+
+        builder.remove(o2.0);
+        let tree = builder.build().unwrap();
+        println!("{:#?}", tree.root);
+    }
+}

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -3030,7 +3030,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "atty",
  "clap 4.4.1",
  "codespan",
  "codespan-reporting",


### PR DESCRIPTION
## Description 

This is a toy project I was working on in response to wanting to do some data validation and integrity checks for some of our databases. This *works* in that it correctly is able to construct a merkle tree with a state root for each checkpoint. With these merkle trees we can iterate over the live object set at any given checkpoint. This PR doesn't have the ability to do diffs between trees but that would be fairly easy to add.

The big hang up on this particular implementation is that its currently very expensive storage wise due to use having a number of "system" objectid that all live on a longest branch. There's an optimization that could be done to dramatically improve and "fold" these long branches down but unless we want to make use of this its probably not worth the time to make such an optimization yet.

