### PR TITLE
[graphql/rpc] easy/chore: fix types

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -68,7 +68,7 @@ type Query {
   epoch(epochId: Int): Epoch
 
   # `protocolVersion` defaults to the latest protocol version.
-  protocolConfig(protocolVersion: Int): ProtocolConfig
+  protocolConfig(protocolVersion: Int): ProtocolConfigs
 
   # If no `id` is provided, fetch the latest available checkpoint.
   checkpoint(id: CheckpointID): Checkpoint
@@ -273,7 +273,7 @@ input TransactionBlockFilter {
   inputObject: SuiAddress
   changedObject: SuiAddress
 
-  transactionIDs: [TransactionBlockID!]
+  transactionIDs: [String!]
 
   # Enhancement (post-MVP), consistency with EventFilter -- timestamp
   # comes from checkpoint timestamp.


### PR DESCRIPTION
## Description 

Cleanup types which fail validation
`TransactionBlockID` was not defined
`ProtocolConfig` should be `ProtocolConfigs`

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
