### PR TITLE
[move-compiler] Print request for linter feedback if linter warnings present

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -222,8 +222,9 @@ impl BuildConfig {
 
 fn report_linter_warnings(report: bool) -> anyhow::Result<()> {
     if report {
-        if let Err(err) = std::io::stderr().write_all(
-            b"Please report feedback on the linter warnings at https://forums.sui.io\n\n",
+        if let Err(err) = writeln!(
+            &mut std::io::stderr(),
+            "Please report feedback on the linter warnings at https://forums.sui.io\n"
         ) {
             anyhow::bail!("Cannot report linter warnings feedback info: {}", err);
         }

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -156,9 +156,9 @@ impl BuildConfig {
             };
             match units_res {
                 Ok((units, warning_diags)) => {
-                    let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
+                    let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX1);
                     report_warnings(&files, warning_diags);
-                    report_linter_warnings(any_linter_warnings)?;
+                    report_linter_feedback_info(any_linter_warnings)?;
                     fn_info = Some(Self::fn_info(&units));
                     Ok((files, units))
                 }
@@ -169,7 +169,7 @@ impl BuildConfig {
                     if let Err(err) = std::io::stderr().write_all(&diags_buf) {
                         anyhow::bail!("Cannot output compiler diagnostics: {}", err);
                     }
-                    report_linter_warnings(any_linter_warnings)?;
+                    report_linter_feedback_info(any_linter_warnings)?;
                     anyhow::bail!("Compilation error");
                 }
             }
@@ -220,7 +220,7 @@ impl BuildConfig {
     }
 }
 
-fn report_linter_warnings(report: bool) -> anyhow::Result<()> {
+fn report_linter_feedback_info(report: bool) -> anyhow::Result<()> {
     if report {
         if let Err(err) = writeln!(
             &mut std::io::stderr(),

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -158,7 +158,9 @@ impl BuildConfig {
                 Ok((units, warning_diags)) => {
                     let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
                     report_warnings(&files, warning_diags);
-                    report_linter_feedback_info(any_linter_warnings)?;
+                    if any_linter_warnings {
+                        eprintln!("Please report feedback on the linter warnings at https://forums.sui.io\n");
+                    }
                     fn_info = Some(Self::fn_info(&units));
                     Ok((files, units))
                 }
@@ -169,7 +171,9 @@ impl BuildConfig {
                     if let Err(err) = std::io::stderr().write_all(&diags_buf) {
                         anyhow::bail!("Cannot output compiler diagnostics: {}", err);
                     }
-                    report_linter_feedback_info(any_linter_warnings)?;
+                    if any_linter_warnings {
+                        eprintln!("Please report feedback on the linter warnings at https://forums.sui.io\n");
+                    }
                     anyhow::bail!("Compilation error");
                 }
             }
@@ -218,18 +222,6 @@ impl BuildConfig {
             error: format!("{:?}", err),
         })
     }
-}
-
-fn report_linter_feedback_info(report: bool) -> anyhow::Result<()> {
-    if report {
-        if let Err(err) = writeln!(
-            &mut std::io::stderr(),
-            "Please report feedback on the linter warnings at https://forums.sui.io\n"
-        ) {
-            anyhow::bail!("Cannot report linter warnings feedback info: {}", err);
-        }
-    }
-    Ok(())
 }
 
 pub fn build_from_resolution_graph(

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -156,7 +156,7 @@ impl BuildConfig {
             };
             match units_res {
                 Ok((units, warning_diags)) => {
-                    let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX1);
+                    let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
                     report_warnings(&files, warning_diags);
                     report_linter_feedback_info(any_linter_warnings)?;
                     fn_info = Some(Self::fn_info(&units));

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -288,6 +288,12 @@ impl Diagnostics {
         }
         v
     }
+
+    pub fn any_with_prefix(&self, prefix: &str) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|d| d.info.external_prefix() == Some(prefix))
+    }
 }
 
 impl Diagnostic {


### PR DESCRIPTION
## Description 

We would like to present to the developer a place where they could provide feedback on the available linters, with the information about how to report feedback being immediately available whenever the linter warnings are generated

## Test Plan 

All existing tests must pass plus manually tested that the message gets printed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

When linter warnings get generated, information about a place where the feedback on linters can be provided will be printed alongside the warning messages.