### PR TITLE
[GraphQL/FunctionalGroups] Configuration disables queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10233,6 +10233,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,7 +17,9 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+once_cell.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_with.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -122,7 +122,7 @@ mod tests {
         let actual = ServiceConfig::read(
             r#" disabled-features = [
                   "coins",
-                  "name-server",
+                  "name-service",
                 ]
             "#,
         )
@@ -131,7 +131,7 @@ mod tests {
         use FunctionalGroup as G;
         let expect = ServiceConfig {
             limits: Limits::default(),
-            disabled_features: BTreeSet::from([G::Coins, G::NameServer]),
+            disabled_features: BTreeSet::from([G::Coins, G::NameService]),
             experiments: Experiments::default(),
         };
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -19,19 +19,25 @@ pub(crate) mod code {
 /// because they will originate from within the GraphQL implementation.  This function is intended
 /// for errors that originated from outside of GraphQL (such as in middleware), but that need to be
 /// ingested by GraphQL clients.
-pub(crate) fn graphql_error(code: &str, message: String) -> GraphQLResponse {
+pub(crate) fn graphql_error_response(code: &str, message: impl Into<String>) -> GraphQLResponse {
+    let error = graphql_error(code, message);
+    Response::from_errors(error.into()).into()
+}
+
+/// Create a generic GraphQL Server Error.
+///
+/// This error has no path, source, or locations, just a message and an error code.
+pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerError {
     let mut ext = ErrorExtensionValues::default();
     ext.set("code", code);
 
-    let error = ServerError {
-        message,
+    ServerError {
+        message: message.into(),
         source: None,
         locations: vec![],
         path: vec![],
         extensions: Some(ext),
-    };
-
-    Response::from_errors(error.into()).into()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
+++ b/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextResolve, ResolveInfo},
+    ServerError, ServerResult, Value,
+};
+use async_trait::async_trait;
+
+use crate::{
+    config::ServiceConfig,
+    error::{code, graphql_error},
+    functional_group::functional_group,
+};
+
+pub(crate) struct FeatureGate;
+
+impl ExtensionFactory for FeatureGate {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(FeatureGate)
+    }
+}
+
+#[async_trait]
+impl Extension for FeatureGate {
+    async fn resolve(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        info: ResolveInfo<'_>,
+        next: NextResolve<'_>,
+    ) -> ServerResult<Option<Value>> {
+        let ResolveInfo {
+            parent_type,
+            name,
+            is_for_introspection,
+            ..
+        } = &info;
+
+        let ServiceConfig {
+            disabled_features, ..
+        } = ctx.data().map_err(|_| {
+            graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                "Unable to fetch service configuration",
+            )
+        })?;
+
+        // TODO: Is there a way to set `is_visible` on `MetaField` and `MetaType` in a generic way
+        // after building the schema? (to a function which reads the `ServiceConfig` from the
+        // `Context`). This is (probably) required to hide disabled types and interfaces in the
+        // schema.
+
+        if let Some(group) = functional_group(parent_type, name) {
+            if disabled_features.contains(&group) {
+                return if *is_for_introspection {
+                    Ok(None)
+                } else {
+                    Err(ServerError::new(
+                        format!(
+                            "Cannot query field \"{name}\" on type \"{parent_type}\". \
+                             Feature {} is disabled.",
+                            group.name(),
+                        ),
+                        // TODO: Fork `async-graphl` to add field position information to
+                        // `ResolveInfo`, so the error can take advantage of it.  Similarly for
+                        // utilising the `path_node` to set the error path.
+                        None,
+                    ))
+                };
+            }
+        }
+
+        next.run(ctx, info).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+    use expect_test::expect;
+
+    use crate::{functional_group::FunctionalGroup, types::query::Query};
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic] // because it tries to access the data provider, which isn't there
+    async fn test_accessing_an_enabled_field() {
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig::default())
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_accessing_a_disabled_field() {
+        let errs: Vec<_> = Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig {
+                disabled_features: BTreeSet::from_iter([FunctionalGroup::SystemState]),
+                ..Default::default()
+            })
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await
+            .into_result()
+            .unwrap_err()
+            .into_iter()
+            .map(|e| e.message)
+            .collect();
+
+        let expect = expect![[r#"
+            [
+                "Cannot query field \"protocolConfig\" on type \"Query\". Feature \"system-state\" is disabled.",
+            ]"#]];
+        expect.assert_eq(&format!("{errs:#?}"));
+    }
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod feature_gate;
 pub(crate) mod limits_info;
 pub(crate) mod logger;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use serde_json as json;
 
 /// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
 /// settings in the RPC's TOML configuration file.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
@@ -18,10 +22,7 @@ pub(crate) enum FunctionalGroup {
     DynamicFields,
 
     /// SuiNS name and reverse name look-up.
-    NameServer,
-
-    /// Struct and function signatures, and popular packages.
-    Packages,
+    NameService,
 
     /// Transaction and Event subscriptions.
     Subscriptions,
@@ -29,4 +30,132 @@ pub(crate) enum FunctionalGroup {
     /// Information about the system that changes from epoch to epoch (protocol config, committee,
     /// reference gas price).
     SystemState,
+}
+
+impl FunctionalGroup {
+    /// Name that the group is referred to by in configuration and responses on the GraphQL API.
+    /// Not a suitable `Display` implementation because it enquotes the representation.
+    pub(crate) fn name(&self) -> String {
+        json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+}
+
+/// Mapping from type and field name in the schema to the functional group it belongs to.
+fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), FunctionalGroup> {
+    // TODO: Introduce a macro to declare the functional group for a field and/or type on the
+    // appropriate type, field, or function, instead of here.  This may also be able to set the
+    // graphql `visible` attribute to control schema visibility by functional groups.
+
+    use FunctionalGroup as G;
+    static GROUPS: Lazy<BTreeMap<(&str, &str), FunctionalGroup>> = Lazy::new(|| {
+        BTreeMap::from_iter([
+            (("Address", "balance"), G::Coins),
+            (("Address", "balanceConnection"), G::Coins),
+            (("Address", "coinConnection"), G::Coins),
+            (("Address", "defaultNameServiceName"), G::NameService),
+            (("Address", "nameServiceConnection"), G::NameService),
+            (("Checkpoint", "addressMetrics"), G::Analytics),
+            (("Checkpoint", "networkTotalTransactions"), G::Analytics),
+            (("Epoch", "protocolConfig"), G::SystemState),
+            (("Epoch", "referenceGasPrice"), G::SystemState),
+            (("Epoch", "safeMode"), G::SystemState),
+            (("Epoch", "storageFund"), G::SystemState),
+            (("Epoch", "systemParameters"), G::SystemState),
+            (("Epoch", "systemStateVersion"), G::SystemState),
+            (("Epoch", "validatorSet"), G::SystemState),
+            (("Object", "balance"), G::Coins),
+            (("Object", "balanceConnection"), G::Coins),
+            (("Object", "coinConnection"), G::Coins),
+            (("Object", "defaultNameServiceName"), G::NameService),
+            (("Object", "dynamicField"), G::DynamicFields),
+            (("Object", "dynamicFieldConnection"), G::DynamicFields),
+            (("Object", "nameServiceConnection"), G::NameService),
+            (("Owner", "balance"), G::Coins),
+            (("Owner", "balanceConnection"), G::Coins),
+            (("Owner", "coinConnection"), G::Coins),
+            (("Owner", "defaultNameServiceName"), G::NameService),
+            (("Owner", "nameServiceConnection"), G::NameService),
+            (("Query", "coinMetadata"), G::Coins),
+            (("Query", "moveCallMetrics"), G::Analytics),
+            (("Query", "networkMetrics"), G::Analytics),
+            (("Query", "protocolConfig"), G::SystemState),
+            (("Query", "resolveNameServiceAddress"), G::NameService),
+            (("Subscription", "events"), G::Subscriptions),
+            (("Subscription", "transactions"), G::Subscriptions),
+        ])
+    });
+
+    Lazy::force(&GROUPS)
+}
+
+/// Map a type and field name to a functional group.  If an explicit group does not exist for the
+/// field, then it is assumed to be a "core" feature.
+pub(crate) fn functional_group(type_: &str, field: &str) -> Option<FunctionalGroup> {
+    functional_groups().get(&(type_, field)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::registry::Registry;
+    use async_graphql::OutputType;
+
+    use crate::types::query::Query;
+
+    use super::*;
+
+    #[test]
+    /// Makes sure all the functional groups correspond to real elements of the schema unless they
+    /// are explicitly recorded as unimplemented.  Complementarily, makes sure that fields marked as
+    /// unimplemented don't appear in the set of unimplemented fields.
+    fn test_groups_match_schema() {
+        let mut registry = Registry::default();
+        Query::create_type_info(&mut registry);
+
+        let unimplemented = BTreeSet::from_iter([
+            ("Checkpoint", "addressMetrics"),
+            ("Epoch", "protocolConfig"),
+            ("Object", "dynamicField"),
+            ("Object", "dynamicFieldConnection"),
+            ("Query", "coinMetadata"),
+            ("Query", "moveCallMetrics"),
+            ("Query", "networkMetrics"),
+            ("Query", "resolveNameServiceAddress"),
+            ("Subscription", "events"),
+            ("Subscription", "transactions"),
+        ]);
+
+        for (type_, field) in &unimplemented {
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                continue;
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                continue;
+            };
+
+            panic!(
+                "Field '{type_}.{field}' is marked as unimplemented in this test, but it's in the \
+                 schema.  Fix this by removing it from the `unimplemented` set."
+            );
+        }
+
+        for (type_, field) in functional_groups().keys() {
+            if unimplemented.contains(&(type_, field)) {
+                continue;
+            }
+
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                panic!("Type '{type_}' from functional group configs does not appear in schema.");
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                panic!(
+                    "Field '{type_}.{field}' from functional group configs does not appear in \
+                     schema."
+                );
+            };
+        }
+    }
 }

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -5,10 +5,11 @@ pub mod commands;
 pub mod config;
 pub mod server;
 
+pub(crate) mod functional_group;
+
 mod context_data;
 mod error;
 mod extensions;
-mod functional_group;
 mod types;
 
 use async_graphql::*;

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -4,6 +4,7 @@
 use crate::config::{ConnectionConfig, ServiceConfig};
 use crate::context_data::data_provider::DataProvider;
 use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_client_v0};
+use crate::extensions::feature_gate::FeatureGate;
 use crate::extensions::limits_info::LimitsInfo;
 use crate::extensions::logger::Logger;
 use crate::extensions::timeout::Timeout;
@@ -29,9 +30,10 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
         .context_data(data_provider)
         .context_data(data_loader)
         .context_data(service_config)
+        .extension(FeatureGate)
+        .extension(LimitsInfo)
         .extension(Logger::default())
         .extension(Timeout::default())
-        .extension(LimitsInfo)
         .build()
         .run()
         .await;

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -9,7 +9,7 @@ use axum::{
     TypedHeader,
 };
 
-use crate::error::{code, graphql_error};
+use crate::error::{code, graphql_error_response};
 
 const RPC_VERSION_FULL: &str = env!("CARGO_PKG_VERSION");
 const RPC_VERSION_YEAR: &str = env!("CARGO_PKG_VERSION_MAJOR");
@@ -58,7 +58,7 @@ pub(crate) async fn check_version_middleware<B>(
         if !rest.is_empty() {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Multiple possible versions found."),
                 ),
@@ -69,7 +69,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Ok(req_version) = std::str::from_utf8(&req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Not a UTF8 string."),
                 ),
@@ -79,7 +79,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Some((year, month)) = parse_version(req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!(
                         "Failed to parse {VERSION_HEADER}: '{req_version}' not a valid \
@@ -92,7 +92,7 @@ pub(crate) async fn check_version_middleware<B>(
         if year != RPC_VERSION_YEAR || month != RPC_VERSION_MONTH {
             return (
                 StatusCode::MISDIRECTED_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::INTERNAL_SERVER_ERROR,
                     format!("Version '{req_version}' not supported."),
                 ),


### PR DESCRIPTION
##  Description

Adds an extension to intercept field resolution to check whether the field being queried belongs to a disabled functional group.  If so, an error is produced instead of allowing the query through.

Changes the functional group enum itself:

- Removing "Packages" (there are no package-specific queries).
- Renaing "NameServer" to "NameService" for consistency.

Currently, disabled fields are not removed from the schema during introspection. This has been left as a follow-up (TODO in the codebase).

Also, the error from the extension does not supply a source location in the query because this is not supplied to the extension by `async-graphql`.  Fixing this requires an upstream change, so this has also been left as a follow-up.

## Test Plan

New tests for extension:

```
sui-graphql-rpc$ cargo nextest run
```

- All configured functional groups must refer to real fields in the schema, unless marked as unimplemented.
- All unimplemented fields must *not* exist in the schema (this is to make sure the tests get cleaned up).
- Querying an enabled field makes it through to the data loader (which panics, but that's okay).
- Querying a disabled field yields an error.