### PR TITLE
[move][receiver syntax][1/n] Move module dependency ordering to after typing

### DIFF
--- a/external-crates/move/move-compiler/src/expansion/mod.rs
+++ b/external-crates/move/move-compiler/src/expansion/mod.rs
@@ -5,6 +5,5 @@
 mod aliases;
 pub mod ast;
 mod byte_string;
-mod dependency_ordering;
 mod hex_string;
 pub(crate) mod translate;

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -195,9 +195,9 @@ pub fn program(
             }
         }
     }
-    let mut module_map = source_module_map;
+    let module_map = source_module_map;
 
-    let mut scripts = {
+    let scripts = {
         let mut collected: BTreeMap<Symbol, Vec<E::Script>> = BTreeMap::new();
         for s in scripts {
             collected
@@ -227,7 +227,6 @@ pub fn program(
         keyed
     };
 
-    super::dependency_ordering::verify(context.env, &mut module_map, &mut scripts);
     E::Program {
         modules: module_map,
         scripts,
@@ -481,9 +480,6 @@ fn module_(
         attributes,
         loc,
         is_source_module: context.is_source_definition,
-        dependency_order: 0,
-        immediate_neighbors: UniqueMap::new(),
-        used_addresses: BTreeSet::new(),
         friends,
         structs,
         constants,
@@ -650,8 +646,6 @@ fn script_(context: &mut Context, package_name: Option<Symbol>, pscript: P::Scri
         package_name,
         attributes,
         loc,
-        immediate_neighbors: UniqueMap::new(),
-        used_addresses: BTreeSet::new(),
         constants,
         function_name,
         function,

--- a/external-crates/move/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/move-compiler/src/hlir/translate.rs
@@ -212,15 +212,19 @@ fn module(
     mdef: T::ModuleDefinition,
 ) -> (ModuleIdent, H::ModuleDefinition) {
     let T::ModuleDefinition {
+        loc: _,
         warning_filter,
         package_name,
         attributes,
         is_source_module,
         dependency_order,
+        immediate_neighbors: _,
+        used_addresses: _,
         friends,
         structs: tstructs,
         functions: tfunctions,
         constants: tconstants,
+        spec_dependencies: _,
     } = mdef;
     context.env.add_warning_filter_scope(warning_filter.clone());
     let structs = tstructs.map(|name, s| struct_def(context, name, s));
@@ -263,9 +267,12 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
         package_name,
         attributes,
         loc,
+        immediate_neighbors: _,
+        used_addresses: _,
         constants: tconstants,
         function_name,
         function: tfunction,
+        spec_dependencies: _,
     } = tscript;
     context.env.add_warning_filter_scope(warning_filter.clone());
     let constants = tconstants.map(|name, c| constant(context, name, c));

--- a/external-crates/move/move-compiler/src/typing/mod.rs
+++ b/external-crates/move/move-compiler/src/typing/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod ast;
 pub mod core;
+mod dependency_ordering;
 mod expand;
 mod globals;
 mod infinite_instantiations;

--- a/external-crates/move/move-compiler/tests/move_check/dependencies/use_cycle_2.exp
+++ b/external-crates/move/move-compiler/tests/move_check/dependencies/use_cycle_2.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/use_cycle_2.move:5:9
    │
  5 │         0x2::B::foo()
-   │         ^^^^^^^^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^^^^^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
    ·
 11 │         0x2::A::foo()
-   │         ----------- '0x2::A' uses '0x2::B'
+   │         ------------- '0x2::A' uses '0x2::B'
 

--- a/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_direct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_direct.exp
@@ -5,5 +5,5 @@ error[E02004]: invalid 'module' declaration
   │     --------- '0x2::B' is a friend of '0x2::A'
   ·
 8 │         B::b()
-  │         ^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+  │         ^^^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
 

--- a/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_friend.exp
+++ b/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_friend.exp
@@ -5,7 +5,7 @@ error[E02004]: invalid 'module' declaration
    │     --------- '0x2::B' is a friend of '0x2::A'
    ·
  9 │         C::c()
-   │         ---- '0x2::C' uses '0x2::A'
+   │         ------ '0x2::C' uses '0x2::A'
    ·
 14 │     friend 0x2::C;
    │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.

--- a/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_use.exp
+++ b/external-crates/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_use.exp
@@ -5,8 +5,8 @@ error[E02004]: invalid 'module' declaration
    │     --------- '0x2::C' is a friend of '0x2::A'
    ·
  9 │         B::b()
-   │         ---- '0x2::B' uses '0x2::A'
+   │         ------ '0x2::B' uses '0x2::A'
    ·
 16 │         C::c()
-   │         ^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
 


### PR DESCRIPTION
- With receiver syntax, we will not be able to determine immediate dependencies until after typing
- As such, module ordering must be done after typing. The logic remains the same

## Test Plan 

Internal compiler change (updated some location information for tests)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
