### PR TITLE
[move-compiler] Added basic stats about suppressed linters

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -158,12 +158,14 @@ impl BuildConfig {
                 Ok((units, warning_diags)) => {
                     let any_linter_warnings = warning_diags.any_with_prefix(LINT_WARNING_PREFIX);
                     let (filtered_diags_num, filtered_categories) =
-                        warning_diags.filtered_user_diags_with_prefix(LINT_WARNING_PREFIX);
+                        warning_diags.filtered_source_diags_with_prefix(LINT_WARNING_PREFIX);
                     report_warnings(&files, warning_diags);
                     if any_linter_warnings {
                         eprintln!("Please report feedback on the linter warnings at https://forums.sui.io\n");
                     }
-                    report_suppressed_linter_warnings(filtered_diags_num, filtered_categories)?;
+                    if filtered_diags_num > 0 {
+                        eprintln!("Total number of linter warnings suppressed: {filtered_diags_num} (filtered categories: {filtered_categories})");
+                    }
                     fn_info = Some(Self::fn_info(&units));
                     Ok((files, units))
                 }
@@ -171,7 +173,7 @@ impl BuildConfig {
                     assert!(!error_diags.is_empty());
                     let any_linter_warnings = error_diags.any_with_prefix(LINT_WARNING_PREFIX);
                     let (filtered_diags_num, filtered_categories) =
-                        error_diags.filtered_user_diags_with_prefix(LINT_WARNING_PREFIX);
+                        error_diags.filtered_source_diags_with_prefix(LINT_WARNING_PREFIX);
                     let diags_buf = report_diagnostics_to_color_buffer(&files, error_diags);
                     if let Err(err) = std::io::stderr().write_all(&diags_buf) {
                         anyhow::bail!("Cannot output compiler diagnostics: {}", err);
@@ -179,7 +181,9 @@ impl BuildConfig {
                     if any_linter_warnings {
                         eprintln!("Please report feedback on the linter warnings at https://forums.sui.io\n");
                     }
-                    report_suppressed_linter_warnings(filtered_diags_num, filtered_categories)?;
+                    if filtered_diags_num > 0 {
+                        eprintln!("Total number of linter warnings suppressed: {filtered_diags_num} (filtered categories: {filtered_categories})");
+                    }
                     anyhow::bail!("Compilation error");
                 }
             }
@@ -228,21 +232,6 @@ impl BuildConfig {
             error: format!("{:?}", err),
         })
     }
-}
-
-fn report_suppressed_linter_warnings(
-    filtered_diags_num: usize,
-    filtered_categories: usize,
-) -> anyhow::Result<()> {
-    if filtered_diags_num > 0 {
-        if let Err(err) = writeln!(
-            &mut std::io::stderr(),
-            "Total number of linter warnings suppressed: {filtered_diags_num} (filtered categories: {filtered_categories})\n"
-        ) {
-            anyhow::bail!("Cannot report linter warnings suppression info: {}", err);
-        }
-    }
-    Ok(())
 }
 
 pub fn build_from_resolution_graph(

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2042,3 +2042,18 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
 
     Ok(())
 }
+
+#[test]
+fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
+    let mut cmd = assert_cmd::Command::cargo_bin("sui").unwrap();
+    let args = vec!["move", "test", "--lint", "--path", "tests/data/linter"];
+    let output = cmd
+        .args(&args)
+        .output()
+        .expect("failed to run 'sui move test'");
+    let out_str = str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        out_str.contains("Total number of linter warnings suppressed: 5 (filtered categories: 3)")
+    );
+    Ok(())
+}

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2043,8 +2043,8 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
     Ok(())
 }
 
-#[test]
-fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
+#[tokio::test]
+async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
     let mut cmd = assert_cmd::Command::cargo_bin("sui").unwrap();
     let args = vec!["move", "test", "--lint", "--path", "tests/data/linter"];
     let output = cmd

--- a/crates/sui/tests/data/linter/Move.toml
+++ b/crates/sui/tests/data/linter/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "linter"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+linter = "0x0"

--- a/crates/sui/tests/data/linter/sources/suppression_stats.move
+++ b/crates/sui/tests/data/linter/sources/suppression_stats.move
@@ -1,0 +1,25 @@
+#[lint_allow(custom_state_change)]
+module linter::suppression_stats {
+    use sui::object::UID;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    #[allow(unused_field)]
+    struct S1 has key, store {
+        id: UID
+    }
+
+    #[lint_allow(self_transfer)]
+    public fun custom_transfer_bad(o: S1, ctx: &mut TxContext) {
+        transfer::transfer(o, tx_context::sender(ctx))
+    }
+
+    #[lint_allow(share_owned)]
+    public fun custom_share_bad(o: S1) {
+        transfer::share_object(o)
+    }
+
+    public fun custom_freeze_bad(o: S1) {
+        transfer::freeze_object(o)
+    }
+}

--- a/crates/sui/tests/data/linter/sources/suppression_stats.move
+++ b/crates/sui/tests/data/linter/sources/suppression_stats.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[lint_allow(custom_state_change)]
 module linter::suppression_stats {
     use sui::object::UID;

--- a/crates/sui/tests/data/linter/sources/suppression_stats.move
+++ b/crates/sui/tests/data/linter/sources/suppression_stats.move
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// This file is used to test linter suppression stats output (the test itself is part of CLI tests
+// in the sui crate)
+
 #[lint_allow(custom_state_change)]
 module linter::suppression_stats {
     use sui::object::UID;

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -57,16 +57,17 @@ pub struct Diagnostic {
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
 pub struct Diagnostics {
     diagnostics: Vec<Diagnostic>,
-    // diagnostics filtered in user code
-    filtered_user_diagnostics: Vec<Diagnostic>,
+    // diagnostics filtered in source code
+    filtered_source_diagnostics: Vec<Diagnostic>,
     severity_count: BTreeMap<Severity, usize>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-/// Used to filter out diagnostics, specifically used for warning suppression. The second field
-/// determines if this filter was created to filter warnings in the user code (false) or library
-/// code (true).
-pub struct WarningFilters(BTreeMap<ExternalPrefix, UnprefixedWarningFilters>, bool);
+/// Used to filter out diagnostics, specifically used for warning suppression
+pub struct WarningFilters {
+    filters: BTreeMap<ExternalPrefix, UnprefixedWarningFilters>,
+    for_dependency: bool, // if false, the filters are used for source code
+}
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 /// Filters split by category and code
@@ -218,7 +219,7 @@ impl Diagnostics {
     pub fn new() -> Self {
         Self {
             diagnostics: vec![],
-            filtered_user_diagnostics: vec![],
+            filtered_source_diagnostics: vec![],
             severity_count: BTreeMap::new(),
         }
     }
@@ -250,14 +251,14 @@ impl Diagnostics {
         }
     }
 
-    pub fn add_user_filtered(&mut self, diag: Diagnostic) {
-        self.filtered_user_diagnostics.push(diag)
+    pub fn add_source_filtered(&mut self, diag: Diagnostic) {
+        self.filtered_source_diagnostics.push(diag)
     }
 
     pub fn extend(&mut self, other: Self) {
         let Self {
             diagnostics,
-            filtered_user_diagnostics: _,
+            filtered_source_diagnostics: _,
             severity_count,
         } = other;
         for (sev, count) in severity_count {
@@ -305,13 +306,13 @@ impl Diagnostics {
             .any(|d| d.info.external_prefix() == Some(prefix))
     }
 
-    /// Returns the number of diags filtered in user code (an not in the library code) that have a
-    /// given prefix (first value returned) and how many different categories of diags were
+    /// Returns the number of diags filtered in source (user) code (an not in the dependencies) that
+    /// have a given prefix (first value returned) and how many different categories of diags were
     /// filtered.
-    pub fn filtered_user_diags_with_prefix(&self, prefix: &str) -> (usize, usize) {
+    pub fn filtered_source_diags_with_prefix(&self, prefix: &str) -> (usize, usize) {
         let mut filtered_diags_num = 0;
         let mut filtered_categories = HashSet::new();
-        self.filtered_user_diagnostics.iter().for_each(|d| {
+        self.filtered_source_diagnostics.iter().for_each(|d| {
             if d.info.external_prefix() == Some(prefix) {
                 filtered_diags_num += 1;
                 filtered_categories.insert(d.info.category());
@@ -404,12 +405,18 @@ macro_rules! diag {
 }
 
 impl WarningFilters {
-    pub fn new() -> Self {
-        Self(BTreeMap::new(), false)
+    pub fn new_for_source() -> Self {
+        Self {
+            filters: BTreeMap::new(),
+            for_dependency: false,
+        }
     }
 
-    pub fn new_for_lib_code() -> Self {
-        Self(BTreeMap::new(), true)
+    pub fn new_for_dependency() -> Self {
+        Self {
+            filters: BTreeMap::new(),
+            for_dependency: true,
+        }
     }
 
     pub fn is_filtered(&self, diag: &Diagnostic) -> bool {
@@ -418,29 +425,28 @@ impl WarningFilters {
 
     fn is_filtered_by_info(&self, info: &DiagnosticInfo) -> bool {
         let prefix = info.external_prefix();
-        self.0
+        self.filters
             .get(&prefix)
             .is_some_and(|filters| filters.is_filtered_by_info(info))
     }
 
     pub fn union(&mut self, other: &Self) {
-        for (prefix, filters) in &other.0 {
-            self.0
+        for (prefix, filters) in &other.filters {
+            self.filters
                 .entry(*prefix)
                 .or_insert_with(UnprefixedWarningFilters::new)
                 .union(filters);
         }
-        // if there is a library code filter on the stack (second field of `WarningFilters` is
-        // true), it means we are filtering library code and this information must be preserved when
-        // stacking up additional filters (which involves union of the current filter with the new
-        // one)
-        self.1 = self.1 || other.1;
+        // if there is a dependency code filter on the stack, it means we are filtering dependent
+        // code and this information must be preserved when stacking up additional filters (which
+        // involves union of the current filter with the new one)
+        self.for_dependency = self.for_dependency || other.for_dependency;
     }
 
     pub fn add(&mut self, filter: WarningFilter) {
         let (prefix, category, code, name) = match filter {
             WarningFilter::All(prefix) => {
-                self.0.insert(prefix, UnprefixedWarningFilters::All);
+                self.filters.insert(prefix, UnprefixedWarningFilters::All);
                 return;
             }
             WarningFilter::Category {
@@ -455,24 +461,24 @@ impl WarningFilters {
                 name,
             } => (prefix, category, Some(code), name),
         };
-        self.0
+        self.filters
             .entry(prefix)
             .or_insert(UnprefixedWarningFilters::Empty)
             .add(category, code, name)
     }
 
     pub fn unused_warnings_filter_for_test() -> Self {
-        Self(
-            BTreeMap::from([(
+        Self {
+            filters: BTreeMap::from([(
                 None,
                 UnprefixedWarningFilters::unused_warnings_filter_for_test(),
             )]),
-            /* for_lib_code */ false,
-        )
+            for_dependency: false,
+        }
     }
 
-    pub fn for_lib_code(&self) -> bool {
-        self.1
+    pub fn for_dependency(&self) -> bool {
+        self.for_dependency
     }
 }
 
@@ -602,7 +608,7 @@ impl From<Vec<Diagnostic>> for Diagnostics {
         }
         Self {
             diagnostics,
-            filtered_user_diagnostics: vec![],
+            filtered_source_diagnostics: vec![],
             severity_count,
         }
     }
@@ -616,7 +622,7 @@ impl From<Option<Diagnostic>> for Diagnostics {
 
 impl AstDebug for WarningFilters {
     fn ast_debug(&self, w: &mut crate::shared::ast_debug::AstWriter) {
-        for (prefix, filters) in &self.0 {
+        for (prefix, filters) in &self.filters {
             let prefix_str = prefix.unwrap_or(WARNING_FILTER_ATTR);
             match filters {
                 UnprefixedWarningFilters::All => w.write(&format!(

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -51,7 +51,7 @@ impl<'env, 'map> Context<'env, 'map> {
         compilation_env: &'env mut CompilationEnv,
         module_members: UniqueMap<ModuleIdent, ModuleMembers>,
     ) -> Self {
-        let mut all_filter_alls = WarningFilters::new_for_lib_code();
+        let mut all_filter_alls = WarningFilters::new_for_dependency();
         for allow in compilation_env.filter_attributes() {
             for f in compilation_env.filter_from_str(FILTER_ALL, *allow) {
                 all_filter_alls.add(f);
@@ -845,7 +845,7 @@ fn warning_filter(
 ) -> WarningFilters {
     use crate::diagnostics::codes::Category;
     use known_attributes::DiagnosticAttribute;
-    let mut warning_filters = WarningFilters::new();
+    let mut warning_filters = WarningFilters::new_for_source();
     let filter_attribute_names = context.env.filter_attributes().clone();
     for allow in filter_attribute_names {
         let Some(attr) = attributes.get_(&allow) else {

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -51,7 +51,7 @@ impl<'env, 'map> Context<'env, 'map> {
         compilation_env: &'env mut CompilationEnv,
         module_members: UniqueMap<ModuleIdent, ModuleMembers>,
     ) -> Self {
-        let mut all_filter_alls = WarningFilters::new();
+        let mut all_filter_alls = WarningFilters::new_for_lib_code();
         for allow in compilation_env.filter_attributes() {
             for f in compilation_env.filter_from_str(FILTER_ALL, *allow) {
                 all_filter_alls.add(f);

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -383,9 +383,9 @@ impl CompilationEnv {
                 }
             }
             self.diags.add(diag)
-        } else if !filter.unwrap().for_lib_code() {
+        } else if !filter.unwrap().for_dependency() {
             // unwrap above is safe as the filter has been used (thus it must exist)
-            self.diags.add_user_filtered(diag)
+            self.diags.add_source_filtered(diag)
         }
     }
 
@@ -693,7 +693,7 @@ impl Default for PackageConfig {
     fn default() -> Self {
         Self {
             is_dependency: false,
-            warning_filter: WarningFilters::new(),
+            warning_filter: WarningFilters::new_for_source(),
             flavor: Flavor::default(),
             edition: Edition::default(),
         }

--- a/external-crates/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -460,7 +460,7 @@ impl Package {
                 .edition
                 .or(config.default_edition)
                 .unwrap_or_default(),
-            warning_filter: WarningFilters::new(),
+            warning_filter: WarningFilters::new_for_source(),
         }
     }
 }


### PR DESCRIPTION
## Description 

This PR adds basic stats about suppressed linters in user code.

## Test Plan 

All existing tests must pass plus manually tested that the correct stats get printed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

When linter warnings in user code are suppressed, basic statistics about suppressed warnings (number of suppresed warnings and number of suppressed warning categories) will be printed.