### PR TITLE
wallet-ext: update dapp approval pages for locked accounts

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
@@ -17,7 +17,6 @@ import { ExplorerLinkType } from '../explorer-link/ExplorerLinkType';
 import { Text } from '_src/ui/app/shared/text';
 
 interface AccountItemProps {
-	name?: string;
 	accountID: string;
 	icon?: ReactNode;
 	after?: ReactNode;
@@ -38,7 +37,6 @@ export const AccountItem = forwardRef<HTMLDivElement, AccountItemProps>(
 			isActiveAccount,
 			disabled,
 			icon,
-			name,
 			accountID,
 			after,
 			footer,

--- a/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
@@ -1,9 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useResolveSuiNSName } from '@mysten/core';
-import { formatAddress } from '@mysten/sui.js/utils';
-
 import { AccountIcon } from './AccountIcon';
 import { AccountItem } from './AccountItem';
 import { LockUnlockButton } from './LockUnlockButton';
@@ -19,13 +16,11 @@ type AccountListItemProps = {
 
 export function AccountListItem({ account, editable }: AccountListItemProps) {
 	const activeAccount = useActiveAccount();
-	const { data: domainName } = useResolveSuiNSName(account?.address);
 	const { unlockAccount, lockAccount, isLoading, accountToUnlock } = useUnlockAccount();
 
 	return (
 		<AccountItem
 			icon={<AccountIcon account={account} />}
-			name={account.nickname || domainName || formatAddress(account.address)}
 			isActiveAccount={account.address === activeAccount?.address}
 			after={
 				<div className="ml-auto">

--- a/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
@@ -1,10 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useResolveSuiNSName } from '@mysten/core';
 import { CheckFill16 } from '@mysten/icons';
 
-import { formatAddress } from '@mysten/sui.js/utils';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import cn from 'classnames';
 import { AccountIcon } from './AccountIcon';
@@ -17,11 +15,9 @@ type AccountMultiSelectItemProps = {
 };
 
 export function AccountMultiSelectItem({ account, state }: AccountMultiSelectItemProps) {
-	const { data: domainName } = useResolveSuiNSName(account.address);
 	return (
 		<ToggleGroup.Item asChild value={account.id}>
 			<AccountItem
-				name={account.nickname ?? domainName ?? formatAddress(account.address)}
 				accountID={account.id}
 				selected={state === 'selected'}
 				disabled={state === 'disabled'}

--- a/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
+++ b/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
@@ -4,9 +4,11 @@
 import cn from 'classnames';
 import { useCallback, useMemo, useState } from 'react';
 
+import { useAccountByAddress } from '../../hooks/useAccountByAddress';
 import { Button } from '../../shared/ButtonUI';
 import { DAppInfoCard } from '../DAppInfoCard';
 
+import { UnlockAccountButton } from '../accounts/UnlockAccountButton';
 import { type PermissionType } from '_src/shared/messaging/messages/payloads/permissions';
 import type { ReactNode } from 'react';
 
@@ -25,6 +27,7 @@ type UserApproveContainerProps = {
 	scrollable?: boolean;
 	blended?: boolean;
 	permissions?: PermissionType[];
+	checkAccountLock?: boolean;
 };
 
 export function UserApproveContainer({
@@ -40,6 +43,7 @@ export function UserApproveContainer({
 	addressHidden = false,
 	address,
 	permissions,
+	checkAccountLock,
 }: UserApproveContainerProps) {
 	const [submitting, setSubmitting] = useState(false);
 	const handleOnResponse = useCallback(
@@ -50,9 +54,8 @@ export function UserApproveContainer({
 		},
 		[onSubmit],
 	);
-
+	const { data: selectedAccount } = useAccountByAddress(address);
 	const parsedOrigin = useMemo(() => new URL(origin), [origin]);
-
 	return (
 		<div className="flex flex-1 flex-col flex-nowrap h-full">
 			<div className="flex-1 pb-0 flex flex-col">
@@ -71,25 +74,31 @@ export function UserApproveContainer({
 						'flex-row-reverse': isWarning,
 					})}
 				>
-					<Button
-						size="tall"
-						variant="secondary"
-						onClick={() => {
-							handleOnResponse(false);
-						}}
-						disabled={submitting}
-						text={rejectTitle}
-					/>
-					<Button
-						size="tall"
-						variant={isWarning ? 'secondary' : 'primary'}
-						onClick={() => {
-							handleOnResponse(true);
-						}}
-						disabled={approveDisabled}
-						loading={submitting || approveLoading}
-						text={approveTitle}
-					/>
+					{!checkAccountLock || !selectedAccount?.isLocked ? (
+						<>
+							<Button
+								size="tall"
+								variant="secondary"
+								onClick={() => {
+									handleOnResponse(false);
+								}}
+								disabled={submitting}
+								text={rejectTitle}
+							/>
+							<Button
+								size="tall"
+								variant={isWarning ? 'secondary' : 'primary'}
+								onClick={() => {
+									handleOnResponse(true);
+								}}
+								disabled={approveDisabled}
+								loading={submitting || approveLoading}
+								text={approveTitle}
+							/>
+						</>
+					) : (
+						<UnlockAccountButton account={selectedAccount} title="Unlock to Approve" />
+					)}
 				</div>
 			</div>
 		</div>

--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -49,11 +49,14 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
 			address={request.tx.accountAddress}
 			scrollable
 			blended
+			checkAccountLock
 		>
 			<PageMainLayoutTitle title="Sign Message" />
-			<Heading variant="heading6" color="gray-90" weight="semibold" centered>
-				Message You Are Signing
-			</Heading>
+			<div className="py-4">
+				<Heading variant="heading6" color="gray-90" weight="semibold" centered>
+					Message You Are Signing
+				</Heading>
+			</div>
 			<div className="flex flex-col flex-nowrap items-stretch border border-solid border-gray-50 rounded-15 overflow-y-auto overflow-x-hidden bg-white shadow-card-soft">
 				<div className="p-5 break-words">
 					<Text variant="pBodySmall" weight="medium" color="steel-darker" mono={type === 'base64'}>

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -93,6 +93,7 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
 				}}
 				address={addressForTransaction}
 				approveLoading={isLoading || isConfirmationVisible}
+				checkAccountLock
 			>
 				<PageMainLayoutTitle title="Approve Transaction" />
 				<div className="flex flex-col">


### PR DESCRIPTION
## Description 

* show unlock button instead of allowing approving when selected account is locked
* show new account UI for the selected account and allow unlocking it
* fix dapp info overflowing
* fix spacing in Sign Message screen

<img width="391" alt="Screenshot 2023-09-19 at 18 19 44" src="https://github.com/MystenLabs/sui/assets/10210143/0442ff13-f631-48c3-8478-273bfea06e94">

https://github.com/MystenLabs/sui/assets/10210143/c9c1449c-1cfa-4b6c-93d7-c8ebcd78e863


https://github.com/MystenLabs/sui/assets/10210143/cd4eae1e-f53b-4007-bab5-0e2798712da2


part of [APPS-1700](https://mysten.atlassian.net/browse/APPS-1700)
closes [APPS-1499](https://mysten.atlassian.net/browse/APPS-1499)

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
