### PR TITLE
[dapp-kit] add new useSignTransactionBlock mutation hook

### DIFF
--- a/sdk/dapp-kit/src/constants/walletMutationKeys.ts
+++ b/sdk/dapp-kit/src/constants/walletMutationKeys.ts
@@ -8,6 +8,7 @@ export const walletMutationKeys = {
 	connectWallet: formMutationKeyFn('connect-wallet'),
 	disconnectWallet: formMutationKeyFn('disconnect-wallet'),
 	signPersonalMessage: formMutationKeyFn('sign-personal-message'),
+	signTransactionBlock: formMutationKeyFn('sign-transaction-block'),
 	switchAccount: formMutationKeyFn('switch-account'),
 };
 

--- a/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SuiSignTransactionBlockInput } from '@mysten/wallet-standard';
+import type { SuiSignTransactionBlockOutput } from '@mysten/wallet-standard';
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
+import {
+	WalletFeatureNotSupportedError,
+	WalletNoAccountSelectedError,
+	WalletNotConnectedError,
+} from '../..//errors/walletErrors.js';
+import type { PartialBy } from '../../types/utilityTypes.js';
+import { useCurrentAccount } from './useCurrentAccount.js';
+import { useCurrentWallet } from './useCurrentWallet.js';
+
+type UseSignTransactionBlockArgs = PartialBy<SuiSignTransactionBlockInput, 'account'>;
+type UseSignTransactionBlockResult = SuiSignTransactionBlockOutput;
+
+type UseSignTransactionBlockMutationOptions = Omit<
+	UseMutationOptions<
+		UseSignTransactionBlockResult,
+		WalletFeatureNotSupportedError | WalletNoAccountSelectedError | WalletNotConnectedError | Error,
+		UseSignTransactionBlockArgs,
+		unknown
+	>,
+	'mutationFn'
+>;
+
+/**
+ * Mutation hook for prompting the user to sign a transaction block.
+ */
+export function useSignTransactionBlock({
+	mutationKey,
+	...mutationOptions
+}: UseSignTransactionBlockMutationOptions = {}) {
+	const currentWallet = useCurrentWallet();
+	const currentAccount = useCurrentAccount();
+
+	return useMutation({
+		mutationKey: walletMutationKeys.signTransactionBlock(mutationKey),
+		mutationFn: async (signTransactionBlockArgs) => {
+			if (!currentWallet) {
+				throw new WalletNotConnectedError('No wallet is connected.');
+			}
+
+			const signerAccount = signTransactionBlockArgs.account ?? currentAccount;
+			if (!signerAccount) {
+				throw new WalletNoAccountSelectedError(
+					'No wallet account is selected to sign the personal message with.',
+				);
+			}
+
+			const walletFeature = currentWallet.features['sui:signTransactionBlock'];
+			if (!walletFeature) {
+				throw new WalletFeatureNotSupportedError(
+					"This wallet doesn't support the `SignTransactionBlock` feature.",
+				);
+			}
+
+			return await walletFeature.signTransactionBlock({
+				...signTransactionBlockArgs,
+				account: signerAccount,
+			});
+		},
+		...mutationOptions,
+	});
+}

--- a/sdk/dapp-kit/src/index.ts
+++ b/sdk/dapp-kit/src/index.ts
@@ -14,6 +14,7 @@ export * from './hooks/wallet/useSwitchAccount.js';
 export * from './hooks/wallet/useConnectWallet.js';
 export * from './hooks/wallet/useDisconnectWallet.js';
 export * from './hooks/wallet/useSignPersonalMessage.js';
+export * from './hooks/wallet/useSignTransactionBlock.js';
 export * from './hooks/useSuiClientMutation.js';
 export * from './hooks/useSuiClientQuery.js';
 export * from './hooks/useSuiClientInfiniteQuery.js';


### PR DESCRIPTION
## Description 

Same as https://github.com/MystenLabs/sui/pull/13720 but for `signTransactionBlock`.

## Test Plan 
- Automated tests
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
