### PR TITLE
[GraphQL][EASY] Update schema to account for multiple senders.

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -607,7 +607,7 @@ type TransactionBlock {
   id: ID!
   digest: String!
 
-  sender: Address
+  senders: [Address]
   gasInput: GasInput
   kind: TransactionBlockKind
   signatures: [TransactionSignature]
@@ -795,7 +795,7 @@ type Event {
   # Type of the event being sent
   eventType: MoveType
 
-  sender: Address
+  senders: [Address]
   timestamp: DateTime
 
   json: String


### PR DESCRIPTION
## Description

The underlying data schema supports multiple senders, which a transaction can have today if it is sponsored.  This feature may also be generalised in future, to allow for multiple accounts to sign for access to their objects in a given transaction.

## Test Plan

:eyes: