### PR TITLE
let indexer processors run forever

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -198,7 +198,8 @@ impl Indexer {
             handle.stopped().await;
         } else if config.fullnode_sync_worker {
             info!("Starting indexer with only fullnode sync");
-            let mut processor_orchestrator = ProcessorOrchestrator::new(store.clone(), registry);
+            let mut processor_orchestrator =
+                ProcessorOrchestrator::new(store.clone(), metrics.clone());
             spawn_monitored_task!(processor_orchestrator.run_forever());
 
             // -1 will be returned when checkpoints table is empty.

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -95,6 +95,9 @@ pub struct IndexerMetrics {
     // indexer state metrics
     pub db_conn_pool_size: IntGauge,
     pub idle_db_conn: IntGauge,
+
+    pub address_processor_failure: IntCounter,
+    pub checkpoint_metrics_processor_failure: IntCounter,
 }
 
 impl IndexerMetrics {
@@ -539,6 +542,18 @@ impl IndexerMetrics {
                 "Number of idle database connections",
                 registry
             ).unwrap(),
+            address_processor_failure: register_int_counter_with_registry!(
+                "address_processor_failure",
+                "Total number of address processor failure",
+                registry,
+            )
+            .unwrap(),
+            checkpoint_metrics_processor_failure: register_int_counter_with_registry!(
+                "checkpoint_metrics_processor_failure",
+                "Total number of checkpoint metrics processor failure",
+                registry,
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/sui-indexer/src/processors/processor_orchestrator.rs
+++ b/crates/sui-indexer/src/processors/processor_orchestrator.rs
@@ -1,102 +1,63 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use backoff::future::retry;
-use backoff::ExponentialBackoff;
 use futures::future::try_join_all;
-use prometheus::Registry;
-use tracing::{error, info, warn};
+use tokio::time::sleep;
+use tracing::{error, info};
 
+use crate::metrics::IndexerMetrics;
 use crate::processors::address_processor::AddressProcessor;
 use crate::processors::checkpoint_metrics_processor::CheckpointMetricsProcessor;
-use crate::processors::object_processor::ObjectProcessor;
 use crate::store::IndexerStore;
 
 pub struct ProcessorOrchestrator<S> {
     store: S,
-    prometheus_registry: Registry,
+    metrics: IndexerMetrics,
 }
 
 impl<S> ProcessorOrchestrator<S>
 where
     S: IndexerStore + Send + Sync + 'static + Clone,
 {
-    pub fn new(store: S, prometheus_registry: &Registry) -> Self {
-        Self {
-            store,
-            prometheus_registry: prometheus_registry.clone(),
-        }
+    pub fn new(store: S, metrics: IndexerMetrics) -> Self {
+        Self { store, metrics }
     }
 
     pub async fn run_forever(&mut self) {
         info!("Processor orchestrator started...");
-        let object_processor = ObjectProcessor::new(self.store.clone(), &self.prometheus_registry);
         let address_stats_processor = AddressProcessor::new(self.store.clone());
         let cp_metrics_processor = CheckpointMetricsProcessor::new(self.store.clone());
 
-        // TODOggao: clean up object processor
-        let obj_handle = tokio::task::spawn(async move {
-            let obj_result = retry(ExponentialBackoff::default(), || async {
-                let obj_processor_exec_res = object_processor.start().await;
-                if let Err(e) = &obj_processor_exec_res {
-                    object_processor
-                        .object_processor_metrics
-                        .total_object_processor_error
-                        .inc();
-                    warn!(
-                        "Indexer object processor failed with error: {:?}, retrying...",
-                        e
-                    );
-                }
-                Ok(obj_processor_exec_res?)
-            })
-            .await;
-            if let Err(e) = obj_result {
-                error!(
-                    "Indexer object processor failed after retrials with error {:?}",
-                    e
-                );
-            }
-        });
+        let metrics_clone = self.metrics.clone();
         let addr_handle = tokio::task::spawn(async move {
-            let addr_stats_result = retry(ExponentialBackoff::default(), || async {
+            loop {
                 let addr_stats_exec_res = address_stats_processor.start().await;
                 if let Err(e) = &addr_stats_exec_res {
-                    warn!(
+                    error!(
                         "Indexer address stats processor failed with error: {:?}, retrying...",
                         e
                     );
                 }
-                Ok(addr_stats_exec_res?)
-            })
-            .await;
-            if let Err(e) = addr_stats_result {
-                error!(
-                    "Indexer address stats processor failed after retries with error {:?}",
-                    e
-                );
+                metrics_clone.address_processor_failure.inc();
+                sleep(tokio::time::Duration::from_secs(5)).await;
             }
         });
+
+        let metrics_clone = self.metrics.clone();
         let cp_metrics_handle = tokio::task::spawn(async move {
-            let cp_metrics_result = retry(ExponentialBackoff::default(), || async {
+            loop {
                 let cp_metrics_exec_res = cp_metrics_processor.start().await;
                 if let Err(e) = &cp_metrics_exec_res {
-                    warn!(
+                    error!(
                         "Indexer checkpoint metrics processor failed with error: {:?}, retrying...",
                         e
                     );
                 }
-                Ok(cp_metrics_exec_res?)
-            })
-            .await;
-            if let Err(e) = cp_metrics_result {
-                error!(
-                    "Indexer checkpoint metrics processor failed after retries with error {:?}",
-                    e
-                );
+                metrics_clone.checkpoint_metrics_processor_failure.inc();
+                sleep(tokio::time::Duration::from_secs(5)).await;
             }
         });
-        try_join_all(vec![obj_handle, addr_handle, cp_metrics_handle])
+        try_join_all(vec![addr_handle, cp_metrics_handle])
             .await
             .expect("Processor orchestrator should not run into errors.");
     }


### PR DESCRIPTION
## Description 

As title. Instead of letting it fail after hitting a certain retry times, keep it run forever. Also add metrics for monitoring

## Test Plan 

Patching to prod indexer.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
