### PR TITLE
[cli] improve display for sui client new-address command

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -58,7 +58,11 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use tabled::settings::Style as TableStyle;
+use tabled::builder::Builder as TableBuilder;
+use tabled::settings::{
+    object::Cell as TableCell, Border as TableBorder, Modify as TableModify, Panel as TablePanel,
+    Style as TableStyle,
+};
 use tracing::info;
 
 macro_rules! serialize_or_execute {
@@ -1051,7 +1055,12 @@ impl SuiClientCommands {
                     derivation_path,
                     word_length,
                 )?;
-                SuiClientCommandResult::NewAddress((address, phrase, scheme))
+
+                SuiClientCommandResult::NewAddress(NewAddressOutput {
+                    address,
+                    key_scheme: scheme,
+                    recovery_phrase: phrase,
+                })
             }
             SuiClientCommands::Gas { address } => {
                 let address = address.unwrap_or(context.active_address()?);
@@ -1385,6 +1394,36 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
+            SuiClientCommandResult::NewAddress(new_address) => {
+                let mut builder = TableBuilder::default();
+
+                builder.push_record(vec!["address", new_address.address.to_string().as_str()]);
+                builder.push_record(vec![
+                    "keyScheme",
+                    new_address.key_scheme.to_string().as_str(),
+                ]);
+                builder.push_record(vec![
+                    "recoveryPhrase",
+                    new_address.recovery_phrase.to_string().as_str(),
+                ]);
+
+                let mut table = builder.build();
+                table.with(TableStyle::rounded());
+                table.with(TablePanel::header(
+                    "Created new keypair and saved it to keystore.",
+                ));
+
+                table.with(
+                    TableModify::new(TableCell::new(0, 0))
+                        .with(TableBorder::default().corner_bottom_right('┬')),
+                );
+                table.with(
+                    TableModify::new(TableCell::new(0, 0))
+                        .with(TableBorder::default().corner_top_right('─')),
+                );
+
+                write!(f, "{}", table)?
+            }
             SuiClientCommandResult::Upgrade(response)
             | SuiClientCommandResult::Publish(response) => {
                 write!(writer, "{}", write_transaction_response(response)?)?;
@@ -1485,15 +1524,6 @@ impl Display for SuiClientCommandResult {
             }
             SuiClientCommandResult::SyncClientState => {
                 writeln!(writer, "Client state sync complete.")?;
-            }
-            // Do not use writer for new address output, which may get sent to logs.
-            #[allow(clippy::print_in_format_impl)]
-            SuiClientCommandResult::NewAddress((address, recovery_phrase, scheme)) => {
-                println!(
-                    "Created new keypair for address with scheme {:?}: [{address}]",
-                    scheme
-                );
-                println!("Secret Recovery Phrase : [{recovery_phrase}]");
             }
             SuiClientCommandResult::Gas(gases) => {
                 // TODO: generalize formatting of CLI
@@ -1735,6 +1765,14 @@ pub struct DynamicFieldOutput {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewAddressOutput {
+    pub address: SuiAddress,
+    pub key_scheme: SignatureScheme,
+    pub recovery_phrase: String,
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum SuiClientCommandResult {
     ActiveAddress(Option<SuiAddress>),
@@ -1747,7 +1785,7 @@ pub enum SuiClientCommandResult {
     ExecuteSignedTx(SuiTransactionBlockResponse),
     Gas(Vec<GasCoin>),
     MergeCoin(SuiTransactionBlockResponse),
-    NewAddress((SuiAddress, String, SignatureScheme)),
+    NewAddress(NewAddressOutput),
     NewEnv(SuiEnv),
     Object(SuiObjectResponse),
     Objects(Vec<SuiObjectResponse>),

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -183,8 +183,9 @@ async fn test_regression_6546() -> Result<(), anyhow::Error> {
     let SuiClientCommandResult::Objects(coins) = SuiClientCommands::Objects {
         address: Some(address),
     }
-        .execute(context)
-        .await? else{
+    .execute(context)
+    .await?
+    else {
         panic!()
     };
     let config_path = test_cluster.swarm.dir().join(SUI_CLIENT_CONFIG);
@@ -1302,8 +1303,8 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     }
     .execute(context)
     .await?;
-    let new_addr = if let SuiClientCommandResult::NewAddress((a, _, _)) = os {
-        a
+    let new_addr = if let SuiClientCommandResult::NewAddress(x) = os {
+        x.address
     } else {
         panic!("Command failed")
     };


### PR DESCRIPTION
## Description 

When requesting a new keypair via `sui client new-address`, display the newly created keypair in a well formatted table. 

## Test Plan 
![image](https://github.com/MystenLabs/sui/assets/135084671/62dd3b38-b347-4419-ba94-4100be187663)


How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
When requesting a new keypair via `sui client new-address`, display the newly created keypair in a well formatted table. Use `--json` to get a standard JSON output.  