### PR TITLE
kv writer: backfill objects

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -9,6 +9,7 @@ use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
 use sui_types::digests::{TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::error::SuiError;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -16,8 +17,9 @@ use sui_types::messages_checkpoint::EndOfEpochData;
 use sui_types::messages_checkpoint::FullCheckpointContents;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::messages_checkpoint::VerifiedCheckpointContents;
-use sui_types::storage::ReadStore;
+use sui_types::object::Object;
 use sui_types::storage::WriteStore;
+use sui_types::storage::{ObjectKey, ReadStore};
 use sui_types::transaction::VerifiedTransaction;
 use typed_store::Map;
 
@@ -48,6 +50,14 @@ impl RocksDbStore {
             highest_verified_checkpoint: Arc::new(Mutex::new(None)),
             highest_synced_checkpoint: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub fn get_objects(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>, SuiError> {
+        self.authority_store.multi_get_object_by_key(object_keys)
+    }
+
+    pub fn get_last_executed_checkpoint(&self) -> Result<Option<VerifiedCheckpoint>, SuiError> {
+        Ok(self.checkpoint_store.get_highest_executed_checkpoint()?)
     }
 }
 

--- a/crates/sui-kvstore/src/client.rs
+++ b/crates/sui-kvstore/src/client.rs
@@ -17,13 +17,14 @@ pub enum KVTable {
     Transactions,
     Effects,
     Events,
+    Objects,
     CheckpointContent,
     CheckpointSummary,
     TransactionToCheckpoint,
     State,
 }
 
-const UPLOAD_PROGRESS_KEY: [u8; 1] = [0];
+const UPLOAD_PROGRESS_KEY: [u8; 6] = [111, 98, 106, 101, 99, 116];
 
 #[async_trait]
 pub trait KVWriteClient {
@@ -84,6 +85,7 @@ impl DynamoDbClient {
             KVTable::Transactions => "tx",
             KVTable::Effects => "fx",
             KVTable::Events => "ev",
+            KVTable::Objects => "ob",
             KVTable::State => "state",
             KVTable::CheckpointContent => "cc",
             KVTable::CheckpointSummary => "cs",

--- a/crates/sui-kvstore/src/writer.rs
+++ b/crates/sui-kvstore/src/writer.rs
@@ -6,14 +6,14 @@ use anyhow::{anyhow, Result};
 use mysten_metrics::spawn_monitored_task;
 use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::collections::HashSet;
-use std::iter::repeat;
+// use std::iter::repeat;
 use std::time::Duration;
 use sui_config::node::TransactionKeyValueStoreWriteConfig;
 use sui_core::storage::RocksDbStore;
-use sui_storage::http_key_value_store::TaggedKey;
-use sui_types::effects::TransactionEffectsAPI;
+// use sui_storage::http_key_value_store::TaggedKey;
+// use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::storage::ReadStore;
+use sui_types::storage::{ObjectKey, ReadStore};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::info;
@@ -26,7 +26,7 @@ impl KVStoreMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
             latest_checkpoint_uploaded_to_kv_store: register_int_gauge_with_registry!(
-                "latest_checkpoint_uploaded_to_kv_store",
+                "latest_checkpoint_uploaded_to_kv_store_objects",
                 "Latest checkpoint to have been uploaded to the remote key value store",
                 registry
             )
@@ -59,7 +59,7 @@ async fn upload_to_kv_store(
     store: RocksDbStore,
     mut receiver: oneshot::Receiver<()>,
     config: TransactionKeyValueStoreWriteConfig,
-    metrics: KVStoreMetrics,
+    _metrics: KVStoreMetrics,
 ) -> Result<()> {
     let mut updates: HashSet<u64> = HashSet::new();
     let mut client = DynamoDbClient::new(&config).await;
@@ -107,9 +107,9 @@ async fn upload_to_kv_store(
                         checkpoint_number += 1;
                     }
                     client.update_state(checkpoint_number).await?;
-                    metrics
-                        .latest_checkpoint_uploaded_to_kv_store
-                        .set(checkpoint_number as i64);
+                    // metrics
+                    //     .latest_checkpoint_uploaded_to_kv_store
+                    //     .set(checkpoint_number as i64);
                 }
             }
         }
@@ -117,89 +117,109 @@ async fn upload_to_kv_store(
     Ok(())
 }
 
-pub async fn uploader<S>(
+pub async fn uploader(
     shard_id: u64,
     mut checkpoint_number: CheckpointSequenceNumber,
-    store: S,
+    store: RocksDbStore,
     config: TransactionKeyValueStoreWriteConfig,
     progress_sender: mpsc::Sender<u64>,
     mut receiver: oneshot::Receiver<()>,
-) -> Result<()>
-where
-    S: ReadStore + Send,
-    <S as ReadStore>::Error: Send,
-{
+) -> Result<()> {
     let mut client = DynamoDbClient::new(&config).await;
     while receiver.try_recv().is_err() {
-        if let Some(checkpoint_summary) = store
-            .get_checkpoint_by_sequence_number(checkpoint_number + shard_id)
-            .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?
-        {
-            if let Some(contents) = store
-                .get_full_checkpoint_contents(&checkpoint_summary.content_digest)
-                .map_err(|_| anyhow!("Failed to read checkpoint content from store"))?
+        let last_executed_checkpoint = store
+            .get_last_executed_checkpoint()?
+            .unwrap()
+            .sequence_number;
+        if checkpoint_number + shard_id < last_executed_checkpoint {
+            if let Some(checkpoint_summary) = store
+                .get_checkpoint_by_sequence_number(checkpoint_number + shard_id)
+                .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?
             {
-                let mut transactions = vec![];
-                let mut effects = vec![];
-                let mut events = vec![];
-                let mut transactions_to_checkpoint = vec![];
+                if let Some(contents) = store
+                    .get_full_checkpoint_contents(&checkpoint_summary.content_digest)
+                    .map_err(|_| anyhow!("Failed to read checkpoint content from store"))?
+                {
+                    // let mut transactions = vec![];
+                    // let mut effects = vec![];
+                    // let mut events = vec![];
+                    // let mut transactions_to_checkpoint = vec![];
+                    let mut objects = vec![];
 
-                for content in contents.iter() {
-                    let transaction_digest = content.transaction.digest().into_inner().to_vec();
-                    effects.push((transaction_digest.clone(), content.effects.clone()));
-                    transactions_to_checkpoint.push((
-                        transaction_digest.clone(),
-                        checkpoint_summary.sequence_number,
-                    ));
-                    transactions.push((transaction_digest, content.transaction.clone()));
-
-                    if let Some(event_digest) = content.effects.events_digest() {
-                        if let Some(tx_events) = store
-                            .get_transaction_events(event_digest)
-                            .map_err(|_| anyhow!("Failed to fetch events from the store"))?
+                    for content in contents.iter() {
+                        // let transaction_digest = content.transaction.digest().into_inner().to_vec();
+                        // effects.push((transaction_digest.clone(), content.effects.clone()));
+                        // transactions_to_checkpoint.push((
+                        //     transaction_digest.clone(),
+                        //     checkpoint_summary.sequence_number,
+                        // ));
+                        // transactions.push((transaction_digest, content.transaction.clone()));
+                        //
+                        // if let Some(event_digest) = content.effects.events_digest() {
+                        //     if let Some(tx_events) = store
+                        //         .get_transaction_events(event_digest)
+                        //         .map_err(|_| anyhow!("Failed to fetch events from the store"))?
+                        //     {
+                        //         events.push((event_digest.into_inner().to_vec(), tx_events));
+                        //     }
+                        // }
+                        let object_keys: Vec<_> = content
+                            .effects
+                            .all_changed_objects()
+                            .iter()
+                            .map(|((obj_id, version, _), _, _)| ObjectKey(*obj_id, *version))
+                            .collect();
+                        let object_values = store.get_objects(&object_keys)?;
+                        for (object_key, value) in
+                            object_keys.into_iter().zip(object_values.into_iter())
                         {
-                            events.push((event_digest.into_inner().to_vec(), tx_events));
+                            objects.push((
+                                bcs::to_bytes(&object_key)?,
+                                value
+                                    .expect(&format!("kv store: missing object {:?}", &object_key)),
+                            ));
                         }
                     }
-                }
-                client
-                    .multi_set(KVTable::Transactions, transactions)
-                    .await?;
-                client.multi_set(KVTable::Effects, effects).await?;
-                client.multi_set(KVTable::Events, events).await?;
-                client
-                    .multi_set(KVTable::TransactionToCheckpoint, transactions_to_checkpoint)
-                    .await?;
+                    // client
+                    //     .multi_set(KVTable::Transactions, transactions)
+                    //     .await?;
+                    // client.multi_set(KVTable::Effects, effects).await?;
+                    // client.multi_set(KVTable::Events, events).await?;
+                    client.multi_set(KVTable::Objects, objects).await?;
+                    // client
+                    //     .multi_set(KVTable::TransactionToCheckpoint, transactions_to_checkpoint)
+                    //     .await?;
 
-                let serialized_checkpoint_number = bcs::to_bytes(
-                    &TaggedKey::CheckpointSequenceNumber(checkpoint_summary.sequence_number),
-                )?;
-                client
-                    .multi_set(
-                        KVTable::CheckpointSummary,
-                        [
-                            serialized_checkpoint_number.clone(),
-                            checkpoint_summary.digest().into_inner().to_vec(),
-                        ]
-                        .into_iter()
-                        .zip(repeat(checkpoint_summary.inner())),
-                    )
-                    .await?;
-                for key in [
-                    serialized_checkpoint_number,
-                    checkpoint_summary.content_digest.into_inner().to_vec(),
-                ] {
-                    client
-                        .upload_blob(
-                            KVTable::CheckpointContent,
-                            key,
-                            contents.checkpoint_contents(),
-                        )
-                        .await?;
+                    // let serialized_checkpoint_number = bcs::to_bytes(
+                    //     &TaggedKey::CheckpointSequenceNumber(checkpoint_summary.sequence_number),
+                    // )?;
+                    // client
+                    //     .multi_set(
+                    //         KVTable::CheckpointSummary,
+                    //         [
+                    //             serialized_checkpoint_number.clone(),
+                    //             checkpoint_summary.digest().into_inner().to_vec(),
+                    //         ]
+                    //         .into_iter()
+                    //         .zip(repeat(checkpoint_summary.inner())),
+                    //     )
+                    //     .await?;
+                    // for key in [
+                    //     serialized_checkpoint_number,
+                    //     checkpoint_summary.content_digest.into_inner().to_vec(),
+                    // ] {
+                    //     client
+                    //         .upload_blob(
+                    //             KVTable::CheckpointContent,
+                    //             key,
+                    //             contents.checkpoint_contents(),
+                    //         )
+                    //         .await?;
+                    // }
+                    progress_sender.send(checkpoint_number + shard_id).await?;
+                    checkpoint_number += config.concurrency as u64;
+                    continue;
                 }
-                progress_sender.send(checkpoint_number + shard_id).await?;
-                checkpoint_number += config.concurrency as u64;
-                continue;
             }
         }
         tokio::time::sleep(Duration::from_secs(3)).await;


### PR DESCRIPTION
PR needs to be shipped on top of 1.10 to ensure no interruptions in kv backfill pipeline