### PR TITLE
[RPC/GraphQL] Lock down exported modules

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -7,7 +7,7 @@ use async_graphql_axum::GraphQLResponse;
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
 /// `<https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes>`
-pub mod code {
+pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod logger;
-pub mod timeout;
+pub(crate) mod logger;
+pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -1,17 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::*;
-use types::owner::ObjectOwner;
-
 pub mod commands;
-pub mod context_data;
-pub mod error;
-pub mod extensions;
 pub mod server;
-pub mod types;
+
+mod context_data;
+mod error;
+mod extensions;
+mod types;
 
 use crate::types::query::Query;
+use async_graphql::*;
+use types::owner::ObjectOwner;
 
 pub fn schema_sdl_export() -> String {
     let schema = Schema::build(Query, EmptyMutation, EmptySubscription)

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod builder;
 pub mod simple_server;
+
+mod builder;
 mod version;


### PR DESCRIPTION
## Description

Mark modules as `pub(crate)` or private where possible, to limit the public interface of the crate.  This is to make it less likely for other crates to depend on it, which should simplify its versioning story (Only one target should depend on this crate, which is the binary for the GraphQL service).

Some modules may need to be re-opened later as more dependencies come, but that's okay -- it's easier to know when to open things up than to know when to close things up.

## Test Plan

```
cargo nextest run
cargo run
```