### PR TITLE
[wallet-kit-core] fix autoconnect should wait wallet connected

### DIFF
--- a/sdk/wallet-kit/core/src/index.ts
+++ b/sdk/wallet-kit/core/src/index.ts
@@ -198,7 +198,7 @@ export function createWalletKitCore({
 			try {
 				const lastWalletName = await storageAdapter.get(storageKey);
 				if (lastWalletName) {
-					walletKit.connect(lastWalletName, { silent: true });
+					await walletKit.connect(lastWalletName, { silent: true });
 				}
 			} catch {
 				/* ignore error */


### PR DESCRIPTION
- fix autoconnect should await wallet connected

## Description 

Please consider, I think it's better if the autoconnect function should wait until the wallet is connected. 
otherwise, we need to use the subscription to check if the wallet is connected which is expensive in some usecases.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- wallet-kit-core autoconnect now will wait for the wallet to connect
