### PR TITLE
[graphql/rpc] track client ip in logs

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -3,13 +3,13 @@
 
 use async_graphql::{
     extensions::{
-        Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery, NextRequest,
-        NextValidation,
+        Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery,
+        NextPrepareRequest, NextValidation,
     },
     parser::types::{ExecutableDocument, OperationType, Selection},
-    PathSegment, Response, ServerError, ServerResult, ValidationResult, Variables,
+    PathSegment, Request, Response, ServerError, ServerResult, ValidationResult, Variables,
 };
-use std::{fmt::Write, sync::Arc};
+use std::{fmt::Write, net::SocketAddr, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::{error, info};
 use uuid::Uuid;
@@ -41,28 +41,43 @@ pub struct Logger {
 impl ExtensionFactory for Logger {
     fn create(&self) -> Arc<dyn Extension> {
         Arc::new(LoggerExtension {
-            session_id: None.into(),
+            session_id: "".to_string().into(),
             config: self.config.clone(),
         })
     }
 }
 
 struct LoggerExtension {
-    session_id: Mutex<Option<Uuid>>,
+    session_id: Mutex<String>,
     config: LoggerConfig,
 }
 
 impl LoggerExtension {
-    async fn session_id(&self) -> Option<Uuid> {
-        *self.session_id.lock().await
+    async fn set_session_id(&self, ip: Option<SocketAddr>) {
+        let ip_component = ip
+            .map(|ip| format!("{}-", ip))
+            .unwrap_or_else(|| "".to_string());
+        let uuid_component = format!("{}", Uuid::new_v4());
+        *self.session_id.lock().await = format!("{}{}", ip_component, uuid_component);
+    }
+
+    async fn session_id(&self) -> String {
+        self.session_id.lock().await.clone()
     }
 }
 
 #[async_trait::async_trait]
 impl Extension for LoggerExtension {
-    async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
-        *self.session_id.lock().await = Some(Uuid::new_v4());
-        next.run(ctx).await
+    /// Called at prepare request.
+    async fn prepare_request(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        request: Request,
+        next: NextPrepareRequest<'_>,
+    ) -> ServerResult<Request> {
+        self.set_session_id(ctx.data_opt::<SocketAddr>().copied())
+            .await;
+        next.run(ctx, request).await
     }
 
     async fn parse_query(
@@ -81,7 +96,7 @@ impl Extension for LoggerExtension {
         if !is_schema && self.config.log_request_query {
             info!(
                 target: "async-graphql",
-                "[Query] {}: {}", self.session_id().await.unwrap(), ctx.stringify_execute_doc(&document, variables)
+                "[Query] {}: {}", self.session_id().await, ctx.stringify_execute_doc(&document, variables)
             );
         }
         Ok(document)
@@ -98,7 +113,7 @@ impl Extension for LoggerExtension {
                 target: "async-graphql",
                 complexity = res.complexity,
                 depth = res.depth,
-                "[Validation] {}", self.session_id().await.unwrap());
+                "[Validation] {}", self.session_id().await);
         }
         Ok(res)
     }
@@ -142,7 +157,7 @@ impl Extension for LoggerExtension {
         } else if self.config.log_response {
             info!(
                 target: "async-graphql",
-                "[Response] {}: {}", self.session_id().await.unwrap(), resp.data
+                "[Response] {}: {}", self.session_id().await, resp.data
             );
         }
         resp


### PR DESCRIPTION
## Description 

Tracking client ip to help filter logs

Example output

```
2023-09-28T18:37:19.109195Z  INFO async-graphql: [Query] 127.0.0.1:50768-4294ede2-2e0c-4e71-aa26-3187eddad366: query { chainIdentifier object(address: "0x000000000000000000000000000000000000000000000000000000000000002") { location kind owner { location asObject { digest } } } }
```
## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
