### PR TITLE
[move-diassembler][small] Display strings in disassembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,6 +5451,7 @@ name = "move-disassembler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "clap",
  "colored",
  "hex",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2709,6 +2709,7 @@ name = "move-disassembler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "clap 4.4.1",
  "colored",
  "hex",

--- a/external-crates/move/tools/move-disassembler/Cargo.toml
+++ b/external-crates/move/tools/move-disassembler/Cargo.toml
@@ -19,6 +19,7 @@ move-binary-format = { path = "../../move-binary-format" }
 move-coverage = { path = "../move-coverage" }
 move-compiler = { path = "../../move-compiler" }
 
+bcs.workspace = true
 clap.workspace = true
 hex = "0.4.3"
 

--- a/external-crates/move/tools/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/tools/move-disassembler/src/disassembler.rs
@@ -1260,8 +1260,19 @@ impl<'a> Disassembler<'a> {
         constant_index: usize,
         Constant { type_, data }: &Constant,
     ) -> Result<String> {
+        let data_str = match type_ {
+            SignatureToken::Vector(x) if x.as_ref() == &SignatureToken::U8 => {
+                match bcs::from_bytes::<Vec<u8>>(data)
+                    .ok()
+                    .and_then(|data| String::from_utf8(data).ok())
+                {
+                    Some(str) => "\"".to_owned() + &str + "\" // interpreted as UTF8 string",
+                    None => hex::encode(data),
+                }
+            }
+            _ => hex::encode(data),
+        };
         let type_str = self.disassemble_sig_tok(type_.clone(), &[])?;
-        let data_str = hex::encode(data);
         Ok(format!("\t{constant_index} => {}: {}", type_str, data_str))
     }
 


### PR DESCRIPTION
## Description 

Tries to determine if a constant in the constant pool can be interpreted as a utf8 string. If it can it displays it as such, and adds a comment saying it's interpreted the data that way.

## Test Plan 

Tested locally: 
```rust
module 0x1::M {
    const X: vector<u8> = b"hello world";
    public fun use_X(): vector<u8> { X }
}
```

```rust
$ move disassemble --name M
// Move bytecode v6
module 1.M {


public use_X(): vector<u8> {
B0:
        0: LdConst[0](Vector(U8): 0b68656c..)
        1: Ret
}

Constants [
        0 => vector<u8>: "hello world" // interpreted as UTF8 string
]
}
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Updated display of constants in disassembled Move bytecode to try and show the deserialized string if the constant is a `vector<u8>` that is valid utf8. 
