### PR TITLE
[dapp-kit] add new useSignAndExecuteTransactionBlock hook 

### DIFF
--- a/sdk/dapp-kit/src/constants/walletMutationKeys.ts
+++ b/sdk/dapp-kit/src/constants/walletMutationKeys.ts
@@ -9,6 +9,7 @@ export const walletMutationKeys = {
 	disconnectWallet: formMutationKeyFn('disconnect-wallet'),
 	signPersonalMessage: formMutationKeyFn('sign-personal-message'),
 	signTransactionBlock: formMutationKeyFn('sign-transaction-block'),
+	signAndExecuteTransactionBlock: formMutationKeyFn('sign-and-execute-transaction-block'),
 	switchAccount: formMutationKeyFn('switch-account'),
 };
 

--- a/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SuiSignAndExecuteTransactionBlockInput } from '@mysten/wallet-standard';
+import type { SuiSignAndExecuteTransactionBlockOutput } from '@mysten/wallet-standard';
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
+import {
+	WalletFeatureNotSupportedError,
+	WalletNoAccountSelectedError,
+	WalletNotConnectedError,
+} from '../../errors/walletErrors.js';
+import type { PartialBy } from '../../types/utilityTypes.js';
+import { useCurrentAccount } from './useCurrentAccount.js';
+import { useCurrentWallet } from './useCurrentWallet.js';
+
+type UseSignAndExecuteTransactionBlockArgs = PartialBy<
+	SuiSignAndExecuteTransactionBlockInput,
+	'account'
+>;
+type UseSignAndExecuteTransactionBlockResult = SuiSignAndExecuteTransactionBlockOutput;
+
+type UseSignAndExecuteTransactionBlockMutationOptions = Omit<
+	UseMutationOptions<
+		UseSignAndExecuteTransactionBlockResult,
+		WalletFeatureNotSupportedError | WalletNoAccountSelectedError | WalletNotConnectedError | Error,
+		UseSignAndExecuteTransactionBlockArgs,
+		unknown
+	>,
+	'mutationFn'
+>;
+
+/**
+ * Mutation hook for prompting the user to sign and execute a transaction block.
+ */
+export function useSignAndExecuteTransactionBlock({
+	mutationKey,
+	...mutationOptions
+}: UseSignAndExecuteTransactionBlockMutationOptions = {}) {
+	const currentWallet = useCurrentWallet();
+	const currentAccount = useCurrentAccount();
+
+	return useMutation({
+		mutationKey: walletMutationKeys.signAndExecuteTransactionBlock(mutationKey),
+		mutationFn: async (signAndExecuteTransactionBlockArgs) => {
+			if (!currentWallet) {
+				throw new WalletNotConnectedError('No wallet is connected.');
+			}
+
+			const signerAccount = signAndExecuteTransactionBlockArgs.account ?? currentAccount;
+			if (!signerAccount) {
+				throw new WalletNoAccountSelectedError(
+					'No wallet account is selected to sign the personal message with.',
+				);
+			}
+
+			const walletFeature = currentWallet.features['sui:signAndExecuteTransactionBlock'];
+			if (!walletFeature) {
+				throw new WalletFeatureNotSupportedError(
+					"This wallet doesn't support the `signAndExecuteTransactionBlock` feature.",
+				);
+			}
+
+			return await walletFeature.signAndExecuteTransactionBlock({
+				...signAndExecuteTransactionBlockArgs,
+				account: signerAccount,
+			});
+		},
+		...mutationOptions,
+	});
+}

--- a/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
@@ -19,12 +19,19 @@ type UseSignAndExecuteTransactionBlockArgs = PartialBy<
 	SuiSignAndExecuteTransactionBlockInput,
 	'account'
 >;
+
 type UseSignAndExecuteTransactionBlockResult = SuiSignAndExecuteTransactionBlockOutput;
+
+type UseSignAndExecuteTransactionBlockError =
+	| WalletFeatureNotSupportedError
+	| WalletNoAccountSelectedError
+	| WalletNotConnectedError
+	| Error;
 
 type UseSignAndExecuteTransactionBlockMutationOptions = Omit<
 	UseMutationOptions<
 		UseSignAndExecuteTransactionBlockResult,
-		WalletFeatureNotSupportedError | WalletNoAccountSelectedError | WalletNotConnectedError | Error,
+		UseSignAndExecuteTransactionBlockError,
 		UseSignAndExecuteTransactionBlockArgs,
 		unknown
 	>,

--- a/sdk/dapp-kit/src/hooks/wallet/useSignPersonalMessage.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignPersonalMessage.ts
@@ -16,12 +16,19 @@ import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 
 type UseSignPersonalMessageArgs = PartialBy<SuiSignPersonalMessageInput, 'account'>;
+
 type UseSignPersonalMessageResult = SuiSignPersonalMessageOutput;
+
+type UseSignPersonalMessageError =
+	| WalletFeatureNotSupportedError
+	| WalletNoAccountSelectedError
+	| WalletNotConnectedError
+	| Error;
 
 type UseSignPersonalMessageMutationOptions = Omit<
 	UseMutationOptions<
 		UseSignPersonalMessageResult,
-		WalletFeatureNotSupportedError | WalletNoAccountSelectedError | WalletNotConnectedError | Error,
+		UseSignPersonalMessageError,
 		UseSignPersonalMessageArgs,
 		unknown
 	>,

--- a/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
@@ -16,12 +16,19 @@ import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 
 type UseSignTransactionBlockArgs = PartialBy<SuiSignTransactionBlockInput, 'account'>;
+
 type UseSignTransactionBlockResult = SuiSignTransactionBlockOutput;
+
+type UseSignTransactionBlockError =
+	| WalletFeatureNotSupportedError
+	| WalletNoAccountSelectedError
+	| WalletNotConnectedError
+	| Error;
 
 type UseSignTransactionBlockMutationOptions = Omit<
 	UseMutationOptions<
 		UseSignTransactionBlockResult,
-		WalletFeatureNotSupportedError | WalletNoAccountSelectedError | WalletNotConnectedError | Error,
+		UseSignTransactionBlockError,
 		UseSignTransactionBlockArgs,
 		unknown
 	>,

--- a/sdk/dapp-kit/src/index.ts
+++ b/sdk/dapp-kit/src/index.ts
@@ -15,6 +15,7 @@ export * from './hooks/wallet/useConnectWallet.js';
 export * from './hooks/wallet/useDisconnectWallet.js';
 export * from './hooks/wallet/useSignPersonalMessage.js';
 export * from './hooks/wallet/useSignTransactionBlock.js';
+export * from './hooks/wallet/useSignAndExecuteTransactionBlock.js';
 export * from './hooks/useSuiClientMutation.js';
 export * from './hooks/useSuiClientQuery.js';
 export * from './hooks/useSuiClientInfiniteQuery.js';

--- a/sdk/dapp-kit/test/hooks/useSignAndExecuteTransactionBlock.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useSignAndExecuteTransactionBlock.test.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useConnectWallet, useSignAndExecuteTransactionBlock } from 'dapp-kit/src';
+import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
+import {
+	WalletFeatureNotSupportedError,
+	WalletNotConnectedError,
+} from 'dapp-kit/src/errors/walletErrors.js';
+import type { Mock } from 'vitest';
+import { suiFeatures } from '../mocks/mockFeatures.js';
+
+describe('useSignAndExecuteTransactionBlock', () => {
+	test('throws an error when trying to sign and execute a transaction block without a wallet connection', async () => {
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(() => useSignAndExecuteTransactionBlock(), { wrapper });
+
+		result.current.mutate({ transactionBlock: new TransactionBlock(), chain: 'sui:testnet' });
+
+		await waitFor(() => expect(result.current.error).toBeInstanceOf(WalletNotConnectedError));
+	});
+
+	test('throws an error when trying to sign and execute a transaction block with a wallet that lacks feature support', async () => {
+		const { unregister, mockWallet } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+		});
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				useSignAndExecuteTransactionBlock: useSignAndExecuteTransactionBlock(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ wallet: mockWallet });
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+
+		result.current.useSignAndExecuteTransactionBlock.mutate({
+			transactionBlock: new TransactionBlock(),
+			chain: 'sui:testnet',
+		});
+		await waitFor(() =>
+			expect(result.current.useSignAndExecuteTransactionBlock.error).toBeInstanceOf(
+				WalletFeatureNotSupportedError,
+			),
+		);
+
+		act(() => unregister());
+	});
+
+	test('signing and executing a transaction block from the currently connected account works successfully', async () => {
+		const { unregister, mockWallet } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			features: suiFeatures,
+		});
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				useSignAndExecuteTransactionBlock: useSignAndExecuteTransactionBlock(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ wallet: mockWallet });
+
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+
+		const useSignAndExecuteTransactionBlockFeature =
+			mockWallet.features['sui:signAndExecuteTransactionBlock'];
+		const useSignAndExecuteTransactionBlockMock = useSignAndExecuteTransactionBlockFeature!
+			.signAndExecuteTransactionBlock as Mock;
+
+		useSignAndExecuteTransactionBlockMock.mockReturnValueOnce({
+			digest: '123',
+		});
+
+		result.current.useSignAndExecuteTransactionBlock.mutate({
+			transactionBlock: new TransactionBlock(),
+			chain: 'sui:testnet',
+		});
+
+		await waitFor(() =>
+			expect(result.current.useSignAndExecuteTransactionBlock.isSuccess).toBe(true),
+		);
+		expect(result.current.useSignAndExecuteTransactionBlock.data).toStrictEqual({
+			digest: '123',
+		});
+
+		act(() => unregister());
+	});
+});


### PR DESCRIPTION
## Description 
This PR adds the final Sui feature mutation hook for signing and executing a transaction block. This is similar to https://github.com/MystenLabs/sui/pull/13741 and https://github.com/MystenLabs/sui/pull/13720.

## Test Plan 
- Automated tests
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
