### PR TITLE
Add file name random suffix

### DIFF
--- a/crates/sui-analytics-indexer/src/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/csv_writer.rs
@@ -27,6 +27,7 @@ pub(crate) struct CSVWriter {
     object_csv: Writer<File>,
     event_csv: Writer<File>,
     move_call_csv: Writer<File>,
+    filename_suffix: u128,
 }
 
 impl CSVWriter {
@@ -34,8 +35,9 @@ impl CSVWriter {
         root_dir: &Path,
         epoch_num: EpochId,
         starting_checkpoint: u64,
+        filename_suffix: u128,
     ) -> Result<Self, AnalyticsIndexerError> {
-        Self::init(root_dir, epoch_num, starting_checkpoint)
+        Self::init(root_dir, epoch_num, starting_checkpoint, filename_suffix)
             .map_err(|e| AnalyticsIndexerError::GenericError(e.to_string()))
     }
 
@@ -43,42 +45,49 @@ impl CSVWriter {
         root_dir_path: &Path,
         epoch_num: EpochId,
         checkpoint_seq_num: u64,
+        filename_suffix: u128,
     ) -> Result<CSVWriter> {
         let transaction_object_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::TransactionObjects,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
         let checkpoint_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::Checkpoint,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
         let object_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::Object,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
         let event_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::Event,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
         let transaction_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::Transaction,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
         let move_call_csv = Self::make_writer(
             root_dir_path.to_path_buf(),
             FileType::MoveCall,
             epoch_num,
             checkpoint_seq_num,
+            filename_suffix,
         )?;
 
         Ok(CSVWriter {
@@ -89,6 +98,7 @@ impl CSVWriter {
             object_csv,
             event_csv,
             move_call_csv,
+            filename_suffix,
         })
     }
 
@@ -97,10 +107,16 @@ impl CSVWriter {
         file_type: FileType,
         epoch_num: EpochId,
         checkpoint_seq_num: u64,
+        filename_suffix: u128,
     ) -> Result<Writer<File>> {
         let file_path = path_to_filesystem(
             root_dir_path,
-            &file_type.file_path(FileFormat::CSV, epoch_num, checkpoint_seq_num),
+            &file_type.file_path(
+                FileFormat::CSV,
+                epoch_num,
+                checkpoint_seq_num,
+                filename_suffix,
+            ),
         )?;
         create_dir_all(file_path.parent().ok_or(anyhow!("Bad directory path"))?)?;
         if file_path.exists() {
@@ -170,7 +186,12 @@ impl TableWriter for CSVWriter {
     }
 
     fn reset(&mut self, epoch_num: EpochId, checkpoint_seq_num: u64) -> Result<()> {
-        let new_csv_writer = CSVWriter::init(&self.root_dir_path, epoch_num, checkpoint_seq_num)?;
+        let new_csv_writer = CSVWriter::init(
+            &self.root_dir_path,
+            epoch_num,
+            checkpoint_seq_num,
+            self.filename_suffix,
+        )?;
         self.checkpoint_csv = new_csv_writer.checkpoint_csv;
         self.object_csv = new_csv_writer.object_csv;
         self.transaction_csv = new_csv_writer.transaction_csv;

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -149,12 +149,14 @@ impl FileType {
         file_format: FileFormat,
         epoch_num: EpochId,
         checkpoint_sequence_num: u64,
+        filename_suffix: u128,
     ) -> Path {
         self.dir_prefix()
             .child(format!("{}{}", EPOCH_DIR_PREFIX, epoch_num))
             .child(format!(
-                "{}.{}",
+                "{}_{}.{}",
                 checkpoint_sequence_num,
+                filename_suffix,
                 file_format.file_suffix()
             ))
     }
@@ -166,6 +168,7 @@ pub struct FileMetadata {
     pub file_format: FileFormat,
     pub epoch_num: u64,
     pub checkpoint_seq_range: Range<u64>,
+    pub filename_suffix: u128,
 }
 
 impl FileMetadata {
@@ -174,12 +177,14 @@ impl FileMetadata {
         file_format: FileFormat,
         epoch_num: u64,
         checkpoint_seq_range: Range<u64>,
+        filename_suffix: u128,
     ) -> FileMetadata {
         FileMetadata {
             file_type,
             file_format,
             epoch_num,
             checkpoint_seq_range,
+            filename_suffix,
         }
     }
 
@@ -188,6 +193,7 @@ impl FileMetadata {
             self.file_format,
             self.epoch_num,
             self.checkpoint_seq_range.start,
+            self.filename_suffix,
         )
     }
 }
@@ -216,10 +222,19 @@ impl CheckpointUpdates {
         file_format: FileFormat,
         epoch_num: u64,
         checkpoint_range: Range<u64>,
+        filename_suffix: u128,
         manifest: &mut Manifest,
     ) -> Self {
         let files: Vec<_> = FileType::iter()
-            .map(|f| FileMetadata::new(f, file_format, epoch_num, checkpoint_range.clone()))
+            .map(|f| {
+                FileMetadata::new(
+                    f,
+                    file_format,
+                    epoch_num,
+                    checkpoint_range.clone(),
+                    filename_suffix,
+                )
+            })
             .collect();
         CheckpointUpdates::new(epoch_num, checkpoint_range.end, files, manifest)
     }


### PR DESCRIPTION
## Description 

When writing to a bucket which is used for snowpipe ingestion, we need to randomize the file names. This is because if for some reason we want to re-run the data pipeline, we will be generating the same file names in the following runs and writing to the bucket and replacing existing files. But snowpipe today would not pick up modified files. 
## Test Plan 

Existing tests, running locally