### PR TITLE
Nit cleanup in bulk object insert

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -247,7 +247,7 @@ impl<'a> TestAuthorityBuilder<'a> {
         if let Some(starting_objects) = self.starting_objects {
             state
                 .database
-                .insert_raw_object_unchecked_for_testing(starting_objects)
+                .insert_objects_unsafe_for_testing_only(starting_objects)
                 .await
                 .unwrap();
         };


### PR DESCRIPTION
## Description 

There is no cfg release. So the current macro guard doesn't actually work, removing it.
Reuse the existing function instead of iterating all objects.
Rename them for better clarity

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
