### PR TITLE
[graphql/rpc] limit number of query nodes

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -7,6 +7,9 @@ use serde::Deserialize;
 
 use crate::functional_group::FunctionalGroup;
 
+const MAX_QUERY_DEPTH: usize = 10;
+const MAX_QUERY_NODES: usize = 100;
+
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 pub struct ConnectionConfig {
     pub(crate) port: u16,
@@ -33,6 +36,8 @@ pub struct ServiceConfig {
 pub struct Limits {
     #[serde(default)]
     pub(crate) max_query_depth: usize,
+    #[serde(default)]
+    pub(crate) max_query_nodes: usize,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq, Default)]
@@ -74,7 +79,8 @@ impl Default for ConnectionConfig {
 impl Default for Limits {
     fn default() -> Self {
         Self {
-            max_query_depth: 10,
+            max_query_depth: MAX_QUERY_DEPTH,
+            max_query_nodes: MAX_QUERY_NODES,
         }
     }
 }
@@ -95,6 +101,7 @@ mod tests {
         let actual = ServiceConfig::read(
             r#" [limits]
                 max-query-depth = 100
+                max-query-nodes = 300
             "#,
         )
         .unwrap();
@@ -102,6 +109,7 @@ mod tests {
         let expect = ServiceConfig {
             limits: Limits {
                 max_query_depth: 100,
+                max_query_nodes: 300,
             },
             ..Default::default()
         };
@@ -154,6 +162,7 @@ mod tests {
 
                 [limits]
                 max-query-depth = 42
+                max-query-nodes = 320
 
                 [experiments]
                 test-flag = true
@@ -164,6 +173,7 @@ mod tests {
         let expect = ServiceConfig {
             limits: Limits {
                 max_query_depth: 42,
+                max_query_nodes: 320,
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
             experiments: Experiments { test_flag: true },

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -49,6 +49,11 @@ impl ServerBuilder {
         self
     }
 
+    pub fn max_query_nodes(mut self, max_nodes: usize) -> Self {
+        self.schema = self.schema.limit_complexity(max_nodes);
+        self
+    }
+
     pub fn context_data(mut self, context_data: impl Any + Send + Sync) -> Self {
         self.schema = self.schema.data(context_data);
         self
@@ -190,6 +195,39 @@ mod tests {
         assert!(resp.is_err());
         let resp = exec_query_depth_limit(
             2,
+            "{ chainIdentifier protocolConfig { configs { value key }} }",
+        )
+        .await;
+        assert!(resp.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_query_node_limit() {
+        async fn exec_query_node_limit(nodes: usize, query: &str) -> Response {
+            let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
+            let data_provider: Box<dyn DataProvider> = Box::new(sdk);
+            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+                .context_data(data_provider)
+                .max_query_nodes(nodes)
+                .build_schema();
+            schema.execute(query).await
+        }
+
+        // Should complete successfully
+        let resp = exec_query_node_limit(1, "{ chainIdentifier }").await;
+        assert!(resp.is_ok());
+        let resp = exec_query_node_limit(
+            5,
+            "{ chainIdentifier protocolConfig { configs { value key }} }",
+        )
+        .await;
+        assert!(resp.is_ok());
+
+        // Should fail
+        let resp = exec_query_node_limit(0, "{ chainIdentifier }").await;
+        assert!(resp.is_err());
+        let resp = exec_query_node_limit(
+            4,
             "{ chainIdentifier protocolConfig { configs { value key }} }",
         )
         .await;

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -24,6 +24,7 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
 
     builder
         .max_query_depth(service_config.limits.max_query_depth)
+        .max_query_nodes(service_config.limits.max_query_nodes)
         .context_data(data_provider)
         .context_data(data_loader)
         .context_data(service_config)


### PR DESCRIPTION
## Description 

Limit the number of nodes in graphql query

## Test Plan 

Unit

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
