### PR TITLE
zklogin: add LRU for zklogin inputs verify

### DIFF
--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -3,10 +3,9 @@
 
 use criterion::*;
 
+use criterion::Criterion;
 use sui_core::signature_verifier::{SignatureVerifierMetrics, VerifiedDigestCache};
 use sui_types::digests::CertificateDigest;
-
-use criterion::Criterion;
 
 fn verified_cert_cache_bench(c: &mut Criterion) {
     let mut digests: Vec<_> = (0..(1 << 18))

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -16,6 +16,8 @@ use shared_crypto::intent::Intent;
 use std::hash::Hash;
 use std::sync::Arc;
 use sui_types::digests::SenderSignedDataDigest;
+use sui_types::digests::ZKLoginInputsDigest;
+use sui_types::signature::GenericSignature;
 use sui_types::transaction::SenderSignedData;
 use sui_types::{
     committee::Committee,
@@ -34,7 +36,6 @@ use tokio::{
     time::{timeout, Duration},
 };
 use tracing::debug;
-
 // Maximum amount of time we wait for a batch to fill up before verifying a partial batch.
 const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
 
@@ -93,6 +94,7 @@ pub struct SignatureVerifier {
     committee: Arc<Committee>,
     certificate_cache: VerifiedDigestCache<CertificateDigest>,
     signed_data_cache: VerifiedDigestCache<SenderSignedDataDigest>,
+    zklogin_inputs_cache: VerifiedDigestCache<ZKLoginInputsDigest>,
 
     /// Map from JwkId (iss, kid) to the fetched JWK for that key.
     /// We use an immutable data structure because verification of ZKLogins may be slow, so we
@@ -134,6 +136,10 @@ impl SignatureVerifier {
             signed_data_cache: VerifiedDigestCache::new(
                 metrics.signed_data_cache_hits.clone(),
                 metrics.signed_data_cache_evictions.clone(),
+            ),
+            zklogin_inputs_cache: VerifiedDigestCache::new(
+                metrics.zklogin_inputs_cache_hits.clone(),
+                metrics.zklogin_inputs_cache_evictions.clone(),
             ),
             jwks: Default::default(),
             queue: Mutex::new(CertBuffer::new(batch_size)),
@@ -320,17 +326,35 @@ impl SignatureVerifier {
     }
 
     pub fn verify_tx(&self, signed_tx: &SenderSignedData) -> SuiResult {
-        self.signed_data_cache
-            .is_verified(signed_tx.full_message_digest(), || {
+        self.signed_data_cache.is_verified(
+            signed_tx.full_message_digest(),
+            || {
                 signed_tx.verify_epoch(self.committee.epoch())?;
                 let jwks = self.jwks.read().clone();
-                let aux_data = VerifyParams::new(
+                let verify_params = VerifyParams::new(
                     jwks,
                     self.zk_login_params.supported_providers.clone(),
                     self.zk_login_params.env.clone(),
                 );
-                signed_tx.verify_message_signature(&aux_data)
-            })
+                signed_tx
+                    .tx_signatures()
+                    .iter()
+                    .try_for_each(|sig| match sig {
+                        // If a zkLogin signature is found, check cache first. If it is in
+                        // the cache, just verifies for uncached checks, otherwise verifies
+                        // the entire zkLogin signature.
+                        GenericSignature::ZkLoginAuthenticator(z) => {
+                            self.zklogin_inputs_cache.is_verified(
+                                z.hash_inputs(),
+                                || signed_tx.verify_message_signature(&verify_params),
+                                || signed_tx.verify_uncached_checks(&verify_params),
+                            )
+                        }
+                        _ => signed_tx.verify_message_signature(&verify_params),
+                    })
+            },
+            || Ok(()),
+        )
     }
 }
 
@@ -339,6 +363,8 @@ pub struct SignatureVerifierMetrics {
     pub certificate_signatures_cache_evictions: IntCounter,
     pub signed_data_cache_hits: IntCounter,
     pub signed_data_cache_evictions: IntCounter,
+    pub zklogin_inputs_cache_hits: IntCounter,
+    pub zklogin_inputs_cache_evictions: IntCounter,
     timeouts: IntCounter,
     full_batches: IntCounter,
     partial_batches: IntCounter,
@@ -372,6 +398,18 @@ impl SignatureVerifierMetrics {
                 "Number of times we evict a pre-existing signed data were known to be verified because of signature cache.",
                 registry
             )
+                .unwrap(),
+                zklogin_inputs_cache_hits: register_int_counter_with_registry!(
+                    "zklogin_inputs_cache_hits",
+                    "Number of zklogin signature which were known to be partially verified because of zklogin inputs cache.",
+                    registry
+                )
+                .unwrap(),
+                zklogin_inputs_cache_evictions: register_int_counter_with_registry!(
+                    "zklogin_inputs_cache_evictions",
+                    "Number of times we evict a pre-existing zklogin inputs digest that was known to be verified because of zklogin inputs cache.",
+                    registry
+                )
                 .unwrap(),
             timeouts: register_int_counter_with_registry!(
                 "async_batch_verifier_timeouts",
@@ -518,13 +556,17 @@ impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
         });
     }
 
-    pub fn is_verified<F>(&self, digest: D, verify_callback: F) -> SuiResult
+    pub fn is_verified<F, G>(&self, digest: D, verify_callback: F, uncached_checks: G) -> SuiResult
     where
         F: FnOnce() -> SuiResult,
+        G: FnOnce() -> SuiResult,
     {
         if !self.is_cached(&digest) {
             verify_callback()?;
             self.cache_digest(digest);
+        } else {
+            // Checks that are required to be performed outside the cache.
+            uncached_checks()?;
         }
         Ok(())
     }

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -816,3 +816,13 @@ impl std::str::FromStr for ObjectDigest {
         Ok(ObjectDigest::new(result))
     }
 }
+
+/// A digest of a ZkLoginInputs, which commits to the signatures as well as the tx.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ZKLoginInputsDigest(Digest);
+
+impl ZKLoginInputsDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+}

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -110,6 +110,9 @@ pub trait Message {
 pub trait AuthenticatedMessage {
     /// Verify internal signatures, e.g. for Transaction we verify the user signature(s).
     fn verify_message_signature(&self, verify_params: &VerifyParams) -> SuiResult;
+
+    /// Checks that still need to be verified outside cache.
+    fn verify_uncached_checks(&self, verify_params: &VerifyParams) -> SuiResult;
 }
 
 /// A marker trait to indicate !AuthenticatedMessage since rust does not allow negative trait

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -78,7 +78,17 @@ impl AuthenticatorTrait for MultiSig {
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> Result<(), SuiError> {
         Ok(())
     }
-
+    fn verify_uncached_checks<T>(
+        &self,
+        _value: &IntentMessage<T>,
+        _author: SuiAddress,
+        _aux_verify_data: &VerifyParams,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize,
+    {
+        Ok(())
+    }
     fn verify_claims<T>(
         &self,
         value: &IntentMessage<T>,

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -90,6 +90,18 @@ impl AuthenticatorTrait for MultiSigLegacy {
         Ok(())
     }
 
+    fn verify_uncached_checks<T>(
+        &self,
+        _value: &IntentMessage<T>,
+        _author: SuiAddress,
+        _aux_verify_data: &VerifyParams,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize,
+    {
+        Ok(())
+    }
+
     fn verify_claims<T>(
         &self,
         value: &IntentMessage<T>,

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -18,7 +18,6 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use shared_crypto::intent::IntentMessage;
 use std::hash::Hash;
-
 #[derive(Default, Debug, Clone)]
 pub struct VerifyParams {
     // map from JwkId (iss, kid) => JWK
@@ -70,6 +69,15 @@ pub trait AuthenticatorTrait {
         }
         self.verify_claims(value, author, aux_verify_data)
     }
+
+    fn verify_uncached_checks<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: SuiAddress,
+        aux_verify_data: &VerifyParams,
+    ) -> SuiResult
+    where
+        T: Serialize;
 }
 
 /// Due to the incompatibility of [enum Signature] (which dispatches a trait that
@@ -177,6 +185,17 @@ impl<'de> ::serde::Deserialize<'de> for GenericSignature {
 /// This ports the wrapper trait to the verify_secure defined on [enum Signature].
 impl AuthenticatorTrait for Signature {
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> SuiResult {
+        Ok(())
+    }
+    fn verify_uncached_checks<T>(
+        &self,
+        _value: &IntentMessage<T>,
+        _author: SuiAddress,
+        _aux_verify_data: &VerifyParams,
+    ) -> SuiResult
+    where
+        T: Serialize,
+    {
         Ok(())
     }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2012,6 +2012,13 @@ impl Message for SenderSignedData {
 }
 
 impl AuthenticatedMessage for SenderSignedData {
+    // Checks that are required to be done outside cache.
+    fn verify_uncached_checks(&self, verify_params: &VerifyParams) -> SuiResult {
+        for (signer, signature) in self.get_signer_sig_mapping()? {
+            signature.verify_uncached_checks(self.intent_message(), signer, verify_params)?;
+        }
+        Ok(())
+    }
     fn verify_message_signature(&self, verify_params: &VerifyParams) -> SuiResult {
         fp_ensure!(
             self.0.len() == 1,


### PR DESCRIPTION
## Description 

add `verify_uncached_checks` to AuthenticatedMessage. this iterates through all GenericSignatures in SenderSignedData and perform `verify_uncached_checks` for (this returns empty ok for all signature schemes except zklogin signature, which calls `verify_zklogin_inputs` that contains the expensive zkproof verification)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
