### PR TITLE
Correct anchor link in connect-sui-network.md

### DIFF
--- a/doc/src/build/connect-sui-network.md
+++ b/doc/src/build/connect-sui-network.md
@@ -41,7 +41,7 @@ See the [Sui Releases](https://github.com/MystenLabs/sui/releases) page to view 
 
 ## Configure Sui client
 
-If you previously ran `sui genesis` to create a local network, it created a Sui client configuration file (client.yaml) that connects to `localhost` at `http://0.0.0.0:9000`. See [Connect to custom RPC endpoint](#connect-to-custom-rpc-endpoint) to update the client.yaml file.
+If you previously ran `sui genesis` to create a local network, it created a Sui client configuration file (client.yaml) that connects to `localhost` at `http://0.0.0.0:9000`. See [Connect to a custom RPC endpoint](#connect-to-a-custom-rpc-endpoint) to update the client.yaml file.
 
 To connect the Sui client to a network, run the following command:
 
@@ -49,7 +49,7 @@ To connect the Sui client to a network, run the following command:
 sui client
 ```
 
-If you receive the `sui-client` help output in the console, you already have a client.yaml file. See [Connect to custom RPC endpoint](#connect-to-custom-rpc-endpoint) to add a new environment alias or to switch the currently active network.
+If you receive the `sui-client` help output in the console, you already have a client.yaml file. See [Connect to a custom RPC endpoint](#connect-to-a-custom-rpc-endpoint) to add a new environment alias or to switch the currently active network.
 
 The first time you start Sui client without having a client.yaml file, the console displays the following message:
 


### PR DESCRIPTION
Both links should point to anchor text "Connect to a custom RPC endpoint" rather than "Connect to custom RPC endpoint".

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
