### PR TITLE
[cli] display sui client envs as a table

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1571,13 +1571,20 @@ impl Display for SuiClientCommandResult {
                 writeln!(writer, "Added new Sui env [{}] to config.", env.alias)?;
             }
             SuiClientCommandResult::Envs(envs, active) => {
+                let mut builder = TableBuilder::default();
+                builder.set_header(["alias", "url", "active"]);
                 for env in envs {
-                    write!(writer, "{} => {}", env.alias, env.rpc)?;
-                    if Some(env.alias.as_str()) == active.as_deref() {
-                        write!(writer, " (active)")?;
-                    }
-                    writeln!(writer)?;
+                    builder.push_record(vec![env.alias.clone(), env.rpc.clone(), {
+                        if Some(env.alias.as_str()) == active.as_deref() {
+                            "*".to_string()
+                        } else {
+                            "".to_string()
+                        }
+                    }]);
                 }
+                let mut table = builder.build();
+                table.with(TableStyle::rounded());
+                write!(f, "{}", table)?
             }
             SuiClientCommandResult::VerifySource => {
                 writeln!(writer, "Source verification succeeded!")?;


### PR DESCRIPTION
## Description 

This PR updates the way the `sui client envs` command is displayed as a well formatted table.

## Test Plan 

<img width="619" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/947eedce-0f3a-423b-a1ae-1327a27e64e8">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR updates the way the `sui client envs` command is displayed as a well formatted table. Use `--json` to get a standard JSON output.