### PR TITLE
[GraphQL/Schema] Standardise Checkpoint transaction block connection

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -587,7 +587,14 @@ type Checkpoint {
   # Only available on the final checkpoint in an epoch
   endOfEpoch: EndOfEpochData
 
-  transactionConnection(first: Int, after: String, last: Int, before: String): TransactionBlockConnection
+  transactionBlockConnection(
+    first: Int,
+    after: String,
+    last: Int,
+    before: String,
+    # Enhancement (post-MVP) relies on compound filters.
+    filter: TransactionBlockFilter,
+  ): TransactionBlockConnection
 
   # NB. Will be moved into a private, explorer-specific extension.
   addressMetrics: AddressMetrics


### PR DESCRIPTION
## Description

- Rename it to `transactionBlockConnection` from just `transactionConnection`.
- Add a `TransactionBlockFilter` parameter as a post-MVP enhancement.

## Test Plan

:eyes:

Also double check that no other transaction block related connections slipped through the net previously.
