### PR TITLE
[graphql/rpc] limit query depth

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -19,13 +19,16 @@ pub enum Command {
     },
     StartServer {
         /// URL of the RPC server for data fetching
-        #[clap(short, long, default_value = "https://fullnode.testnet.sui.io:443/")]
-        rpc_url: String,
+        #[clap(short, long)]
+        rpc_url: Option<String>,
         /// Port to bind the server to
-        #[clap(short, long, default_value = "8000")]
-        port: u16,
-        /// Host to bind the server to
-        #[clap(long, default_value = "127.0.0.1")]
-        host: String,
+        #[clap(short, long)]
+        port: Option<u16>,
+        #[clap(long)]
+        host: Option<String>,
+
+        /// Maximum depth of query
+        #[clap(long)]
+        max_query_depth: Option<usize>,
     },
 }

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -24,12 +24,21 @@ async fn main() {
             rpc_url,
             port,
             host,
+            max_query_depth,
         } => {
-            let config = ServerConfig {
-                port,
-                host,
-                rpc_url,
-            };
+            let mut config = ServerConfig::default();
+            if let Some(rpc_url) = rpc_url {
+                config.rpc_url = rpc_url;
+            }
+            if let Some(port) = port {
+                config.port = port;
+            }
+            if let Some(host) = host {
+                config.host = host;
+            }
+            if let Some(max_query_depth) = max_query_depth {
+                config.max_query_depth = max_query_depth;
+            }
 
             println!("Starting server...");
             start_example_server(Some(config)).await;

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -14,6 +14,7 @@ use std::any::Any;
 
 pub(crate) const DEFAULT_PORT: u16 = 8000;
 pub(crate) const DEFAULT_HOST: &str = "127.0.0.1";
+pub(crate) const DEFAULT_DEPTH_LIMIT: usize = 10;
 
 pub(crate) struct Server {
     pub server: hyper::Server<hyper::server::conn::AddrIncoming, IntoMakeService<Router>>,
@@ -57,6 +58,11 @@ impl ServerBuilder {
             self.host.as_ref().unwrap_or(&DEFAULT_HOST.to_string()),
             self.port.unwrap_or(DEFAULT_PORT)
         )
+    }
+
+    pub fn max_query_depth(mut self, max_depth: usize) -> Self {
+        self.schema = self.schema.limit_depth(max_depth);
+        self
     }
 
     pub fn context_data(mut self, context_data: impl Any + Send + Sync) -> Self {

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -9,12 +9,13 @@ use crate::server::builder::ServerBuilder;
 
 use std::default::Default;
 
-use super::builder::{DEFAULT_HOST, DEFAULT_PORT};
+use super::builder::{DEFAULT_DEPTH_LIMIT, DEFAULT_HOST, DEFAULT_PORT};
 
 pub struct ServerConfig {
     pub port: u16,
     pub host: String,
     pub rpc_url: String,
+    pub max_query_depth: usize,
 }
 
 impl std::default::Default for ServerConfig {
@@ -23,6 +24,7 @@ impl std::default::Default for ServerConfig {
             port: DEFAULT_PORT,
             host: DEFAULT_HOST.to_string(),
             rpc_url: "https://fullnode.testnet.sui.io:443/".to_string(),
+            max_query_depth: DEFAULT_DEPTH_LIMIT,
         }
     }
 }
@@ -51,6 +53,7 @@ pub async fn start_example_server(config: Option<ServerConfig>) {
     ServerBuilder::new()
         .port(config.port)
         .host(config.host)
+        .max_query_depth(config.max_query_depth)
         .context_data(data_provider)
         .context_data(data_loader)
         .extension(Logger::default())


### PR DESCRIPTION
## Description 

Implements query depth limiting.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
