### PR TITLE
[dapp-kit] evolve wallet test mocks to support passing multiple accounts and do some re-organizing

### DIFF
--- a/sdk/dapp-kit/test/components/WalletProvider.test.tsx
+++ b/sdk/dapp-kit/test/components/WalletProvider.test.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook } from '@testing-library/react';
+import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
+import { useWallet } from 'dapp-kit/src/index.js';
+
+describe('WalletProvider', () => {
+	test('the correct wallet and account information is returned on initial render', () => {
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(() => useWallet(), { wrapper });
+
+		expect(result.current).toStrictEqual({
+			accounts: [],
+			currentAccount: null,
+			wallets: [],
+			currentWallet: null,
+			connectionStatus: 'disconnected',
+		});
+	});
+
+	test('the list of wallets is ordered correctly by preference', () => {
+		const { unregister: unregister1 } = registerMockWallet({ walletName: 'Mock Wallet 1' });
+		const { unregister: unregister2 } = registerMockWallet({ walletName: 'Mock Wallet 2' });
+		const { unregister: unregister3 } = registerMockWallet({ walletName: 'Mock Wallet 3' });
+
+		const wrapper = createWalletProviderContextWrapper({
+			preferredWallets: ['Mock Wallet 2', 'Mock Wallet 1'],
+		});
+		const { result } = renderHook(() => useWallet(), { wrapper });
+		const walletNames = result.current.wallets.map((wallet) => wallet.name);
+
+		expect(walletNames).toStrictEqual(['Mock Wallet 2', 'Mock Wallet 1', 'Mock Wallet 3']);
+
+		act(() => {
+			unregister1();
+			unregister2();
+			unregister3();
+		});
+	});
+
+	test('the unsafe burner wallet is registered when enableUnsafeBurner is set', async () => {
+		const wrapper = createWalletProviderContextWrapper({
+			enableUnsafeBurner: true,
+		});
+		const { result } = renderHook(() => useWallet(), { wrapper });
+		const walletNames = result.current.wallets.map((wallet) => wallet.name);
+
+		expect(walletNames).toStrictEqual(['Unsafe Burner Wallet']);
+	});
+
+	test('unregistered wallets are removed from the list of wallets', async () => {
+		const { unregister: unregister1 } = registerMockWallet({ walletName: 'Mock Wallet 1' });
+		const { unregister: unregister2 } = registerMockWallet({ walletName: 'Mock Wallet 2' });
+		const { unregister: unregister3 } = registerMockWallet({ walletName: 'Mock Wallet 3' });
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(() => useWallet(), { wrapper });
+
+		act(() => unregister2());
+
+		const walletNames = result.current.wallets.map((wallet) => wallet.name);
+		expect(walletNames).toStrictEqual(['Mock Wallet 1', 'Mock Wallet 3']);
+
+		act(() => {
+			unregister1();
+			unregister3();
+		});
+	});
+
+	test('the list of wallets is correctly filtered by required features', () => {
+		const { unregister: unregister1 } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			additionalFeatures: {
+				'my-dapp:super-cool-feature': {
+					version: '1.0.0',
+					superCoolFeature: () => {},
+				},
+			},
+		});
+		const { unregister: unregister2 } = registerMockWallet({ walletName: 'Mock Wallet 2' });
+
+		const wrapper = createWalletProviderContextWrapper({
+			requiredFeatures: ['my-dapp:super-cool-feature'],
+		});
+		const { result } = renderHook(() => useWallet(), { wrapper });
+		const walletNames = result.current.wallets.map((wallet) => wallet.name);
+
+		expect(walletNames).toStrictEqual(['Mock Wallet 1']);
+
+		act(() => {
+			unregister1();
+			unregister2();
+		});
+	});
+});

--- a/sdk/dapp-kit/test/hooks/useConnectWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useConnectWallet.test.tsx
@@ -9,7 +9,7 @@ import type { Mock } from 'vitest';
 
 describe('useConnectWallet', () => {
 	test('throws an error when connecting to a wallet when a connection is already active', async () => {
-		const { unregister, mockWallet } = registerMockWallet('Mock Wallet 1');
+		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(
@@ -34,7 +34,7 @@ describe('useConnectWallet', () => {
 	});
 
 	test('throws an error when a user fails to connect their wallet', async () => {
-		const { unregister, mockWallet } = registerMockWallet('Mock Wallet 1');
+		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(
@@ -63,7 +63,7 @@ describe('useConnectWallet', () => {
 	});
 
 	test('connecting to a wallet works successfully', async () => {
-		const { unregister, mockWallet } = registerMockWallet('Mock Wallet 1');
+		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(

--- a/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useDisconnectWallet.test.tsx
@@ -17,7 +17,7 @@ describe('useDisconnectWallet', () => {
 	});
 
 	test('that disconnecting works successfully', async () => {
-		const { unregister, mockWallet } = registerMockWallet('Mock Wallet 1');
+		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(

--- a/sdk/dapp-kit/test/hooks/useWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useWallet.test.tsx
@@ -1,99 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useWallet } from 'dapp-kit/src';
-import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
 
 describe('useWallet', () => {
 	test('throws an error when rendered without a provider', () => {
 		expect(() => renderHook(() => useWallet())).toThrowError(
 			'Could not find WalletContext. Ensure that you have set up the WalletProvider.',
 		);
-	});
-
-	test('the correct wallet and account information is returned on initial render', () => {
-		const wrapper = createWalletProviderContextWrapper();
-		const { result } = renderHook(() => useWallet(), { wrapper });
-
-		expect(result.current).toStrictEqual({
-			accounts: [],
-			currentAccount: null,
-			wallets: [],
-			currentWallet: null,
-			connectionStatus: 'disconnected',
-		});
-	});
-
-	test('the list of wallets is ordered correctly by preference', () => {
-		const { unregister: unregister1 } = registerMockWallet('Mock Wallet 1');
-		const { unregister: unregister2 } = registerMockWallet('Mock Wallet 2');
-		const { unregister: unregister3 } = registerMockWallet('Mock Wallet 3');
-
-		const wrapper = createWalletProviderContextWrapper({
-			preferredWallets: ['Mock Wallet 2', 'Mock Wallet 1'],
-		});
-		const { result } = renderHook(() => useWallet(), { wrapper });
-		const walletNames = result.current.wallets.map((wallet) => wallet.name);
-
-		expect(walletNames).toStrictEqual(['Mock Wallet 2', 'Mock Wallet 1', 'Mock Wallet 3']);
-
-		act(() => {
-			unregister1();
-			unregister2();
-			unregister3();
-		});
-	});
-
-	test('the unsafe burner wallet is registered when enableUnsafeBurner is set', async () => {
-		const wrapper = createWalletProviderContextWrapper({
-			enableUnsafeBurner: true,
-		});
-		const { result } = renderHook(() => useWallet(), { wrapper });
-		const walletNames = result.current.wallets.map((wallet) => wallet.name);
-
-		expect(walletNames).toStrictEqual(['Unsafe Burner Wallet']);
-	});
-
-	test('unregistered wallets are removed from the list of wallets', async () => {
-		const { unregister: unregister1 } = registerMockWallet('Mock Wallet 1');
-		const { unregister: unregister2 } = registerMockWallet('Mock Wallet 2');
-		const { unregister: unregister3 } = registerMockWallet('Mock Wallet 3');
-
-		const wrapper = createWalletProviderContextWrapper();
-		const { result } = renderHook(() => useWallet(), { wrapper });
-
-		act(() => unregister2());
-
-		const walletNames = result.current.wallets.map((wallet) => wallet.name);
-		expect(walletNames).toStrictEqual(['Mock Wallet 1', 'Mock Wallet 3']);
-
-		act(() => {
-			unregister1();
-			unregister3();
-		});
-	});
-
-	test('the list of wallets is correctly filtered by required features', () => {
-		const { unregister: unregister1 } = registerMockWallet('Mock Wallet 1', {
-			'my-dapp:super-cool-feature': {
-				version: '1.0.0',
-				superCoolFeature: () => {},
-			},
-		});
-		const { unregister: unregister2 } = registerMockWallet('Mock Wallet 2');
-
-		const wrapper = createWalletProviderContextWrapper({
-			requiredFeatures: ['my-dapp:super-cool-feature'],
-		});
-		const { result } = renderHook(() => useWallet(), { wrapper });
-		const walletNames = result.current.wallets.map((wallet) => wallet.name);
-
-		expect(walletNames).toStrictEqual(['Mock Wallet 1']);
-
-		act(() => {
-			unregister1();
-			unregister2();
-		});
 	});
 });

--- a/sdk/dapp-kit/test/mocks/mockAccount.ts
+++ b/sdk/dapp-kit/test/mocks/mockAccount.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { WalletAccount } from '@mysten/wallet-standard';
+import { ReadonlyWalletAccount } from '@mysten/wallet-standard';
+import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
+
+export function createMockAccount(accountOverrides: Partial<WalletAccount> = {}) {
+	const keypair = new Ed25519Keypair();
+	return new ReadonlyWalletAccount({
+		address: keypair.getPublicKey().toSuiAddress(),
+		publicKey: keypair.getPublicKey().toSuiBytes(),
+		chains: ['sui:unknown'],
+		features: ['sui:signAndExecuteTransactionBlock', 'sui:signTransactionBlock'],
+		...accountOverrides,
+	});
+}

--- a/sdk/dapp-kit/test/test-utils.tsx
+++ b/sdk/dapp-kit/test/test-utils.tsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SuiClient } from '@mysten/sui.js/client';
-import type { IdentifierRecord } from '@mysten/wallet-standard';
+import type { IdentifierRecord, ReadonlyWalletAccount } from '@mysten/wallet-standard';
 import { getWallets } from '@mysten/wallet-standard';
 import { SuiClientProvider, WalletProvider } from 'dapp-kit/src';
-import { MockWallet } from './mockWallet.js';
+import { MockWallet } from './mocks/mockWallet.js';
 import type { ComponentProps } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createMockAccount } from './mocks/mockAccount.js';
 
 export function createSuiClientContextWrapper(client: SuiClient) {
 	return function SuiClientContextWrapper({ children }: { children: React.ReactNode }) {
@@ -30,12 +31,17 @@ export function createWalletProviderContextWrapper(
 	};
 }
 
-export function registerMockWallet(
-	walletName: string,
-	additionalFeatures: IdentifierRecord<unknown> = {},
-) {
+export function registerMockWallet({
+	walletName,
+	accounts = [createMockAccount()],
+	additionalFeatures = {},
+}: {
+	walletName: string;
+	accounts?: ReadonlyWalletAccount[];
+	additionalFeatures?: IdentifierRecord<unknown>;
+}) {
 	const walletsApi = getWallets();
-	const mockWallet = new MockWallet(walletName, additionalFeatures);
+	const mockWallet = new MockWallet(walletName, accounts, additionalFeatures);
 	return {
 		unregister: walletsApi.register(mockWallet),
 		mockWallet,


### PR DESCRIPTION
## Description 
I originally included these changes in the auto-connection PR, but that PR was starting to get hard to review so I decided to pull this into its own PR. This PR just moves some tests from `useWallet.test.tsx` to `WalletProvider.test.tsx` since we're really testing the component logic as opposed to the hook logic. It also modifies the `MockWallet` class to support the creation of multiple accounts in tests which is needed for the auto-connection logic PR.

## Test Plan 
- Automated tests pass
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
