### PR TITLE
[dapp-kit] add new useSwitchAccount mutation hook

### DIFF
--- a/sdk/dapp-kit/src/constants/walletMutationKeys.ts
+++ b/sdk/dapp-kit/src/constants/walletMutationKeys.ts
@@ -7,6 +7,7 @@ export const walletMutationKeys = {
 	all: { baseScope: 'wallet' },
 	connectWallet: formMutationKeyFn('connect-wallet'),
 	disconnectWallet: formMutationKeyFn('disconnect-wallet'),
+	switchAccount: formMutationKeyFn('switch-account'),
 };
 
 function formMutationKeyFn(baseEntity: string) {

--- a/sdk/dapp-kit/src/errors/walletErrors.ts
+++ b/sdk/dapp-kit/src/errors/walletErrors.ts
@@ -10,3 +10,8 @@ export class WalletAlreadyConnectedError extends Error {}
  * An error that is instantiated when someone attempts to perform an action that requires an active wallet connection.
  */
 export class WalletNotConnectedError extends Error {}
+
+/**
+ * An error that is instantiated when a wallet account can't be found for a specific wallet.
+ */
+export class WalletAccountNotFoundError extends Error {}

--- a/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
@@ -15,7 +15,12 @@ type SwitchAccountArgs = {
 type SwitchAccountResult = void;
 
 type UseSwitchAccountMutationOptions = Omit<
-	UseMutationOptions<SwitchAccountResult, Error, SwitchAccountArgs, unknown>,
+	UseMutationOptions<
+		SwitchAccountResult,
+		WalletNotConnectedError | WalletAccountNotFoundError | Error,
+		SwitchAccountArgs,
+		unknown
+	>,
 	'mutationFn'
 >;
 

--- a/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { WalletAccount } from '@mysten/wallet-standard';
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useWalletContext } from '../../components/WalletProvider.js';
+import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
+import { WalletAccountNotFoundError, WalletNotConnectedError } from '../../errors/walletErrors.js';
+
+type SwitchAccountArgs = {
+	account: WalletAccount;
+};
+
+type SwitchAccountResult = void;
+
+type UseSwitchAccountMutationOptions = Omit<
+	UseMutationOptions<SwitchAccountResult, Error, SwitchAccountArgs, unknown>,
+	'mutationFn'
+>;
+
+/**
+ * Mutation hook for switching to a specific wallet account.
+ */
+export function useSwitchAccount({
+	mutationKey,
+	...mutationOptions
+}: UseSwitchAccountMutationOptions = {}) {
+	const { currentWallet, dispatch } = useWalletContext();
+
+	return useMutation({
+		mutationKey: walletMutationKeys.switchAccount(mutationKey),
+		mutationFn: async ({ account }) => {
+			if (!currentWallet) {
+				throw new WalletNotConnectedError('No wallet is connected.');
+			}
+
+			const accountToSelect = currentWallet.accounts.find(
+				(walletAccount) => walletAccount.address === account.address,
+			);
+			if (!accountToSelect) {
+				throw new WalletAccountNotFoundError(
+					`No account with address ${account.address} is connected to ${currentWallet.name}.`,
+				);
+			}
+
+			dispatch({ type: 'wallet-account-switched', payload: accountToSelect });
+		},
+		...mutationOptions,
+	});
+}

--- a/sdk/dapp-kit/src/reducers/walletReducer.ts
+++ b/sdk/dapp-kit/src/reducers/walletReducer.ts
@@ -45,12 +45,18 @@ type WalletDisconnectedAction = {
 	payload?: never;
 };
 
+type WalletAccountSwitchedAction = {
+	type: 'wallet-account-switched';
+	payload: WalletAccount;
+};
+
 export type WalletAction =
 	| WalletConnectionStatusUpdatedAction
 	| WalletConnectedAction
 	| WalletDisconnectedAction
 	| WalletRegisteredAction
-	| WalletUnregisteredAction;
+	| WalletUnregisteredAction
+	| WalletAccountSwitchedAction;
 
 export function walletReducer(state: WalletState, { type, payload }: WalletAction): WalletState {
 	switch (type) {
@@ -98,6 +104,11 @@ export function walletReducer(state: WalletState, { type, payload }: WalletActio
 				connectionStatus: 'disconnected',
 			};
 		}
+		case 'wallet-account-switched':
+			return {
+				...state,
+				currentAccount: payload,
+			};
 		default:
 			assertUnreachable(type);
 	}

--- a/sdk/dapp-kit/test/hooks/useSwitchAccount.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useSwitchAccount.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useConnectWallet, useWallet } from 'dapp-kit/src';
+import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
+import { useSwitchAccount } from 'dapp-kit/src/hooks/wallet/useSwitchAccount.js';
+import {
+	WalletAccountNotFoundError,
+	WalletNotConnectedError,
+} from 'dapp-kit/src/errors/walletErrors.js';
+import { createMockAccount } from '../mocks/mockAccount.js';
+
+describe('useSwitchAccount', () => {
+	test('throws an error when trying to switch accounts with no active connection', async () => {
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(() => useSwitchAccount(), { wrapper });
+
+		result.current.mutate({ account: createMockAccount() });
+		await waitFor(() => expect(result.current.error).toBeInstanceOf(WalletNotConnectedError));
+	});
+
+	test('throws an error when trying to switch to a non-authorized account', async () => {
+		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				switchAccount: useSwitchAccount(),
+				walletInfo: useWallet(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ wallet: mockWallet });
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+
+		result.current.switchAccount.mutate({ account: createMockAccount() });
+		await waitFor(() =>
+			expect(result.current.switchAccount.error).toBeInstanceOf(WalletAccountNotFoundError),
+		);
+
+		act(() => unregister());
+	});
+
+	test('switching accounts works successfully', async () => {
+		const { unregister, mockWallet } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			accounts: [createMockAccount(), createMockAccount(), createMockAccount()],
+		});
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				switchAccount: useSwitchAccount(),
+				walletInfo: useWallet(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ wallet: mockWallet });
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+		expect(result.current.walletInfo.currentAccount).toBeTruthy();
+
+		result.current.switchAccount.mutate({ account: mockWallet.accounts[1] });
+		await waitFor(() => expect(result.current.switchAccount.isSuccess).toBe(true));
+		expect(result.current.walletInfo.currentAccount!.address).toBe(mockWallet.accounts[1].address);
+
+		act(() => unregister());
+	});
+});


### PR DESCRIPTION
## Description 

This PR adds a new `useSwitchAccount` mutation hook for switching between different wallet accounts. Not sure if we prefer `useSelectAccount` or `useSwitchAccount` for naming, but I thought saying "I'm using this hook to switch accounts" out loud made more sense than "I'm using this hook to select an account" 😛 .

## Test Plan 
- Automated tests
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
