### PR TITLE
[Explorer]: add orientation for objectVideoImg

### DIFF
--- a/apps/core/tailwind.config.ts
+++ b/apps/core/tailwind.config.ts
@@ -183,6 +183,7 @@ export default {
 				120: '30rem',
 				300: '75rem',
 				coinsAndAssetsContainer: '31.25rem',
+				objectVideoImgEvenXl: '22.5rem',
 			},
 			maxHeight: {
 				coinsAndAssetsContainer: '31.25rem',
@@ -192,6 +193,14 @@ export default {
 				12.5: '3.125rem',
 				31.5: '7.5rem',
 				walletLogo: '4.813rem',
+				objectVideoImgEvenXl: '22.5rem',
+				objectVideoImgPortraitLarge: '9.38rem',
+				objectVideoImgPortraitXl: '16.88rem',
+				objectVideoImgLandscapeXs: '2.67rem',
+				objectVideoImgLandscapeSmall: '5.33rem',
+				objectVideoImgLandscapeMedium: '10.5rem',
+				objectVideoImgLandscapeLarge: '16.67rem',
+				objectVideoImgLandscapeXl: '30rem',
 			},
 			maxWidth: {
 				80: '20rem',

--- a/apps/explorer/src/ui/ObjectVideoImage.tsx
+++ b/apps/explorer/src/ui/ObjectVideoImage.tsx
@@ -4,17 +4,24 @@
 import { MediaPlay16 } from '@mysten/icons';
 import { cva, type VariantProps } from 'class-variance-authority';
 import clsx from 'clsx';
+import { useState } from 'react';
 
 import { ObjectModal } from '~/ui/Modal/ObjectModal';
-import { Image } from '~/ui/image/Image';
+import { Image as ImageComponent, type ImageProps } from '~/ui/image/Image';
 
 const imageStyles = cva(['z-0 flex-shrink-0 relative'], {
 	variants: {
 		variant: {
-			xs: 'h-8 w-8',
-			small: 'h-16 w-16',
-			medium: 'md:h-31.5 md:w-31.5 h-16 w-16',
-			large: 'h-50 w-50',
+			xs: 'h-8',
+			small: 'h-16',
+			medium: 'md:h-31.5 h-16',
+			large: 'h-50',
+			xl: 'h-objectVideoImgEvenXl',
+		},
+		orientation: {
+			landscape: '',
+			portrait: '',
+			even: '',
 		},
 		disablePreview: {
 			true: '',
@@ -23,20 +30,127 @@ const imageStyles = cva(['z-0 flex-shrink-0 relative'], {
 	},
 	defaultVariants: {
 		disablePreview: false,
+		orientation: 'even',
 	},
+	compoundVariants: [
+		// orientation: even
+		{
+			variant: 'xs',
+			orientation: 'even',
+			className: 'w-8',
+		},
+		{
+			variant: 'small',
+			orientation: 'even',
+			className: 'w-16',
+		},
+		{
+			variant: 'medium',
+			orientation: 'even',
+			className: 'md:w-31.5 w-16',
+		},
+		{
+			variant: 'large',
+			orientation: 'even',
+			className: 'w-50',
+		},
+		{
+			variant: 'xl',
+			orientation: 'even',
+			className: 'w-objectVideoImgEvenXl',
+		},
+		// orientation: portrait
+		{
+			variant: 'xs',
+			orientation: 'portrait',
+			className: 'w-6',
+		},
+		{
+			variant: 'small',
+			orientation: 'portrait',
+			className: 'w-12',
+		},
+		{
+			variant: 'medium',
+			orientation: 'portrait',
+			className: 'md:w-24 w-12',
+		},
+		{
+			variant: 'large',
+			orientation: 'portrait',
+			className: 'w-objectVideoImgPortraitLarge',
+		},
+		{
+			variant: 'xl',
+			orientation: 'portrait',
+			className: 'w-objectVideoImgPortraitXl',
+		},
+		// orientation: landscape
+		{
+			variant: 'xs',
+			orientation: 'landscape',
+			className: 'w-objectVideoImgLandscapeXs',
+		},
+		{
+			variant: 'small',
+			orientation: 'landscape',
+			className: 'w-objectVideoImgLandscapeSmall',
+		},
+		{
+			variant: 'medium',
+			orientation: 'landscape',
+			className: 'md:w-objectVideoImgLandscapeMedium w-objectVideoImgLandscapeSmall',
+		},
+		{
+			variant: 'large',
+			orientation: 'landscape',
+			className: 'w-objectVideoImgLandscapeLarge',
+		},
+		{
+			variant: 'xl',
+			orientation: 'landscape',
+			className: 'w-objectVideoImgLandscapeXl',
+		},
+	],
 });
 
 type ImageStylesProps = VariantProps<typeof imageStyles>;
 
-interface Props extends ImageStylesProps {
+export interface ObjectVideoImageProps extends Omit<ImageStylesProps, 'orientation'> {
 	title: string;
 	subtitle: string;
 	src: string;
 	open?: boolean;
 	setOpen?: (open: boolean) => void;
 	video?: string | null;
+	rounded?: ImageProps['rounded'];
 	disablePreview?: boolean;
 	fadeIn?: boolean;
+	dynamicOrientation?: boolean;
+}
+
+function useImageOrientation(
+	src: string,
+	dynamicOrientation: boolean,
+): ImageStylesProps['orientation'] {
+	const [orientation, setOrientation] = useState<ImageStylesProps['orientation']>('even');
+	const img = new Image();
+	img.src = src;
+	img.onload = () => {
+		if (!dynamicOrientation) {
+			return;
+		}
+
+		if (img.naturalWidth > img.naturalHeight) {
+			setOrientation('landscape');
+		} else if (img.naturalWidth < img.naturalHeight) {
+			setOrientation('portrait');
+		} else {
+			setOrientation('even');
+		}
+	};
+
+	return orientation;
 }
 
 export function ObjectVideoImage({
@@ -49,7 +163,10 @@ export function ObjectVideoImage({
 	setOpen,
 	disablePreview,
 	fadeIn,
-}: Props) {
+	dynamicOrientation,
+}: ObjectVideoImageProps) {
+	const orientation = useImageOrientation(src, !!dynamicOrientation);
+
 	const close = () => {
 		if (disablePreview) {
 			return;
@@ -80,8 +197,8 @@ export function ObjectVideoImage({
 				video={video}
 				alt={title}
 			/>
-			<div className={imageStyles({ variant, disablePreview })}>
-				<Image rounded="md" onClick={openPreview} alt={title} src={src} fadeIn={fadeIn} />
+			<div className={imageStyles({ variant, disablePreview, orientation })}>
+				<ImageComponent rounded="md" onClick={openPreview} alt={title} src={src} fadeIn={fadeIn} />
 				{video && (
 					<div className="pointer-events-none absolute bottom-2 right-2 z-10 flex items-center justify-center rounded-full opacity-80">
 						<MediaPlay16 className={clsx(variant === 'large' ? 'h-8 w-8' : 'h-5 w-5')} />

--- a/apps/explorer/src/ui/stories/ObjectVideoImage.stories.tsx
+++ b/apps/explorer/src/ui/stories/ObjectVideoImage.stories.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiClientProvider } from '@mysten/dapp-kit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ObjectVideoImage, type ObjectVideoImageProps } from '../ObjectVideoImage';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+	component: ObjectVideoImage,
+	decorators: [
+		(Story) => (
+			<MemoryRouter>
+				<QueryClientProvider client={new QueryClient()}>
+					<SuiClientProvider>
+						<Story />
+					</SuiClientProvider>
+				</QueryClientProvider>
+			</MemoryRouter>
+		),
+	],
+} as Meta;
+
+const variants: ObjectVideoImageProps['variant'][] = ['xs', 'small', 'medium', 'large', 'xl'];
+
+export const Default: StoryObj<ObjectVideoImageProps> = {
+	render: (props) => (
+		<div className="flex flex-col gap-2">
+			{variants.map((variant: ObjectVideoImageProps['variant']) => (
+				<ObjectVideoImage key={variant} {...props} variant={variant} />
+			))}
+		</div>
+	),
+	args: {
+		title: 'Test Image Title',
+		subtitle: 'Test Subtitle',
+		src: 'https://ipfs.io/ipfs/QmTwPRCH4xpTzn7ArJDMvqSgzkuK3AVhTgGGpC7LFRfAGU',
+	},
+};
+
+export const Portrait: StoryObj<ObjectVideoImageProps> = {
+	render: (props) => (
+		<div className="flex flex-col gap-2">
+			{variants.map((variant: ObjectVideoImageProps['variant']) => (
+				<ObjectVideoImage dynamicOrientation key={variant} {...props} variant={variant} />
+			))}
+		</div>
+	),
+	args: {
+		title: 'Test Image Title',
+		subtitle: 'Test Subtitle',
+		src: 'https://i.imgur.com/3DtOjtB.jpg',
+	},
+};
+
+export const Landscape: StoryObj<ObjectVideoImageProps> = {
+	render: (props) => (
+		<div className="flex flex-col gap-2">
+			{variants.map((variant: ObjectVideoImageProps['variant']) => (
+				<ObjectVideoImage dynamicOrientation key={variant} {...props} variant={variant} />
+			))}
+		</div>
+	),
+	args: {
+		title: 'Test Image Title',
+		subtitle: 'Test Subtitle',
+		src: 'https://www.morrisanimalinn.com/wp-content/uploads/shutterstock_679338581.jpg',
+	},
+};


### PR DESCRIPTION
## Description 

- Changes needed for the updated Object Page

Portrait

<img width="388" alt="Screenshot 2023-09-11 at 2 52 46 PM" src="https://github.com/MystenLabs/sui/assets/127577476/c923fee1-ccdc-4944-b6ed-dcebcc520bf1">

Landscape


<img width="660" alt="Screenshot 2023-09-11 at 2 53 19 PM" src="https://github.com/MystenLabs/sui/assets/127577476/18f62920-0c84-4c00-8539-5e59487fc6ed">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
