### PR TITLE
Switch to using pipe as delimiter in csv writer for analytics

### DIFF
--- a/crates/sui-analytics-indexer/src/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/csv_writer.rs
@@ -108,6 +108,7 @@ impl CSVWriter {
         }
         let writer = WriterBuilder::new()
             .has_headers(false)
+            .delimiter(b'|')
             .from_path(file_path)?;
         Ok(writer)
     }


### PR DESCRIPTION
## Description 

Some of the fields contain `,` which makes snowflake snowpipe fail parsing file parsing(rightly so). So switching to a different delimiter will likely fix the issue here. One such field is:
`"0x2::dynamic_field::Field<u64, 0x3::sui_system_state_inner::SuiSystemStateInnerV2>"`
