### PR TITLE
Using version-sort when sorting

### DIFF
--- a/.github/workflows/release-notes-monitor.yml
+++ b/.github/workflows/release-notes-monitor.yml
@@ -30,7 +30,7 @@ jobs:
         export new_commit_hash=$(git rev-parse HEAD)
         export existing_commit_tag=$(git tag --points-at ${new_commit_hash} | grep -E 'sui_v(.*)_rel_notes' | head -n 1)
 
-        export previous_tag=$(git tag | grep -E 'sui_v1(.*)_rel_notes' | sort -r | head -1)
+        export previous_tag=$(git tag | grep -E 'sui_v1(.*)_rel_notes' | sort -rV | head -1)
         export previous_commit_hash=$(git rev-list -n 1 ${previous_tag})
         
         export list_of_prs=$(git log --grep "\[x\]" --pretty=oneline --abbrev-commit ${previous_commit_hash}...${new_commit_hash} -- crates dashboards doc docker external-crates kiosk narwhal nre sui-execution | grep -o '#[0-9]\+' | grep -o '[0-9]\+' | jq -R -s -c 'split("\n")[:-1]')


### PR DESCRIPTION
## Description 
Currently, we are not accounting for sorting by number/version without 0 padding. Adding `-V` to account for it

## Test Plan 
Before
```
eugene@mac-studio ~/code/sui (eugene/fix_release_notes_tag_lookup) $ git tag | grep -E 'sui_v1(.*)_rel_notes' | sort -r | head -1
sui_v1.9.0_1693613519_rel_notes
```
After
```
eugene@mac-studio ~/code/sui (eugene/fix_release_notes_tag_lookup) $ git tag | grep -E 'sui_v1(.*)_rel_notes' | sort -rV | head -1
sui_v1.10.0_1694185668_rel_notes
```
[Run via the branch](https://github.com/MystenLabs/sui/actions/runs/6123742749)