### PR TITLE
simulacrum: introduce a tool for simulating Sui chain state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9258,6 +9258,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "simulacrum"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "fastcrypto",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "narwhal-config",
+ "once_cell",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto",
+ "sui-config",
+ "sui-execution",
+ "sui-framework",
+ "sui-genesis-builder",
+ "sui-keys",
+ "sui-protocol-config",
+ "sui-storage",
+ "sui-swarm-config",
+ "sui-transaction-checks",
+ "sui-types",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11212,6 +11242,7 @@ dependencies = [
  "anyhow",
  "fastcrypto",
  "insta",
+ "move-bytecode-utils",
  "narwhal-config",
  "prometheus",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "crates/mysten-util-mem-derive",
     "crates/prometheus-closure-metric",
     "crates/shared-crypto",
+    "crates/simulacrum",
     "crates/sui",
     "crates/sui-adapter-transactional-tests",
     "crates/sui-analytics-indexer",

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "sui-swarm-config"
-version = "0.0.0"
+name = "simulacrum"
+version = "0.1.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
 edition = "2021"
 
 [dependencies]
-anemo.workspace = true
 anyhow.workspace = true
+bcs.workspace = true
 fastcrypto.workspace = true
+move-binary-format.workspace = true
+move-core-types.workspace = true
+once_cell.workspace = true
 rand.workspace = true
 serde.workspace = true
-serde_with.workspace = true
-serde_yaml.workspace = true
-tempfile.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 
@@ -22,16 +22,13 @@ move-bytecode-utils.workspace = true
 narwhal-config.workspace = true
 shared-crypto.workspace = true
 sui-config.workspace = true
+sui-framework.workspace = true
+sui-keys.workspace = true
 sui-protocol-config.workspace = true
+sui-storage.workspace = true
 sui-types.workspace = true
 sui-genesis-builder.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
-[target.'cfg(msim)'.dependencies]
-sui-simulator.workspace = true
-
-[dev-dependencies]
-insta.workspace = true
-tempfile.workspace = true
-
 sui-execution.workspace = true
+sui-swarm-config.workspace = true
+sui-transaction-checks.workspace = true
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/simulacrum/src/checkpoint_builder.rs
+++ b/crates/simulacrum/src/checkpoint_builder.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_types::{
+    base_types::VerifiedExecutionData,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+    gas::GasCostSummary,
+    messages_checkpoint::{
+        CheckpointContents, CheckpointSummary, EndOfEpochData, VerifiedCheckpoint,
+    },
+    transaction::VerifiedTransaction,
+};
+
+use super::CommitteeWithKeys;
+
+#[derive(Debug)]
+pub struct CheckpointBuilder {
+    previous_checkpoint: VerifiedCheckpoint,
+    transactions: Vec<VerifiedExecutionData>,
+    epoch_rolling_gas_cost_summary: GasCostSummary,
+    epoch: u64,
+}
+
+impl CheckpointBuilder {
+    pub fn new(previous_checkpoint: VerifiedCheckpoint) -> Self {
+        let epoch_rolling_gas_cost_summary =
+            previous_checkpoint.epoch_rolling_gas_cost_summary.clone();
+        let epoch = previous_checkpoint.epoch;
+
+        Self {
+            previous_checkpoint,
+            transactions: Vec::new(),
+            epoch_rolling_gas_cost_summary,
+            epoch,
+        }
+    }
+
+    pub fn epoch_rolling_gas_cost_summary(&self) -> &GasCostSummary {
+        &self.epoch_rolling_gas_cost_summary
+    }
+
+    pub fn push_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+    ) {
+        self.epoch_rolling_gas_cost_summary += effects.gas_cost_summary();
+
+        self.transactions
+            .push(VerifiedExecutionData::new(transaction, effects))
+    }
+
+    /// Builds a checkpoint using internally buffered transactions.
+    pub fn build(
+        &mut self,
+        committee: &CommitteeWithKeys<'_>,
+        timestamp_ms: u64,
+    ) -> (VerifiedCheckpoint, CheckpointContents) {
+        self.build_internal(committee, timestamp_ms, None)
+    }
+
+    pub fn build_end_of_epoch(
+        &mut self,
+        committee: &CommitteeWithKeys<'_>,
+        timestamp_ms: u64,
+        new_epoch: u64,
+        end_of_epoch_data: EndOfEpochData,
+    ) -> (VerifiedCheckpoint, CheckpointContents) {
+        self.build_internal(
+            committee,
+            timestamp_ms,
+            Some((new_epoch, end_of_epoch_data)),
+        )
+    }
+
+    fn build_internal(
+        &mut self,
+        committee: &CommitteeWithKeys<'_>,
+        timestamp_ms: u64,
+        new_epoch_data: Option<(u64, EndOfEpochData)>,
+    ) -> (VerifiedCheckpoint, CheckpointContents) {
+        let contents =
+            CheckpointContents::new_with_causally_ordered_execution_data(self.transactions.iter());
+        self.transactions.clear();
+
+        let (epoch, epoch_rolling_gas_cost_summary, end_of_epoch_data) =
+            if let Some((next_epoch, end_of_epoch_data)) = new_epoch_data {
+                let epoch = std::mem::replace(&mut self.epoch, next_epoch);
+                assert_eq!(next_epoch, epoch + 1);
+                let epoch_rolling_gas_cost_summary =
+                    std::mem::take(&mut self.epoch_rolling_gas_cost_summary);
+
+                (
+                    epoch,
+                    epoch_rolling_gas_cost_summary,
+                    Some(end_of_epoch_data),
+                )
+            } else {
+                (
+                    self.epoch,
+                    self.epoch_rolling_gas_cost_summary.clone(),
+                    None,
+                )
+            };
+
+        let summary = CheckpointSummary {
+            epoch,
+            sequence_number: self.previous_checkpoint.sequence_number.saturating_add(1),
+            network_total_transactions: self.previous_checkpoint.network_total_transactions
+                + contents.size() as u64,
+            content_digest: *contents.digest(),
+            previous_digest: Some(*self.previous_checkpoint.digest()),
+            epoch_rolling_gas_cost_summary,
+            end_of_epoch_data,
+            timestamp_ms,
+            version_specific_data: Vec::new(),
+            checkpoint_commitments: Default::default(),
+        };
+
+        let checkpoint = committee.create_certified_checkpoint(summary);
+
+        self.previous_checkpoint = checkpoint.clone();
+        (checkpoint, contents)
+    }
+}

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, sync::Arc};
+
+use anyhow::Result;
+use sui_config::transaction_deny_config::TransactionDenyConfig;
+use sui_execution::Executor;
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use sui_types::{
+    committee::{Committee, EpochId},
+    effects::TransactionEffects,
+    inner_temporary_store::InnerTemporaryStore,
+    metrics::BytecodeVerifierMetrics,
+    metrics::LimitsMetrics,
+    sui_system_state::{
+        epoch_start_sui_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
+        SuiSystemState, SuiSystemStateTrait,
+    },
+    transaction::VerifiedTransaction,
+};
+
+use crate::store::InMemoryStore;
+
+pub struct EpochState {
+    epoch_start_state: EpochStartSystemState,
+    committee: Committee,
+    protocol_config: ProtocolConfig,
+    limits_metrics: Arc<LimitsMetrics>,
+    bytecode_verifier_metrics: Arc<BytecodeVerifierMetrics>,
+    executor: Arc<dyn Executor + Send + Sync>,
+    /// A counter that advances each time we advance the clock in order to ensure that each update
+    /// txn has a unique digest. This is reset on epoch changes
+    next_consensus_round: u64,
+}
+
+impl EpochState {
+    pub fn new(system_state: SuiSystemState) -> Self {
+        let epoch_start_state = system_state.into_epoch_start_state();
+        let committee = epoch_start_state.get_sui_committee();
+        let protocol_config =
+            ProtocolConfig::get_for_version(epoch_start_state.protocol_version(), Chain::Unknown);
+        let registry = prometheus::Registry::new();
+        let limits_metrics = Arc::new(LimitsMetrics::new(&registry));
+        let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(&registry));
+        let executor = sui_execution::executor(&protocol_config, false, true).unwrap();
+
+        Self {
+            epoch_start_state,
+            committee,
+            protocol_config,
+            limits_metrics,
+            bytecode_verifier_metrics,
+            executor,
+            next_consensus_round: 0,
+        }
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        self.epoch_start_state.epoch()
+    }
+
+    pub fn reference_gas_price(&self) -> u64 {
+        self.epoch_start_state.reference_gas_price()
+    }
+
+    pub fn next_consensus_round(&mut self) -> u64 {
+        let round = self.next_consensus_round;
+        self.next_consensus_round += 1;
+        round
+    }
+
+    pub fn committee(&self) -> &Committee {
+        &self.committee
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_config().version
+    }
+
+    pub fn protocol_config(&self) -> &ProtocolConfig {
+        &self.protocol_config
+    }
+
+    pub fn execute_transaction(
+        &self,
+        store: &InMemoryStore,
+        deny_config: &TransactionDenyConfig,
+        transaction: &VerifiedTransaction,
+    ) -> Result<(
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<(), sui_types::error::ExecutionError>,
+    )> {
+        // Run the transaction input checks that would run when submitting the txn to a validator
+        // for signing
+        let (gas_status, input_objects) = sui_transaction_checks::check_transaction_input(
+            store,
+            &self.protocol_config,
+            self.epoch_start_state.reference_gas_price(),
+            transaction.data().transaction_data(),
+            deny_config,
+            &self.bytecode_verifier_metrics,
+        )?;
+
+        let tx_digest = *transaction.digest();
+        let transaction_data = transaction.data().transaction_data();
+        let (kind, signer, gas) = transaction_data.execution_parts();
+        Ok(self.executor.execute_transaction_to_effects(
+            store,
+            &self.protocol_config,
+            self.limits_metrics.clone(),
+            false,           // enable_expensive_checks
+            &HashSet::new(), // certificate_deny_set
+            &self.epoch_start_state.epoch(),
+            self.epoch_start_state.epoch_start_timestamp_ms(),
+            input_objects,
+            gas,
+            gas_status,
+            kind,
+            signer,
+            tx_digest,
+        ))
+    }
+}

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1,0 +1,469 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `Simulacrum` of Sui.
+//!
+//! The word simulacrum is latin for "likeness, semblance", it is also a spell in D&D which creates
+//! a copy of a creature which then follows the player's commands and wishes. As such this crate
+//! provides the [`Simulacrum`] type which is a implementation or instantiation of a sui
+//! blockcahin, one which doesn't do anything unless acted upon.
+//!
+//! [`Simulacrum`]: crate::Simulacrum
+
+use anyhow::{anyhow, Result};
+use rand::rngs::OsRng;
+use sui_config::{genesis, transaction_deny_config::TransactionDenyConfig};
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_types::{
+    base_types::SuiAddress,
+    committee::Committee,
+    crypto::{AuthoritySignInfo, AuthoritySignature, SuiAuthoritySignature},
+    effects::TransactionEffects,
+    gas_coin::MIST_PER_SUI,
+    inner_temporary_store::InnerTemporaryStore,
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointSummary, EndOfEpochData, VerifiedCheckpoint,
+    },
+    signature::VerifyParams,
+    transaction::{Transaction, VerifiedTransaction},
+};
+
+use self::checkpoint_builder::CheckpointBuilder;
+use self::epoch_state::EpochState;
+pub use self::store::InMemoryStore;
+use self::store::KeyStore;
+
+mod checkpoint_builder;
+mod epoch_state;
+mod store;
+
+/// A `Simulacrum` of Sui.
+///
+/// This type represents a simulated instantiation of a Sui blockchain that needs to be driven
+/// manually, that is time doesn't advance and checkpoints are not formed unless explicitly
+/// requested.
+///
+/// See [module level][mod] documentation for more details.
+///
+/// [mod]: index.html
+pub struct Simulacrum<R = OsRng> {
+    rng: R,
+    keystore: KeyStore,
+    #[allow(unused)]
+    genesis: genesis::Genesis,
+    store: InMemoryStore,
+    checkpoint_builder: CheckpointBuilder,
+
+    // Epoch specific data
+    epoch_state: EpochState,
+
+    // Other
+    deny_config: TransactionDenyConfig,
+}
+
+impl Simulacrum {
+    /// Create a new, random Simulacrum instance using an `OsRng` as the source of randomness.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::new_with_rng(OsRng)
+    }
+}
+
+impl<R> Simulacrum<R>
+where
+    R: rand::RngCore + rand::CryptoRng,
+{
+    /// Create a new Simulacrum instance using the provided `rng`.
+    ///
+    /// This allows you to create a fully deterministic initial chainstate when a seeded rng is
+    /// used.
+    ///
+    /// ```
+    /// use simulacrum::Simulacrum;
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let simulacrum = Simulacrum::new_with_rng(rng);
+    /// # }
+    /// ```
+    pub fn new_with_rng(mut rng: R) -> Self {
+        let config = ConfigBuilder::new_with_temp_dir()
+            .rng(&mut rng)
+            .with_chain_start_timestamp_ms(1)
+            .build();
+        let keystore = KeyStore::from_newtork_config(&config);
+        let store = InMemoryStore::new(&config.genesis);
+        let checkpoint_builder = CheckpointBuilder::new(config.genesis.checkpoint());
+
+        let genesis = config.genesis;
+        let epoch_state = EpochState::new(genesis.sui_system_object());
+
+        Self {
+            rng,
+            keystore,
+            genesis,
+            store,
+            checkpoint_builder,
+            epoch_state,
+            deny_config: TransactionDenyConfig::default(),
+        }
+    }
+}
+
+impl<R> Simulacrum<R> {
+    /// Attempts to execute the provided Transaction.
+    ///
+    /// The provided Transaction undergoes the same types of checks that a Validator does prior to
+    /// signing and executing in the production system. Some of these checks are as follows:
+    /// - User signature is valid
+    /// - Sender owns all OwnedObject inputs
+    /// - etc
+    ///
+    /// If the above checks are successful then the transaction is immediately executed, enqueued
+    /// to be included in the next checkpoint (the next time `create_checkpoint` is called) and the
+    /// corresponding TransactionEffects are returned.
+    pub fn execute_transaction(&mut self, transaction: Transaction) -> Result<TransactionEffects> {
+        // This only supports traditional authenticators and not zklogin
+        let transaction = transaction.verify(&VerifyParams::default())?;
+
+        let (inner_temporary_store, effects, _execution_error_opt) = self
+            .epoch_state
+            .execute_transaction(&self.store, &self.deny_config, &transaction)?;
+
+        let InnerTemporaryStore {
+            written, events, ..
+        } = inner_temporary_store;
+
+        self.store.insert_executed_transaction(
+            transaction.clone(),
+            effects.clone(),
+            events,
+            written,
+        );
+
+        // Insert into checkpoint builder
+        self.checkpoint_builder
+            .push_transaction(transaction, effects.clone());
+
+        Ok(effects)
+    }
+
+    /// Creates the next Checkpoint using the Transactions enqueued since the last checkpoint was
+    /// created.
+    pub fn create_checkpoint(&mut self) -> VerifiedCheckpoint {
+        let committee = CommitteeWithKeys::new(&self.keystore, self.epoch_state.committee());
+        let (checkpoint, contents) = self
+            .checkpoint_builder
+            .build(&committee, self.store.get_clock().timestamp_ms());
+        self.store.insert_checkpoint(checkpoint.clone());
+        self.store.insert_checkpoint_contents(contents);
+        checkpoint
+    }
+
+    /// Advances the clock by `duration`.
+    ///
+    /// This creates and executes a ConsensusCommitPrologue transaction which advances the chain
+    /// Clock by the provided duration.
+    pub fn advance_clock(&mut self, duration: std::time::Duration) -> TransactionEffects {
+        let epoch = self.epoch_state.epoch();
+        let round = self.epoch_state.next_consensus_round();
+        let timestamp_ms = self.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
+        let consensus_commit_prologue_transaction =
+            VerifiedTransaction::new_consensus_commit_prologue(epoch, round, timestamp_ms);
+
+        self.execute_transaction(consensus_commit_prologue_transaction.into())
+            .expect("advancing the clock cannot fail")
+    }
+
+    /// Advances the epoch.
+    ///
+    /// This creates and executes an EpochChange transaction which advances the chain into the next
+    /// epoch. Since the EpochChange transaction is required to be the final transaction in an
+    /// epoch, the final checkpoint in the epoch is also created.
+    ///
+    /// NOTE: This function does not currently support updating the protocol version or the system
+    /// packages
+    pub fn advance_epoch(&mut self) {
+        let next_epoch = self.epoch_state.epoch() + 1;
+        let next_epoch_protocol_version = self.epoch_state.protocol_version();
+        let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
+        let epoch_start_timestamp_ms = self.store.get_clock().timestamp_ms();
+        let next_epoch_system_package_bytes = vec![];
+        let tx = VerifiedTransaction::new_change_epoch(
+            next_epoch,
+            next_epoch_protocol_version,
+            gas_cost_summary.storage_cost,
+            gas_cost_summary.computation_cost,
+            gas_cost_summary.storage_rebate,
+            gas_cost_summary.non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            next_epoch_system_package_bytes,
+        );
+
+        self.execute_transaction(tx.into())
+            .expect("advancing the epoch cannot fail");
+
+        let new_epoch_state = EpochState::new(self.store.get_system_state());
+        let end_of_epoch_data = EndOfEpochData {
+            next_epoch_committee: new_epoch_state.committee().voting_rights.clone(),
+            next_epoch_protocol_version,
+            epoch_commitments: vec![],
+        };
+        let committee = CommitteeWithKeys::new(&self.keystore, self.epoch_state.committee());
+        let (checkpoint, contents) = self.checkpoint_builder.build_end_of_epoch(
+            &committee,
+            self.store.get_clock().timestamp_ms(),
+            next_epoch,
+            end_of_epoch_data,
+        );
+
+        self.store.insert_checkpoint(checkpoint);
+        self.store.insert_checkpoint_contents(contents);
+        self.epoch_state = new_epoch_state;
+    }
+
+    pub fn store(&self) -> &InMemoryStore {
+        &self.store
+    }
+
+    pub fn keystore(&self) -> &KeyStore {
+        &self.keystore
+    }
+
+    /// Return a handle to the internally held RNG.
+    ///
+    /// Returns a handle to the RNG used to create this Simulacrum for use as a source of
+    /// randomness. Using a seeded RNG to build a Simulacrum and then utilizing the stored RNG as a
+    /// source of randomness can lead to a fully deterministic chain evolution.
+    pub fn rng(&mut self) -> &mut R {
+        &mut self.rng
+    }
+
+    /// Return the reference gas price for the current epoch
+    pub fn reference_gas_price(&self) -> u64 {
+        self.epoch_state.reference_gas_price()
+    }
+
+    /// Request that `amount` Mist be sent to `address` from a faucet account.
+    ///
+    /// ```
+    /// use simulacrum::Simulacrum;
+    /// use sui_types::base_types::SuiAddress;
+    /// use sui_types::gas_coin::MIST_PER_SUI;
+    ///
+    /// # fn main() {
+    /// let mut simulacrum = Simulacrum::new();
+    /// let address = SuiAddress::generate(simulacrum.rng());
+    /// simulacrum.request_gas(address, MIST_PER_SUI).unwrap();
+    ///
+    /// // `account` now has a Coin<SUI> object with single SUI in it.
+    /// // ...
+    /// # }
+    /// ```
+    pub fn request_gas(&mut self, address: SuiAddress, amount: u64) -> Result<TransactionEffects> {
+        // For right now we'll just use the first account as the `faucet` account. We may want to
+        // explicitly cordon off the faucet account from the rest of the accounts though.
+        let (sender, key) = self.keystore().accounts().next().unwrap();
+        let object = self
+            .store()
+            .owned_objects(*sender)
+            .find(|object| {
+                object.is_gas_coin() && object.get_coin_value_unsafe() > amount + MIST_PER_SUI
+            })
+            .ok_or_else(|| {
+                anyhow!("unable to find a coin with enough to satisfy request for {amount} Mist")
+            })?;
+
+        let gas_data = sui_types::transaction::GasData {
+            payment: vec![object.compute_object_reference()],
+            owner: *sender,
+            price: self.reference_gas_price(),
+            budget: MIST_PER_SUI,
+        };
+
+        let pt = {
+            let mut builder =
+                sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(address, Some(amount));
+            builder.finish()
+        };
+
+        let kind = sui_types::transaction::TransactionKind::ProgrammableTransaction(pt);
+        let tx_data =
+            sui_types::transaction::TransactionData::new_with_gas_data(kind, *sender, gas_data);
+        let tx = Transaction::from_data_and_signer(
+            tx_data,
+            shared_crypto::intent::Intent::sui_transaction(),
+            vec![key],
+        );
+
+        self.execute_transaction(tx)
+    }
+}
+
+pub struct CommitteeWithKeys<'a> {
+    keystore: &'a KeyStore,
+    committee: &'a Committee,
+}
+
+impl<'a> CommitteeWithKeys<'a> {
+    fn new(keystore: &'a KeyStore, committee: &'a Committee) -> Self {
+        Self {
+            keystore,
+            committee,
+        }
+    }
+
+    pub fn committee(&self) -> &Committee {
+        self.committee
+    }
+
+    pub fn keystore(&self) -> &KeyStore {
+        self.keystore
+    }
+
+    fn create_certified_checkpoint(&self, checkpoint: CheckpointSummary) -> VerifiedCheckpoint {
+        let signatures = self
+            .committee()
+            .voting_rights
+            .iter()
+            .map(|(name, _)| {
+                let intent_msg = shared_crypto::intent::IntentMessage::new(
+                    shared_crypto::intent::Intent::sui_app(
+                        shared_crypto::intent::IntentScope::CheckpointSummary,
+                    ),
+                    &checkpoint,
+                );
+                let key = self.keystore().validator(name).unwrap();
+                let signature = AuthoritySignature::new_secure(&intent_msg, &checkpoint.epoch, key);
+                AuthoritySignInfo {
+                    epoch: checkpoint.epoch,
+                    authority: *name,
+                    signature,
+                }
+            })
+            .collect();
+
+        let checkpoint = CertifiedCheckpointSummary::new(checkpoint, signatures, self.committee())
+            .unwrap()
+            .verify(self.committee())
+            .unwrap();
+
+        checkpoint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use shared_crypto::intent::Intent;
+    use sui_types::{
+        base_types::SuiAddress,
+        effects::TransactionEffectsAPI,
+        gas_coin::GasCoin,
+        programmable_transaction_builder::ProgrammableTransactionBuilder,
+        transaction::{GasData, TransactionData, TransactionKind},
+    };
+
+    use super::*;
+
+    #[test]
+    fn simple() {
+        let steps = 10;
+        let mut chain = Simulacrum::new();
+
+        let clock = chain.store().get_clock();
+        let start_time_ms = clock.timestamp_ms();
+        println!("clock: {:#?}", clock);
+        for _ in 0..steps {
+            chain.advance_clock(Duration::from_millis(1));
+            chain.create_checkpoint();
+            let clock = chain.store().get_clock();
+            println!("clock: {:#?}", clock);
+        }
+        let end_time_ms = chain.store().get_clock().timestamp_ms();
+        assert_eq!(end_time_ms - start_time_ms, steps);
+        dbg!(chain.store().get_highest_checkpint());
+    }
+
+    #[test]
+    fn simple_epoch() {
+        let steps = 10;
+        let mut chain = Simulacrum::new();
+
+        let start_epoch = chain.store.get_highest_checkpint().unwrap().epoch;
+        for i in 0..steps {
+            chain.advance_epoch();
+            chain.advance_clock(Duration::from_millis(1));
+            chain.create_checkpoint();
+            println!("{i}");
+        }
+        let end_epoch = chain.store.get_highest_checkpint().unwrap().epoch;
+        assert_eq!(end_epoch - start_epoch, steps);
+        dbg!(chain.store().get_highest_checkpint());
+    }
+
+    #[test]
+    fn transfer() {
+        let mut sim = Simulacrum::new();
+        let recipient = SuiAddress::generate(sim.rng());
+        let (sender, key) = sim.keystore().accounts().next().unwrap();
+        let sender = *sender;
+
+        let object = sim
+            .store()
+            .owned_objects(sender)
+            .find(|object| object.is_gas_coin())
+            .unwrap();
+        let gas_coin = GasCoin::try_from(object).unwrap();
+        let gas_id = object.id();
+        let transfer_amount = gas_coin.value() / 2;
+
+        gas_coin.value();
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(recipient, Some(transfer_amount));
+            builder.finish()
+        };
+
+        let kind = TransactionKind::ProgrammableTransaction(pt);
+        let gas_data = GasData {
+            payment: vec![object.compute_object_reference()],
+            owner: sender,
+            price: sim.reference_gas_price(),
+            budget: 1_000_000_000,
+        };
+        let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data);
+        let tx = Transaction::from_data_and_signer(tx_data, Intent::sui_transaction(), vec![key]);
+
+        let effects = sim.execute_transaction(tx).unwrap();
+        let gas_summary = effects.gas_cost_summary();
+        let gas_paid = gas_summary.net_gas_usage();
+
+        assert_eq!(
+            (transfer_amount as i64 - gas_paid) as u64,
+            sim.store()
+                .get_object(&gas_id)
+                .and_then(|object| GasCoin::try_from(object).ok())
+                .unwrap()
+                .value()
+        );
+
+        assert_eq!(
+            transfer_amount,
+            sim.store()
+                .owned_objects(recipient)
+                .next()
+                .and_then(|object| GasCoin::try_from(object).ok())
+                .unwrap()
+                .value()
+        );
+
+        let checkpoint = sim.create_checkpoint();
+
+        assert_eq!(&checkpoint.epoch_rolling_gas_cost_summary, gas_summary);
+        assert_eq!(checkpoint.network_total_transactions, 2); // genesis + 1 txn
+    }
+}

--- a/crates/simulacrum/src/store.rs
+++ b/crates/simulacrum/src/store.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+
+use move_binary_format::CompiledModule;
+use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
+use sui_config::genesis;
+use sui_types::{
+    base_types::{AuthorityName, ObjectID, SequenceNumber, SuiAddress},
+    committee::{Committee, EpochId},
+    crypto::{AccountKeyPair, AuthorityKeyPair},
+    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    error::SuiError,
+    messages_checkpoint::{
+        CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+        VerifiedCheckpoint,
+    },
+    object::{Object, Owner},
+    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
+    transaction::VerifiedTransaction,
+};
+
+#[derive(Debug, Default)]
+pub struct InMemoryStore {
+    // Checkpoint data
+    checkpoints: BTreeMap<CheckpointSequenceNumber, VerifiedCheckpoint>,
+    checkpoint_digest_to_sequence_number: HashMap<CheckpointDigest, CheckpointSequenceNumber>,
+    checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
+
+    // Transaction data
+    transactions: HashMap<TransactionDigest, VerifiedTransaction>,
+    effects: HashMap<TransactionDigest, TransactionEffects>,
+    events: HashMap<TransactionEventsDigest, TransactionEvents>,
+
+    // Committee data
+    epoch_to_committee: Vec<Committee>,
+
+    // Object data
+    live_objects: HashMap<ObjectID, SequenceNumber>,
+    objects: HashMap<ObjectID, BTreeMap<SequenceNumber, Object>>,
+}
+
+impl InMemoryStore {
+    pub fn new(genesis: &genesis::Genesis) -> Self {
+        let mut store = Self::default();
+
+        store.insert_checkpoint(genesis.checkpoint());
+        store.insert_checkpoint_contents(genesis.checkpoint_contents().clone());
+        store.insert_committee(genesis.committee().unwrap());
+        store.insert_transaction(VerifiedTransaction::new_unchecked(
+            genesis.transaction().clone(),
+        ));
+        store.insert_transaction_effects(genesis.effects().clone());
+        store.insert_events(genesis.events().clone());
+
+        for object in genesis.objects() {
+            let object_id = object.id();
+            let version = object.version();
+            store.live_objects.insert(object_id, version);
+            store
+                .objects
+                .entry(object_id)
+                .or_default()
+                .insert(version, object.clone());
+        }
+
+        store
+    }
+
+    pub fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.checkpoints.get(&sequence_number)
+    }
+
+    pub fn get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.checkpoint_digest_to_sequence_number
+            .get(digest)
+            .and_then(|sequence_number| self.get_checkpoint_by_sequence_number(*sequence_number))
+    }
+
+    pub fn get_highest_checkpint(&self) -> Option<&VerifiedCheckpoint> {
+        self.checkpoints
+            .last_key_value()
+            .map(|(_, checkpoint)| checkpoint)
+    }
+
+    pub fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<&CheckpointContents> {
+        self.checkpoint_contents.get(digest)
+    }
+
+    pub fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee> {
+        self.epoch_to_committee.get(epoch as usize)
+    }
+
+    pub fn get_transaction(&self, digest: &TransactionDigest) -> Option<&VerifiedTransaction> {
+        self.transactions.get(digest)
+    }
+
+    pub fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<&TransactionEffects> {
+        self.effects.get(digest)
+    }
+
+    pub fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Option<&TransactionEvents> {
+        self.events.get(digest)
+    }
+
+    pub fn get_object(&self, id: &ObjectID) -> Option<&Object> {
+        let version = self.live_objects.get(id)?;
+        self.get_object_at_version(id, *version)
+    }
+
+    pub fn get_object_at_version(&self, id: &ObjectID, version: SequenceNumber) -> Option<&Object> {
+        self.objects
+            .get(id)
+            .and_then(|versions| versions.get(&version))
+    }
+
+    pub fn get_system_state(&self) -> sui_types::sui_system_state::SuiSystemState {
+        sui_types::sui_system_state::get_sui_system_state(self).expect("system state must exist")
+    }
+
+    pub fn get_clock(&self) -> sui_types::clock::Clock {
+        self.get_object(&sui_types::SUI_CLOCK_OBJECT_ID)
+            .expect("clock should exist")
+            .to_rust()
+            .expect("clock object should deserialize")
+    }
+
+    pub fn owned_objects(&self, owner: SuiAddress) -> impl Iterator<Item = &Object> {
+        self.live_objects
+            .iter()
+            .flat_map(|(id, version)| self.get_object_at_version(id, *version))
+            .filter(
+                move |object| matches!(object.owner, Owner::AddressOwner(addr) if addr == owner),
+            )
+    }
+}
+
+impl InMemoryStore {
+    pub fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        if let Some(end_of_epoch_data) = &checkpoint.data().end_of_epoch_data {
+            let next_committee = end_of_epoch_data
+                .next_epoch_committee
+                .iter()
+                .cloned()
+                .collect();
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee);
+            self.insert_committee(committee);
+        }
+
+        self.checkpoint_digest_to_sequence_number
+            .insert(*checkpoint.digest(), *checkpoint.sequence_number());
+        self.checkpoints
+            .insert(*checkpoint.sequence_number(), checkpoint);
+    }
+
+    pub fn insert_checkpoint_contents(&mut self, contents: CheckpointContents) {
+        self.checkpoint_contents
+            .insert(*contents.digest(), contents);
+    }
+
+    pub fn insert_committee(&mut self, committee: Committee) {
+        let epoch = committee.epoch as usize;
+
+        if self.epoch_to_committee.get(epoch).is_some() {
+            return;
+        }
+
+        if self.epoch_to_committee.len() == epoch {
+            self.epoch_to_committee.push(committee);
+        } else {
+            panic!("committee was inserted into EpochCommitteeMap out of order");
+        }
+    }
+
+    pub fn insert_executed_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        written_objects: BTreeMap<ObjectID, Object>,
+    ) {
+        let deleted_objects = effects.deleted();
+        self.insert_transaction(transaction);
+        self.insert_transaction_effects(effects);
+        self.insert_events(events);
+        self.update_objects(written_objects, deleted_objects);
+    }
+
+    pub fn insert_transaction(&mut self, transaction: VerifiedTransaction) {
+        self.transactions.insert(*transaction.digest(), transaction);
+    }
+
+    pub fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
+        self.effects.insert(*effects.transaction_digest(), effects);
+    }
+
+    pub fn insert_events(&mut self, events: TransactionEvents) {
+        self.events.insert(events.digest(), events);
+    }
+
+    pub fn update_objects(
+        &mut self,
+        written_objects: BTreeMap<ObjectID, Object>,
+        deleted_objects: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    ) {
+        for (object_id, _, _) in deleted_objects {
+            self.live_objects.remove(&object_id);
+        }
+
+        for (object_id, object) in written_objects {
+            let version = object.version();
+            self.live_objects.insert(object_id, version);
+            self.objects
+                .entry(object_id)
+                .or_default()
+                .insert(version, object);
+        }
+    }
+}
+
+impl BackingPackageStore for InMemoryStore {
+    fn get_package_object(
+        &self,
+        package_id: &ObjectID,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        Ok(self.get_object(package_id).cloned())
+    }
+}
+
+impl ChildObjectResolver for InMemoryStore {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        let child_object = match self.get_object(child).cloned() {
+            None => return Ok(None),
+            Some(obj) => obj,
+        };
+
+        let parent = *parent;
+        if child_object.owner != Owner::ObjectOwner(parent.into()) {
+            return Err(SuiError::InvalidChildObjectAccess {
+                object: *child,
+                given_parent: parent,
+                actual_owner: child_object.owner,
+            });
+        }
+
+        if child_object.version() > child_version_upper_bound {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "TODO InMemoryStorage::read_child_object does not yet support bounded reads"
+                    .to_owned(),
+            });
+        }
+
+        Ok(Some(child_object))
+    }
+}
+
+impl GetModule for InMemoryStore {
+    type Error = SuiError;
+    type Item = CompiledModule;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(self
+            .get_module(id)?
+            .map(|bytes| CompiledModule::deserialize_with_defaults(&bytes).unwrap()))
+    }
+}
+
+impl ModuleResolver for InMemoryStore {
+    type Error = SuiError;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self
+            .get_package(&ObjectID::from(*module_id.address()))?
+            .and_then(|package| {
+                package
+                    .serialized_module_map()
+                    .get(module_id.name().as_str())
+                    .cloned()
+            }))
+    }
+}
+
+impl ObjectStore for InMemoryStore {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+        Ok(self.get_object(object_id).cloned())
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: sui_types::base_types::VersionNumber,
+    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+        Ok(self.get_object_at_version(object_id, version).cloned())
+    }
+}
+
+impl ParentSync for InMemoryStore {
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        _object_id: ObjectID,
+    ) -> sui_types::error::SuiResult<Option<sui_types::base_types::ObjectRef>> {
+        panic!("Never called in newer protocol versions")
+    }
+}
+
+#[derive(Debug)]
+pub struct KeyStore {
+    validator_keys: BTreeMap<AuthorityName, AuthorityKeyPair>,
+    #[allow(unused)]
+    account_keys: BTreeMap<SuiAddress, AccountKeyPair>,
+}
+
+impl KeyStore {
+    pub fn from_newtork_config(
+        network_config: &sui_swarm_config::network_config::NetworkConfig,
+    ) -> Self {
+        use fastcrypto::traits::KeyPair;
+
+        let validator_keys = network_config
+            .validator_configs()
+            .iter()
+            .map(|config| {
+                (
+                    config.protocol_public_key(),
+                    config.protocol_key_pair().copy(),
+                )
+            })
+            .collect();
+
+        let account_keys = network_config
+            .account_keys
+            .iter()
+            .map(|key| (key.public().into(), key.copy()))
+            .collect();
+        Self {
+            validator_keys,
+            account_keys,
+        }
+    }
+
+    pub fn validator(&self, name: &AuthorityName) -> Option<&AuthorityKeyPair> {
+        self.validator_keys.get(name)
+    }
+
+    pub fn accounts(&self) -> impl Iterator<Item = (&SuiAddress, &AccountKeyPair)> {
+        self.account_keys.iter()
+    }
+}

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -1070,7 +1070,7 @@ pub fn generate_genesis_system_object(
         builder.finish()
     };
 
-    let InnerTemporaryStore { written, .. } = executor.update_genesis_state(
+    let InnerTemporaryStore { mut written, .. } = executor.update_genesis_state(
         &*store,
         &protocol_config,
         metrics,
@@ -1078,6 +1078,16 @@ pub fn generate_genesis_system_object(
         InputObjects::new(vec![]),
         pt,
     )?;
+
+    // update the value of the clock to match the chain start time
+    {
+        let object = written.get_mut(&sui_types::SUI_CLOCK_OBJECT_ID).unwrap();
+        object
+            .data
+            .try_as_move_mut()
+            .unwrap()
+            .set_clock_timestamp_ms_unsafe(genesis_chain_parameters.chain_start_timestamp_ms);
+    }
 
     let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written);

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -898,7 +898,6 @@ fn create_genesis_objects(
     }
 
     {
-        let store = Arc::get_mut(&mut store).expect("only one reference to store");
         for object in input_objects {
             store.insert_object(object.to_owned());
         }
@@ -915,12 +914,11 @@ fn create_genesis_objects(
     )
     .unwrap();
 
-    let store = Arc::try_unwrap(store).expect("only one reference to store");
     store.into_inner().into_values().collect()
 }
 
 fn process_package(
-    store: &mut Arc<InMemoryStorage>,
+    store: &mut InMemoryStorage,
     executor: &dyn Executor,
     ctx: &mut TxContext,
     modules: &[CompiledModule],
@@ -983,14 +981,13 @@ fn process_package(
         pt,
     )?;
 
-    let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written);
 
     Ok(())
 }
 
 pub fn generate_genesis_system_object(
-    store: &mut Arc<InMemoryStorage>,
+    store: &mut InMemoryStorage,
     executor: &dyn Executor,
     genesis_validators: &[GenesisValidatorMetadata],
     genesis_ctx: &mut TxContext,
@@ -1089,7 +1086,6 @@ pub fn generate_genesis_system_object(
             .set_clock_timestamp_ms_unsafe(genesis_chain_parameters.chain_start_timestamp_ms);
     }
 
-    let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written);
 
     Ok(())

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -114,6 +114,13 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_chain_start_timestamp_ms(mut self, chain_start_timestamp_ms: u64) -> Self {
+        self.get_or_init_genesis_config()
+            .parameters
+            .chain_start_timestamp_ms = chain_start_timestamp_ms;
+        self
+    }
+
     pub fn with_objects<I: IntoIterator<Item = Object>>(mut self, objects: I) -> Self {
         self.additional_objects.extend(objects);
         self

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -1,8 +1,8 @@
 ---
-source: crates/sui-config/tests/snapshot_tests.rs
+source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.clock()
 ---
 id:
   id: "0x0000000000000000000000000000000000000000000000000000000000000006"
-timestamp_ms: 0
+timestamp_ms: 10
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -468,6 +468,11 @@ impl SuiAddress {
         AccountAddress::random().into()
     }
 
+    pub fn generate<R: rand::RngCore + rand::CryptoRng>(mut rng: R) -> Self {
+        let buf: [u8; SUI_ADDRESS_LENGTH] = rng.gen();
+        Self(buf)
+    }
+
     /// Serialize an `Option<SuiAddress>` in Hex.
     pub fn optional_address_as_hex<S>(
         key: &Option<SuiAddress>,

--- a/crates/sui-types/src/clock.rs
+++ b/crates/sui-types/src/clock.rs
@@ -24,6 +24,10 @@ pub struct Clock {
 }
 
 impl Clock {
+    pub fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
     pub fn type_() -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -211,10 +211,25 @@ pub mod checked {
     impl std::fmt::Display for GasCostSummary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(
-            f,
-            "computation_cost: {}, storage_cost: {},  storage_rebate: {}, non_refundable_storage_fee: {}",
-            self.computation_cost, self.storage_cost, self.storage_rebate, self.non_refundable_storage_fee,
-        )
+                f,
+                "computation_cost: {}, storage_cost: {},  storage_rebate: {}, non_refundable_storage_fee: {}",
+                self.computation_cost, self.storage_cost, self.storage_rebate, self.non_refundable_storage_fee,
+            )
+        }
+    }
+
+    impl std::ops::AddAssign<&Self> for GasCostSummary {
+        fn add_assign(&mut self, other: &Self) {
+            self.computation_cost += other.computation_cost;
+            self.storage_cost += other.storage_cost;
+            self.storage_rebate += other.storage_rebate;
+            self.non_refundable_storage_fee += other.non_refundable_storage_fee;
+        }
+    }
+
+    impl std::ops::AddAssign<Self> for GasCostSummary {
+        fn add_assign(&mut self, other: Self) {
+            self.add_assign(&other)
         }
     }
 

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -14,7 +14,6 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 // TODO: We should use AuthorityTemporaryStore instead.
 // Keeping this functionally identical to AuthorityTemporaryStore is a pain.
@@ -148,12 +147,12 @@ impl GetModule for InMemoryStorage {
 }
 
 impl InMemoryStorage {
-    pub fn new(objects: Vec<Object>) -> Arc<Self> {
+    pub fn new(objects: Vec<Object>) -> Self {
         let mut persistent = BTreeMap::new();
         for o in objects {
             persistent.insert(o.id(), o);
         }
-        Arc::new(Self { persistent })
+        Self { persistent }
     }
 
     pub fn get_object(&self, id: &ObjectID) -> Option<&Object> {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -358,6 +358,27 @@ impl CheckpointContents {
         })
     }
 
+    pub fn new_with_causally_ordered_execution_data<'a, T>(contents: T) -> Self
+    where
+        T: IntoIterator<Item = &'a VerifiedExecutionData>,
+    {
+        let (transactions, user_signatures): (Vec<_>, Vec<_>) = contents
+            .into_iter()
+            .map(|data| {
+                (
+                    data.digests(),
+                    data.transaction.inner().data().tx_signatures().to_owned(),
+                )
+            })
+            .unzip();
+        assert_eq!(transactions.len(), user_signatures.len());
+        Self::V1(CheckpointContentsV1 {
+            digest: Default::default(),
+            transactions,
+            user_signatures,
+        })
+    }
+
     fn as_v1(&self) -> &CheckpointContentsV1 {
         match self {
             Self::V1(v) => v,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -217,7 +217,9 @@ impl MoveObject {
     }
 
     /// Update the `timestamp_ms: u64` field of the `Clock` type.
-    pub fn set_clock_timestamp_ms(&mut self, timestamp_ms: u64) {
+    ///
+    /// Panics if the object isn't a `Clock`.
+    pub fn set_clock_timestamp_ms_unsafe(&mut self, timestamp_ms: u64) {
         assert!(self.is_clock());
         // 32 bytes for object ID, 8 for timestamp
         assert!(self.contents.len() == 40);

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -216,8 +216,22 @@ impl MoveObject {
         self.contents.splice(ID_END_INDEX.., value.to_le_bytes());
     }
 
+    /// Update the `timestamp_ms: u64` field of the `Clock` type.
+    pub fn set_clock_timestamp_ms(&mut self, timestamp_ms: u64) {
+        assert!(self.is_clock());
+        // 32 bytes for object ID, 8 for timestamp
+        assert!(self.contents.len() == 40);
+
+        self.contents
+            .splice(ID_END_INDEX.., timestamp_ms.to_le_bytes());
+    }
+
     pub fn is_coin(&self) -> bool {
         self.type_.is_coin()
+    }
+
+    pub fn is_clock(&self) -> bool {
+        self.type_.is(&crate::clock::Clock::type_())
     }
 
     pub fn version(&self) -> SequenceNumber {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -359,6 +359,10 @@ impl MoveObject {
         self.to_move_struct(&self.get_layout(format, resolver)?)
     }
 
+    pub fn to_rust<'de, T: Deserialize<'de>>(&'de self) -> Option<T> {
+        bcs::from_bytes(self.contents()).ok()
+    }
+
     /// Approximate size of the object in bytes. This is used for gas metering.
     /// For the type tag field, we serialize it on the spot to get the accurate size.
     /// This should not be very expensive since the type tag is usually simple, and
@@ -905,6 +909,10 @@ impl Object {
         // Index access safe due to checks above.
         let type_tag = move_struct.type_params[0].clone();
         Ok(type_tag)
+    }
+
+    pub fn to_rust<'de, T: Deserialize<'de>>(&'de self) -> Option<T> {
+        self.data.try_as_move().and_then(|data| data.to_rust())
     }
 }
 


### PR DESCRIPTION
This patch adds a new crate `simulacrum` which contains tooling for
creating an instance of a Sui Blockchain that is fully simulated. In
other words it is a chain that only advances state when explicitly
cranked. The intent of this is to enable producing fully deterministic
chain states for testing of downstream applications or for smart
contract developers that want a cheap, local development environment
without needing to spin up full consensus.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
