### PR TITLE
[GraphQL/Schema] ExecutionResults expose full effects

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -604,7 +604,7 @@ type CommitteeMember {
 }
 
 type TransactionBlock {
-  id: ID!
+  id: ID
   digest: String!
 
   sender: Address
@@ -1041,9 +1041,9 @@ type AddressMetrics {
 
 # Execution
 
-# Either Transaction Digest on success, or error on failure.
+# Either TransactionBlockEffects on success, or error on failure.
 type ExecutionResult {
-  digest: String
+  effects: TransactionBlockEffects
   errors: String
 }
 


### PR DESCRIPTION
## Description

Rather than just return a digest on success, execution should return the full effects.  This is so that people who want to avoid including indexing in their transaction critical path can maintain object versions locally and use that to form subsequent transactions.

This change requires making `ID` a nullable field on `TransactionBlock` because a transaction block that is part of a `TransactionBlockEffect` that was returned from execution will not have an `ID` until it has been put in a checkpoint which has subsequently been indexed.

## Test Plan

:eyes: