### PR TITLE
[move-compiler] Add public struct type support to the parser

### DIFF
--- a/external-crates/move/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/move-compiler/src/editions/mod.rs
@@ -29,6 +29,7 @@ pub struct Edition {
 pub enum FeatureGate {
     PublicPackage,
     PostFixAbilities,
+    StructTypeVisibility,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -48,7 +49,8 @@ pub fn check_feature(
     feature: &FeatureGate,
     loc: Loc,
 ) -> bool {
-    if !edition.supports(feature) {
+    let supports_feature = edition.supports(feature);
+    if !supports_feature {
         let valid_editions = valid_editions_for_feature(feature)
             .into_iter()
             .map(|e| e.to_string())
@@ -69,10 +71,8 @@ pub fn check_feature(
             or via command line flag if invoking the compiler directly.",
         );
         env.add_diag(diag);
-        false
-    } else {
-        true
     }
+    supports_feature
 }
 
 pub fn valid_editions_for_feature(feature: &FeatureGate) -> Vec<Edition> {
@@ -90,8 +90,11 @@ pub fn valid_editions_for_feature(feature: &FeatureGate) -> Vec<Edition> {
 static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
-const E2024_ALPHA_FEATURES: &[FeatureGate] =
-    &[FeatureGate::PublicPackage, FeatureGate::PostFixAbilities];
+const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
+    FeatureGate::PublicPackage,
+    FeatureGate::PostFixAbilities,
+    FeatureGate::StructTypeVisibility,
+];
 
 impl Edition {
     pub const LEGACY: Self = Self {

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -534,6 +534,10 @@ impl CompilationEnv {
         edition_check_feature(self, self.package_config(package).edition, feature, loc)
     }
 
+    pub fn supports_feature(&self, package: Option<Symbol>, feature: &FeatureGate) -> bool {
+        self.package_config(package).edition.supports(feature)
+    }
+
     pub fn package_config(&self, package: Option<Symbol>) -> &PackageConfig {
         package
             .and_then(|p| self.package_configs.get(&p))

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.exp
@@ -1,8 +1,8 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix.move:4:34
+  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix.move:4:41
   │
-4 │     struct Foo has copy, drop {} has store;
-  │                ---               ^^^ Duplicate ability declaration. Abilities can be declared before or after the field declarations, but not both.
-  │                │                  
-  │                Ability declaration previously given here
+4 │     public struct Foo has copy, drop {} has store;
+  │                       ---               ^^^ Duplicate ability declaration. Abilities can be declared before or after the field declarations, but not both.
+  │                       │                  
+  │                       Ability declaration previously given here
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // has both prefix and postfix ability declarations
-    struct Foo has copy, drop {} has store;
+    public struct Foo has copy, drop {} has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move:5:39
+  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move:5:46
   │
-5 │     native struct Foo has copy, drop; has store;
-  │                                       ^^^
-  │                                       │
-  │                                       Unexpected 'has'
-  │                                       Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'
+5 │     public native struct Foo has copy, drop; has store;
+  │                                              ^^^
+  │                                              │
+  │                                              Unexpected 'has'
+  │                                              Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move
@@ -2,6 +2,6 @@ address 0x42 {
 module M {
     // has both invalid declaration since postfix ability declarations
     // are not allowed for native structs
-    native struct Foo has copy, drop; has store;
+    public native struct Foo has copy, drop; has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move:4:38
+  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move:4:45
   │
-4 │     native struct Foo has copy, drop has store;
-  │                                      ^^^
-  │                                      │
-  │                                      Unexpected 'has'
-  │                                      Expected one of: ',', '{', or ';'
+4 │     public native struct Foo has copy, drop has store;
+  │                                             ^^^
+  │                                             │
+  │                                             Unexpected 'has'
+  │                                             Expected one of: ',', '{', or ';'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // has both prefix and invalid postfix ability declarations
-    native struct Foo has copy, drop has store;
+    public native struct Foo has copy, drop has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.exp
@@ -1,6 +1,6 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move:4:39
+  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move:4:46
   │
-4 │     native struct Foo has copy, drop, has store;
-  │                                       ^^^ Unexpected 'has'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
+4 │     public native struct Foo has copy, drop, has store;
+  │                                              ^^^ Unexpected 'has'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // has both prefix and invalid postfix ability declarations
-    native struct Foo has copy, drop, has store;
+    public native struct Foo has copy, drop, has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_commas.move:4:29
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_commas.move:4:36
   │
-4 │     struct Foo {} has store copy;
-  │                             ^^^^
-  │                             │
-  │                             Unexpected 'copy'
-  │                             Expected one of: ',' or ';'
+4 │     public struct Foo {} has store copy;
+  │                                    ^^^^
+  │                                    │
+  │                                    Unexpected 'copy'
+  │                                    Expected one of: ',' or ';'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // Ability declarations require commas between them.
-    struct Foo {} has store copy;
+    public struct Foo {} has store copy;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:5:5
   │
-5 │     struct Bar has key {}
+5 │     public struct Bar has key {}
   │     ^^^^^^
   │     │
-  │     Unexpected 'struct'
+  │     Unexpected 'public'
   │     Expected one of: ',' or ';'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move
@@ -1,8 +1,8 @@
 address 0x42 {
 module M {
     // Postfix ability declarations require semicolons at the end.
-    struct Foo {} has store
-    struct Bar has key {}
+    public struct Foo {} has store
+    public struct Bar has key {}
 }
 }
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // Postfix ability declarations require at least one ability.
-    struct Foo {} has
+    public struct Foo {} has
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.exp
@@ -1,6 +1,6 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move:4:22
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move:4:29
   │
-4 │     struct Foo {} has;
-  │                      ^ Unexpected ';'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
+4 │     public struct Foo {} has;
+  │                             ^ Unexpected ';'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // Postfix ability declarations require at least one ability.
-    struct Foo {} has;
+    public struct Foo {} has;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_fields.move:4:38
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_fields.move:4:45
   │
-4 │     native struct Foo has copy, drop has store;
-  │                                      ^^^
-  │                                      │
-  │                                      Unexpected 'has'
-  │                                      Expected one of: ',', '{', or ';'
+4 │     public native struct Foo has copy, drop has store;
+  │                                             ^^^
+  │                                             │
+  │                                             Unexpected 'has'
+  │                                             Expected one of: ',', '{', or ';'
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // native structs cannot have suffix ability declarations.
-    native struct Foo has copy, drop has store;
+    public native struct Foo has copy, drop has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.move
@@ -1,6 +1,6 @@
 address 0x42 {
 module M {
     // Postfix ability declarations require semicolons.
-    struct Foo {} has store
+    public struct Foo {} has store
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_with_semi.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/ability_modifier_postfix_with_semi.move
@@ -1,5 +1,5 @@
 address 0x42 {
 module M {
-    struct Foo {} has store;
+    public struct Foo {} has store;
 }
 }

--- a/external-crates/move/move-compiler/tests/move_2024/parser/struct_public.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/struct_public.exp
@@ -1,0 +1,40 @@
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/parser/struct_public.move:3:5
+  │
+3 │     struct Foo {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/parser/struct_public.move:4:5
+  │
+4 │     public(friend) struct Foo {}
+  │     ^^^^^^^^^^^^^^ Invalid struct declaration. 'public(friend)' struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_2024/parser/struct_public.move:4:27
+  │
+3 │     struct Foo {}
+  │            --- Alias previously defined here
+4 │     public(friend) struct Foo {}
+  │                           ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/parser/struct_public.move:5:5
+  │
+5 │     public(package) struct Foo {}
+  │     ^^^^^^^^^^^^^^^ Invalid struct declaration. 'public(package)' struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_2024/parser/struct_public.move:5:28
+  │
+4 │     public(friend) struct Foo {}
+  │                           --- Alias previously defined here
+5 │     public(package) struct Foo {}
+  │                            ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+

--- a/external-crates/move/move-compiler/tests/move_2024/parser/struct_public.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/struct_public.move
@@ -1,6 +1,6 @@
 module 0x42::M {
     // visibility modifiers on structs fail during parsing
-    public struct Foo {}
+    struct Foo {}
     public(friend) struct Foo {}
     public(package) struct Foo {}
 }

--- a/external-crates/move/move-compiler/tests/move_2024/struct_invalid_visibility_progress_inside.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/struct_invalid_visibility_progress_inside.exp
@@ -1,0 +1,14 @@
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/struct_invalid_visibility_progress_inside.move:2:5
+  │
+2 │     struct Foo {
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E03004]: unbound type
+  ┌─ tests/move_2024/struct_invalid_visibility_progress_inside.move:3:12
+  │
+3 │         x: Bar<foo>,
+  │            ^^^ Unbound type 'Bar' in current scope
+

--- a/external-crates/move/move-compiler/tests/move_2024/struct_invalid_visibility_progress_inside.move
+++ b/external-crates/move/move-compiler/tests/move_2024/struct_invalid_visibility_progress_inside.move
@@ -1,0 +1,5 @@
+module 0x42::M {
+    struct Foo {
+        x: Bar<foo>,
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/parser/struct_public.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/struct_public.exp
@@ -1,6 +1,32 @@
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/parser/struct_public.move:3:5
+  │
+3 │     public struct Foo {}
+  │     ^^^^^^  not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
 error[E01003]: invalid modifier
   ┌─ tests/move_check/parser/struct_public.move:3:5
   │
 3 │     public struct Foo {}
   │     ^^^^^^ Invalid struct declaration. Structs cannot have visibility modifiers as they are always 'public'
+  │
+  = Starting in the Move 2024 edition visibility must be annotated on struct declarations.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_check/parser/struct_public.move:4:5
+  │
+4 │     public(friend) struct Foo {}
+  │     ^^^^^^^^^^^^^^ Invalid struct declaration. Structs cannot have visibility modifiers as they are always 'public'
+  │
+  = Starting in the Move 2024 edition visibility must be annotated on struct declarations.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_check/parser/struct_public.move:5:5
+  │
+5 │     public(package) struct Foo {}
+  │     ^^^^^^^^^^^^^^^ Invalid struct declaration. Structs cannot have visibility modifiers as they are always 'public'
+  │
+  = Starting in the Move 2024 edition visibility must be annotated on struct declarations.
 

--- a/external-crates/move/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/move-compiler/tests/move_check_testsuite.rs
@@ -12,7 +12,7 @@ use move_compiler::{
     command_line::compiler::move_check_for_errors,
     diagnostics::*,
     editions::{Edition, Flavor},
-    shared::{Flags, NumericalAddress, PackageConfig},
+    shared::{Flags, NumericalAddress, PackageConfig, PackagePaths},
     Compiler, PASS_PARSER,
 };
 
@@ -161,15 +161,23 @@ pub fn run_test(
     default_config: PackageConfig,
 ) -> anyhow::Result<()> {
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
+    let named_address_map = default_testing_addresses(default_config.flavor);
+    let deps = vec![PackagePaths {
+        name: Some(("stdlib".into(), PackageConfig::default())),
+        paths: move_stdlib::move_stdlib_files(),
+        named_address_map: named_address_map.clone(),
+    }];
+    let targets = vec![PackagePaths {
+        name: None,
+        paths: targets,
+        named_address_map,
+    }];
 
-    let (files, comments_and_compiler_res) = Compiler::from_files(
-        targets,
-        move_stdlib::move_stdlib_files(),
-        default_testing_addresses(default_config.flavor),
-    )
-    .set_flags(flags)
-    .set_default_config(default_config)
-    .run::<PASS_PARSER>()?;
+    let (files, comments_and_compiler_res) = Compiler::from_package_paths(targets, deps)
+        .unwrap()
+        .set_flags(flags)
+        .set_default_config(default_config)
+        .run::<PASS_PARSER>()?;
     let diags = move_check_for_errors(comments_and_compiler_res);
 
     let has_diags = !diags.is_empty();

--- a/external-crates/move/move-compiler/transactional-tests/tests/dependencies/public_package.move
+++ b/external-crates/move/move-compiler/transactional-tests/tests/dependencies/public_package.move
@@ -3,7 +3,7 @@
 //# publish
 address 0x42 {
     module x {
-        struct T has drop {}
+        public struct T has drop {}
 
         public(package) fun new(): T {
             T {}

--- a/external-crates/move/move-compiler/transactional-tests/tests/dependencies/public_package_different_packages.move
+++ b/external-crates/move/move-compiler/transactional-tests/tests/dependencies/public_package_different_packages.move
@@ -2,7 +2,7 @@
 
 //# publish
 module 0x42::X {
-    struct T has drop {}
+    public struct T has drop {}
     public(package) fun new(): T {
         T {}
     }


### PR DESCRIPTION
## Description 

Add support for `public struct` declarations in the Move 2024 edition.

To my knowledge this is the first backwards incompatible change, so we need to split off a separate version of the move-stdlib that tracks the new 2024 edition as well. 

The bottom commit of this PR does this, and also refactors the test runner so we aren't passing so many fields all the time in the test runner. 

## Test Plan 

Added additional tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Adds initial `public struct` type visibility support to Move 2024.alpha. When using the Move 2024.alpha edition you will be required to write `public` in front of the struct type which will keep the same semantics as `struct` with no visibility modifiers today (i.e., in the `legacy` edition), this is to allow for future support of private struct types.  
