### PR TITLE
[explorer] add missing dependency from previous PR that I accidentally forgot about

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -98,6 +98,7 @@
 		"@types/react": "^18.2.15",
 		"@types/react-dom": "^18.2.7",
 		"@types/topojson-client": "^3.1.1",
+		"@vanilla-extract/vite-plugin": "^3.9.0",
 		"@vitejs/plugin-react": "^4.0.3",
 		"@vitest/ui": "^0.33.0",
 		"autoprefixer": "^10.4.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@types/topojson-client':
         specifier: ^3.1.1
         version: 3.1.1
+      '@vanilla-extract/vite-plugin':
+        specifier: ^3.9.0
+        version: 3.9.0(@types/node@20.4.2)(vite@4.4.4)
       '@vitejs/plugin-react':
         specifier: ^4.0.3
         version: 4.0.3(vite@4.4.4)
@@ -1360,8 +1363,6 @@ importers:
       vitest:
         specifier: ^0.33.0
         version: 0.33.0(@vitest/ui@0.33.0)(happy-dom@10.5.1)
-
-  sdk/move-binary-format-wasm/pkg: {}
 
   sdk/suins-toolkit:
     dependencies:
@@ -9801,6 +9802,28 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+
+  /@vanilla-extract/vite-plugin@3.9.0(@types/node@20.4.2)(vite@4.4.4):
+    resolution: {integrity: sha512-Q2HYAyEJ93Uy7GHQPPiP8SXwPMHGpd4d0YnrIQqB0YZccYbGJR/WFIln9Dmbzx2pdngQUoOfhwEg6kJF8sQrog==}
+    peerDependencies:
+      vite: ^2.2.3 || ^3.0.0 || ^4.0.3
+    dependencies:
+      '@vanilla-extract/integration': 6.2.2(@types/node@20.4.2)
+      outdent: 0.8.0
+      postcss: 8.4.26
+      postcss-load-config: 3.1.4(postcss@8.4.26)
+      vite: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
+    dev: true
 
   /@vanilla-extract/vite-plugin@3.9.0(vite@4.4.4):
     resolution: {integrity: sha512-Q2HYAyEJ93Uy7GHQPPiP8SXwPMHGpd4d0YnrIQqB0YZccYbGJR/WFIln9Dmbzx2pdngQUoOfhwEg6kJF8sQrog==}


### PR DESCRIPTION
## Description 

I don't know how this passed CI, but I forgot to add `@vanilla-extract/vite-plugin` as a dev dependency to Sui Explorer which is used for bundling the CSS from `dapp-kit`. This was the original PR: https://github.com/MystenLabs/sui/pull/13845

## Test Plan 
- No more local type error in `vite.config.ts`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
