### PR TITLE
[bcs] Fix parsing of hex strings where leading 0s have been trimmed

### DIFF
--- a/.changeset/stale-wolves-relate.md
+++ b/.changeset/stale-wolves-relate.md
@@ -1,0 +1,5 @@
+---
+'@mysten/bcs': patch
+---
+
+Fix parsing of hex strings where leading 0s have been trimmed

--- a/sdk/bcs/src/hex.ts
+++ b/sdk/bcs/src/hex.ts
@@ -2,15 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export function fromHEX(hexStr: string): Uint8Array {
-	// @ts-ignore
-	let intArr = hexStr
-		.replace('0x', '')
-		.match(/.{1,2}/g)
-		.map((byte) => parseInt(byte, 16));
-
-	if (intArr === null) {
-		throw new Error(`Unable to parse HEX: ${hexStr}`);
-	}
+	const normalized = hexStr.startsWith('0x') ? hexStr.slice(2) : hexStr;
+	const padded = normalized.length % 2 === 0 ? normalized : `0${normalized}}`;
+	const intArr = padded.match(/.{2}/g)?.map((byte) => parseInt(byte, 16)) ?? [];
 
 	return Uint8Array.from(intArr);
 }

--- a/sdk/bcs/tests/encodings.test.ts
+++ b/sdk/bcs/tests/encodings.test.ts
@@ -54,4 +54,23 @@ describe('BCS: Encodings', () => {
 		expect(deserialized.base58).toEqual(b58_str);
 		expect(deserialized.base64).toEqual(b64_str);
 	});
+
+	it('should deserialize hex with leading 0s', () => {
+		const addressLeading0 = 'a7429d7a356dd98f688f11a330a32e0a3cc1908734a8c5a5af98f34ec93df0c';
+		expect(toHEX(Uint8Array.from([0, 1]))).toEqual('0001');
+		expect(fromHEX('0x1')).toEqual(Uint8Array.from([1]));
+		expect(fromHEX('1')).toEqual(Uint8Array.from([1]));
+		expect(fromHEX('111')).toEqual(Uint8Array.from([1, 17]));
+		expect(fromHEX('001')).toEqual(Uint8Array.from([0, 1]));
+		expect(fromHEX('011')).toEqual(Uint8Array.from([0, 17]));
+		expect(fromHEX('0011')).toEqual(Uint8Array.from([0, 17]));
+		expect(fromHEX('0x0011')).toEqual(Uint8Array.from([0, 17]));
+		expect(fromHEX(addressLeading0)).toEqual(
+			Uint8Array.from([
+				10, 116, 41, 215, 163, 86, 221, 152, 246, 136, 241, 26, 51, 10, 50, 224, 163, 204, 25, 8,
+				115, 74, 140, 90, 90, 249, 143, 52, 236, 147, 223, 12,
+			]),
+		);
+		expect(toHEX(fromHEX(addressLeading0))).toEqual(`0${addressLeading0}`);
+	});
 });


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
