### PR TITLE
Do not expose impl details of effects

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -414,7 +414,6 @@ mod tests {
     use sui_types::coin::TreasuryCap;
     use sui_types::digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest};
     use sui_types::effects::TransactionEffects;
-    use sui_types::effects::TransactionEffectsV1;
     use sui_types::error::{SuiError, SuiResult};
     use sui_types::gas_coin::GAS;
     use sui_types::id::UID;
@@ -1217,8 +1216,7 @@ mod tests {
         #[tokio::test]
         async fn test_object_not_found() {
             let transaction_digest = TransactionDigest::from([0; 32]);
-            let transaction_effects: TransactionEffects =
-                TransactionEffects::V1(TransactionEffectsV1::default());
+            let transaction_effects = TransactionEffects::default();
 
             let mut mock_state = MockStateRead::new();
             mock_state
@@ -1328,8 +1326,7 @@ mod tests {
             let package_id = get_test_package_id();
             let (coin_name, _, _, _, _) = get_test_treasury_cap_peripherals(package_id);
             let transaction_digest = TransactionDigest::from([0; 32]);
-            let transaction_effects: TransactionEffects =
-                TransactionEffects::V1(TransactionEffectsV1::default());
+            let transaction_effects = TransactionEffects::default();
 
             let mut mock_state = MockStateRead::new();
             mock_state


### PR DESCRIPTION
## Description 

EffectsV1 is behind a trait type and hence we should never directly access its fields.
This PR makes all fields of EffectsV1 private and access them through trait functions.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
