### PR TITLE
[GraphQL] Support for MoveValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10233,6 +10233,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10233,6 +10233,7 @@ dependencies = [
  "hex",
  "hyper",
  "insta",
+ "move-core-types",
  "once_cell",
  "serde",
  "serde_json",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+move-core-types.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -17,7 +17,9 @@ clap.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 hex.workspace = true
 hyper.workspace = true
+once_cell.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_with.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true

--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -177,6 +177,20 @@ scalar Base64
 # ISO-8601 Date and Time
 scalar DateTime
 
+# Scalar representing the contents of a Move Value, corresponding to
+# the following recursive type:
+#
+# type MoveData =
+#     { Number:  BigInt }
+#   | { Bool:    bool }
+#   | { Address: SuiAddress }
+#   | { UID:     SuiAddress }
+#   | { String:  string }
+#   | { Vector:  [MoveData] }
+#   | { Option:   MoveData? }
+#   | { Struct:  [{ name: string, value: MoveData }] }
+scalar MoveData
+
 # The extra data required to turn a `TransactionKind` into a
 # `TransactionData` in a dry-run.
 input TransactionMetadata {
@@ -942,7 +956,7 @@ type MoveModule {
   fileFormatVersion: Int!
 
   moduleId: MoveModuleId!
-  friends: [MoveModuleId]
+  friends: [MoveModule!]
 
   struct(name: String!): MoveStructDecl
   structConnection(
@@ -970,10 +984,10 @@ type MoveStructDecl {
   name: String!
   abilities: [MoveAbility]
   typeParameters: [MoveStructTypeParameterDecl]
-  fields: [MoveField]
+  fields: [MoveFieldDecl]
 }
 
-type MoveField {
+type MoveFieldDecl {
   name: String
   type: OpenMoveType
 }
@@ -996,30 +1010,6 @@ type MoveValue {
   data: MoveData
 
   bcs: Base64
-}
-
-union MoveData =
-    MoveNumber
-  | MoveBool
-  | MoveAddress
-  | MoveUID
-  | MoveString
-  | MoveVector
-  | MoveOption
-  | MoveStruct
-
-type MoveNumber  { number: String! }
-type MoveBool    { bool: Boolean! }
-type MoveAddress { address: SuiAddress! }
-type MoveUID     { uid: SuiAddress! }
-type MoveString  { string: String! }
-type MoveVector  { elements: [MoveValue!]! }
-type MoveOption  { element: MoveValue }
-type MoveStruct  { fields: [MoveField!]! }
-
-type MoveField {
-  name: String!
-  value: MoveValue!
 }
 
 type MoveTypeName {

--- a/crates/sui-graphql-rpc/schema/draft_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_schema.graphql
@@ -20,12 +20,15 @@ schema {
 
 type Query {
   # First four bytes of the network's genesis checkpoint digest
-  # (uniquely defines the network)
+  # (uniquely identifies the network)
   chainIdentifier: String!
 
   # Range of checkpoints that the RPC has data available for (for data
   # that can be tied to a particular checkpoint).
   availableRange: AvailableRange!
+
+  # Configuration for this RPC service
+  serviceConfig: ServiceConfig!
 
   # Simulate running a transaction to inspect its effects without
   # committing to them on-chain.
@@ -285,6 +288,23 @@ input DynamicFieldFilter {
 type AvailableRange {
   first: Checkpoint
   last: Checkpoint
+}
+
+type ServiceConfig {
+  enabledFeatures: [Feature!]
+  isEnabled(feature: Feature!): Boolean!
+
+  maxQueryDepth: Int
+  maxQueryNodes: Int
+}
+
+enum Feature {
+  ANALYTICS
+  COINS
+  DYNAMIC_FIELDS
+  NAME_SERVICE
+  SUBSCRIPTIONS
+  SYSTEM_STATE
 }
 
 interface ObjectOwner {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -122,7 +122,7 @@ mod tests {
         let actual = ServiceConfig::read(
             r#" disabled-features = [
                   "coins",
-                  "name-server",
+                  "name-service",
                 ]
             "#,
         )
@@ -131,7 +131,7 @@ mod tests {
         use FunctionalGroup as G;
         let expect = ServiceConfig {
             limits: Limits::default(),
-            disabled_features: BTreeSet::from([G::Coins, G::NameServer]),
+            disabled_features: BTreeSet::from([G::Coins, G::NameService]),
             experiments: Experiments::default(),
         };
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -19,19 +19,25 @@ pub(crate) mod code {
 /// because they will originate from within the GraphQL implementation.  This function is intended
 /// for errors that originated from outside of GraphQL (such as in middleware), but that need to be
 /// ingested by GraphQL clients.
-pub(crate) fn graphql_error(code: &str, message: String) -> GraphQLResponse {
+pub(crate) fn graphql_error_response(code: &str, message: impl Into<String>) -> GraphQLResponse {
+    let error = graphql_error(code, message);
+    Response::from_errors(error.into()).into()
+}
+
+/// Create a generic GraphQL Server Error.
+///
+/// This error has no path, source, or locations, just a message and an error code.
+pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerError {
     let mut ext = ErrorExtensionValues::default();
     ext.set("code", code);
 
-    let error = ServerError {
-        message,
+    ServerError {
+        message: message.into(),
         source: None,
         locations: vec![],
         path: vec![],
         extensions: Some(ext),
-    };
-
-    Response::from_errors(error.into()).into()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
+++ b/crates/sui-graphql-rpc/src/extensions/feature_gate.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextResolve, ResolveInfo},
+    ServerError, ServerResult, Value,
+};
+use async_trait::async_trait;
+
+use crate::{
+    config::ServiceConfig,
+    error::{code, graphql_error},
+    functional_group::functional_group,
+};
+
+pub(crate) struct FeatureGate;
+
+impl ExtensionFactory for FeatureGate {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(FeatureGate)
+    }
+}
+
+#[async_trait]
+impl Extension for FeatureGate {
+    async fn resolve(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        info: ResolveInfo<'_>,
+        next: NextResolve<'_>,
+    ) -> ServerResult<Option<Value>> {
+        let ResolveInfo {
+            parent_type,
+            name,
+            is_for_introspection,
+            ..
+        } = &info;
+
+        let ServiceConfig {
+            disabled_features, ..
+        } = ctx.data().map_err(|_| {
+            graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                "Unable to fetch service configuration",
+            )
+        })?;
+
+        // TODO: Is there a way to set `is_visible` on `MetaField` and `MetaType` in a generic way
+        // after building the schema? (to a function which reads the `ServiceConfig` from the
+        // `Context`). This is (probably) required to hide disabled types and interfaces in the
+        // schema.
+
+        if let Some(group) = functional_group(parent_type, name) {
+            if disabled_features.contains(&group) {
+                return if *is_for_introspection {
+                    Ok(None)
+                } else {
+                    Err(ServerError::new(
+                        format!(
+                            "Cannot query field \"{name}\" on type \"{parent_type}\". \
+                             Feature {} is disabled.",
+                            group.name(),
+                        ),
+                        // TODO: Fork `async-graphl` to add field position information to
+                        // `ResolveInfo`, so the error can take advantage of it.  Similarly for
+                        // utilising the `path_node` to set the error path.
+                        None,
+                    ))
+                };
+            }
+        }
+
+        next.run(ctx, info).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+    use expect_test::expect;
+
+    use crate::{functional_group::FunctionalGroup, types::query::Query};
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic] // because it tries to access the data provider, which isn't there
+    async fn test_accessing_an_enabled_field() {
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig::default())
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_accessing_a_disabled_field() {
+        let errs: Vec<_> = Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(ServiceConfig {
+                disabled_features: BTreeSet::from_iter([FunctionalGroup::SystemState]),
+                ..Default::default()
+            })
+            .extension(FeatureGate)
+            .finish()
+            .execute("{ protocolConfig(protocolVersion: 1) { protocolVersion } }")
+            .await
+            .into_result()
+            .unwrap_err()
+            .into_iter()
+            .map(|e| e.message)
+            .collect();
+
+        let expect = expect![[r#"
+            [
+                "Cannot query field \"protocolConfig\" on type \"Query\". Feature \"system-state\" is disabled.",
+            ]"#]];
+        expect.assert_eq(&format!("{errs:#?}"));
+    }
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod feature_gate;
 pub(crate) mod limits_info;
 pub(crate) mod logger;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -3,14 +3,16 @@
 
 use std::collections::BTreeMap;
 
+use async_graphql::*;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 
-/// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
-/// settings in the RPC's TOML configuration file.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+/// Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+/// or disable these features.
+#[derive(Enum, Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
+#[graphql(name = "Feature")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
     Analytics,
@@ -37,6 +39,20 @@ impl FunctionalGroup {
     /// Not a suitable `Display` implementation because it enquotes the representation.
     pub(crate) fn name(&self) -> String {
         json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+
+    /// List of all functional groups
+    pub(crate) fn all() -> &'static [FunctionalGroup] {
+        use FunctionalGroup as G;
+        static ALL: &[FunctionalGroup] = &[
+            G::Analytics,
+            G::Coins,
+            G::DynamicFields,
+            G::NameService,
+            G::Subscriptions,
+            G::SystemState,
+        ];
+        ALL
     }
 }
 

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use serde_json as json;
 
 /// Logical Groups categorise APIs exposed by GraphQL.  Groups can be enabled or disabled based on
 /// settings in the RPC's TOML configuration file.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum FunctionalGroup {
     /// Statistics about how the network was running (TPS, top packages, APY, etc)
@@ -18,10 +22,7 @@ pub(crate) enum FunctionalGroup {
     DynamicFields,
 
     /// SuiNS name and reverse name look-up.
-    NameServer,
-
-    /// Struct and function signatures, and popular packages.
-    Packages,
+    NameService,
 
     /// Transaction and Event subscriptions.
     Subscriptions,
@@ -29,4 +30,132 @@ pub(crate) enum FunctionalGroup {
     /// Information about the system that changes from epoch to epoch (protocol config, committee,
     /// reference gas price).
     SystemState,
+}
+
+impl FunctionalGroup {
+    /// Name that the group is referred to by in configuration and responses on the GraphQL API.
+    /// Not a suitable `Display` implementation because it enquotes the representation.
+    pub(crate) fn name(&self) -> String {
+        json::ser::to_string(self).expect("Serializing `FunctionalGroup` cannot fail.")
+    }
+}
+
+/// Mapping from type and field name in the schema to the functional group it belongs to.
+fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), FunctionalGroup> {
+    // TODO: Introduce a macro to declare the functional group for a field and/or type on the
+    // appropriate type, field, or function, instead of here.  This may also be able to set the
+    // graphql `visible` attribute to control schema visibility by functional groups.
+
+    use FunctionalGroup as G;
+    static GROUPS: Lazy<BTreeMap<(&str, &str), FunctionalGroup>> = Lazy::new(|| {
+        BTreeMap::from_iter([
+            (("Address", "balance"), G::Coins),
+            (("Address", "balanceConnection"), G::Coins),
+            (("Address", "coinConnection"), G::Coins),
+            (("Address", "defaultNameServiceName"), G::NameService),
+            (("Address", "nameServiceConnection"), G::NameService),
+            (("Checkpoint", "addressMetrics"), G::Analytics),
+            (("Checkpoint", "networkTotalTransactions"), G::Analytics),
+            (("Epoch", "protocolConfig"), G::SystemState),
+            (("Epoch", "referenceGasPrice"), G::SystemState),
+            (("Epoch", "safeMode"), G::SystemState),
+            (("Epoch", "storageFund"), G::SystemState),
+            (("Epoch", "systemParameters"), G::SystemState),
+            (("Epoch", "systemStateVersion"), G::SystemState),
+            (("Epoch", "validatorSet"), G::SystemState),
+            (("Object", "balance"), G::Coins),
+            (("Object", "balanceConnection"), G::Coins),
+            (("Object", "coinConnection"), G::Coins),
+            (("Object", "defaultNameServiceName"), G::NameService),
+            (("Object", "dynamicField"), G::DynamicFields),
+            (("Object", "dynamicFieldConnection"), G::DynamicFields),
+            (("Object", "nameServiceConnection"), G::NameService),
+            (("Owner", "balance"), G::Coins),
+            (("Owner", "balanceConnection"), G::Coins),
+            (("Owner", "coinConnection"), G::Coins),
+            (("Owner", "defaultNameServiceName"), G::NameService),
+            (("Owner", "nameServiceConnection"), G::NameService),
+            (("Query", "coinMetadata"), G::Coins),
+            (("Query", "moveCallMetrics"), G::Analytics),
+            (("Query", "networkMetrics"), G::Analytics),
+            (("Query", "protocolConfig"), G::SystemState),
+            (("Query", "resolveNameServiceAddress"), G::NameService),
+            (("Subscription", "events"), G::Subscriptions),
+            (("Subscription", "transactions"), G::Subscriptions),
+        ])
+    });
+
+    Lazy::force(&GROUPS)
+}
+
+/// Map a type and field name to a functional group.  If an explicit group does not exist for the
+/// field, then it is assumed to be a "core" feature.
+pub(crate) fn functional_group(type_: &str, field: &str) -> Option<FunctionalGroup> {
+    functional_groups().get(&(type_, field)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use async_graphql::registry::Registry;
+    use async_graphql::OutputType;
+
+    use crate::types::query::Query;
+
+    use super::*;
+
+    #[test]
+    /// Makes sure all the functional groups correspond to real elements of the schema unless they
+    /// are explicitly recorded as unimplemented.  Complementarily, makes sure that fields marked as
+    /// unimplemented don't appear in the set of unimplemented fields.
+    fn test_groups_match_schema() {
+        let mut registry = Registry::default();
+        Query::create_type_info(&mut registry);
+
+        let unimplemented = BTreeSet::from_iter([
+            ("Checkpoint", "addressMetrics"),
+            ("Epoch", "protocolConfig"),
+            ("Object", "dynamicField"),
+            ("Object", "dynamicFieldConnection"),
+            ("Query", "coinMetadata"),
+            ("Query", "moveCallMetrics"),
+            ("Query", "networkMetrics"),
+            ("Query", "resolveNameServiceAddress"),
+            ("Subscription", "events"),
+            ("Subscription", "transactions"),
+        ]);
+
+        for (type_, field) in &unimplemented {
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                continue;
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                continue;
+            };
+
+            panic!(
+                "Field '{type_}.{field}' is marked as unimplemented in this test, but it's in the \
+                 schema.  Fix this by removing it from the `unimplemented` set."
+            );
+        }
+
+        for (type_, field) in functional_groups().keys() {
+            if unimplemented.contains(&(type_, field)) {
+                continue;
+            }
+
+            let Some(meta_type) = registry.concrete_type_by_name(type_) else {
+                panic!("Type '{type_}' from functional group configs does not appear in schema.");
+            };
+
+            let Some(_) = meta_type.field_by_name(field) else {
+                panic!(
+                    "Field '{type_}.{field}' from functional group configs does not appear in \
+                     schema."
+                );
+            };
+        }
+    }
 }

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -5,10 +5,11 @@ pub mod commands;
 pub mod config;
 pub mod server;
 
+pub(crate) mod functional_group;
+
 mod context_data;
 mod error;
 mod extensions;
-mod functional_group;
 mod types;
 
 use async_graphql::*;

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -44,13 +44,13 @@ impl ServerBuilder {
         format!("{}:{}", self.host, self.port)
     }
 
-    pub fn max_query_depth(mut self, max_depth: usize) -> Self {
-        self.schema = self.schema.limit_depth(max_depth);
+    pub fn max_query_depth(mut self, max_depth: u32) -> Self {
+        self.schema = self.schema.limit_depth(max_depth as usize);
         self
     }
 
-    pub fn max_query_nodes(mut self, max_nodes: usize) -> Self {
-        self.schema = self.schema.limit_complexity(max_nodes);
+    pub fn max_query_nodes(mut self, max_nodes: u32) -> Self {
+        self.schema = self.schema.limit_complexity(max_nodes as usize);
         self
     }
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_depth_limit() {
-        async fn exec_query_depth_limit(depth: usize, query: &str) -> Response {
+        async fn exec_query_depth_limit(depth: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
@@ -203,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_node_limit() {
-        async fn exec_query_node_limit(nodes: usize, query: &str) -> Response {
+        async fn exec_query_node_limit(nodes: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -4,6 +4,7 @@
 use crate::config::{ConnectionConfig, ServiceConfig};
 use crate::context_data::data_provider::DataProvider;
 use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_client_v0};
+use crate::extensions::feature_gate::FeatureGate;
 use crate::extensions::limits_info::LimitsInfo;
 use crate::extensions::logger::Logger;
 use crate::extensions::timeout::Timeout;
@@ -29,9 +30,10 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
         .context_data(data_provider)
         .context_data(data_loader)
         .context_data(service_config)
+        .extension(FeatureGate)
+        .extension(LimitsInfo)
         .extension(Logger::default())
         .extension(Timeout::default())
-        .extension(LimitsInfo)
         .build()
         .run()
         .await;

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -9,7 +9,7 @@ use axum::{
     TypedHeader,
 };
 
-use crate::error::{code, graphql_error};
+use crate::error::{code, graphql_error_response};
 
 const RPC_VERSION_FULL: &str = env!("CARGO_PKG_VERSION");
 const RPC_VERSION_YEAR: &str = env!("CARGO_PKG_VERSION_MAJOR");
@@ -58,7 +58,7 @@ pub(crate) async fn check_version_middleware<B>(
         if !rest.is_empty() {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Multiple possible versions found."),
                 ),
@@ -69,7 +69,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Ok(req_version) = std::str::from_utf8(&req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!("Failed to parse {VERSION_HEADER}: Not a UTF8 string."),
                 ),
@@ -79,7 +79,7 @@ pub(crate) async fn check_version_middleware<B>(
         let Some((year, month)) = parse_version(req_version) else {
             return (
                 StatusCode::BAD_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::BAD_REQUEST,
                     format!(
                         "Failed to parse {VERSION_HEADER}: '{req_version}' not a valid \
@@ -92,7 +92,7 @@ pub(crate) async fn check_version_middleware<B>(
         if year != RPC_VERSION_YEAR || month != RPC_VERSION_MONTH {
             return (
                 StatusCode::MISDIRECTED_REQUEST,
-                graphql_error(
+                graphql_error_response(
                     code::INTERNAL_SERVER_ERROR,
                     format!("Version '{req_version}' not supported."),
                 ),

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -8,7 +8,7 @@ use fastcrypto::encoding::Base64 as FastCryptoBase64;
 use fastcrypto::encoding::Encoding as FastCryptoEncoding;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Base64(Vec<u8>);
+pub(crate) struct Base64(pub(crate) Vec<u8>);
 
 #[Scalar]
 impl ScalarType for Base64 {

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod display;
 pub(crate) mod end_of_epoch_data;
 pub(crate) mod epoch;
 pub(crate) mod gas;
+pub(crate) mod move_value;
 pub(crate) mod name_service;
 pub(crate) mod object;
 pub(crate) mod owner;

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -56,7 +56,8 @@ type MoveData =
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum MoveData {
     Address(SuiAddress),
-    UID(SuiAddress),
+    #[serde(rename = "UID")]
+    Uid(SuiAddress),
     Bool(bool),
     Number(BigInt),
     String(String),
@@ -127,15 +128,14 @@ impl TryFrom<value::MoveValue> for MoveData {
                 if is_type(&type_, &STD, MOD_OPTION, TYP_OPTION) {
                     // 0x1::option::Option
                     Self::Option(extract_option(&type_, fields)?)
-                } else if is_type(&type_, &STD, MOD_ASCII, TYP_STRING) {
-                    // 0x1::ascii::String
-                    Self::String(extract_string(&type_, fields)?)
-                } else if is_type(&type_, &STD, MOD_STRING, TYP_STRING) {
-                    // 0x1::string::String
+                } else if is_type(&type_, &STD, MOD_ASCII, TYP_STRING)
+                    || is_type(&type_, &STD, MOD_STRING, TYP_STRING)
+                {
+                    // 0x1::ascii::String, 0x1::string::String
                     Self::String(extract_string(&type_, fields)?)
                 } else if is_type(&type_, &SUI, MOD_OBJECT, TYP_UID) {
                     // 0x2::object::UID
-                    Self::UID(extract_uid(&type_, fields)?)
+                    Self::Uid(extract_uid(&type_, fields)?)
                 } else {
                     // Arbitrary structs
                     let fields: Result<Vec<_>> =
@@ -242,7 +242,7 @@ fn extract_string(
 
         // Provide a sample of the string in question.
         let sample = if bytes.len() < PREFIX {
-            String::from_utf8_lossy(&bytes)
+            String::from_utf8_lossy(bytes)
         } else {
             String::from_utf8_lossy(&bytes[..PREFIX - 3]) + "..."
         };
@@ -472,7 +472,7 @@ mod tests {
         });
 
         let v = data(l, address("0x42"));
-        let expect = expect!["Ok(UID(SuiAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])))"];
+        let expect = expect!["Ok(Uid(SuiAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])))"];
         expect.assert_eq(&format!("{v:?}"));
     }
 

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -1,0 +1,713 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::{IdentStr, Identifier},
+    language_storage::{StructTag, TypeTag},
+    value::{self, MoveTypeLayout},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{code, graphql_error};
+
+use super::{base64::Base64, big_int::BigInt, sui_address::SuiAddress};
+
+const STD: AccountAddress = AccountAddress::ONE;
+const SUI: AccountAddress = AccountAddress::TWO;
+
+const MOD_ASCII: &IdentStr = ident_str!("ascii");
+const MOD_OBJECT: &IdentStr = ident_str!("object");
+const MOD_OPTION: &IdentStr = ident_str!("option");
+const MOD_STRING: &IdentStr = ident_str!("string");
+
+const TYP_ID: &IdentStr = ident_str!("ID");
+const TYP_OPTION: &IdentStr = ident_str!("Option");
+const TYP_STRING: &IdentStr = ident_str!("String");
+const TYP_UID: &IdentStr = ident_str!("UID");
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+pub(crate) struct MoveValue {
+    #[graphql(skip)]
+    layout: MoveTypeLayout,
+    bcs: Base64,
+}
+
+scalar!(
+    MoveData,
+    r#"\
+The contents of a Move Value, corresponding to the following recursive type:
+
+type MoveData =
+    { Address: SuiAddress }
+  | { UID:     SuiAddress }
+  | { Bool:    bool }
+  | { Number:  BigInt }
+  | { String:  string }
+  | { Vector:  [MoveData] }
+  | { Option:   MoveData? }
+  | { Struct:  [{ name: string, value: MoveData }] }
+"#
+);
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum MoveData {
+    Address(SuiAddress),
+    UID(SuiAddress),
+    Bool(bool),
+    Number(BigInt),
+    String(String),
+    Vector(Vec<MoveData>),
+    Option(Option<Box<MoveData>>),
+    Struct(Vec<MoveField>),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct MoveField {
+    name: String,
+    value: MoveData,
+}
+
+#[ComplexObject]
+impl MoveValue {
+    async fn data(&self) -> Result<MoveData> {
+        // Factor out into its own non-GraphQL, non-async function for better testability
+        self.data_impl()
+    }
+}
+
+impl MoveValue {
+    fn data_impl(&self) -> Result<MoveData> {
+        // TODO: If this becomes a performance bottleneck, it can be made more efficient by not
+        // deserializing via `value::MoveValue` (but this is significantly more code).
+        let value: value::MoveValue =
+            bcs::from_bytes_seed(&self.layout, &self.bcs.0[..]).map_err(|_| {
+                let type_tag: Option<TypeTag> = (&self.layout).try_into().ok();
+                let message = if let Some(type_tag) = type_tag {
+                    format!("Failed to deserialize Move value for type: {}", type_tag)
+                } else {
+                    "Failed to deserialize Move value for type: <unknown>".to_string()
+                };
+
+                graphql_error(code::INTERNAL_SERVER_ERROR, message)
+            })?;
+
+        MoveData::try_from(value)
+    }
+}
+
+impl TryFrom<value::MoveValue> for MoveData {
+    type Error = async_graphql::Error;
+
+    fn try_from(value: value::MoveValue) -> Result<Self> {
+        use value::MoveValue as V;
+
+        Ok(match value {
+            V::U8(n) => Self::Number(BigInt::from(n)),
+            V::U16(n) => Self::Number(BigInt::from(n)),
+            V::U32(n) => Self::Number(BigInt::from(n)),
+            V::U64(n) => Self::Number(BigInt::from(n)),
+            V::U128(n) => Self::Number(BigInt::from(n)),
+            V::U256(n) => Self::Number(BigInt::from(n)),
+
+            V::Bool(b) => Self::Bool(b),
+            V::Address(a) => Self::Address(a.into()),
+
+            V::Vector(v) => Self::Vector(
+                v.into_iter()
+                    .map(MoveData::try_from)
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+
+            V::Struct(s) => {
+                let (type_, fields) = with_type(s)?;
+                if is_type(&type_, &STD, MOD_OPTION, TYP_OPTION) {
+                    // 0x1::option::Option
+                    Self::Option(extract_option(&type_, fields)?)
+                } else if is_type(&type_, &STD, MOD_ASCII, TYP_STRING) {
+                    // 0x1::ascii::String
+                    Self::String(extract_string(&type_, fields)?)
+                } else if is_type(&type_, &STD, MOD_STRING, TYP_STRING) {
+                    // 0x1::string::String
+                    Self::String(extract_string(&type_, fields)?)
+                } else if is_type(&type_, &SUI, MOD_OBJECT, TYP_UID) {
+                    // 0x2::object::UID
+                    Self::UID(extract_uid(&type_, fields)?)
+                } else {
+                    // Arbitrary structs
+                    let fields: Result<Vec<_>> =
+                        fields.into_iter().map(MoveField::try_from).collect();
+                    Self::Struct(fields?)
+                }
+            }
+
+            // Sui does not support `signer` as a type.
+            V::Signer(_) => {
+                return Err(graphql_error(
+                    code::INTERNAL_SERVER_ERROR,
+                    "Unexpected value of type: signer.",
+                )
+                .into())
+            }
+        })
+    }
+}
+
+impl TryFrom<(Identifier, value::MoveValue)> for MoveField {
+    type Error = async_graphql::Error;
+
+    fn try_from((ident, value): (Identifier, value::MoveValue)) -> Result<Self> {
+        Ok(MoveField {
+            name: ident.to_string(),
+            value: MoveData::try_from(value)?,
+        })
+    }
+}
+
+fn is_type(tag: &StructTag, address: &AccountAddress, module: &IdentStr, name: &IdentStr) -> bool {
+    &tag.address == address
+        && tag.module.as_ident_str() == module
+        && tag.name.as_ident_str() == name
+}
+
+fn with_type(
+    struct_: value::MoveStruct,
+) -> Result<(StructTag, Vec<(Identifier, value::MoveValue)>)> {
+    if let value::MoveStruct::WithTypes { type_, fields } = struct_ {
+        Ok((type_, fields))
+    } else {
+        Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Move Struct without type information.",
+        )
+        .into())
+    }
+}
+
+macro_rules! extract_field {
+    ($type:expr, $fields:expr, $name:ident) => {{
+        let _name = ident_str!(stringify!($name));
+        let _type = $type;
+        if let Some(value) = ($fields)
+            .into_iter()
+            .find_map(|(name, value)| (&*name == _name).then_some(value))
+        {
+            value
+        } else {
+            return Err(graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                format!("Couldn't find expected field '{_name}' of {_type}."),
+            )
+            .into());
+        }
+    }};
+}
+
+/// Extracts a vector of bytes from `value`, assuming it's a `MoveValue::Vector` where all the
+/// values are `MoveValue::U8`s.
+fn extract_bytes(value: value::MoveValue) -> Result<Vec<u8>> {
+    use value::MoveValue as V;
+    let V::Vector(elements) = value else {
+        return Err(graphql_error(code::INTERNAL_SERVER_ERROR, "Expected a vector.").into());
+    };
+
+    let mut bytes = Vec::with_capacity(elements.len());
+    for element in elements {
+        let V::U8(byte) = element else {
+            return Err(graphql_error(code::INTERNAL_SERVER_ERROR, "Expected a byte.").into());
+        };
+        bytes.push(byte)
+    }
+
+    Ok(bytes)
+}
+
+/// Extracts a Rust String from the contents of a Move Struct assuming that struct matches the
+/// contents of Move String:
+///
+///     { bytes: vector<u8> }
+///
+/// Which is conformed to by both `std::ascii::String` and `std::string::String`.
+fn extract_string(
+    type_: &StructTag,
+    fields: Vec<(Identifier, value::MoveValue)>,
+) -> Result<String> {
+    let bytes = extract_bytes(extract_field!(type_, fields, bytes))?;
+    String::from_utf8(bytes).map_err(|e| {
+        const PREFIX: usize = 30;
+        let bytes = e.as_bytes();
+
+        // Provide a sample of the string in question.
+        let sample = if bytes.len() < PREFIX {
+            String::from_utf8_lossy(&bytes)
+        } else {
+            String::from_utf8_lossy(&bytes[..PREFIX - 3]) + "..."
+        };
+
+        graphql_error(code::INTERNAL_SERVER_ERROR, format!("{e} in {sample:?}")).into()
+    })
+}
+
+/// Extracts an address from the contents of a Move Struct, assuming the struct matches the
+/// following shape:
+///
+///     { id: 0x1::object::ID { bytes: address } }
+///
+/// Which matches `0x2::object::UID`.
+fn extract_uid(
+    type_: &StructTag,
+    fields: Vec<(Identifier, value::MoveValue)>,
+) -> Result<SuiAddress> {
+    use value::MoveValue as V;
+    let V::Struct(s) = extract_field!(type_, fields, id) else {
+        return Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Expected UID.id to be a struct",
+        )
+        .into());
+    };
+
+    let (type_, fields) = with_type(s)?;
+    if !is_type(&type_, &SUI, MOD_OBJECT, TYP_ID) {
+        return Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Expected UID.id to have to type ID.",
+        )
+        .into());
+    }
+
+    let V::Address(addr) = extract_field!(type_, fields, bytes) else {
+        return Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Expected ID.bytes to have type address.",
+        )
+        .into());
+    };
+
+    Ok(addr.into())
+}
+
+/// Extracts a value from the contents of a Move Struct, assuming the struct matches the following
+/// shape:
+///
+///     { vec: vector<T> }
+///
+/// Where `vec` contains at most one element.  This matches the shape of `0x1::option::Option<T>`.
+fn extract_option(
+    type_: &StructTag,
+    fields: Vec<(Identifier, value::MoveValue)>,
+) -> Result<Option<Box<MoveData>>> {
+    let value::MoveValue::Vector(mut elements) = extract_field!(type_, fields, vec) else {
+        return Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Expected Option.vec to be a vector.",
+        )
+        .into());
+    };
+
+    if elements.len() > 1 {
+        return Err(graphql_error(
+            code::INTERNAL_SERVER_ERROR,
+            "Expected Option.vec to contain at most one element.",
+        )
+        .into());
+    };
+
+    Ok(match elements.pop() {
+        Some(value) => Some(Box::new(MoveData::try_from(value)?)),
+        None => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use expect_test::expect;
+    use move_core_types::{
+        u256::U256, value::MoveFieldLayout, value::MoveStructLayout as S,
+        value::MoveTypeLayout as L,
+    };
+
+    use super::*;
+
+    macro_rules! struct_layout {
+        ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
+            MoveTypeLayout::Struct(S::WithTypes {
+                type_: StructTag::from_str($type).expect("Failed to parse struct"),
+                fields: vec![$(MoveFieldLayout {
+                    name: ident_str!($name).to_owned(),
+                    layout: $layout,
+                }),*]
+            })
+        }
+    }
+
+    macro_rules! vector_layout {
+        ($inner:expr) => {
+            MoveTypeLayout::Vector(Box::new($inner))
+        };
+    }
+
+    fn address(a: &str) -> SuiAddress {
+        SuiAddress::from_str(a).unwrap()
+    }
+
+    fn data<T: Serialize>(layout: MoveTypeLayout, data: T) -> Result<MoveData> {
+        let bcs = Base64(bcs::to_bytes(&data).unwrap());
+        MoveValue { layout, bcs }.data_impl()
+    }
+
+    #[test]
+    fn bool_value() {
+        let v = data(L::Bool, true);
+        let expect = expect!["Ok(Bool(true))"];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u8_value() {
+        let v = data(L::U8, 42u8);
+        let expect = expect![[r#"Ok(Number(BigInt("42")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u16_value() {
+        let v = data(L::U16, 424u16);
+        let expect = expect![[r#"Ok(Number(BigInt("424")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u32_value() {
+        let v = data(L::U32, 424_242u32);
+        let expect = expect![[r#"Ok(Number(BigInt("424242")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u64_value() {
+        let v = data(L::U64, 42_424_242_424u64);
+        let expect = expect![[r#"Ok(Number(BigInt("42424242424")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u128_value() {
+        let v = data(L::U128, 424_242_424_242_424_242_424u128);
+        let expect = expect![[r#"Ok(Number(BigInt("424242424242424242424")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn u256_value() {
+        let v = data(
+            L::U256,
+            U256::from_str("42424242424242424242424242424242424242424").unwrap(),
+        );
+        let expect =
+            expect![[r#"Ok(Number(BigInt("42424242424242424242424242424242424242424")))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn ascii_string_value() {
+        let l = struct_layout!("0x1::ascii::String" {
+            "bytes": vector_layout!(L::U8)
+        });
+
+        let v = data(l, "The quick brown fox");
+        let expect = expect![[r#"Ok(String("The quick brown fox"))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn utf8_string_value() {
+        let l = struct_layout!("0x1::string::String" {
+            "bytes": vector_layout!(L::U8)
+        });
+
+        let v = data(l, "jumped over the lazy dog.");
+        let expect = expect![[r#"Ok(String("jumped over the lazy dog."))"#]];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn string_encoding_error() {
+        let l = struct_layout!("0x1::string::String" {
+            "bytes": vector_layout!(L::U8)
+        });
+
+        let mut bytes = "Lorem ipsum dolor sit amet consectetur".as_bytes().to_vec();
+        bytes[5] = 0xff;
+
+        let v = data(l, bytes);
+        let expect = expect![[r#"
+            Err(
+                Error {
+                    message: "invalid utf-8 sequence of 1 bytes from index 5 in \"Lorem�ipsum dolor sit amet ...\"",
+                    extensions: None,
+                },
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+
+    #[test]
+    fn address_value() {
+        let v = data(L::Address, address("0x42"));
+        let expect = expect!["Ok(Address(SuiAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])))"];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn uid_value() {
+        let l = struct_layout!("0x2::object::UID" {
+            "id": struct_layout!("0x2::object::ID" {
+                "bytes": L::Address,
+            })
+        });
+
+        let v = data(l, address("0x42"));
+        let expect = expect!["Ok(UID(SuiAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])))"];
+        expect.assert_eq(&format!("{v:?}"));
+    }
+
+    #[test]
+    fn compound_data() {
+        let l = struct_layout!("0x42::foo::Bar" {
+            "baz": struct_layout!("0x1::option::Option" { "vec": vector_layout!(L::U8) }),
+            "qux": vector_layout!(struct_layout!("0x43::xy::Zzy" {
+                "quy": L::U16,
+                "quz": struct_layout!("0x1::option::Option" {
+                    "vec": vector_layout!(struct_layout!("0x1::ascii::String" {
+                        "bytes": vector_layout!(L::U8),
+                    }))
+                }),
+                "frob": L::Address,
+            })),
+        });
+
+        let v = data(
+            l,
+            (
+                vec![] as Vec<Vec<u8>>,
+                vec![
+                    (44u16, vec!["Hello, world!"], address("0x45")),
+                    (46u16, vec![], address("0x47")),
+                ],
+            ),
+        );
+
+        let expect = expect![[r#"
+            Ok(
+                Struct(
+                    [
+                        MoveField {
+                            name: "baz",
+                            value: Option(
+                                None,
+                            ),
+                        },
+                        MoveField {
+                            name: "qux",
+                            value: Vector(
+                                [
+                                    Struct(
+                                        [
+                                            MoveField {
+                                                name: "quy",
+                                                value: Number(
+                                                    BigInt(
+                                                        "44",
+                                                    ),
+                                                ),
+                                            },
+                                            MoveField {
+                                                name: "quz",
+                                                value: Option(
+                                                    Some(
+                                                        String(
+                                                            "Hello, world!",
+                                                        ),
+                                                    ),
+                                                ),
+                                            },
+                                            MoveField {
+                                                name: "frob",
+                                                value: Address(
+                                                    SuiAddress(
+                                                        [
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            69,
+                                                        ],
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    ),
+                                    Struct(
+                                        [
+                                            MoveField {
+                                                name: "quy",
+                                                value: Number(
+                                                    BigInt(
+                                                        "46",
+                                                    ),
+                                                ),
+                                            },
+                                            MoveField {
+                                                name: "quz",
+                                                value: Option(
+                                                    None,
+                                                ),
+                                            },
+                                            MoveField {
+                                                name: "frob",
+                                                value: Address(
+                                                    SuiAddress(
+                                                        [
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            0,
+                                                            71,
+                                                        ],
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        },
+                    ],
+                ),
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+
+    #[test]
+    fn no_type_information() {
+        // This layout looks like a string, but we don't have the type information, so we can't say
+        // for sure -- so we always require that move struct come `WithTypes`.
+        let l = L::Struct(S::WithFields(vec![MoveFieldLayout {
+            name: ident_str!("bytes").to_owned(),
+            layout: vector_layout!(L::U8),
+        }]));
+
+        let v = data(l, "Hello, world!");
+        let expect = expect![[r#"
+            Err(
+                Error {
+                    message: "Move Struct without type information.",
+                    extensions: None,
+                },
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+
+    #[test]
+    fn no_field_information() {
+        // Even less information about the layout -- even less likely to succeed.
+        let l = L::Struct(S::Runtime(vec![vector_layout!(L::U8)]));
+        let v = data(l, "Hello, world!");
+        let expect = expect![[r#"
+            Err(
+                Error {
+                    message: "Move Struct without type information.",
+                    extensions: None,
+                },
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+
+    #[test]
+    fn signer_value() {
+        let v = data(L::Signer, address("0x42"));
+        let expect = expect![[r#"
+            Err(
+                Error {
+                    message: "Unexpected value of type: signer.",
+                    extensions: None,
+                },
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+
+    #[test]
+    fn signer_nested_value() {
+        let v = data(
+            vector_layout!(L::Signer),
+            vec![address("0x42"), address("0x43")],
+        );
+        let expect = expect![[r#"
+            Err(
+                Error {
+                    message: "Unexpected value of type: signer.",
+                    extensions: None,
+                },
+            )"#]];
+        expect.assert_eq(&format!("{v:#?}"));
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -228,7 +228,9 @@ fn extract_bytes(value: value::MoveValue) -> Result<Vec<u8>> {
 /// Extracts a Rust String from the contents of a Move Struct assuming that struct matches the
 /// contents of Move String:
 ///
+/// ```notrust
 ///     { bytes: vector<u8> }
+/// ```
 ///
 /// Which is conformed to by both `std::ascii::String` and `std::string::String`.
 fn extract_string(
@@ -254,7 +256,9 @@ fn extract_string(
 /// Extracts an address from the contents of a Move Struct, assuming the struct matches the
 /// following shape:
 ///
-///     { id: 0x1::object::ID { bytes: address } }
+/// ```notrust
+///     { id: 0x2::object::ID { bytes: address } }
+/// ```
 ///
 /// Which matches `0x2::object::UID`.
 fn extract_uid(
@@ -293,7 +297,9 @@ fn extract_uid(
 /// Extracts a value from the contents of a Move Struct, assuming the struct matches the following
 /// shape:
 ///
+/// ```notrust
 ///     { vec: vector<T> }
+/// ```
 ///
 /// Where `vec` contains at most one element.  This matches the shape of `0x1::option::Option<T>`.
 fn extract_option(

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -1,43 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use async_graphql::*;
+use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 const SUI_ADDRESS_LENGTH: usize = 32;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
 pub(crate) struct SuiAddress([u8; SUI_ADDRESS_LENGTH]);
+
+#[derive(Error, Debug, Eq, PartialEq)]
+pub(crate) enum FromStrError {
+    #[error("Invalid SuiAddress. Missing 0x prefix.")]
+    NoPrefix,
+
+    #[error(
+        "Expected SuiAddress string with between 1 and {} digits ({} bytes), received {0}",
+        SUI_ADDRESS_LENGTH * 2,
+        SUI_ADDRESS_LENGTH,
+    )]
+    WrongLength(usize),
+
+    #[error("Invalid character {0:?} at position {1}")]
+    BadHex(char, usize),
+}
+
 #[Scalar]
 impl ScalarType for SuiAddress {
     fn parse(value: Value) -> InputValueResult<Self> {
-        match value {
-            Value::String(mut s) => {
-                if s.starts_with("0x") {
-                    s = s[2..].to_string();
-                } else {
-                    return Err(InputValueError::custom(
-                        "Invalid SuiAddress. Missing 0x prefix",
-                    ));
-                }
-                if s.is_empty() || s.len() > SUI_ADDRESS_LENGTH * 2 {
-                    return Err(InputValueError::custom(format!(
-                        "Expected SuiAddress string ranging from length 1 up to {} ({} bytes) or less, received {}.",
-                        SUI_ADDRESS_LENGTH * 2,
-                        SUI_ADDRESS_LENGTH,
-                        s.len()
-                    )));
-                }
-                // Pad to SUI_ADDRESS_LENGTH*2 width
-                s = format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2);
+        let Value::String(s) = value else {
+            return Err(InputValueError::expected_type(value));
+        };
 
-                let bytes = hex::decode(s)?;
-                let mut arr = [0u8; SUI_ADDRESS_LENGTH];
-                arr.copy_from_slice(&bytes);
-                Ok(SuiAddress(arr))
-            }
-            _ => Err(InputValueError::expected_type(value)),
-        }
+        Ok(SuiAddress::from_str(&s)?)
     }
 
     fn to_value(&self) -> Value {
@@ -59,147 +58,129 @@ impl SuiAddress {
     }
 }
 
+impl From<AccountAddress> for SuiAddress {
+    fn from(value: AccountAddress) -> Self {
+        SuiAddress(value.into_bytes())
+    }
+}
+
+impl FromStr for SuiAddress {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, FromStrError> {
+        let Some(s) = s.strip_prefix("0x") else {
+            return Err(FromStrError::NoPrefix);
+        };
+
+        if s.is_empty() || s.len() > SUI_ADDRESS_LENGTH * 2 {
+            return Err(FromStrError::WrongLength(s.len()));
+        }
+
+        let mut arr = [0u8; SUI_ADDRESS_LENGTH];
+        hex::decode_to_slice(
+            // Left pad with `0`-s up to SUI_ADDRESS_LENGTH * 2 characters long.
+            format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2),
+            &mut arr[..],
+        ).map_err(|e| {
+            match e {
+                hex::FromHexError::InvalidHexCharacter { c, index } =>
+                    FromStrError::BadHex(c, index + 2),
+                hex::FromHexError::OddLength =>
+                    unreachable!("SAFETY: Prevented by padding"),
+                hex::FromHexError::InvalidStringLength =>
+                    unreachable!("SAFETY: Prevented by bounds check"),
+            }
+        })?;
+
+        Ok(SuiAddress(arr))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use async_graphql::Value;
 
-    fn assert_input_value_error<T>(result: Result<T, InputValueError<T>>) {
-        match result {
-            Err(InputValueError { .. }) => {}
-            _ => panic!("Expected InputValueError"),
-        }
-    }
+    const STR_ADDRESS: &str = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ARR_ADDRESS: [u8; SUI_ADDRESS_LENGTH] = [
+        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
+        103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
+    ];
+    const SUI_ADDRESS: SuiAddress = SuiAddress(ARR_ADDRESS);
 
     #[test]
     fn test_parse_valid_suiaddress() {
-        let input = Value::String(
-            "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input).unwrap();
-        assert_eq!(
-            parsed.0,
-            [
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        let parsed = SuiAddress::from_str(STR_ADDRESS).unwrap();
+        assert_eq!(parsed.0, ARR_ADDRESS);
     }
 
     #[test]
     fn test_to_value() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let value = <SuiAddress as ScalarType>::to_value(&addr);
-        assert_eq!(
-            value,
-            Value::String(
-                "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string()
-            )
-        );
+        let value = ScalarType::to_value(&SUI_ADDRESS);
+        assert_eq!(value, Value::String(STR_ADDRESS.to_string()));
     }
 
     #[test]
     fn test_into_array() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let arr = addr.into_array();
-        assert_eq!(
-            arr,
-            [
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        let arr = SUI_ADDRESS.into_array();
+        assert_eq!(arr, ARR_ADDRESS);
     }
 
     #[test]
     fn test_from_array() {
-        let arr = [
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ];
-        let addr = SuiAddress::from_array(arr);
-        assert_eq!(
-            addr,
-            SuiAddress([
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ])
-        );
+        let addr = SuiAddress::from_array(ARR_ADDRESS);
+        assert_eq!(addr, SUI_ADDRESS);
     }
 
     #[test]
     fn test_as_slice() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let slice = addr.as_slice();
-        assert_eq!(
-            slice,
-            &[
-                1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-                103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
-            ]
-        );
+        assert_eq!(SUI_ADDRESS.as_slice(), &ARR_ADDRESS);
     }
 
     #[test]
     fn test_round_trip() {
-        let addr = SuiAddress([
-            1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
-            137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
-        ]);
-        let value = <SuiAddress as ScalarType>::to_value(&addr);
-        let parsed_back = <SuiAddress as ScalarType>::parse(value).unwrap();
-        assert_eq!(addr, parsed_back);
+        let value = ScalarType::to_value(&SUI_ADDRESS);
+        let parsed_back = ScalarType::parse(value).unwrap();
+        assert_eq!(SUI_ADDRESS, parsed_back);
     }
 
     #[test]
     fn test_parse_no_prefix() {
-        let input = Value::String(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let err = SuiAddress::from_str(&STR_ADDRESS[2..]).unwrap_err();
+        assert_eq!(FromStrError::NoPrefix, err);
     }
 
     #[test]
     fn test_parse_invalid_prefix() {
-        let input = Value::String(
-            "1x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = "1x".to_string() + &STR_ADDRESS[2..];
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::NoPrefix, err)
     }
 
     #[test]
     fn test_parse_invalid_length() {
-        let input = Value::String(
-            "0x0123456789abcdef0123456789abcdef01000023456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = STR_ADDRESS.to_string() + "0123";
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::WrongLength(68), err)
     }
 
     #[test]
     fn test_parse_invalid_characters() {
-        let input = Value::String(
-            "0x0123456789abcdefg0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        );
-        let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        let input = "0xg".to_string() + &STR_ADDRESS[3..];
+        let err = SuiAddress::from_str(&input).unwrap_err();
+        assert_eq!(FromStrError::BadHex('g', 2), err);
     }
 
     #[test]
     fn test_unicode_gibberish() {
-        let input = Value::String("aAௗ0㌀0".to_string());
+        let parsed = SuiAddress::from_str("aAௗ0㌀0");
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn bad_scalar_type() {
+        let input = Value::Number(0x42.into());
         let parsed = <SuiAddress as ScalarType>::parse(input);
-        assert_input_value_error(parsed);
+        assert!(parsed.is_err());
     }
 }

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -81,14 +81,14 @@ impl FromStr for SuiAddress {
             // Left pad with `0`-s up to SUI_ADDRESS_LENGTH * 2 characters long.
             format!("{:0>width$}", s, width = SUI_ADDRESS_LENGTH * 2),
             &mut arr[..],
-        ).map_err(|e| {
-            match e {
-                hex::FromHexError::InvalidHexCharacter { c, index } =>
-                    FromStrError::BadHex(c, index + 2),
-                hex::FromHexError::OddLength =>
-                    unreachable!("SAFETY: Prevented by padding"),
-                hex::FromHexError::InvalidStringLength =>
-                    unreachable!("SAFETY: Prevented by bounds check"),
+        )
+        .map_err(|e| match e {
+            hex::FromHexError::InvalidHexCharacter { c, index } => {
+                FromStrError::BadHex(c, index + 2)
+            }
+            hex::FromHexError::OddLength => unreachable!("SAFETY: Prevented by padding"),
+            hex::FromHexError::InvalidStringLength => {
+                unreachable!("SAFETY: Prevented by bounds check")
             }
         })?;
 
@@ -103,8 +103,8 @@ mod tests {
 
     const STR_ADDRESS: &str = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const ARR_ADDRESS: [u8; SUI_ADDRESS_LENGTH] = [
-        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69,
-        103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239
+        1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
+        137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239,
     ];
     const SUI_ADDRESS: SuiAddress = SuiAddress(ARR_ADDRESS);
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -164,6 +164,38 @@ enum ExecutionStatus {
 	FAILURE
 }
 
+"""
+Groups of features served by the RPC service.  The GraphQL Service can be configured to enable
+or disable these features.
+"""
+enum Feature {
+	"""
+	Statistics about how the network was running (TPS, top packages, APY, etc)
+	"""
+	ANALYTICS
+	"""
+	Coin metadata, per-address coin and balance information.
+	"""
+	COINS
+	"""
+	Querying an object's dynamic fields.
+	"""
+	DYNAMIC_FIELDS
+	"""
+	SuiNS name and reverse name look-up.
+	"""
+	NAME_SERVICE
+	"""
+	Transaction and Event subscriptions.
+	"""
+	SUBSCRIPTIONS
+	"""
+	Information about the system that changes from epoch to epoch (protocol config, committee,
+	reference gas price).
+	"""
+	SYSTEM_STATE
+}
+
 
 type GasCostSummary {
 	computationCost: BigInt
@@ -350,7 +382,15 @@ type ProtocolConfigs {
 }
 
 type Query {
+	"""
+	First four bytes of the network's genesis checkpoint digest (uniquely identifies the
+	network).
+	"""
 	chainIdentifier: String!
+	"""
+	Configuration for this RPC service
+	"""
+	serviceConfig: ServiceConfig!
 	owner(address: SuiAddress!): ObjectOwner
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
@@ -361,6 +401,25 @@ type Query {
 type SafeMode {
 	enabled: Boolean
 	gasSummary: GasCostSummary
+}
+
+type ServiceConfig {
+	"""
+	Check whether `feature` is enabled on this GraphQL service.
+	"""
+	isEnabled(feature: Feature!): Boolean!
+	"""
+	List of all features that are enabled on this GraphQL service.
+	"""
+	enabledFeatures: [Feature!]!
+	"""
+	The maximum depth a GraphQL query can be to be accepted by this service.
+	"""
+	maxQueryDepth: Int!
+	"""
+	The maximum number of nodes (field names) the service will accept in a single query.
+	"""
+	maxQueryNodes: Int!
 }
 
 type Stake {
@@ -536,3 +595,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+


### PR DESCRIPTION
## Description

Adds a new GraphQL object type: `MoveValue` and a new scalar type to represent structured move value contents: `MoveData`.

This PR proposes that `MoveData` should be a scalar rather than a GraphQL (output) type because of its recursive nature:  It would be difficult/impossible to selectively query into its nested structure.

## Test Plan

This type and scalar are not currently hooked into the schema, because to do so requires implementing a module resolver that can be used to generate a type layout for any given type, but unit tests have been added for the value representation:

```
sui-graphql-rpc$ cargo nextest run -- move_value
```