### PR TITLE
[GraphQL] API for exposing ServiceConfig

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -20,12 +20,15 @@ schema {
 
 type Query {
   # First four bytes of the network's genesis checkpoint digest
-  # (uniquely defines the network)
+  # (uniquely identifies the network)
   chainIdentifier: String!
 
   # Range of checkpoints that the RPC has data available for (for data
   # that can be tied to a particular checkpoint).
   availableRange: AvailableRange!
+
+  # Configuration for this RPC service
+  serviceConfig: ServiceConfig!
 
   # Simulate running a transaction to inspect its effects without
   # committing to them on-chain.
@@ -285,6 +288,23 @@ input DynamicFieldFilter {
 type AvailableRange {
   first: Checkpoint
   last: Checkpoint
+}
+
+type ServiceConfig {
+  enabledFeatures: [Feature!]
+  isEnabled(feature: Feature!): Boolean!
+
+  maxQueryDepth: Int
+  maxQueryNodes: Int
+}
+
+enum Feature {
+  ANALYTICS
+  COINS
+  DYNAMIC_FIELDS
+  NAME_SERVICE
+  SUBSCRIPTIONS
+  SYSTEM_STATE
 }
 
 interface ObjectOwner {

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -3,14 +3,16 @@
 
 use std::collections::BTreeMap;
 
+use async_graphql::*;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 
-/// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
-/// settings in the RPC's TOML configuration file.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+/// Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+/// or disable these features.
+#[derive(Enum, Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
+#[graphql(name = "Feature")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
     Analytics,
@@ -37,6 +39,20 @@ impl FunctionalGroup {
     /// Not a suitable `Display` implementation because it enquotes the representation.
     pub(crate) fn name(&self) -> String {
         json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+
+    /// List of all functional groups
+    pub(crate) fn all() -> &'static [FunctionalGroup] {
+        use FunctionalGroup as G;
+        static ALL: &[FunctionalGroup] = &[
+            G::Analytics,
+            G::Coins,
+            G::DynamicFields,
+            G::NameService,
+            G::Subscriptions,
+            G::SystemState,
+        ];
+        ALL
     }
 }
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -44,13 +44,13 @@ impl ServerBuilder {
         format!("{}:{}", self.host, self.port)
     }
 
-    pub fn max_query_depth(mut self, max_depth: usize) -> Self {
-        self.schema = self.schema.limit_depth(max_depth);
+    pub fn max_query_depth(mut self, max_depth: u32) -> Self {
+        self.schema = self.schema.limit_depth(max_depth as usize);
         self
     }
 
-    pub fn max_query_nodes(mut self, max_nodes: usize) -> Self {
-        self.schema = self.schema.limit_complexity(max_nodes);
+    pub fn max_query_nodes(mut self, max_nodes: u32) -> Self {
+        self.schema = self.schema.limit_complexity(max_nodes as usize);
         self
     }
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_depth_limit() {
-        async fn exec_query_depth_limit(depth: usize, query: &str) -> Response {
+        async fn exec_query_depth_limit(depth: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
@@ -203,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_node_limit() {
-        async fn exec_query_node_limit(nodes: usize, query: &str) -> Response {
+        async fn exec_query_node_limit(nodes: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -164,6 +164,38 @@ enum ExecutionStatus {
 	FAILURE
 }
 
+"""
+Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+or disable these features.
+"""
+enum Feature {
+	"""
+	Statistics about how the network was running (TPS, top packages, APY, etc)
+	"""
+	ANALYTICS
+	"""
+	Coin metadata, per-address coin and balance information.
+	"""
+	COINS
+	"""
+	Querying an object's dynamic fields.
+	"""
+	DYNAMIC_FIELDS
+	"""
+	SuiNS name and reverse name look-up.
+	"""
+	NAME_SERVICE
+	"""
+	Transaction and Event subscriptions.
+	"""
+	SUBSCRIPTIONS
+	"""
+	Information about the system that changes from epoch to epoch (protocol config, committee,
+	reference gas price).
+	"""
+	SYSTEM_STATE
+}
+
 
 type GasCostSummary {
 	computationCost: BigInt
@@ -350,7 +382,15 @@ type ProtocolConfigs {
 }
 
 type Query {
+	"""
+	First four bytes of the network's genesis checkpoint digest (uniquely identifies the
+	network).
+	"""
 	chainIdentifier: String!
+	"""
+	Configuration for this RPC service
+	"""
+	serviceConfig: ServiceConfig!
 	owner(address: SuiAddress!): ObjectOwner
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
@@ -361,6 +401,25 @@ type Query {
 type SafeMode {
 	enabled: Boolean
 	gasSummary: GasCostSummary
+}
+
+type ServiceConfig {
+	"""
+	Check whether `feature` is enabled on this GraphQL service.
+	"""
+	isEnabled(feature: Feature!): Boolean!
+	"""
+	List of all features that are enabled on this GraphQL service.
+	"""
+	enabledFeatures: [Feature!]!
+	"""
+	The maximum depth a GraphQL query can be to be accepted by this service.
+	"""
+	maxQueryDepth: Int!
+	"""
+	The maximum number of nodes (field names) the service will accept in a single query.
+	"""
+	maxQueryNodes: Int!
 }
 
 type Stake {
@@ -536,3 +595,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+


### PR DESCRIPTION
##  Description

Expose the limits and enabled features that the service was configured with under its own GraphQL API.

Now that the limits are exposed over GraphQL as numbers, their types have been changed from `usize` to `u32` to guarantee they won't lose precision when shared in the API (this should still be more than big enough to hold any reasonable limit).

## Test Plan

Tested with GraphiQL

![Screenshot 2023-09-21 at 4 58 24 PM](https://github.com/MystenLabs/sui/assets/332275/bf737a4d-f769-43f0-ab5c-d8e2fb3ec6d2)
