### PR TITLE
[dapp-kit][wallet-standard] fix type mismatch in the wallet provider for wallets

### DIFF
--- a/.changeset/sixty-balloons-run.md
+++ b/.changeset/sixty-balloons-run.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-standard': minor
+---
+
+Added new isWalletWithRequiredFeatureSet utility and accompanying type

--- a/sdk/dapp-kit/src/components/WalletProvider.tsx
+++ b/sdk/dapp-kit/src/components/WalletProvider.tsx
@@ -3,7 +3,7 @@
 
 import type { Dispatch, ReactNode } from 'react';
 import { createContext, useCallback, useContext, useMemo, useReducer } from 'react';
-import type { Wallet } from '@mysten/wallet-standard';
+import type { Wallet, WalletWithRequiredFeatures } from '@mysten/wallet-standard';
 import { getWallets } from '@mysten/wallet-standard';
 import { localStorageAdapter } from '../utils/storageAdapters.js';
 import type { StorageAdapter } from '../utils/storageAdapters.js';
@@ -24,7 +24,7 @@ interface WalletProviderProps {
 	storageKey?: string;
 
 	/** A list of features that are required for the dApp to function. This filters the list of wallets presented to users when selecting a wallet to connect from, ensuring that only wallets that meet the dApps requirements can connect. */
-	requiredFeatures?: string[];
+	requiredFeatures?: (keyof WalletWithRequiredFeatures['features'])[];
 
 	/** Enables automatically reconnecting to the most recently used wallet account upon mounting. */
 	autoConnect?: boolean;

--- a/sdk/dapp-kit/src/reducers/walletReducer.ts
+++ b/sdk/dapp-kit/src/reducers/walletReducer.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WalletWithSuiFeatures, WalletAccount, Wallet } from '@mysten/wallet-standard';
+import type { WalletAccount, Wallet, WalletWithRequiredFeatures } from '@mysten/wallet-standard';
 import { assertUnreachable } from '../utils/assertUnreachable.js';
 
 export type WalletState = {
-	wallets: WalletWithSuiFeatures[];
-	currentWallet: WalletWithSuiFeatures | null;
+	wallets: WalletWithRequiredFeatures[];
+	currentWallet: WalletWithRequiredFeatures | null;
 	accounts: readonly WalletAccount[];
 	currentAccount: WalletAccount | null;
 	connectionStatus: 'disconnected' | 'connecting' | 'connected';
@@ -15,14 +15,14 @@ export type WalletState = {
 type WalletRegisteredAction = {
 	type: 'wallet-registered';
 	payload: {
-		updatedWallets: WalletWithSuiFeatures[];
+		updatedWallets: WalletWithRequiredFeatures[];
 	};
 };
 
 type WalletUnregisteredAction = {
 	type: 'wallet-unregistered';
 	payload: {
-		updatedWallets: WalletWithSuiFeatures[];
+		updatedWallets: WalletWithRequiredFeatures[];
 		unregisteredWallet: Wallet;
 	};
 };

--- a/sdk/dapp-kit/src/utils/walletUtils.ts
+++ b/sdk/dapp-kit/src/utils/walletUtils.ts
@@ -1,23 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Wallet, WalletWithSuiFeatures } from '@mysten/wallet-standard';
-import { isWalletWithSuiFeatures } from '@mysten/wallet-standard';
+import type {
+	MinimallyRequiredFeatures,
+	Wallet,
+	WalletWithFeatures,
+} from '@mysten/wallet-standard';
+import { isWalletWithRequiredFeatureSet } from '@mysten/wallet-standard';
 
-export function sortWallets(
+export function sortWallets<AdditionalFeatures extends Wallet['features']>(
 	wallets: readonly Wallet[],
 	preferredWallets: string[],
-	requiredFeatures?: string[],
-): WalletWithSuiFeatures[] {
-	const suiWallets = wallets.filter((wallet): wallet is WalletWithSuiFeatures =>
-		isWalletWithSuiFeatures(wallet, requiredFeatures),
+	requiredFeatures?: (keyof AdditionalFeatures)[],
+) {
+	const suiWallets = wallets.filter(
+		(wallet): wallet is WalletWithFeatures<MinimallyRequiredFeatures & AdditionalFeatures> =>
+			isWalletWithRequiredFeatureSet(wallet, requiredFeatures),
 	);
 
 	return [
 		// Preferred wallets, in order:
 		...(preferredWallets
 			.map((name) => suiWallets.find((wallet) => wallet.name === name))
-			.filter(Boolean) as WalletWithSuiFeatures[]),
+			.filter(Boolean) as WalletWithFeatures<MinimallyRequiredFeatures & AdditionalFeatures>[]),
 
 		// Wallets in default order:
 		...suiWallets.filter((wallet) => !preferredWallets.includes(wallet.name)),

--- a/sdk/wallet-standard/src/detect.ts
+++ b/sdk/wallet-standard/src/detect.ts
@@ -11,6 +11,7 @@ const REQUIRED_FEATURES: (keyof MinimallyRequiredFeatures)[] = [
 	'standard:events',
 ];
 
+/** @deprecated Use isWalletWithRequiredFeatureSet instead since it provides more accurate typing! */
 export function isWalletWithSuiFeatures(
 	wallet: Wallet,
 	/** Extra features that are required to be present, in addition to the expected feature set. */

--- a/sdk/wallet-standard/src/detect.ts
+++ b/sdk/wallet-standard/src/detect.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Wallet } from '@wallet-standard/core';
-import { WalletWithSuiFeatures } from './features';
+import { Wallet, WalletWithFeatures } from '@wallet-standard/core';
+import { MinimallyRequiredFeatures, WalletWithSuiFeatures } from './features';
 
 // These features are absolutely required for wallets to function in the Sui ecosystem.
 // Eventually, as wallets have more consistent support of features, we may want to extend this list.
-const REQUIRED_FEATURES: (keyof WalletWithSuiFeatures['features'])[] = [
+const REQUIRED_FEATURES: (keyof MinimallyRequiredFeatures)[] = [
 	'standard:connect',
 	'standard:events',
 ];
@@ -17,4 +17,13 @@ export function isWalletWithSuiFeatures(
 	features: string[] = [],
 ): wallet is WalletWithSuiFeatures {
 	return [...REQUIRED_FEATURES, ...features].every((feature) => feature in wallet.features);
+}
+
+export function isWalletWithRequiredFeatureSet<AdditionalFeatures extends Wallet['features']>(
+	wallet: Wallet,
+	additionalFeatures: (keyof AdditionalFeatures)[] = [],
+): wallet is WalletWithFeatures<MinimallyRequiredFeatures & AdditionalFeatures> {
+	return [...REQUIRED_FEATURES, ...additionalFeatures].every(
+		(feature) => feature in wallet.features,
+	);
 }

--- a/sdk/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-standard/src/features/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+	IdentifierRecord,
 	StandardConnectFeature,
 	StandardDisconnectFeature,
 	StandardEventsFeature,
@@ -28,6 +29,18 @@ export type WalletWithSuiFeatures = WalletWithFeatures<
 		// Disconnect is an optional feature:
 		Partial<StandardDisconnectFeature>
 >;
+
+/**
+ * Represents a wallet with the absolute minimum feature set required to function in the Sui ecosystem.
+ */
+export type WalletWithRequiredFeatures = WalletWithFeatures<
+	MinimallyRequiredFeatures &
+		Partial<SuiFeatures> &
+		Partial<StandardDisconnectFeature> &
+		IdentifierRecord<unknown>
+>;
+
+export type MinimallyRequiredFeatures = StandardConnectFeature & StandardEventsFeature;
 
 export * from './suiSignMessage';
 export * from './suiSignTransactionBlock';


### PR DESCRIPTION
## Description 

In `wallet-standard`, we only enforce that a wallet has `standard:connect` and `standard:events` to function. However, we make a type assertion in `isWalletWithSuiFeatures` that any wallet with these two features + any other features has all Sui features which isn't a safe assumption to make. This leads to type mismatches like the one below - you could register a wallet without `sui:signPersonalMessage` but TypeScript is going to think the wallet automatically has that feature within `wallet-kit`.

<img width="1183" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/3cf74bfe-e397-488c-bd52-d2a97a236d72">


To fix this, we can introduce a new `WalletWithRequiredFeatures` type to more accurately reflect what features are available. I didn't change anything in `wallet-kit` since we're working on deprecating that library, but I did make the updates for `dapp-kit` regarding the `currentWallet` and `wallets` states. With this, Sui features will now correctly be optional.

## Test Plan 
- Verified types work and look correct in my IDE
- Automated tests for `requiredFeatures` still pass

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
