### PR TITLE
[GraphQL/Schema] Refine schema to match data layer

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -218,6 +218,9 @@ input ObjectKey {
 input EventFilter {
   sender: SuiAddress
   transactionDigest: String
+  # Enhancement (post-MVP), requires compound filters to be useful.
+  afterCheckpoint: Int
+  beforeCheckpoint: Int
 
   # Cascading (module requires package)
   emittingPackage: SuiAddress
@@ -228,15 +231,15 @@ input EventFilter {
   eventModule: String
   eventType: String
 
-  eventField: EventField
-
+  # Enhancement (post-MVP), requires compound filters to be useful.
   startTime: DateTime
   endTime: DateTime
-}
 
-input EventField {
-  path: String!
-  json: String!
+  # Enhancement (post-MVP), compound filters.  Compound filters are
+  # exclusive (must be the only filter set if they are used).
+  any: [EventFilter]
+  all: [EventFilter]
+  not: EventFilter
 }
 
 input TransactionBlockFilter {
@@ -246,7 +249,8 @@ input TransactionBlockFilter {
   function: String
 
   kind: TransactionBlockKindInput
-  checkpoint: Int
+  afterCheckpoint: Int
+  beforeCheckpoint: Int
 
   signAddress: SuiAddress
   sentAddress: SuiAddress
@@ -255,6 +259,17 @@ input TransactionBlockFilter {
 
   inputObject: SuiAddress
   changedObject: SuiAddress
+
+  # Enhancement (post-MVP), consistency with EventFilter -- timestamp
+  # comes from checkpoint timestamp.
+  startTime: DateTime
+  endTime: DateTime
+
+  # Enhancement (post-MVP), compound filters.  Compound filters are
+  # exclusive (must be the only filter set if they are used).
+  any: [TransactionBlockFilter]
+  all: [TransactionBlockFilter]
+  not: TransactionBlockFilter
 }
 
 input DynamicFieldFilter {


### PR DESCRIPTION
## Description

Updates to the schema based on what we now understand to be possible to serve from the data layer:

- Remove `eventField` filtering (generic filtering by the contents of events).
- Mark filtering by event timestamps as a post-MVP enhancement, as it is not useful without compound filtering.
- Add filter for events by checkpoint as another post-MVP enhancement (similar to time-range filtering: bound checkpoints from above and from below).
- Update transaction block checkpoint filtering to match.
- Add a timestamp range based filter to transaction blocks for consistency with event filters (again, as a post-MVP enhancement).
- Add generic compound filters to transaction block and event-based filtering, as a post-MVP enhancement.

## Test Plan

:eyes: