### PR TITLE
executor: simplify interface

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1199,7 +1199,7 @@ impl AuthorityState {
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (inner_temp_store, effects, execution_error_opt) =
             epoch_store.executor().execute_transaction_to_effects(
-                self.database.clone(),
+                &self.database,
                 protocol_config,
                 self.metrics.limits_metrics.clone(),
                 // TODO: would be nice to pass the whole NodeConfig here, but it creates a
@@ -1300,7 +1300,7 @@ impl AuthorityState {
         let expensive_checks = false;
         let (inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
-                self.database.clone(),
+                &self.database,
                 protocol_config,
                 self.metrics.limits_metrics.clone(),
                 expensive_checks,
@@ -1420,7 +1420,7 @@ impl AuthorityState {
         .expect("Creating an executor should not fail here");
         let expensive_checks = false;
         let (inner_temp_store, effects, execution_result) = executor.dev_inspect_transaction(
-            self.database.clone(),
+            &self.database,
             protocol_config,
             self.metrics.limits_metrics.clone(),
             expensive_checks,

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -832,7 +832,7 @@ fn create_genesis_transaction(
         let input_objects = InputObjects::new(vec![]);
         let (inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
-                InMemoryStorage::new(Vec::new()),
+                &InMemoryStorage::new(Vec::new()),
                 protocol_config,
                 metrics,
                 expensive_checks,
@@ -978,7 +978,7 @@ fn process_package(
         builder.finish()
     };
     let InnerTemporaryStore { written, .. } = executor.update_genesis_state(
-        store.clone(),
+        &*store,
         protocol_config,
         metrics,
         ctx,
@@ -1074,7 +1074,7 @@ pub fn generate_genesis_system_object(
     };
 
     let InnerTemporaryStore { written, .. } = executor.update_genesis_state(
-        store.clone(),
+        &*store,
         &protocol_config,
         metrics,
         genesis_ctx,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -663,13 +663,6 @@ impl LocalExec {
         Ok((succeeded, num as u64))
     }
 
-    // TODO: Could we get rid of this strange self move?
-    #[allow(clippy::wrong_self_convention, clippy::redundant_allocation)]
-    fn to_backing_store(&mut self) -> Arc<&mut LocalExec> {
-        // Execution interface requires Arc for the store.
-        Arc::new(self)
-    }
-
     pub async fn execution_engine_execute_with_tx_info_impl(
         &mut self,
         tx_info: &OnChainTransactionInfo,
@@ -727,12 +720,11 @@ impl LocalExec {
         // All prep done
         let expensive_checks = true;
         let certificate_deny_set = HashSet::new();
-        let store = self.to_backing_store();
         let res = if let Ok(gas_status) =
             SuiGasStatus::new(tx_info.gas_budget, tx_info.gas_price, rgp, protocol_config)
         {
             executor.execute_transaction_to_effects(
-                store,
+                &self,
                 protocol_config,
                 metrics,
                 expensive_checks,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -408,7 +408,7 @@ mod test {
 
         let (_inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(
-                InMemoryStorage::new(Vec::new()),
+                &InMemoryStorage::new(Vec::new()),
                 &protocol_config,
                 metrics,
                 expensive_checks,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -90,8 +90,8 @@ mod checked {
     }
 
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-    pub fn execute_transaction_to_effects<Mode: ExecutionMode, 'backing>(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
         input_objects: InputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -215,7 +215,7 @@ mod checked {
     }
 
     pub fn execute_genesis_state_update(
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -9,7 +9,6 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -43,7 +42,7 @@ pub struct TemporaryStore<'backing> {
     // in the input objects. They will be fetched from the backing store.
     // Also used for fetching the backing parent_sync to get the last known version for wrapped
     // objects
-    store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
@@ -71,7 +70,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Creates a new store associated with an authority store, and populates it with
     /// initial objects.
     pub fn new(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &'backing dyn BackingStore,
         input_objects: InputObjects,
         tx_digest: TransactionDigest,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -21,9 +21,9 @@ use sui_types::{
 
 /// Abstracts over access to the VM across versions of the execution layer.
 pub trait Executor {
-    fn execute_transaction_to_effects<'backing>(
+    fn execute_transaction_to_effects(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
@@ -49,7 +49,7 @@ pub trait Executor {
 
     fn dev_inspect_transaction(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
@@ -75,7 +75,7 @@ pub trait Executor {
 
     fn update_genesis_state(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         // Configuration
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -75,9 +75,9 @@ impl<'m> Verifier<'m> {
 }
 
 impl executor::Executor for Executor {
-    fn execute_transaction_to_effects<'backing>(
+    fn execute_transaction_to_effects(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -115,7 +115,7 @@ impl executor::Executor for Executor {
 
     fn dev_inspect_transaction(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -153,7 +153,7 @@ impl executor::Executor for Executor {
 
     fn update_genesis_state(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,

--- a/sui-execution/src/suivm.rs
+++ b/sui-execution/src/suivm.rs
@@ -75,9 +75,9 @@ impl<'m> Verifier<'m> {
 }
 
 impl executor::Executor for Executor {
-    fn execute_transaction_to_effects<'backing>(
+    fn execute_transaction_to_effects(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -115,7 +115,7 @@ impl executor::Executor for Executor {
 
     fn dev_inspect_transaction(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -153,7 +153,7 @@ impl executor::Executor for Executor {
 
     fn update_genesis_state(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -75,9 +75,9 @@ impl<'m> Verifier<'m> {
 }
 
 impl executor::Executor for Executor {
-    fn execute_transaction_to_effects<'backing>(
+    fn execute_transaction_to_effects(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -115,7 +115,7 @@ impl executor::Executor for Executor {
 
     fn dev_inspect_transaction(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
@@ -153,7 +153,7 @@ impl executor::Executor for Executor {
 
     fn update_genesis_state(
         &self,
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,

--- a/sui-execution/suivm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/suivm/sui-adapter/src/execution_engine.rs
@@ -85,8 +85,8 @@ mod checked {
     }
 
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-    pub fn execute_transaction_to_effects<Mode: ExecutionMode, 'backing>(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
         input_objects: InputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -209,7 +209,7 @@ mod checked {
     }
 
     pub fn execute_genesis_state_update(
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,

--- a/sui-execution/suivm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/suivm/sui-adapter/src/temporary_store.rs
@@ -9,7 +9,6 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -43,7 +42,7 @@ pub struct TemporaryStore<'backing> {
     // in the input objects. They will be fetched from the backing store.
     // Also used for fetching the backing parent_sync to get the last known version for wrapped
     // objects
-    store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
@@ -71,7 +70,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Creates a new store associated with an authority store, and populates it with
     /// initial objects.
     pub fn new(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &'backing dyn BackingStore,
         input_objects: InputObjects,
         tx_digest: TransactionDigest,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -85,8 +85,8 @@ mod checked {
     }
 
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-    pub fn execute_transaction_to_effects<Mode: ExecutionMode, 'backing>(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
         input_objects: InputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -209,7 +209,7 @@ mod checked {
     }
 
     pub fn execute_genesis_state_update(
-        store: Arc<dyn BackingStore + Send + Sync>,
+        store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -9,7 +9,6 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -43,7 +42,7 @@ pub struct TemporaryStore<'backing> {
     // in the input objects. They will be fetched from the backing store.
     // Also used for fetching the backing parent_sync to get the last known version for wrapped
     // objects
-    store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+    store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
     input_objects: BTreeMap<ObjectID, Object>,
     /// The version to assign to all objects written by the transaction using this store.
@@ -71,7 +70,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// Creates a new store associated with an authority store, and populates it with
     /// initial objects.
     pub fn new(
-        store: Arc<dyn BackingStore + Send + Sync + 'backing>,
+        store: &'backing dyn BackingStore,
         input_objects: InputObjects,
         tx_digest: TransactionDigest,
         protocol_config: &ProtocolConfig,


### PR DESCRIPTION
## Description 

This simplifies the executor interface, removing the need for the backing store to be an Arc and removes the lifetime from the interface

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
