### PR TITLE
[graphql/rpc] Impl custom query limiter for early termination

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::functional_group::FunctionalGroup;
 
-const MAX_QUERY_DEPTH: u32 = 3;
-const MAX_QUERY_NODES: u32 = 10;
+const MAX_QUERY_DEPTH: u32 = 10;
+const MAX_QUERY_NODES: u32 = 100;
 
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 pub struct ConnectionConfig {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::functional_group::FunctionalGroup;
 
-const MAX_QUERY_DEPTH: u32 = 10;
-const MAX_QUERY_NODES: u32 = 100;
+const MAX_QUERY_DEPTH: u32 = 3;
+const MAX_QUERY_NODES: u32 = 10;
 
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 pub struct ConnectionConfig {
@@ -32,7 +32,7 @@ pub struct ServiceConfig {
     pub(crate) experiments: Experiments,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
 #[serde(rename_all = "kebab-case")]
 pub struct Limits {
     #[serde(default)]

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -4,4 +4,5 @@
 pub(crate) mod feature_gate;
 pub(crate) mod limits_info;
 pub(crate) mod logger;
+pub(crate) mod query_limits_checker;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::ServiceConfig;
+use async_graphql::extensions::NextParseQuery;
+use async_graphql::parser::types::ExecutableDocument;
+use async_graphql::parser::types::Selection::Field;
+use async_graphql::Pos;
+use async_graphql::ServerResult;
+use async_graphql::Variables;
+use async_graphql::{
+    extensions::{Extension, ExtensionContext, ExtensionFactory},
+    ServerError,
+};
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct QueryLimitsChecker;
+
+impl ExtensionFactory for QueryLimitsChecker {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(QueryLimitsChecker)
+    }
+}
+
+#[async_trait::async_trait]
+impl Extension for QueryLimitsChecker {
+    async fn parse_query(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        query: &str,
+        variables: &Variables,
+        next: NextParseQuery<'_>,
+    ) -> ServerResult<ExecutableDocument> {
+        // TODO: limit number of variables, fragments, etc
+
+        // Use BFS to analyze the query and
+        // count the number of nodes and the depth of the query
+
+        let cfg = ctx
+            .data::<ServiceConfig>()
+            .expect("No service config provided in schema data");
+        // Document layout of the query
+        let doc = next.run(ctx, query, variables).await?;
+        // Queue to store the nodes at each level
+        let mut que = VecDeque::new();
+        // Number of nodes in the query
+        let mut num_nodes: u32 = 0;
+        // Depth of the query
+        let mut depth: u32 = 0;
+        // Number of nodes at each level
+        let mut level_len;
+
+        for (_name, oper) in doc.operations.iter() {
+            for sel in oper.node.selection_set.node.items.iter() {
+                que.push_back(sel);
+                num_nodes += 1;
+                self.check_limits(cfg, num_nodes, depth, Some(sel.pos))?;
+            }
+        }
+        // Track the number of nodes at first level if any
+        level_len = que.len();
+
+        while !que.is_empty() {
+            // Signifies the start of a new level
+            depth += 1;
+            self.check_limits(cfg, num_nodes, depth, None)?;
+            while level_len > 0 {
+                let sel = que.pop_front().unwrap();
+                // TODO: check for fragments, variables, etc
+                if let Field(f) = &sel.node {
+                    // TODO: check for directives, variables, etc
+                    for sel in f.node.selection_set.node.items.iter() {
+                        que.push_back(sel);
+                        num_nodes += 1;
+                        self.check_limits(cfg, num_nodes, depth, Some(sel.pos))?;
+                    }
+                }
+                level_len -= 1;
+            }
+            level_len = que.len();
+        }
+
+        Ok(doc)
+    }
+}
+
+impl QueryLimitsChecker {
+    fn check_limits(
+        &self,
+        cfg: &ServiceConfig,
+        nodes: u32,
+        depth: u32,
+        pos: Option<Pos>,
+    ) -> ServerResult<()> {
+        if nodes > cfg.limits.max_query_nodes {
+            return Err(ServerError::new(
+                format!(
+                    "Query has too many nodes. The maximum allowed is {}",
+                    cfg.limits.max_query_nodes
+                ),
+                pos,
+            ));
+        }
+
+        if depth > cfg.limits.max_query_depth {
+            return Err(ServerError::new(
+                format!(
+                    "Query has too many levels of nesting. The maximum allowed is {}",
+                    cfg.limits.max_query_depth
+                ),
+                pos,
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -7,6 +7,7 @@ use crate::context_data::sui_sdk_data_provider::{lru_cache_data_loader, sui_sdk_
 use crate::extensions::feature_gate::FeatureGate;
 use crate::extensions::limits_info::LimitsInfo;
 use crate::extensions::logger::Logger;
+use crate::extensions::query_limits_checker::QueryLimitsChecker;
 use crate::extensions::timeout::Timeout;
 use crate::server::builder::ServerBuilder;
 
@@ -30,6 +31,7 @@ pub async fn start_example_server(conn: ConnectionConfig, service_config: Servic
         .context_data(data_provider)
         .context_data(data_loader)
         .context_data(service_config)
+        .extension(QueryLimitsChecker)
         .extension(FeatureGate)
         .extension(LimitsInfo)
         .extension(Logger::default())


### PR DESCRIPTION
## Description 

Current limit checking logic in async-graphql library does not terminate early if limits are reached. This is wasteful as it allows other validations and checks to go through.
Created an upstream [issue](https://github.com/async-graphql/async-graphql/issues/1383) to support this but in meantime we can run an extension early which approximates the desired behavior.

In future we can add limits for other query components in this extension

Todo: reconcile this logic with the remaining query logic and extensions

## Test Plan 

Manual
Unit TBD

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
