### PR TITLE
wallet-ext: fix redux selector warning

### DIFF
--- a/apps/wallet/src/ui/app/hooks/useExplorerLink.ts
+++ b/apps/wallet/src/ui/app/hooks/useExplorerLink.ts
@@ -38,8 +38,8 @@ function useAddress(linkConfig: ExplorerLinkConfig) {
 export function useExplorerLink(linkConfig: ExplorerLinkConfig) {
 	const { type } = linkConfig;
 	const address = useAddress(linkConfig);
-	const [selectedApiEnv, customRPC] = useAppSelector(({ app }) => [app.apiEnv, app.customRPC]);
-
+	const selectedApiEnv = useAppSelector(({ app }) => app.apiEnv);
+	const customRPC = useAppSelector(({ app }) => app.customRPC);
 	const objectID = type === ExplorerLinkType.object ? linkConfig.objectID : null;
 	const transactionID = type === ExplorerLinkType.transaction ? linkConfig.transactionID : null;
 	const validator = type === ExplorerLinkType.validator ? linkConfig.validator : null;


### PR DESCRIPTION
## Description 

removes the following warning

<img width="1203" alt="Screenshot 2023-09-19 at 14 40 19" src="https://github.com/MystenLabs/sui/assets/10210143/d74f1029-d157-4673-ac6d-5d0408ee5f21">



## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
