### PR TITLE
[GraphQL] BigInt from primitive integer types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10233,6 +10233,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10233,6 +10233,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "move-core-types",
  "once_cell",
  "serde",
  "serde_json",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+move-core-types.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,7 +17,9 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+once_cell.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_with.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true

--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -20,12 +20,15 @@ schema {
 
 type Query {
   # First four bytes of the network's genesis checkpoint digest
-  # (uniquely defines the network)
+  # (uniquely identifies the network)
   chainIdentifier: String!
 
   # Range of checkpoints that the RPC has data available for (for data
   # that can be tied to a particular checkpoint).
   availableRange: AvailableRange!
+
+  # Configuration for this RPC service
+  serviceConfig: ServiceConfig!
 
   # Simulate running a transaction to inspect its effects without
   # committing to them on-chain.
@@ -285,6 +288,23 @@ input DynamicFieldFilter {
 type AvailableRange {
   first: Checkpoint
   last: Checkpoint
+}
+
+type ServiceConfig {
+  enabledFeatures: [Feature!]
+  isEnabled(feature: Feature!): Boolean!
+
+  maxQueryDepth: Int
+  maxQueryNodes: Int
+}
+
+enum Feature {
+  ANALYTICS
+  COINS
+  DYNAMIC_FIELDS
+  NAME_SERVICE
+  SUBSCRIPTIONS
+  SYSTEM_STATE
 }
 
 interface ObjectOwner {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -122,7 +122,7 @@ mod tests {
         let actual = ServiceConfig::read(
             r#" disabled-features = [
                   "coins",
-                  "name-server",
+                  "name-service",
                 ]
             "#,
         )
@@ -131,7 +131,7 @@ mod tests {
         use FunctionalGroup as G;
         let expect = ServiceConfig {
             limits: Limits::default(),
-            disabled_features: BTreeSet::from([G::Coins, G::NameServer]),
+            disabled_features: BTreeSet::from([G::Coins, G::NameService]),
             experiments: Experiments::default(),
         };
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -19,19 +19,25 @@ pub(crate) mod code {
 /// because they will originate from within the GraphQL implementation.  This function is intended
 /// for errors that originated from outside of GraphQL (such as in middleware), but that need to be
 /// ingested by GraphQL clients.
-pub(crate) fn graphql_error(code: &str, message: String) -> GraphQLResponse {
+pub(crate) fn graphql_error_response(code: &str, message: impl Into<String>) -> GraphQLResponse {
+    let error = graphql_error(code, message);
+    Response::from_errors(error.into()).into()
+}
+
+/// Create a generic GraphQL Server Error.
+///
+/// This error has no path, source, or locations, just a message and an error code.
+pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerError {
     let mut ext = ErrorExtensionValues::default();
     ext.set("code", code);
 
-    let error = ServerError {
-        message,
+    ServerError {
+        message: message.into(),
         source: None,
         locations: vec![],
         path: vec![],
         extensions: Some(ext),
-    };
-
-    Response::from_errors(error.into()).into()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
+++ b/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextResolve, ResolveInfo},
+    ServerError, ServerResult, Value,
+};
+use async_trait::async_trait;
+
+use crate::{
+    config::ServiceConfig,
+    error::{code, graphql_error},
+    functional_group::functional_group,
+};
+
+pub(crate) struct FeatureGate;
+
+impl ExtensionFactory for FeatureGate {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(FeatureGate)
+    }
+}
+
+#[async_trait]
+impl Extension for FeatureGate {
+    async fn resolve(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        info: ResolveInfo<'_>,
+        next: NextResolve<'_>,
+    ) -> ServerResult<Option<Value>> {
+        let ResolveInfo {
+            parent_type,
+            name,
+            is_for_introspection,
+            ..
+        } = &info;
+
+        let ServiceConfig {
+            disabled_features, ..
+        } = ctx.data().map_err(|_| {
+            graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                "Unable to fetch service configuration",
+            )
+        })?;
+
+        // TODO: Is there a way to set `is_visible` on `MetaField` and `MetaType` in a generic way
+        // after building the schema? (to a function which reads the `ServiceConfig` from the
+        // `Context`). This is (probably) required to hide disabled types and interfaces in the
+        // schema.
+
+        if let Some(group) = functional_group(parent_type, name) {
+            if disabled_features.contains(&group) {
+                return if *is_for_introspection {
+                    Ok(None)
+                } else {
+                    Err(ServerError::new(
+                        format!(
+                            "Cannot query field \"{name}\" on type \"{parent_type}\". \
+                             Feature {} is disabled.",
+                            group.name(),
+                        ),
+                        // TODO: Fork `async-graphl` to add field position information to
+                        // `ResolveInfo`, so the error can take advantage of it.  Similarly for
+                        // utilising the `path_node` to set the error path.
+                        None,
+                    ))
+                };
+            }
+        }
+
+        next.run(ctx, info).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+    use expect_test::expect;
+
+    use crate::{functional_group::FunctionalGroup, types::query::Query};
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic] // because it tries to access the data provider, which isn't there
+    async fn test_accessing_an_enabled_field() {
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig::default())
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_accessing_a_disabled_field() {
+        let errs: Vec<_> = Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig {
+                disabled_features: BTreeSet::from_iter([FunctionalGroup::SystemState]),
+                ..Default::default()
+            })
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await
+            .into_result()
+            .unwrap_err()
+            .into_iter()
+            .map(|e| e.message)
+            .collect();
+
+        let expect = expect![[r#"
+            [
+                "Cannot query field \"protocolConfig\" on type \"Query\". Feature \"system-state\" is disabled.",
+            ]"#]];
+        expect.assert_eq(&format!("{errs:#?}"));
+    }
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod feature_gate;
 pub(crate) mod limits_info;
 pub(crate) mod logger;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -3,14 +3,16 @@
 
 use std::collections::BTreeMap;
 
+use async_graphql::*;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 
-/// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
-/// settings in the RPC's TOML configuration file.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+/// Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+/// or disable these features.
+#[derive(Enum, Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
+#[graphql(name = "Feature")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
     Analytics,
@@ -37,6 +39,20 @@ impl FunctionalGroup {
     /// Not a suitable `Display` implementation because it enquotes the representation.
     pub(crate) fn name(&self) -> String {
         json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+
+    /// List of all functional groups
+    pub(crate) fn all() -> &'static [FunctionalGroup] {
+        use FunctionalGroup as G;
+        static ALL: &[FunctionalGroup] = &[
+            G::Analytics,
+            G::Coins,
+            G::DynamicFields,
+            G::NameService,
+            G::Subscriptions,
+            G::SystemState,
+        ];
+        ALL
     }
 }
 

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use serde_json as json;
 
 /// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
 /// settings in the RPC's TOML configuration file.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
@@ -18,10 +22,7 @@ pub(crate) enum FunctionalGroup {
     DynamicFields,
 
     /// SuiNS name and reverse name look-up.
-    NameServer,
-
-    /// Struct and function signatures, and popular packages.
-    Packages,
+    NameService,
 
     /// Transaction and Event subscriptions.
     Subscriptions,
@@ -29,4 +30,132 @@ pub(crate) enum FunctionalGroup {
     /// Information about the system that changes from epoch to epoch (protocol config, committee,
     /// reference gas price).
     SystemState,
+}
+
+impl FunctionalGroup {
+    /// Name that the group is referred to by in configuration and responses on the GraphQL API.
+    /// Not a suitable `Display` implementation because it enquotes the representation.
+    pub(crate) fn name(&self) -> String {
+        json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+}
+
+/// Mapping from type and field name in the schema to the functional group it belongs to.
+fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), FunctionalGroup> {
+    // TODO: Introduce a macro to declare the functional group for a field and/or type on the
+    // appropriate type, field, or function, instead of here.  This may also be able to set the
+    // graphql `visible` attribute to control schema visibility by functional groups.
+
+    use FunctionalGroup as G;
+    static GROUPS: Lazy<BTreeMap<(&str, &str), FunctionalGroup>> = Lazy::new(|| {
+        BTreeMap::from_iter([
+            (("Address", "balance"), G::Coins),
+            (("Address", "balanceConnection"), G::Coins),
+            (("Address", "coinConnection"), G::Coins),
+            (("Address", "defaultNameServiceName"), G::NameService),
+            (("Address", "nameServiceConnection"), G::NameService),
+            (("Checkpoint", "addressMetrics"), G::Analytics),
+            (("Checkpoint", "networkTotalTransactions"), G::Analytics),
+            (("Epoch", "protocolConfig"), G::SystemState),
+            (("Epoch", "referenceGasPrice"), G::SystemState),
+            (("Epoch", "safeMode"), G::SystemState),
+            (("Epoch", "storageFund"), G::SystemState),
+            (("Epoch", "systemParameters"), G::SystemState),
+            (("Epoch", "systemStateVersion"), G::SystemState),
+            (("Epoch", "validatorSet"), G::SystemState),
+            (("Object", "balance"), G::Coins),
+            (("Object", "balanceConnection"), G::Coins),
+            (("Object", "coinConnection"), G::Coins),
+            (("Object", "defaultNameServiceName"), G::NameService),
+            (("Object", "dynamicField"), G::DynamicFields),
+            (("Object", "dynamicFieldConnection"), G::DynamicFields),
+            (("Object", "nameServiceConnection"), G::NameService),
+            (("Owner", "balance"), G::Coins),
+            (("Owner", "balanceConnection"), G::Coins),
+            (("Owner", "coinConnection"), G::Coins),
+            (("Owner", "defaultNameServiceName"), G::NameService),
+            (("Owner", "nameServiceConnection"), G::NameService),
+            (("Query", "coinMetadata"), G::Coins),
+            (("Query", "moveCallMetrics"), G::Analytics),
+            (("Query", "networkMetrics"), G::Analytics),
+            (("Query", "protocolConfig"), G::SystemState),
+            (("Query", "resolveNameServiceAddress"), G::NameService),
+            (("Subscription", "events"), G::Subscriptions),
+            (("Subscription", "transactions"), G::Subscriptions),
+        ])
+    });
+
+    Lazy::force(&GROUPS)
+}
+
+/// Map a type and field name to a functional group.  If an explicit group does not exist for the
+/// field, then it is assumed to be a "core" feature.
+pub(crate) fn functional_group(type_: &str, field: &str) -> Option<FunctionalGroup> {
+    functional_groups().get(&(type_, field)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::registry::Registry;
+    use async_graphql::OutputType;
+
+    use crate::types::query::Query;
+
+    use super::*;
+
+    #[test]
+    /// Makes sure all the functional groups correspond to real elements of the schema unless they
+    /// are explicitly recorded as unimplemented.  Complementarily, makes sure that fields marked as
+    /// unimplemented don't appear in the set of unimplemented fields.
+    fn test_groups_match_schema() {
+        let mut registry = Registry::default();
+        Query::create_type_info(&mut registry);
+
+        let unimplemented = BTreeSet::from_iter([
+            ("Checkpoint", "addressMetrics"),
+            ("Epoch", "protocolConfig"),
+            ("Object", "dynamicField"),
+            ("Object", "dynamicFieldConnection"),
+            ("Query", "coinMetadata"),
+            ("Query", "moveCallMetrics"),
+            ("Query", "networkMetrics"),
+            ("Query", "resolveNameServiceAddress"),
+            ("Subscription", "events"),
+            ("Subscription", "transactions"),
+        ]);
+
+        for (type_, field) in &unimplemented {
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                continue;
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                continue;
+            };
+
+            panic!(
+                "Field '{type_}.{field}' is marked as unimplemented in this test, but it's in the \
+                 schema.  Fix this by removing it from the `unimplemented` set."
+            );
+        }
+
+        for (type_, field) in functional_groups().keys() {
+            if unimplemented.contains(&(type_, field)) {
+                continue;
+            }
+
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                panic!("Type '{type_}' from functional group configs does not appear in schema.");
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                panic!(
+                    "Field '{type_}.{field}' from functional group configs does not appear in \
+                     schema."
+                );
+            };
+        }
+    }
 }

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -5,10 +5,11 @@ pub mod commands;
 pub mod config;
 pub mod server;
 
+pub(crate) mod functional_group;
+
 mod context_data;
 mod error;
 mod extensions;
-mod functional_group;
 mod types;
 
 use async_graphql::*;

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -44,13 +44,13 @@ impl ServerBuilder {
         format!("{}:{}", self.host, self.port)
     }
 
-    pub fn max_query_depth(mut self, max_depth: usize) -> Self {
-        self.schema = self.schema.limit_depth(max_depth);
+    pub fn max_query_depth(mut self, max_depth: u32) -> Self {
+        self.schema = self.schema.limit_depth(max_depth as usize);
         self
     }
 
-    pub fn max_query_nodes(mut self, max_nodes: usize) -> Self {
-        self.schema = self.schema.limit_complexity(max_nodes);
+    pub fn max_query_nodes(mut self, max_nodes: u32) -> Self {
+        self.schema = self.schema.limit_complexity(max_nodes as usize);
         self
     }
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_depth_limit() {
-        async fn exec_query_depth_limit(depth: usize, query: &str) -> Response {
+        async fn exec_query_depth_limit(depth: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
@@ -203,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_node_limit() {
-        async fn exec_query_node_limit(nodes: usize, query: &str) -> Response {
+        async fn exec_query_node_limit(nodes: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -4,6 +4,7 @@
 use crate::config::{ConnectionConfig, ServiceConfig};
 use crate::context_data::data_provider::DataProvider;
 use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_client_v0};
+use crate::extensions::feature_gate::FeatureGate;
 use crate::extensions::limits_info::LimitsInfo;
 use crate::extensions::logger::Logger;
 use crate::extensions::timeout::Timeout;
@@ -29,9 +30,10 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
         .context_data(data_provider)
         .context_data(data_loader)
         .context_data(service_config)
+        .extension(FeatureGate)
+        .extension(LimitsInfo)
         .extension(Logger::default())
         .extension(Timeout::default())
-        .extension(LimitsInfo)
         .build()
         .run()
         .await;

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -9,7 +9,7 @@ use axum::{
     TypedHeader,
 };
 
-use crate::error::{code, graphql_error};
+use crate::error::{code, graphql_error_response};
 
 const RPC_VERSION_FULL: &str = env!("CARGO_PKG_VERSION");
 const RPC_VERSION_YEAR: &str = env!("CARGO_PKG_VERSION_MAJOR");
@@ -58,7 +58,7 @@ pub(crate) async fn check_version_middleware<B>(
         if !rest.is_empty() {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Multiple possible versions found."),
                 ),
@@ -69,7 +69,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Ok(req_version) = std::str::from_utf8(&req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Not a UTF8 string."),
                 ),
@@ -79,7 +79,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Some((year, month)) = parse_version(req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!(
                         "Failed to parse {VERSION_HEADER}: '{req_version}' not a valid \
@@ -92,7 +92,7 @@ pub(crate) async fn check_version_middleware<B>(
         if year != RPC_VERSION_YEAR || month != RPC_VERSION_MONTH {
             return (
                 StatusCode::MISDIRECTED_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::INTERNAL_SERVER_ERROR,
                     format!("Version '{req_version}' not supported."),
                 ),

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -1,43 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use async_graphql::*;
+use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 const SUI_ADDRESS_LENGTH: usize = 32;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
 pub(crate) struct SuiAddress([u8; SUI_ADDRESS_LENGTH]);
+
+#[derive(Error, Debug, Eq, PartialEq)]
+pub(crate) enum FromStrError {
+    #[error("Invalid SuiAddress. Missing 0x prefix.")]
+    NoPrefix,
+
+    #[error(
+        "Expected SuiAddress string with between 1 and {} digits ({} bytes), received {0}",
+        SUI_ADDRESS_LENGTH * 2,
+        SUI_ADDRESS_LENGTH,
+    )]
+    WrongLength(usize),
+
+    #[error("Invalid character {0:?} at position {1}")]
+    BadHex(char, usize),
+}
+
 #[Scalar]
 impl ScalarType for SuiAddress {
     fn parse(value: Value) -> InputValueResult<Self> {
-        match value {
-            Value::String(mut s) => {
-                if s.starts_with("0x") {
-                    s = s[2..].to_string();
-                } else {
-                    return Err(InputValueError::custom(
-                        "Invalid SuiAddress. Missing 0x prefix",
-                    ));
-                }
-                if s.is_empty() || s.len() > SUI_ADDRESS_LENGTH * 2 {
-                    return Err(InputValueError::custom(format!(
-                        "Expected SuiAddress string ranging from length 1 up to {} ({} bytes) or less, received {}.",
-                        SUI_ADDRESS_LENGTH * 2,
-                        SUI_ADDRESS_LENGTH,
-                        s.len()
-                    )));
-                }
-                // Pad to SUI_ADDRESS_LENGTH*2 width
-                s = format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2);
+        let Value::String(s) = value else {
+            return Err(InputValueError::expected_type(value));
+        };
 
-                let bytes = hex::decode(s)?;
-                let mut arr = [0u8; SUI_ADDRESS_LENGTH];
-                arr.copy_from_slice(&bytes);
-                Ok(SuiAddress(arr))
-            }
-            _ => Err(InputValueError::expected_type(value)),
-        }
+        Ok(SuiAddress::from_str(&s)?)
     }
 
     fn to_value(&self) -> Value {
@@ -59,147 +58,129 @@ impl SuiAddress {
     }
 }
 
+impl From<AccountAddress> for SuiAddress {
+    fn from(value: AccountAddress) -> Self {
+        SuiAddress(value.into_bytes())
+    }
+}
+
+impl FromStr for SuiAddress {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, FromStrError> {
+        let Some(s) = s.strip_prefix("0x") else {
+            return Err(FromStrError::NoPrefix);
+        };
+
+        if s.is_empty() || s.len() > SUI_ADDRESS_LENGTH * 2 {
+            return Err(FromStrError::WrongLength(s.len()));
+        }
+
+        let mut arr = [0u8; SUI_ADDRESS_LENGTH];
+        hex::decode_to_slice(
+            // Left pad with `0`-s up to SUI_ADDRESS_LENGTH * 2 characters long.
+            format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2),
+            &mut arr[..],
+        ).map_err(|e| {
+            match e {
+                hex::FromHexError::InvalidHexCharacter { c, index } =>
+                    FromStrError::BadHex(c, index + 2),
+                hex::FromHexError::OddLength =>
+                    unreachable!("SAFETY: Prevented by padding"),
+                hex::FromHexError::InvalidStringLength =>
+                    unreachable!("SAFETY: Prevented by bounds check"),
+            }
+        })?;
+
+        Ok(SuiAddress(arr))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use async_graphql::Value;
 
-    fn assert_input_value_error<T>(result: Result<T, InputValueError<T>>) {
-        match result {
-            Err(InputValueError { .. }) => {}
-            _ => panic!("Expected InputValueError"),
-        }
-    }
+    const STR_ADDRESS: &str = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ARR_ADDRESS: [u8; SUI_ADDRESS_LENGTH] = [
+        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
+        103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
+    ];
+    const SUI_ADDRESS: SuiAddress = SuiAddress(ARR_ADDRESS);
 
     #[test]
     fn test_parse_valid_suiaddress() {
-        let input = Value::String(
-            "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input).unwrap();
-        assert_eq!(
-            parsed.0,
-            [
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        let parsed = SuiAddress::from_str(STR_ADDRESS).unwrap();
+        assert_eq!(parsed.0, ARR_ADDRESS);
     }
 
     #[test]
     fn test_to_value() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let value = <SuiAddress as ScalarType>::to_value(&addr);
-        assert_eq!(
-            value,
-            Value::String(
-                "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string()
-            )
-        );
+        let value = ScalarType::to_value(&SUI_ADDRESS);
+        assert_eq!(value, Value::String(STR_ADDRESS.to_string()));
     }
 
     #[test]
     fn test_into_array() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let arr = addr.into_array();
-        assert_eq!(
-            arr,
-            [
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        let arr = SUI_ADDRESS.into_array();
+        assert_eq!(arr, ARR_ADDRESS);
     }
 
     #[test]
     fn test_from_array() {
-        let arr = [
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ];
-        let addr = SuiAddress::from_array(arr);
-        assert_eq!(
-            addr,
-            SuiAddress([
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ])
-        );
+        let addr = SuiAddress::from_array(ARR_ADDRESS);
+        assert_eq!(addr, SUI_ADDRESS);
     }
 
     #[test]
     fn test_as_slice() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let slice = addr.as_slice();
-        assert_eq!(
-            slice,
-            &[
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        assert_eq!(SUI_ADDRESS.as_slice(), &ARR_ADDRESS);
     }
 
     #[test]
     fn test_round_trip() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let value = <SuiAddress as ScalarType>::to_value(&addr);
-        let parsed_back = <SuiAddress as ScalarType>::parse(value).unwrap();
-        assert_eq!(addr, parsed_back);
+        let value = ScalarType::to_value(&SUI_ADDRESS);
+        let parsed_back = ScalarType::parse(value).unwrap();
+        assert_eq!(SUI_ADDRESS, parsed_back);
     }
 
     #[test]
     fn test_parse_no_prefix() {
-        let input = Value::String(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let err = SuiAddress::from_str(&STR_ADDRESS[2..]).unwrap_err();
+        assert_eq!(FromStrError::NoPrefix, err);
     }
 
     #[test]
     fn test_parse_invalid_prefix() {
-        let input = Value::String(
-            "1x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = "1x".to_string() + &STR_ADDRESS[2..];
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::NoPrefix, err)
     }
 
     #[test]
     fn test_parse_invalid_length() {
-        let input = Value::String(
-            "0x0123456789abcdef0123456789abcdef01000023456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = STR_ADDRESS.to_string() + "0123";
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::WrongLength(68), err)
     }
 
     #[test]
     fn test_parse_invalid_characters() {
-        let input = Value::String(
-            "0x0123456789abcdefg0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = "0xg".to_string() + &STR_ADDRESS[3..];
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::BadHex('g', 2), err);
     }
 
     #[test]
     fn test_unicode_gibberish() {
-        let input = Value::String("aAௗ0㌀0".to_string());
+        let parsed = SuiAddress::from_str("aAௗ0㌀0");
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn bad_scalar_type() {
+        let input = Value::Number(0x42.into());
         let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        assert!(parsed.is_err());
     }
 }

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -81,14 +81,14 @@ impl FromStr for SuiAddress {
             // Left pad with `0`-s up to SUI_ADDRESS_LENGTH * 2 characters long.
             format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2),
             &mut arr[..],
-        ).map_err(|e| {
-            match e {
-                hex::FromHexError::InvalidHexCharacter { c, index } =>
-                    FromStrError::BadHex(c, index + 2),
-                hex::FromHexError::OddLength =>
-                    unreachable!("SAFETY: Prevented by padding"),
-                hex::FromHexError::InvalidStringLength =>
-                    unreachable!("SAFETY: Prevented by bounds check"),
+        )
+        .map_err(|e| match e {
+            hex::FromHexError::InvalidHexCharacter { c, index } => {
+                FromStrError::BadHex(c, index + 2)
+            }
+            hex::FromHexError::OddLength => unreachable!("SAFETY: Prevented by padding"),
+            hex::FromHexError::InvalidStringLength => {
+                unreachable!("SAFETY: Prevented by bounds check")
             }
         })?;
 
@@ -103,8 +103,8 @@ mod tests {
 
     const STR_ADDRESS: &str = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const ARR_ADDRESS: [u8; SUI_ADDRESS_LENGTH] = [
-        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-        103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
+        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
+        137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
     ];
     const SUI_ADDRESS: SuiAddress = SuiAddress(ARR_ADDRESS);
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -164,6 +164,38 @@ enum ExecutionStatus {
 	FAILURE
 }
 
+"""
+Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+or disable these features.
+"""
+enum Feature {
+	"""
+	Statistics about how the network was running (TPS, top packages, APY, etc)
+	"""
+	ANALYTICS
+	"""
+	Coin metadata, per-address coin and balance information.
+	"""
+	COINS
+	"""
+	Querying an object's dynamic fields.
+	"""
+	DYNAMIC_FIELDS
+	"""
+	SuiNS name and reverse name look-up.
+	"""
+	NAME_SERVICE
+	"""
+	Transaction and Event subscriptions.
+	"""
+	SUBSCRIPTIONS
+	"""
+	Information about the system that changes from epoch to epoch (protocol config, committee,
+	reference gas price).
+	"""
+	SYSTEM_STATE
+}
+
 
 type GasCostSummary {
 	computationCost: BigInt
@@ -350,7 +382,15 @@ type ProtocolConfigs {
 }
 
 type Query {
+	"""
+	First four bytes of the network's genesis checkpoint digest (uniquely identifies the
+	network).
+	"""
 	chainIdentifier: String!
+	"""
+	Configuration for this RPC service
+	"""
+	serviceConfig: ServiceConfig!
 	owner(address: SuiAddress!): ObjectOwner
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
@@ -361,6 +401,25 @@ type Query {
 type SafeMode {
 	enabled: Boolean
 	gasSummary: GasCostSummary
+}
+
+type ServiceConfig {
+	"""
+	Check whether `feature` is enabled on this GraphQL service.
+	"""
+	isEnabled(feature: Feature!): Boolean!
+	"""
+	List of all features that are enabled on this GraphQL service.
+	"""
+	enabledFeatures: [Feature!]!
+	"""
+	The maximum depth a GraphQL query can be to be accepted by this service.
+	"""
+	maxQueryDepth: Int!
+	"""
+	The maximum number of nodes (field names) the service will accept in a single query.
+	"""
+	maxQueryNodes: Int!
 }
 
 type Stake {
@@ -536,3 +595,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+


### PR DESCRIPTION
## Description

Generate `From<uint>` implementations for `BigInt` for each of the unsigned integer types.  This is necessary to support the representing Move Values which are stored in a primitive form, and need to be converted to a `BigInt`.

Also makes `BigInt` serializable, with a transparent representation, for use within the `MoveValue` type.

## Test Plan

Tests have been simplified to be written in terms of `BigInt`'s `FromStr` implementation, which allows us to avoid having to test both the `InputType` and `ScalarType` paths.

Additional tests have been added for conversion from primitive types.

```
sui-graphql-rpc$ cargo nextest run -- big_int
```