### PR TITLE
[EffectsV2 2/n] Record modified object ids only in execution results

### DIFF
--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -87,9 +87,9 @@ pub struct ExecutionResultsV1 {
 pub struct ExecutionResultsV2 {
     /// All objects written regardless of whether they were mutated, created, or unwrapped.
     pub written_objects: BTreeMap<ObjectID, Object>,
-    /// All objects loaded with the intention to be modified, with their original sequence number and digest.
-    /// If any object is not found in written_objects, they must be either deleted or wrapped.
-    pub objects_modified_at: BTreeMap<ObjectID, (SequenceNumber, ObjectDigest, Owner)>,
+    /// All objects that existed prior to this transaction, and are modified in this transaction.
+    /// This includes any type of modification, including mutated, wrapped and deleted objects.
+    pub modified_objects: BTreeSet<ObjectID>,
     /// All object IDs created in this transaction.
     pub created_object_ids: BTreeSet<ObjectID>,
     /// All object IDs deleted in this transaction.
@@ -97,7 +97,6 @@ pub struct ExecutionResultsV2 {
     pub deleted_object_ids: BTreeSet<ObjectID>,
     /// All Move events emitted in this transaction.
     pub user_events: Vec<Event>,
-    // TODO: capture loaded child objects if we want to.
 }
 
 #[derive(Clone, Debug)]
@@ -106,7 +105,6 @@ pub struct InputObjectMetadata {
     pub is_mutable_input: bool,
     pub owner: Owner,
     pub version: SequenceNumber,
-    pub digest: ObjectDigest,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -578,7 +578,7 @@ mod checked {
                     object_metadata: Some(InputObjectMetadata {
                         // We are only interested in mutable inputs.
                         is_mutable_input: true,
-                        id, owner, version, digest,
+                        id, version, owner,
                     }),
                     inner: ResultValue { value, .. },
                 } = input else {
@@ -588,8 +588,6 @@ mod checked {
                     id,
                     LoadedRuntimeObject {
                         version,
-                        digest,
-                        owner,
                         is_modified: true,
                     },
                 );
@@ -783,13 +781,9 @@ mod checked {
 
             Ok(ExecutionResults::V2(ExecutionResultsV2 {
                 written_objects,
-                objects_modified_at: loaded_runtime_objects
+                modified_objects: loaded_runtime_objects
                     .into_iter()
-                    .filter_map(|(id, loaded)| {
-                        loaded
-                            .is_modified
-                            .then_some((id, (loaded.version, loaded.digest, loaded.owner)))
-                    })
+                    .filter_map(|(id, loaded)| loaded.is_modified.then_some(id))
                     .collect(),
                 created_object_ids: created_object_ids.into_iter().map(|(id, _)| id).collect(),
                 deleted_object_ids: deleted_object_ids.into_iter().map(|(id, _)| id).collect(),
@@ -1130,7 +1124,6 @@ mod checked {
             is_mutable_input,
             owner,
             version,
-            digest: obj.digest(),
         };
         let obj_value = value_from_object(vm, session, obj)?;
         let contained_uids = {

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -34,7 +34,6 @@ use sui_types::{
 pub(crate) mod object_store;
 
 use object_store::ChildObjectStore;
-use sui_types::base_types::ObjectDigest;
 
 use self::object_store::{ChildObjectEffect, ObjectResult};
 
@@ -65,8 +64,6 @@ pub(crate) struct TestInventories {
 
 pub struct LoadedRuntimeObject {
     pub version: SequenceNumber,
-    pub digest: ObjectDigest,
-    pub owner: Owner,
     pub is_modified: bool,
 }
 
@@ -293,7 +290,7 @@ impl<'a> ObjectRuntime<'a> {
         let transfer_result = if self.state.new_ids.contains_key(&id) {
             TransferResult::New
         } else if is_framework_obj {
-            // framework objects are always created when they are transfered, but the id is
+            // framework objects are always created when they are transferred, but the id is
             // hard-coded so it is not yet in new_ids
             self.state.new_ids.insert(id, ());
             TransferResult::New
@@ -463,8 +460,6 @@ impl ObjectRuntimeState {
                     id,
                     LoadedRuntimeObject {
                         version: metadata.version,
-                        digest: metadata.digest,
-                        owner: metadata.owner,
                         is_modified: false,
                     },
                 )

--- a/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/suivm/sui-adapter/src/programmable_transactions/context.rs
@@ -569,7 +569,7 @@ mod checked {
                     object_metadata: Some(InputObjectMetadata {
                         // We are only interested in mutable inputs.
                         is_mutable_input: true,
-                        id, owner, version, digest,
+                        id, owner, version,
                     }),
                     inner: ResultValue { value, .. },
                 } = input else {
@@ -579,8 +579,6 @@ mod checked {
                     id,
                     LoadedRuntimeObject {
                         version,
-                        digest,
-                        owner,
                         is_modified: true,
                     },
                 );
@@ -748,13 +746,9 @@ mod checked {
 
             Ok(ExecutionResults::V2(ExecutionResultsV2 {
                 written_objects,
-                objects_modified_at: loaded_runtime_objects
+                modified_objects: loaded_runtime_objects
                     .into_iter()
-                    .filter_map(|(id, loaded)| {
-                        loaded
-                            .is_modified
-                            .then_some((id, (loaded.version, loaded.digest, loaded.owner)))
-                    })
+                    .filter_map(|(id, loaded)| loaded.is_modified.then_some(id))
                     .collect(),
                 created_object_ids: created_object_ids.into_iter().map(|(id, _)| id).collect(),
                 deleted_object_ids: deleted_object_ids.into_iter().map(|(id, _)| id).collect(),
@@ -1129,7 +1123,6 @@ mod checked {
             is_mutable_input,
             owner,
             version,
-            digest: obj.digest(),
         };
         let obj_value = value_from_object(vm, linkage_view, new_packages, obj)?;
         let contained_uids = {

--- a/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/suivm/sui-move-natives/src/object_runtime/mod.rs
@@ -34,7 +34,6 @@ use sui_types::{
 pub(crate) mod object_store;
 
 use object_store::ChildObjectStore;
-use sui_types::base_types::ObjectDigest;
 
 use self::object_store::{ChildObjectEffect, ObjectResult};
 
@@ -65,8 +64,6 @@ pub(crate) struct TestInventories {
 
 pub struct LoadedRuntimeObject {
     pub version: SequenceNumber,
-    pub digest: ObjectDigest,
-    pub owner: Owner,
     pub is_modified: bool,
 }
 
@@ -450,8 +447,6 @@ impl ObjectRuntimeState {
                     id,
                     LoadedRuntimeObject {
                         version: metadata.version,
-                        digest: metadata.digest,
-                        owner: metadata.owner,
                         is_modified: false,
                     },
                 )

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -1181,7 +1181,6 @@ mod checked {
             is_mutable_input,
             owner,
             version,
-            digest: obj.digest(),
         };
         let obj_value = value_from_object(vm, session, obj)?;
         let contained_uids = {


### PR DESCRIPTION
## Description 

In the current implementation, we track the input object metadata at runtime, including object digest. Then in the end, we put that information in objects_modified_at, which we could use to get the old object information in effects v2.
There are two issues with this approach:
1. These information are somewhat redundant to what we already have and record in mutable inputs and loaded child objects. Having another copy is inefficient and leaves space for mistakes.
2. In fact, the object digest in the input object metadata is not guaranteed to be the same as the original input object digest, since we may be smashing gas prior to entering PT. So it's actually incorrect to use that information.

This PR simplifies the modified_at in execution results to just modified_objects as a list of IDs.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
