### PR TITLE
[cli] format output of `sui client gas` to a well formatted table

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -56,11 +56,11 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use tabled::builder::Builder as TableBuilder;
 use tabled::settings::{
     object::Cell as TableCell, Border as TableBorder, Modify as TableModify, Panel as TablePanel,
     Style as TableStyle,
 };
+use tabled::{builder::Builder as TableBuilder, settings::style::HorizontalLine};
 use tracing::info;
 
 macro_rules! serialize_or_execute {
@@ -1401,6 +1401,47 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
+            SuiClientCommandResult::Gas(gas_coins) => {
+                let gas_coins = gas_coins
+                    .iter()
+                    .map(GasCoinOutput::from)
+                    .collect::<Vec<_>>();
+                if gas_coins.is_empty() {
+                    write!(f, "No gas coins are owned by this address")?;
+                    return Ok(());
+                }
+
+                let mut builder = TableBuilder::default();
+                builder.set_header(vec!["gasCoinId", "gasBalance"]);
+                for coin in &gas_coins {
+                    builder.push_record(vec![
+                        coin.gas_coin_id.to_string(),
+                        coin.gas_balance.to_string(),
+                    ]);
+                }
+                let mut table = builder.build();
+                table.with(TableStyle::rounded());
+                if gas_coins.len() > 10 {
+                    table.with(TablePanel::header(format!(
+                        "Showing {} gas coins and their balances.",
+                        gas_coins.len()
+                    )));
+                    table.with(TablePanel::footer(format!(
+                        "Showing {} gas coins and their balances.",
+                        gas_coins.len()
+                    )));
+                    table.with(TableStyle::rounded().horizontals([
+                        HorizontalLine::new(1, TableStyle::modern().get_horizontal()),
+                        HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
+                        HorizontalLine::new(
+                            gas_coins.len() + 2,
+                            TableStyle::modern().get_horizontal(),
+                        ),
+                    ]));
+                    table.with(tabled::settings::style::BorderSpanCorrection);
+                }
+                write!(f, "{}", table)?;
+            }
             SuiClientCommandResult::NewAddress(new_address) => {
                 let mut builder = TableBuilder::default();
 
@@ -1531,17 +1572,6 @@ impl Display for SuiClientCommandResult {
             }
             SuiClientCommandResult::SyncClientState => {
                 writeln!(writer, "Client state sync complete.")?;
-            }
-            SuiClientCommandResult::Gas(gases) => {
-                // TODO: generalize formatting of CLI
-                writeln!(writer, " {0: ^66} | {1: ^11}", "Object ID", "Gas Value")?;
-                writeln!(
-                    writer,
-                    "----------------------------------------------------------------------------------"
-                )?;
-                for gas in gases {
-                    writeln!(writer, " {0: ^66} | {1: ^11}", gas.id(), gas.value())?;
-                }
             }
             SuiClientCommandResult::ChainIdentifier(ci) => {
                 writeln!(writer, "{}", ci)?;
@@ -1700,6 +1730,13 @@ pub fn write_transaction_response(
 impl Debug for SuiClientCommandResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = unwrap_err_to_string(|| match self {
+            SuiClientCommandResult::Gas(gas_coins) => {
+                let gas_coins = gas_coins
+                    .iter()
+                    .map(GasCoinOutput::from)
+                    .collect::<Vec<_>>();
+                Ok(serde_json::to_string_pretty(&gas_coins)?)
+            }
             SuiClientCommandResult::Object(object_read) => {
                 let object = object_read.object()?;
                 Ok(serde_json::to_string_pretty(&object)?)
@@ -1777,6 +1814,22 @@ pub struct NewAddressOutput {
     pub address: SuiAddress,
     pub key_scheme: SignatureScheme,
     pub recovery_phrase: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasCoinOutput {
+    pub gas_coin_id: ObjectID,
+    pub gas_balance: u64,
+}
+
+impl From<&GasCoin> for GasCoinOutput {
+    fn from(gas_coin: &GasCoin) -> Self {
+        Self {
+            gas_coin_id: *gas_coin.id(),
+            gas_balance: gas_coin.value(),
+        }
+    }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Description 

This PR displays the output of `sui client gas [address]` as a well formatted table. If there are more than 10 coins, it will add an extra header and footer with the number of coins. 

## Test Plan 
<img width="1049" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/596aa083-1067-41eb-8e59-92b1cb7e3067">
<img width="1049" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/596396ee-136f-4542-b833-44c15a278221">

*Found an address with lots of coins on devnet*
<img width="1049" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/361415ff-0418-4f9a-a77d-1c40e0e982d5">
<img width="1049" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/37bd528f-d67a-4a77-b853-1283b2cd122b">




---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [x] breaking change for the `sui client gas` command's JSON output
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR changes the output of `sui client gas [address]` to a well-formatted table. This breaks the previous JSON format, when using `--json` flag, due to changing the `GasCoin` output type to a simpler one. For example, you might have previously accessed the gas coin ID using `id.id` and the value using `balance.value` from the original JSON, as in the following example: 
```
{
    "id": {
      "id": "0x20365c5cee12091faf31e3ea5f3586a4ea5f1ae49d71cda99c104b5ae8325f8b"
    },
    "balance": {
      "value": 997250075972
    }
}
``` 
With this change, now you must use `gasCoinId` to access the ID and `gasBalance` for the balance vlaue. The JSON output now resembles the following:
``` 
{
   "gasCoinId": "0x20365c5cee12091faf31e3ea5f3586a4ea5f1ae49d71cda99c104b5ae8325f8b",
   "gasBalance": 997250075972
}
 ```