### PR TITLE
fix cargo-deny for quinn-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7791,9 +7791,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
+checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -9128,7 +9128,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,7 +364,7 @@ prost = "0.11.8"
 prost-build = "0.11.8"
 protobuf = { version = "2.28", features = ["with-bytes"] }
 protobuf-src = "1.1.0"
-quinn-proto = "^0.10.0"
+quinn-proto = "^0.10.5"
 quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.5.3"


### PR DESCRIPTION
## Description 

Detected from cargo-deny
2023-09-21T16:26:16.0342685Z     [0m[34m=[0m Announcement: https://github.com/quinn-rs/quinn/pull/1667
2023-09-21T16:26:16.0343117Z     [0m[34m=[0m Solution: Upgrade to ^0.9.5 OR >=0.10.5
pointing to https://github.com/quinn-rs/quinn/pull/1667 with solution to update to 10.5 or above

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
