### PR TITLE
[dapp-kit] add new useDisconnectWallet mutation hook

### DIFF
--- a/sdk/dapp-kit/src/constants/walletMutationKeys.ts
+++ b/sdk/dapp-kit/src/constants/walletMutationKeys.ts
@@ -6,6 +6,7 @@ import type { MutationKey } from '@tanstack/react-query';
 export const walletMutationKeys = {
 	all: { baseScope: 'wallet' },
 	connectWallet: formMutationKeyFn('connect-wallet'),
+	disconnectWallet: formMutationKeyFn('disconnect-wallet'),
 };
 
 function formMutationKeyFn(baseEntity: string) {

--- a/sdk/dapp-kit/src/errors/walletErrors.ts
+++ b/sdk/dapp-kit/src/errors/walletErrors.ts
@@ -5,3 +5,8 @@
  * An error that is instantiated when someone attempts to connect to a wallet that they're already connected to.
  */
 export class WalletAlreadyConnectedError extends Error {}
+
+/**
+ * An error that is instantiated when someone attempts to perform an action that requires an active wallet connection.
+ */
+export class WalletNotConnectedError extends Error {}

--- a/sdk/dapp-kit/src/hooks/wallet/useDisconnectWallet.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useDisconnectWallet.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useWalletContext } from '../../components/WalletProvider.js';
+import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
+import { WalletNotConnectedError } from '../../errors/walletErrors.js';
+
+type UseDisconnectWalletMutationOptions = Omit<
+	UseMutationOptions<void, Error, void, unknown>,
+	'mutationFn'
+>;
+
+/**
+ * Mutation hook for disconnecting from an active wallet connection, if currently connected.
+ */
+export function useDisconnectWallet({
+	mutationKey,
+	...mutationOptions
+}: UseDisconnectWalletMutationOptions = {}) {
+	const { currentWallet, storageAdapter, storageKey, dispatch } = useWalletContext();
+
+	return useMutation({
+		mutationKey: walletMutationKeys.disconnectWallet(mutationKey),
+		mutationFn: async () => {
+			if (!currentWallet) {
+				throw new WalletNotConnectedError('No wallet is connected.');
+			}
+
+			try {
+				// Wallets aren't required to implement the disconnect feature, so we'll
+				// optionally call the disconnect feature if it exists and reset the UI
+				// state on the frontend at a minimum.
+				await currentWallet.features['standard:disconnect']?.disconnect();
+			} catch (error) {
+				console.error('Failed to disconnect the application from the current wallet.', error);
+			}
+
+			dispatch({ type: 'wallet-disconnected' });
+
+			try {
+				await storageAdapter.remove(storageKey);
+			} catch (error) {
+				// We'll skip error handling here and just report the error to the console since deleting connection
+				// info isn't essential functionality and storage adapters can be plugged in by the consumer.
+				console.error(
+					'[dApp-kit] Error: Failed to remove wallet connection info from storage.',
+					error,
+				);
+			}
+		},
+		...mutationOptions,
+	});
+}

--- a/sdk/dapp-kit/src/index.ts
+++ b/sdk/dapp-kit/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/WalletProvider.js';
 export * from './hooks/useRpcApiVersion.js';
 export * from './hooks/rpc/index.js';
 export * from './hooks/wallet/useConnectWallet.js';
+export * from './hooks/wallet/useDisconnectWallet.js';
 export * from './hooks/wallet/useWallet.js';
 export * from './hooks/useSuiClientMutation.js';
 export * from './hooks/useSuiClientQuery.js';

--- a/sdk/dapp-kit/src/reducers/walletReducer.ts
+++ b/sdk/dapp-kit/src/reducers/walletReducer.ts
@@ -40,9 +40,15 @@ type WalletConnectedAction = {
 	};
 };
 
+type WalletDisconnectedAction = {
+	type: 'wallet-disconnected';
+	payload?: never;
+};
+
 export type WalletAction =
 	| WalletConnectionStatusUpdatedAction
 	| WalletConnectedAction
+	| WalletDisconnectedAction
 	| WalletRegisteredAction
 	| WalletUnregisteredAction;
 
@@ -83,6 +89,15 @@ export function walletReducer(state: WalletState, { type, payload }: WalletActio
 				currentAccount: payload.currentAccount,
 				connectionStatus: 'connected',
 			};
+		case 'wallet-disconnected': {
+			return {
+				...state,
+				currentWallet: null,
+				accounts: [],
+				currentAccount: null,
+				connectionStatus: 'disconnected',
+			};
+		}
 		default:
 			assertUnreachable(type);
 	}

--- a/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
@@ -17,7 +17,7 @@ describe('useDisconnectWallet', () => {
 	});
 
 	test('that disconnecting works successfully', async () => {
-		const unregister = registerMockWallet('Mock Wallet 1');
+		const { unregister, mockWallet } = registerMockWallet('Mock Wallet 1');
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(
@@ -29,7 +29,7 @@ describe('useDisconnectWallet', () => {
 			{ wrapper },
 		);
 
-		result.current.connectWallet.mutate({ walletName: 'Mock Wallet 1' });
+		result.current.connectWallet.mutate({ wallet: mockWallet });
 
 		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
 		expect(result.current.walletInfo.connectionStatus).toBe('connected');

--- a/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useConnectWallet, useDisconnectWallet, useWallet } from 'dapp-kit/src';
+import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
+import { WalletNotConnectedError } from 'dapp-kit/src/errors/walletErrors.js';
+
+describe('useDisconnectWallet', () => {
+	test('that an error is thrown when trying to disconnect with no active connection', async () => {
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(() => useDisconnectWallet(), { wrapper });
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.error).toBeInstanceOf(WalletNotConnectedError));
+	});
+
+	test('that disconnecting works successfully', async () => {
+		const unregister = registerMockWallet('Mock Wallet 1');
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				disconnectWallet: useDisconnectWallet(),
+				walletInfo: useWallet(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ walletName: 'Mock Wallet 1' });
+
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+		expect(result.current.walletInfo.connectionStatus).toBe('connected');
+
+		expect(window.localStorage.getItem('sui-dapp-kit:wallet-connection-info')).toBeTruthy();
+
+		result.current.disconnectWallet.mutate();
+		await waitFor(() => expect(result.current.disconnectWallet.isSuccess).toBe(true));
+
+		expect(result.current.walletInfo.currentWallet).toBeNull();
+		expect(result.current.walletInfo.accounts).toStrictEqual([]);
+		expect(result.current.walletInfo.currentAccount).toBeNull();
+		expect(result.current.walletInfo.connectionStatus).toBe('disconnected');
+
+		expect(window.localStorage.getItem('sui-dapp-kit:wallet-connection-info')).toBeFalsy();
+
+		act(() => {
+			unregister();
+		});
+	});
+});


### PR DESCRIPTION
## Description 

This PR adds a new `useDisconnectWallet` mutation hook with tests for disconnecting from an active wallet connection!

Equivalent PR for connecting: https://github.com/MystenLabs/sui/pull/13661

## Test Plan 
- Automated tests pass
- Manual testing in an example dApp
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
