### PR TITLE
[graphql][2/n] Refactor convert_to_transaction_block

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/data_provider.rs
@@ -12,6 +12,7 @@ use async_graphql::*;
 use async_trait::async_trait;
 use sui_json_rpc_types::SuiObjectDataOptions;
 use sui_sdk::types::base_types::ObjectID;
+use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 #[async_trait]
 pub(crate) trait DataProvider: Send + Sync {
@@ -63,4 +64,6 @@ pub(crate) trait DataProvider: Send + Sync {
     async fn fetch_chain_id(&self) -> Result<String>;
 
     async fn fetch_protocol_config(&self, version: Option<u64>) -> Result<ProtocolConfigs>;
+
+    async fn get_latest_sui_system_state(&self) -> Result<SuiSystemStateSummary>;
 }

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -48,7 +48,6 @@ use sui_sdk::{
     types::{
         base_types::{ObjectID as NativeObjectID, SuiAddress as NativeSuiAddress},
         digests::TransactionDigest as NativeTransactionDigest,
-        gas::GasCostSummary as NativeGasCostSummary,
         object::Owner as NativeOwner,
         sui_system_state::sui_system_state_summary::SuiValidatorSummary,
     },
@@ -404,7 +403,7 @@ pub(crate) fn convert_json_rpc_checkpoint(
     let network_total_transactions = Some(c.network_total_transactions);
     let rolling_gas_summary: GasCostSummary = (&c.epoch_rolling_gas_cost_summary).into();
     let epoch = convert_to_epoch(
-        &c.epoch_rolling_gas_cost_summary,
+        (&c.epoch_rolling_gas_cost_summary).into(),
         system_state,
         protocol_configs,
     )
@@ -484,12 +483,11 @@ fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
 }
 
 pub(crate) fn convert_to_epoch(
-    gcs: &NativeGasCostSummary,
+    gas_summary: GasCostSummary,
     system_state: &SuiSystemStateSummary,
     protocol_configs: &ProtocolConfigs,
 ) -> Result<Epoch> {
     let epoch_id = system_state.epoch;
-    let gas_summary = gcs.into();
     let active_validators = convert_to_validators(system_state.active_validators.clone())?;
 
     let start_timestamp = i64::try_from(system_state.epoch_start_timestamp_ms).map_err(|_| {

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -90,7 +90,7 @@ impl Loader<TransactionDigest> for SuiClientLoader {
             .await?
         {
             let digest = TransactionDigest::from_array(tx.digest.into_inner());
-            let mtx = convert_to_transaction_block(&self.client, tx).await?;
+            let mtx = TransactionBlock::from(tx);
             map.insert(digest, mtx);
         }
         Ok(map)
@@ -324,8 +324,7 @@ impl DataProvider for SuiClient {
                 SuiTransactionBlockResponseOptions::full_content(),
             )
             .await?;
-
-        convert_to_transaction_block(self, tx).await.map(Some)
+        Ok(Some(TransactionBlock::from(tx)))
     }
 
     async fn fetch_chain_id(&self) -> Result<String> {

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -400,13 +400,8 @@ pub(crate) fn convert_json_rpc_checkpoint(
 
     let previous_checkpoint_digest = c.previous_digest.map(|x| x.to_string());
     let network_total_transactions = Some(c.network_total_transactions);
-    let rolling_gas_summary: GasCostSummary = (&c.epoch_rolling_gas_cost_summary).into();
-    let epoch = convert_to_epoch(
-        (&c.epoch_rolling_gas_cost_summary).into(),
-        system_state,
-        protocol_configs,
-    )
-    .ok();
+    let rolling_gas_summary = GasCostSummary::from(&c.epoch_rolling_gas_cost_summary);
+    let epoch = convert_to_epoch(rolling_gas_summary, system_state, protocol_configs).ok();
 
     let end_of_epoch_data = &c.end_of_epoch_data;
     let end_of_epoch = end_of_epoch_data.clone().map(|e| {

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::server::{context_ext::DataProviderContextExt, sui_sdk_data_provider::convert_to_epoch};
+use crate::context_data::{
+    context_ext::DataProviderContextExt, sui_sdk_data_provider::convert_to_epoch,
+};
 
 use super::{
     address::Address,
@@ -60,9 +62,11 @@ impl TransactionBlock {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, SimpleObject)]
+#[graphql(complex)]
 pub(crate) struct TransactionBlockEffects {
     pub digest: TransactionDigest,
+    #[graphql(skip)]
     pub gas_effects: GasEffects,
     pub status: ExecutionStatus,
     pub errors: Option<String>,
@@ -94,20 +98,8 @@ impl From<&SuiTransactionBlockEffects> for TransactionBlockEffects {
     }
 }
 
-#[Object]
+#[ComplexObject]
 impl TransactionBlockEffects {
-    async fn digest(&self) -> TransactionDigest {
-        self.digest
-    }
-
-    async fn status(&self) -> ExecutionStatus {
-        self.status
-    }
-
-    async fn errors(&self) -> Option<String> {
-        self.errors.clone()
-    }
-
     async fn gas_effects(&self) -> Option<GasEffects> {
         Some(self.gas_effects)
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::server::{context_ext::DataProviderContextExt, sui_sdk_data_provider::convert_to_epoch};
+
 use super::{
     address::Address,
     base64::Base64,
@@ -10,32 +12,106 @@ use super::{
     tx_digest::TransactionDigest,
 };
 use async_graphql::*;
+use sui_json_rpc_types::{
+    SuiExecutionStatus, SuiTransactionBlockDataAPI, SuiTransactionBlockEffects,
+    SuiTransactionBlockEffectsAPI,
+};
+use sui_sdk::types::digests::TransactionDigest as NativeTransactionDigest;
 
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct TransactionBlock {
-    pub digest: TransactionDigest,
-    pub effects: Option<TransactionBlockEffects>,
-    pub sender: Option<Address>,
-    pub bcs: Option<Base64>,
-    pub gas_input: Option<GasInput>,
-    pub expiration: Option<Epoch>,
+#[derive(Clone)]
+pub(crate) struct TransactionBlock(pub sui_json_rpc_types::SuiTransactionBlockResponse);
+
+#[Object]
+impl TransactionBlock {
+    async fn digest(&self) -> TransactionDigest {
+        TransactionDigest::from_array(self.0.digest.into_inner())
+    }
+
+    async fn effects(&self) -> Result<Option<TransactionBlockEffects>> {
+        let tx_effects = self.0.effects.as_ref();
+
+        Ok(Some(TransactionBlockEffects {
+            digest: self.0.digest,
+            tx_effects,
+        }))
+    }
+
+    async fn sender(&self) -> Option<Address> {
+        Some(Address {
+            address: SuiAddress::from_array(
+                self.0
+                    .transaction
+                    .as_ref()
+                    .unwrap()
+                    .data
+                    .sender()
+                    .to_inner(),
+            ),
+        })
+    }
+
+    async fn bcs(&self) -> Option<Base64> {
+        Some(Base64::from(&self.0.raw_transaction))
+    }
+
+    async fn gas_input(&self) -> Option<GasInput> {
+        Some(self.0.transaction.as_ref().unwrap().data.gas_data().into())
+    }
+
+    async fn expiration(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        let tx_effects = self.0.effects.as_ref().unwrap();
+        let gcs = tx_effects.gas_cost_summary();
+        let data_provider = ctx.data_provider();
+        let system_state = data_provider.get_latest_sui_system_state().await?;
+        let protocol_configs = data_provider.fetch_protocol_config(None).await?;
+        let epoch = convert_to_epoch(gcs, &system_state, &protocol_configs)?;
+        Ok(Some(epoch))
+    }
 }
 
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct TransactionBlockEffects {
-    pub digest: TransactionDigest,
-    pub gas_effects: Option<GasEffects>,
-    pub epoch: Option<Epoch>,
-    pub status: Option<ExecutionStatus>,
-    pub errors: Option<String>,
-    // pub transaction_block: TransactionBlock,
-    // pub dependencies: Vec<TransactionBlock>,
-    // pub lamport_version: Option<u64>,
-    // pub object_reads: Vec<Object>,
-    // pub object_changes: Vec<ObjectChange>,
-    // pub balance_changes: Vec<BalanceChange>,
-    // pub epoch: Epoch
-    // pub checkpoint: Checkpoint
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct TransactionBlockEffects<'a> {
+    pub digest: NativeTransactionDigest,
+    pub tx_effects: Option<&'a SuiTransactionBlockEffects>,
+}
+
+#[Object]
+impl TransactionBlockEffects<'_> {
+    async fn digest(&self) -> TransactionDigest {
+        TransactionDigest::from_array(self.digest.into_inner())
+    }
+
+    async fn gas_effects(&self) -> Option<GasEffects> {
+        let tx_effects = self.tx_effects.unwrap();
+        let gas_effects = GasEffects::new(tx_effects.gas_cost_summary(), tx_effects.gas_object());
+        Some(gas_effects)
+    }
+
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        let tx_effects = self.tx_effects.unwrap();
+        let gcs = tx_effects.gas_cost_summary();
+        let data_provider = ctx.data_provider();
+        let system_state = data_provider.get_latest_sui_system_state().await?;
+        let protocol_configs = data_provider.fetch_protocol_config(None).await?;
+        let epoch = convert_to_epoch(gcs, &system_state, &protocol_configs)?;
+        Ok(Some(epoch))
+    }
+
+    async fn status(&self) -> Option<ExecutionStatus> {
+        let tx_effects = self.tx_effects.unwrap();
+        Some(match tx_effects.status() {
+            SuiExecutionStatus::Success => ExecutionStatus::Success,
+            SuiExecutionStatus::Failure { error: _ } => ExecutionStatus::Failure,
+        })
+    }
+
+    async fn errors(&self) -> Option<String> {
+        let tx_effects = self.tx_effects.unwrap();
+        match tx_effects.status() {
+            SuiExecutionStatus::Success => None,
+            SuiExecutionStatus::Failure { error } => Some(error.clone()),
+        }
+    }
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -463,10 +463,10 @@ type TransactionBlockEdge {
 
 type TransactionBlockEffects {
 	digest: TransactionDigest!
+	status: ExecutionStatus!
+	errors: String
 	gasEffects: GasEffects
 	epoch: Epoch
-	status: ExecutionStatus
-	errors: String
 }
 
 input TransactionBlockFilter {
@@ -538,4 +538,3 @@ type ValidatorSet {
 schema {
 	query: Query
 }
-


### PR DESCRIPTION
## Description 

Continuing off https://github.com/MystenLabs/sui/pull/13714. 
It looks like the effects field of TransactionBlock have some heavy overlaps with other top-level fields of TransactionBlock. We already have the data needed to resolve every field on effects: TransactionBlockEffects. In fact, if a caller specifies both tx.effects.epoch and tx.expiration, we make redundant calls for sui_system_state and fetch_protocol_config. It's also a little strange to me that we pass tx_effects to TransactionBlockEffects for status and errors. Wondering if it's worth it right now to modify schema for TransactionBlock and TransactionBlockEffects? We could remove the redundant digest, lift status and errors to top-level, etc.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
