### PR TITLE
[refactor] consensus handler

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -54,8 +54,6 @@ pub struct ConsensusHandler<T> {
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     /// The narwhal committee used to do stake computations for deciding set of low scoring authorities
     committee: Committee,
-    /// Mappings used for logging and metrics
-    authority_names_to_hostnames: HashMap<AuthorityName, String>,
     // TODO: ConsensusHandler doesn't really share metrics with AuthorityState. We could define
     // a new metrics type here if we want to.
     metrics: Arc<AuthorityMetrics>,
@@ -73,7 +71,6 @@ impl<T> ConsensusHandler<T> {
         transaction_manager: Arc<TransactionManager>,
         object_store: T,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
-        authority_names_to_hostnames: HashMap<AuthorityName, String>,
         committee: Committee,
         metrics: Arc<AuthorityMetrics>,
     ) -> Self {
@@ -91,7 +88,6 @@ impl<T> ConsensusHandler<T> {
             object_store,
             low_scoring_authorities,
             committee,
-            authority_names_to_hostnames,
             metrics,
             processed_cache: LruCache::new(NonZeroUsize::new(PROCESSED_CACHE_CAP).unwrap()),
             transaction_scheduler,
@@ -225,7 +221,6 @@ impl<T: ObjectStore + Send + Sync> ExecutionState for ConsensusHandler<T> {
             self.low_scoring_authorities.clone(),
             &self.committee,
             consensus_output.sub_dag.reputation_score.clone(),
-            self.authority_names_to_hostnames.clone(),
             &self.metrics,
             self.epoch_store.protocol_config(),
         );

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -133,7 +133,7 @@ fn update_hash(
 impl<T: ObjectStore + Send + Sync> ExecutionState for ConsensusHandler<T> {
     /// This function will be called by Narwhal, after Narwhal sequenced this certificate.
     #[instrument(level = "trace", skip_all)]
-    async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
+    async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
         let _scope = monitored_scope("HandleConsensusOutput");
 
         // This code no longer supports old protocol versions.

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -128,7 +128,7 @@ fn update_low_scoring_authorities_v2(
 
             metrics
                 .consensus_handler_scores
-                .with_label_values(&[&format!("{:?}", authority.hostname())])
+                .with_label_values(&[authority.hostname()])
                 .set(score as i64);
         }
     }

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -5,7 +5,7 @@ use crate::authority::AuthorityMetrics;
 use crate::math::median;
 use arc_swap::ArcSwap;
 use fastcrypto::traits::ToFromBytes;
-use narwhal_config::{Committee, Stake};
+use narwhal_config::{Authority, Committee, Stake};
 use narwhal_crypto::PublicKey;
 use narwhal_types::ReputationScores;
 use std::collections::HashMap;
@@ -45,7 +45,6 @@ pub fn update_low_scoring_authorities(
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     committee: &Committee,
     reputation_scores: ReputationScores,
-    authority_names_to_hostnames: HashMap<AuthorityName, String>,
     metrics: &Arc<AuthorityMetrics>,
     protocol_config: &ProtocolConfig,
 ) {
@@ -56,7 +55,6 @@ pub fn update_low_scoring_authorities(
             low_scoring_authorities,
             committee,
             reputation_scores,
-            authority_names_to_hostnames,
             metrics,
             protocol_config,
         );
@@ -66,7 +64,6 @@ pub fn update_low_scoring_authorities(
             low_scoring_authorities,
             committee,
             reputation_scores,
-            authority_names_to_hostnames,
             metrics,
             protocol_config.scoring_decision_mad_divisor(),
             protocol_config.scoring_decision_cutoff_value(),
@@ -83,7 +80,6 @@ fn update_low_scoring_authorities_v2(
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     committee: &Committee,
     reputation_scores: ReputationScores,
-    authority_names_to_hostnames: HashMap<AuthorityName, String>,
     metrics: &Arc<AuthorityMetrics>,
     protocol_config: &ProtocolConfig,
 ) {
@@ -95,7 +91,7 @@ fn update_low_scoring_authorities_v2(
 
     // We order the authorities by score ascending order in the exact same way as the reputation
     // scores do - so we keep complete alignment between implementations
-    let scores_per_authority_order_asc: Vec<(AuthorityName, u64, Stake)> = reputation_scores
+    let scores_per_authority_order_asc: Vec<(AuthorityName, u64, &Authority)> = reputation_scores
         .authorities_by_score_desc()
         .iter()
         .rev() // we reverse so we get them in asc order
@@ -103,14 +99,14 @@ fn update_low_scoring_authorities_v2(
             let authority = committee.authority(authority_id).unwrap();
             let name: AuthorityName = authority.protocol_key().into();
 
-            (name, *score, authority.stake())
+            (name, *score, authority)
         })
         .collect();
 
     let mut final_low_scoring_map = HashMap::new();
     let mut total_stake = 0;
-    for (authority_name, score, stake) in scores_per_authority_order_asc {
-        total_stake += stake;
+    for (authority_name, score, authority) in scores_per_authority_order_asc {
+        total_stake += authority.stake();
 
         let included = if total_stake
             <= (protocol_config.consensus_bad_nodes_stake_threshold() * committee.total_stake())
@@ -122,15 +118,17 @@ fn update_low_scoring_authorities_v2(
             false
         };
 
-        if let Some(hostname) = authority_names_to_hostnames.get(&authority_name) {
+        if !authority.hostname().is_empty() {
             debug!(
                 "authority {} has score {}, is low scoring: {}",
-                hostname, score, included
+                authority.hostname(),
+                score,
+                included
             );
 
             metrics
                 .consensus_handler_scores
-                .with_label_values(&[&format!("{:?}", hostname)])
+                .with_label_values(&[&format!("{:?}", authority.hostname())])
                 .set(score as i64);
         }
     }
@@ -145,7 +143,6 @@ fn update_low_scoring_authorities_v1(
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     committee: &Committee,
     reputation_scores: ReputationScores,
-    authority_names_to_hostnames: HashMap<AuthorityName, String>,
     metrics: &Arc<AuthorityMetrics>,
     mad_divisor: f64,
     cut_off_value: f64,
@@ -164,12 +161,12 @@ fn update_low_scoring_authorities_v1(
             let name: AuthorityName = authority.protocol_key().into();
 
             // report the scores
-            if let Some(hostname) = authority_names_to_hostnames.get(&name) {
-                debug!("authority {} has score {}", hostname, score);
+            if !authority.hostname().is_empty() {
+                debug!("authority {} has score {}", authority.hostname(), score);
 
                 metrics
                     .consensus_handler_scores
-                    .with_label_values(&[&format!("{:?}", hostname)])
+                    .with_label_values(&[&format!("{:?}", authority.hostname())])
                     .set(score as i64);
             }
 
@@ -223,22 +220,24 @@ fn update_low_scoring_authorities_v1(
 
     // take low scoring authorities while we haven't reached validity threshold (f+1)
     let mut total_stake = 0;
-    for (authority, score) in low_scoring {
-        total_stake += committee
-            .authority_by_key(&PublicKey::from_bytes(authority.as_ref()).unwrap())
-            .unwrap()
-            .stake();
+    for (authority_name, score) in low_scoring {
+        let authority = committee
+            .authority_by_key(&PublicKey::from_bytes(authority_name.as_ref()).unwrap())
+            .unwrap();
+        total_stake += authority.stake();
 
         let included = if !committee.reached_validity(total_stake) {
-            final_low_scoring_map.insert(*authority, score);
+            final_low_scoring_map.insert(*authority_name, score);
             true
         } else {
             false
         };
-        if let Some(hostname) = authority_names_to_hostnames.get(authority) {
+        if !authority.hostname().is_empty() {
             debug!(
                 "low scoring authority {} has score {}, included: {}",
-                hostname, score, included
+                authority.hostname(),
+                score,
+                included
             );
         }
     }
@@ -266,7 +265,7 @@ mod tests {
     use prometheus::Registry;
     use rand::rngs::{OsRng, StdRng};
     use rand::SeedableRng;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::crypto::NetworkPublicKey;
@@ -280,8 +279,6 @@ mod tests {
     #[test]
     pub fn test_update_low_scoring_authorities_v2() {
         // GIVEN
-        let peer_id_map = HashMap::new();
-
         // Total stake is 8 for this committee and every authority has equal stake = 1
         let committee = generate_committee(8);
 
@@ -323,7 +320,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores.clone(),
-            peer_id_map.clone(),
             &metrics,
             &protocol_config,
         );
@@ -346,7 +342,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map,
             &metrics,
             &protocol_config,
         );
@@ -377,7 +372,6 @@ mod tests {
             final_of_schedule: false,
         };
         low_scoring.swap(Arc::new(inner));
-        let peer_id_map = HashMap::new();
 
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
 
@@ -386,7 +380,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map.clone(),
             &metrics,
             &protocol_v5(),
         );
@@ -408,7 +401,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map.clone(),
             &metrics,
             &protocol_v5(),
         );
@@ -431,7 +423,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map.clone(),
             &metrics,
             &protocol_v5(),
         );
@@ -466,7 +457,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map.clone(),
             &metrics,
             &protocol_v5(),
         );
@@ -485,7 +475,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map,
             &metrics,
             &protocol_v5(),
         );
@@ -542,7 +531,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            HashMap::new(),
             &metrics,
             &protocol_v5(),
         );
@@ -600,7 +588,6 @@ mod tests {
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            HashMap::new(),
             &metrics,
             &protocol_v5(),
         );
@@ -666,164 +653,15 @@ mod tests {
             final_of_schedule: true,
         };
 
-        let peer_id_map = HashMap::new();
-
         // When protocol v5
         update_low_scoring_authorities(
             low_scoring.clone(),
             &committee,
             reputation_scores,
-            peer_id_map,
             &metrics,
             &protocol_v5(),
         );
 
         assert_eq!(low_scoring.load().len(), 12);
-    }
-
-    /// A test to use when need to tune the score parameters based on some score data retrieved by
-    /// and external environment (ex devnet, testnet etc). A CSV file where the first line is the
-    /// header with the host names, and every other line the scores for each authority on the
-    /// instance of time. Example:
-    /// "validator-0","validator-10","validator-11",...
-    /// 184,185,144,...
-    ///
-    /// The method prints a matrix of the pruned hosts for each score "round"
-    /// and the corresponding score. When a node has not been pruned for a round then the corresponding
-    /// score will appear as "--".
-    #[test]
-    #[ignore]
-    pub fn test_update_low_scoring_authorities_with_score_data() {
-        use std::collections::{BTreeMap, HashMap};
-
-        // read the file
-        let (authority_host_names, all_authority_scores) = read_scores_csv("example.csv");
-
-        let mut authority_names_to_hostnames = HashMap::new();
-
-        // construct the committee
-        let low_scoring = Arc::new(ArcSwap::from_pointee(HashMap::new()));
-        let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
-        let committee = generate_committee(authority_host_names.len());
-        let mut authorities = committee.authorities();
-
-        // associate authorities to host names
-        for name in authority_host_names.iter().take(committee.size()) {
-            let authority = authorities.next().unwrap();
-            authority_names_to_hostnames.insert(authority.protocol_key().into(), name.clone());
-        }
-
-        let mut low_scoring_authorities_per_round: BTreeMap<String, BTreeMap<usize, Option<u64>>> =
-            BTreeMap::new();
-
-        // Now iterate over the scores
-        for (index, authority_scores) in all_authority_scores.iter().enumerate() {
-            let mut scores = HashMap::new();
-            let mut authorities = committee.authorities();
-
-            // create the scores map and just map them to some authorities
-            for score in authority_scores.iter().take(committee.size()) {
-                let authority = authorities.next().unwrap();
-                scores.insert(authority.id(), *score);
-            }
-
-            let reputation_scores = ReputationScores {
-                scores_per_authority: scores,
-                final_of_schedule: true,
-            };
-
-            update_low_scoring_authorities(
-                low_scoring.clone(),
-                &committee,
-                reputation_scores,
-                authority_names_to_hostnames.clone(),
-                &metrics,
-                &protocol_v5(),
-            );
-
-            // snapshot the low scoring authorities
-            for (name, host_name) in &authority_names_to_hostnames {
-                if let Some(score) = low_scoring.load().get(name) {
-                    low_scoring_authorities_per_round
-                        .entry(host_name.clone())
-                        .or_default()
-                        .insert(index, Some(*score));
-                } else {
-                    // it's not a low scoring authority
-                    low_scoring_authorities_per_round
-                        .entry(host_name.clone())
-                        .or_default()
-                        .insert(index, None);
-                }
-            }
-        }
-
-        // Now print the authorities per "round"
-        let mut total_low_scoring_authorities_per_round: BTreeMap<usize, usize> = BTreeMap::new();
-        for (host_name, scores_per_round) in low_scoring_authorities_per_round {
-            // quickly check if this host has been marked ever as low scoring - otherwise skip
-            if scores_per_round.iter().any(|(_, value)| value.is_some()) {
-                print!("{:30}", host_name);
-
-                for (index, score) in scores_per_round {
-                    if let Some(score) = score {
-                        print!("{score:0>2}\t");
-                        total_low_scoring_authorities_per_round
-                            .entry(index)
-                            .and_modify(|e| *e += 1)
-                            .or_insert(1);
-                    } else {
-                        total_low_scoring_authorities_per_round
-                            .entry(index)
-                            .or_insert(0);
-                        print!("--\t");
-                    }
-                }
-                println!();
-            }
-        }
-
-        // print the total low scoring authorities
-        println!("---------------");
-        print!("{:30}", "Total");
-        for (_index, total) in total_low_scoring_authorities_per_round {
-            print!("{total:0>2}\t");
-        }
-    }
-
-    fn read_scores_csv(path: &str) -> (Vec<String>, Vec<Vec<u64>>) {
-        use std::fs::File;
-        use std::io::BufRead;
-        use std::io::BufReader;
-
-        let file = File::open(path).unwrap();
-        let reader = BufReader::new(file);
-
-        let mut headers = Vec::new();
-        let mut scores = Vec::new();
-        let mut scores_set: HashSet<u64> = HashSet::new();
-
-        for line in reader.lines() {
-            if headers.is_empty() {
-                headers = line.unwrap().split(',').map(|s| s.to_string()).collect();
-            } else {
-                let l = line.unwrap();
-
-                let s: Vec<u64> = l
-                    .split(',')
-                    .map(|s| s.parse::<f64>().unwrap() as u64)
-                    .collect();
-
-                if s.is_empty() {
-                    continue;
-                }
-
-                if scores_set.insert(s.iter().sum()) {
-                    scores.push(s);
-                }
-            }
-        }
-
-        (headers, scores)
     }
 }

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -28,7 +28,7 @@ struct NoOpExecutionState {
 
 #[async_trait::async_trait]
 impl ExecutionState for NoOpExecutionState {
-    async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
+    async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
         for batches in consensus_output.batches {
             for batch in batches {
                 for transaction in batch.transactions().iter() {
@@ -114,9 +114,9 @@ async fn test_narwhal_manager() {
         let narwhal_committee = system_state.get_narwhal_committee();
         let worker_cache = system_state.get_narwhal_worker_cache(transactions_addr);
 
-        let execution_state = Arc::new(NoOpExecutionState {
+        let execution_state = || NoOpExecutionState {
             epoch: narwhal_committee.epoch(),
-        });
+        };
 
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
@@ -137,7 +137,7 @@ async fn test_narwhal_manager() {
                 narwhal_committee.clone(),
                 latest_protocol_version(),
                 worker_cache.clone(),
-                Arc::new(execution_state.clone()),
+                execution_state,
                 TrivialTransactionValidator::default(),
             )
             .await;
@@ -189,9 +189,9 @@ async fn test_narwhal_manager() {
         let narwhal_committee = system_state.get_narwhal_committee();
         let worker_cache = system_state.get_narwhal_worker_cache(&transactions_addr);
 
-        let execution_state = Arc::new(NoOpExecutionState {
+        let execution_state = || NoOpExecutionState {
             epoch: narwhal_committee.epoch(),
-        });
+        };
 
         // start narwhal with advanced epoch
         narwhal_manager
@@ -199,7 +199,7 @@ async fn test_narwhal_manager() {
                 narwhal_committee.clone(),
                 latest_protocol_version(),
                 worker_cache.clone(),
-                Arc::new(execution_state.clone()),
+                execution_state,
                 TrivialTransactionValidator::default(),
             )
             .await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -990,16 +990,18 @@ impl SuiNode {
         let new_epoch_start_state = epoch_store.epoch_start_state();
         let committee = new_epoch_start_state.get_narwhal_committee();
 
-        let consensus_handler = Arc::new(ConsensusHandler::new(
-            epoch_store.clone(),
-            checkpoint_service.clone(),
-            state.transaction_manager().clone(),
-            state.db(),
-            low_scoring_authorities,
-            authority_names_to_hostnames,
-            committee,
-            state.metrics.clone(),
-        ));
+        let consensus_handler_initializer = || {
+            ConsensusHandler::new(
+                epoch_store.clone(),
+                checkpoint_service.clone(),
+                state.transaction_manager().clone(),
+                state.db(),
+                low_scoring_authorities.clone(),
+                authority_names_to_hostnames.clone(),
+                committee.clone(),
+                state.metrics.clone(),
+            )
+        };
 
         let transactions_addr = &config
             .consensus_config
@@ -1013,7 +1015,7 @@ impl SuiNode {
                 new_epoch_start_state.get_narwhal_committee(),
                 epoch_store.protocol_config().clone(),
                 worker_cache,
-                consensus_handler,
+                consensus_handler_initializer,
                 SuiTxValidator::new(
                     epoch_store.clone(),
                     checkpoint_service.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -549,10 +549,6 @@ impl SuiNode {
             .epoch_start_state()
             .get_authority_names_to_peer_ids();
 
-        let authority_names_to_hostnames = epoch_store
-            .epoch_start_state()
-            .get_authority_names_to_hostnames();
-
         let network_connection_metrics =
             NetworkConnectionMetrics::new("sui", &registry_service.default_registry());
 
@@ -583,7 +579,6 @@ impl SuiNode {
                 state_sync_handle.clone(),
                 accumulator.clone(),
                 connection_monitor_status.clone(),
-                authority_names_to_hostnames,
                 &registry_service,
             )
             .await?;
@@ -901,7 +896,6 @@ impl SuiNode {
         state_sync_handle: state_sync::Handle,
         accumulator: Arc<StateAccumulator>,
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
-        authority_names_to_hostnames: HashMap<AuthorityName, String>,
         registry_service: &RegistryService,
     ) -> Result<ValidatorComponents> {
         let consensus_config = config
@@ -946,7 +940,6 @@ impl SuiNode {
             narwhal_manager,
             narwhal_epoch_data_remover,
             accumulator,
-            authority_names_to_hostnames,
             validator_server_handle,
             checkpoint_metrics,
             sui_tx_validator_metrics,
@@ -964,7 +957,6 @@ impl SuiNode {
         narwhal_manager: NarwhalManager,
         narwhal_epoch_data_remover: EpochDataRemover,
         accumulator: Arc<StateAccumulator>,
-        authority_names_to_hostnames: HashMap<AuthorityName, String>,
         validator_server_handle: JoinHandle<Result<()>>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
         sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
@@ -997,7 +989,6 @@ impl SuiNode {
                 state.transaction_manager().clone(),
                 state.db(),
                 low_scoring_authorities.clone(),
-                authority_names_to_hostnames.clone(),
                 committee.clone(),
                 state.metrics.clone(),
             )
@@ -1303,9 +1294,6 @@ impl SuiNode {
             self.connection_monitor_status
                 .update_mapping_for_epoch(authority_names_to_peer_ids);
 
-            let authority_names_to_hostnames =
-                new_epoch_start_state.get_authority_names_to_hostnames();
-
             cur_epoch_store.record_epoch_reconfig_start_time_metric();
 
             let _ = send_trusted_peer_change(
@@ -1359,7 +1347,6 @@ impl SuiNode {
                             narwhal_manager,
                             narwhal_epoch_data_remover,
                             self.accumulator.clone(),
-                            authority_names_to_hostnames,
                             validator_server_handle,
                             checkpoint_metrics,
                             sui_tx_validator_metrics,
@@ -1393,7 +1380,6 @@ impl SuiNode {
                             self.state_sync.clone(),
                             self.accumulator.clone(),
                             self.connection_monitor_status.clone(),
-                            authority_names_to_hostnames,
                             &self.registry_service,
                         )
                         .await?,

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -33,10 +33,9 @@ pub type SerializedTransactionDigest = u64;
 
 #[automock]
 #[async_trait]
-// Important - if you add method with the default implementation here make sure to update impl ExecutionState for Arc<T>
 pub trait ExecutionState {
     /// Execute the transaction and atomically persist the consensus index.
-    async fn handle_consensus_output(&self, consensus_output: ConsensusOutput);
+    async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput);
 
     /// Load the last executed sub-dag index from storage
     async fn last_executed_sub_dag_index(&self) -> u64;
@@ -124,17 +123,4 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
     }
 
     Ok(sub_dags)
-}
-
-#[async_trait]
-impl<T: ExecutionState + 'static + Send + Sync> ExecutionState for Arc<T> {
-    async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
-        self.as_ref()
-            .handle_consensus_output(consensus_output)
-            .await
-    }
-
-    async fn last_executed_sub_dag_index(&self) -> u64 {
-        self.as_ref().last_executed_sub_dag_index().await
-    }
 }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -99,7 +99,7 @@ pub fn spawn_subscriber<State: ExecutionState + Send + Sync + 'static>(
 }
 
 async fn run_notify<State: ExecutionState + Send + Sync + 'static>(
-    state: State,
+    mut state: State,
     mut rx_notify: metered_channel::Receiver<ConsensusOutput>,
     mut rx_shutdown: ConditionalBroadcastReceiver,
 ) {

--- a/narwhal/node/src/execution_state.rs
+++ b/narwhal/node/src/execution_state.rs
@@ -20,7 +20,7 @@ impl SimpleExecutionState {
 
 #[async_trait]
 impl ExecutionState for SimpleExecutionState {
-    async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
+    async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
         for batches in consensus_output.batches {
             for batch in batches {
                 for transaction in batch.transactions().iter() {

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -23,10 +23,7 @@ use node::{
     metrics::{primary_metrics_registry, start_prometheus_server, worker_metrics_registry},
 };
 use prometheus::Registry;
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 use storage::{CertificateStoreCacheMetrics, NodeStorage};
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_network_keypair_from_file,
@@ -318,7 +315,7 @@ async fn run(
                     worker_cache,
                     client.clone(),
                     &store,
-                    Arc::new(SimpleExecutionState::new(_tx_transaction_confirmation)),
+                    SimpleExecutionState::new(_tx_transaction_confirmation),
                 )
                 .await?;
 

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -69,7 +69,7 @@ impl PrimaryNodeInner {
         // TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The state used by the client to execute transactions.
-        execution_state: Arc<State>,
+        execution_state: State,
     ) -> Result<(), NodeError>
     where
         State: ExecutionState + Send + Sync + 'static,
@@ -193,7 +193,7 @@ impl PrimaryNodeInner {
         // The configuration parameters.
         parameters: Parameters,
         // The state used by the client to execute transactions.
-        execution_state: Arc<State>,
+        execution_state: State,
         // A prometheus exporter Registry to use for the metrics
         registry: &Registry,
         // The channel to send the shutdown signal
@@ -415,7 +415,7 @@ impl PrimaryNode {
         // TODO: replace this by a path so the method can open and independent storage
         store: &NodeStorage,
         // The state used by the client to execute transactions.
-        execution_state: Arc<State>,
+        execution_state: State,
     ) -> Result<(), NodeError>
     where
         State: ExecutionState + Send + Sync + 'static,

--- a/narwhal/node/tests/node_test.rs
+++ b/narwhal/node/tests/node_test.rs
@@ -10,7 +10,6 @@ use narwhal_node::worker_node::WorkerNodes;
 use network::client::NetworkClient;
 use prometheus::Registry;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
 use std::time::Duration;
 use storage::NodeStorage;
 use test_utils::{latest_protocol_version, temp_dir, CommitteeFixture};
@@ -40,7 +39,7 @@ async fn simple_primary_worker_node_start_stop() {
     let store = NodeStorage::reopen(temp_dir(), None);
 
     let (tx_confirmation, _rx_confirmation) = channel(10);
-    let execution_state = Arc::new(SimpleExecutionState::new(tx_confirmation));
+    let execution_state = SimpleExecutionState::new(tx_confirmation);
 
     // WHEN
     let primary_node = PrimaryNode::new(parameters.clone(), registry_service.clone());
@@ -124,7 +123,7 @@ async fn primary_node_restart() {
     let store = NodeStorage::reopen(temp_dir(), None);
 
     let (tx_confirmation, _rx_confirmation) = channel(10);
-    let execution_state = Arc::new(SimpleExecutionState::new(tx_confirmation));
+    let execution_state = SimpleExecutionState::new(tx_confirmation.clone());
 
     // AND
     let primary_node = PrimaryNode::new(parameters.clone(), registry_service.clone());
@@ -137,7 +136,7 @@ async fn primary_node_restart() {
             worker_cache.clone(),
             client.clone(),
             &store,
-            execution_state.clone(),
+            execution_state,
         )
         .await
         .unwrap();
@@ -150,6 +149,7 @@ async fn primary_node_restart() {
     primary_node.shutdown().await;
 
     // AND start again the node
+    let execution_state = SimpleExecutionState::new(tx_confirmation.clone());
     primary_node
         .start(
             key_pair.copy(),

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -355,7 +355,7 @@ impl PrimaryNodeDetails {
                 self.worker_cache.clone(),
                 client,
                 &primary_store,
-                Arc::new(SimpleExecutionState::new(tx_transaction_confirmation)),
+                SimpleExecutionState::new(tx_transaction_confirmation),
             )
             .await
             .unwrap();


### PR DESCRIPTION
## Description 

Refactored consensus handler to pass as value to Narwhal since it's only managed by the subscriber anyways and the certificate processing is sequential. That also allow us to not use any Mutexes for internal state management but rather act on a `&mut self` reference. Also did some clean up so we do use the injected hostname map for metric reporting , but rather rely on the existing injected committee object to derive the same info.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
