### PR TITLE
[replay] fix end of epoch change tx

### DIFF
--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -29,7 +29,7 @@ use sui_types::digests::TransactionDigest;
 use sui_types::object::Object;
 use sui_types::transaction::SenderSignedData;
 use sui_types::transaction::TransactionDataAPI;
-use sui_types::transaction::TransactionKind;
+use sui_types::transaction::{EndOfEpochTransactionKind, TransactionKind};
 use tracing::error;
 
 /// This trait defines the interfaces for fetching data from some local or remote store
@@ -507,14 +507,30 @@ impl DataFetcher for RemoteFetcher {
         let orig_tx: SenderSignedData = bcs::from_bytes(&tx_info.raw_transaction).unwrap();
         let tx_kind_orig = orig_tx.transaction_data().kind();
 
-        if let TransactionKind::ChangeEpoch(change) = tx_kind_orig {
-            // Backfill cache
-            self.epoch_info_cache.write().put(
-                epoch_id,
-                (change.epoch_start_timestamp_ms, reference_gas_price),
-            );
+        match tx_kind_orig {
+            TransactionKind::ChangeEpoch(change) => {
+                // Backfill cache
+                self.epoch_info_cache.write().put(
+                    epoch_id,
+                    (change.epoch_start_timestamp_ms, reference_gas_price),
+                );
 
-            return Ok((change.epoch_start_timestamp_ms, reference_gas_price));
+                return Ok((change.epoch_start_timestamp_ms, reference_gas_price));
+            }
+            TransactionKind::EndOfEpochTransaction(kinds) => {
+                for kind in kinds {
+                    if let EndOfEpochTransactionKind::ChangeEpoch(change) = kind {
+                        // Backfill cache
+                        self.epoch_info_cache.write().put(
+                            epoch_id,
+                            (change.epoch_start_timestamp_ms, reference_gas_price),
+                        );
+
+                        return Ok((change.epoch_start_timestamp_ms, reference_gas_price));
+                    }
+                }
+            }
+            _ => {}
         }
         Err(ReplayEngineError::InvalidEpochChangeTx { epoch: epoch_id })
     }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -335,7 +335,7 @@ impl LocalExec {
 
         if let Some(url) = rpc_url.clone() {
             info!("Using RPC URL: {}", url);
-            if let Ok(x) = inner_exec(
+            match inner_exec(
                 url,
                 tx_digest,
                 expensive_safety_check_config.clone(),
@@ -345,9 +345,14 @@ impl LocalExec {
             )
             .await
             {
-                return Ok(x);
+                Ok(exec_state) => return Ok(exec_state),
+                Err(e) => {
+                    warn!(
+                        "Failed to execute transaction with provided RPC URL: Error {}",
+                        e
+                    );
+                }
             }
-            warn!("Failed to execute transaction with provided RPC URL. Attempting to load configs from file");
         }
 
         let cfg = ReplayableNetworkConfigSet::load_config(path)?;


### PR DESCRIPTION
## Description 

End of epoch logic changed in testnet due to this PR https://github.com/MystenLabs/sui/pull/13576
Replay logic has been changed to account for this.
Will add more unit tests to prevent such in future

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
