### PR TITLE
[graphql] refactor convert_obj

### DIFF
--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -3,6 +3,8 @@
 
 use async_graphql::dataloader::{DataLoader, LruCache};
 use async_graphql::{connection::Connection, *};
+use sui_json_rpc_types::SuiRawData;
+use sui_sdk::types::object::Owner as NativeOwner;
 
 use super::big_int::BigInt;
 use super::name_service::NameService;
@@ -14,16 +16,52 @@ use super::{
 use crate::server::sui_sdk_data_provider::SuiClientLoader;
 use crate::{server::context_ext::DataProviderContextExt, types::base64::Base64};
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, SimpleObject)]
+#[graphql(complex)]
 pub(crate) struct Object {
     pub address: SuiAddress,
     pub version: u64,
     pub digest: String,
     pub storage_rebate: Option<BigInt>,
-    pub owner: Option<SuiAddress>,
+    pub owner: Option<Owner>,
     pub bcs: Option<Base64>,
     pub previous_transaction: Option<TransactionDigest>,
     pub kind: Option<ObjectKind>,
+}
+
+impl From<&sui_json_rpc_types::SuiObjectData> for Object {
+    fn from(s: &sui_json_rpc_types::SuiObjectData) -> Self {
+        Self {
+            version: s.version.into(),
+            digest: s.digest.to_string(),
+            storage_rebate: s.storage_rebate.map(BigInt::from),
+            address: SuiAddress::from_array(**s.object_id),
+            owner: s
+                .owner
+                .unwrap()
+                .get_owner_address()
+                .map(|x| SuiAddress::from_array(x.to_inner()))
+                .ok()
+                .map(|q| Owner { address: q }),
+            bcs: s.bcs.as_ref().map(|raw| match raw {
+                SuiRawData::Package(raw_package) => {
+                    Base64::from(bcs::to_bytes(raw_package).unwrap())
+                }
+                SuiRawData::MoveObject(raw_object) => Base64::from(&raw_object.bcs_bytes),
+            }),
+            previous_transaction: Some(TransactionDigest::from_array(
+                s.previous_transaction.unwrap().into_inner(),
+            )),
+            kind: Some(match s.owner.unwrap() {
+                NativeOwner::AddressOwner(_) => ObjectKind::Owned,
+                NativeOwner::ObjectOwner(_) => ObjectKind::Child,
+                NativeOwner::Shared {
+                    initial_shared_version: _,
+                } => ObjectKind::Shared,
+                NativeOwner::Immutable => ObjectKind::Immutable,
+            }),
+        }
+    }
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
@@ -53,24 +91,8 @@ pub(crate) struct ObjectKey {
 
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
-#[Object]
+#[ComplexObject]
 impl Object {
-    async fn version(&self) -> u64 {
-        self.version
-    }
-
-    async fn digest(&self) -> String {
-        self.digest.clone()
-    }
-
-    async fn storage_rebate(&self) -> Option<BigInt> {
-        self.storage_rebate.clone()
-    }
-
-    async fn bcs(&self) -> Option<Base64> {
-        self.bcs.clone()
-    }
-
     async fn previous_transaction_block(
         &self,
         ctx: &Context<'_>,
@@ -81,14 +103,6 @@ impl Object {
         } else {
             Ok(None)
         }
-    }
-
-    async fn kind(&self) -> Option<ObjectKind> {
-        self.kind
-    }
-
-    async fn owner(&self) -> Option<Owner> {
-        self.owner.as_ref().map(|q| Owner { address: *q })
     }
 
     // =========== Owner interface methods =============

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -24,7 +24,7 @@ impl Query {
         // Currently only an account address can own an object
         let o = ctx.data_provider().fetch_obj(address, None).await?;
         Ok(o.and_then(|q| q.owner)
-            .map(|o| ObjectOwner::Address(Address { address: o })))
+            .map(|o| ObjectOwner::Address(Address { address: o.address })))
     }
 
     async fn object(


### PR DESCRIPTION
## Description 

Thanks to @amnn 's comment on this PR https://github.com/MystenLabs/sui/pull/13714#issuecomment-1713199034, I think there are two approaches to resolving GraphQL objects

1. Reserve the `#[Object]` Macro for Resolving Edges. 
2. Include all GraphQL-related logic in the `#[Object]` or `#[ComplexObject]` macro.

I originally favored approach 2, but I think that the optimizations from delaying data conversions are minimal, and trying to define the boundary of conversion was difficult as well - it led to scenarios where some structs would have a mix of "Native" and "GraphQL" typings. I think it's clearer overall to convert to graphql typing when we receive data from an external source, and then work with that throughout the rest of the application. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
