### PR TITLE
[chore] consensus clean up

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -402,9 +402,7 @@ impl Bullshark {
         reputation_scores: &ReputationScores,
     ) -> bool {
         // Do not perform any update if the feature is disabled
-        if self.protocol_config.narwhal_new_leader_election_schedule()
-            && reputation_scores.final_of_schedule
-        {
+        if reputation_scores.final_of_schedule {
             // create the new swap table and update the scheduler
             self.leader_schedule
                 .update_leader_swap_table(LeaderSwapTable::new(

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -220,24 +220,16 @@ impl LeaderSchedule {
         store: Arc<ConsensusStore>,
         protocol_config: ProtocolConfig,
     ) -> Self {
-        // Only try to restore when the new leader election schedule is enabled, otherwise fallback to
-        // default swap table, which basically means there will be no swaps.
-        let table = if protocol_config.narwhal_new_leader_election_schedule() {
-            store
-                .read_latest_commit_with_final_reputation_scores()
-                .map_or(LeaderSwapTable::default(), |commit| {
-                    LeaderSwapTable::new(
-                        &committee,
-                        commit.leader_round(),
-                        &commit.reputation_score(),
-                        protocol_config.consensus_bad_nodes_stake_threshold(),
-                    )
-                })
-        } else {
-            LeaderSwapTable::default()
-        };
-
-        // create the schedule
+        let table = store
+            .read_latest_commit_with_final_reputation_scores()
+            .map_or(LeaderSwapTable::default(), |commit| {
+                LeaderSwapTable::new(
+                    &committee,
+                    commit.leader_round(),
+                    &commit.reputation_score(),
+                    protocol_config.consensus_bad_nodes_stake_threshold(),
+                )
+            });
         Self::new(committee, table)
     }
 

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -89,22 +89,9 @@ async fn commit_one_with_leader_schedule_change() {
 
     let test_cases: Vec<TestCase> = vec![
         TestCase {
-            description: "When no schedule change is enabled, then all leaders commit in round robin fashion".to_string(),
-            protocol_config: latest_protocol_version(),
-            rounds: 11,
-            expected_leaders: VecDeque::from(vec![
-                AuthorityIdentifier(0),
-                AuthorityIdentifier(1),
-                AuthorityIdentifier(2),
-                AuthorityIdentifier(3),
-                AuthorityIdentifier(0),
-            ]),
-        },
-        TestCase {
             description: "When schedule change is enabled, then authority 0 is bad node and swapped with authority 3".to_string(),
             protocol_config: {
                 let mut config: ProtocolConfig = latest_protocol_version();
-                config.set_narwhal_new_leader_election_schedule(true);
                 config.set_consensus_bad_nodes_stake_threshold(33);
                 config
             },
@@ -250,7 +237,6 @@ async fn not_enough_support_with_leader_schedule_change() {
     certificates.extend(out);
 
     let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_narwhal_new_leader_election_schedule(true);
     config.set_consensus_bad_nodes_stake_threshold(33);
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use storage::{ConsensusStore, NodeStorage};
 use sui_protocol_config::ProtocolConfig;
 use telemetry_subscribers::TelemetryGuards;
-use test_utils::{get_protocol_config, latest_protocol_version, mock_certificate};
+use test_utils::{latest_protocol_version, mock_certificate};
 use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
@@ -38,21 +38,8 @@ use types::{
 /// * no forks created
 #[tokio::test]
 async fn test_consensus_recovery_with_bullshark() {
-    let _guard = setup_tracing();
-
-    // TODO: remove once the new leader schedule has been enabled.
-    // Run with default config settings where the new leader schedule is disabled
-    let config: ProtocolConfig = get_protocol_config(19);
-    test_consensus_recovery_with_bullshark_with_config(config).await;
-
-    // Run with the new leader election schedule enabled
-    let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
-    test_consensus_recovery_with_bullshark_with_config(config).await;
-}
-
-async fn test_consensus_recovery_with_bullshark_with_config(config: ProtocolConfig) {
     // GIVEN
+    let _guard = setup_tracing();
     let num_sub_dags_per_schedule = 3;
     let storage = NodeStorage::reopen(temp_dir(), None);
 
@@ -62,6 +49,9 @@ async fn test_consensus_recovery_with_bullshark_with_config(config: ProtocolConf
     // AND Setup consensus
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
+
+    let mut config: ProtocolConfig = latest_protocol_version();
+    config.set_consensus_bad_nodes_stake_threshold(33);
 
     // AND make certificates for rounds 1 to 7 (inclusive)
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
@@ -523,7 +513,6 @@ async fn test_leader_schedule_from_store() {
 
     // WHEN flag is enabled for the new schedule algorithm
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.set_narwhal_new_leader_election_schedule(true);
     protocol_config.set_consensus_bad_nodes_stake_threshold(33);
     let schedule = LeaderSchedule::from_store(committee, store, protocol_config);
 

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -22,9 +22,9 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use storage::ConsensusStore;
 use sui_protocol_config::ProtocolConfig;
+use test_utils::latest_protocol_version;
 use test_utils::mock_certificate_with_rand;
 use test_utils::CommitteeFixture;
-use test_utils::{get_protocol_config, latest_protocol_version};
 #[allow(unused_imports)]
 use tokio::sync::mpsc::channel;
 use types::CertificateAPI;
@@ -75,18 +75,6 @@ impl ExecutionPlan {
 #[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn bullshark_randomised_tests() {
-    // Run the consensus tests without the new consensus schedule changes
-    let protocol_config = get_protocol_config(19);
-    bullshark_randomised_tests_with_config(protocol_config).await;
-
-    // TODO: remove once the new leader election schedule feature is enabled on a protocol version
-    // Run the consensus tests with the new consensus schedule changes enabled
-    let mut config: ProtocolConfig = latest_protocol_version();
-    config.set_consensus_bad_nodes_stake_threshold(33);
-    bullshark_randomised_tests_with_config(config).await;
-}
-
-async fn bullshark_randomised_tests_with_config(protocol_config: ProtocolConfig) {
     // Configuration regarding the randomized tests. The tests will run for different values
     // on the below parameters to increase the different cases we can generate.
 
@@ -120,6 +108,9 @@ async fn bullshark_randomised_tests_with_config(protocol_config: ProtocolConfig)
             minimum_committee_size: None,
         },
     ];
+
+    let mut config: ProtocolConfig = latest_protocol_version();
+    config.set_consensus_bad_nodes_stake_threshold(33);
 
     let mut test_execution_list = FuturesUnordered::new();
     let (tx, mut rx) = channel(1000);
@@ -185,7 +176,7 @@ async fn bullshark_randomised_tests_with_config(protocol_config: ProtocolConfig)
 
                 let consensus_store = store.clone();
 
-                let config = protocol_config.clone();
+                let config = config.clone();
 
                 let handle = tokio::spawn(async move {
                     // Create a randomized DAG

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -143,12 +143,8 @@ impl ConsensusStore {
 mod test {
     use crate::ConsensusStore;
     use std::collections::HashMap;
-    use store::Map;
     use test_utils::CommitteeFixture;
-    use types::{
-        Certificate, CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2,
-        ReputationScores, TimestampMs,
-    };
+    use types::{Certificate, CommittedSubDag, ReputationScores};
 
     #[tokio::test]
     async fn test_read_latest_final_reputation_scores() {

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -7,33 +7,25 @@ use std::collections::HashMap;
 use store::rocks::{open_cf, DBMap, MetricConf, ReadWriteOptions};
 use store::{reopen, Map, TypedStoreError};
 use tracing::debug;
-use types::{
-    CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2, Round,
-    SequenceNumber,
-};
+use types::{CommittedSubDag, ConsensusCommit, ConsensusCommitV2, Round, SequenceNumber};
 
 /// The persistent storage of the sequencer.
 pub struct ConsensusStore {
     /// The latest committed round of each validator.
     last_committed: DBMap<AuthorityIdentifier, Round>,
-    /// TODO: remove once released to validators
-    /// The global consensus sequence.
-    committed_sub_dags_by_index: DBMap<SequenceNumber, CommittedSubDagShell>,
     /// The global consensus sequence
-    committed_sub_dags_by_index_v2: DBMap<SequenceNumber, ConsensusCommit>,
+    committed_sub_dags_by_index: DBMap<SequenceNumber, ConsensusCommit>,
 }
 
 impl ConsensusStore {
     /// Create a new consensus store structure by using already loaded maps.
     pub fn new(
         last_committed: DBMap<AuthorityIdentifier, Round>,
-        sequence: DBMap<SequenceNumber, CommittedSubDagShell>,
         committed_sub_dags_map: DBMap<SequenceNumber, ConsensusCommit>,
     ) -> Self {
         Self {
             last_committed,
-            committed_sub_dags_by_index: sequence,
-            committed_sub_dags_by_index_v2: committed_sub_dags_map,
+            committed_sub_dags_by_index: committed_sub_dags_map,
         }
     }
 
@@ -44,20 +36,18 @@ impl ConsensusStore {
             MetricConf::default(),
             &[
                 NodeStorage::LAST_COMMITTED_CF,
-                NodeStorage::SUB_DAG_INDEX_CF,
                 NodeStorage::COMMITTED_SUB_DAG_INDEX_CF,
             ],
         )
         .expect("Cannot open database");
-        let (last_committed_map, sub_dag_index_map, committed_sub_dag_map) = reopen!(&rocksdb, NodeStorage::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>, NodeStorage::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>, NodeStorage::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>);
-        Self::new(last_committed_map, sub_dag_index_map, committed_sub_dag_map)
+        let (last_committed_map, committed_sub_dag_map) = reopen!(&rocksdb, NodeStorage::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>, NodeStorage::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>);
+        Self::new(last_committed_map, committed_sub_dag_map)
     }
 
     /// Clear the store.
     pub fn clear(&self) -> StoreResult<()> {
         self.last_committed.unsafe_clear()?;
         self.committed_sub_dags_by_index.unsafe_clear()?;
-        self.committed_sub_dags_by_index_v2.unsafe_clear()?;
         Ok(())
     }
 
@@ -72,7 +62,7 @@ impl ConsensusStore {
         let mut write_batch = self.last_committed.batch();
         write_batch.insert_batch(&self.last_committed, last_committed.iter())?;
         write_batch.insert_batch(
-            &self.committed_sub_dags_by_index_v2,
+            &self.committed_sub_dags_by_index,
             std::iter::once((sub_dag.sub_dag_index, commit)),
         )?;
         write_batch.write()
@@ -85,18 +75,6 @@ impl ConsensusStore {
 
     /// Gets the latest sub dag index from the store
     pub fn get_latest_sub_dag_index(&self) -> SequenceNumber {
-        if let Some(s) = self
-            .committed_sub_dags_by_index_v2
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(seq, _)| seq)
-        {
-            return s;
-        }
-
-        // TODO: remove once this has been released to the validators
-        // If nothing has been found on v2, just fallback on the previous storage
         self.committed_sub_dags_by_index
             .unbounded_iter()
             .skip_to_last()
@@ -108,25 +86,11 @@ impl ConsensusStore {
     /// Returns thet latest subdag committed. If none is committed yet, then
     /// None is returned instead.
     pub fn get_latest_sub_dag(&self) -> Option<ConsensusCommit> {
-        if let Some(sub_dag) = self
-            .committed_sub_dags_by_index_v2
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(_, sub_dag)| sub_dag)
-        {
-            return Some(sub_dag);
-        }
-
-        // TODO: remove once this has been released to the validators
-        // If nothing has been found to the v2 table, just fallback to the previous one. We expect this
-        // to happen only after validator has upgraded. After that point the v2 table will populated
-        // and an entry should be found there.
         self.committed_sub_dags_by_index
             .unbounded_iter()
             .skip_to_last()
             .next()
-            .map(|(_, sub_dag)| ConsensusCommit::V1(sub_dag))
+            .map(|(_, sub_dag)| sub_dag)
     }
 
     /// Load all the sub dags committed with sequence number of at least `from`.
@@ -134,24 +98,12 @@ impl ConsensusStore {
         &self,
         from: &SequenceNumber,
     ) -> StoreResult<Vec<ConsensusCommit>> {
-        // TODO: remove once this has been released to the validators
-        // start from the previous table first to ensure we haven't missed anything.
-        let mut sub_dags = self
+        Ok(self
             .committed_sub_dags_by_index
             .unbounded_iter()
             .skip_to(from)?
-            .map(|(_, sub_dag)| ConsensusCommit::V1(sub_dag))
-            .collect::<Vec<ConsensusCommit>>();
-
-        sub_dags.extend(
-            self.committed_sub_dags_by_index_v2
-                .unbounded_iter()
-                .skip_to(from)?
-                .map(|(_, sub_dag)| sub_dag)
-                .collect::<Vec<ConsensusCommit>>(),
-        );
-
-        Ok(sub_dags)
+            .map(|(_, sub_dag)| sub_dag)
+            .collect::<Vec<ConsensusCommit>>())
     }
 
     /// Load consensus commit with a given sequence number.
@@ -159,14 +111,14 @@ impl ConsensusStore {
         &self,
         seq: &SequenceNumber,
     ) -> StoreResult<Option<ConsensusCommit>> {
-        self.committed_sub_dags_by_index_v2.get(seq)
+        self.committed_sub_dags_by_index.get(seq)
     }
 
     /// Reads from storage the latest commit sub dag where its ReputationScores are marked as "final".
     /// If none exists yet then this method will return None.
     pub fn read_latest_commit_with_final_reputation_scores(&self) -> Option<ConsensusCommit> {
         for commit in self
-            .committed_sub_dags_by_index_v2
+            .committed_sub_dags_by_index
             .unbounded_iter()
             .skip_to_last()
             .reverse()
@@ -255,65 +207,5 @@ mod test {
 
         assert!(commit.reputation_score().final_of_schedule);
         assert_eq!(commit.sub_dag_index(), 20)
-    }
-
-    #[tokio::test]
-    async fn test_v1_v2_backwards_compatibility() {
-        let store = ConsensusStore::new_for_tests();
-
-        // Create few sub dags of V1 and write in the committed_sub_dags_by_index storage
-        for i in 0..3 {
-            let s = CommittedSubDagShell {
-                certificates: vec![],
-                leader: Default::default(),
-                leader_round: 2,
-                sub_dag_index: i,
-                reputation_score: Default::default(),
-            };
-
-            store
-                .committed_sub_dags_by_index
-                .insert(&s.sub_dag_index, &s)
-                .unwrap();
-        }
-
-        // Create few sub dags of V2 and write in the committed_sub_dags_by_index_v2 storage
-        for i in 3..6 {
-            let s = ConsensusCommitV2 {
-                certificates: vec![],
-                leader: Default::default(),
-                leader_round: 2,
-                sub_dag_index: i,
-                reputation_score: Default::default(),
-                commit_timestamp: i,
-            };
-
-            store
-                .committed_sub_dags_by_index_v2
-                .insert(&s.sub_dag_index.clone(), &ConsensusCommit::V2(s))
-                .unwrap();
-        }
-
-        // Read from index 0, all the sub dags should be returned
-        let sub_dags = store.read_committed_sub_dags_from(&0).unwrap();
-
-        assert_eq!(sub_dags.len(), 6);
-
-        for (index, sub_dag) in sub_dags.iter().enumerate() {
-            assert_eq!(sub_dag.sub_dag_index(), index as u64);
-            if index < 3 {
-                assert_eq!(sub_dag.commit_timestamp(), 0);
-            } else {
-                assert_eq!(sub_dag.commit_timestamp(), index as TimestampMs);
-            }
-        }
-
-        // Read the last sub dag, and the sub dag with index 5 should be returned
-        let last_sub_dag = store.get_latest_sub_dag();
-        assert_eq!(last_sub_dag.unwrap().sub_dag_index(), 5);
-
-        // Read the last sub dag index
-        let index = store.get_latest_sub_dag_index();
-        assert_eq!(index, 5);
     }
 }

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -16,8 +16,8 @@ use store::metrics::SamplingInterval;
 use store::reopen;
 use store::rocks::{default_db_options, open_cf_opts, DBMap, MetricConf, ReadWriteOptions};
 use types::{
-    Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusCommit,
-    Header, Round, SequenceNumber, VoteInfo,
+    Batch, BatchDigest, Certificate, CertificateDigest, ConsensusCommit, Header, Round,
+    SequenceNumber, VoteInfo,
 };
 
 // A type alias marking the "payload" tokens sent by workers to their primary as batch acknowledgements
@@ -44,7 +44,6 @@ impl NodeStorage {
     pub(crate) const PAYLOAD_CF: &'static str = "payload";
     pub(crate) const BATCHES_CF: &'static str = "batches";
     pub(crate) const LAST_COMMITTED_CF: &'static str = "last_committed";
-    pub(crate) const SUB_DAG_INDEX_CF: &'static str = "sub_dag";
     pub(crate) const COMMITTED_SUB_DAG_INDEX_CF: &'static str = "committed_sub_dag";
 
     // 100 nodes * 60 rounds (assuming 1 round/sec this will hold data for about the last 1 minute
@@ -82,7 +81,6 @@ impl NodeStorage {
                     .options,
             ),
             (Self::LAST_COMMITTED_CF, cf_options.clone()),
-            (Self::SUB_DAG_INDEX_CF, cf_options.clone()),
             (Self::COMMITTED_SUB_DAG_INDEX_CF, cf_options),
         ];
         let rocksdb = open_cf_opts(
@@ -102,7 +100,6 @@ impl NodeStorage {
             payload_map,
             batch_map,
             last_committed_map,
-            sub_dag_index_map,
             committed_sub_dag_map,
         ) = reopen!(&rocksdb,
             Self::LAST_PROPOSED_CF;<ProposerKey, Header>,
@@ -113,7 +110,6 @@ impl NodeStorage {
             Self::PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>,
             Self::BATCHES_CF;<BatchDigest, Batch>,
             Self::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>,
-            Self::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>,
             Self::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>
         );
 
@@ -134,7 +130,6 @@ impl NodeStorage {
         let batch_store = batch_map;
         let consensus_store = Arc::new(ConsensusStore::new(
             last_committed_map,
-            sub_dag_index_map,
             committed_sub_dag_map,
         ));
 


### PR DESCRIPTION
## Description 

Cleaning up consensus from:
* unnecessary flag as from now on testnet/mainnet is using the reputation based leader election by default
* unused storage since v2 is used from now on

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
