### PR TITLE
[graphql][1/n] Refactor gas-related convert_to fns to utilize async-graphql's Object macro

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     InvalidCursor(String),
     #[error("Data has changed since cursor was generated: {0}")]
     CursorConnectionFetchFailed(String),
+    #[error("Error received in multi-get query: {0}")]
+    MultiGet(String),
     #[error("Internal error occurred while processing request.")]
     Internal(String),
 }
@@ -57,7 +59,8 @@ impl ErrorExtensions for Error {
             | Error::CursorNoFirstLast
             | Error::CursorNoReversePagination
             | Error::InvalidCursor(_)
-            | Error::CursorConnectionFetchFailed(_) => {
+            | Error::CursorConnectionFetchFailed(_)
+            | Error::MultiGet(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }
             Error::Internal(_) => {

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -10,6 +10,8 @@ use crate::types::{object::Object, sui_address::SuiAddress};
 use async_graphql::connection::Connection;
 use async_graphql::*;
 use async_trait::async_trait;
+use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_sdk::types::base_types::ObjectID;
 
 #[async_trait]
 pub(crate) trait DataProvider: Send + Sync {
@@ -24,6 +26,18 @@ pub(crate) trait DataProvider: Send + Sync {
         before: Option<String>,
         _filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>>;
+
+    async fn get_object_with_options(
+        &self,
+        object_id: ObjectID,
+        options: SuiObjectDataOptions,
+    ) -> Result<Object>;
+
+    async fn multi_get_object_with_options(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: SuiObjectDataOptions,
+    ) -> Result<Vec<Object>>;
 
     async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance>;
 

--- a/crates/sui-graphql-rpc/src/server/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/data_provider.rs
@@ -31,7 +31,7 @@ pub(crate) trait DataProvider: Send + Sync {
         &self,
         object_id: ObjectID,
         options: SuiObjectDataOptions,
-    ) -> Result<Object>;
+    ) -> Result<Option<Object>>;
 
     async fn multi_get_object_with_options(
         &self,

--- a/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
@@ -29,7 +29,7 @@ use crate::types::validator_credentials::ValidatorCredentials;
 use crate::types::validator_set::ValidatorSet;
 
 use crate::server::data_provider::DataProvider;
-use crate::types::gas::{GasCostSummary, GasEffects, GasInput};
+use crate::types::gas::{GasCostSummary, GasEffects};
 use async_graphql::connection::{Connection, Edge};
 use async_graphql::dataloader::*;
 use async_graphql::*;
@@ -38,7 +38,7 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use std::collections::HashMap;
 use std::str::FromStr;
 use sui_json_rpc_types::{
-    OwnedObjectRef, SuiExecutionStatus, SuiGasData, SuiObjectDataOptions, SuiObjectResponseQuery,
+    OwnedObjectRef, SuiExecutionStatus, SuiObjectDataOptions, SuiObjectResponseQuery,
     SuiPastObjectResponse, SuiRawData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
     SuiTransactionBlockResponseOptions,
 };
@@ -170,6 +170,34 @@ impl DataProvider for SuiClient {
             Edge::new(g.object_id.to_string(), o)
         }));
         Ok(connection)
+    }
+
+    async fn get_object_with_options(
+        &self,
+        object_id: NativeObjectID,
+        options: SuiObjectDataOptions,
+    ) -> Result<Object> {
+        let obj = self
+            .read_api()
+            .get_object_with_options(object_id, options)
+            .await?;
+        Ok(convert_obj(&obj.data.unwrap()))
+    }
+
+    async fn multi_get_object_with_options(
+        &self,
+        object_ids: Vec<NativeObjectID>,
+        options: SuiObjectDataOptions,
+    ) -> Result<Vec<Object>> {
+        let obj_responses = self
+            .read_api()
+            .multi_get_object_with_options(object_ids, options)
+            .await?;
+        let objs = obj_responses
+            .iter()
+            .map(|x| convert_obj(x.data.as_ref().unwrap()))
+            .collect();
+        Ok(objs)
     }
 
     async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance> {
@@ -331,7 +359,7 @@ pub(crate) fn convert_json_rpc_checkpoint(
 
     let previous_checkpoint_digest = c.previous_digest.map(|x| x.to_string());
     let network_total_transactions = Some(c.network_total_transactions);
-    let rolling_gas_summary = convert_to_gas_cost_summary(&c.epoch_rolling_gas_cost_summary).ok();
+    let rolling_gas_summary: GasCostSummary = (&c.epoch_rolling_gas_cost_summary).into();
     let epoch = convert_to_epoch(
         &c.epoch_rolling_gas_cost_summary,
         system_state,
@@ -369,13 +397,13 @@ pub(crate) fn convert_json_rpc_checkpoint(
         previous_checkpoint_digest,
         live_object_set_digest: None, // TODO fix this
         network_total_transactions,
-        rolling_gas_summary,
+        rolling_gas_summary: Some(rolling_gas_summary),
         epoch,
         end_of_epoch,
     })
 }
 
-fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
+pub(crate) fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
     Object {
         version: s.version.into(),
         digest: s.digest.to_string(),
@@ -412,66 +440,13 @@ fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
     }
 }
 
-pub(crate) async fn convert_to_gas_input(
-    cl: &SuiClient,
-    gas_data: &SuiGasData,
-) -> Result<GasInput> {
-    let payment_obj_ids: Vec<_> = gas_data.payment.iter().map(|o| o.object_id).collect();
-
-    let obj_responses = cl
-        .read_api()
-        .multi_get_object_with_options(payment_obj_ids, SuiObjectDataOptions::full_content())
-        .await?;
-
-    let payment_objs = obj_responses
-        .iter()
-        .map(|x| convert_obj(x.data.as_ref().unwrap()))
-        .collect();
-
-    Ok(GasInput {
-        gas_sponsor: Some(Address::from(SuiAddress::from(gas_data.owner))),
-        gas_payment: Some(payment_objs),
-        gas_price: Some(BigInt::from(gas_data.price)),
-        gas_budget: Some(BigInt::from(gas_data.budget)),
-    })
-}
-
-pub(crate) fn convert_to_gas_cost_summary(gcs: &NativeGasCostSummary) -> Result<GasCostSummary> {
-    Ok(GasCostSummary {
-        computation_cost: Some(BigInt::from(gcs.computation_cost)),
-        storage_cost: Some(BigInt::from(gcs.storage_cost)),
-        storage_rebate: Some(BigInt::from(gcs.storage_rebate)),
-        non_refundable_storage_fee: Some(BigInt::from(gcs.non_refundable_storage_fee)),
-    })
-}
-
-pub(crate) async fn convert_to_gas_effects(
-    cl: &SuiClient,
-    gcs: &NativeGasCostSummary,
-    gas_obj_ref: &OwnedObjectRef,
-) -> Result<GasEffects> {
-    let gas_summary = convert_to_gas_cost_summary(gcs)?;
-    let gas_obj = cl
-        .read_api()
-        .get_object_with_options(
-            gas_obj_ref.object_id(),
-            SuiObjectDataOptions::full_content(),
-        )
-        .await?;
-    let gas_object = convert_obj(&gas_obj.data.unwrap());
-    Ok(GasEffects {
-        gas_object: Some(gas_object),
-        gas_summary: Some(gas_summary),
-    })
-}
-
 pub(crate) fn convert_to_epoch(
     gcs: &NativeGasCostSummary,
     system_state: &SuiSystemStateSummary,
     protocol_configs: &ProtocolConfigs,
 ) -> Result<Epoch> {
     let epoch_id = system_state.epoch;
-    let gas_summary = convert_to_gas_cost_summary(gcs)?;
+    let gas_summary = gcs.into();
     let active_validators = convert_to_validators(system_state.active_validators.clone())?;
 
     let start_timestamp = i64::try_from(system_state.epoch_start_timestamp_ms).map_err(|_| {
@@ -604,8 +579,7 @@ async fn convert_to_transaction_block(
     let tx_data = tx.transaction.as_ref().unwrap();
     let tx_effects = tx.effects.as_ref().unwrap();
     let sender = *tx_data.data.sender();
-    let gas_effects =
-        convert_to_gas_effects(cl, tx_effects.gas_cost_summary(), tx_effects.gas_object()).await?;
+    let gas_effects = GasEffects::new(tx_effects.gas_cost_summary(), tx_effects.gas_object());
     let gcs = tx_effects.gas_cost_summary();
     let system_state = cl.governance_api().get_latest_sui_system_state().await?;
     let protocol_configs = cl.fetch_protocol_config(None).await?;
@@ -631,7 +605,7 @@ async fn convert_to_transaction_block(
             address: SuiAddress::from_array(sender.to_inner()),
         }),
         bcs: Some(Base64::from(&tx.raw_transaction)),
-        gas_input: Some(convert_to_gas_input(cl, tx_data.data.gas_data()).await?),
+        gas_input: Some(tx_data.data.gas_data().into()),
         expiration: Some(expiration),
     })
 }

--- a/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
@@ -579,7 +579,7 @@ async fn convert_to_transaction_block(
     let tx_data = tx.transaction.as_ref().unwrap();
     let tx_effects = tx.effects.as_ref().unwrap();
     let sender = *tx_data.data.sender();
-    let gas_effects = GasEffects::new(tx_effects.gas_cost_summary(), tx_effects.gas_object());
+    let gas_effects = GasEffects::from((tx_effects.gas_cost_summary(), tx_effects.gas_object()));
     let gcs = tx_effects.gas_cost_summary();
     let system_state = cl.governance_api().get_latest_sui_system_state().await?;
     let protocol_configs = cl.fetch_protocol_config(None).await?;

--- a/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/server/sui_sdk_data_provider.rs
@@ -38,8 +38,8 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use std::collections::HashMap;
 use std::str::FromStr;
 use sui_json_rpc_types::{
-    OwnedObjectRef, SuiExecutionStatus, SuiObjectDataOptions, SuiObjectResponseQuery,
-    SuiPastObjectResponse, SuiRawData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
+    SuiExecutionStatus, SuiObjectDataOptions, SuiObjectResponseQuery, SuiPastObjectResponse,
+    SuiRawData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
     SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::types::sui_serde::BigInt as SerdeBigInt;

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -95,10 +95,10 @@ impl GasCostSummary {
 }
 
 // Struct mirroring GraphQL object contains fields needed to produce GraphQL object
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct GasEffects {
-    gcs: GasCostSummary,
-    object_id: ObjectID,
+    pub gcs: GasCostSummary,
+    pub object_id: ObjectID,
 }
 
 // From trait to convert data into GasEffects

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -56,7 +56,7 @@ impl GasInput {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct GasCostSummary {
     pub computation_cost: u64,
     pub storage_cost: u64,
@@ -94,21 +94,24 @@ impl GasCostSummary {
     }
 }
 
+// Struct mirroring GraphQL object contains fields needed to produce GraphQL object
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GasEffects {
-    gcs: NativeGasCostSummary,
+    gcs: GasCostSummary,
     object_id: ObjectID,
 }
 
-impl GasEffects {
-    pub fn new(gcs: &NativeGasCostSummary, gas_obj_ref: &OwnedObjectRef) -> Self {
+// From trait to convert data into GasEffects
+impl From<(&NativeGasCostSummary, &OwnedObjectRef)> for GasEffects {
+    fn from((gcs, gas_obj_ref): (&NativeGasCostSummary, &OwnedObjectRef)) -> Self {
         Self {
-            gcs: gcs.clone(),
+            gcs: gcs.into(),
             object_id: gas_obj_ref.object_id(),
         }
     }
 }
 
+// impl #[Object] macro handles conversions and data fetches
 #[Object]
 impl GasEffects {
     async fn gas_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
@@ -120,6 +123,6 @@ impl GasEffects {
     }
 
     async fn gas_summary(&self) -> Option<GasCostSummary> {
-        Some((&self.gcs).into())
+        Some(self.gcs)
     }
 }

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -1,29 +1,125 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::object::Object;
+use crate::{server::context_ext::DataProviderContextExt, types::object::Object};
 use async_graphql::*;
+use sui_json_rpc_types::{OwnedObjectRef, SuiGasData, SuiObjectDataOptions};
+use sui_sdk::types::{
+    base_types::{ObjectID, SuiAddress as NativeSuiAddress},
+    gas::GasCostSummary as NativeGasCostSummary,
+};
 
-use super::{address::Address, big_int::BigInt};
+use super::{address::Address, big_int::BigInt, sui_address::SuiAddress};
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GasInput {
-    pub gas_sponsor: Option<Address>,
-    pub gas_payment: Option<Vec<Object>>,
-    pub gas_price: Option<BigInt>,
-    pub gas_budget: Option<BigInt>,
+    pub owner: NativeSuiAddress,
+    pub price: u64,
+    pub budget: u64,
+    pub payment_obj_ids: Vec<ObjectID>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+impl From<&SuiGasData> for GasInput {
+    fn from(s: &SuiGasData) -> Self {
+        Self {
+            owner: s.owner,
+            price: s.price,
+            budget: s.budget,
+            payment_obj_ids: s.payment.iter().map(|o| o.object_id).collect(),
+        }
+    }
+}
+
+#[Object]
+impl GasInput {
+    async fn gas_sponsor(&self) -> Option<Address> {
+        Some(Address::from(SuiAddress::from(self.owner)))
+    }
+
+    async fn gas_payment(&self, ctx: &Context<'_>) -> Result<Option<Vec<Object>>> {
+        let payment_objs = ctx
+            .data_provider()
+            .multi_get_object_with_options(
+                self.payment_obj_ids.to_vec(),
+                SuiObjectDataOptions::full_content(),
+            )
+            .await?;
+        Ok(Some(payment_objs))
+    }
+
+    async fn gas_price(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.price))
+    }
+
+    async fn gas_budget(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.budget))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GasCostSummary {
-    pub computation_cost: Option<BigInt>,
-    pub storage_cost: Option<BigInt>,
-    pub storage_rebate: Option<BigInt>,
-    pub non_refundable_storage_fee: Option<BigInt>,
+    pub computation_cost: u64,
+    pub storage_cost: u64,
+    pub storage_rebate: u64,
+    pub non_refundable_storage_fee: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+impl From<&NativeGasCostSummary> for GasCostSummary {
+    fn from(gcs: &NativeGasCostSummary) -> Self {
+        Self {
+            computation_cost: gcs.computation_cost,
+            storage_cost: gcs.storage_cost,
+            storage_rebate: gcs.storage_rebate,
+            non_refundable_storage_fee: gcs.non_refundable_storage_fee,
+        }
+    }
+}
+
+#[Object]
+impl GasCostSummary {
+    async fn computation_cost(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.computation_cost))
+    }
+
+    async fn storage_cost(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.storage_cost))
+    }
+
+    async fn storage_rebate(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.storage_rebate))
+    }
+
+    async fn non_refundable_storage_fee(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.non_refundable_storage_fee))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GasEffects {
-    pub gas_object: Option<Object>,
-    pub gas_summary: Option<GasCostSummary>,
+    gcs: NativeGasCostSummary,
+    object_id: ObjectID,
+}
+
+impl GasEffects {
+    pub fn new(gcs: &NativeGasCostSummary, gas_obj_ref: &OwnedObjectRef) -> Self {
+        Self {
+            gcs: gcs.clone(),
+            object_id: gas_obj_ref.object_id(),
+        }
+    }
+}
+
+#[Object]
+impl GasEffects {
+    async fn gas_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
+        let gas_obj = ctx
+            .data_provider()
+            .get_object_with_options(self.object_id, SuiObjectDataOptions::full_content())
+            .await?;
+        Ok(Some(gas_obj))
+    }
+
+    async fn gas_summary(&self) -> Option<GasCostSummary> {
+        Some((&self.gcs).into())
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -119,7 +119,7 @@ impl GasEffects {
             .data_provider()
             .get_object_with_options(self.object_id, SuiObjectDataOptions::full_content())
             .await?;
-        Ok(Some(gas_obj))
+        Ok(gas_obj)
     }
 
     async fn gas_summary(&self) -> Option<GasCostSummary> {


### PR DESCRIPTION
## Description 

This PR refactors convert_to_gas_input, convert_to_gas_cost_summary, and convert_to_gas_effects in favor of utilizing the `#[Object]` macro. These convert_to functions are intended to convert struct objects into GraphQL objects, but the issue is that they will always make computations and data fetches for each field, even if the caller did not specify those fields. For example, if I make a query for TransactionBlock for the gasInput field and only specify the gas_price, we nonetheless make the extra conversions for gas_sponsor, gas_budget, and the data fetch for gas_payment. 

Continuing with the example above, in this refactor, the struct definition of the GraphQL object GasInput now has the corresponding "native" fields, and implements From SuiGasData. The impl Object for GasInput block then resolves those fields, doing the necessary conversions and data fetches.

1/n as there are other convert_to fns I'd like to refactor.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
