### PR TITLE
wallet-ext: remove accounts

### DIFF
--- a/apps/wallet/src/shared/messaging/messages/payloads/MethodPayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/MethodPayload.ts
@@ -69,6 +69,7 @@ type MethodPayloads = {
 	verifyPasswordRecoveryData: {
 		data: PasswordRecoveryData;
 	};
+	removeAccount: { accountID: string };
 };
 
 type Methods = keyof MethodPayloads;

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -554,6 +554,18 @@ export class BackgroundClient {
 		);
 	}
 
+	public removeAccount(args: MethodPayload<'removeAccount'>['args']) {
+		return lastValueFrom(
+			this.sendMessage(
+				createMessage<MethodPayload<'removeAccount'>>({
+					type: 'method-payload',
+					method: 'removeAccount',
+					args,
+				}),
+			).pipe(take(1)),
+		);
+	}
+
 	private loadFeatures() {
 		return lastValueFrom(
 			this.sendMessage(

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ArrowBgFill16, Plus12 } from '@mysten/icons';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
-import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { forwardRef, useState } from 'react';
+import toast from 'react-hot-toast';
 import { type AccountType, type SerializedUIAccount } from '_src/background/accounts/Account';
 import { isZkAccountSerializedUI } from '_src/background/accounts/zk/ZkAccount';
 import { type ZkProvider } from '_src/background/accounts/zk/providers';
@@ -11,8 +13,18 @@ import { AccountItem } from '_src/ui/app/components/accounts/AccountItem';
 import { useAccountsFormContext } from '_src/ui/app/components/accounts/AccountsFormContext';
 import { NicknameDialog } from '_src/ui/app/components/accounts/NicknameDialog';
 import { VerifyPasswordModal } from '_src/ui/app/components/accounts/VerifyPasswordModal';
+import { useAccounts } from '_src/ui/app/hooks/useAccounts';
+import { useBackgroundClient } from '_src/ui/app/hooks/useBackgroundClient';
 import { useCreateAccountsMutation } from '_src/ui/app/hooks/useCreateAccountMutation';
 import { Button } from '_src/ui/app/shared/ButtonUI';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '_src/ui/app/shared/Dialog';
 import { Heading } from '_src/ui/app/shared/heading';
 import { Text } from '_src/ui/app/shared/text';
 import { ButtonOrLink, type ButtonOrLinkProps } from '_src/ui/app/shared/utils/ButtonOrLink';
@@ -40,38 +52,91 @@ export function getGroupTitle(aGroupAccount: SerializedUIAccount) {
 
 // todo: we probbaly have some duplication here with the various FooterLink / ButtonOrLink
 // components - we should look to add these to base components somewhere
-function FooterLink({ children, to, ...props }: ButtonOrLinkProps) {
-	return (
-		<ButtonOrLink
-			className="text-hero-darkest/40 no-underline uppercase hover:text-hero outline-none border-none bg-transparent hover:cursor-pointer"
-			to={to}
-			{...props}
-		>
-			<Text variant="captionSmallExtra" weight="medium">
-				{children}
-			</Text>
-		</ButtonOrLink>
-	);
-}
+const FooterLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonOrLinkProps>(
+	({ children, to, ...props }, ref) => {
+		return (
+			<ButtonOrLink
+				ref={ref}
+				className="text-hero-darkest/40 no-underline uppercase hover:text-hero outline-none border-none bg-transparent hover:cursor-pointer"
+				to={to}
+				{...props}
+			>
+				<Text variant="captionSmallExtra" weight="medium">
+					{children}
+				</Text>
+			</ButtonOrLink>
+		);
+	},
+);
 
 // todo: this is slightly different than the account footer in the AccountsList - look to consolidate :(
 function AccountFooter({ accountID, showExport }: { accountID: string; showExport?: boolean }) {
+	const allAccounts = useAccounts();
+	const totalAccounts = allAccounts?.data?.length || 0;
+	const backgroundClient = useBackgroundClient();
+	const [isConfirmationVisible, setIsConfirmationVisible] = useState(false);
+	const removeAccountMutation = useMutation({
+		mutationKey: ['remove account mutation', accountID],
+		mutationFn: async () => {
+			await backgroundClient.removeAccount({ accountID });
+			setIsConfirmationVisible(false);
+		},
+	});
 	return (
-		<div className="flex flex-shrink-0 w-full">
-			<div className="flex gap-3 items-center">
-				<div className="w-1.5" />
-				<NicknameDialog accountID={accountID} trigger={<FooterLink>Edit Nickname</FooterLink>} />
-				{showExport ? (
-					<FooterLink to={`/accounts/export/${accountID}`}>
-						<div>Export Private Key</div>
-					</FooterLink>
-				) : null}
-				{/* TODO: Remove Account functionality */}
-				{/* <FooterLink to="/remove">
-					<div>Remove</div>
-				</FooterLink> */}
+		<>
+			<div className="flex flex-shrink-0 w-full">
+				<div className="flex gap-0.5 items-center">
+					<NicknameDialog accountID={accountID} trigger={<FooterLink>Edit Nickname</FooterLink>} />
+					{showExport ? (
+						<FooterLink to={`/accounts/export/${accountID}`}>Export Private Key</FooterLink>
+					) : null}
+					{allAccounts.isLoading ? null : (
+						<FooterLink
+							onClick={() => setIsConfirmationVisible(true)}
+							disabled={isConfirmationVisible}
+						>
+							Remove
+						</FooterLink>
+					)}
+				</div>
 			</div>
-		</div>
+			<Dialog open={isConfirmationVisible}>
+				<DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
+					<DialogHeader>
+						<DialogTitle>Are you sure you want to remove this account?</DialogTitle>
+					</DialogHeader>
+					{totalAccounts === 1 ? (
+						<div className="text-center">
+							<DialogDescription>
+								Removing this account will require you to set up your Sui wallet again.
+							</DialogDescription>
+						</div>
+					) : null}
+					<DialogFooter>
+						<div className="flex gap-2.5">
+							<Button
+								variant="outline"
+								size="tall"
+								text="Cancel"
+								onClick={() => setIsConfirmationVisible(false)}
+							/>
+							<Button
+								variant="warning"
+								size="tall"
+								text="Remove"
+								loading={removeAccountMutation.isLoading}
+								onClick={() => {
+									removeAccountMutation.mutate(undefined, {
+										onSuccess: () => toast.success('Account removed'),
+										onError: (e) => toast.error((e as Error)?.message || 'Something went wrong'),
+									});
+								}}
+							/>
+						</div>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 }
 

--- a/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/AccountGroup.tsx
@@ -85,7 +85,7 @@ function AccountFooter({ accountID, showExport }: { accountID: string; showExpor
 	return (
 		<>
 			<div className="flex flex-shrink-0 w-full">
-				<div className="flex gap-0.5 items-center">
+				<div className="flex gap-0.5 items-center whitespace-nowrap">
 					<NicknameDialog accountID={accountID} trigger={<FooterLink>Edit Nickname</FooterLink>} />
 					{showExport ? (
 						<FooterLink to={`/accounts/export/${accountID}`}>Export Private Key</FooterLink>

--- a/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
@@ -4,12 +4,13 @@ import { useNavigate } from 'react-router-dom';
 import { AccountGroup } from './AccountGroup';
 import Overlay from '../../../components/overlay';
 import { type AccountType } from '_src/background/accounts/Account';
+import { useInitializedGuard } from '_src/ui/app/hooks';
 import { useAccountGroups } from '_src/ui/app/hooks/useAccountGroups';
 
 export function ManageAccountsPage() {
 	const navigate = useNavigate();
 	const groupedAccounts = useAccountGroups();
-
+	useInitializedGuard(true);
 	return (
 		<Overlay showModal title="Manage Accounts" closeOverlay={() => navigate('/home')}>
 			<div className="flex flex-col gap-4 flex-1">


### PR DESCRIPTION
## Description 

* allow removing accounts in manage page
* removing all accounts of an account source will remove the account source as well
* removed mnemonic accounts will be added back by creating a new account for the account source (deriving next account will fill any gaps)


https://github.com/MystenLabs/sui/assets/10210143/5ac1440f-e1be-4426-9c53-b48d8ce2d8d3


https://github.com/MystenLabs/sui/assets/10210143/eb065db8-94e2-42f6-8969-24532fbcf593

closes APPS-1615

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
