### PR TITLE
wallet-ext: connect to dapp ui polish and fixes

### DIFF
--- a/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
+++ b/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
@@ -87,6 +87,8 @@ export function DAppInfoCard({
 							/>
 						</div>
 					}
+					hideCopy
+					hideExplorerLink
 				/>
 			) : null}
 			{permissions?.length ? (

--- a/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
@@ -27,6 +27,8 @@ interface AccountItemProps {
 	isActiveAccount?: boolean; // whether the account is the active account in the context of the account list
 	background?: 'gradient';
 	editable?: boolean;
+	hideExplorerLink?: boolean;
+	hideCopy?: boolean;
 }
 
 export const AccountItem = forwardRef<HTMLDivElement, AccountItemProps>(
@@ -41,6 +43,8 @@ export const AccountItem = forwardRef<HTMLDivElement, AccountItemProps>(
 			after,
 			footer,
 			editable,
+			hideExplorerLink,
+			hideCopy,
 			...props
 		},
 		ref,
@@ -88,14 +92,14 @@ export const AccountItem = forwardRef<HTMLDivElement, AccountItemProps>(
 								{formatAddress(account.address)}
 							</Text>
 							<div className="opacity-0 group-hover:opacity-100 flex gap-1 duration-100">
-								<IconButton icon={<Copy12 />} onClick={copyAddress} />
-								{explorerHref ? (
+								{hideCopy ? null : <IconButton icon={<Copy12 />} onClick={copyAddress} />}
+								{hideExplorerLink || !explorerHref ? null : (
 									<IconButton
 										title="View on Explorer"
 										href={explorerHref}
 										icon={<ArrowUpRight12 />}
 									/>
-								) : null}
+								)}
 							</div>
 						</div>
 					</div>

--- a/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountListItem.tsx
@@ -12,9 +12,17 @@ type AccountListItemProps = {
 	account: SerializedUIAccount;
 	editable?: boolean;
 	showLock?: boolean;
+	hideCopy?: boolean;
+	hideExplorerLink?: boolean;
 };
 
-export function AccountListItem({ account, editable, showLock = false }: AccountListItemProps) {
+export function AccountListItem({
+	account,
+	editable,
+	showLock,
+	hideCopy,
+	hideExplorerLink,
+}: AccountListItemProps) {
 	const activeAccount = useActiveAccount();
 	const { unlockAccount, lockAccount, isLoading, accountToUnlock } = useUnlockAccount();
 
@@ -45,6 +53,8 @@ export function AccountListItem({ account, editable, showLock = false }: Account
 			}
 			accountID={account.id}
 			editable={editable}
+			hideCopy={hideCopy}
+			hideExplorerLink={hideExplorerLink}
 		/>
 	);
 }

--- a/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountMultiSelectItem.tsx
@@ -31,6 +31,8 @@ export function AccountMultiSelectItem({ account, state }: AccountMultiSelectIte
 						<CheckFill16 className={cn('h-4 w-4', { 'opacity-50': state === 'disabled' })} />
 					</div>
 				}
+				hideCopy
+				hideExplorerLink
 			/>
 		</ToggleGroup.Item>
 	);

--- a/apps/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/apps/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 import { SectionHeader } from '../../components/SectionHeader';
 import { AccountListItem } from '../../components/accounts/AccountListItem';
 import { AccountMultiSelectWithControls } from '../../components/accounts/AccountMultiSelect';
+import Alert from '../../components/alert';
 import { useAccountGroups } from '../../hooks/useAccountGroups';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
 
@@ -39,7 +40,7 @@ function SiteConnectPage() {
 	const unlockedAccounts = accounts.filter((account) => !account.isLocked);
 	const lockedAccounts = accounts.filter((account) => account.isLocked);
 	const [accountsToConnect, setAccountsToConnect] = useState<SerializedUIAccount[]>(() =>
-		activeAccount ? [activeAccount] : [],
+		activeAccount && !activeAccount.isLocked ? [activeAccount] : [],
 	);
 	const handleOnSubmit = useCallback(
 		async (allowed: boolean) => {
@@ -129,7 +130,7 @@ function SiteConnectPage() {
 					>
 						<PageMainLayoutTitle title="Approve Connection" />
 						<div className="flex flex-col gap-8 py-6">
-							{unlockedAccounts.length > 0 && (
+							{unlockedAccounts.length > 0 ? (
 								<AccountMultiSelectWithControls
 									selectedAccountIDs={accountsToConnect.map((account) => account.id)}
 									accounts={unlockedAccounts ?? []}
@@ -137,12 +138,22 @@ function SiteConnectPage() {
 										setAccountsToConnect(value.map((id) => accounts?.find((a) => a.id === id)!));
 									}}
 								/>
+							) : (
+								<Alert mode="warning">
+									All accounts are currently locked. Unlock accounts to connect.
+								</Alert>
 							)}
 							{lockedAccounts?.length > 0 && (
 								<div className="flex flex-col gap-3">
 									<SectionHeader title="Locked & Unavailable" />
 									{lockedAccounts?.map((account) => (
-										<AccountListItem key={account.id} account={account} showLock />
+										<AccountListItem
+											key={account.id}
+											account={account}
+											showLock
+											hideCopy
+											hideExplorerLink
+										/>
 									))}
 								</div>
 							)}


### PR DESCRIPTION
## Description 
* stop auto selecting active account when locked
* remove copy and explorer icons from approve connection and dapp status
* show message when all accounts are locked

before


https://github.com/MystenLabs/sui/assets/10210143/6c4c32a0-02b9-4af5-a64b-b8918b0c59ef


https://github.com/MystenLabs/sui/assets/10210143/ecfa39ae-3cd6-4582-956a-d8e12084c460


https://github.com/MystenLabs/sui/assets/10210143/32fcd73c-60f7-49d2-9cd4-39801c24f303


after


https://github.com/MystenLabs/sui/assets/10210143/48e213b2-2cbb-4c89-82cc-f051bd86f59d


https://github.com/MystenLabs/sui/assets/10210143/f23a2d45-2a7e-4508-bc35-7f1c79b5d966



closes [APPS-1700](https://mysten.atlassian.net/browse/APPS-1700)
closes [APPS-1698](https://mysten.atlassian.net/browse/APPS-1698)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
