### PR TITLE
[cli] add alias support for sui addresses in the CLI

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -355,7 +355,9 @@ pub async fn new_wallet_context_from_cluster(
     let keystore_path = config_dir.join(SUI_KEYSTORE_FILENAME);
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let address: SuiAddress = key_pair.public().into();
-    keystore.add_key(SuiKeyPair::Ed25519(key_pair)).unwrap();
+    keystore
+        .add_key(None, SuiKeyPair::Ed25519(key_pair))
+        .unwrap();
     SuiClientConfig {
         keystore,
         envs: vec![SuiEnv {

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -26,6 +26,7 @@ pub const SUI_NETWORK_CONFIG: &str = "network.yaml";
 pub const SUI_FULLNODE_CONFIG: &str = "fullnode.yaml";
 pub const SUI_CLIENT_CONFIG: &str = "client.yaml";
 pub const SUI_KEYSTORE_FILENAME: &str = "sui.keystore";
+pub const SUI_KEYSTORE_ALIASES_FILENAME: &str = "sui.aliases";
 pub const SUI_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME: &str = "benchmark.keystore";
 pub const SUI_GENESIS_FILENAME: &str = "genesis.blob";
 pub const SUI_DEV_NET_URL: &str = "https://fullnode.devnet.sui.io:443";

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -919,11 +919,11 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
     context
         .config
         .keystore
-        .add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
+        .add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
     context
         .config
         .keystore
-        .add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
+        .add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
 
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::key_derive::{derive_key_pair_from_path, generate_new_key};
-use anyhow::anyhow;
+use crate::random_names::{random_name, random_names};
+use anyhow::{anyhow, bail, Context};
 use bip32::DerivationPath;
 use bip39::{Language, Mnemonic, Seed};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use shared_crypto::intent::{Intent, IntentMessage};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::fs;
@@ -29,7 +30,7 @@ pub enum Keystore {
 }
 #[enum_dispatch]
 pub trait AccountKeystore: Send + Sync {
-    fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
+    fn add_key(&mut self, alias: Option<String>, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
     fn keys(&self) -> Vec<PublicKey>;
     fn get_key(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error>;
 
@@ -47,15 +48,32 @@ pub trait AccountKeystore: Send + Sync {
         self.keys().iter().map(|k| k.into()).collect()
     }
 
+    fn aliases(&self) -> Vec<&Alias>;
+    fn alias_names(&self) -> Vec<&str> {
+        self.aliases()
+            .into_iter()
+            .map(|a| a.alias.as_str())
+            .collect()
+    }
+    fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
+
+    /// Check if an alias exists by its name
+    fn alias_exists(&self, alias: &str) -> bool {
+        self.alias_names().contains(&alias)
+    }
+
+    fn create_alias(&self, alias: Option<String>) -> Result<String, anyhow::Error>;
+
     fn generate_and_add_new_key(
         &mut self,
         key_scheme: SignatureScheme,
+        alias: Option<String>,
         derivation_path: Option<DerivationPath>,
         word_length: Option<String>,
     ) -> Result<(SuiAddress, String, SignatureScheme), anyhow::Error> {
         let (address, kp, scheme, phrase) =
             generate_new_key(key_scheme, derivation_path, word_length)?;
-        self.add_key(kp)?;
+        self.add_key(alias, kp)?;
         Ok((address, phrase, scheme))
     }
 
@@ -70,7 +88,7 @@ pub trait AccountKeystore: Send + Sync {
         let seed = Seed::new(&mnemonic, "");
         match derive_key_pair_from_path(seed.as_bytes(), derivation_path, &key_scheme) {
             Ok((address, kp)) => {
-                self.add_key(kp)?;
+                self.add_key(None, kp)?;
                 Ok(address)
             }
             Err(e) => Err(anyhow!("error getting keypair {:?}", e)),
@@ -95,9 +113,16 @@ impl Display for Keystore {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Alias {
+    alias: String,
+    public_key_base64: String,
+}
+
 #[derive(Default)]
 pub struct FileBasedKeystore {
     keys: BTreeMap<SuiAddress, SuiKeyPair>,
+    aliases: BTreeMap<SuiAddress, Alias>,
     path: Option<PathBuf>,
 }
 
@@ -153,15 +178,55 @@ impl AccountKeystore for FileBasedKeystore {
         ))
     }
 
-    fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
+    fn add_key(&mut self, alias: Option<String>, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
         let address: SuiAddress = (&keypair.public()).into();
+        let alias = self.create_alias(alias)?;
+        self.aliases.insert(
+            address,
+            Alias {
+                alias,
+                public_key_base64: EncodeDecodeBase64::encode_base64(&keypair.public()),
+            },
+        );
         self.keys.insert(address, keypair);
         self.save()?;
         Ok(())
     }
 
+    /// Return an array of `Alias`, consisting of every alias and its corresponding public key.
+    fn aliases(&self) -> Vec<&Alias> {
+        self.aliases.values().collect()
+    }
+
     fn keys(&self) -> Vec<PublicKey> {
         self.keys.values().map(|key| key.public()).collect()
+    }
+
+    /// This function returns an error if the provided alias already exists. If the alias
+    /// has not already been used, then it returns the alias.
+    /// If no alias has been passed, it will generate a new alias.
+    fn create_alias(&self, alias: Option<String>) -> Result<String, anyhow::Error> {
+        match alias {
+            Some(a) if self.alias_exists(&a) => {
+                bail!("Alias {a} already exists. Please choose another alias.")
+            }
+            Some(a) => Ok(a),
+            None => Ok(random_name(
+                &self
+                    .alias_names()
+                    .into_iter()
+                    .map(|x| x.to_string())
+                    .collect::<HashSet<_>>(),
+            )),
+        }
+    }
+
+    /// Get the alias if it exists, or return an error if it does not exist.
+    fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error> {
+        match self.aliases.get(address) {
+            Some(alias) => Ok(alias.alias.clone()),
+            None => bail!("Cannot find alias for address {address}"),
+        }
     }
 
     fn get_key(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error> {
@@ -175,26 +240,90 @@ impl AccountKeystore for FileBasedKeystore {
 impl FileBasedKeystore {
     pub fn new(path: &PathBuf) -> Result<Self, anyhow::Error> {
         let keys = if path.exists() {
-            let reader = BufReader::new(
-                File::open(path)
-                    .map_err(|e| anyhow!("Can't open FileBasedKeystore from {:?}: {e}", path))?,
-            );
-            let kp_strings: Vec<String> = serde_json::from_reader(reader)
-                .map_err(|e| anyhow!("Can't deserialize FileBasedKeystore from {:?}: {e}", path))?;
+            let reader =
+                BufReader::new(File::open(path).with_context(|| {
+                    format!("Cannot open the keystore file: {}", path.display())
+                })?);
+            let kp_strings: Vec<String> = serde_json::from_reader(reader).with_context(|| {
+                format!("Cannot deserialize the keystore file: {}", path.display(),)
+            })?;
             kp_strings
                 .iter()
                 .map(|kpstr| {
                     let key = SuiKeyPair::decode_base64(kpstr);
-                    key.map(|k| (Into::<SuiAddress>::into(&k.public()), k))
+                    key.map(|k| (SuiAddress::from(&k.public()), k))
                 })
                 .collect::<Result<BTreeMap<_, _>, _>>()
-                .map_err(|e| anyhow::anyhow!("Invalid Keypair file {:#?} {:?}", e, path))?
+                .map_err(|e| anyhow!("Invalid keystore file: {}. {}", path.display(), e))?
         } else {
             BTreeMap::new()
         };
 
+        // check aliases
+        let mut aliases_path = path.clone();
+        aliases_path.set_extension("aliases");
+
+        let aliases = if aliases_path.exists() {
+            let reader = BufReader::new(File::open(&aliases_path).with_context(|| {
+                format!(
+                    "Cannot open aliases file in keystore: {}",
+                    aliases_path.display()
+                )
+            })?);
+
+            let aliases: Vec<Alias> = serde_json::from_reader(reader).with_context(|| {
+                format!(
+                    "Cannot deserialize aliases file in keystore: {}",
+                    aliases_path.display(),
+                )
+            })?;
+
+            aliases
+                .into_iter()
+                .map(|alias| {
+                    let key = SuiKeyPair::decode_base64(&alias.public_key_base64);
+                    key.map(|k| (Into::<SuiAddress>::into(&k.public()), alias))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()
+                .map_err(|e| {
+                    anyhow!(
+                        "Invalid aliases file in keystore: {}. {}",
+                        aliases_path.display(),
+                        e
+                    )
+                })?
+        } else if keys.is_empty() {
+            BTreeMap::new()
+        } else {
+            let names: Vec<String> = random_names(HashSet::new(), keys.len());
+            let aliases = keys
+                .iter()
+                .zip(names)
+                .map(|((sui_address, skp), alias)| {
+                    let public_key_base64 = EncodeDecodeBase64::encode_base64(&skp.public());
+                    (
+                        *sui_address,
+                        Alias {
+                            alias,
+                            public_key_base64,
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            let aliases_store = serde_json::to_string_pretty(&aliases.values().collect::<Vec<_>>())
+                .with_context(|| {
+                    format!(
+                        "Cannot serialize aliases to file in keystore: {}",
+                        aliases_path.display()
+                    )
+                })?;
+            fs::write(aliases_path, aliases_store)?;
+            aliases
+        };
+
         Ok(Self {
             keys,
+            aliases,
             path: Some(path.to_path_buf()),
         })
     }
@@ -203,7 +332,25 @@ impl FileBasedKeystore {
         self.path = Some(path.to_path_buf());
     }
 
-    pub fn save(&self) -> Result<(), anyhow::Error> {
+    pub fn save_aliases(&self) -> Result<(), anyhow::Error> {
+        if let Some(path) = &self.path {
+            let aliases_store =
+                serde_json::to_string_pretty(&self.aliases.values().collect::<Vec<_>>())
+                    .with_context(|| {
+                        format!(
+                            "Cannot serialize aliases to file in keystore: {}",
+                            path.display()
+                        )
+                    })?;
+
+            let mut aliases_path = path.clone();
+            aliases_path.set_extension("aliases");
+            fs::write(aliases_path, aliases_store)?
+        }
+        Ok(())
+    }
+
+    pub fn save_keystore(&self) -> Result<(), anyhow::Error> {
         if let Some(path) = &self.path {
             let store = serde_json::to_string_pretty(
                 &self
@@ -212,9 +359,15 @@ impl FileBasedKeystore {
                     .map(EncodeDecodeBase64::encode_base64)
                     .collect::<Vec<_>>(),
             )
-            .unwrap();
-            fs::write(path, store)?
+            .with_context(|| format!("Cannot serialize keystore to file: {}", path.display()))?;
+            fs::write(path, store)?;
         }
+        Ok(())
+    }
+
+    pub fn save(&self) -> Result<(), anyhow::Error> {
+        self.save_aliases()?;
+        self.save_keystore()?;
         Ok(())
     }
 
@@ -225,6 +378,7 @@ impl FileBasedKeystore {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct InMemKeystore {
+    aliases: BTreeMap<SuiAddress, Alias>,
     keys: BTreeMap<SuiAddress, SuiKeyPair>,
 }
 
@@ -254,10 +408,31 @@ impl AccountKeystore for InMemKeystore {
         ))
     }
 
-    fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
+    fn add_key(&mut self, alias: Option<String>, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
         let address: SuiAddress = (&keypair.public()).into();
+        let alias = alias.unwrap_or_else(|| {
+            random_name(
+                &self
+                    .aliases()
+                    .iter()
+                    .map(|x| x.alias.clone())
+                    .collect::<HashSet<_>>(),
+            )
+        });
+
+        let public_key_base64 = EncodeDecodeBase64::encode_base64(&keypair.public());
+        let alias = Alias {
+            alias,
+            public_key_base64,
+        };
+        self.aliases.insert(address, alias);
         self.keys.insert(address, keypair);
         Ok(())
+    }
+
+    /// Get all aliases objects
+    fn aliases(&self) -> Vec<&Alias> {
+        self.aliases.values().collect()
     }
 
     fn keys(&self) -> Vec<PublicKey> {
@@ -270,6 +445,33 @@ impl AccountKeystore for InMemKeystore {
             None => Err(anyhow!("Cannot find key for address: [{address}]")),
         }
     }
+
+    /// Get an alias by its address
+    fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error> {
+        match self.aliases.get(address) {
+            Some(alias) => Ok(alias.alias.clone()),
+            None => bail!("Cannot find alias for address {address}"),
+        }
+    }
+
+    /// This function returns an error if the provided alias already exists. If the alias
+    /// has not already been used, then it returns the alias.
+    /// If no alias has been passed, it will generate a new alias.
+    fn create_alias(&self, alias: Option<String>) -> Result<String, anyhow::Error> {
+        match alias {
+            Some(a) if self.alias_exists(&a) => {
+                bail!("Alias {a} already exists. Please choose another alias.")
+            }
+            Some(a) => Ok(a),
+            None => Ok(random_name(
+                &self
+                    .alias_names()
+                    .into_iter()
+                    .map(|x| x.to_string())
+                    .collect::<HashSet<_>>(),
+            )),
+        }
+    }
 }
 
 impl InMemKeystore {
@@ -280,6 +482,21 @@ impl InMemKeystore {
             .map(|(ad, k)| (ad, SuiKeyPair::Ed25519(k)))
             .collect::<BTreeMap<SuiAddress, SuiKeyPair>>();
 
-        Self { keys }
+        let aliases = keys
+            .iter()
+            .zip(random_names(HashSet::new(), keys.len()))
+            .map(|((sui_address, skp), alias)| {
+                let public_key_base64 = EncodeDecodeBase64::encode_base64(&skp.public());
+                (
+                    *sui_address,
+                    Alias {
+                        alias,
+                        public_key_base64,
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        Self { aliases, keys }
     }
 }

--- a/crates/sui-keys/src/lib.rs
+++ b/crates/sui-keys/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod key_derive;
 pub mod keypair_file;
 pub mod keystore;
+pub mod random_names;

--- a/crates/sui-keys/src/random_names.rs
+++ b/crates/sui-keys/src/random_names.rs
@@ -1,0 +1,219 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::{rngs::ThreadRng, thread_rng, Rng};
+use std::collections::HashSet;
+
+/// This library provides two functions to generate
+/// a random combination of an adjective
+/// and a precious stone name as a well formatted
+/// string, or a list of these strings.
+
+/// A list of adjectives
+const LEFT_NAMES: [&str; 108] = [
+    "admiring",
+    "adoring",
+    "affectionate",
+    "agitated",
+    "amazing",
+    "angry",
+    "awesome",
+    "beautiful",
+    "blissful",
+    "bold",
+    "boring",
+    "brave",
+    "busy",
+    "charming",
+    "clever",
+    "compassionate",
+    "competent",
+    "condescending",
+    "confident",
+    "cool",
+    "cranky",
+    "crazy",
+    "dazzling",
+    "determined",
+    "distracted",
+    "dreamy",
+    "eager",
+    "ecstatic",
+    "elastic",
+    "elated",
+    "elegant",
+    "eloquent",
+    "epic",
+    "exciting",
+    "fervent",
+    "festive",
+    "flamboyant",
+    "focused",
+    "friendly",
+    "frosty",
+    "funny",
+    "gallant",
+    "gifted",
+    "goofy",
+    "gracious",
+    "great",
+    "happy",
+    "hardcore",
+    "heuristic",
+    "hopeful",
+    "hungry",
+    "infallible",
+    "inspiring",
+    "intelligent",
+    "interesting",
+    "jolly",
+    "jovial",
+    "keen",
+    "kind",
+    "laughing",
+    "loving",
+    "lucid",
+    "magical",
+    "modest",
+    "musing",
+    "mystifying",
+    "naughty",
+    "nervous",
+    "nice",
+    "nifty",
+    "nostalgic",
+    "objective",
+    "optimistic",
+    "peaceful",
+    "pedantic",
+    "pensive",
+    "practical",
+    "priceless",
+    "quirky",
+    "quizzical",
+    "recursing",
+    "relaxed",
+    "reverent",
+    "romantic",
+    "sad",
+    "serene",
+    "sharp",
+    "silly",
+    "sleepy",
+    "stoic",
+    "strange",
+    "stupefied",
+    "suspicious",
+    "sweet",
+    "tender",
+    "thirsty",
+    "trusting",
+    "unruffled",
+    "upbeat",
+    "vibrant",
+    "vigilant",
+    "vigorous",
+    "wizardly",
+    "wonderful",
+    "xenodochial",
+    "youthful",
+    "zealous",
+    "zen",
+];
+
+const LEFT_LENGTH: usize = LEFT_NAMES.len();
+
+/// A list of precious stones
+const RIGHT_NAMES: [&str; 53] = [
+    "agates",
+    "alexandrite",
+    "amber",
+    "amethyst",
+    "apatite",
+    "avanturine",
+    "axinite",
+    "beryl",
+    "beryl",
+    "carnelian",
+    "chalcedony",
+    "chrysoberyl",
+    "chrysolite",
+    "chrysoprase",
+    "coral",
+    "corundum",
+    "crocidolite",
+    "cyanite",
+    "cymophane",
+    "diamond",
+    "dichroite",
+    "emerald",
+    "epidote",
+    "euclase",
+    "felspar",
+    "garnet",
+    "heliotrope",
+    "hematite",
+    "hiddenite",
+    "hypersthene",
+    "idocrase",
+    "jasper",
+    "jet",
+    "labradorite",
+    "malachite",
+    "moonstone",
+    "obsidian",
+    "opal",
+    "pearl",
+    "phenacite",
+    "plasma",
+    "prase",
+    "quartz",
+    "ruby",
+    "sapphire",
+    "sphene",
+    "spinel",
+    "spodumene",
+    "sunstone",
+    "topaz",
+    "tourmaline",
+    "turquois",
+    "zircon",
+];
+const RIGHT_LENGTH: usize = RIGHT_NAMES.len();
+
+/// Return a random name formatted as first-second from a list of strings.
+///
+/// The main purpose of this function is to generate random aliases for addresses.
+pub fn random_name(conflicts: &HashSet<String>) -> String {
+    let mut rng = thread_rng();
+    // as long as the generated name is in the list of conflicts,
+    // we try to find a different name that is not in the list yet
+    loop {
+        let output = generate(&mut rng);
+        if !conflicts.contains(&output) {
+            return output;
+        }
+    }
+}
+
+/// Return a unique collection of names.
+pub fn random_names(mut conflicts: HashSet<String>, output_size: usize) -> Vec<String> {
+    let mut names = Vec::with_capacity(output_size);
+    names.resize_with(output_size, || {
+        let name = random_name(&conflicts);
+        conflicts.insert(name.clone());
+        name
+    });
+    names
+}
+
+// Generate a random name as a pair from left and right string arrays
+fn generate(rng: &mut ThreadRng) -> String {
+    let left_idx = rng.gen_range(0..LEFT_LENGTH);
+    let right_idx = rng.gen_range(0..RIGHT_LENGTH);
+    format!(
+        "{}-{}",
+        LEFT_NAMES.get(left_idx).unwrap(),
+        RIGHT_NAMES.get(right_idx).unwrap()
+    )
+}

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -248,10 +248,10 @@ fn test_read_keystore() {
     let path = temp_dir.path().join("sui.keystore");
     let mut ks = Keystore::from(FileBasedKeystore::new(&path).unwrap());
     let key1 = ks
-        .generate_and_add_new_key(SignatureScheme::ED25519, None, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
         .unwrap();
     let key2 = ks
-        .generate_and_add_new_key(SignatureScheme::Secp256k1, None, None)
+        .generate_and_add_new_key(SignatureScheme::Secp256k1, None, None, None)
         .unwrap();
 
     let accounts = read_prefunded_account(&path).unwrap();

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -299,11 +299,13 @@ pub async fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     let default_active_address = if let Some(address) = keystore.addresses().first() {
         *address
     } else {
-        keystore.generate_and_add_new_key(ED25519, None, None)?.0
+        keystore
+            .generate_and_add_new_key(ED25519, None, None, None)?
+            .0
     };
 
     if keystore.addresses().len() < 2 {
-        keystore.generate_and_add_new_key(ED25519, None, None)?;
+        keystore.generate_and_add_new_key(ED25519, None, None, None)?;
     }
 
     client_config.active_address = Some(default_active_address);

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -11,7 +11,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_and_add_new_key(SignatureScheme::ED25519, None, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -95,7 +95,10 @@ pub enum KeyToolCommand {
     /// the key scheme flag {ed25519 | secp256k1 | secp256r1} and an optional derivation path,
     /// default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
     /// or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24.
+    /// You can set an alias for the key through the --alias flag. If no alias is provided,
+    /// the tool will automatically generate one.
     Import {
+        alias: Option<String>,
         input_string: String,
         key_scheme: SignatureScheme,
         derivation_path: Option<DerivationPath>,
@@ -502,6 +505,7 @@ impl KeyToolCommand {
             },
 
             KeyToolCommand::Import {
+                alias,
                 input_string,
                 key_scheme,
                 derivation_path,
@@ -527,7 +531,7 @@ impl KeyToolCommand {
                         _ => return Err(anyhow!("Unsupported scheme")),
                     };
                     let key = Key::from(&skp);
-                    keystore.add_key(skp)?;
+                    keystore.add_key(alias, skp)?;
                     CommandOutput::Import(key)
                 } else {
                     let sui_address = keystore.import_from_mnemonic(
@@ -821,7 +825,7 @@ impl KeyToolCommand {
                 let pk = skp.public();
                 let ephemeral_key_identifier: SuiAddress = (&skp.public()).into();
                 println!("Ephemeral key identifier: {ephemeral_key_identifier}");
-                keystore.add_key(skp)?;
+                keystore.add_key(None, skp)?;
 
                 let mut eph_pk_bytes = vec![pk.flag()];
                 eph_pk_bytes.extend(pk.as_ref());

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -95,9 +95,10 @@ pub enum KeyToolCommand {
     /// the key scheme flag {ed25519 | secp256k1 | secp256r1} and an optional derivation path,
     /// default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
     /// or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24.
-    /// You can set an alias for the key through the --alias flag. If no alias is provided,
+    /// Set an alias for the key with the --alias flag. If no alias is provided,
     /// the tool will automatically generate one.
     Import {
+        #[clap(long)]
         alias: Option<String>,
         input_string: String,
         key_scheme: SignatureScheme,

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -98,6 +98,7 @@ pub enum KeyToolCommand {
     /// Set an alias for the key with the --alias flag. If no alias is provided,
     /// the tool will automatically generate one.
     Import {
+        /// Sets an alias for this address
         #[clap(long)]
         alias: Option<String>,
         input_string: String,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -404,7 +404,7 @@ async fn genesis(
                 let path = sui_config_dir.join(SUI_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME);
                 let mut keystore = FileBasedKeystore::new(&path)?;
                 for gas_key in GenesisConfig::benchmark_gas_keys(ips.len()) {
-                    keystore.add_key(gas_key)?;
+                    keystore.add_key(None, gas_key)?;
                 }
                 keystore.save()?;
 
@@ -452,7 +452,7 @@ async fn genesis(
 
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
-        keystore.add_key(SuiKeyPair::Ed25519(key.copy()))?;
+        keystore.add_key(None, SuiKeyPair::Ed25519(key.copy()))?;
     }
     let active_address = keystore.addresses().pop();
 
@@ -629,9 +629,10 @@ async fn prompt_if_no_config(
                 }
             };
             let (new_address, phrase, scheme) =
-                keystore.generate_and_add_new_key(key_scheme, None, None)?;
+                keystore.generate_and_add_new_key(key_scheme, None, None, None)?;
+            let alias = keystore.get_alias_by_address(&new_address)?;
             println!(
-                "Generated new keypair for address with scheme {:?} [{new_address}]",
+                "Generated new keypair and alias for address with scheme {:?} [{alias}: {new_address}]",
                 scheme.to_string()
             );
             println!("Secret Recovery Phrase : [{phrase}]");

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -45,7 +45,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Add another 3 Secp256k1 KeyPairs
     for _ in 0..3 {
-        keystore.add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
+        keystore.add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
     }
 
     // List all addresses with flag
@@ -57,8 +57,8 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
 
-    keystore.add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
-    keystore.add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
+    keystore.add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
+    keystore.add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
 
     for pk in keystore.keys() {
         let pk1 = pk.clone();
@@ -219,6 +219,7 @@ async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
     for (private_key, base64, address) in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
+            alias: None,
             input_string: private_key.to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
@@ -235,6 +236,7 @@ async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
     for (private_key, _, _) in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         let output = KeyToolCommand::Import {
+            alias: None,
             input_string: private_key[..25].to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
@@ -257,6 +259,7 @@ async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
+            alias: None,
             input_string: t[0].to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
@@ -281,6 +284,7 @@ async fn test_mnemonics_secp256k1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
+            alias: None,
             input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256k1,
             derivation_path: None,
@@ -319,6 +323,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
+            alias: None,
             input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256r1,
             derivation_path: None,
@@ -340,6 +345,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
 async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/1'/0'/0/0".parse().unwrap()),
@@ -349,6 +355,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/0'/784'/0'/0/0".parse().unwrap()),
@@ -358,6 +365,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/54'/784'/0'/0/0".parse().unwrap()),
@@ -367,6 +375,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0'/0'".parse().unwrap()),
@@ -376,6 +385,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/44'/784'/0'/0/0".parse().unwrap()),
@@ -391,6 +401,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
 async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/0'".parse().unwrap()),
@@ -400,6 +411,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/1'".parse().unwrap()),
@@ -409,6 +421,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/1'/0'/1'".parse().unwrap()),
@@ -418,6 +431,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0/1".parse().unwrap()),
@@ -427,6 +441,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
+        alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/1'/0/1".parse().unwrap()),

--- a/crates/sui/src/zklogin_commands_util.rs
+++ b/crates/sui/src/zklogin_commands_util.rs
@@ -116,7 +116,7 @@ pub async fn perform_zk_login_test_tx(
     )?;
 
     let sender = if test_multisig {
-        keystore.add_key(skp1)?;
+        keystore.add_key(None, skp1)?;
         println!("Use multisig address as sender");
         SuiAddress::from(&multisig_pk)
     } else {

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -26,7 +26,7 @@ use sui::{
 };
 use sui_config::{
     PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG, SUI_GENESIS_FILENAME,
-    SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
+    SUI_KEYSTORE_ALIASES_FILENAME, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -82,13 +82,13 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         .flat_map(|r| r.map(|file| file.file_name().to_str().unwrap().to_owned()))
         .collect::<Vec<_>>();
 
-    assert_eq!(9, files.len());
+    assert_eq!(10, files.len());
     assert!(files.contains(&SUI_CLIENT_CONFIG.to_string()));
     assert!(files.contains(&SUI_NETWORK_CONFIG.to_string()));
     assert!(files.contains(&SUI_FULLNODE_CONFIG.to_string()));
     assert!(files.contains(&SUI_GENESIS_FILENAME.to_string()));
-
     assert!(files.contains(&SUI_KEYSTORE_FILENAME.to_string()));
+    assert!(files.contains(&SUI_KEYSTORE_ALIASES_FILENAME.to_string()));
 
     // Check network config
     let network_conf =
@@ -131,7 +131,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
         context
             .config
             .keystore
-            .add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
+            .add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
     }
 
     // Print all addresses
@@ -1836,6 +1836,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     // Create a new address
     let os = SuiClientCommands::NewAddress {
         key_scheme: SignatureScheme::ED25519,
+        alias: None,
         derivation_path: None,
         word_length: None,
     }
@@ -1888,6 +1889,7 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
 
     SuiClientCommands::NewAddress {
         key_scheme: SignatureScheme::Secp256k1,
+        alias: None,
         derivation_path: None,
         word_length: None,
     }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -951,7 +951,7 @@ impl TestClusterBuilder {
         swarm.config().save(&network_path)?;
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         for key in &swarm.config().account_keys {
-            keystore.add_key(SuiKeyPair::Ed25519(key.copy()))?;
+            keystore.add_key(None, SuiKeyPair::Ed25519(key.copy()))?;
         }
 
         let active_address = keystore.addresses().first().cloned();


### PR DESCRIPTION
## Description 

This PR adds support for basic alias naming of Sui addresses in the keystore. If an alias is not provided, it will automatically generate a random name as `first-second` based on a list of predefined strings (adjectives and precious stone gems). 

## Test Plan 
Added tests to ensure new functionality works as expected. 

Manual tests:
`sui client new-address ed25519 my_alias_test / sui client new-address ed25519`
<img width="1088" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/5a53238b-dc7a-4120-8024-1e62df80a6bf">



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added initial support for basic alias naming of Sui addresses in the keystore. 