### PR TITLE
[bcs] Add new bcs builder methods

### DIFF
--- a/sdk/bcs/src/bcs-type.ts
+++ b/sdk/bcs/src/bcs-type.ts
@@ -1,0 +1,228 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BcsReader } from './reader';
+import { ulebEncode } from './uleb';
+import { BcsWriter, BcsWriterOptions } from './writer';
+
+export interface BcsTypeOptions<T, Input = T> {
+	name?: string;
+	validate?: (value: Input) => void;
+}
+
+export class BcsType<T, Input = T> {
+	name: string;
+	read: (reader: BcsReader) => T;
+	serializedSize: (value: Input, options?: BcsWriterOptions) => number | null;
+	validate: (value: Input) => void;
+	protected _write: (value: Input, writer: BcsWriter) => void;
+	protected _serialize: (value: Input, options?: BcsWriterOptions) => Uint8Array;
+
+	constructor(
+		options: {
+			name: string;
+			read: (reader: BcsReader) => T;
+			write: (value: Input, writer: BcsWriter) => void;
+			serialize?: (value: Input, options?: BcsWriterOptions) => Uint8Array;
+			serializedSize?: (value: Input) => number | null;
+			validate?: (value: Input) => void;
+		} & BcsTypeOptions<T, Input>,
+	) {
+		this.name = options.name;
+		this.read = options.read;
+		this.serializedSize = options.serializedSize ?? (() => null);
+		this._write = options.write;
+		this._serialize =
+			options.serialize ??
+			((value, options) => {
+				const writer = new BcsWriter({ size: this.serializedSize(value) ?? undefined, ...options });
+				this._write(value, writer);
+				return writer.toBytes();
+			});
+
+		this.validate = options.validate ?? (() => {});
+	}
+
+	write(value: Input, writer: BcsWriter) {
+		this.validate(value);
+		this._write(value, writer);
+	}
+
+	serialize(value: Input, options?: BcsWriterOptions) {
+		this.validate(value);
+		return this._serialize(value, options);
+	}
+
+	parse(bytes: Uint8Array): T {
+		const reader = new BcsReader(bytes);
+		return this.read(reader);
+	}
+
+	transform<T2, Input2>({
+		name,
+		input,
+		output,
+	}: {
+		input: (val: Input2) => Input;
+		output: (value: T) => T2;
+	} & BcsTypeOptions<T2, Input2>) {
+		return new BcsType<T2, Input2>({
+			name: name ?? this.name,
+			read: (reader) => output(this.read(reader)),
+			write: (value, writer) => this._write(input(value), writer),
+			serializedSize: (value) => this.serializedSize(input(value)),
+			serialize: (value, options) => this._serialize(input(value), options),
+			validate: (value) => this.validate(input(value)),
+		});
+	}
+}
+
+export function fixedSizeBcsType<T, Input = T>({
+	size,
+	...options
+}: {
+	name: string;
+	size: number;
+	read: (reader: BcsReader) => T;
+	write: (value: Input, writer: BcsWriter) => void;
+} & BcsTypeOptions<T, Input>) {
+	return new BcsType<T, Input>({
+		...options,
+		serializedSize: () => size,
+	});
+}
+
+export function uIntBcsType({
+	readMethod,
+	writeMethod,
+	...options
+}: {
+	name: string;
+	size: number;
+	readMethod: `read${8 | 16 | 32}`;
+	writeMethod: `write${8 | 16 | 32}`;
+	maxValue: number;
+} & BcsTypeOptions<number, number>) {
+	return fixedSizeBcsType<number>({
+		...options,
+		read: (reader) => reader[readMethod](),
+		write: (value, writer) => writer[writeMethod](value),
+		validate: (value) => {
+			if (value < 0 || value > options.maxValue) {
+				throw new TypeError(
+					`Invalid ${options.name} value: ${value}. Expected value in range 0-${options.maxValue}`,
+				);
+			}
+			options.validate?.(value);
+		},
+	});
+}
+
+export function bigUIntBcsType({
+	readMethod,
+	writeMethod,
+	...options
+}: {
+	name: string;
+	size: number;
+	readMethod: `read${64 | 128 | 256}`;
+	writeMethod: `write${64 | 128 | 256}`;
+	maxValue: bigint;
+} & BcsTypeOptions<string, string | number | bigint>) {
+	return fixedSizeBcsType<string, string | number | bigint>({
+		...options,
+		read: (reader) => reader[readMethod](),
+		write: (value, writer) => writer[writeMethod](BigInt(value)),
+		validate: (val) => {
+			const value = BigInt(val);
+			if (value < 0 || value > options.maxValue) {
+				throw new TypeError(
+					`Invalid ${options.name} value: ${value}. Expected value in range 0-${options.maxValue}`,
+				);
+			}
+			options.validate?.(value);
+		},
+	});
+}
+
+export function dynamicSizeBcsType<T, Input = T>({
+	serialize,
+	...options
+}: {
+	name: string;
+	read: (reader: BcsReader) => T;
+	serialize: (value: Input, options?: BcsWriterOptions) => Uint8Array;
+} & BcsTypeOptions<T, Input>) {
+	const type = new BcsType<T, Input>({
+		...options,
+		serialize,
+		write: (value, writer) => {
+			for (const byte of type.serialize(value)) {
+				writer.write8(byte);
+			}
+		},
+	});
+
+	return type;
+}
+
+export function stringLikeBcsType({
+	toBytes,
+	fromBytes,
+	...options
+}: {
+	name: string;
+	toBytes: (value: string) => Uint8Array;
+	fromBytes: (bytes: Uint8Array) => string;
+	serializedSize?: (value: string) => number | null;
+} & BcsTypeOptions<string>) {
+	return new BcsType<string>({
+		...options,
+		read: (reader) => {
+			const length = reader.readULEB();
+			const bytes = reader.readBytes(length);
+
+			return fromBytes(bytes);
+		},
+		write: (hex, writer) => {
+			const bytes = toBytes(hex);
+			writer.writeULEB(bytes.length);
+			for (let i = 0; i < bytes.length; i++) {
+				writer.write8(bytes[i]);
+			}
+		},
+		serialize: (value) => {
+			const bytes = toBytes(value);
+			const size = ulebEncode(bytes.length);
+			const result = new Uint8Array(size.length + bytes.length);
+			result.set(size, 0);
+			result.set(bytes, size.length);
+
+			return result;
+		},
+		validate: (value) => {
+			if (typeof value !== 'string') {
+				throw new TypeError(`Invalid ${options.name} value: ${value}. Expected string`);
+			}
+			options.validate?.(value);
+		},
+	});
+}
+
+export function lazyBcsType<T, Input>(cb: () => BcsType<T, Input>) {
+	let lazyType: BcsType<T, Input> | null = null;
+	function getType() {
+		if (!lazyType) {
+			lazyType = cb();
+		}
+		return lazyType;
+	}
+
+	return new BcsType<T, Input>({
+		name: 'lazy' as never,
+		read: (data) => getType().read(data),
+		serializedSize: (value) => getType().serializedSize(value),
+		write: (value, writer) => getType().write(value, writer),
+		serialize: (value, options) => getType().serialize(value, options),
+	});
+}

--- a/sdk/bcs/src/bcs.ts
+++ b/sdk/bcs/src/bcs.ts
@@ -1,0 +1,404 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toHEX, fromHEX } from './hex.js';
+import { fromB64, toB64 } from './b64.js';
+import { fromB58, toB58 } from './b58.js';
+import { ulebEncode } from './uleb.js';
+import {
+	BcsTypeOptions,
+	BcsType,
+	bigUIntBcsType,
+	dynamicSizeBcsType,
+	fixedSizeBcsType,
+	stringLikeBcsType,
+	uIntBcsType,
+	lazyBcsType,
+} from './bcs-type.js';
+import { GenericPlaceholder, ReplaceBcsGenerics } from './types.js';
+
+export const bcs = {
+	u8(options?: BcsTypeOptions<number>) {
+		return uIntBcsType({
+			name: 'u8',
+			readMethod: 'read8',
+			writeMethod: 'write8',
+			size: 1,
+			maxValue: 2 ** 8 - 1,
+			...options,
+		});
+	},
+
+	u16(options?: BcsTypeOptions<number>) {
+		return uIntBcsType({
+			name: 'u16',
+			readMethod: 'read16',
+			writeMethod: 'write16',
+			size: 2,
+			maxValue: 2 ** 16 - 1,
+			...options,
+		});
+	},
+
+	u32(options?: BcsTypeOptions<number>) {
+		return uIntBcsType({
+			name: 'u32',
+			readMethod: 'read32',
+			writeMethod: 'write32',
+			size: 4,
+			maxValue: 2 ** 32 - 1,
+			...options,
+		});
+	},
+
+	u64(options?: BcsTypeOptions<string, number | bigint | string>) {
+		return bigUIntBcsType({
+			name: 'u64',
+			readMethod: 'read64',
+			writeMethod: 'write64',
+			size: 8,
+			maxValue: 2n ** 64n - 1n,
+			...options,
+		});
+	},
+
+	u128(options?: BcsTypeOptions<string, number | bigint | string>) {
+		return bigUIntBcsType({
+			name: 'u128',
+			readMethod: 'read128',
+			writeMethod: 'write128',
+			size: 16,
+			maxValue: 2n ** 128n - 1n,
+			...options,
+		});
+	},
+
+	u256(options?: BcsTypeOptions<string, number | bigint | string>) {
+		return bigUIntBcsType({
+			name: 'u256',
+			readMethod: 'read256',
+			writeMethod: 'write256',
+			size: 32,
+			maxValue: 2n ** 256n - 1n,
+			...options,
+		});
+	},
+
+	bool(options?: BcsTypeOptions<boolean>) {
+		return fixedSizeBcsType<boolean>({
+			name: 'bool',
+			size: 1,
+			read: (reader) => reader.read8() === 1,
+			write: (value, writer) => writer.write8(value ? 1 : 0),
+			...options,
+		});
+	},
+
+	// TODO should be a bigint?
+	uleb128(options?: BcsTypeOptions<number>) {
+		return dynamicSizeBcsType<number>({
+			name: 'uleb128',
+			read: (reader) => reader.readULEB(),
+			serialize: (value) => {
+				return Uint8Array.from(ulebEncode(value));
+			},
+			...options,
+		});
+	},
+
+	bytes<T extends number>(size: T, options?: BcsTypeOptions<Uint8Array, Iterable<number>>) {
+		return fixedSizeBcsType<Uint8Array>({
+			name: `bytes[${size}]`,
+			size,
+			read: (reader) => reader.readBytes(size),
+			write: (value, writer) => {
+				for (let i = 0; i < size; i++) {
+					writer.write8(value[i] ?? 0);
+				}
+			},
+			...options,
+		});
+	},
+
+	string(options?: BcsTypeOptions<string>) {
+		return stringLikeBcsType({
+			name: 'string',
+			toBytes: (value) => new TextEncoder().encode(value),
+			fromBytes: (bytes) => new TextDecoder().decode(bytes),
+			...options,
+		});
+	},
+
+	hex(options?: BcsTypeOptions<string>) {
+		return stringLikeBcsType({
+			name: 'hex',
+			toBytes: (value) => fromHEX(value),
+			fromBytes: (bytes) => toHEX(bytes),
+			...options,
+		});
+	},
+
+	base58(options?: BcsTypeOptions<string>) {
+		return stringLikeBcsType({
+			name: 'base58',
+			toBytes: (value) => fromB58(value),
+			fromBytes: (bytes) => toB58(bytes),
+			...options,
+		});
+	},
+
+	base64(options?: BcsTypeOptions<string>) {
+		return stringLikeBcsType({
+			name: 'base64',
+			toBytes: (value) => fromB64(value),
+			fromBytes: (bytes) => toB64(bytes),
+			...options,
+		});
+	},
+
+	fixedArray<T, Input>(size: number, type: BcsType<T, Input>) {
+		return new BcsType<T[], Iterable<Input> & { length: number }>({
+			name: `${type.name}[${size}]`,
+			read: (reader) => {
+				const result: T[] = new Array(size);
+				for (let i = 0; i < size; i++) {
+					result[i] = type.read(reader);
+				}
+				return result;
+			},
+			write: (value, writer) => {
+				for (const item of value) {
+					type.write(item, writer);
+				}
+			},
+		});
+	},
+
+	option<T, Input>(type: BcsType<T, Input>) {
+		return bcs.optionEnum(type).transform({
+			input: (value: Input | null | undefined) => {
+				if (value == null) {
+					return { None: null };
+				}
+
+				return { Some: value };
+			},
+			output: (value) => {
+				if ('Some' in value) {
+					return value.Some;
+				}
+
+				return null;
+			},
+		});
+	},
+
+	optionEnum<T, Input>(type: BcsType<T, Input>) {
+		return bcs.enum(`Option<${type.name}>`, {
+			None: null,
+			Some: type,
+		});
+	},
+
+	vector<T, Input>(type: BcsType<T, Input>) {
+		return new BcsType<T[], Iterable<Input> & { length: number }>({
+			name: `vector<${type.name}>`,
+			read: (reader) => {
+				const length = reader.readULEB();
+				const result: T[] = new Array(length);
+				for (let i = 0; i < length; i++) {
+					result[i] = type.read(reader);
+				}
+				return result;
+			},
+			write: (value, writer) => {
+				writer.writeULEB(value.length);
+				for (const item of value) {
+					type.write(item, writer);
+				}
+			},
+		});
+	},
+
+	tuple<const Types extends readonly BcsType<any>[]>(types: Types) {
+		return new BcsType<
+			{
+				-readonly [K in keyof Types]: Types[K] extends BcsType<infer T, any> ? T : never;
+			},
+			{
+				[K in keyof Types]: Types[K] extends BcsType<any, infer T> ? T : never;
+			}
+		>({
+			name: `(${types.map((t) => t.name).join(', ')})`,
+			serializedSize: (values) => {
+				let total = 0;
+				for (let i = 0; i < types.length; i++) {
+					const size = types[i].serializedSize(values[i]);
+					if (size == null) {
+						return null;
+					}
+
+					total += size;
+				}
+
+				return total;
+			},
+			read: (reader) => {
+				const result: unknown[] = [];
+				for (const type of types) {
+					result.push(type.read(reader));
+				}
+				return result as never;
+			},
+			write: (value, writer) => {
+				for (let i = 0; i < types.length; i++) {
+					types[i].write(value[i], writer);
+				}
+			},
+		});
+	},
+
+	struct<T extends Record<string, BcsType<any>>>(
+		name: string,
+		fields: T,
+		options?: Omit<
+			BcsTypeOptions<
+				{
+					[K in keyof T]: T[K] extends BcsType<infer U, any> ? U : never;
+				},
+				{
+					[K in keyof T]: T[K] extends BcsType<any, infer U> ? U : never;
+				}
+			>,
+			'name'
+		>,
+	) {
+		const canonicalOrder = Object.entries(fields);
+
+		return new BcsType<
+			{
+				[K in keyof T]: T[K] extends BcsType<infer U, any> ? U : never;
+			},
+			{
+				[K in keyof T]: T[K] extends BcsType<any, infer U> ? U : never;
+			}
+		>({
+			name,
+			serializedSize: (values) => {
+				let total = 0;
+				for (const [field, type] of canonicalOrder) {
+					const size = type.serializedSize(values[field]);
+					if (size == null) {
+						return null;
+					}
+
+					total += size;
+				}
+
+				return total;
+			},
+			read: (reader) => {
+				const result: Record<string, unknown> = {};
+				for (const [field, type] of canonicalOrder) {
+					result[field] = type.read(reader);
+				}
+
+				return result as never;
+			},
+			write: (value, writer) => {
+				for (const [field, type] of canonicalOrder) {
+					type.write(value[field], writer);
+				}
+			},
+			...options,
+		});
+	},
+
+	enum<T>(
+		name: string,
+		values: T,
+		options?: Omit<
+			BcsTypeOptions<
+				{
+					[K in keyof T]: T[K] extends BcsType<infer U, any>
+						? { [K2 in K]: U }
+						: { [K2 in K]: true };
+				}[keyof T],
+				{
+					[K in keyof T]: T[K] extends BcsType<any, infer U>
+						? { [K2 in K]: U }
+						: { [K2 in K]: null | boolean };
+				}[keyof T]
+			>,
+			'name'
+		>,
+	) {
+		const canonicalOrder = Object.entries(values as object);
+		return new BcsType<
+			{
+				[K in keyof T]: T[K] extends BcsType<infer U, any> ? { [K2 in K]: U } : { [K2 in K]: true };
+			}[keyof T],
+			{
+				[K in keyof T]: T[K] extends BcsType<any, infer U>
+					? { [K2 in K]: U }
+					: { [K2 in K]: null | boolean };
+			}[keyof T]
+		>({
+			name,
+			read: (reader) => {
+				const index = reader.readULEB();
+				const [name, type] = canonicalOrder[index];
+				return {
+					[name]: type?.read(reader) ?? true,
+				} as never;
+			},
+			write: (value, writer) => {
+				const [name, val] = Object.entries(value)[0];
+				for (let i = 0; i < canonicalOrder.length; i++) {
+					const [optionName, optionType] = canonicalOrder[i];
+					if (optionName === name) {
+						writer.writeULEB(i);
+						optionType?.write(val, writer);
+						return;
+					}
+				}
+			},
+			...options,
+		});
+	},
+
+	map<K, V, InputK = K, InputV = V>(keyType: BcsType<K, InputK>, valueType: BcsType<V, InputV>) {
+		return bcs.vector(bcs.tuple([keyType, valueType])).transform({
+			name: `Map<${keyType.name}, ${valueType.name}>`,
+			input: (value: Map<InputK, InputV>) => {
+				return [...value.entries()];
+			},
+			output: (value) => {
+				const result = new Map<K, V>();
+				for (const [key, val] of value) {
+					result.set(key, val);
+				}
+				return result;
+			},
+		});
+	},
+
+	generic<const Names extends readonly string[], const Type extends BcsType<any>>(
+		names: Names,
+		cb: (...types: { [K in keyof Names]: BcsType<GenericPlaceholder<Names[K]>> }) => Type,
+	): <T extends { [K in keyof Names]: BcsType<any> }>(
+		...types: T
+	) => ReplaceBcsGenerics<Type, Names, T> {
+		return (...types) => {
+			return cb(...types).transform({
+				name: `${cb.name}<${types.map((t) => t.name).join(', ')}>`,
+				input: (value) => value,
+				output: (value) => value,
+			}) as never;
+		};
+	},
+
+	lazy<T extends BcsType<any>>(cb: () => T): T {
+		return lazyBcsType(cb) as T;
+	},
+};

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -16,12 +16,17 @@ import { toB64, fromB64 } from './b64.js';
 import { toHEX, fromHEX } from './hex.js';
 import { BcsReader } from './reader.js';
 import { BcsWriter, BcsWriterOptions } from './writer.js';
+import { bcs } from './bcs.js';
 import { encodeStr, decodeStr, splitGenericParameters } from './utils.js';
+import { BcsType, BcsTypeOptions } from './bcs-type.js';
 
 export * from './legacy-registry.js';
 
 // Re-export all encoding dependencies.
 export {
+	bcs,
+	BcsType,
+	type BcsTypeOptions,
 	toB58,
 	fromB58,
 	toB64,

--- a/sdk/bcs/src/types.ts
+++ b/sdk/bcs/src/types.ts
@@ -1,8 +1,60 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { BcsType } from './bcs-type';
+
 /**
  * Supported encodings.
  * Used in `Reader.toString()` as well as in `decodeStr` and `encodeStr` functions.
  */
 export type Encoding = 'base58' | 'base64' | 'hex';
+
+type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any
+	? { [K in keyof R]: R[K] }
+	: never;
+
+type RecursivelyReplacePlaceholder<
+	T,
+	R extends Record<string, unknown>,
+> = T extends GenericPlaceholder<infer K extends keyof R>
+	? R[K]
+	: T extends Record<string, unknown> | unknown[]
+	? { [K in keyof T]: RecursivelyReplacePlaceholder<T[K], R> }
+	: T extends Map<infer K, infer V>
+	? Map<RecursivelyReplacePlaceholder<K, R>, RecursivelyReplacePlaceholder<V, R>>
+	: T;
+
+const bcsGenericPlaceholder = Symbol('bcsPlaceholder');
+
+export interface GenericPlaceholder<T> {
+	[bcsGenericPlaceholder]: T;
+}
+
+export type ReplaceBcsGenerics<
+	Type extends BcsType<any>,
+	Names extends readonly string[],
+	Types extends { [K in keyof Names]: BcsType<any> },
+> = Type extends BcsType<infer U, any>
+	? BcsType<
+			RecursivelyReplacePlaceholder<
+				U,
+				UnionToIntersection<
+					{
+						[K in keyof Names]: Types[K] extends BcsType<infer R, any>
+							? { [K2 in Names[K]]: R }
+							: never;
+					}[number]
+				>
+			>,
+			RecursivelyReplacePlaceholder<
+				U,
+				UnionToIntersection<
+					{
+						[K in keyof Names]: Types[K] extends BcsType<any, infer R>
+							? { [K2 in Names[K]]: R }
+							: never;
+					}[number]
+				>
+			>
+	  >
+	: never;

--- a/sdk/bcs/tests/builder.test.ts
+++ b/sdk/bcs/tests/builder.test.ts
@@ -1,0 +1,282 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { bcs } from '../src/bcs.js';
+import { toHEX, BcsWriter, BcsReader, toB58 } from '../src';
+import { BcsType } from '../src/bcs-type.js';
+
+describe('bcs', () => {
+	describe('base types', () => {
+		testType('true', bcs.bool(), true, '01');
+		testType('false', bcs.bool(), false, '00');
+		testType('uleb128 0', bcs.uleb128(), 0, '00');
+		testType('uleb128 1', bcs.uleb128(), 1, '01');
+		testType('uleb128 127', bcs.uleb128(), 127, '7f');
+		testType('uleb128 128', bcs.uleb128(), 128, '8001');
+		testType('uleb128 255', bcs.uleb128(), 255, 'ff01');
+		testType('uleb128 256', bcs.uleb128(), 256, '8002');
+		testType('uleb128 16383', bcs.uleb128(), 16383, 'ff7f');
+		testType('uleb128 16384', bcs.uleb128(), 16384, '808001');
+		testType('uleb128 2097151', bcs.uleb128(), 2097151, 'ffff7f');
+		testType('uleb128 2097152', bcs.uleb128(), 2097152, '80808001');
+		testType('uleb128 268435455', bcs.uleb128(), 268435455, 'ffffff7f');
+		testType('uleb128 268435456', bcs.uleb128(), 268435456, '8080808001');
+		testType('u8 0', bcs.u8(), 0, '00');
+		testType('u8 1', bcs.u8(), 1, '01');
+		testType('u8 255', bcs.u8(), 255, 'ff');
+		testType('u16 0', bcs.u16(), 0, '0000');
+		testType('u16 1', bcs.u16(), 1, '0100');
+		testType('u16 255', bcs.u16(), 255, 'ff00');
+		testType('u16 256', bcs.u16(), 256, '0001');
+		testType('u16 65535', bcs.u16(), 65535, 'ffff');
+		testType('u32 0', bcs.u32(), 0, '00000000');
+		testType('u32 1', bcs.u32(), 1, '01000000');
+		testType('u32 255', bcs.u32(), 255, 'ff000000');
+		testType('u32 256', bcs.u32(), 256, '00010000');
+		testType('u32 65535', bcs.u32(), 65535, 'ffff0000');
+		testType('u32 65536', bcs.u32(), 65536, '00000100');
+		testType('u32 16777215', bcs.u32(), 16777215, 'ffffff00');
+		testType('u32 16777216', bcs.u32(), 16777216, '00000001');
+		testType('u32 4294967295', bcs.u32(), 4294967295, 'ffffffff');
+		testType('u64 0', bcs.u64(), 0, '0000000000000000', '0');
+		testType('u64 1', bcs.u64(), 1, '0100000000000000', '1');
+		testType('u64 255', bcs.u64(), 255n, 'ff00000000000000', '255');
+		testType('u64 256', bcs.u64(), 256n, '0001000000000000', '256');
+		testType('u64 65535', bcs.u64(), 65535n, 'ffff000000000000', '65535');
+		testType('u64 65536', bcs.u64(), 65536n, '0000010000000000', '65536');
+		testType('u64 16777215', bcs.u64(), 16777215n, 'ffffff0000000000', '16777215');
+		testType('u64 16777216', bcs.u64(), 16777216n, '0000000100000000', '16777216');
+		testType('u64 4294967295', bcs.u64(), 4294967295n, 'ffffffff00000000', '4294967295');
+		testType('u64 4294967296', bcs.u64(), 4294967296n, '0000000001000000', '4294967296');
+		testType('u64 1099511627775', bcs.u64(), 1099511627775n, 'ffffffffff000000', '1099511627775');
+		testType('u64 1099511627776', bcs.u64(), 1099511627776n, '0000000000010000', '1099511627776');
+		testType(
+			'u64 281474976710655',
+			bcs.u64(),
+			281474976710655n,
+			'ffffffffffff0000',
+			'281474976710655',
+		);
+		testType(
+			'u64 281474976710656',
+			bcs.u64(),
+			281474976710656n,
+			'0000000000000100',
+			'281474976710656',
+		);
+		testType(
+			'u64 72057594037927935',
+			bcs.u64(),
+			72057594037927935n,
+			'ffffffffffffff00',
+			'72057594037927935',
+		);
+		testType(
+			'u64 72057594037927936',
+			bcs.u64(),
+			72057594037927936n,
+			'0000000000000001',
+			'72057594037927936',
+		);
+		testType(
+			'u64 18446744073709551615',
+			bcs.u64(),
+			18446744073709551615n,
+			'ffffffffffffffff',
+			'18446744073709551615',
+		);
+		testType('u128 0', bcs.u128(), 0n, '00000000000000000000000000000000', '0');
+		testType('u128 1', bcs.u128(), 1n, '01000000000000000000000000000000', '1');
+		testType('u128 255', bcs.u128(), 255n, 'ff000000000000000000000000000000', '255');
+		testType(
+			'u128 18446744073709551615',
+			bcs.u128(),
+			18446744073709551615n,
+			'ffffffffffffffff0000000000000000',
+			'18446744073709551615',
+		);
+		testType(
+			'u128 18446744073709551615',
+			bcs.u128(),
+			18446744073709551616n,
+			'00000000000000000100000000000000',
+			'18446744073709551616',
+		);
+		testType(
+			'u128 340282366920938463463374607431768211455',
+			bcs.u128(),
+			340282366920938463463374607431768211455n,
+			'ffffffffffffffffffffffffffffffff',
+			'340282366920938463463374607431768211455',
+		);
+	});
+
+	describe('vector', () => {
+		testType('vector([])', bcs.vector(bcs.u8()), [], '00');
+		testType('vector([1, 2, 3])', bcs.vector(bcs.u8()), [1, 2, 3], '03010203');
+		testType(
+			'vector([1, null, 3])',
+			bcs.vector(bcs.option(bcs.u8())),
+			[1, null, 3],
+			// eslint-disable-next-line no-useless-concat
+			'03' + '0101' + '00' + '0103',
+		);
+	});
+
+	describe('fixedVector', () => {
+		testType('fixedVector([])', bcs.fixedArray(0, bcs.u8()), [], '');
+		testType('vector([1, 2, 3])', bcs.fixedArray(3, bcs.u8()), [1, 2, 3], '010203');
+		testType(
+			'fixedVector([1, null, 3])',
+			bcs.fixedArray(3, bcs.option(bcs.u8())),
+			[1, null, 3],
+			// eslint-disable-next-line no-useless-concat
+			'0101' + '00' + '0103',
+		);
+	});
+
+	describe('options', () => {
+		testType('optional u8 undefined', bcs.option(bcs.u8()), undefined, '00', null);
+		testType('optional u8 null', bcs.option(bcs.u8()), null, '00');
+		testType('optional u8 0', bcs.option(bcs.u8()), 0, '0100');
+		testType('optional vector(null)', bcs.option(bcs.vector(bcs.u8())), null, '00');
+		testType(
+			'optional vector([1, 2, 3])',
+			bcs.option(bcs.vector(bcs.option(bcs.u8()))),
+			[1, null, 3],
+			// eslint-disable-next-line no-useless-concat
+			'01' + '03' + '0101' + '00' + '0103',
+		);
+	});
+
+	describe('string', () => {
+		testType('string empty', bcs.string(), '', '00');
+		testType('string hello', bcs.string(), 'hello', '0568656c6c6f');
+		testType(
+			'string çå∞≠¢õß∂ƒ∫',
+			bcs.string(),
+			'çå∞≠¢õß∂ƒ∫',
+			'18c3a7c3a5e2889ee289a0c2a2c3b5c39fe28882c692e288ab',
+		);
+	});
+
+	describe('bytes', () => {
+		testType('bytes', bcs.bytes(4), new Uint8Array([1, 2, 3, 4]), '01020304');
+	});
+
+	describe('hex', () => {
+		testType('hex', bcs.hex(), '01020304', '0401020304');
+	});
+
+	describe('base64', () => {
+		testType('base64', bcs.base64(), 'AQIDBA==', '0401020304');
+	});
+
+	describe('b58', () => {
+		testType('b58', bcs.base58(), toB58(new Uint8Array([1, 2, 3, 4])), '0401020304');
+	});
+
+	describe('tuples', () => {
+		testType('tuple(u8, u8)', bcs.tuple([bcs.u8(), bcs.u8()]), [1, 2], '0102');
+		testType(
+			'tuple(u8, string, boolean)',
+			bcs.tuple([bcs.u8(), bcs.string(), bcs.bool()]),
+			[1, 'hello', true],
+			'010568656c6c6f01',
+		);
+
+		testType(
+			'tuple(null, u8)',
+			bcs.tuple([bcs.option(bcs.u8()), bcs.option(bcs.u8())]),
+			[null, 1],
+			'000101',
+		);
+	});
+
+	describe('structs', () => {
+		const MyStruct = bcs.struct('MyStruct', {
+			boolean: bcs.bool(),
+			bytes: bcs.vector(bcs.u8()),
+			label: bcs.string(),
+		});
+
+		const Wrapper = bcs.struct('Wrapper', {
+			inner: MyStruct,
+			name: bcs.string(),
+		});
+
+		testType(
+			'struct { boolean: bool, bytes: Vec<u8>, label: String }',
+			MyStruct,
+			{
+				boolean: true,
+				bytes: new Uint8Array([0xc0, 0xde]),
+				label: 'a',
+			},
+			'0102c0de0161',
+			{
+				boolean: true,
+				bytes: [0xc0, 0xde],
+				label: 'a',
+			},
+		);
+
+		testType(
+			'struct { inner: MyStruct, name: String }',
+			Wrapper,
+			{
+				inner: {
+					boolean: true,
+					bytes: new Uint8Array([0xc0, 0xde]),
+					label: 'a',
+				},
+
+				name: 'b',
+			},
+			'0102c0de01610162',
+			{
+				inner: {
+					boolean: true,
+					bytes: [0xc0, 0xde],
+					label: 'a',
+				},
+				name: 'b',
+			},
+		);
+	});
+
+	describe('enums', () => {
+		const E = bcs.enum('E', {
+			Variant0: bcs.u16(),
+			Variant1: bcs.u8(),
+			Variant2: bcs.string(),
+		});
+
+		testType('Enum::Variant0(1)', E, { Variant0: 1 }, '000100');
+		testType('Enum::Variant1(1)', E, { Variant1: 1 }, '0101');
+		testType('Enum::Variant2("hello")', E, { Variant2: 'hello' }, '020568656c6c6f');
+	});
+});
+
+function testType<T, Input>(
+	name: string,
+	schema: BcsType<T, Input>,
+	value: Input,
+	hex: string,
+	expected: T = value as never,
+) {
+	test(name, () => {
+		const bytes = schema.serialize(value);
+		expect(toHEX(bytes)).toBe(hex);
+		const deserialized = schema.parse(bytes);
+		expect(deserialized).toEqual(expected);
+
+		const writer = new BcsWriter({ size: bytes.length });
+		schema.write(value, writer);
+		expect(toHEX(writer.toBytes())).toBe(hex);
+
+		const reader = new BcsReader(bytes);
+		expect(schema.read(reader)).toEqual(expected);
+	});
+}


### PR DESCRIPTION
## Description 

This PR adds all the new bcs builder methods, it is not tageting `main`, and changes for the typescript SDK and other packages will come in a separate PR. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
