### PR TITLE
Protect changes in gas charging

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1469,6 +1469,9 @@ impl ProtocolConfig {
                     cfg.max_jwk_votes_per_validator_per_epoch = Some(240);
                     cfg.max_age_of_jwk_in_epochs = Some(1);
                 }
+                26 => {
+                    cfg.gas_model_version = Some(7);
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -35,6 +35,11 @@ pub fn txn_base_cost_as_multiplier(protocol_config: &ProtocolConfig) -> bool {
     protocol_config.txn_base_cost_as_multiplier()
 }
 
+// If true, charge differently for package upgrades
+pub fn charge_upgrades(gas_model_version: u64) -> bool {
+    gas_model_version >= 7
+}
+
 // Return the version supported cost table
 pub fn cost_table_for_version(gas_model: u64) -> CostTable {
     if gas_model <= 3 {

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -11,7 +11,9 @@ pub mod checked {
     use crate::temporary_store::TemporaryStore;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::gas::{deduct_gas, GasCostSummary, SuiGasStatus};
-    use sui_types::gas_model::gas_predicates::dont_charge_budget_on_storage_oog;
+    use sui_types::gas_model::gas_predicates::{
+        charge_upgrades, dont_charge_budget_on_storage_oog,
+    };
     use sui_types::{
         base_types::{ObjectID, ObjectRef},
         digests::TransactionDigest,
@@ -205,6 +207,14 @@ pub mod checked {
 
         pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
             self.gas_status.charge_publish_package(size)
+        }
+
+        pub fn charge_upgrade_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+            if charge_upgrades(self.gas_model_version) {
+                self.gas_status.charge_publish_package(size)
+            } else {
+                Ok(())
+            }
         }
 
         pub fn charge_input_objects(

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -523,7 +523,7 @@ mod checked {
         );
         context
             .gas_charger
-            .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
+            .charge_upgrade_package(module_bytes.iter().map(|v| v.len()).sum())?;
 
         let upgrade_ticket_type = context
             .load_type_from_struct(&UpgradeTicket::type_())


### PR DESCRIPTION
## Description 

as titled we were too aggressive in pushing the change not under protocol version

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Package upgrade is now charging for the bytes being published. That is more in line with our charging model.
