### PR TITLE
[Indexer-v2 5/n] add indexer_store_v2 trait and DataToCommit structs

### DIFF
--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -3,3 +3,33 @@
 
 pub mod checkpoint_handler;
 pub mod tx_processor;
+
+use sui_types::base_types::ObjectRef;
+
+use crate::types_v2::{
+    IndexedCheckpoint, IndexedEpochInfo, IndexedEvent, IndexedObject, IndexedPackage,
+    IndexedTransaction, TxIndex,
+};
+
+#[derive(Debug)]
+pub struct CheckpointDataToCommit {
+    pub checkpoint: IndexedCheckpoint,
+    pub transactions: Vec<IndexedTransaction>,
+    pub events: Vec<IndexedEvent>,
+    pub tx_indices: Vec<TxIndex>,
+    pub object_changes: TransactionObjectChangesToCommit,
+    pub packages: Vec<IndexedPackage>,
+    pub epoch: Option<EpochToCommit>,
+}
+
+#[derive(Debug)]
+pub struct TransactionObjectChangesToCommit {
+    pub changed_objects: Vec<IndexedObject>,
+    pub deleted_objects: Vec<ObjectRef>,
+}
+
+#[derive(Debug)]
+pub struct EpochToCommit {
+    pub last_epoch: Option<IndexedEpochInfo>,
+    pub new_epoch: IndexedEpochInfo,
+}

--- a/crates/sui-indexer/src/store/indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/indexer_store_v2.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use move_binary_format::CompiledModule;
+use move_bytecode_utils::module_cache::GetModule;
+use std::sync::Arc;
+
+use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::object::ObjectRead;
+
+use crate::errors::IndexerError;
+use crate::handlers::{EpochToCommit, TransactionObjectChangesToCommit};
+use crate::metrics::IndexerMetrics;
+
+use crate::types_v2::{
+    IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex,
+};
+
+#[async_trait]
+pub trait IndexerStoreV2 {
+    type ModuleCache: GetModule<Item = Arc<CompiledModule>, Error = anyhow::Error>
+        + Send
+        + Sync
+        + 'static;
+
+    async fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
+
+    async fn get_object_read(
+        &self,
+        object_id: ObjectID,
+        version: Option<SequenceNumber>,
+    ) -> Result<ObjectRead, IndexerError>;
+
+    async fn persist_objects(
+        &self,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_checkpoints(
+        &self,
+        checkpoints: Vec<IndexedCheckpoint>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_transactions(
+        &self,
+        transactions: Vec<IndexedTransaction>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_tx_indices(
+        &self,
+        indices: Vec<TxIndex>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_events(
+        &self,
+        events: Vec<IndexedEvent>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_packages(
+        &self,
+        packages: Vec<IndexedPackage>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_epoch(
+        &self,
+        data: Vec<EpochToCommit>,
+        metrics: IndexerMetrics,
+    ) -> Result<(), IndexerError>;
+
+    async fn get_network_total_transactions_in_epoch(
+        &self,
+        epoch: u64,
+    ) -> Result<u64, IndexerError>;
+
+    fn module_cache(&self) -> Arc<Self::ModuleCache>;
+}

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -5,6 +5,7 @@ pub use indexer_store::*;
 pub use pg_indexer_store::PgIndexerStore;
 
 mod indexer_store;
+mod indexer_store_v2;
 mod module_resolver;
 mod module_resolver_v2;
 mod pg_indexer_store;


### PR DESCRIPTION
## Description 

This PR adds `IndexerStoreV2` trait and a few helper structs. `IndexerStoreV2` only contains the necessary functions for now, and will be immediately used in next PR in the stack.


Stack:
1. https://github.com/MystenLabs/sui/pull/13760
2. https://github.com/MystenLabs/sui/pull/13774
3. https://github.com/MystenLabs/sui/pull/13804
4. https://github.com/MystenLabs/sui/pull/13805
5. https://github.com/MystenLabs/sui/pull/13832
6. https://github.com/MystenLabs/sui/pull/13834

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
