### PR TITLE
wallet-ext: fix wallet ApiProvider error

### DIFF
--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -112,3 +112,5 @@ export default class ApiProvider {
 		return this._signerByAddress.get(key)!;
 	}
 }
+
+export const walletApiProvider = new ApiProvider();

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -6,10 +6,10 @@ import { isLedgerAccountSerializedUI } from '_src/background/accounts/LedgerAcco
 import { isQredoAccountSerializedUI } from '_src/background/accounts/QredoAccount';
 import { useSuiClient } from '@mysten/dapp-kit';
 
+import { walletApiProvider } from '../ApiProvider';
 import { useSuiLedgerClient } from '../components/ledger/SuiLedgerClientProvider';
 import { LedgerSigner } from '../LedgerSigner';
 import { QredoSigner } from '../QredoSigner';
-import { thunkExtras } from '../redux/store/thunk-extras';
 import { type WalletSigner } from '../WalletSigner';
 import useAppSelector from './useAppSelector';
 import { useBackgroundClient } from './useBackgroundClient';
@@ -34,5 +34,5 @@ export function useSigner(account: SerializedUIAccount | null): WalletSigner | n
 	if (isQredoAccountSerializedUI(account)) {
 		return qredoAPI ? new QredoSigner(api, account, qredoAPI, networkName) : null;
 	}
-	return thunkExtras.api.getSignerInstance(account, background);
+	return walletApiProvider.getSignerInstance(account, background);
 }

--- a/apps/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/app/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DEFAULT_API_ENV } from '_app/ApiProvider';
+import { DEFAULT_API_ENV, walletApiProvider } from '_app/ApiProvider';
 import type { RootState } from '_redux/RootReducer';
 import type { API_ENV, NetworkEnvType } from '_src/shared/api-env';
 import type { AppThunkConfig } from '_store/thunk-extras';
@@ -32,16 +32,13 @@ export const changeActiveNetwork = createAsyncThunk<
 	void,
 	{ network: NetworkEnvType; store?: boolean },
 	AppThunkConfig
->(
-	'changeRPCNetwork',
-	async ({ network, store = false }, { extra: { background, api }, dispatch }) => {
-		if (store) {
-			await background.setActiveNetworkEnv(network);
-		}
-		api.setNewJsonRpcProvider(network.env, network.customRpcUrl);
-		await dispatch(slice.actions.setActiveNetwork(network));
-	},
-);
+>('changeRPCNetwork', async ({ network, store = false }, { extra: { background }, dispatch }) => {
+	if (store) {
+		await background.setActiveNetworkEnv(network);
+	}
+	walletApiProvider.setNewJsonRpcProvider(network.env, network.customRpcUrl);
+	await dispatch(slice.actions.setActiveNetwork(network));
+});
 
 const slice = createSlice({
 	name: 'app',

--- a/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
+++ b/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
@@ -1,16 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import ApiProvider from '_app/ApiProvider';
 import { BackgroundClient } from '_app/background-client';
 import { growthbook } from '_app/experimentation/feature-gating';
 import type { RootState } from '_redux/RootReducer';
 import type { AppDispatch } from '_store';
 
-export const api = new ApiProvider();
-
 export const thunkExtras = {
-	api,
 	growthbook,
 	background: new BackgroundClient(),
 };

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -11,7 +11,7 @@ import { initAmplitude } from '_src/shared/analytics/amplitude';
 import { setAttributes } from '_src/shared/experimentation/features';
 import initSentry from '_src/ui/app/helpers/sentry';
 import store from '_store';
-import { api, thunkExtras } from '_store/thunk-extras';
+import { thunkExtras } from '_store/thunk-extras';
 import { GrowthBookProvider } from '@growthbook/growthbook-react';
 import { SuiClientProvider } from '@mysten/dapp-kit';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
@@ -22,6 +22,7 @@ import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
 import App from './app';
+import { walletApiProvider } from './app/ApiProvider';
 import { AccountsFormProvider } from './app/components/accounts/AccountsFormContext';
 import { UnlockAccountProvider } from './app/components/accounts/UnlockAccountContext';
 import { SuiLedgerClientProvider } from './app/components/ledger/SuiLedgerClientProvider';
@@ -79,7 +80,9 @@ function AppWrapper() {
 								},
 							}}
 						>
-							<SuiClientProvider networks={{ [api.apiEnv]: api.instance.fullNode }}>
+							<SuiClientProvider
+								networks={{ [walletApiProvider.apiEnv]: walletApiProvider.instance.fullNode }}
+							>
 								<AccountsFormProvider>
 									<UnlockAccountProvider>
 										<div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1361,8 +1361,6 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0(@vitest/ui@0.33.0)(happy-dom@10.5.1)
 
-  sdk/move-binary-format-wasm/pkg: {}
-
   sdk/suins-toolkit:
     dependencies:
       '@mysten/sui.js':


### PR DESCRIPTION
## Description 

* seems that the change in order of imports broke the wallet
* removing ApiProvider from thunks fixes it

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
