### PR TITLE
Tests for pathologcial jwk cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11803,6 +11803,7 @@ name = "test-cluster"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9777,6 +9777,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "duration-str",
+ "fastcrypto-zkp",
  "futures",
  "hdrhistogram",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10004,6 +10004,7 @@ dependencies = [
  "clap",
  "expect-test",
  "fastcrypto",
+ "fastcrypto-zkp",
  "fs_extra",
  "futures",
  "indexmap",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -40,6 +40,7 @@ sui-swarm-config.workspace = true
 telemetry-subscribers.workspace = true
 roaring.workspace = true
 regex.workspace = true
+fastcrypto-zkp.workspace = true
 
 move-core-types.workspace = true
 mysten-metrics.workspace = true

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -3,6 +3,7 @@
 
 #[cfg(msim)]
 mod test {
+    use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
     use rand::{distributions::uniform::SampleRange, thread_rng, Rng};
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -405,6 +406,26 @@ mod test {
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
     ) -> TestCluster {
+        sui_node::set_jwk_injector(Arc::new(|_authority, provider| {
+            // generate random (and possibly conflicting) id/key pairings.
+            let id_num = rand::thread_rng().gen_range(1..=4);
+            let key_num = rand::thread_rng().gen_range(1..=4);
+
+            let id = JwkId {
+                iss: provider.get_config().iss,
+                kid: format!("kid{}", id_num),
+            };
+
+            let jwk = JWK {
+                kty: "kty".to_string(),
+                e: format!("e{}", key_num),
+                n: "n".to_string(),
+                alg: "alg".to_string(),
+            };
+
+            Ok(vec![(id, jwk)])
+        }));
+
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
             .build()
             .await

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -406,26 +406,6 @@ mod test {
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
     ) -> TestCluster {
-        sui_node::set_jwk_injector(Arc::new(|_authority, provider| {
-            // generate random (and possibly conflicting) id/key pairings.
-            let id_num = rand::thread_rng().gen_range(1..=4);
-            let key_num = rand::thread_rng().gen_range(1..=4);
-
-            let id = JwkId {
-                iss: provider.get_config().iss,
-                kid: format!("kid{}", id_num),
-            };
-
-            let jwk = JWK {
-                kty: "kty".to_string(),
-                e: format!("e{}", key_num),
-                n: "n".to_string(),
-                alg: "alg".to_string(),
-            };
-
-            Ok(vec![(id, jwk)])
-        }));
-
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
             .build()
             .await

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -152,12 +152,19 @@ pub struct NodeConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_kv_store_write_config: Option<TransactionKeyValueStoreWriteConfig>,
+
+    #[serde(default = "default_jwk_fetch_interval_seconds")]
+    pub jwk_fetch_interval_seconds: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TransactionKeyValueStoreReadConfig {
     pub base_url: String,
+}
+
+fn default_jwk_fetch_interval_seconds() -> u64 {
+    3600
 }
 
 fn default_transaction_kv_store_config() -> TransactionKeyValueStoreReadConfig {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -29,7 +29,7 @@ use sui_types::transaction::{
     AuthenticatorStateUpdate, CertifiedTransaction, SenderSignedData, SharedInputObject,
     TransactionDataAPI, VerifiedCertificate, VerifiedSignedTransaction,
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, error_span, info, trace, warn};
 use typed_store::rocks::{
     default_db_options, DBBatch, DBMap, DBOptions, MetricConf, TypedStoreError,
 };
@@ -431,6 +431,10 @@ impl AuthorityPerEpochStore {
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
+
+        let span = error_span!("AuthorityPerEpochStore::new", ?epoch_id);
+        let _guard = span.enter();
+
         let tables = AuthorityEpochTables::open(epoch_id, parent_path, db_options.clone());
         let end_of_publish =
             StakeAggregator::from_iter(committee.clone(), tables.end_of_publish.unbounded_iter());

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -306,12 +306,19 @@ impl SignatureVerifier {
         });
     }
 
-    /// Insert a JWK into the verifier state based on provider. Returns true if the kid of the JWK has not already
-    /// been inserted.
+    /// Insert a JWK into the verifier state. Pre-existing entries for a given JwkId will not be
+    /// overwritten.
     pub(crate) fn insert_jwk(&self, jwk_id: &JwkId, jwk: &JWK) {
-        debug!("insert JWK with kid: {:?}", jwk_id);
         let mut jwks = self.jwks.write();
-        jwks.insert(jwk_id.clone(), jwk.clone());
+        match jwks.entry(jwk_id.clone()) {
+            im::hashmap::Entry::Occupied(_) => {
+                debug!("JWK with kid {:?} already exists", jwk_id);
+            }
+            im::hashmap::Entry::Vacant(entry) => {
+                debug!("inserting JWK with kid: {:?}", jwk_id);
+                entry.insert(jwk.clone());
+            }
+        }
     }
 
     pub fn has_jwk(&self, jwk_id: &JwkId, jwk: &JWK) -> bool {

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -319,6 +319,10 @@ impl SignatureVerifier {
         jwks.get(jwk_id) == Some(jwk)
     }
 
+    pub fn get_jwks(&self) -> ImHashMap<JwkId, JWK> {
+        self.jwks.read().clone()
+    }
+
     pub fn verify_tx(&self, signed_tx: &SenderSignedData) -> SuiResult {
         self.signed_data_cache
             .is_verified(signed_tx.full_message_digest(), || {

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -34,6 +34,7 @@ move-binary-format.workspace = true
 move-package.workspace = true
 telemetry-subscribers.workspace = true
 fastcrypto.workspace = true
+fastcrypto-zkp.workspace = true
 move-core-types.workspace = true
 
 sui-core.workspace = true

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -66,7 +66,7 @@ async fn test_zklogin_provider_not_supported() {
 
 #[sim_test]
 async fn zklogin_end_to_end_test() {
-    run_zklogin_end_to_end_test(TestClusterBuilder::new().build().await).await;
+    run_zklogin_end_to_end_test(TestClusterBuilder::new().with_default_jwks().build().await).await;
 }
 
 #[sim_test]
@@ -75,6 +75,7 @@ async fn zklogin_end_to_end_test_with_auth_state_creation() {
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
         .with_epoch_duration_ms(10000)
+        .with_default_jwks()
         .build()
         .await;
 
@@ -183,7 +184,6 @@ async fn test_create_authenticator_state_object() {
 #[cfg(msim)]
 #[sim_test]
 async fn test_conflicting_jwks() {
-    use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
     use futures::StreamExt;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
@@ -191,27 +191,6 @@ async fn test_conflicting_jwks() {
     use sui_json_rpc_types::TransactionFilter;
     use sui_types::base_types::ObjectID;
     use sui_types::transaction::{TransactionDataAPI, TransactionKind};
-
-    sui_node::set_jwk_injector(Arc::new(|_authority, provider| {
-        use rand::Rng;
-        // generate random (and possibly conflicting) id/key pairings.
-        let id_num = rand::thread_rng().gen_range(1..=4);
-        let key_num = rand::thread_rng().gen_range(1..=4);
-
-        let id = JwkId {
-            iss: provider.get_config().iss,
-            kid: format!("kid{}", id_num),
-        };
-
-        let jwk = JWK {
-            kty: "kty".to_string(),
-            e: format!("e{}", key_num),
-            n: "n".to_string(),
-            alg: "alg".to_string(),
-        };
-
-        Ok(vec![(id, jwk)])
-    }));
 
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(45000)

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -5,11 +5,7 @@
 use std::collections::BTreeSet;
 use tokio::time::{sleep, Duration};
 
-use futures::StreamExt;
-use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
-use sui_json_rpc_types::TransactionFilter;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::ObjectID;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::utils::{get_zklogin_user_address, make_zklogin_tx, sign_zklogin_tx};
 use sui_types::SUI_AUTHENTICATOR_STATE_OBJECT_ID;
@@ -188,8 +184,12 @@ async fn test_create_authenticator_state_object() {
 #[sim_test]
 async fn test_conflicting_jwks() {
     use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
+    use futures::StreamExt;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
+    use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+    use sui_json_rpc_types::TransactionFilter;
+    use sui_types::base_types::ObjectID;
     use sui_types::transaction::{TransactionDataAPI, TransactionKind};
 
     sui_node::set_jwk_injector(Arc::new(|_authority, provider| {

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -5,7 +5,11 @@
 use std::collections::BTreeSet;
 use tokio::time::{sleep, Duration};
 
+use futures::StreamExt;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+use sui_json_rpc_types::TransactionFilter;
 use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::base_types::ObjectID;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::utils::{get_zklogin_user_address, make_zklogin_tx, sign_zklogin_tx};
 use sui_types::SUI_AUTHENTICATOR_STATE_OBJECT_ID;
@@ -175,5 +179,85 @@ async fn test_create_authenticator_state_object() {
                 .unwrap()
                 .expect("auth state object should exist");
         });
+    }
+}
+
+// This test is intended to look for forks caused by conflicting / repeated JWK votes from
+// validators.
+#[cfg(msim)]
+#[sim_test]
+async fn test_conflicting_jwks() {
+    use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+    use sui_types::transaction::{TransactionDataAPI, TransactionKind};
+
+    sui_node::set_jwk_injector(Arc::new(|_authority, provider| {
+        use rand::Rng;
+        // generate random (and possibly conflicting) id/key pairings.
+        let id_num = rand::thread_rng().gen_range(1..=4);
+        let key_num = rand::thread_rng().gen_range(1..=4);
+
+        let id = JwkId {
+            iss: provider.get_config().iss,
+            kid: format!("kid{}", id_num),
+        };
+
+        let jwk = JWK {
+            kty: "kty".to_string(),
+            e: format!("e{}", key_num),
+            n: "n".to_string(),
+            alg: "alg".to_string(),
+        };
+
+        Ok(vec![(id, jwk)])
+    }));
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(45000)
+        .with_jwk_fetch_interval(Duration::from_secs(5))
+        .build()
+        .await;
+
+    let jwks = Arc::new(Mutex::new(Vec::new()));
+    let jwks_clone = jwks.clone();
+
+    test_cluster.fullnode_handle.sui_node.with(|node| {
+        let mut txns = node.state().subscription_handler.subscribe_transactions(
+            TransactionFilter::ChangedObject(ObjectID::from_hex_literal("0x7").unwrap()),
+        );
+        let state = node.state();
+
+        tokio::spawn(async move {
+            while let Some(tx) = txns.next().await {
+                let digest = *tx.transaction_digest();
+                let tx = state
+                    .database
+                    .get_transaction_block(&digest)
+                    .unwrap()
+                    .unwrap();
+                match &tx.data().intent_message().value.kind() {
+                    TransactionKind::EndOfEpochTransaction(_) => (),
+                    TransactionKind::AuthenticatorStateUpdate(update) => {
+                        let jwks = &mut *jwks_clone.lock().unwrap();
+                        for jwk in &update.new_active_jwks {
+                            jwks.push(jwk.clone());
+                        }
+                    }
+                    _ => panic!("{:?}", tx),
+                }
+            }
+        });
+    });
+
+    for _ in 0..5 {
+        test_cluster.wait_for_epoch(None).await;
+    }
+
+    let mut seen_jwks = HashSet::new();
+
+    // ensure no jwk is repeated.
+    for jwk in jwks.lock().unwrap().iter() {
+        assert!(seen_jwks.insert((jwk.jwk_id.clone(), jwk.jwk.clone(), jwk.epoch)));
     }
 }

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -8,6 +8,7 @@ use fastcrypto::traits::KeyPair;
 use narwhal_config::{NetworkAdminServerParameters, PrometheusMetricsParameters};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
     AuthorityKeyPairWithPath, AuthorityStorePruningConfig, DBCheckpointConfig,
@@ -30,6 +31,7 @@ pub struct ValidatorConfigBuilder {
     config_directory: Option<PathBuf>,
     supported_protocol_versions: Option<SupportedProtocolVersions>,
     force_unpruned_checkpoints: bool,
+    jwk_fetch_interval: Option<Duration>,
 }
 
 impl ValidatorConfigBuilder {
@@ -54,6 +56,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_unpruned_checkpoints(mut self) -> Self {
         self.force_unpruned_checkpoints = true;
+        self
+    }
+
+    pub fn with_jwk_fetch_interval(mut self, i: Duration) -> Self {
+        self.jwk_fetch_interval = Some(i);
         self
     }
 
@@ -157,6 +164,10 @@ impl ValidatorConfigBuilder {
             transaction_kv_store_read_config: Default::default(),
             transaction_kv_store_write_config: None,
             enable_experimental_rest_api: true,
+            jwk_fetch_interval_seconds: self
+                .jwk_fetch_interval
+                .map(|i| i.as_secs())
+                .unwrap_or(3600),
         }
     }
 
@@ -390,6 +401,8 @@ impl FullnodeConfigBuilder {
             transaction_kv_store_read_config: Default::default(),
             transaction_kv_store_write_config: Default::default(),
             enable_experimental_rest_api: true,
+            // note: not used by fullnodes.
+            jwk_fetch_interval_seconds: 3600,
         }
     }
 }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -90,6 +90,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -177,6 +178,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -264,6 +266,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -351,6 +354,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -438,6 +442,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -525,6 +530,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -612,6 +618,7 @@ validator_configs:
     indexer-max-subscriptions: ~
     transaction-kv-store-read-config:
       base-url: ""
+    jwk-fetch-interval-seconds: 3600
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x136589c04a38aaebc5b9fa3a972e7cb757019cd3e11b3ff1d36c68088d6547ab"
+            id: "0x221be5fff0a1af84b5a0ce4d4b01c41c0b25e25c6aede323f9aff07fa6c8c7df"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xef531104995b3fc65b310cbb270720746ce2f85b3b84c1847c890ab02fd4ad8c"
+      operation_cap_id: "0xc22d8ec5f13063a3873418b40be4eba3eb4889f4b8ee273f59dbcccbefc1297d"
       gas_price: 1000
       staking_pool:
-        id: "0x9df759d8d44c9d6a9c100c64e859e3882ea7dbe590ad7a5aa07d594f8ed6efa2"
+        id: "0x0f37b07b4f0cda6a697b051b67e0fb59cdd4a9310d726310d9eb0cfd30ac4067"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xcfe2c53d186ddf9c2f09b353ed28e5fa47736007c709cd2a5a918519b1cbb6af"
+          id: "0xcd2142b63bf3318e4c0139f306f8a8cf4c8df4dd86700ce6bb98127f06969806"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xc96799b2815e38bcfe6913195875c379194990bd9b90a7f0237782882c917c37"
+            id: "0x20a3431688e00cd9934b1549a101d8b8b3815822be29094a97048f193761c23e"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x82c130014781e97948243932e8719a4e601b4a5daf4ff361a75fdf0900a17187"
+          id: "0xe8f7e0dc209c5155fa847ad4a7784290bcc6fb747851c1ce8e6867b483c89218"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x668d258def2a35a28468226a73e8a4e6e5d2501932b05605509b68832ad7c637"
+      id: "0x3c5544b0d1866fa703a9aac249fb459029183b4ac01a17ae1c39c18201445ca3"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xca68beb72137e300c3457c03f01096cbc60856d0b17c8d703a88b10657d914cd"
+    id: "0x11775015a71451fd203f4930a05fbff82adc2f11072d348e00bfee3e8454d7c3"
     size: 1
   inactive_validators:
-    id: "0x7a256c61747fa1357d2ea929d9a870f6219cc7ceaa86ffd862294f23404f23a5"
+    id: "0x44421650240f8c100482c5d87f8d63ec236d6c6732e1a7ee6c14d0ab785108b9"
     size: 0
   validator_candidates:
-    id: "0xcc27ae59ac421cf33b68a42b4d5f31535bf38e68c52f6e013d8d4dc2afbcc706"
+    id: "0xabe99d1bd214f05c3c21c95a398ebaf4267008ede550b25b2c54a3100dd6e165"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xa9e758115fcb42af35577bc752caabacaecbcb7be8a15296ee4b8e27160e4061"
+      id: "0x1a1a4a981aeea5746929c69cd29554ccba6b564b31bf68be33d1541674bcddd8"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x554adf1135ea1b3a1d2557020fcff0f0c7246214ebd33530ada0898b3ec0fc5c"
+      id: "0x1f8924eac4bbe396b92a1c1fc1997aaf01ef5db6aa15d25c645e461256ec431d"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xe64514a0bb729f212827983441dcdd889847f3157aebe30096cb46e0a705c9f9"
+      id: "0x0bcd86873490cb5338ce118aa7cc4c615bce2bdef8b22069a427650fff09e95d"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xd1566e6de55a4f187d65f8e5c6e0ba105edca4075cf3486c78a4c5cba149a770"
+    id: "0x4427052e145b8ac8a3f7e98493d08ec3d9d8db2fafc009d139f3b2765aace1b5"
   size: 0
 

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -8,6 +8,7 @@ use rand::rngs::OsRng;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::time::Duration;
 use std::{
     mem, ops,
     path::{Path, PathBuf},
@@ -41,6 +42,7 @@ pub struct SwarmBuilder<R = OsRng> {
     // Default to supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
     db_checkpoint_config: DBCheckpointConfig,
+    jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
 }
 
@@ -60,6 +62,7 @@ impl SwarmBuilder {
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config: DBCheckpointConfig::default(),
+            jwk_fetch_interval: None,
             num_unpruned_validators: None,
         }
     }
@@ -81,6 +84,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_supported_protocol_versions_config: self
                 .fullnode_supported_protocol_versions_config,
             db_checkpoint_config: self.db_checkpoint_config,
+            jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
         }
     }
@@ -117,6 +121,11 @@ impl<R> SwarmBuilder<R> {
     pub fn with_num_unpruned_validators(mut self, n: usize) -> Self {
         assert!(self.network_config.is_none());
         self.num_unpruned_validators = Some(n);
+        self
+    }
+
+    pub fn with_jwk_fetch_interval(mut self, i: Duration) -> Self {
+        self.jwk_fetch_interval = Some(i);
         self
     }
 
@@ -226,6 +235,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             if let Some(num_unpruned_validators) = self.num_unpruned_validators {
                 config_builder =
                     config_builder.with_num_unpruned_validators(num_unpruned_validators);
+            }
+
+            if let Some(jwk_fetch_interval) = self.jwk_fetch_interval {
+                config_builder = config_builder.with_jwk_fetch_interval(jwk_fetch_interval);
             }
 
             config_builder

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -33,6 +33,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true
+fastcrypto-zkp.workspace = true
 
 [dev-dependencies]
 sui-macros.workspace = true

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -604,6 +604,7 @@ pub struct TestClusterBuilder {
     db_checkpoint_config_validators: DBCheckpointConfig,
     db_checkpoint_config_fullnodes: DBCheckpointConfig,
     num_unpruned_validators: Option<usize>,
+    jwk_fetch_interval: Option<Duration>,
     config_dir: Option<PathBuf>,
 }
 
@@ -621,6 +622,7 @@ impl TestClusterBuilder {
             db_checkpoint_config_validators: DBCheckpointConfig::default(),
             db_checkpoint_config_fullnodes: DBCheckpointConfig::default(),
             num_unpruned_validators: None,
+            jwk_fetch_interval: None,
             config_dir: None,
         }
     }
@@ -695,6 +697,11 @@ impl TestClusterBuilder {
 
     pub fn with_supported_protocol_versions(mut self, c: SupportedProtocolVersions) -> Self {
         self.validator_supported_protocol_versions_config = ProtocolVersionsConfig::Global(c);
+        self
+    }
+
+    pub fn with_jwk_fetch_interval(mut self, i: Duration) -> Self {
+        self.jwk_fetch_interval = Some(i);
         self
     }
 
@@ -816,6 +823,10 @@ impl TestClusterBuilder {
         }
         if let Some(num_unpruned_validators) = self.num_unpruned_validators {
             builder = builder.with_num_unpruned_validators(num_unpruned_validators);
+        }
+
+        if let Some(jwk_fetch_interval) = self.jwk_fetch_interval {
+            builder = builder.with_jwk_fetch_interval(jwk_fetch_interval);
         }
 
         if let Some(config_dir) = self.config_dir.take() {


### PR DESCRIPTION
Tests for handling duplicated / conflicting JWKs.

These cases are unlikely to happen in practice, as oauth providers will almost certainly remain well-behaved. Nevertheless, we want to continue behaving correctly even with pathological inputs.
