### PR TITLE
[indexerv2] Array<Nullable<Bytea>> for validators on StoredEpochInfo?

### DIFF
--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -12,7 +12,7 @@ use sui_json_rpc_types::{EndOfEpochInfo, EpochInfo};
 #[diesel(table_name = epochs)]
 pub struct StoredEpochInfo {
     pub epoch: i64,
-    pub validators: Vec<Vec<u8>>,
+    pub validators: Vec<Option<Vec<u8>>>,
     pub epoch_total_transactions: i64,
     pub first_checkpoint_id: i64,
     pub epoch_start_timestamp: i64,
@@ -41,7 +41,7 @@ impl From<&IndexedEpochInfo> for StoredEpochInfo {
             validators: e
                 .validators
                 .iter()
-                .map(|v| bcs::to_bytes(v).unwrap())
+                .map(|v| Some(bcs::to_bytes(v).unwrap()))
                 .collect(),
             epoch_total_transactions: e.epoch_total_transactions as i64,
             first_checkpoint_id: e.first_checkpoint_id as i64,
@@ -101,6 +101,7 @@ impl TryInto<EpochInfo> for StoredEpochInfo {
         let validators = self
             .validators
             .into_iter()
+            .filter_map(|opt_v| opt_v)
             .map(|v| {
                 bcs::from_bytes(&v).map_err(|_| {
                     IndexerError::PersistentStorageDataCorruptionError(format!(


### PR DESCRIPTION
## Description 

Did we want validators array to be Vec<Vec<u8>> or Vec<Option<Vec<u8>>>?

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
