### PR TITLE
wallet-ext: fix explorer link of accounts

### DIFF
--- a/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountItem.tsx
@@ -98,6 +98,7 @@ export const AccountItem = forwardRef<HTMLDivElement, AccountItemProps>(
 										title="View on Explorer"
 										href={explorerHref}
 										icon={<ArrowUpRight12 />}
+										onClick={(e) => e.stopPropagation()}
 									/>
 								)}
 							</div>


### PR DESCRIPTION
## Description 

* do not select the account when user clicks on the explorer link

before

https://github.com/MystenLabs/sui/assets/10210143/aafb9a35-7ffd-4336-b8d0-837eddb0188c


after


https://github.com/MystenLabs/sui/assets/10210143/8e31814a-93a5-4b92-b5fe-c10a8892210d


closes [APPS-1690](https://mysten.atlassian.net/browse/APPS-1690)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
