### PR TITLE
wallet-ext: mnemonic accounts skip pass when account source is unlocked

### DIFF
--- a/apps/wallet/src/background/accounts/Account.ts
+++ b/apps/wallet/src/background/accounts/Account.ts
@@ -160,7 +160,7 @@ export interface SerializedUIAccount {
 
 export interface PasswordUnlockableAccount {
 	readonly unlockType: 'password';
-	passwordUnlock(password: string): Promise<void>;
+	passwordUnlock(password?: string): Promise<void>;
 	verifyPassword(password: string): Promise<void>;
 }
 

--- a/apps/wallet/src/background/accounts/ImportedAccount.ts
+++ b/apps/wallet/src/background/accounts/ImportedAccount.ts
@@ -94,7 +94,10 @@ export class ImportedAccount
 		};
 	}
 
-	async passwordUnlock(password: string): Promise<void> {
+	async passwordUnlock(password?: string): Promise<void> {
+		if (!password) {
+			throw new Error('Missing password to unlock the account');
+		}
 		const { encrypted } = await this.getStoredData();
 		const { keyPair } = await decrypt<EncryptedData>(password, encrypted);
 		await this.setEphemeralValue({ keyPair });

--- a/apps/wallet/src/background/accounts/LedgerAccount.ts
+++ b/apps/wallet/src/background/accounts/LedgerAccount.ts
@@ -78,7 +78,10 @@ export class LedgerAccount
 		return !(await this.getEphemeralValue())?.unlocked;
 	}
 
-	async passwordUnlock(password: string): Promise<void> {
+	async passwordUnlock(password?: string): Promise<void> {
+		if (!password) {
+			throw new Error('Missing password to unlock the account');
+		}
 		const { encrypted } = await this.getStoredData();
 		await decrypt<string>(password, encrypted);
 		await this.setEphemeralValue({ unlocked: true });

--- a/apps/wallet/src/background/accounts/MnemonicAccount.ts
+++ b/apps/wallet/src/background/accounts/MnemonicAccount.ts
@@ -82,10 +82,15 @@ export class MnemonicAccount
 		await this.onLocked(allowRead);
 	}
 
-	async passwordUnlock(password: string): Promise<void> {
-		const { derivationPath } = await this.getStoredData();
+	async passwordUnlock(password?: string): Promise<void> {
 		const mnemonicSource = await this.#getMnemonicSource();
-		await mnemonicSource.unlock(password);
+		if ((await mnemonicSource.isLocked()) && !password) {
+			throw new Error('Missing password to unlock the account');
+		}
+		const { derivationPath } = await this.getStoredData();
+		if (password) {
+			await mnemonicSource.unlock(password);
+		}
 		await this.setEphemeralValue({
 			keyPair: (await mnemonicSource.deriveKeyPair(derivationPath)).export(),
 		});

--- a/apps/wallet/src/background/accounts/QredoAccount.ts
+++ b/apps/wallet/src/background/accounts/QredoAccount.ts
@@ -55,7 +55,10 @@ export class QredoAccount
 		await this.onLocked(allowRead);
 	}
 
-	async passwordUnlock(password: string): Promise<void> {
+	async passwordUnlock(password?: string): Promise<void> {
+		if (!password) {
+			throw new Error('Missing password to unlock the account');
+		}
 		await (await this.#getQredoSource()).unlock(password);
 		await this.setEphemeralValue({ unlocked: true });
 		await this.onUnlocked();

--- a/apps/wallet/src/background/accounts/index.ts
+++ b/apps/wallet/src/background/accounts/index.ts
@@ -212,9 +212,6 @@ export async function accountsHandleUIMessage(msg: Message, uiConnection: UiConn
 		const account = await getAccountByID(id);
 		if (account) {
 			if (isPasswordUnLockable(account)) {
-				if (!password) {
-					throw new Error('Missing password to unlock the account');
-				}
 				await account.passwordUnlock(password);
 			} else {
 				await account.unlock();

--- a/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
+++ b/apps/wallet/src/ui/app/hooks/useCreateAccountMutation.ts
@@ -22,7 +22,7 @@ function validateAccountFormValues<T extends CreateType>(
 	if (values.type !== createType) {
 		throw new Error('Account data values type mismatch');
 	}
-	if (values.type !== 'zk' && !password) {
+	if (values.type !== 'zk' && values.type !== 'mnemonic-derived' && !password) {
 		throw new Error('Missing password');
 	}
 	return true;
@@ -69,10 +69,12 @@ export function useCreateAccountsMutation() {
 				type === 'mnemonic-derived' &&
 				validateAccountFormValues(type, accountsFormValues, password)
 			) {
-				await backgroundClient.unlockAccountSourceOrAccount({
-					password,
-					id: accountsFormValues.sourceID,
-				});
+				if (password) {
+					await backgroundClient.unlockAccountSourceOrAccount({
+						password,
+						id: accountsFormValues.sourceID,
+					});
+				}
 				createdAccounts = await backgroundClient.createAccounts({
 					type: 'mnemonic-derived',
 					sourceID: accountsFormValues.sourceID,

--- a/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/ManageAccountsPage.tsx
@@ -20,7 +20,7 @@ export function ManageAccountsPage() {
 							<AccountGroup
 								key={`${type}-${key}`}
 								accounts={accounts}
-								accountSource={key}
+								accountSourceID={key}
 								type={type as AccountType}
 							/>
 						);


### PR DESCRIPTION
## Description 


https://github.com/MystenLabs/sui/assets/10210143/a5f00e51-3912-46d2-8b49-37503fbae4b8

closes [APPS-1701](https://mysten.atlassian.net/browse/APPS-1701)

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
