### PR TITLE
[Narwhal] reduce max header timeout from 2s to 1s

### DIFF
--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -27,7 +27,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -113,7 +113,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -199,7 +199,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -285,7 +285,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -371,7 +371,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -457,7 +457,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms
@@ -543,7 +543,7 @@ validator_configs:
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
-        max_header_delay: 2000ms
+        max_header_delay: 1000ms
         min_header_delay: 500ms
         gc_depth: 50
         sync_retry_delay: 5000ms

--- a/narwhal/Docker/validators/parameters.json
+++ b/narwhal/Docker/validators/parameters.json
@@ -5,7 +5,7 @@
     "max_header_num_of_batches": 1000,
     "max_batch_delay": "200ms",
     "max_concurrent_requests": 500000,
-    "max_header_delay": "2000ms",
+    "max_header_delay": "1000ms",
     "sync_retry_delay": "10_000ms",
     "sync_retry_nodes": 3,
     "prometheus_metrics": {

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -39,7 +39,7 @@ The nodes parameters determine the configuration for the primaries and workers:
 node_params = {
     'header_num_of_batches_threshold': 32,
     'max_header_num_of_batches': 1000,
-    'max_header_delay': '2000ms',
+    'max_header_delay': '1000ms',
     'min_header_delay': '500ms',
     'gc_depth': 50,
     'sync_retry_delay': '10000ms',

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -27,7 +27,7 @@ def local(ctx, debug=True):
     node_params = {
         'header_num_of_batches_threshold': 32,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '2000ms',  # ms
+        'max_header_delay': '1000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
@@ -64,7 +64,7 @@ def smoke(ctx, debug=True, release=False):
     node_params = {
         'header_num_of_batches_threshold': 32,
         'max_header_num_of_batches': 1000,
-        'max_header_delay': '2000ms',  # ms
+        'max_header_delay': '1000ms',  # ms
         'gc_depth': 50,  # rounds
         'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
@@ -144,7 +144,7 @@ def demo(ctx, debug=True):
         "max_header_num_of_batches": 1000,
         "max_batch_delay": "200ms",  # ms
         "max_concurrent_requests": 500_000,
-        "max_header_delay": "2000ms",  # ms
+        "max_header_delay": "1000ms",  # ms
         "sync_retry_delay": "10_000ms",  # ms
         "sync_retry_nodes": 3,  # number of nodes
         'prometheus_metrics': {

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -181,7 +181,7 @@ impl Parameters {
     }
 
     fn default_max_header_delay() -> Duration {
-        Duration::from_secs(2)
+        Duration::from_secs(1)
     }
 
     fn default_min_header_delay() -> Duration {

--- a/narwhal/config/tests/snapshots/config_tests__parameters.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters.snap
@@ -5,7 +5,7 @@ expression: parameters
 {
   "header_num_of_batches_threshold": 32,
   "max_header_num_of_batches": 1000,
-  "max_header_delay": "2000ms",
+  "max_header_delay": "1000ms",
   "min_header_delay": "500ms",
   "gc_depth": 50,
   "sync_retry_delay": "5000ms",

--- a/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/narwhal/config/tests/snapshots/config_tests__parameters_import.snap
@@ -5,7 +5,7 @@ expression: params
 {
   "header_num_of_batches_threshold": 32,
   "max_header_num_of_batches": 1000,
-  "max_header_delay": "2000ms",
+  "max_header_delay": "1000ms",
   "min_header_delay": "500ms",
   "gc_depth": 50,
   "sync_retry_delay": "5000ms",

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -260,7 +260,6 @@ impl Cluster {
     fn parameters() -> Parameters {
         Parameters {
             batch_size: 200,
-            max_header_delay: Duration::from_secs(2),
             ..Parameters::default()
         }
     }

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -16,7 +16,7 @@ consensus-config:
   narwhal-config:
     header_num_of_batches_threshold: 32
     max_header_num_of_batches: 1000
-    max_header_delay: 2000ms
+    max_header_delay: 1000ms
     gc_depth: 50
     sync_retry_delay: 5000ms
     sync_retry_nodes: 3


### PR DESCRIPTION
## Description 

This change should be less relevant after leader schedule change rolls out. And dynamic config will be strictly better. Still, when a validator is down, 2s timeout is too disruptive. Reducing it to 1s.

## Test Plan 

Watching private testnet metrics.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
