### PR TITLE
wallet-ext: enable zklogin with twitch

### DIFF
--- a/apps/wallet/src/background/accounts/zk/ZkAccount.ts
+++ b/apps/wallet/src/background/accounts/zk/ZkAccount.ts
@@ -97,7 +97,7 @@ export class ZkAccount
 	}: {
 		provider: ZkProvider;
 	}): Promise<Omit<ZkAccountSerialized, 'id'>> {
-		const jwt = await zkLogin({ provider, prompt: 'select_account' });
+		const jwt = await zkLogin({ provider, prompt: true });
 		const salt = await fetchSalt(jwt);
 		const decodedJWT = decodeJwt(jwt);
 		if (!decodedJWT.sub || !decodedJWT.iss || !decodedJWT.aud) {

--- a/apps/wallet/src/background/accounts/zk/providers.ts
+++ b/apps/wallet/src/background/accounts/zk/providers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export type ZkProvider = 'google' | 'twitch' | 'facebook' | 'microsoft';
+export type ZkProvider = 'google' | 'twitch' | 'facebook';
 
 export interface ZkProviderData {
 	clientID: string;
@@ -12,6 +12,7 @@ export interface ZkProviderData {
 		loginHint?: string;
 		params: URLSearchParams;
 	}) => void;
+	enabled: boolean;
 }
 
 export const zkProviderDataMap: Record<ZkProvider, ZkProviderData> = {
@@ -30,6 +31,7 @@ export const zkProviderDataMap: Record<ZkProvider, ZkProviderData> = {
 				params.append('login_hint', loginHint);
 			}
 		},
+		enabled: true,
 	},
 	twitch: {
 		clientID: 'uzpfot3uotf7fp9hklsyctn2735bcw',
@@ -51,8 +53,7 @@ export const zkProviderDataMap: Record<ZkProvider, ZkProviderData> = {
 				params.append('force_verify', 'true');
 			}
 		},
+		enabled: true,
 	},
-	// TODO: update this before enabling them
-	facebook: { clientID: '', url: '' },
-	microsoft: { clientID: '', url: '' },
+	facebook: { clientID: '', url: '', enabled: false },
 };

--- a/apps/wallet/src/background/accounts/zk/providers.ts
+++ b/apps/wallet/src/background/accounts/zk/providers.ts
@@ -6,15 +6,53 @@ export type ZkProvider = 'google' | 'twitch' | 'facebook' | 'microsoft';
 export interface ZkProviderData {
 	clientID: string;
 	url: string;
+	extraParams?: Record<string, string>;
+	buildExtraParams?: (inputs: {
+		prompt?: boolean;
+		loginHint?: string;
+		params: URLSearchParams;
+	}) => void;
 }
 
 export const zkProviderDataMap: Record<ZkProvider, ZkProviderData> = {
 	google: {
 		clientID: '946731352276-pk5glcg8cqo38ndb39h7j093fpsphusu.apps.googleusercontent.com',
 		url: 'https://accounts.google.com/o/oauth2/v2/auth',
+		extraParams: {
+			response_type: 'id_token',
+			scope: 'openid email profile',
+		},
+		buildExtraParams: ({ prompt, loginHint, params }) => {
+			if (prompt) {
+				params.append('prompt', 'select_account');
+			}
+			if (loginHint) {
+				params.append('login_hint', loginHint);
+			}
+		},
+	},
+	twitch: {
+		clientID: 'uzpfot3uotf7fp9hklsyctn2735bcw',
+		url: 'https://id.twitch.tv/oauth2/authorize',
+		extraParams: {
+			// adding token seems to stop showing the authorization window
+			response_type: 'token id_token',
+			scope: 'openid user:read:email',
+			claims: JSON.stringify({
+				id_token: {
+					email: null,
+					email_verified: null,
+					picture: null,
+				},
+			}),
+		},
+		buildExtraParams: ({ prompt, params }) => {
+			if (prompt) {
+				params.append('force_verify', 'true');
+			}
+		},
 	},
 	// TODO: update this before enabling them
-	twitch: { clientID: '', url: '' },
 	facebook: { clientID: '', url: '' },
 	microsoft: { clientID: '', url: '' },
 };

--- a/apps/wallet/src/background/accounts/zk/providers.ts
+++ b/apps/wallet/src/background/accounts/zk/providers.ts
@@ -37,7 +37,7 @@ export const zkProviderDataMap: Record<ZkProvider, ZkProviderData> = {
 		clientID: 'uzpfot3uotf7fp9hklsyctn2735bcw',
 		url: 'https://id.twitch.tv/oauth2/authorize',
 		extraParams: {
-			// adding token seems to stop showing the authorization window
+			// adding token in the response_type allows the silent auth to work - without it, every time the auth window is shown
 			response_type: 'token id_token',
 			scope: 'openid user:read:email',
 			claims: JSON.stringify({

--- a/apps/wallet/src/background/accounts/zk/utils.ts
+++ b/apps/wallet/src/background/accounts/zk/utils.ts
@@ -32,26 +32,22 @@ export async function zkLogin({
 }: {
 	provider: ZkProvider;
 	nonce?: string;
+	// This can be used for logins after the user has already connected an account
+	// and we need to make sure that the user logged in with the correct account
+	// seems only google supports this
 	loginHint?: string;
-	prompt?: 'select_account' | 'consent';
+	prompt?: boolean;
 }) {
 	if (!nonce) {
 		nonce = base64url.encode(randomBytes(20));
 	}
-	const { clientID, url } = zkProviderDataMap[provider];
-	const params = new URLSearchParams();
+	const { clientID, url, extraParams, buildExtraParams } = zkProviderDataMap[provider];
+	const params = new URLSearchParams(extraParams);
 	params.append('client_id', clientID);
-	params.append('response_type', 'id_token');
 	params.append('redirect_uri', Browser.identity.getRedirectURL());
-	params.append('scope', 'openid email profile');
 	params.append('nonce', nonce);
-	// This can be used for logins after the user has already connected a google account
-	// and we need to make sure that the user logged in with the correct account
-	if (loginHint) {
-		params.append('login_hint', loginHint);
-	}
-	if (prompt) {
-		params.append('prompt', prompt);
+	if (buildExtraParams) {
+		buildExtraParams({ prompt, loginHint, params });
 	}
 	const authUrl = `${url}?${params.toString()}`;
 	const responseURL = new URL(

--- a/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
@@ -5,26 +5,19 @@ import { cx } from 'class-variance-authority';
 import { useState } from 'react';
 import { useCountAccountsByType } from '../../hooks/useCountAccountByType';
 import { SocialButton } from '../../shared/SocialButton';
-import { type ZkProvider } from '_src/background/accounts/zk/providers';
+import { zkProviderDataMap, type ZkProvider } from '_src/background/accounts/zk/providers';
 import { ampli, type ClickedSocialSignInButtonProperties } from '_src/shared/analytics/ampli';
 
-const zkLoginProviders: {
-	provider: ZkProvider;
-	disabled?: boolean;
-	hidden?: boolean;
-	tooltip?: string;
-}[] = [
-	{ provider: 'google' },
-	{ provider: 'twitch' },
-	{ provider: 'facebook', disabled: true, tooltip: 'Coming soon' },
-	// { provider: 'microsoft', disabled: true, hidden: true },
-];
+const zkLoginProviders = Object.entries(zkProviderDataMap).map(([provider, { enabled }]) => ({
+	provider: provider as ZkProvider,
+	enabled,
+	tooltip: !enabled ? 'Coming soon!' : undefined,
+}));
 
 const providerToAmpli: Record<ZkProvider, ClickedSocialSignInButtonProperties['signInProvider']> = {
 	google: 'Google',
 	twitch: 'Twitch',
 	facebook: 'Facebook',
-	microsoft: 'Microsoft',
 };
 
 export type ZkLoginButtonsProps = {
@@ -53,40 +46,38 @@ export function ZkLoginButtons({
 				'flex-row gap-2': layout === 'row',
 			})}
 		>
-			{zkLoginProviders
-				.filter(({ hidden }) => !hidden)
-				.map(({ provider, disabled, tooltip }) => (
-					<div key={provider} className="flex-1">
-						<SocialButton
-							title={accountsTotalByType?.zk?.extra?.[provider] ? 'Already signed-in' : tooltip}
-							provider={provider}
-							onClick={async () => {
-								ampli.clickedSocialSignInButton({
-									signInProvider: providerToAmpli[provider],
-									sourceFlow,
-								});
-								setCreateInProgressProvider(provider);
-								try {
-									if (onButtonClick) {
-										await onButtonClick(provider);
-									}
-								} finally {
-									setCreateInProgressProvider(null);
+			{zkLoginProviders.map(({ provider, enabled, tooltip }) => (
+				<div key={provider} className="flex-1">
+					<SocialButton
+						title={accountsTotalByType?.zk?.extra?.[provider] ? 'Already signed-in' : tooltip}
+						provider={provider}
+						onClick={async () => {
+							ampli.clickedSocialSignInButton({
+								signInProvider: providerToAmpli[provider],
+								sourceFlow,
+							});
+							setCreateInProgressProvider(provider);
+							try {
+								if (onButtonClick) {
+									await onButtonClick(provider);
 								}
-							}}
-							disabled={
-								disabled ||
-								buttonsDisabled ||
-								createInProgressProvider !== null ||
-								isLoading ||
-								!!accountsTotalByType?.zk?.extra?.[provider] ||
-								!!forcedZkLoginProvider
+							} finally {
+								setCreateInProgressProvider(null);
 							}
-							loading={createInProgressProvider === provider || forcedZkLoginProvider === provider}
-							showLabel={showLabel}
-						/>
-					</div>
-				))}
+						}}
+						disabled={
+							!enabled ||
+							buttonsDisabled ||
+							createInProgressProvider !== null ||
+							isLoading ||
+							!!accountsTotalByType?.zk?.extra?.[provider] ||
+							!!forcedZkLoginProvider
+						}
+						loading={createInProgressProvider === provider || forcedZkLoginProvider === provider}
+						showLabel={showLabel}
+					/>
+				</div>
+			))}
 		</div>
 	);
 }

--- a/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/ZkLoginButtons.tsx
@@ -15,9 +15,9 @@ const zkLoginProviders: {
 	tooltip?: string;
 }[] = [
 	{ provider: 'google' },
-	{ provider: 'twitch', disabled: true, tooltip: 'Coming soon' },
+	{ provider: 'twitch' },
 	{ provider: 'facebook', disabled: true, tooltip: 'Coming soon' },
-	{ provider: 'microsoft', disabled: true, hidden: true },
+	// { provider: 'microsoft', disabled: true, hidden: true },
 ];
 
 const providerToAmpli: Record<ZkProvider, ClickedSocialSignInButtonProperties['signInProvider']> = {

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -28,7 +28,6 @@ const providerToLabel: Record<ZkProvider, string> = {
 	google: 'Google',
 	twitch: 'Twitch',
 	facebook: 'Facebook',
-	microsoft: 'Microsoft',
 };
 
 // todo: we probbaly have some duplication here with the various FooterLink / ButtonOrLink


### PR DESCRIPTION
## Description 

* adds twitch in enabled providers


https://github.com/MystenLabs/sui/assets/10210143/f145a0dd-8197-4be3-8a99-bd247f6817f0


https://github.com/MystenLabs/sui/assets/10210143/8a3f6f36-fd7a-4191-b039-79d27cfd004f



* includes a workaround to avoid calling `identity.launchWebAuthFlow` when a silent auth flow can work
  * twitch is using html/js redirect instead of response headers and that makes the browser to open a window and then close it right after
  * we need this workaround to avoid closing the popup window and also avoid a flickering effect from opening and closing the auth window
  * this does a get request to the auth url and extracts the `redirect_url` from the response
  
  without the workaround
  

  https://github.com/MystenLabs/sui/assets/10210143/4d5da125-491f-45d1-a82f-7fb3bac12e3e

  with the workaround
  

  https://github.com/MystenLabs/sui/assets/10210143/5d721614-b8b9-49c8-8811-362c94de912c


  
  
closes APPS-1603

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
