### PR TITLE
[GraphQL/Schema]  Remove reference to EndOfEpochData

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -530,7 +530,7 @@ type Epoch {
   netInflow: BigInt
   fundInflow: BigInt
   fundOutflow: BigInt
-  
+
   # TODO: Identify non-duplicate fields in `EndOfEpochInfo`
 
   checkpointConnection(
@@ -704,9 +704,6 @@ type Checkpoint {
 
   epoch: Epoch
 
-  # Only available on the final checkpoint in an epoch
-  endOfEpoch: EndOfEpochData
-
   transactionBlockConnection(
     first: Int,
     after: String,
@@ -718,16 +715,6 @@ type Checkpoint {
 
   # NB. Will be moved into a private, explorer-specific extension.
   addressMetrics: AddressMetrics
-}
-
-type EndOfEpochData {
-  newCommittee: [CommitteeMember]
-  nextProtocolVersion: Int
-}
-
-type CommitteeMember {
-  authorityName: String
-  stakeUnit: Int
 }
 
 type TransactionBlock {


### PR DESCRIPTION
## Description

All the information that was contained in this structure is derivable from other sources.  Originally we thought that we would need to surface the end of epoch commitments specially but this too is already exposed as:

```graphql
query {
  epoch(epochId: E) {
    checkpointConnection(last: 1) {
      previousCheckpointDigest
      liveObjectSetDigest
    }
  }
}
```

## Test Plan

:eyes: