### PR TITLE
Fix minor discrepancy in the zkLogin docs

### DIFF
--- a/doc/src/build/zk_login.md
+++ b/doc/src/build/zk_login.md
@@ -161,10 +161,11 @@ In Mainnet, you must configure the client ID (`$CLIENT_ID`) and redirect URL (`$
 ```typescript
 import { generateNonce, generateRandomness } from '@mysten/zklogin';
 
-const suiClient = await getActiveNetworkSuiClient();
+const FULLNODE_URL = 'https://fullnode.devnet.sui.io'; // replace with the RPC URL you want to use
+const suiClient = new SuiClient({ url: FULLNODE_URL });
 const { epoch, epochDurationMs, epochStartTimestampMs } = await suiClient.getLatestSuiSystemState();
 
-const maxEpoch = epoch + 2; // this means the ephemeral key will be active for 2 epochs from now.
+const maxEpoch = Number(epoch) + 2; // this means the ephemeral key will be active for 2 epochs from now.
 const ephemeralKeyPair = new Ed25519Keypair();
 const randomness = generateRandomness();
 const nonce = generateNonce(ephemeralKeyPair.getPublicKey(), maxEpoch, randomness);


### PR DESCRIPTION
## Description 

Changed 2 lines in the zkLogin docs example.
- Show the construction of sui client
- epoch is returned as a string and maxEpoch is used as number so the epoch is converted to a number

## Test Plan 

I tested that code is working

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
