### PR TITLE
[sui-genesis-builder] Start genesis with correct framework for protocol version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10094,6 +10094,7 @@ dependencies = [
  "sui-config",
  "sui-execution",
  "sui-framework",
+ "sui-framework-snapshot",
  "sui-protocol-config",
  "sui-simulator",
  "sui-types",

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -25,6 +25,7 @@ shared-crypto.workspace = true
 sui-config.workspace = true
 sui-execution.workspace = true
 sui-framework.workspace = true
+sui-framework-snapshot.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }


### PR DESCRIPTION
Previously we would always start genesis with the current set of framework modules. This causes issues in the compatibility tests if the current version of the framework is not backwards compatible with the old version (e.g., by adding a new type in the new version of the framework). 

This updates the genesis creation to now use the correct framework snapshot for all protocol 
versions, defaulting to the current framework if a snapshot for the given protocol version is not found. 

This also updates framework snapshots to be ordered based on the order in which they need to be published.

## Test Plan 

Added a type to the framework locally, and made sure the `test_upgrade_compatibility` test passes with these changes. 

