### PR TITLE
Switch to a formatted table for verify bytecode meter

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1595,30 +1595,29 @@ impl Display for SuiClientCommandResult {
                 used_function_ticks,
                 used_module_ticks,
             } => {
-                writeln!(
-                    writer,
-                    "{0: ^15} | {1: ^15} | {2: ^15}",
-                    "", "Module", "Function"
-                )?;
-                writeln!(writer, "------------------------------------------------")?;
-                writeln!(
-                    writer,
-                    "{0: ^15} | {1: ^15} | {2: ^15}",
-                    "Max", max_module_ticks, max_function_ticks,
-                )?;
-                writeln!(
-                    writer,
-                    "{0: ^15} | {1: ^15} | {2: ^15}",
-                    "Used", used_module_ticks, used_function_ticks,
-                )?;
-
+                let mut builder = TableBuilder::default();
+                builder.set_header(vec!["", "Module", "Function"]);
+                builder.push_record(vec![
+                    "Max".to_string(),
+                    max_module_ticks.to_string(),
+                    max_function_ticks.to_string(),
+                ]);
+                builder.push_record(vec![
+                    "Used".to_string(),
+                    used_module_ticks.to_string(),
+                    used_function_ticks.to_string(),
+                ]);
+                let mut table = builder.build();
+                table.with(TableStyle::rounded());
                 if (used_module_ticks > max_module_ticks)
                     || (used_function_ticks > max_function_ticks)
                 {
-                    writeln!(writer, "Module will NOT pass metering check!")?;
+                    table.with(TablePanel::header("Module will NOT pass metering check!"));
                 } else {
-                    writeln!(writer, "Module will pass metering check!")?;
+                    table.with(TablePanel::header("Module will pass metering check!"));
                 }
+                table.with(tabled::settings::style::BorderSpanCorrection);
+                writeln!(f, "{}", table)?;
             }
         }
         write!(f, "{}", writer.trim_end_matches('\n'))


### PR DESCRIPTION
## Description 

This PR changes the output format for `sui client verify-bytecode-meter` to a well formatted table. 

## Test Plan 

<img width="425" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/45102471-bc1e-4186-a457-0f60503b74fc">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR changes the output format for `sui client verify-bytecode-meter` to a well formatted table. 