### PR TITLE
[sui-sdk] jsonrpc error response classification and handling

### DIFF
--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -15,7 +15,7 @@ use tokio::task::JoinError;
 
 use crate::authority_state::StateReadError;
 
-pub const TRANSIENT_ERROR_CODE: i32 = -32001;
+pub const TRANSIENT_ERROR_CODE: i32 = -32050;
 pub const TRANSACTION_EXECUTION_CLIENT_ERROR_CODE: i32 = -32002;
 
 pub type RpcInterimResult<T = ()> = Result<T, Error>;
@@ -318,7 +318,7 @@ mod tests {
             let rpc_error: RpcError = Error::QuorumDriverError(quorum_driver_error).into();
 
             let error_object: ErrorObjectOwned = rpc_error.into();
-            let expected_code = expect!["-32001"];
+            let expected_code = expect!["-32050"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect!["Transaction timed out before reaching finality"];
             expected_message.assert_eq(error_object.message());
@@ -334,7 +334,7 @@ mod tests {
             let rpc_error: RpcError = Error::QuorumDriverError(quorum_driver_error).into();
 
             let error_object: ErrorObjectOwned = rpc_error.into();
-            let expected_code = expect!["-32001"];
+            let expected_code = expect!["-32050"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
                 "Transaction failed to reach finality with transient error after 10 attempts."
@@ -468,7 +468,7 @@ mod tests {
             let rpc_error: RpcError = Error::QuorumDriverError(quorum_driver_error).into();
 
             let error_object: ErrorObjectOwned = rpc_error.into();
-            let expected_code = expect!["-32001"];
+            let expected_code = expect!["-32050"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect!["Transaction is not processed because 10 of validators by stake are overloaded with certificates pending execution."];
             expected_message.assert_eq(error_object.message());

--- a/crates/sui-sdk/examples/json_rpc_errors.rs
+++ b/crates/sui-sdk/examples/json_rpc_errors.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod utils;
+use sui_sdk::error::{Error, JsonRpcError};
+use utils::setup_for_read;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let (sui, active_address) = setup_for_read().await?;
+    let coin_type = Some("0x42".to_string());
+    let coins = sui
+        .coin_read_api()
+        .get_coins(active_address, coin_type.clone(), None, Some(5))
+        .await;
+    let error = coins.unwrap_err();
+    if let Error::RpcError(rpc_error) = error {
+        let converted: JsonRpcError = rpc_error.into();
+        println!(" *** RpcError ***");
+        println!("{converted}");
+        println!("{}", converted.is_client_error());
+    } else {
+        panic!("Expected Error::RpcError, got {:?}", error);
+    }
+    Ok(())
+}

--- a/crates/sui-sdk/examples/json_rpc_errors.rs
+++ b/crates/sui-sdk/examples/json_rpc_errors.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod utils;
+use anyhow::bail;
 use sui_sdk::error::{Error, JsonRpcError};
 use utils::setup_for_read;
 
@@ -20,7 +21,7 @@ async fn main() -> Result<(), anyhow::Error> {
         println!("{converted}");
         println!("{}", converted.is_client_error());
     } else {
-        panic!("Expected Error::RpcError, got {:?}", error);
+        bail!("Expected Error::RpcError, got {:?}", error);
     }
     Ok(())
 }

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -51,6 +51,11 @@ pub const SUI_FAUCET: &str = "https://faucet.testnet.sui.io/v1/gas"; // testnet 
 /// e.g., transfering objects from one address to another.
 pub async fn setup_for_write() -> Result<(SuiClient, SuiAddress, SuiAddress), anyhow::Error> {
     let (client, active_address) = setup_for_read().await?;
+    // make sure we have some SUI (5_000_000 MIST) on this address
+    let coin = fetch_coin(&client, &active_address).await?;
+    if coin.is_none() {
+        request_tokens_from_faucet(active_address, &client).await?;
+    }
     let wallet = retrieve_wallet().await?;
     let addresses = wallet.get_addresses();
     let addresses = addresses
@@ -77,15 +82,7 @@ pub async fn setup_for_read() -> Result<(SuiClient, SuiAddress), anyhow::Error> 
     assert!(wallet.get_addresses().len() >= 2);
     let active_address = wallet.active_address()?;
 
-    println!("Local wallet active address is: {active_address}");
-
-    // make sure we have some SUI (5_000_000 MIST) on this address
-    let coin = fetch_coin(&client, &active_address).await?;
-
-    if coin.is_none() {
-        request_tokens_from_faucet(active_address, &client).await?;
-    }
-
+    println!("Wallet active address is: {active_address}");
     Ok((client, active_address))
 }
 

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
+use jsonrpsee::types::ErrorObjectOwned;
+use sui_json_rpc::error::{TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE};
 use sui_types::base_types::{SuiAddress, TransactionDigest};
 use sui_types::error::UserInputError;
 use thiserror::Error;
@@ -30,4 +33,53 @@ pub enum Error {
     },
     #[error("Insufficient fund for address [{address}], requested amount: {amount}")]
     InsufficientFund { address: SuiAddress, amount: u128 },
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcErrorObject {
+    code: ErrorCode,
+    message: String,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ErrorCode {
+    InvalidParams,
+    InternalError,
+    TransientError,
+    TransactionExecutionClientError,
+    Custom(i32),
+}
+
+impl ErrorCode {
+    pub fn code(&self) -> i32 {
+        match self {
+            ErrorCode::InvalidParams => INVALID_PARAMS_CODE,
+            ErrorCode::InternalError => INTERNAL_ERROR_CODE,
+            ErrorCode::TransientError => TRANSIENT_ERROR_CODE,
+            ErrorCode::TransactionExecutionClientError => TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
+            ErrorCode::Custom(code) => *code,
+        }
+    }
+}
+
+impl From<i32> for ErrorCode {
+    fn from(code: i32) -> Self {
+        match code {
+            INVALID_PARAMS_CODE => ErrorCode::InvalidParams,
+            INTERNAL_ERROR_CODE => ErrorCode::InternalError,
+            TRANSIENT_ERROR_CODE => ErrorCode::TransientError,
+            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE => ErrorCode::TransactionExecutionClientError,
+            _ => ErrorCode::Custom(code),
+        }
+    }
+}
+
+impl From<jsonrpsee::core::Error> for RpcErrorObject {
+    fn from(err: jsonrpsee::core::Error) -> Self {
+        let error_object_owned: ErrorObjectOwned = err.into();
+        RpcErrorObject {
+            code: ErrorCode::from(error_object_owned.code()),
+            message: error_object_owned.message().to_string(),
+        }
+    }
 }

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
-use jsonrpsee::types::ErrorObjectOwned;
-use sui_json_rpc::error::{TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE};
+pub use crate::json_rpc_error::Error as JsonRpcError;
 use sui_types::base_types::{SuiAddress, TransactionDigest};
 use sui_types::error::UserInputError;
 use thiserror::Error;
@@ -12,6 +10,8 @@ pub type SuiRpcResult<T = ()> = Result<T, Error>;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    RpcError(#[from] jsonrpsee::core::Error),
     #[error(transparent)]
     JsonRpcError(JsonRpcError),
     #[error(transparent)]
@@ -31,77 +31,4 @@ pub enum Error {
     },
     #[error("Insufficient fund for address [{address}], requested amount: {amount}")]
     InsufficientFund { address: SuiAddress, amount: u128 },
-}
-
-#[derive(Error, Debug, Clone)]
-pub struct JsonRpcError {
-    pub code: ErrorCode,
-    pub message: String,
-    pub data: Option<serde_json::Value>,
-}
-
-impl std::fmt::Display for JsonRpcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "code: {}, message: {}",
-            self.code.message(),
-            self.message
-        )
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ErrorCode {
-    InvalidParams,
-    InternalError,
-    TransientError,
-    TransactionExecutionClientError,
-    Custom(i32),
-}
-
-impl ErrorCode {
-    pub fn code(&self) -> i32 {
-        match self {
-            ErrorCode::InvalidParams => INVALID_PARAMS_CODE,
-            ErrorCode::InternalError => INTERNAL_ERROR_CODE,
-            ErrorCode::TransientError => TRANSIENT_ERROR_CODE,
-            ErrorCode::TransactionExecutionClientError => TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-            ErrorCode::Custom(code) => *code,
-        }
-    }
-
-    pub fn message(&self) -> &str {
-        match self {
-            ErrorCode::InvalidParams => "Invalid params",
-            ErrorCode::InternalError => "Internal error",
-            ErrorCode::TransientError => "Transient error",
-            ErrorCode::TransactionExecutionClientError => "Transaction execution client error",
-            ErrorCode::Custom(_) => "Custom error",
-        }
-    }
-}
-
-impl From<i32> for ErrorCode {
-    fn from(code: i32) -> Self {
-        match code {
-            INVALID_PARAMS_CODE => ErrorCode::InvalidParams,
-            INTERNAL_ERROR_CODE => ErrorCode::InternalError,
-            TRANSIENT_ERROR_CODE => ErrorCode::TransientError,
-            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE => ErrorCode::TransactionExecutionClientError,
-            _ => ErrorCode::Custom(code),
-        }
-    }
-}
-
-impl From<jsonrpsee::core::Error> for Error {
-    fn from(err: jsonrpsee::core::Error) -> Self {
-        let error_object_owned: ErrorObjectOwned = err.into();
-        Error::JsonRpcError(JsonRpcError {
-            code: ErrorCode::from(error_object_owned.code()),
-            message: error_object_owned.message().to_string(),
-            // TODO: as this SDK is specialized for the Sui JSON RPC implementation, we should define structured representation for the data field if applicable
-            data: None,
-        })
-    }
 }

--- a/crates/sui-sdk/src/json_rpc_error.rs
+++ b/crates/sui-sdk/src/json_rpc_error.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use jsonrpsee::types::ErrorObjectOwned;
+pub use sui_json_rpc::error::{TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE};
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+pub struct Error {
+    pub code: i32,
+    pub message: String,
+    // TODO: as this SDK is specialized for the Sui JSON RPC implementation, we should define structured representation for the data field if applicable
+    pub data: Option<serde_json::Value>,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "code: '{}', message: '{}'", self.code, self.message)
+    }
+}
+
+impl Error {
+    pub fn is_client_error(&self) -> bool {
+        use jsonrpsee::types::error::{
+            BATCHES_NOT_SUPPORTED_CODE, INVALID_PARAMS_CODE, INVALID_REQUEST_CODE,
+            METHOD_NOT_FOUND_CODE, OVERSIZED_REQUEST_CODE, PARSE_ERROR_CODE,
+        };
+        matches!(
+            self.code,
+            PARSE_ERROR_CODE
+                | OVERSIZED_REQUEST_CODE
+                | INVALID_PARAMS_CODE
+                | INVALID_REQUEST_CODE
+                | METHOD_NOT_FOUND_CODE
+                | BATCHES_NOT_SUPPORTED_CODE
+                | TRANSACTION_EXECUTION_CLIENT_ERROR_CODE
+        )
+    }
+
+    pub fn is_execution_error(&self) -> bool {
+        self.code == TRANSACTION_EXECUTION_CLIENT_ERROR_CODE
+    }
+
+    pub fn is_transient_error(&self) -> bool {
+        self.code == TRANSIENT_ERROR_CODE
+    }
+}
+
+impl From<jsonrpsee::core::Error> for Error {
+    fn from(err: jsonrpsee::core::Error) -> Self {
+        let error_object_owned: ErrorObjectOwned = err.into();
+        Error {
+            code: error_object_owned.code(),
+            message: error_object_owned.message().to_string(),
+            // TODO: as this SDK is specialized for the Sui JSON RPC implementation, we should define structured representation for the data field if applicable
+            data: None,
+        }
+    }
+}

--- a/crates/sui-sdk/src/json_rpc_error.rs
+++ b/crates/sui-sdk/src/json_rpc_error.rs
@@ -51,7 +51,6 @@ impl From<jsonrpsee::core::Error> for Error {
         Error {
             code: error_object_owned.code(),
             message: error_object_owned.message().to_string(),
-            // TODO: as this SDK is specialized for the Sui JSON RPC implementation, we should define structured representation for the data field if applicable
             data: None,
         }
     }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -48,15 +48,15 @@
 //!         .build("http://127.0.0.1:9000") // provide the Sui network URL
 //!         .await?;
 //!     println!("Sui local network version: {:?}", sui.api_version());
-//!     
+//!
 //!     // local Sui network, same result as above except using the dedicated function
 //!     let sui_local = SuiClientBuilder::default().build_localnet().await?;
 //!     println!("Sui local network version: {:?}", sui_local.api_version());
-//!     
+//!
 //!     // Sui devnet running at `https://fullnode.devnet.io:443`
 //!     let sui_devnet = SuiClientBuilder::default().build_devnet().await?;
 //!     println!("Sui devnet version: {:?}", sui_devnet.api_version());
-//!     
+//!
 //!     // Sui testnet running at `https://testnet.devnet.io:443`
 //!     let sui_testnet = SuiClientBuilder::default().build_testnet().await?;
 //!     println!("Sui testnet version: {:?}", sui_testnet.api_version());
@@ -101,6 +101,7 @@ use crate::error::{Error, SuiRpcResult};
 
 pub mod apis;
 pub mod error;
+pub mod json_rpc_error;
 pub mod sui_client_config;
 pub mod wallet_context;
 pub const SUI_COIN_TYPE: &str = "0x2::sui::SUI";
@@ -386,7 +387,7 @@ impl SuiClientBuilder {
 ///        .await?;
 ///
 ///     println!("{:?}", owned_objects);
-///    
+///
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
## Description 

Users of our rust sdk should not need to import the jsonrpsee crate just to error match on jsonrpc errors, nor should clients be encouraged to do string matching on the error message.
1. Introduce json_rpc_error::Error, and a conversion from jsonrpsee::Error to json_rpc_error::Error, so we don't make any breaking changes
2. json_rpc_error::Error has some basic api to determine error type for further manual handling
3. It seems like the jsonrpsee crate makes liberal use of error codes in the -32000 to -32099 range, and unfortunately our -32001 transient error code conflicts with their unknown error code. Bumped our transient error code to -32050.

Further improvements:
From here, we can consider providing more detailed classification of errors, if useful. For example, if we receive TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, it's not clear whether this is due to InvalidUserSignature, ObjectsDoubleUsed, or NonRecoverableTransactionError. We can consider populating this in the data field.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
You can now determine whether an rpc error response is a client or transient error by converting the sui_sdk::error::Error::RpcError into an sui_sdk::error::JsonRpcError. After converting, you can inspect the code, message, and data of the error, and use the methods is_call_error, is_client_error, is_execution_error, and is_transient_error. You can find an example of this usage at sui-sdk/examples/json_rpc_errors.rs. Note that transient errors now map to code -32050, and -32001 is reserved for any unknown errors returned by the rpc.