### PR TITLE
Record owner in loaded runtime objects

### DIFF
--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -89,7 +89,7 @@ pub struct ExecutionResultsV2 {
     pub written_objects: BTreeMap<ObjectID, Object>,
     /// All objects loaded with the intention to be modified, with their original sequence number and digest.
     /// If any object is not found in written_objects, they must be either deleted or wrapped.
-    pub objects_modified_at: BTreeMap<ObjectID, (SequenceNumber, ObjectDigest)>,
+    pub objects_modified_at: BTreeMap<ObjectID, (SequenceNumber, ObjectDigest, Owner)>,
     /// All object IDs created in this transaction.
     pub created_object_ids: BTreeSet<ObjectID>,
     /// All object IDs deleted in this transaction.
@@ -113,6 +113,7 @@ pub struct InputObjectMetadata {
 pub struct LoadedChildObjectMetadata {
     pub version: SequenceNumber,
     pub digest: ObjectDigest,
+    pub owner: Owner,
     pub storage_rebate: u64,
 }
 

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -589,6 +589,7 @@ mod checked {
                     LoadedRuntimeObject {
                         version,
                         digest,
+                        owner,
                         is_modified: true,
                     },
                 );
@@ -787,7 +788,7 @@ mod checked {
                     .filter_map(|(id, loaded)| {
                         loaded
                             .is_modified
-                            .then_some((id, (loaded.version, loaded.digest)))
+                            .then_some((id, (loaded.version, loaded.digest, loaded.owner)))
                     })
                     .collect(),
                 created_object_ids: created_object_ids.into_iter().map(|(id, _)| id).collect(),

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1011,14 +1011,14 @@ impl<'backing> Storage for TemporaryStore<'backing> {
 
         for id in results.deleted_object_ids {
             let delete_kind: DeleteKindWithOldVersion =
-                if let Some((version, _)) = results.objects_modified_at.get(&id) {
+                if let Some((version, ..)) = results.objects_modified_at.get(&id) {
                     DeleteKindWithOldVersion::Normal(*version)
                 } else {
                     DeleteKindWithOldVersion::UnwrapThenDelete
                 };
             object_changes.insert(id, ObjectChange::Delete(delete_kind));
         }
-        for (id, (version, _)) in results.objects_modified_at {
+        for (id, (version, ..)) in results.objects_modified_at {
             object_changes.entry(id).or_insert(ObjectChange::Delete(
                 DeleteKindWithOldVersion::Wrap(version),
             ));

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -66,6 +66,7 @@ pub(crate) struct TestInventories {
 pub struct LoadedRuntimeObject {
     pub version: SequenceNumber,
     pub digest: ObjectDigest,
+    pub owner: Owner,
     pub is_modified: bool,
 }
 
@@ -418,6 +419,7 @@ impl<'a> ObjectRuntime<'a> {
                             version: obj.version(),
                             digest: obj.digest(),
                             storage_rebate: obj.storage_rebate,
+                            owner: obj.owner,
                         },
                     )
                 })
@@ -457,6 +459,7 @@ impl ObjectRuntimeState {
                     LoadedRuntimeObject {
                         version: metadata.version,
                         digest: metadata.digest,
+                        owner: metadata.owner,
                         is_modified: false,
                     },
                 )

--- a/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
@@ -522,8 +522,8 @@ mod checked {
             self.new_packages.push(package);
         }
 
-        /// Return the last pacakge pushed in `write_package`.
-        /// This function should be used in block of codes that push a pacakge, verify
+        /// Return the last package pushed in `write_package`.
+        /// This function should be used in block of codes that push a package, verify
         /// it, run the init and in case of error will remove the package.
         /// The package has to be pushed for the init to run correctly.
         pub fn pop_package(&mut self) -> Option<MovePackage> {
@@ -580,6 +580,7 @@ mod checked {
                     LoadedRuntimeObject {
                         version,
                         digest,
+                        owner,
                         is_modified: true,
                     },
                 );
@@ -752,7 +753,7 @@ mod checked {
                     .filter_map(|(id, loaded)| {
                         loaded
                             .is_modified
-                            .then_some((id, (loaded.version, loaded.digest)))
+                            .then_some((id, (loaded.version, loaded.digest, loaded.owner)))
                     })
                     .collect(),
                 created_object_ids: created_object_ids.into_iter().map(|(id, _)| id).collect(),
@@ -1308,7 +1309,7 @@ mod checked {
 
     // Implementation of the `DataStore` trait for the Move VM.
     // When used during execution it may have a list of new packages that have
-    // just been published in the current context. Thos are used for module/type
+    // just been published in the current context. Those are used for module/type
     // resolution when executing module init.
     // It may be created with an empty slice of packages either when no publish/upgrade
     // are performed or when a type is requested not during execution.
@@ -1339,7 +1340,7 @@ mod checked {
         }
     }
 
-    // TODO: `DataStore` wil be reworked and this is likely to disappear.
+    // TODO: `DataStore` will be reworked and this is likely to disappear.
     //       Leaving this comment around until then as testament to better days to come...
     impl<'state, 'a> DataStore for SuiDataStore<'state, 'a> {
         fn link_context(&self) -> AccountAddress {

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -1011,14 +1011,14 @@ impl<'backing> Storage for TemporaryStore<'backing> {
 
         for id in results.deleted_object_ids {
             let delete_kind: DeleteKindWithOldVersion =
-                if let Some((version, _)) = results.objects_modified_at.get(&id) {
+                if let Some((version, ..)) = results.objects_modified_at.get(&id) {
                     DeleteKindWithOldVersion::Normal(*version)
                 } else {
                     DeleteKindWithOldVersion::UnwrapThenDelete
                 };
             object_changes.insert(id, ObjectChange::Delete(delete_kind));
         }
-        for (id, (version, _)) in results.objects_modified_at {
+        for (id, (version, ..)) in results.objects_modified_at {
             object_changes.entry(id).or_insert(ObjectChange::Delete(
                 DeleteKindWithOldVersion::Wrap(version),
             ));

--- a/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
@@ -66,6 +66,7 @@ pub(crate) struct TestInventories {
 pub struct LoadedRuntimeObject {
     pub version: SequenceNumber,
     pub digest: ObjectDigest,
+    pub owner: Owner,
     pub is_modified: bool,
 }
 
@@ -410,6 +411,7 @@ impl<'a> ObjectRuntime<'a> {
                             version: obj.version(),
                             digest: obj.digest(),
                             storage_rebate: obj.storage_rebate,
+                            owner: obj.owner,
                         },
                     )
                 })
@@ -449,6 +451,7 @@ impl ObjectRuntimeState {
                     LoadedRuntimeObject {
                         version: metadata.version,
                         digest: metadata.digest,
+                        owner: metadata.owner,
                         is_modified: false,
                     },
                 )

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -413,6 +413,7 @@ impl<'a> ObjectRuntime<'a> {
                             version: obj.version(),
                             digest: obj.digest(),
                             storage_rebate: obj.storage_rebate,
+                            owner: obj.owner,
                         },
                     )
                 })


### PR DESCRIPTION
## Description 

This will allow us to record the old owner in effects v2.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
