### PR TITLE
[Indexer-v2 6/n] add Checkpoint Handler v2 and committer

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044052_epochs/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044052_epochs/up.sql
@@ -2,13 +2,13 @@ CREATE TABLE epochs
 (
     epoch                           BIGINT      PRIMARY KEY,
     validators                      bytea[]     NOT NULL,
-    epoch_total_transactions        BIGINT      NOT NULL,
     first_checkpoint_id             BIGINT      NOT NULL,
     epoch_start_timestamp           BIGINT      NOT NULL,
     reference_gas_price             BIGINT      NOT NULL,
     protocol_version                BIGINT      NOT NULL,
     -- The following fields are nullable because they are filled in
     -- only at the end of an epoch.
+    epoch_total_transactions        BIGINT,
     last_checkpoint_id              BIGINT,
     epoch_end_timestamp             BIGINT,
     -- The following fields are from SystemEpochInfoEvent emitted

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -1,0 +1,635 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused)]
+
+use crate::handlers::committer::start_tx_checkpoint_commit_task;
+use crate::handlers::tx_processor::IndexingPackageCache;
+use async_trait::async_trait;
+use itertools::Itertools;
+use move_bytecode_utils::module_cache::GetModule;
+use mysten_metrics::{get_metrics, spawn_monitored_task};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use sui_rest_api::CheckpointData;
+use sui_rest_api::CheckpointTransaction;
+use sui_types::base_types::ObjectRef;
+use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::dynamic_field::DynamicFieldName;
+use sui_types::dynamic_field::DynamicFieldType;
+use sui_types::object::Object;
+use sui_types::object::ObjectFormatOptions;
+use tokio::sync::watch;
+use tracing::debug;
+
+use std::collections::hash_map::Entry;
+use std::collections::HashSet;
+use sui_json_rpc_types::SuiMoveValue;
+use sui_types::base_types::SequenceNumber;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::event::SystemEpochInfoEvent;
+use sui_types::object::Owner;
+use sui_types::transaction::TransactionDataAPI;
+use tap::tap::TapFallible;
+use tracing::{error, info, warn};
+
+use sui_types::base_types::ObjectID;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
+use sui_types::sui_system_state::{get_sui_system_state, SuiSystemStateTrait};
+
+use crate::errors::IndexerError;
+use crate::framework::interface::Handler;
+use crate::metrics::IndexerMetrics;
+
+use crate::store::module_resolver_v2::InterimModuleResolver;
+use crate::store::IndexerStoreV2;
+use crate::types_v2::IndexedEpochInfo;
+use crate::types_v2::{
+    IndexedCheckpoint, IndexedEvent, IndexedTransaction, IndexerResult, TransactionKind, TxIndex,
+};
+use crate::types_v2::{IndexedObject, IndexedPackage};
+use crate::IndexerConfig;
+
+use super::tx_processor::EpochEndIndexingObjectStore;
+use super::tx_processor::TxChangesProcessor;
+use super::CheckpointDataToCommit;
+use super::EpochToCommit;
+use super::TransactionObjectChangesToCommit;
+
+const CHECKPOINT_QUEUE_SIZE: usize = 1000;
+
+pub async fn new_handlers<S>(
+    state: S,
+    metrics: IndexerMetrics,
+    config: &IndexerConfig,
+) -> Result<CheckpointHandler<S>, IndexerError>
+where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    let checkpoint_queue_size = std::env::var("CHECKPOINT_QUEUE_SIZE")
+        .unwrap_or(CHECKPOINT_QUEUE_SIZE.to_string())
+        .parse::<usize>()
+        .unwrap();
+    let global_metrics = get_metrics().unwrap();
+    let (indexed_checkpoint_sender, indexed_checkpoint_receiver) =
+        mysten_metrics::metered_channel::channel(
+            checkpoint_queue_size,
+            &global_metrics
+                .channels
+                .with_label_values(&["checkpoint_indexing"]),
+        );
+
+    let state_clone = state.clone();
+    let metrics_clone = metrics.clone();
+    let config_clone = config.clone();
+    let (tx, rx) = watch::channel(None);
+    spawn_monitored_task!(start_tx_checkpoint_commit_task(
+        state_clone,
+        metrics_clone,
+        config_clone,
+        indexed_checkpoint_receiver,
+        tx,
+    ));
+
+    let checkpoint_handler = CheckpointHandler {
+        state,
+        metrics,
+        indexed_checkpoint_sender,
+        package_cache: IndexingPackageCache::start(rx),
+    };
+
+    Ok(checkpoint_handler)
+}
+
+pub struct CheckpointHandler<S> {
+    state: S,
+    metrics: IndexerMetrics,
+    indexed_checkpoint_sender: mysten_metrics::metered_channel::Sender<CheckpointDataToCommit>,
+    // Map from checkpoint sequence number and its starting transaction sequence number
+    // This thing is small enough to be kept in memory
+    package_cache: Arc<Mutex<IndexingPackageCache>>,
+}
+
+#[async_trait]
+impl<S> Handler for CheckpointHandler<S>
+where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    fn name(&self) -> &str {
+        "checkpoint-handler"
+    }
+
+    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> anyhow::Result<()> {
+        let checkpoint_seq = checkpoint_data.checkpoint_summary.sequence_number();
+        info!(checkpoint_seq, "Checkpoint received by CheckpointHandler");
+
+        // Index checkpoint data
+        let index_timer = self.metrics.checkpoint_index_latency.start_timer();
+        let checkpoint = Self::index_checkpoint_and_epoch(
+            &self.state,
+            checkpoint_data.clone(),
+            self.package_cache.clone(),
+            &self.metrics,
+        )
+        .await
+        .tap_err(|e| {
+            error!(
+                checkpoint_seq,
+                "Failed to index checkpoints with error: {}",
+                e.to_string()
+            );
+        })?;
+        let elapsed = index_timer.stop_and_record();
+
+        info!(
+            checkpoint_seq,
+            elapsed, "Checkpoint indexing finished, about to sending to commit handler"
+        );
+        // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
+        // Checkpoints are sent sequentially to stick to the order of checkpoint sequence numbers.
+        self.indexed_checkpoint_sender
+            .send(checkpoint)
+            .await
+            .tap_ok(|_| info!(checkpoint_seq, "Checkpoint sent to commit handler"))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "checkpoint channel send should not fail, but got error: {:?}",
+                    e
+                )
+            });
+
+        Ok(())
+    }
+}
+
+impl<S> CheckpointHandler<S>
+where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    async fn index_epoch(
+        state: &S,
+        data: &CheckpointData,
+    ) -> Result<Option<EpochToCommit>, IndexerError> {
+        let checkpoint_object_store = EpochEndIndexingObjectStore::new(data);
+
+        let CheckpointData {
+            transactions,
+            checkpoint_summary,
+            checkpoint_contents: _,
+        } = data;
+
+        // Genesis epoch
+        if *checkpoint_summary.sequence_number() == 0 {
+            info!("Processing genesis epoch");
+            let system_state: SuiSystemStateSummary =
+                get_sui_system_state(&checkpoint_object_store)?.into_sui_system_state_summary();
+            return Ok(Some(EpochToCommit {
+                last_epoch: None,
+                new_epoch: IndexedEpochInfo::from_new_system_state_summary(
+                    system_state,
+                    0, //first_checkpoint_id
+                ),
+            }));
+        }
+
+        // If not end of epoch, return
+        if checkpoint_summary.end_of_epoch_data.is_none() {
+            return Ok(None);
+        }
+
+        let system_state: SuiSystemStateSummary =
+            get_sui_system_state(&checkpoint_object_store)?.into_sui_system_state_summary();
+
+        let epoch_event = transactions
+            .iter()
+            .flat_map(|t| t.events.as_ref().map(|e| &e.data))
+            .flatten()
+            .find(|ev| ev.is_system_epoch_info_event())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Can't find SystemEpochInfoEvent in epoch end checkpoint {}",
+                    checkpoint_summary.sequence_number()
+                )
+            });
+
+        let event = bcs::from_bytes::<SystemEpochInfoEvent>(&epoch_event.contents)?;
+
+        let last_epoch = system_state.epoch - 1;
+        let network_tx_count_prev_epoch = state
+            .get_network_total_transactions_by_end_of_epoch(last_epoch)
+            .await?;
+
+        Ok(Some(EpochToCommit {
+            last_epoch: Some(IndexedEpochInfo::from_end_of_epoch_data(
+                checkpoint_summary,
+                &event,
+                network_tx_count_prev_epoch,
+            )),
+            new_epoch: IndexedEpochInfo::from_new_system_state_summary(
+                system_state,
+                checkpoint_summary.sequence_number + 1, // first_checkpoint_id
+            ),
+        }))
+    }
+
+    async fn index_checkpoint_and_epoch(
+        state: &S,
+        data: CheckpointData,
+        package_cache: Arc<Mutex<IndexingPackageCache>>,
+        metrics: &IndexerMetrics,
+    ) -> Result<CheckpointDataToCommit, IndexerError> {
+        let (checkpoint, db_transactions, db_events, db_indices) = {
+            let CheckpointData {
+                transactions,
+                checkpoint_summary,
+                checkpoint_contents,
+            } = &data;
+            let checkpoint_seq = checkpoint_summary.sequence_number();
+            let mut db_transactions = Vec::new();
+            let mut db_events = Vec::new();
+            let mut db_indices = Vec::new();
+
+            let mut tx_seq_num_iter = checkpoint_contents
+                .enumerate_transactions(checkpoint_summary)
+                .map(|(seq, execution_digest)| (execution_digest.transaction, seq));
+
+            if checkpoint_contents.size() != transactions.len() {
+                return Err(IndexerError::FullNodeReadingError(format!(
+                    "CheckpointContents has different size {} compared to Transactions {} for checkpoint {}",
+                    checkpoint_contents.size(),
+                    transactions.len(),
+                    checkpoint_seq
+                )));
+            }
+
+            for (idx, tx) in transactions.iter().enumerate() {
+                let CheckpointTransaction {
+                    transaction: sender_signed_data,
+                    effects: fx,
+                    events,
+                    input_objects,
+                    output_objects,
+                } = tx;
+                // Unwrap safe - we checked they have equal length above
+                let (tx_digest, tx_sequence_number) = tx_seq_num_iter.next().unwrap();
+                if tx_digest != *sender_signed_data.digest() {
+                    return Err(IndexerError::FullNodeReadingError(format!(
+                        "Transactions has different ordering from CheckpointContents, for checkpoint {}, Mismatch found at {} v.s. {}",
+                        checkpoint_seq, tx_digest, sender_signed_data.digest()
+                    )));
+                }
+                let tx = sender_signed_data.transaction_data();
+                let events = events
+                    .as_ref()
+                    .map(|events| events.data.clone())
+                    .unwrap_or_default();
+
+                let transaction_kind = if tx.is_system_tx() {
+                    TransactionKind::SystemTransaction
+                } else {
+                    TransactionKind::ProgrammableTransaction
+                };
+
+                db_events.extend(events.iter().enumerate().map(|(idx, event)| {
+                    IndexedEvent::from_event(
+                        tx_sequence_number,
+                        idx as u64,
+                        *checkpoint_seq,
+                        tx_digest,
+                        event,
+                        checkpoint_summary.timestamp_ms,
+                    )
+                }));
+
+                let objects = input_objects
+                    .iter()
+                    .chain(output_objects.iter())
+                    .collect::<Vec<_>>();
+
+                let (balance_change, object_changes) =
+                    TxChangesProcessor::new(&objects, metrics.clone())
+                        .get_changes(tx, fx, &tx_digest)
+                        .await?;
+
+                let db_txn = IndexedTransaction {
+                    tx_sequence_number,
+                    tx_digest,
+                    checkpoint_sequence_number: *checkpoint_summary.sequence_number(),
+                    timestamp_ms: checkpoint_summary.timestamp_ms,
+                    sender_signed_data: sender_signed_data.data().clone(),
+                    effects: fx.clone(),
+                    object_changes,
+                    balance_change,
+                    events,
+                    transaction_kind,
+                    successful_tx_num: if fx.status().is_ok() {
+                        tx.kind().num_commands() as u64
+                    } else {
+                        0
+                    },
+                };
+
+                db_transactions.push(db_txn);
+
+                // Input Objects
+                let input_objects = tx
+                    .input_objects()
+                    .expect("committed txns have been validated")
+                    .into_iter()
+                    .map(|obj_kind| obj_kind.object_id())
+                    .collect::<Vec<_>>();
+
+                // Changed Objects
+                let changed_objects = fx
+                    .all_changed_objects()
+                    .into_iter()
+                    .map(|(object_ref, _owner, _write_kind)| object_ref.0)
+                    .collect::<Vec<_>>();
+
+                // Senders
+                let senders = vec![tx.sender()];
+
+                // Recipients
+                let recipients = fx
+                    .all_changed_objects()
+                    .into_iter()
+                    .filter_map(|(_object_ref, owner, _write_kind)| match owner {
+                        Owner::AddressOwner(address) => Some(address),
+                        _ => None,
+                    })
+                    .unique()
+                    .collect::<Vec<_>>();
+
+                // Move Calls
+                let move_calls = tx
+                    .move_calls()
+                    .iter()
+                    .map(|(p, m, f)| (*<&ObjectID>::clone(p), m.to_string(), f.to_string()))
+                    .collect();
+
+                db_indices.push(TxIndex {
+                    tx_sequence_number,
+                    transaction_digest: tx_digest,
+                    checkpoint_sequence_number: *checkpoint_seq,
+                    input_objects,
+                    changed_objects,
+                    senders,
+                    recipients,
+                    move_calls,
+                });
+            }
+            let successful_tx_num: u64 = db_transactions.iter().map(|t| t.successful_tx_num).sum();
+            (
+                IndexedCheckpoint::from_sui_checkpoint(
+                    checkpoint_summary,
+                    checkpoint_contents,
+                    successful_tx_num as usize,
+                ),
+                db_transactions,
+                db_events,
+                db_indices,
+            )
+        };
+
+        let epoch = Self::index_epoch(state, &data).await?;
+
+        // Index Objects
+        let (object_changes, packages) =
+            Self::index_checkpoint(state, data, package_cache, metrics);
+
+        Ok(CheckpointDataToCommit {
+            checkpoint,
+            transactions: db_transactions,
+            events: db_events,
+            tx_indices: db_indices,
+            object_changes,
+            packages,
+            epoch,
+        })
+    }
+
+    fn index_checkpoint(
+        state: &S,
+        data: CheckpointData,
+        package_cache: Arc<Mutex<IndexingPackageCache>>,
+        metrics: &IndexerMetrics,
+    ) -> (TransactionObjectChangesToCommit, Vec<IndexedPackage>) {
+        let checkpoint_seq = data.checkpoint_summary.sequence_number;
+        info!(checkpoint_seq, "Indexing checkpoint");
+        let packages = Self::index_packages(&data, metrics);
+
+        let object_changes = Self::index_objects(state, data, &packages, package_cache, metrics);
+
+        (object_changes, packages)
+    }
+
+    fn index_objects(
+        state: &S,
+        data: CheckpointData,
+        packages: &[IndexedPackage],
+        package_cache: Arc<Mutex<IndexingPackageCache>>,
+        metrics: &IndexerMetrics,
+    ) -> TransactionObjectChangesToCommit {
+        let _timer = metrics.indexing_objects_latency.start_timer();
+        let checkpoint_seq = data.checkpoint_summary.sequence_number;
+        let module_resolver = InterimModuleResolver::new(
+            state.module_cache(),
+            package_cache,
+            packages,
+            checkpoint_seq,
+            metrics.clone(),
+        );
+        let deleted_objects = data
+            .transactions
+            .iter()
+            .flat_map(|tx| get_deleted_objects(&tx.effects))
+            .collect::<Vec<_>>();
+
+        let deleted_object_ids = deleted_objects
+            .iter()
+            .map(|o| (o.0, o.1))
+            .collect::<HashSet<_>>();
+
+        let (objects, intermediate_versions) = get_latest_objects(data.output_objects());
+
+        let changed_objects = data
+            .transactions
+            .iter()
+            .flat_map(|tx| {
+                let CheckpointTransaction {
+                    transaction: tx,
+                    effects: fx,
+                    ..
+                } = tx;
+                fx.all_changed_objects()
+                    .into_iter()
+                    .filter_map(|(oref, _owner, _kind)| {
+                        // We don't care about objects that are deleted or updated more than once
+                        if intermediate_versions.contains(&(oref.0, oref.1))
+                            || deleted_object_ids.contains(&(oref.0, oref.1))
+                        {
+                            return None;
+                        }
+                        let object = objects.get(&(oref.0)).unwrap_or_else(|| {
+                            panic!(
+                                "object {:?} not found in CheckpointData (tx_digest: {})",
+                                oref.0,
+                                tx.digest()
+                            )
+                        });
+                        assert_eq!(oref.1, object.version());
+                        let df_info =
+                            try_create_dynamic_field_info(object, &objects, &module_resolver)
+                                .unwrap_or_else(|e| {
+                                    panic!(
+                                "failed to create dynamic field info for obj: {:?}:{:?}. Err: {e}",
+                                object.id(),
+                                object.version()
+                            )
+                                });
+
+                        Some(IndexedObject::from_object(
+                            checkpoint_seq,
+                            object.clone(),
+                            df_info,
+                        ))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        TransactionObjectChangesToCommit {
+            changed_objects,
+            deleted_objects,
+        }
+    }
+
+    fn index_packages(
+        checkpoint_data: &CheckpointData,
+        metrics: &IndexerMetrics,
+    ) -> Vec<IndexedPackage> {
+        let _timer = metrics.indexing_packages_latency.start_timer();
+        checkpoint_data
+            .output_objects()
+            .iter()
+            .filter_map(|o| {
+                if let sui_types::object::Data::Package(p) = &o.data {
+                    Some(IndexedPackage {
+                        package_id: o.id(),
+                        move_package: p.clone(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+pub fn get_deleted_objects(effects: &TransactionEffects) -> Vec<ObjectRef> {
+    let deleted = effects.deleted().into_iter();
+    let wrapped = effects.wrapped().into_iter();
+    let unwrapped_then_deleted = effects.unwrapped_then_deleted().into_iter();
+    deleted
+        .chain(wrapped)
+        .chain(unwrapped_then_deleted)
+        .collect::<Vec<_>>()
+}
+
+pub fn get_latest_objects(
+    objects: Vec<&Object>,
+) -> (
+    HashMap<ObjectID, Object>,
+    HashSet<(ObjectID, SequenceNumber)>,
+) {
+    let mut latest_objects = HashMap::new();
+    let mut discarded_versions = HashSet::new();
+    for object in objects {
+        match latest_objects.entry(object.id()) {
+            Entry::Vacant(e) => {
+                e.insert(object.clone());
+            }
+            Entry::Occupied(mut e) => {
+                if object.version() > e.get().version() {
+                    discarded_versions.insert((e.get().id(), e.get().version()));
+                    e.insert(object.clone());
+                }
+            }
+        }
+    }
+    (latest_objects, discarded_versions)
+}
+
+fn try_create_dynamic_field_info(
+    o: &Object,
+    written: &HashMap<ObjectID, Object>,
+    resolver: &impl GetModule,
+) -> IndexerResult<Option<DynamicFieldInfo>> {
+    // Skip if not a move object
+    let Some(move_object) = o.data.try_as_move().cloned() else {
+        return Ok(None);
+    };
+
+    if !move_object.type_().is_dynamic_field() {
+        return Ok(None);
+    }
+
+    let move_struct = move_object
+        .to_move_struct_with_resolver(ObjectFormatOptions::default(), resolver)
+        .map_err(|e| {
+            IndexerError::ResolveMoveStructError(format!(
+                "Failed to create dynamic field info for obj {}:{}, type: {}. Error: {e}",
+                o.id(),
+                o.version(),
+                move_object.type_(),
+            ))
+        })?;
+
+    let (name_value, type_, object_id) =
+        DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| warn!("{e}"))?;
+
+    let name_type = move_object.type_().try_extract_field_name(&type_)?;
+
+    let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
+        IndexerError::SerdeError(format!(
+            "Failed to serialize dynamic field name {:?}: {e}",
+            name_value
+        ))
+    })?;
+
+    let name = DynamicFieldName {
+        type_: name_type,
+        value: SuiMoveValue::from(name_value).to_json_value(),
+    };
+    Ok(Some(match type_ {
+        DynamicFieldType::DynamicObject => {
+            let object = written
+                .get(&object_id)
+                .ok_or(IndexerError::UncategorizedError(anyhow::anyhow!(
+                    "Failed to find object_id {:?} when trying to create dynamic field info",
+                    object_id
+                )))?;
+            let version = object.version();
+            let digest = object.digest();
+            let object_type = object.data.type_().unwrap().clone();
+            DynamicFieldInfo {
+                name,
+                bcs_name,
+                type_,
+                object_type: object_type.to_string(),
+                object_id,
+                version,
+                digest,
+            }
+        }
+        DynamicFieldType::DynamicField => DynamicFieldInfo {
+            name,
+            bcs_name,
+            type_,
+            object_type: move_object.into_type().into_type_params()[1].to_string(),
+            object_id: o.id(),
+            version: o.version(),
+            digest: o.digest(),
+        },
+    }))
+}

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio::sync::watch;
+use tracing::instrument;
+
+use tap::tap::TapFallible;
+use tracing::{error, info};
+
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+use crate::metrics::IndexerMetrics;
+
+use crate::store::IndexerStoreV2;
+use crate::types_v2::IndexerResult;
+use crate::IndexerConfig;
+
+use super::CheckpointDataToCommit;
+
+pub async fn start_tx_checkpoint_commit_task<S>(
+    state: S,
+    metrics: IndexerMetrics,
+    config: IndexerConfig,
+    tx_indexing_receiver: mysten_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
+    commit_notifier: watch::Sender<Option<CheckpointSequenceNumber>>,
+) where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    use futures::StreamExt;
+
+    info!("Indexer checkpoint commit task started...");
+    let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
+        .unwrap_or(5.to_string())
+        .parse::<usize>()
+        .unwrap();
+    info!("Using checkpoint commit batch size {checkpoint_commit_batch_size}");
+
+    let mut stream = mysten_metrics::metered_channel::ReceiverStream::new(tx_indexing_receiver)
+        .ready_chunks(checkpoint_commit_batch_size);
+
+    while let Some(indexed_checkpoint_batch) = stream.next().await {
+        // TODO: don't batch checkpoints across epoch boundary (for partitioning management)
+        // impossible but as a safety check
+        if indexed_checkpoint_batch.is_empty() {
+            continue;
+        }
+        if config.skip_db_commit {
+            info!(
+                "[Checkpoint/Tx] Downloaded and indexed checkpoint {:?} - {:?} successfully, skipping DB commit...",
+                indexed_checkpoint_batch.first().map(|c| c.checkpoint.sequence_number),
+                indexed_checkpoint_batch.last().map(|c| c.checkpoint.sequence_number),
+            );
+            continue;
+        }
+        commit_checkpoints(&state, indexed_checkpoint_batch, &metrics, &commit_notifier).await;
+    }
+}
+
+// Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty
+#[instrument(skip_all, fields(
+    first = indexed_checkpoint_batch.first().as_ref().unwrap().checkpoint.sequence_number,
+    last = indexed_checkpoint_batch.last().as_ref().unwrap().checkpoint.sequence_number
+))]
+async fn commit_checkpoints<S>(
+    state: &S,
+    indexed_checkpoint_batch: Vec<CheckpointDataToCommit>,
+    metrics: &IndexerMetrics,
+    commit_notifier: &watch::Sender<Option<CheckpointSequenceNumber>>,
+) where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    let mut checkpoint_batch = vec![];
+    let mut tx_batch = vec![];
+    let mut events_batch = vec![];
+    let mut tx_indices_batch = vec![];
+    let mut object_changes_batch = vec![];
+    let mut packages_batch = vec![];
+    let mut epochs_batch = vec![];
+
+    for indexed_checkpoint in indexed_checkpoint_batch {
+        let CheckpointDataToCommit {
+            checkpoint,
+            transactions,
+            events,
+            tx_indices,
+            object_changes,
+            packages,
+            epoch,
+        } = indexed_checkpoint;
+        checkpoint_batch.push(checkpoint);
+        tx_batch.push(transactions);
+        events_batch.push(events);
+        tx_indices_batch.push(tx_indices);
+        object_changes_batch.push(object_changes);
+        packages_batch.push(packages);
+        if let Some(epoch) = epoch {
+            epochs_batch.push(epoch);
+        }
+    }
+
+    let first_checkpoint_seq = checkpoint_batch.first().as_ref().unwrap().sequence_number;
+    let last_checkpoint_seq = checkpoint_batch.last().as_ref().unwrap().sequence_number;
+
+    let guard = metrics.checkpoint_db_commit_latency.start_timer();
+    let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
+    let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
+    let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
+    let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
+    let checkpoint_num = checkpoint_batch.len();
+    let tx_count = tx_batch.len();
+    let epochs_count = epochs_batch.len();
+
+    {
+        let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
+        futures::future::join_all(vec![
+            state.persist_transactions(tx_batch, metrics.clone()),
+            state.persist_tx_indices(tx_indices_batch, metrics.clone()),
+            state.persist_events(events_batch, metrics.clone()),
+            state.persist_packages(packages_batch, metrics.clone()),
+            state.persist_objects(object_changes_batch, metrics.clone()),
+            state.persist_epoch(epochs_batch, metrics.clone()),
+        ])
+        .await
+        .into_iter()
+        .map(|res| {
+            if res.is_err() {
+                error!("Failed to persist data with error: {:?}", res);
+            }
+            res
+        })
+        .collect::<IndexerResult<Vec<_>>>()
+        .expect("Persisting data into DB should not fail.");
+    }
+
+    state
+        .persist_checkpoints(checkpoint_batch, metrics.clone())
+        .await
+        .tap_err(|e| {
+            error!(
+                "Failed to persist checkpoint data with error: {}",
+                e.to_string()
+            );
+        })
+        .expect("Persisting data into DB should not fail.");
+    let elapsed = guard.stop_and_record();
+
+    commit_notifier
+        .send(Some(last_checkpoint_seq))
+        .expect("Commit watcher should not be closed");
+
+    metrics
+        .latest_tx_checkpoint_sequence_number
+        .set(last_checkpoint_seq as i64);
+
+    metrics
+        .total_tx_checkpoint_committed
+        .inc_by(checkpoint_num as u64);
+    metrics.total_transaction_committed.inc_by(tx_count as u64);
+    metrics.total_epoch_committed.inc_by(epochs_count as u64);
+    info!(
+        elapsed,
+        "Checkpoint {}-{} committed with {} transactions.",
+        first_checkpoint_seq,
+        last_checkpoint_seq,
+        tx_count,
+    );
+    metrics
+        .transaction_per_checkpoint
+        .observe(tx_count as f64 / (last_checkpoint_seq - first_checkpoint_seq + 1) as f64);
+    // 1000.0 is not necessarily the batch size, it's to roughly map average tx commit latency to [0.1, 1] seconds,
+    // which is well covered by DB_COMMIT_LATENCY_SEC_BUCKETS.
+    metrics
+        .thousand_transaction_avg_db_commit_latency
+        .observe(elapsed * 1000.0 / tx_count as f64);
+}

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod checkpoint_handler;
+pub mod checkpoint_handler_v2;
+pub mod committer;
 pub mod tx_processor;
 
 use sui_types::base_types::ObjectRef;

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -13,11 +13,11 @@ use sui_json_rpc_types::{EndOfEpochInfo, EpochInfo};
 pub struct StoredEpochInfo {
     pub epoch: i64,
     pub validators: Vec<Option<Vec<u8>>>,
-    pub epoch_total_transactions: i64,
     pub first_checkpoint_id: i64,
     pub epoch_start_timestamp: i64,
     pub reference_gas_price: i64,
     pub protocol_version: i64,
+    pub epoch_total_transactions: Option<i64>,
     pub last_checkpoint_id: Option<i64>,
     pub epoch_end_timestamp: Option<i64>,
     pub storage_fund_reinvestment: Option<i64>,
@@ -43,7 +43,7 @@ impl From<&IndexedEpochInfo> for StoredEpochInfo {
                 .iter()
                 .map(|v| Some(bcs::to_bytes(v).unwrap()))
                 .collect(),
-            epoch_total_transactions: e.epoch_total_transactions as i64,
+            epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
             first_checkpoint_id: e.first_checkpoint_id as i64,
             epoch_start_timestamp: e.epoch_start_timestamp as i64,
             reference_gas_price: e.reference_gas_price as i64,
@@ -113,7 +113,7 @@ impl TryInto<EpochInfo> for StoredEpochInfo {
         Ok(EpochInfo {
             epoch: self.epoch as u64,
             validators,
-            epoch_total_transactions: self.epoch_total_transactions as u64,
+            epoch_total_transactions: self.epoch_total_transactions.unwrap_or(0) as u64,
             first_checkpoint_id: self.first_checkpoint_id as u64,
             epoch_start_timestamp: self.epoch_start_timestamp as u64,
             end_of_epoch_info,

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -26,11 +26,11 @@ diesel::table! {
     epochs (epoch) {
         epoch -> Int8,
         validators -> Array<Nullable<Bytea>>,
-        epoch_total_transactions -> Int8,
         first_checkpoint_id -> Int8,
         epoch_start_timestamp -> Int8,
         reference_gas_price -> Int8,
         protocol_version -> Int8,
+        epoch_total_transactions -> Nullable<Int8>,
         last_checkpoint_id -> Nullable<Int8>,
         epoch_end_timestamp -> Nullable<Int8>,
         storage_fund_reinvestment -> Nullable<Int8>,

--- a/crates/sui-indexer/src/store/indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/indexer_store_v2.rs
@@ -74,7 +74,7 @@ pub trait IndexerStoreV2 {
         metrics: IndexerMetrics,
     ) -> Result<(), IndexerError>;
 
-    async fn get_network_total_transactions_in_epoch(
+    async fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
     ) -> Result<u64, IndexerError>;

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use indexer_store::*;
+pub(crate) use indexer_store_v2::*;
 pub use pg_indexer_store::PgIndexerStore;
 
 mod indexer_store;
 mod indexer_store_v2;
 mod module_resolver;
-mod module_resolver_v2;
+pub(crate) mod module_resolver_v2;
 mod pg_indexer_store;
 mod query;
 

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -12,11 +12,16 @@ use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::TransactionDigest;
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::effects::TransactionEffects;
-use sui_types::messages_checkpoint::{CheckpointCommitment, CheckpointDigest, EndOfEpochData};
+use sui_types::event::SystemEpochInfoEvent;
+use sui_types::messages_checkpoint::{
+    CertifiedCheckpointSummary, CheckpointCommitment, CheckpointDigest, EndOfEpochData,
+};
 use sui_types::move_package::MovePackage;
 use sui_types::object::{Object, Owner};
 use sui_types::sui_serde::SuiStructTag;
-use sui_types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
+use sui_types::sui_system_state::sui_system_state_summary::{
+    SuiSystemStateSummary, SuiValidatorSummary,
+};
 use sui_types::transaction::SenderSignedData;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
@@ -75,15 +80,15 @@ impl IndexedCheckpoint {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IndexedEpochInfo {
     pub epoch: u64,
     pub validators: Vec<SuiValidatorSummary>,
-    pub epoch_total_transactions: u64,
     pub first_checkpoint_id: u64,
     pub epoch_start_timestamp: u64,
     pub reference_gas_price: u64,
     pub protocol_version: u64,
+    pub epoch_total_transactions: Option<u64>,
     pub last_checkpoint_id: Option<u64>,
     pub epoch_end_timestamp: Option<u64>,
     pub storage_fund_reinvestment: Option<u64>,
@@ -98,6 +103,62 @@ pub struct IndexedEpochInfo {
     pub epoch_commitments: Option<Vec<CheckpointCommitment>>,
     pub next_epoch_reference_gas_price: Option<u64>,
     pub next_epoch_protocol_version: Option<u64>,
+}
+
+impl IndexedEpochInfo {
+    pub fn from_new_system_state_summary(
+        new_system_state_summary: SuiSystemStateSummary,
+        first_checkpoint_id: u64,
+    ) -> IndexedEpochInfo {
+        Self {
+            epoch: new_system_state_summary.epoch,
+            validators: new_system_state_summary.active_validators,
+            first_checkpoint_id,
+            epoch_start_timestamp: new_system_state_summary.epoch_start_timestamp_ms,
+            reference_gas_price: new_system_state_summary.reference_gas_price,
+            protocol_version: new_system_state_summary.protocol_version,
+            ..Default::default()
+        }
+    }
+
+    pub fn from_end_of_epoch_data(
+        last_checkpoint_summary: &CertifiedCheckpointSummary,
+        event: &SystemEpochInfoEvent,
+        network_total_tx_num_at_last_epoch_end: u64,
+    ) -> IndexedEpochInfo {
+        Self {
+            epoch: last_checkpoint_summary.epoch,
+            epoch_total_transactions: Some(
+                last_checkpoint_summary.network_total_transactions
+                    - network_total_tx_num_at_last_epoch_end,
+            ),
+            last_checkpoint_id: Some(*last_checkpoint_summary.sequence_number()),
+            epoch_end_timestamp: Some(last_checkpoint_summary.timestamp_ms),
+            next_epoch_protocol_version: Some(event.protocol_version),
+            next_epoch_reference_gas_price: Some(event.reference_gas_price),
+            new_total_stake: Some(event.total_stake),
+            storage_fund_reinvestment: Some(event.storage_fund_reinvestment),
+            storage_charge: Some(event.storage_charge),
+            storage_rebate: Some(event.storage_rebate),
+            leftover_storage_fund_inflow: Some(event.leftover_storage_fund_inflow),
+            stake_subsidy_amount: Some(event.stake_subsidy_amount),
+            storage_fund_balance: Some(event.storage_fund_balance),
+            total_gas_fees: Some(event.total_gas_fees),
+            total_stake_rewards_distributed: Some(event.total_stake_rewards_distributed),
+            epoch_commitments: last_checkpoint_summary
+                .end_of_epoch_data
+                .as_ref()
+                .map(|e| e.epoch_commitments.clone()),
+
+            // The following felds will not and shall not be upserted
+            // into DB. We have them below to make compiler and diesel happy
+            validators: vec![],
+            first_checkpoint_id: 0,
+            epoch_start_timestamp: 0,
+            reference_gas_price: 0,
+            protocol_version: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sui-rest-api/src/checkpoints.rs
+++ b/crates/sui-rest-api/src/checkpoints.rs
@@ -173,6 +173,30 @@ pub struct CheckpointData {
     pub transactions: Vec<CheckpointTransaction>,
 }
 
+impl CheckpointData {
+    pub fn output_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.output_objects)
+            .collect()
+    }
+
+    pub fn input_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.input_objects)
+            .collect()
+    }
+
+    pub fn all_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.input_objects)
+            .chain(self.transactions.iter().flat_map(|tx| &tx.output_objects))
+            .collect()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointTransaction {
     /// The input Transaction

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use anyhow::ensure;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
+use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -21,6 +22,7 @@ use crate::error::{SuiError, SuiResult};
 use crate::object::{MoveObject, ObjectFormatOptions};
 use crate::sui_serde::BigInt;
 use crate::sui_serde::Readable;
+use crate::SUI_SYSTEM_ADDRESS;
 
 /// A universal Sui event type encapsulating different types of events
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,6 +141,12 @@ impl Event {
             }
         })
     }
+
+    pub fn is_system_epoch_info_event(&self) -> bool {
+        self.type_.address == SUI_SYSTEM_ADDRESS
+            && self.type_.module.as_ident_str() == ident_str!("sui_system_state_inner")
+            && self.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEvent")
+    }
 }
 
 impl Event {
@@ -156,4 +164,21 @@ impl Event {
             contents: vec![],
         }
     }
+}
+
+// Event emitted in move code `fun advance_epoch`
+#[derive(Deserialize)]
+pub struct SystemEpochInfoEvent {
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub reference_gas_price: u64,
+    pub total_stake: u64,
+    pub storage_fund_reinvestment: u64,
+    pub storage_charge: u64,
+    pub storage_rebate: u64,
+    pub storage_fund_balance: u64,
+    pub stake_subsidy_amount: u64,
+    pub total_gas_fees: u64,
+    pub total_stake_rewards_distributed: u64,
+    pub leftover_storage_fund_inflow: u64,
 }


### PR DESCRIPTION
## Description 

This PR has the following major things:
1. implement `CheckpointHandlerV2`, a `Hanlder` that indices data passed by fetcher.
2. implement `committer`. `Committer` consumes indexed data from handler then commits to the db store.

It also changes `epoch_total_transactions` column in Epoch table to nullable since it's only accessible at the end of an epoch.

Stack:
1. https://github.com/MystenLabs/sui/pull/13760
2. https://github.com/MystenLabs/sui/pull/13774
3. https://github.com/MystenLabs/sui/pull/13804
4. https://github.com/MystenLabs/sui/pull/13805
5. https://github.com/MystenLabs/sui/pull/13832
6. https://github.com/MystenLabs/sui/pull/13834
7. https://github.com/MystenLabs/sui/pull/13881
8. https://github.com/MystenLabs/sui/pull/13882
9. https://github.com/MystenLabs/sui/pull/13884
10. https://github.com/MystenLabs/sui/pull/13892




## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
