### PR TITLE
[GraphQL/Config] TOML-based config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10309,6 +10309,7 @@ dependencies = [
 name = "sui-graphql-rpc"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-graphql",
  "async-graphql-axum",
  "async-trait",
@@ -10330,6 +10331,7 @@ dependencies = [
  "telemetry-subscribers",
  "thiserror",
  "tokio",
+ "toml 0.7.4",
  "tower",
  "tracing",
  "uuid",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 
 [dependencies]
+anyhow.workspace = true
 async-graphql = {workspace = true, features = ["dataloader"] }
 async-graphql-axum = { version = "5.0.10" }
 async-trait.workspace = true
@@ -22,6 +23,7 @@ serde_with.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+toml.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 

--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 )]
 pub enum Command {
     GenerateSchema {
+        /// Path to output GraphQL schema to, in SDL format.
         #[clap(short, long)]
         file: Option<PathBuf>,
     },
@@ -24,11 +25,11 @@ pub enum Command {
         /// Port to bind the server to
         #[clap(short, long)]
         port: Option<u16>,
+        /// Host to bind the server to
         #[clap(long)]
         host: Option<String>,
-
-        /// Maximum depth of query
-        #[clap(long)]
-        max_query_depth: Option<usize>,
+        /// Path to TOML file containing configuration for service.
+        #[clap(short, long)]
+        config: Option<PathBuf>,
     },
 }

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+use crate::functional_group::FunctionalGroup;
+
+/// Configuration on connections for the RPC, passed in as command-line arguments.
+pub struct ConnectionConfig {
+    pub(crate) port: u16,
+    pub(crate) host: String,
+    pub(crate) rpc_url: String,
+}
+
+/// Configuration on features supported by the RPC, passed in a TOML-based file.
+#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct ServiceConfig {
+    #[serde(default)]
+    pub(crate) limits: Limits,
+
+    #[serde(default)]
+    pub(crate) disabled_features: BTreeSet<FunctionalGroup>,
+
+    #[serde(default)]
+    pub(crate) experiments: Experiments,
+}
+
+#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Limits {
+    #[serde(default)]
+    pub(crate) max_query_depth: usize,
+}
+
+#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct Experiments {
+    // Add experimental flags here, to provide access to them through-out the GraphQL
+    // implementation.
+    #[cfg(test)]
+    test_flag: bool,
+}
+
+impl ConnectionConfig {
+    pub fn new(port: Option<u16>, host: Option<String>, rpc_url: Option<String>) -> Self {
+        let default = Self::default();
+        Self {
+            port: port.unwrap_or(default.port),
+            host: host.unwrap_or(default.host),
+            rpc_url: rpc_url.unwrap_or(default.rpc_url),
+        }
+    }
+}
+
+impl ServiceConfig {
+    pub fn read(contents: &str) -> Result<Self, toml::de::Error> {
+        toml::de::from_str::<Self>(contents)
+    }
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            port: 8000,
+            host: "127.0.0.1".to_string(),
+            rpc_url: "https://fullnode.testnet.sui.io:443/".to_string(),
+        }
+    }
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_query_depth: 10,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_empty_service_config() {
+        let actual = ServiceConfig::read("").unwrap();
+        let expect = ServiceConfig::default();
+        assert_eq!(actual, expect);
+    }
+
+    #[test]
+    fn test_read_limits_in_service_config() {
+        let actual = ServiceConfig::read(
+            r#" [limits]
+                max-query-depth = 100
+            "#,
+        )
+        .unwrap();
+
+        let expect = ServiceConfig {
+            limits: Limits {
+                max_query_depth: 100,
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(actual, expect)
+    }
+
+    #[test]
+    fn test_read_enabled_features_in_service_config() {
+        let actual = ServiceConfig::read(
+            r#" disabled-features = [
+                  "coins",
+                  "name-server",
+                ]
+            "#,
+        )
+        .unwrap();
+
+        use FunctionalGroup as G;
+        let expect = ServiceConfig {
+            limits: Limits::default(),
+            disabled_features: BTreeSet::from([G::Coins, G::NameServer]),
+            experiments: Experiments::default(),
+        };
+
+        assert_eq!(actual, expect)
+    }
+
+    #[test]
+    fn test_read_experiments_in_service_config() {
+        let actual = ServiceConfig::read(
+            r#" [experiments]
+                test-flag = true
+            "#,
+        )
+        .unwrap();
+
+        let expect = ServiceConfig {
+            experiments: Experiments { test_flag: true },
+            ..Default::default()
+        };
+
+        assert_eq!(actual, expect)
+    }
+
+    #[test]
+    fn test_read_everything_in_service_config() {
+        let actual = ServiceConfig::read(
+            r#" disabled-features = ["analytics"]
+
+                [limits]
+                max-query-depth = 42
+
+                [experiments]
+                test-flag = true
+            "#,
+        )
+        .unwrap();
+
+        let expect = ServiceConfig {
+            limits: Limits {
+                max_query_depth: 42,
+            },
+            disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
+            experiments: Experiments { test_flag: true },
+        };
+
+        assert_eq!(actual, expect);
+    }
+}

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+
+/// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
+/// settings in the RPC's TOML configuration file.
+#[derive(Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum FunctionalGroup {
+    /// Statistics about how the network was running (TPS, top packages, APY, etc)
+    Analytics,
+
+    /// Coin metadata, per-address coin and balance information.
+    Coins,
+
+    /// Querying an object's dynamic fields.
+    DynamicFields,
+
+    /// SuiNS name and reverse name look-up.
+    NameServer,
+
+    /// Struct and function signatures, and popular packages.
+    Packages,
+
+    /// Transaction and Event subscriptions.
+    Subscriptions,
+
+    /// Information about the system that changes from epoch to epoch (protocol config, committee,
+    /// reference gas price).
+    SystemState,
+}

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod commands;
+pub mod config;
 pub mod server;
 
 mod context_data;
 mod error;
 mod extensions;
+mod functional_group;
 mod types;
 
-use crate::types::query::Query;
 use async_graphql::*;
 use types::owner::ObjectOwner;
+
+use crate::types::query::Query;
 
 pub fn schema_sdl_export() -> String {
     let schema = Schema::build(Query, EmptyMutation, EmptySubscription)

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -1,11 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs;
+use std::path::PathBuf;
+
 use clap::Parser;
 use sui_graphql_rpc::commands::Command;
+use sui_graphql_rpc::config::{ConnectionConfig, ServiceConfig};
 use sui_graphql_rpc::schema_sdl_export;
 use sui_graphql_rpc::server::simple_server::start_example_server;
-use sui_graphql_rpc::server::simple_server::ServerConfig;
 
 #[tokio::main]
 async fn main() {
@@ -24,24 +27,22 @@ async fn main() {
             rpc_url,
             port,
             host,
-            max_query_depth,
+            config,
         } => {
-            let mut config = ServerConfig::default();
-            if let Some(rpc_url) = rpc_url {
-                config.rpc_url = rpc_url;
-            }
-            if let Some(port) = port {
-                config.port = port;
-            }
-            if let Some(host) = host {
-                config.host = host;
-            }
-            if let Some(max_query_depth) = max_query_depth {
-                config.max_query_depth = max_query_depth;
-            }
+            let conn = ConnectionConfig::new(port, host, rpc_url);
+            let service_config = service_config(config);
 
             println!("Starting server...");
-            start_example_server(Some(config)).await;
+            start_example_server(conn, service_config).await;
         }
     }
+}
+
+fn service_config(path: Option<PathBuf>) -> ServiceConfig {
+    let Some(path) = path else {
+        return ServiceConfig::default();
+    };
+
+    let contents = fs::read_to_string(path).expect("Reading configuration");
+    ServiceConfig::read(&contents).expect("Deserializing configuration")
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -12,10 +12,6 @@ use axum::middleware;
 use axum::{routing::IntoMakeService, Router};
 use std::any::Any;
 
-pub(crate) const DEFAULT_PORT: u16 = 8000;
-pub(crate) const DEFAULT_HOST: &str = "127.0.0.1";
-pub(crate) const DEFAULT_DEPTH_LIMIT: usize = 10;
-
 pub(crate) struct Server {
     pub server: hyper::Server<hyper::server::conn::AddrIncoming, IntoMakeService<Router>>,
 }
@@ -27,37 +23,23 @@ impl Server {
 }
 
 pub(crate) struct ServerBuilder {
-    port: Option<u16>,
-    host: Option<String>,
+    port: u16,
+    host: String,
 
     schema: SchemaBuilder<Query, EmptyMutation, EmptySubscription>,
 }
 
 impl ServerBuilder {
-    pub fn new() -> Self {
+    pub fn new(port: u16, host: String) -> Self {
         Self {
-            port: None,
-            host: None,
+            port,
+            host,
             schema: async_graphql::Schema::build(Query, EmptyMutation, EmptySubscription),
         }
     }
 
-    pub fn port(mut self, port: u16) -> Self {
-        self.port = Some(port);
-        self
-    }
-
-    pub fn host(mut self, host: String) -> Self {
-        self.host = Some(host);
-        self
-    }
-
     pub fn address(&self) -> String {
-        format!(
-            "{}:{}",
-            self.host.as_ref().unwrap_or(&DEFAULT_HOST.to_string()),
-            self.port.unwrap_or(DEFAULT_PORT)
-        )
+        format!("{}:{}", self.host, self.port)
     }
 
     pub fn max_query_depth(mut self, max_depth: usize) -> Self {

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::{ConnectionConfig, ServiceConfig};
 use crate::context_data::data_provider::DataProvider;
 use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_client_v0};
 use crate::extensions::logger::Logger;
@@ -9,53 +10,23 @@ use crate::server::builder::ServerBuilder;
 
 use std::default::Default;
 
-use super::builder::{DEFAULT_DEPTH_LIMIT, DEFAULT_HOST, DEFAULT_PORT};
-
-pub struct ServerConfig {
-    pub port: u16,
-    pub host: String,
-    pub rpc_url: String,
-    pub max_query_depth: usize,
-}
-
-impl std::default::Default for ServerConfig {
-    fn default() -> Self {
-        Self {
-            port: DEFAULT_PORT,
-            host: DEFAULT_HOST.to_string(),
-            rpc_url: "https://fullnode.testnet.sui.io:443/".to_string(),
-            max_query_depth: DEFAULT_DEPTH_LIMIT,
-        }
-    }
-}
-
-impl ServerConfig {
-    pub fn url(&self) -> String {
-        format!("http://{}", self.address())
-    }
-
-    pub fn address(&self) -> String {
-        format!("{}:{}", self.host, self.port)
-    }
-}
-
-pub async fn start_example_server(config: Option<ServerConfig>) {
-    let config = config.unwrap_or_default();
+pub async fn start_example_server(conn: ConnectionConfig, service_config: ServiceConfig) {
     let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 
-    let sui_sdk_client_v0 = sui_sdk_client_v0(&config.rpc_url).await;
+    let sui_sdk_client_v0 = sui_sdk_client_v0(&conn.rpc_url).await;
     let data_provider: Box<dyn DataProvider> = Box::new(sui_sdk_client_v0.clone());
     let data_loader = lru_cache_data_loader(&sui_sdk_client_v0).await;
-    println!("Launch GraphiQL IDE at: {}", config.url());
 
-    ServerBuilder::new()
-        .port(config.port)
-        .host(config.host)
-        .max_query_depth(config.max_query_depth)
+    let builder = ServerBuilder::new(conn.port, conn.host);
+    println!("Launch GraphiQL IDE at: http://{}", builder.address());
+
+    builder
+        .max_query_depth(service_config.limits.max_query_depth)
         .context_data(data_provider)
         .context_data(data_loader)
+        .context_data(service_config)
         .extension(Logger::default())
         .extension(Timeout::default())
         .build()


### PR DESCRIPTION
## Description

Introduce config for functional groups to enable and disable groups of features in the schema, so that different operators can choose to run the RPC service with different sets of features enabled (for example running public nodes without analytics).

The precise set of functional groups may shift -- the current list is derived from the list in the RFC (#13700).

This PR only introduces the config, and not the logic in the schema to listen to the functional group config.  The config is read from a TOML file whose path is passed as a command-line parameter.  It is stored as data in the schema's context so that it can later be accessed by whatever system limits access to endpoints by flags.

A stub "experiments" section has also been added as a place to keep ad-hoc experimental flags (to gate in-progress features).

This PR also brings the `ServerConfig` (renamed to `ConnectionConfig`) into the same module, and applies a common pattern to ensure there's a single source of truth for default values (the `Default` impl for the config structs).


Finally, `max_query_depth` is moved from `ConnectionConfig` to `ServiceConfig` as it's a config that we would want to share between multiple instances of the RPC service in the fleet.

## Stack

- #13745

## Test Plan

New unit tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-rpc$ cargo run
```