### PR TITLE
[sui-graphql-rpc] Refactor conversion fns for Validator, Epoch, and Checkpoint

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -273,7 +273,7 @@ impl DataProvider for SuiClient {
             .map(SerdeBigInt::from);
 
         let pg = self.read_api().get_checkpoints(after, count, false).await?;
-        let checkpoints: Vec<Checkpoint> = pg.data.iter().map(Checkpoint::from).collect();
+        let checkpoints: Vec<_> = pg.data.iter().map(Checkpoint::from).collect();
 
         let mut connection = Connection::new(false, pg.has_next_page);
         connection.edges.extend(

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-
 use super::big_int::BigInt;
 use crate::types::owner::Owner;
 use async_graphql::*;
@@ -18,7 +16,7 @@ impl From<sui_json_rpc_types::Balance> for Balance {
     fn from(balance: sui_json_rpc_types::Balance) -> Self {
         Self {
             coin_object_count: balance.coin_object_count as u64,
-            total_balance: BigInt::from_str(&format!("{}", balance.total_balance)).unwrap(),
+            total_balance: BigInt::from(balance.total_balance),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use super::big_int::BigInt;
 use crate::types::owner::Owner;
 use async_graphql::*;
@@ -10,6 +12,15 @@ pub(crate) struct Balance {
     // pub(crate) coin_type: MoveType,
     pub(crate) coin_object_count: u64,
     pub(crate) total_balance: BigInt,
+}
+
+impl From<sui_json_rpc_types::Balance> for Balance {
+    fn from(balance: sui_json_rpc_types::Balance) -> Self {
+        Self {
+            coin_object_count: balance.coin_object_count as u64,
+            total_balance: BigInt::from_str(&format!("{}", balance.total_balance)).unwrap(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]

--- a/crates/sui-graphql-rpc/src/types/big_int.rs
+++ b/crates/sui-graphql-rpc/src/types/big_int.rs
@@ -49,11 +49,20 @@ impl FromStr for BigInt {
     }
 }
 
-impl From<u64> for BigInt {
-    fn from(value: u64) -> Self {
-        BigInt::from_str(&value.to_string()).expect("Cannot parse u64 into BigInt")
-    }
+macro_rules! impl_from_for_bigint {
+    ($($t:ty),*) => {
+        $(
+            impl From<$t> for BigInt {
+                fn from(value: $t) -> Self {
+                    BigInt::from_str(&value.to_string())
+                          .expect(&format!("Cannot parse {} into BigInt", stringify!($t)))
+                }
+            }
+        )*
+    };
 }
+
+impl_from_for_bigint!(u64, u128, i32);
 
 #[cfg(test)]
 mod tests {

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -29,23 +29,17 @@ impl From<&sui_json_rpc_types::Checkpoint> for Checkpoint {
     fn from(c: &sui_json_rpc_types::Checkpoint) -> Self {
         let end_of_epoch_data = &c.end_of_epoch_data;
         let end_of_epoch = end_of_epoch_data.clone().map(|e| {
-            let committees = e.next_epoch_committee;
-            let new_committee = if committees.is_empty() {
-                None
-            } else {
-                Some(
-                    committees
-                        .iter()
-                        .map(|c| CommitteeMember {
-                            authority_name: Some(c.0.into_concise().to_string()),
-                            stake_unit: Some(c.1),
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            };
+            let committee: Vec<_> = e
+                .next_epoch_committee
+                .iter()
+                .map(|(authority, stake)| CommitteeMember {
+                    authority_name: Some(authority.into_concise().to_string()),
+                    stake_unit: Some(*stake),
+                })
+                .collect();
 
             EndOfEpochData {
-                new_committee,
+                new_committee: Some(committee),
                 next_protocol_version: Some(e.next_epoch_protocol_version.as_u64()),
             }
         });

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -19,7 +19,7 @@ pub(crate) struct Checkpoint {
     pub live_object_set_digest: Option<String>,
     pub network_total_transactions: Option<u64>,
     pub rolling_gas_summary: Option<GasCostSummary>,
-    pub epoch: Epoch,
+    pub epoch: Option<Epoch>,
     pub end_of_epoch: Option<EndOfEpochData>,
     // transactionConnection(first: Int, after: String, last: Int, before: String): TransactionBlockConnection
     // address_metrics: AddressMetrics,
@@ -60,10 +60,10 @@ impl From<&sui_json_rpc_types::Checkpoint> for Checkpoint {
             live_object_set_digest: None, // TODO fix this
             network_total_transactions: Some(c.network_total_transactions),
             rolling_gas_summary: Some(GasCostSummary::from(&c.epoch_rolling_gas_cost_summary)),
-            epoch: Epoch {
+            epoch: Some(Epoch {
                 epoch_id: c.epoch,
                 gas_cost_summary: Some(GasCostSummary::from(&c.epoch_rolling_gas_cost_summary)),
-            },
+            }),
             end_of_epoch,
         }
     }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -119,6 +119,7 @@ impl Epoch {
     }
 
     async fn protocol_configs(&self, ctx: &Context<'_>) -> Result<Option<ProtocolConfigs>> {
+        // TODO: Fetch protocol configs for the epoch_id?
         Ok(Some(ctx.data_provider().fetch_protocol_config(None).await?))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -1,27 +1,127 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::context_data::context_ext::DataProviderContextExt;
+
 use super::big_int::BigInt;
 use super::date_time::DateTime;
+use super::gas::GasCostSummary;
 use super::protocol_config::ProtocolConfigs;
 use super::safe_mode::SafeMode;
 use super::stake_subsidy::StakeSubsidy;
 use super::storage_fund::StorageFund;
 use super::system_parameters::SystemParameters;
+use super::validator::Validator;
 use super::validator_set::ValidatorSet;
+use crate::error::Error;
 use async_graphql::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Epoch {
     pub epoch_id: u64,
-    pub system_state_version: Option<BigInt>,
-    pub protocol_configs: Option<ProtocolConfigs>,
-    pub reference_gas_price: Option<BigInt>,
-    pub system_parameters: Option<SystemParameters>,
-    pub stake_subsidy: Option<StakeSubsidy>,
-    pub validator_set: Option<ValidatorSet>,
-    pub storage_fund: Option<StorageFund>,
-    pub safe_mode: Option<SafeMode>,
-    pub start_timestamp: Option<DateTime>,
+    pub gas_cost_summary: Option<GasCostSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+pub(crate) struct SystemStateSummary {
+    system_state_version: Option<BigInt>,
+    reference_gas_price: Option<BigInt>,
+    system_parameters: Option<SystemParameters>,
+    stake_subsidy: Option<StakeSubsidy>,
+    validator_set: Option<ValidatorSet>,
+    storage_fund: Option<StorageFund>,
+    safe_mode: Option<SafeMode>,
+    start_timestamp: Option<DateTime>,
     // pub end_timestamp: Option<DateTime>, //TODO decide if we want this data exposed or not
+}
+
+#[Object]
+impl Epoch {
+    async fn epoch_id(&self) -> u64 {
+        self.epoch_id
+    }
+
+    async fn system_state_summary(&self, ctx: &Context<'_>) -> Result<Option<SystemStateSummary>> {
+        let system_state = ctx.data_provider().get_latest_sui_system_state().await?;
+        let active_validators = system_state
+            .active_validators
+            .clone()
+            .into_iter()
+            .map(Validator::from)
+            .collect();
+        let start_timestamp = i64::try_from(system_state.epoch_start_timestamp_ms).map_err(|_| {
+            Error::Internal(format!(
+                "Cannot convert start timestamp u64 ({}) of epoch ({}) into i64 required by DateTime",
+                system_state.epoch_start_timestamp_ms, self.epoch_id
+            ))
+        })?;
+
+        let start_timestamp = DateTime::from_ms(start_timestamp).ok_or_else(|| {
+            Error::Internal(format!(
+                "Cannot convert start timestamp ({}) of epoch ({}) into a DateTime",
+                start_timestamp, self.epoch_id
+            ))
+        })?;
+        Ok(Some(SystemStateSummary {
+            system_state_version: Some(BigInt::from(system_state.system_state_version)),
+            reference_gas_price: Some(BigInt::from(system_state.reference_gas_price)),
+            system_parameters: Some(SystemParameters {
+                duration_ms: Some(BigInt::from(system_state.epoch_duration_ms)),
+                stake_subsidy_start_epoch: Some(system_state.stake_subsidy_start_epoch),
+                min_validator_count: Some(system_state.max_validator_count),
+                max_validator_count: Some(system_state.max_validator_count),
+                min_validator_joining_stake: Some(BigInt::from(
+                    system_state.min_validator_joining_stake,
+                )),
+                validator_low_stake_threshold: Some(BigInt::from(
+                    system_state.validator_low_stake_threshold,
+                )),
+                validator_very_low_stake_threshold: Some(BigInt::from(
+                    system_state.validator_very_low_stake_threshold,
+                )),
+                validator_low_stake_grace_period: Some(BigInt::from(
+                    system_state.validator_low_stake_grace_period,
+                )),
+            }),
+            stake_subsidy: Some(StakeSubsidy {
+                balance: Some(BigInt::from(system_state.stake_subsidy_balance)),
+                distribution_counter: Some(system_state.stake_subsidy_distribution_counter),
+                current_distribution_amount: Some(BigInt::from(
+                    system_state.stake_subsidy_current_distribution_amount,
+                )),
+                period_length: Some(system_state.stake_subsidy_period_length),
+                decrease_rate: Some(system_state.stake_subsidy_decrease_rate as u64),
+            }),
+            validator_set: Some(ValidatorSet {
+                total_stake: Some(BigInt::from(system_state.total_stake)),
+                active_validators: Some(active_validators),
+                pending_removals: Some(system_state.pending_removals.clone()),
+                pending_active_validators_size: Some(system_state.pending_active_validators_size),
+                stake_pool_mappings_size: Some(system_state.staking_pool_mappings_size),
+                inactive_pools_size: Some(system_state.inactive_pools_size),
+                validator_candidates_size: Some(system_state.validator_candidates_size),
+            }),
+            storage_fund: Some(StorageFund {
+                total_object_storage_rebates: Some(BigInt::from(
+                    system_state.storage_fund_total_object_storage_rebates,
+                )),
+                non_refundable_balance: Some(BigInt::from(
+                    system_state.storage_fund_non_refundable_balance,
+                )),
+            }),
+            safe_mode: Some(SafeMode {
+                enabled: Some(system_state.safe_mode),
+                gas_summary: self.gas_cost_summary,
+            }),
+            start_timestamp: Some(start_timestamp),
+        }))
+    }
+
+    async fn protocol_configs(&self, ctx: &Context<'_>) -> Result<Option<ProtocolConfigs>> {
+        Ok(Some(
+            ctx.data_provider()
+                .fetch_protocol_config(Some(self.epoch_id))
+                .await?,
+        ))
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -42,6 +42,7 @@ impl Epoch {
     }
 
     async fn system_state_summary(&self, ctx: &Context<'_>) -> Result<Option<SystemStateSummary>> {
+        // TODO: Shouldn't we fetch the system state at the epoch_id instead of the latest one?
         let system_state = ctx.data_provider().get_latest_sui_system_state().await?;
         let active_validators = system_state
             .active_validators
@@ -118,10 +119,6 @@ impl Epoch {
     }
 
     async fn protocol_configs(&self, ctx: &Context<'_>) -> Result<Option<ProtocolConfigs>> {
-        Ok(Some(
-            ctx.data_provider()
-                .fetch_protocol_config(Some(self.epoch_id))
-                .await?,
-        ))
+        Ok(Some(ctx.data_provider().fetch_protocol_config(None).await?))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -57,7 +57,7 @@ impl TransactionBlock {
         let data_provider = ctx.data_provider();
         let system_state = data_provider.get_latest_sui_system_state().await?;
         let protocol_configs = data_provider.fetch_protocol_config(None).await?;
-        let epoch = convert_to_epoch(gcs.into(), &system_state, &protocol_configs)?;
+        let epoch = convert_to_epoch(gcs, &system_state, &protocol_configs)?;
         Ok(Some(epoch))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -66,7 +66,8 @@ pub(crate) struct TransactionBlockEffects {
     // pub object_reads: Vec<Object>,
     // pub object_changes: Vec<ObjectChange>,
     // pub balance_changes: Vec<BalanceChange>,
-    pub epoch: Epoch, // pub checkpoint: Checkpoint
+    pub epoch: Epoch,
+    // pub checkpoint: Checkpoint
 }
 
 impl From<&SuiTransactionBlockEffects> for TransactionBlockEffects {

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -57,7 +57,7 @@ impl TransactionBlock {
         let data_provider = ctx.data_provider();
         let system_state = data_provider.get_latest_sui_system_state().await?;
         let protocol_configs = data_provider.fetch_protocol_config(None).await?;
-        let epoch = convert_to_epoch(gcs, &system_state, &protocol_configs)?;
+        let epoch = convert_to_epoch(gcs.into(), &system_state, &protocol_configs)?;
         Ok(Some(epoch))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -3,9 +3,11 @@
 
 use super::address::Address;
 use super::big_int::BigInt;
+use super::sui_address::SuiAddress;
 // use super::sui_address::SuiAddress;
 use super::validator_credentials::ValidatorCredentials;
 use async_graphql::*;
+use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct Validator {
@@ -37,4 +39,40 @@ pub(crate) struct Validator {
     // pub at_risk: Option<u64>,
     // pub report_records: Option<Vec<SuiAddress>>,
     // pub apy: Option<u64>,
+}
+
+impl From<SuiValidatorSummary> for Validator {
+    fn from(v: SuiValidatorSummary) -> Self {
+        let credentials = ValidatorCredentials::from(&v);
+        Validator {
+            address: Address {
+                address: SuiAddress::from(v.sui_address),
+            },
+            next_epoch_credentials: Some(credentials.clone()),
+            credentials: Some(credentials),
+            name: Some(v.name),
+            description: Some(v.description),
+            image_url: Some(v.image_url),
+            project_url: Some(v.project_url),
+            exchange_rates_size: Some(v.exchange_rates_size),
+
+            staking_pool_activation_epoch: Some(v.staking_pool_activation_epoch.unwrap()),
+            staking_pool_sui_balance: Some(BigInt::from(v.staking_pool_sui_balance)),
+            rewards_pool: Some(BigInt::from(v.rewards_pool)),
+            pool_token_balance: Some(BigInt::from(v.pool_token_balance)),
+            pending_stake: Some(BigInt::from(v.pending_stake)),
+            pending_total_sui_withdraw: Some(BigInt::from(v.pending_total_sui_withdraw)),
+            pending_pool_token_withdraw: Some(BigInt::from(v.pending_pool_token_withdraw)),
+            voting_power: Some(v.voting_power),
+            // stake_units: todo!(),
+            gas_price: Some(BigInt::from(v.gas_price)),
+            commission_rate: Some(v.commission_rate),
+            next_epoch_stake: Some(BigInt::from(v.next_epoch_stake)),
+            next_epoch_gas_price: Some(BigInt::from(v.next_epoch_gas_price)),
+            next_epoch_commission_rate: Some(v.next_epoch_commission_rate),
+            // at_risk: todo!(),
+            // report_records: todo!(),
+            // apy: todo!(),
+        }
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/validator_credentials.rs
+++ b/crates/sui-graphql-rpc/src/types/validator_credentials.rs
@@ -3,6 +3,7 @@
 
 use super::base64::Base64;
 use async_graphql::*;
+use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct ValidatorCredentials {
@@ -14,4 +15,19 @@ pub(crate) struct ValidatorCredentials {
     pub p2p_address: Option<String>,
     pub primary_address: Option<String>,
     pub worker_address: Option<String>,
+}
+
+impl From<&SuiValidatorSummary> for ValidatorCredentials {
+    fn from(v: &SuiValidatorSummary) -> Self {
+        Self {
+            protocol_pub_key: Some(Base64::from(v.protocol_pubkey_bytes.clone())),
+            network_pub_key: Some(Base64::from(v.network_pubkey_bytes.clone())),
+            worker_pub_key: Some(Base64::from(v.worker_pubkey_bytes.clone())),
+            proof_of_possession: Some(Base64::from(v.proof_of_possession_bytes.clone())),
+            net_address: Some(v.net_address.clone()),
+            p2p_address: Some(v.p2p_address.clone()),
+            primary_address: Some(v.primary_address.clone()),
+            worker_address: Some(v.worker_address.clone()),
+        }
+    }
 }


### PR DESCRIPTION
## Description 

The bulk of this refactor comes down to Epoch. Currently, to instantiate Epoch, we need to fetch get_latest_sui_system_state and get_protocol_config. This would need to be done in multiple locations, Checkpoint.epoch, Transactionblock.expiration, TransactionBlock.effects.epoch, and ConsensusCommitPrologueTransaction. This PR centralizes the fetches to the Epoch object. Will fast-follow and replace w/ DataLoader if these changes check out.

1. I couldn't come up with a straightforward way to refactor Epoch. My take on it is that most of its fields can be encapsulated in a SystemStateSummary child object, such that Epoch = join(SystemStateSummary, ProtocolConfig). Alternatively, we can keep flattened(SystemStateSummary), have each field resolve by calling data_provider.get_latest_sui_system_state, and let DataLoader optimize, but this seems to be overkill as they all derive from the same piece of data.
2. I probably just lack context here, but is it correct for us to always return the latest SuiSystemState and ProtocolConfig for Epoch? The Checkpoint or TransactionBlock that we query for may not always belong to the latest epoch, and these configurations may change across epochs
3. It also appears to me that TransactionBlock.expiration == TransactionBlock.effects.epoch. Again, I'm probably missing context here.
4. Other learnings: I ended up not needing it, but we can always flag a field on the graphql-mirrored Rust struct with #[graphql(skip)] so the Object or ComplexObject implementation block can leverage it without having the field show up on the schema

## Test Plan 

Will update w/ new schema + snapshot test. Otherwise did some manual queries.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
