### PR TITLE
cli: add a cli to verify a zkLogin signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.6"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3547ed059927007c7ff48e729ed59da3dbb6a2e3#3547ed059927007c7ff48e729ed59da3dbb6a2e3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=59e15ab83999b464a6da37b6cdf0910fedd1216c#59e15ab83999b464a6da37b6cdf0910fedd1216c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3547ed059927007c7ff48e729ed59da3dbb6a2e3#3547ed059927007c7ff48e729ed59da3dbb6a2e3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=59e15ab83999b464a6da37b6cdf0910fedd1216c#59e15ab83999b464a6da37b6cdf0910fedd1216c"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2 1.0.66",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3547ed059927007c7ff48e729ed59da3dbb6a2e3#3547ed059927007c7ff48e729ed59da3dbb6a2e3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=59e15ab83999b464a6da37b6cdf0910fedd1216c#59e15ab83999b464a6da37b6cdf0910fedd1216c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9530,6 +9530,7 @@ dependencies = [
  "fastcrypto-zkp",
  "fs_extra",
  "git-version",
+ "im",
  "inquire",
  "jemalloc-ctl",
  "json_to_table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,8 +514,8 @@ move-stackless-bytecode = { path = "external-crates/move/move-prover/bytecode" }
 move-symbol-pool = { path = "external-crates/move/move-symbol-pool" }
 move-abstract-stack = { path = "external-crates/move/move-abstract-stack" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", package = "fastcrypto-zkp" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1169850e6af127397068cd86764c29b1d49dbe35" }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -33,6 +33,7 @@ const-str.workspace = true
 num-bigint.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+im.workspace = true
 
 sui-config.workspace = true
 sui-execution = { path = "../../sui-execution" }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::zklogin_commands_util::{perform_zk_login_test_tx, read_cli_line};
 use anyhow::anyhow;
 use bip32::DerivationPath;
 use clap::*;
@@ -9,10 +10,14 @@ use fastcrypto::hash::HashFunction;
 use fastcrypto::secp256k1::recoverable::Secp256k1Sig;
 use fastcrypto::traits::{KeyPair, ToFromBytes};
 use fastcrypto_zkp::bn254::utils::get_oidc_url;
-use fastcrypto_zkp::bn254::zk_login::OIDCProvider;
+use fastcrypto_zkp::bn254::zk_login::{fetch_jwks, OIDCProvider};
+use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
+use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
+use im::hashmap::HashMap as ImHashMap;
 use json_to_table::{json_to_table, Orientation};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
+use rand::Rng;
 use rand::SeedableRng;
 use rusoto_core::Region;
 use rusoto_kms::{Kms, KmsClient, SignRequest};
@@ -22,6 +27,7 @@ use shared_crypto::intent::{Intent, IntentMessage};
 use std::fmt::{Debug, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use sui_keys::key_derive::generate_new_key;
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
@@ -36,14 +42,10 @@ use sui_types::multisig::{MultiSig, MultiSigPublicKey, ThresholdUnit, WeightUnit
 use sui_types::multisig_legacy::{MultiSigLegacy, MultiSigPublicKeyLegacy};
 use sui_types::signature::{AuthenticatorTrait, GenericSignature, VerifyParams};
 use sui_types::transaction::TransactionData;
-use tracing::info;
-
-use rand::Rng;
 use tabled::builder::Builder;
 use tabled::settings::Rotate;
 use tabled::settings::{object::Rows, Modify, Width};
-
-use crate::zklogin_commands_util::{perform_zk_login_test_tx, read_cli_line};
+use tracing::info;
 
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
@@ -204,6 +206,20 @@ pub enum KeyToolCommand {
         #[clap(long, default_value = "devnet")]
         network: String,
     },
+
+    /// Given a zkLogin signature, parse it if valid. If tx_bytes provided,
+    /// it verifies the zkLogin signature based on provider and its latest JWK fetched.
+    /// Example request: sui keytool zk-login-sig-verify --sig $SERIALIZED_ZKLOGIN_SIG --tx-bytes $TX_BYTES --provider Google --curr-epoch 10
+    ZkLoginSigVerify {
+        #[clap(long)]
+        sig: String,
+        #[clap(long)]
+        tx_bytes: Option<String>,
+        #[clap(long)]
+        provider: Option<String>,
+        #[clap(long)]
+        curr_epoch: Option<EpochId>,
+    },
 }
 
 // Command Output types
@@ -338,6 +354,7 @@ pub enum CommandOutput {
     Sign(SignData),
     SignKMS(SerializedSig),
     ZkLoginSignAndExecuteTx(ZkLoginSignAndExecuteTx),
+    ZkLoginSigVerify(String),
 }
 
 impl KeyToolCommand {
@@ -803,6 +820,58 @@ impl KeyToolCommand {
                 )
                 .await?;
                 CommandOutput::ZkLoginSignAndExecuteTx(ZkLoginSignAndExecuteTx { tx_digest })
+            }
+
+            KeyToolCommand::ZkLoginSigVerify {
+                sig,
+                tx_bytes,
+                provider,
+                curr_epoch,
+            } => {
+                match GenericSignature::from_bytes(
+                    &Base64::decode(&sig).map_err(|e| anyhow!("Invalid base64 sig: {:?}", e))?,
+                )? {
+                    GenericSignature::ZkLoginAuthenticator(zk) => {
+                        if tx_bytes.is_none() || provider.is_none() {
+                            return Ok(CommandOutput::ZkLoginSigVerify(format!(
+                                "Parsed zkLogin signature: {:?}",
+                                zk
+                            )));
+                        }
+                        println!("Parsed zkLogin signature: {:?}", zk);
+
+                        let tx_data: TransactionData = bcs::from_bytes(
+                            &Base64::decode(&tx_bytes.unwrap())
+                                .map_err(|e| anyhow!("Invalid base64 tx data: {:?}", e))?,
+                        )?;
+                        let client = reqwest::Client::new();
+                        let parsed: ImHashMap<JwkId, JWK> = fetch_jwks(
+                            &OIDCProvider::from_str(&provider.clone().unwrap()).unwrap(),
+                            &client,
+                        )
+                        .await?
+                        .into_iter()
+                        .collect();
+                        println!("Latest JWKs for provider {:?} : {:?}", provider, parsed);
+                        let aux_verify_data = VerifyParams::new(
+                            parsed.clone(),
+                            vec![
+                                OIDCProvider::Facebook,
+                                OIDCProvider::Twitch,
+                                OIDCProvider::Google,
+                            ],
+                            ZkLoginEnv::Prod,
+                        );
+                        let res = zk.verify_authenticator(
+                            &IntentMessage::new(Intent::sui_transaction(), tx_data.clone()),
+                            tx_data.execution_parts().1,
+                            Some(curr_epoch.unwrap()),
+                            &aux_verify_data,
+                        );
+                        CommandOutput::ZkLoginSigVerify(format!("Verification result: {:?}", res))
+                    }
+                    _ => CommandOutput::Error("Not a zkLogin signature".to_string()),
+                }
             }
         });
 

--- a/crates/sui/src/zklogin_commands_util.rs
+++ b/crates/sui/src/zklogin_commands_util.rs
@@ -120,7 +120,7 @@ pub async fn perform_zk_login_test_tx(
         .await?;
     println!(
         "Faucet requested and created test transaction: {:?}",
-        Base64::encode(&bcs::to_bytes(&txb_res).unwrap())
+        Base64::encode(bcs::to_bytes(&txb_res).unwrap())
     );
 
     // Sign transaction with the ephemeral key

--- a/crates/sui/src/zklogin_commands_util.rs
+++ b/crates/sui/src/zklogin_commands_util.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::jwt_utils::parse_and_validate_jwt;
 use fastcrypto::traits::EncodeDecodeBase64;
 use fastcrypto_zkp::bn254::utils::{gen_address_seed, get_zk_login_address};
@@ -13,6 +14,8 @@ use serde_json::json;
 use shared_crypto::intent::Intent;
 use std::io;
 use std::io::Write;
+use std::thread::sleep;
+use std::time::Duration;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_keys::keystore::{AccountKeystore, Keystore};
 use sui_sdk::SuiClientBuilder;
@@ -95,6 +98,7 @@ pub async fn perform_zk_login_test_tx(
     // Request some coin from faucet and build a test transaction.
     let sui = SuiClientBuilder::default().build(fullnode_url).await?;
     request_tokens_from_faucet(zklogin_address, gas_url).await?;
+    sleep(Duration::from_secs(10));
 
     let Some(coin) = sui
         .coin_read_api()
@@ -116,7 +120,7 @@ pub async fn perform_zk_login_test_tx(
         .await?;
     println!(
         "Faucet requested and created test transaction: {:?}",
-        txb_res
+        Base64::encode(&bcs::to_bytes(&txb_res).unwrap())
     );
 
     // Sign transaction with the ephemeral key

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -251,8 +251,8 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail = { version = "0.4", default-features = false }
 fast_chemail = { version = "0.9", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", features = ["copy_key"] }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", default-features = false }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", features = ["copy_key"] }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", default-features = false }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
 fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
 fd-lock = { version = "3", default-features = false }
@@ -1019,9 +1019,9 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail = { version = "0.4", default-features = false }
 fast_chemail = { version = "0.9", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", features = ["copy_key"] }
-fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", default-features = false }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3547ed059927007c7ff48e729ed59da3dbb6a2e3", default-features = false }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", features = ["copy_key"] }
+fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", default-features = false }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "59e15ab83999b464a6da37b6cdf0910fedd1216c", default-features = false }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
 fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
 fd-lock = { version = "3", default-features = false }


### PR DESCRIPTION
## Description 

Add a way to verify zkLogin signature based on the provider and its latest JWK. 
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
