### PR TITLE
wallet-ext: only show the faucet button when account is unlocked

### DIFF
--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -4,7 +4,7 @@
 import { requestSuiFromFaucetV0 } from '@mysten/sui.js/faucet';
 import { useIsMutating, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 
-import { useActiveAddress } from '../../hooks/useActiveAddress';
+import { useActiveAccount } from '../../hooks/useActiveAccount';
 
 type UseFaucetMutationOptions = Pick<UseMutationOptions, 'onError'> & {
 	host: string | null;
@@ -12,7 +12,8 @@ type UseFaucetMutationOptions = Pick<UseMutationOptions, 'onError'> & {
 };
 
 export function useFaucetMutation(options?: UseFaucetMutationOptions) {
-	const activeAddress = useActiveAddress();
+	const activeAccount = useActiveAccount();
+	const activeAddress = activeAccount?.address || null;
 	const addressToTopUp = options?.address || activeAddress;
 	const mutationKey = ['faucet-request-tokens', activeAddress];
 	const mutation = useMutation({
@@ -39,8 +40,8 @@ export function useFaucetMutation(options?: UseFaucetMutationOptions) {
 	});
 	return {
 		...mutation,
-		/** If the currently-configured endpoint supports faucet: */
-		enabled: !!options?.host,
+		/** If the currently-configured endpoint supports faucet and the active account is unlocked */
+		enabled: !!options?.host && !!activeAccount && !activeAccount.isLocked,
 		/**
 		 * is any faucet request in progress across different instances of the mutation
 		 */


### PR DESCRIPTION
## Description 

before

https://github.com/MystenLabs/sui/assets/10210143/9f0273b7-eff7-4536-8af6-f85f4780bd00

after


https://github.com/MystenLabs/sui/assets/10210143/e2cef14c-3289-485f-a689-f3812b7a0d1c

closes APPS-1628


## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
