### PR TITLE
[dapp-kit] remove WalletAlreadyConnectedError from useConnectWallet

### DIFF
--- a/sdk/dapp-kit/src/errors/walletErrors.ts
+++ b/sdk/dapp-kit/src/errors/walletErrors.ts
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * An error that is instantiated when someone attempts to connect to a wallet that they're already connected to.
- */
-export class WalletAlreadyConnectedError extends Error {}
-
-/**
  * An error that is instantiated when someone attempts to perform an action that requires an active wallet connection.
  */
 export class WalletNotConnectedError extends Error {}

--- a/sdk/dapp-kit/src/hooks/wallet/useConnectWallet.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useConnectWallet.ts
@@ -9,10 +9,8 @@ import type {
 	WalletAccount,
 	WalletWithRequiredFeatures,
 } from '@mysten/wallet-standard';
-import { WalletAlreadyConnectedError } from '../../errors/walletErrors.js';
 import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
 import { useWalletStore } from './useWalletStore.js';
-import { useCurrentWallet } from './useCurrentWallet.js';
 
 type ConnectWalletArgs = {
 	/** The wallet to connect to. */
@@ -36,20 +34,11 @@ export function useConnectWallet({
 	mutationKey,
 	...mutationOptions
 }: UseConnectWalletMutationOptions = {}) {
-	const currentWallet = useCurrentWallet();
 	const setWalletConnected = useWalletStore((state) => state.setWalletConnected);
 
 	return useMutation({
 		mutationKey: walletMutationKeys.connectWallet(mutationKey),
 		mutationFn: async ({ wallet, accountAddress, ...standardConnectInput }) => {
-			if (currentWallet) {
-				throw new WalletAlreadyConnectedError(
-					currentWallet.name === wallet.name
-						? `The user is already connected to wallet ${wallet.name}.`
-						: "You must disconnect the wallet you're currently connected to before connecting to a new wallet.",
-				);
-			}
-
 			const connectResult = await wallet.features['standard:connect'].connect(standardConnectInput);
 			const selectedAccount = getSelectedAccount(connectResult.accounts, accountAddress);
 

--- a/sdk/dapp-kit/test/hooks/useConnectWallet.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useConnectWallet.test.tsx
@@ -4,27 +4,9 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useConnectWallet, useCurrentWallet, useCurrentAccount } from 'dapp-kit/src';
 import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
-import { WalletAlreadyConnectedError } from 'dapp-kit/src/errors/walletErrors.js';
 import type { Mock } from 'vitest';
 
 describe('useConnectWallet', () => {
-	test('throws an error when connecting to a wallet when a connection is already active', async () => {
-		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
-
-		const wrapper = createWalletProviderContextWrapper();
-		const { result } = renderHook(() => useConnectWallet(), { wrapper });
-
-		result.current.mutate({ wallet: mockWallet });
-		await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-		result.current.mutate({ wallet: mockWallet });
-		await waitFor(() => expect(result.current.error).toBeInstanceOf(WalletAlreadyConnectedError));
-
-		act(() => {
-			unregister();
-		});
-	});
-
 	test('throws an error when a user fails to connect their wallet', async () => {
 		const { unregister, mockWallet } = registerMockWallet({ walletName: 'Mock Wallet 1' });
 


### PR DESCRIPTION
## Description 
@Jordan-Mysten brought up a good point during a discussion last week that we shouldn't impose the constraint for people to disconnect a wallet connection before connecting a new wallet since disconnecting is really a facade sort of concept. This PR removes the associated logic, so people can technically connect as many wallets as they please 🔌 

## Test Plan 
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
