### PR TITLE
[consensus] enable reputation based leader election for mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1400,6 +1400,8 @@ impl ProtocolConfig {
                 }
                 23 => {
                     cfg.feature_flags.loaded_child_object_format_type = true;
+                    cfg.feature_flags.narwhal_new_leader_election_schedule = true;
+                    cfg.consensus_bad_nodes_stake_threshold = Some(20);
                 }
                 24 => {
                     cfg.feature_flags.simple_conservation_checks = true;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -67,6 +67,9 @@ const MAX_PROTOCOL_VERSION: u64 = 24;
 //             value. Both values are set for all the environments except mainnet.
 // Version 21: ZKLogin known providers.
 // Version 22: Child object format change.
+// Version 23: Enabling the flag `narwhal_new_leader_election_schedule` for the new narwhal leader
+//             schedule algorithm for enhanced fault tolerance and sets the bad node stake threshold
+//             value for mainnet.
 // Version 24: Re-enable simple gas conservation checks.
 //             Package publish/upgrade number in a single transaction limited.
 
@@ -1401,6 +1404,11 @@ impl ProtocolConfig {
                 23 => {
                     cfg.feature_flags.loaded_child_object_format_type = true;
                     cfg.feature_flags.narwhal_new_leader_election_schedule = true;
+                    // Taking a baby step approach, we consider only 20% by stake as bad nodes so we
+                    // have a 80% by stake of nodes participating in the leader committee. That allow
+                    // us for more redundancy in case we have validators under performing - since the
+                    // responsibility is shared amongst more nodes. We can increase that once we do have
+                    // higher confidence.
                     cfg.consensus_bad_nodes_stake_threshold = Some(20);
                 }
                 24 => {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_23.snap
@@ -23,6 +23,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   loaded_child_object_format_type: true
 max_tx_size_bytes: 131072
@@ -188,4 +189,5 @@ hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
 execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_24.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_24.snap
@@ -23,6 +23,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
@@ -190,4 +191,5 @@ hmac_hmac_sha3_256_input_cost_per_block: 2
 scoring_decision_mad_divisor: 2.3
 scoring_decision_cutoff_value: 2.5
 execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
 


### PR DESCRIPTION
## Description 

Enabling the reputation based leader election for mainnet . So far it was enabled for any enviornment but mainnet.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
