### PR TITLE
[GraphQL] Factor out SuiAddress parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10236,6 +10236,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "move-core-types",
  "once_cell",
  "serde",
  "serde_json",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+move-core-types.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Description

Implement `FromStr` and `From<AccountAddress>` for `SuiAddress`, for use in implementing the `MoveValue` type.

This also simplifies many of the tests, which can now be written in terms of `FromStr` rather than via the `InputType`/`ScalarType` interface.

Also fixes a small bug in the error response when failing to parse an address because of an invalid hex code -- previously the implementation forwarded the error directly from the `hex` crate, but this results in an index that is off-by-two, because we stripped the leading "0x" from the string before we passed it to `hex::decode`.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run -- sui_address
```