### PR TITLE
[indexer-v2 9/n] wire things up - allow to use indexer v2 in startup

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -34,7 +34,7 @@ fn indexer_benchmark(c: &mut Criterion) {
     let rt: Runtime = Runtime::new().unwrap();
     let (mut _checkpoints, store) = rt.block_on(async {
         let blocking_cp = new_pg_connection_pool(&db_url).unwrap();
-        reset_database(&mut blocking_cp.get().unwrap(), true).unwrap();
+        reset_database(&mut blocking_cp.get().unwrap(), true, false).unwrap();
         let registry = Registry::default();
         let indexer_metrics = IndexerMetrics::new(&registry);
 

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -112,6 +112,9 @@ pub struct IndexerConfig {
     // NOTE: experimental only, do not use in production.
     #[clap(long)]
     pub skip_db_commit: bool,
+
+    #[clap(long)]
+    pub use_v2: bool,
 }
 
 impl IndexerConfig {
@@ -166,6 +169,7 @@ impl Default for IndexerConfig {
             fullnode_sync_worker: true,
             rpc_server_worker: true,
             skip_db_commit: false,
+            use_v2: false,
         }
     }
 }

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -26,6 +26,7 @@ pub async fn start_test_indexer(
                 .get()
                 .map_err(|e| anyhow!("Fail to get pg_connection_pool {e}"))?,
             true,
+            false,
         )?;
     }
 


### PR DESCRIPTION
## Description 

This is the final PR that completes the basic indexer writer skeleton. It adds the option to use v2 when the binary starts.

Stack:
1. https://github.com/MystenLabs/sui/pull/13760
2. https://github.com/MystenLabs/sui/pull/13774
3. https://github.com/MystenLabs/sui/pull/13804
4. https://github.com/MystenLabs/sui/pull/13805
5. https://github.com/MystenLabs/sui/pull/13832
6. https://github.com/MystenLabs/sui/pull/13834
7. https://github.com/MystenLabs/sui/pull/13881
8. https://github.com/MystenLabs/sui/pull/13882
9. https://github.com/MystenLabs/sui/pull/13884
10. https://github.com/MystenLabs/sui/pull/13892




## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
