### PR TITLE
Extend execution_layer.py to support dashes

### DIFF
--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -401,7 +401,7 @@ def cut_directories(f):
 
 def impl(feature):
     """Path to the impl module for this feature"""
-    return Path() / "sui-execution" / "src" / (feature + ".rs")
+    return Path() / "sui-execution" / "src" / (feature.replace("-", "_") + ".rs")
 
 
 def clean_up_cut(feature):
@@ -443,7 +443,7 @@ def generate_impls(feature, copy):
     orig = Path() / "sui-execution" / "src" / "latest.rs"
     with open(orig, mode="r") as orig, open(copy, mode="w") as copy:
         for line in orig:
-            line = re.sub(r"^use (.*)_latest::", rf"use \1_{feature}::", line)
+            line = re.sub(r"^use (.*)_latest::", rf"use \1_{feature.replace('-', '_')}::", line)
             copy.write(line)
 
 
@@ -591,7 +591,8 @@ def discover_cuts():
     # assigned versions in lexicographical order.
     for i, feature in enumerate(features):
         version = f"u64::MAX - {i}" if i > 0 else "u64::MAX"
-        cuts.append((version, feature.stem.upper(), feature.stem))
+        feature_stem = feature.stem.replace("-", "_")
+        cuts.append((version, feature_stem.upper(), feature_stem))
 
     return cuts
 


### PR DESCRIPTION
## Description 

I wanted to create a feature branch vm-rework, but the script today will create Rust files and refer to the feature as "vm-rework", which breaks Rust convention. This PR extends the script so that we can still reference feature cuts w/ dashes, but will create Rust files and references with "vm_rework". Verified this works with ./scripts/execution_layer.py cut vm-rework, and then rebasing with ./scripts/execution_layer.py rebase latest

## Test Plan 

Verified this works with ./scripts/execution_layer.py cut vm-rework, and then rebasing with ./scripts/execution_layer.py rebase latest

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
