### PR TITLE
[indexer-writer] send multiple checkpoints to handler to process in parallel

### DIFF
--- a/crates/sui-indexer/src/framework/interface.rs
+++ b/crates/sui-indexer/src/framework/interface.rs
@@ -12,7 +12,7 @@ pub trait Handler: Send {
 }
 
 pub trait BackfillHandler: Handler {
-    fn last_processed_checkpoints(&self) -> Option<CheckpointSequenceNumber>;
+    fn last_processed_checkpoint(&self) -> Option<CheckpointSequenceNumber>;
 }
 
 #[async_trait::async_trait]

--- a/crates/sui-indexer/src/framework/interface.rs
+++ b/crates/sui-indexer/src/framework/interface.rs
@@ -8,17 +8,17 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 #[async_trait::async_trait]
 pub trait Handler: Send {
     fn name(&self) -> &str;
-    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> Result<()>;
+    async fn process_checkpoints(&mut self, checkpoints: &[CheckpointData]) -> Result<()>;
 }
 
 pub trait BackfillHandler: Handler {
-    fn last_processed_checkpoint(&self) -> Option<CheckpointSequenceNumber>;
+    fn last_processed_checkpoints(&self) -> Option<CheckpointSequenceNumber>;
 }
 
 #[async_trait::async_trait]
 pub trait OutOfOrderHandler: Send + Sync {
     fn name(&self) -> &str;
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()>;
+    async fn process_checkpoints(&self, checkpoints: &[CheckpointData]) -> Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -27,7 +27,7 @@ impl<T: OutOfOrderHandler> Handler for T {
         OutOfOrderHandler::name(self)
     }
 
-    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> Result<()> {
-        OutOfOrderHandler::process_checkpoint(self, checkpoint_data).await
+    async fn process_checkpoints(&mut self, checkpoints: &[CheckpointData]) -> Result<()> {
+        OutOfOrderHandler::process_checkpoints(self, checkpoints).await
     }
 }

--- a/crates/sui-indexer/src/framework/runner.rs
+++ b/crates/sui-indexer/src/framework/runner.rs
@@ -5,18 +5,24 @@ use sui_rest_api::CheckpointData;
 
 use super::interface::Handler;
 
-pub async fn run<S>(mut stream: S, mut handlers: Vec<Box<dyn Handler>>)
+pub async fn run<S>(stream: S, mut handlers: Vec<Box<dyn Handler>>)
 where
     S: futures::Stream<Item = CheckpointData> + std::marker::Unpin,
 {
     use futures::StreamExt;
 
-    while let Some(checkpoint) = stream.next().await {
+    let batch_size = std::env::var("CHECKPOINT_PROCESSING_BATCH_SIZE")
+        .unwrap_or(25.to_string())
+        .parse::<usize>()
+        .unwrap();
+    tracing::info!("Indexer runner is starting with {batch_size}");
+    let mut chunks: futures::stream::ReadyChunks<S> = stream.ready_chunks(batch_size);
+    while let Some(checkpoints) = chunks.next().await {
         //TODO create tracing spans for processing
         futures::future::join_all(
             handlers
                 .iter_mut()
-                .map(|handler| async { handler.process_checkpoint(&checkpoint).await.unwrap() }),
+                .map(|handler| async { handler.process_checkpoints(&checkpoints).await.unwrap() }),
         )
         .await;
     }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -127,16 +127,14 @@ pub struct CheckpointProcessor<S> {
     checkpoint_sender: mysten_metrics::metered_channel::Sender<TemporaryCheckpointStore>,
 }
 
-#[async_trait::async_trait]
-impl<S> Handler for CheckpointProcessor<S>
+impl<S> CheckpointProcessor<S>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
-    fn name(&self) -> &str {
-        "checkpoint-transaction-and-epoch-indexer"
-    }
-
-    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> anyhow::Result<()> {
+    async fn process_one_checkpoint(
+        &mut self,
+        checkpoint_data: &CheckpointData,
+    ) -> anyhow::Result<()> {
         info!(
             checkpoint_seq = checkpoint_data.checkpoint_summary.sequence_number(),
             "Checkpoint received by indexing processor"
@@ -197,6 +195,23 @@ where
                 )
             });
 
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> Handler for CheckpointProcessor<S>
+where
+    S: IndexerStore + Clone + Sync + Send + 'static,
+{
+    fn name(&self) -> &str {
+        "checkpoint-transaction-and-epoch-indexer"
+    }
+
+    async fn process_checkpoints(&mut self, checkpoints: &[CheckpointData]) -> anyhow::Result<()> {
+        for checkpoint_data in checkpoints {
+            self.process_one_checkpoint(checkpoint_data).await?;
+        }
         Ok(())
     }
 }
@@ -824,16 +839,14 @@ pub struct ObjectsProcessor<S> {
     state: S,
 }
 
-#[async_trait::async_trait]
-impl<S> Handler for ObjectsProcessor<S>
+impl<S> ObjectsProcessor<S>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
-    fn name(&self) -> &str {
-        "objects-indexer"
-    }
-
-    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> anyhow::Result<()> {
+    async fn process_one_checkpoint(
+        &mut self,
+        checkpoint_data: &CheckpointData,
+    ) -> anyhow::Result<()> {
         let checkpoint_seq = *checkpoint_data.checkpoint_summary.sequence_number();
         info!(checkpoint_seq, "Objects received by indexing processor");
         // Index checkpoint data
@@ -853,7 +866,23 @@ where
                     e
                 )
             });
+        Ok(())
+    }
+}
 
+#[async_trait::async_trait]
+impl<S> Handler for ObjectsProcessor<S>
+where
+    S: IndexerStore + Clone + Sync + Send + 'static,
+{
+    fn name(&self) -> &str {
+        "objects-indexer"
+    }
+
+    async fn process_checkpoints(&mut self, checkpoints: &[CheckpointData]) -> anyhow::Result<()> {
+        for checkpoint_data in checkpoints {
+            self.process_one_checkpoint(checkpoint_data).await?;
+        }
         Ok(())
     }
 }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused)]
-
 use crate::handlers::committer::start_tx_checkpoint_commit_task;
 use crate::handlers::tx_processor::IndexingPackageCache;
 use async_trait::async_trait;
@@ -17,10 +15,10 @@ use sui_types::base_types::ObjectRef;
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::dynamic_field::DynamicFieldName;
 use sui_types::dynamic_field::DynamicFieldType;
+use sui_types::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
 use sui_types::object::Object;
 use sui_types::object::ObjectFormatOptions;
 use tokio::sync::watch;
-use tracing::debug;
 
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
@@ -34,7 +32,6 @@ use tap::tap::TapFallible;
 use tracing::{error, info, warn};
 
 use sui_types::base_types::ObjectID;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemStateTrait};
 
@@ -120,45 +117,87 @@ where
         "checkpoint-handler"
     }
 
-    async fn process_checkpoint(&mut self, checkpoint_data: &CheckpointData) -> anyhow::Result<()> {
-        let checkpoint_seq = checkpoint_data.checkpoint_summary.sequence_number();
-        info!(checkpoint_seq, "Checkpoint received by CheckpointHandler");
+    async fn process_checkpoints(&mut self, checkpoints: &[CheckpointData]) -> anyhow::Result<()> {
+        if checkpoints.is_empty() {
+            return Ok(());
+        }
+        // Safe to unwrap, checked emptiness above
+        let first_checkpoint_seq = checkpoints
+            .first()
+            .unwrap()
+            .checkpoint_summary
+            .sequence_number();
+        let last_checkpoint_seq = checkpoints
+            .last()
+            .unwrap()
+            .checkpoint_summary
+            .sequence_number();
+        info!(
+            first = first_checkpoint_seq,
+            last = last_checkpoint_seq,
+            "Checkpoints received by CheckpointHandler"
+        );
 
-        // Index checkpoint data
-        let index_timer = self.metrics.checkpoint_index_latency.start_timer();
-        let checkpoint = Self::index_checkpoint_and_epoch(
-            &self.state,
-            checkpoint_data.clone(),
+        let indexing_timer = self.metrics.checkpoint_index_latency.start_timer();
+        // It's important to index packages first to populate ModuleResolver
+        let packages = Self::index_packages(checkpoints, &self.metrics);
+        let module_resolver = Arc::new(InterimModuleResolver::new(
+            self.state.module_cache(),
             self.package_cache.clone(),
-            &self.metrics,
-        )
-        .await
-        .tap_err(|e| {
-            error!(
-                checkpoint_seq,
-                "Failed to index checkpoints with error: {}",
-                e.to_string()
-            );
-        })?;
-        let elapsed = index_timer.stop_and_record();
+            &packages,
+            self.metrics.clone(),
+        ));
+        let mut packages_per_checkpoint: HashMap<_, Vec<_>> = HashMap::new();
+        for package in packages {
+            packages_per_checkpoint
+                .entry(package.checkpoint_sequence_number)
+                .or_default()
+                .push(package);
+        }
+        let mut tasks = vec![];
+        for checkpoint in checkpoints {
+            let packages = packages_per_checkpoint
+                .remove(checkpoint.checkpoint_summary.sequence_number())
+                .unwrap_or_default();
+            tasks.push(Self::index_one_checkpoint(
+                &self.state,
+                checkpoint.clone(),
+                &self.metrics,
+                packages,
+                module_resolver.clone(),
+            ));
+        }
+        let checkpoint_data_to_commit = futures::future::join_all(tasks)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| {
+                error!("Failed to index checkpoints with error: {}", e.to_string());
+            })?;
+        let elapsed = indexing_timer.stop_and_record();
 
         info!(
-            checkpoint_seq,
-            elapsed, "Checkpoint indexing finished, about to sending to commit handler"
+            first = first_checkpoint_seq,
+            last = last_checkpoint_seq,
+            elapsed,
+            "Checkpoints indexing finished, about to sending to commit handler"
         );
+
         // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
         // Checkpoints are sent sequentially to stick to the order of checkpoint sequence numbers.
-        self.indexed_checkpoint_sender
-            .send(checkpoint)
-            .await
-            .tap_ok(|_| info!(checkpoint_seq, "Checkpoint sent to commit handler"))
-            .unwrap_or_else(|e| {
-                panic!(
-                    "checkpoint channel send should not fail, but got error: {:?}",
-                    e
-                )
-            });
-
+        for checkpoint_data in checkpoint_data_to_commit {
+            let checkpoint_seq = checkpoint_data.checkpoint.sequence_number;
+            self.indexed_checkpoint_sender
+                .send(checkpoint_data)
+                .await
+                .tap_ok(|_| info!(checkpoint_seq, "Checkpoint sent to commit handler"))
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "checkpoint channel send should not fail, but got error: {:?}",
+                        e
+                    )
+                });
+        }
         Ok(())
     }
 }
@@ -233,161 +272,42 @@ where
         }))
     }
 
-    async fn index_checkpoint_and_epoch(
+    async fn index_one_checkpoint(
         state: &S,
         data: CheckpointData,
-        package_cache: Arc<Mutex<IndexingPackageCache>>,
         metrics: &IndexerMetrics,
+        packages: Vec<IndexedPackage>,
+        module_resolver: Arc<impl GetModule>,
     ) -> Result<CheckpointDataToCommit, IndexerError> {
+        let checkpoint_seq = data.checkpoint_summary.sequence_number;
+        info!(checkpoint_seq, "Indexing checkpoint data blob");
+
+        // Index epoch
+        let epoch = Self::index_epoch(state, &data).await?;
+
+        // Index Objects
+        let object_changes = Self::index_objects(data.clone(), metrics, &module_resolver);
+
         let (checkpoint, db_transactions, db_events, db_indices) = {
             let CheckpointData {
                 transactions,
                 checkpoint_summary,
                 checkpoint_contents,
-            } = &data;
-            let checkpoint_seq = checkpoint_summary.sequence_number();
-            let mut db_transactions = Vec::new();
-            let mut db_events = Vec::new();
-            let mut db_indices = Vec::new();
+            } = data;
 
-            let mut tx_seq_num_iter = checkpoint_contents
-                .enumerate_transactions(checkpoint_summary)
-                .map(|(seq, execution_digest)| (execution_digest.transaction, seq));
+            let (db_transactions, db_events, db_indices) = Self::index_transactions(
+                transactions,
+                &checkpoint_summary,
+                &checkpoint_contents,
+                metrics,
+            )
+            .await?;
 
-            if checkpoint_contents.size() != transactions.len() {
-                return Err(IndexerError::FullNodeReadingError(format!(
-                    "CheckpointContents has different size {} compared to Transactions {} for checkpoint {}",
-                    checkpoint_contents.size(),
-                    transactions.len(),
-                    checkpoint_seq
-                )));
-            }
-
-            for (idx, tx) in transactions.iter().enumerate() {
-                let CheckpointTransaction {
-                    transaction: sender_signed_data,
-                    effects: fx,
-                    events,
-                    input_objects,
-                    output_objects,
-                } = tx;
-                // Unwrap safe - we checked they have equal length above
-                let (tx_digest, tx_sequence_number) = tx_seq_num_iter.next().unwrap();
-                if tx_digest != *sender_signed_data.digest() {
-                    return Err(IndexerError::FullNodeReadingError(format!(
-                        "Transactions has different ordering from CheckpointContents, for checkpoint {}, Mismatch found at {} v.s. {}",
-                        checkpoint_seq, tx_digest, sender_signed_data.digest()
-                    )));
-                }
-                let tx = sender_signed_data.transaction_data();
-                let events = events
-                    .as_ref()
-                    .map(|events| events.data.clone())
-                    .unwrap_or_default();
-
-                let transaction_kind = if tx.is_system_tx() {
-                    TransactionKind::SystemTransaction
-                } else {
-                    TransactionKind::ProgrammableTransaction
-                };
-
-                db_events.extend(events.iter().enumerate().map(|(idx, event)| {
-                    IndexedEvent::from_event(
-                        tx_sequence_number,
-                        idx as u64,
-                        *checkpoint_seq,
-                        tx_digest,
-                        event,
-                        checkpoint_summary.timestamp_ms,
-                    )
-                }));
-
-                let objects = input_objects
-                    .iter()
-                    .chain(output_objects.iter())
-                    .collect::<Vec<_>>();
-
-                let (balance_change, object_changes) =
-                    TxChangesProcessor::new(&objects, metrics.clone())
-                        .get_changes(tx, fx, &tx_digest)
-                        .await?;
-
-                let db_txn = IndexedTransaction {
-                    tx_sequence_number,
-                    tx_digest,
-                    checkpoint_sequence_number: *checkpoint_summary.sequence_number(),
-                    timestamp_ms: checkpoint_summary.timestamp_ms,
-                    sender_signed_data: sender_signed_data.data().clone(),
-                    effects: fx.clone(),
-                    object_changes,
-                    balance_change,
-                    events,
-                    transaction_kind,
-                    successful_tx_num: if fx.status().is_ok() {
-                        tx.kind().num_commands() as u64
-                    } else {
-                        0
-                    },
-                };
-
-                db_transactions.push(db_txn);
-
-                // Input Objects
-                let input_objects = tx
-                    .input_objects()
-                    .expect("committed txns have been validated")
-                    .into_iter()
-                    .map(|obj_kind| obj_kind.object_id())
-                    .collect::<Vec<_>>();
-
-                // Changed Objects
-                let changed_objects = fx
-                    .all_changed_objects()
-                    .into_iter()
-                    .map(|(object_ref, _owner, _write_kind)| object_ref.0)
-                    .collect::<Vec<_>>();
-
-                // Payers
-                let payers = vec![tx.gas_owner()];
-
-                // Senders
-                let senders = vec![tx.sender()];
-
-                // Recipients
-                let recipients = fx
-                    .all_changed_objects()
-                    .into_iter()
-                    .filter_map(|(_object_ref, owner, _write_kind)| match owner {
-                        Owner::AddressOwner(address) => Some(address),
-                        _ => None,
-                    })
-                    .unique()
-                    .collect::<Vec<_>>();
-
-                // Move Calls
-                let move_calls = tx
-                    .move_calls()
-                    .iter()
-                    .map(|(p, m, f)| (*<&ObjectID>::clone(p), m.to_string(), f.to_string()))
-                    .collect();
-
-                db_indices.push(TxIndex {
-                    tx_sequence_number,
-                    transaction_digest: tx_digest,
-                    checkpoint_sequence_number: *checkpoint_seq,
-                    input_objects,
-                    changed_objects,
-                    senders,
-                    payers,
-                    recipients,
-                    move_calls,
-                });
-            }
             let successful_tx_num: u64 = db_transactions.iter().map(|t| t.successful_tx_num).sum();
             (
                 IndexedCheckpoint::from_sui_checkpoint(
-                    checkpoint_summary,
-                    checkpoint_contents,
+                    &checkpoint_summary,
+                    &checkpoint_contents,
                     successful_tx_num as usize,
                 ),
                 db_transactions,
@@ -395,12 +315,6 @@ where
                 db_indices,
             )
         };
-
-        let epoch = Self::index_epoch(state, &data).await?;
-
-        // Index Objects
-        let (object_changes, packages) =
-            Self::index_checkpoint(state, data, package_cache, metrics);
 
         Ok(CheckpointDataToCommit {
             checkpoint,
@@ -413,37 +327,161 @@ where
         })
     }
 
-    fn index_checkpoint(
-        state: &S,
-        data: CheckpointData,
-        package_cache: Arc<Mutex<IndexingPackageCache>>,
+    async fn index_transactions(
+        transactions: Vec<CheckpointTransaction>,
+        checkpoint_summary: &CertifiedCheckpointSummary,
+        checkpoint_contents: &CheckpointContents,
         metrics: &IndexerMetrics,
-    ) -> (TransactionObjectChangesToCommit, Vec<IndexedPackage>) {
-        let checkpoint_seq = data.checkpoint_summary.sequence_number;
-        info!(checkpoint_seq, "Indexing checkpoint");
-        let packages = Self::index_packages(&data, metrics);
+    ) -> IndexerResult<(Vec<IndexedTransaction>, Vec<IndexedEvent>, Vec<TxIndex>)> {
+        let checkpoint_seq = checkpoint_summary.sequence_number();
 
-        let object_changes = Self::index_objects(state, data, &packages, package_cache, metrics);
+        let mut tx_seq_num_iter = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .map(|(seq, execution_digest)| (execution_digest.transaction, seq));
 
-        (object_changes, packages)
+        if checkpoint_contents.size() != transactions.len() {
+            return Err(IndexerError::FullNodeReadingError(format!(
+                "CheckpointContents has different size {} compared to Transactions {} for checkpoint {}",
+                checkpoint_contents.size(),
+                transactions.len(),
+                checkpoint_seq
+            )));
+        }
+
+        let mut db_transactions = Vec::new();
+        let mut db_events = Vec::new();
+        let mut db_indices = Vec::new();
+
+        for tx in transactions {
+            let CheckpointTransaction {
+                transaction: sender_signed_data,
+                effects: fx,
+                events,
+                input_objects,
+                output_objects,
+            } = tx;
+            // Unwrap safe - we checked they have equal length above
+            let (tx_digest, tx_sequence_number) = tx_seq_num_iter.next().unwrap();
+            if tx_digest != *sender_signed_data.digest() {
+                return Err(IndexerError::FullNodeReadingError(format!(
+                    "Transactions has different ordering from CheckpointContents, for checkpoint {}, Mismatch found at {} v.s. {}",
+                    checkpoint_seq, tx_digest, sender_signed_data.digest()
+                )));
+            }
+            let tx = sender_signed_data.transaction_data();
+            let events = events
+                .as_ref()
+                .map(|events| events.data.clone())
+                .unwrap_or_default();
+
+            let transaction_kind = if tx.is_system_tx() {
+                TransactionKind::SystemTransaction
+            } else {
+                TransactionKind::ProgrammableTransaction
+            };
+
+            db_events.extend(events.iter().enumerate().map(|(idx, event)| {
+                IndexedEvent::from_event(
+                    tx_sequence_number,
+                    idx as u64,
+                    *checkpoint_seq,
+                    tx_digest,
+                    event,
+                    checkpoint_summary.timestamp_ms,
+                )
+            }));
+
+            let objects = input_objects
+                .iter()
+                .chain(output_objects.iter())
+                .collect::<Vec<_>>();
+
+            let (balance_change, object_changes) =
+                TxChangesProcessor::new(&objects, metrics.clone())
+                    .get_changes(tx, &fx, &tx_digest)
+                    .await?;
+
+            let db_txn = IndexedTransaction {
+                tx_sequence_number,
+                tx_digest,
+                checkpoint_sequence_number: *checkpoint_summary.sequence_number(),
+                timestamp_ms: checkpoint_summary.timestamp_ms,
+                sender_signed_data: sender_signed_data.data().clone(),
+                effects: fx.clone(),
+                object_changes,
+                balance_change,
+                events,
+                transaction_kind,
+                successful_tx_num: if fx.status().is_ok() {
+                    tx.kind().num_commands() as u64
+                } else {
+                    0
+                },
+            };
+
+            db_transactions.push(db_txn);
+
+            // Input Objects
+            let input_objects = tx
+                .input_objects()
+                .expect("committed txns have been validated")
+                .into_iter()
+                .map(|obj_kind| obj_kind.object_id())
+                .collect::<Vec<_>>();
+
+            // Changed Objects
+            let changed_objects = fx
+                .all_changed_objects()
+                .into_iter()
+                .map(|(object_ref, _owner, _write_kind)| object_ref.0)
+                .collect::<Vec<_>>();
+
+            // Payers
+            let payers = vec![tx.gas_owner()];
+
+            // Senders
+            let senders = vec![tx.sender()];
+
+            // Recipients
+            let recipients = fx
+                .all_changed_objects()
+                .into_iter()
+                .filter_map(|(_object_ref, owner, _write_kind)| match owner {
+                    Owner::AddressOwner(address) => Some(address),
+                    _ => None,
+                })
+                .unique()
+                .collect::<Vec<_>>();
+
+            // Move Calls
+            let move_calls = tx
+                .move_calls()
+                .iter()
+                .map(|(p, m, f)| (*<&ObjectID>::clone(p), m.to_string(), f.to_string()))
+                .collect();
+
+            db_indices.push(TxIndex {
+                tx_sequence_number,
+                transaction_digest: tx_digest,
+                checkpoint_sequence_number: *checkpoint_seq,
+                input_objects,
+                changed_objects,
+                senders,
+                payers,
+                recipients,
+                move_calls,
+            });
+        }
+        Ok((db_transactions, db_events, db_indices))
     }
 
     fn index_objects(
-        state: &S,
         data: CheckpointData,
-        packages: &[IndexedPackage],
-        package_cache: Arc<Mutex<IndexingPackageCache>>,
         metrics: &IndexerMetrics,
+        module_resolver: &impl GetModule,
     ) -> TransactionObjectChangesToCommit {
         let _timer = metrics.indexing_objects_latency.start_timer();
         let checkpoint_seq = data.checkpoint_summary.sequence_number;
-        let module_resolver = InterimModuleResolver::new(
-            state.module_cache(),
-            package_cache,
-            packages,
-            checkpoint_seq,
-            metrics.clone(),
-        );
         let deleted_objects = data
             .transactions
             .iter()
@@ -484,7 +522,7 @@ where
                         });
                         assert_eq!(oref.1, object.version());
                         let df_info =
-                            try_create_dynamic_field_info(object, &objects, &module_resolver)
+                            try_create_dynamic_field_info(object, &objects, module_resolver)
                                 .unwrap_or_else(|e| {
                                     panic!(
                                 "failed to create dynamic field info for obj: {:?}:{:?}. Err: {e}",
@@ -509,22 +547,28 @@ where
     }
 
     fn index_packages(
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: &[CheckpointData],
         metrics: &IndexerMetrics,
     ) -> Vec<IndexedPackage> {
         let _timer = metrics.indexing_packages_latency.start_timer();
         checkpoint_data
-            .output_objects()
             .iter()
-            .filter_map(|o| {
-                if let sui_types::object::Data::Package(p) = &o.data {
-                    Some(IndexedPackage {
-                        package_id: o.id(),
-                        move_package: p.clone(),
+            .flat_map(|data| {
+                let checkpoint_sequence_number = data.checkpoint_summary.sequence_number;
+                data.output_objects()
+                    .iter()
+                    .filter_map(|o| {
+                        if let sui_types::object::Data::Package(p) = &o.data {
+                            Some(IndexedPackage {
+                                package_id: o.id(),
+                                move_package: p.clone(),
+                                checkpoint_sequence_number,
+                            })
+                        } else {
+                            None
+                        }
                     })
-                } else {
-                    None
-                }
+                    .collect::<Vec<_>>()
             })
             .collect()
     }

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -88,11 +88,7 @@ impl IndexingPackageCache {
         }
     }
 
-    pub fn insert_packages(
-        &mut self,
-        new_packages: &[IndexedPackage],
-        checkpoint_seq: CheckpointSequenceNumber,
-    ) {
+    pub fn insert_packages(&mut self, new_packages: &[IndexedPackage]) {
         let new_packages = new_packages
             .iter()
             .flat_map(|p| {
@@ -103,7 +99,7 @@ impl IndexingPackageCache {
                         let module = CompiledModule::deserialize_with_defaults(bytes).unwrap();
                         (
                             (p.package_id, module_name.clone()),
-                            (Arc::new(module), checkpoint_seq),
+                            (Arc::new(module), p.checkpoint_sequence_number),
                         )
                     })
             })

--- a/crates/sui-indexer/src/store/module_resolver_v2.rs
+++ b/crates/sui-indexer/src/store/module_resolver_v2.rs
@@ -14,7 +14,6 @@ use move_core_types::language_storage::ModuleId;
 use move_core_types::resolver::ModuleResolver;
 use std::sync::{Arc, Mutex};
 use sui_types::base_types::ObjectID;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::MovePackage;
 
 use crate::errors::{Context, IndexerError};
@@ -28,7 +27,6 @@ pub struct IndexerStoreModuleResolver {
 }
 
 impl IndexerStoreModuleResolver {
-    // TODO remove this after integration is done
     #[allow(dead_code)]
     pub fn new(cp: PgConnectionPool) -> Self {
         Self { cp }
@@ -75,19 +73,14 @@ pub struct InterimModuleResolver<GM> {
 }
 
 impl<GM> InterimModuleResolver<GM> {
-    // TODO remove this after integration is done
     #[allow(dead_code)]
     pub fn new(
         backup: GM,
         package_cache: Arc<Mutex<IndexingPackageCache>>,
         new_packages: &[IndexedPackage],
-        checkpoint_seq: CheckpointSequenceNumber,
         metrics: IndexerMetrics,
     ) -> Self {
-        package_cache
-            .lock()
-            .unwrap()
-            .insert_packages(new_packages, checkpoint_seq);
+        package_cache.lock().unwrap().insert_packages(new_packages);
         Self {
             backup,
             package_cache,

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -272,6 +272,7 @@ impl IndexedObject {
 pub struct IndexedPackage {
     pub package_id: ObjectID,
     pub move_package: MovePackage,
+    pub checkpoint_sequence_number: u64,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description 

Experiment results show that sometimes indexing could be the bottleneck. This PR changes the Handler's interface, to process `Vec<CheckpointData>` so they can be handled in parallel. Also break down `fn index_checkpoint_epoch` as it's too lengthy.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR changes the Handler's interface, to process Vec<CheckpointData> so they can be handled in parallel. Also break down fn index_checkpoint_epoch as it's too lengthy.


