### PR TITLE
[storeage] Change `object_per_epoch_marker_table` layout

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -10,7 +10,7 @@ use sui_types::accumulator::Accumulator;
 use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::TransactionEffects;
-use sui_types::storage::MarkerKind;
+use sui_types::storage::MarkerValue;
 use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::util::{empty_compaction_filter, reference_count_merge_operator};
 use typed_store::rocks::{
@@ -120,12 +120,12 @@ pub struct AuthorityPerpetualTables {
     /// This number is the result of storage_fund_balance - sum(storage_rebate).
     pub(crate) expected_storage_fund_imbalance: DBMap<(), i64>,
 
-    /// Table that stores the set of received objects and deleted shared objects and the version at
+    /// Table that stores the set of received objects and deleted objects and the version at
     /// which they were received. This is used to prevent possible race conditions around receiving
     /// objects (since they are not locked by the transaction manager) and for tracking shared
     /// objects that have been deleted. This table is meant to be pruned per-epoch, and all
     /// previous epochs other than the current epoch may be pruned safely.
-    pub(crate) object_per_epoch_marker_table: DBMap<(EpochId, ObjectKey, MarkerKind), ()>,
+    pub(crate) object_per_epoch_marker_table: DBMap<(EpochId, ObjectKey), MarkerValue>,
 }
 
 impl AuthorityPerpetualTables {

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -55,13 +55,16 @@ pub enum DeleteKind {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
-pub enum MarkerKind {
+pub enum MarkerValue {
     /// An object was received at the given version in the transaction and is no longer able
     /// to be received at that version in subequent transactions.
     Received,
+    /// An owned object was deleted (or wrapped) at the given version, and is no longer able to be
+    /// accessed or used in subsequent transactions.
+    OwnedDeleted,
     /// A shared object was deleted by the transaction and is no longer able to be accessed or
     /// used in subsequent transactions.
-    SharedObjectDeleted,
+    SharedDeleted(TransactionDigest),
 }
 
 /// DeleteKind together with the old sequence number prior to the deletion, if available.


### PR DESCRIPTION

## Description 
Changes the layout of the `object_per_marker_table` layout to not contain the `MarkerKind` in the key, and instead map to a `MarkerValue` which will contain specific data depending on if the object was received, owned-deleted, or shared-deleted.

## Test Plan 

This table has been and remains unused for now so changing the layout of it should be fine. 


