### PR TITLE
[graphql/rpc] show query limits and usage

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeSet;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::functional_group::FunctionalGroup;
 
@@ -18,7 +18,7 @@ pub struct ConnectionConfig {
 }
 
 /// Configuration on features supported by the RPC, passed in a TOML-based file.
-#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceConfig {
     #[serde(default)]
@@ -31,7 +31,7 @@ pub struct ServiceConfig {
     pub(crate) experiments: Experiments,
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Limits {
     #[serde(default)]
@@ -40,7 +40,7 @@ pub struct Limits {
     pub(crate) max_query_nodes: usize,
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Experiments {
     // Add experimental flags here, to provide access to them through-out the GraphQL

--- a/crates/sui-graphql-rpc/src/extensions/limits_info.rs
+++ b/crates/sui-graphql-rpc/src/extensions/limits_info.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextRequest, NextValidation},
+    value, Response, ServerError, ValidationResult,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::config::ServiceConfig;
+
+pub struct LimitsInfo;
+
+impl ExtensionFactory for LimitsInfo {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(LimitsInfoExtension::default())
+    }
+}
+
+#[derive(Default)]
+struct LimitsInfoExtension {
+    validation_result: Mutex<Option<ValidationResult>>,
+}
+
+#[async_trait::async_trait]
+impl Extension for LimitsInfoExtension {
+    async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
+        let cfg = ctx
+            .data::<ServiceConfig>()
+            .expect("No service config provided in schema data");
+        let mut resp = next.run(ctx).await;
+        let validation_result = self.validation_result.lock().await.take();
+        if let Some(validation_result) = validation_result {
+            resp = resp.extension(
+                "usage", // need better name for this
+                value! ({
+                    "nodes": validation_result.complexity,
+                    "depth": validation_result.depth,
+                }),
+            );
+            resp = resp.extension(
+                "limits",
+                value! ({
+                    "maxNodes": cfg.limits.max_query_nodes,
+                    "maxDepth": cfg.limits.max_query_depth,
+                }),
+            );
+        }
+        resp
+    }
+
+    async fn validation(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        next: NextValidation<'_>,
+    ) -> Result<ValidationResult, Vec<ServerError>> {
+        let res = next.run(ctx).await?;
+        *self.validation_result.lock().await = Some(res);
+        Ok(res)
+    }
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod limits_info;
 pub(crate) mod logger;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
 /// settings in the RPC's TOML configuration file.
-#[derive(Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -4,6 +4,7 @@
 use crate::config::{ConnectionConfig, ServiceConfig};
 use crate::context_data::data_provider::DataProvider;
 use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_client_v0};
+use crate::extensions::limits_info::LimitsInfo;
 use crate::extensions::logger::Logger;
 use crate::extensions::timeout::Timeout;
 use crate::server::builder::ServerBuilder;
@@ -30,6 +31,7 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
         .context_data(service_config)
         .extension(Logger::default())
         .extension(Timeout::default())
+        .extension(LimitsInfo)
         .build()
         .run()
         .await;


### PR DESCRIPTION
## Description 

Extension which shows the query limits and usages

## Test Plan 

Coming soon

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
