### PR TITLE
[GraphQL/Schema] Remove reference to effects digest

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -70,9 +70,8 @@ type Query {
   # If no `id` is provided, fetch the latest available checkpoint.
   checkpoint(id: CheckpointID): Checkpoint
 
-  # Find a transaction block either by its transaction digest or its
-  # effects digest.
-  transactionBlock(filter: TransactionBlockID!): TransactionBlock
+  # Find a transaction block by its transaction digest
+  transactionBlock(digest: String!): TransactionBlock
 
   coinMetadata(coinType: String!): CoinMetadata
 
@@ -154,10 +153,9 @@ type Mutation {
   # `signatures` are a list of `flag || signature || pubkey` bytes,
   #     Base64-encoded.
   #
-  # Waits until the transaction has been finalised on chain and an
-  # effects digest is available, and returns that.  If the
-  # transaction could not be finalised, returns the errors that
-  # prevented it, instead.
+  # Waits until the transaction has been finalised on chain to return
+  # its transaction digest.  If the transaction could not be
+  # finalised, returns the errors that prevented it, instead.
   executeTransactionBlock(
     txBytes: Base64!,
     signatures: [Base64!]!,
@@ -189,14 +187,6 @@ input TransactionMetadata {
 input CheckpointID {
   digest: String
   sequenceNumber: Int
-}
-
-# TODO: Do we want to support querying by effects digest at all?
-# Find a transaction block either by its transaction digest, or its
-# effects digest (can't be both, can't be neither).
-input TransactionBlockID {
-  transactionDigest: String
-  effectsDigest: String
 }
 
 input ObjectFilter {
@@ -730,7 +720,6 @@ type MakeMoveVecTransaction {
 type TransactionSignature
 
 type TransactionBlockEffects {
-  digest: String!
   status: ExecutionStatus!
 
   errors: String
@@ -1052,8 +1041,9 @@ type AddressMetrics {
 
 # Execution
 
+# Either Transaction Digest on success, or error on failure.
 type ExecutionResult {
-  effectsDigest: String
+  digest: String
   errors: String
 }
 


### PR DESCRIPTION
## Description

As per discussion in #13574 -- we may not want to expose effects digest (favouring using transaction digest everywhere). This PR removes:

- `TransactionBlockEffects.digest`
- The ability to find a transaction block by its effects digest (now it can only be found by its transaction digest).
- The ability for execution to return an effects digest (now returns a transaction digest on success).

## Test Plan

:eyes: