### PR TITLE
[faucet] adding get to faucet with params

### DIFF
--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/", get(health))
         .route("/gas", post(request_gas))
         .route("/v1/gas", post(batch_request_gas))
-        .route("/v1/status", get(request_status))
+        .route("/v1/status", post(request_status))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -3,6 +3,7 @@
 
 use axum::{
     error_handling::HandleErrorLayer,
+    extract::Path,
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
@@ -91,7 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/", get(health))
         .route("/gas", post(request_gas))
         .route("/v1/gas", post(batch_request_gas))
-        .route("/v1/status", post(request_status))
+        .route("/v1/status/:task_id", get(request_status))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))
@@ -210,36 +211,26 @@ async fn batch_request_gas(
 /// handler for batch_get_status requests
 async fn request_status(
     Extension(state): Extension<Arc<AppState>>,
-    Json(payload): Json<FaucetRequest>,
+    Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match payload {
-        FaucetRequest::GetBatchSendStatusRequest(requests) => {
-            match Uuid::parse_str(&requests.task_id) {
-                Ok(task_id) => {
-                    let result = state.faucet.get_batch_send_status(task_id).await;
-                    match result {
-                        Ok(v) => (
-                            StatusCode::CREATED,
-                            Json(BatchStatusFaucetResponse::from(v)),
-                        ),
-                        Err(v) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(BatchStatusFaucetResponse::from(v)),
-                        ),
-                    }
-                }
-                Err(e) => (
+    match Uuid::parse_str(&id) {
+        Ok(task_id) => {
+            let result = state.faucet.get_batch_send_status(task_id).await;
+            match result {
+                Ok(v) => (
+                    StatusCode::CREATED,
+                    Json(BatchStatusFaucetResponse::from(v)),
+                ),
+                Err(v) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(BatchStatusFaucetResponse::from(FaucetError::Internal(
-                        e.to_string(),
-                    ))),
+                    Json(BatchStatusFaucetResponse::from(v)),
                 ),
             }
         }
-        _ => (
-            StatusCode::BAD_REQUEST,
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(BatchStatusFaucetResponse::from(FaucetError::Internal(
-                "Input Error.".to_string(),
+                e.to_string(),
             ))),
         ),
     }


### PR DESCRIPTION
## Description 

Added params to GET call to follow API schema/ patterns


## Test Plan 
Local Testing: 

<img width="955" alt="image" src="https://github.com/MystenLabs/sui/assets/123408603/db651813-eef6-45e7-82ea-0086373dce80">


How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
