### PR TITLE
[graphql/rpc] query complexity limiting: add request time limiter

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod logger;
+pub mod timeout;

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextRequest},
+    Response, ServerError,
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+
+// 10s
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+#[derive(Clone, Debug, Copy)]
+pub struct TimeoutConfig {
+    pub request_timeout: Duration,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Timeout {
+    config: TimeoutConfig,
+}
+
+impl ExtensionFactory for Timeout {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(TimeoutExtension {
+            config: self.config,
+        })
+    }
+}
+
+struct TimeoutExtension {
+    config: TimeoutConfig,
+}
+
+#[async_trait::async_trait]
+impl Extension for TimeoutExtension {
+    async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
+        timeout(self.config.request_timeout, next.run(ctx))
+            .await
+            .unwrap_or_else(|_| {
+                Response::from_errors(vec![ServerError::new(
+                    format!(
+                        "Request timed out. Limit: {}s",
+                        self.config.request_timeout.as_secs_f32()
+                    ),
+                    None,
+                )])
+            })
+    }
+}

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::extensions::logger::Logger;
+use crate::extensions::timeout::Timeout;
 use crate::server::sui_sdk_data_provider::SuiClientLoader;
 use crate::{
     server::{
@@ -88,6 +89,7 @@ pub async fn start_example_server(config: Option<ServerConfig>) {
         .data(data_provider)
         .data(data_loader)
         .extension(Logger::default())
+        .extension(Timeout::default())
         .finish();
 
     let app = axum::Router::new()


### PR DESCRIPTION
## Description 

Allows setting a timeout for the overall request. This helps limit long running queries.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
