### PR TITLE
[refactor] restore consensus committed sub dags from last index + 1

### DIFF
--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -169,8 +169,8 @@ impl SuiTxValidatorMetrics {
 mod tests {
     use crate::{
         checkpoints::CheckpointServiceNoop,
-        consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
         consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics},
+        test_utils::{test_certificates, test_gas_objects},
     };
 
     use narwhal_test_utils::latest_protocol_version;

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -27,7 +27,7 @@ pub mod state_accumulator;
 pub mod storage;
 pub mod streamer;
 pub mod subscription_handler;
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(any(test, msim, feature = "test-utils"))]
 pub mod test_utils;
 pub mod transaction_input_checker;
 mod transaction_manager;

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -92,14 +92,14 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
     certificate_store: CertificateStore,
     execution_state: &State,
 ) -> Result<Vec<CommittedSubDag>, SubscriberError> {
-    // We always want to recover at least the last committed sub-dag since we can't know
-    // whether the execution has been interrupted and there are still batches/transactions
-    // that need to be sent for execution.
-
+    // We can safely recover from the `last_executed_sub_dag_index + 1` as we have the guarantee
+    // from the consumer that the `last_executed_sub_dag_index` transactions have been atomically processed
+    // and don't need to re-send the last sub dag.
     let last_executed_sub_dag_index = execution_state.last_executed_sub_dag_index().await;
+    let restore_sub_dag_index_from = last_executed_sub_dag_index + 1;
 
     let compressed_sub_dags =
-        consensus_store.read_committed_sub_dags_from(&last_executed_sub_dag_index)?;
+        consensus_store.read_committed_sub_dags_from(&restore_sub_dag_index_from)?;
 
     let mut sub_dags = Vec::new();
     for compressed_sub_dag in compressed_sub_dags {


### PR DESCRIPTION
## Description 

Following this work https://github.com/MystenLabs/sui/pull/13819 we can now safely restore the committed sub dags from the last index + 1 since the consumer is atomically processing all the transactions and we don't need to re-send the last index subdag.

## Test Plan 



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
