### PR TITLE
Clean up some AuthorityServer functions

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -131,6 +131,7 @@ use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::checkpoints::checkpoint_executor::CheckpointExecutor;
 use crate::checkpoints::CheckpointStore;
+use crate::consensus_adapter::ConsensusAdapter;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
 use crate::module_cache_metrics::ResolverMetrics;
@@ -757,6 +758,16 @@ impl AuthorityState {
                     .1,
             }),
         }
+    }
+
+    pub(crate) fn check_system_overload(
+        &self,
+        consensus_adapter: &Arc<ConsensusAdapter>,
+        tx_data: &SenderSignedData,
+    ) -> SuiResult {
+        self.transaction_manager.check_execution_overload(tx_data)?;
+        consensus_adapter.check_consensus_overload()?;
+        Ok(())
     }
 
     /// Executes a transaction that's known to have correct effects.

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -48,6 +48,7 @@ use mysten_metrics::{spawn_monitored_task, GaugeGuard, GaugeGuardFutureExt};
 use sui_simulator::anemo::PeerId;
 use sui_simulator::narwhal_network::connectivity::ConnectionStatus;
 use sui_types::base_types::AuthorityName;
+use sui_types::fp_ensure;
 use sui_types::messages_consensus::ConsensusTransaction;
 use sui_types::messages_consensus::ConsensusTransactionKind;
 use tokio::time::Duration;
@@ -424,7 +425,7 @@ impl ConsensusAdapter {
         committee: &Committee,
         tx_digest: &TransactionDigest,
     ) -> (Duration, usize, usize, usize) {
-        let (mut position, positions_moved, preceding_disconected) =
+        let (mut position, positions_moved, preceding_disconnected) =
             self.submission_position(committee, tx_digest);
 
         const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
@@ -450,7 +451,7 @@ impl ConsensusAdapter {
             delay_step * position as u32,
             position,
             positions_moved,
-            preceding_disconected,
+            preceding_disconnected,
         )
     }
 
@@ -565,6 +566,14 @@ impl ConsensusAdapter {
         }
         // Then check if submit_semaphore has permits
         self.submit_semaphore.available_permits() > 0
+    }
+
+    pub(crate) fn check_consensus_overload(&self) -> SuiResult {
+        fp_ensure!(
+            self.check_limits(),
+            SuiError::TooManyTransactionsPendingConsensus
+        );
+        Ok(())
     }
 
     fn submit_unchecked(

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -6,10 +6,10 @@ use crate::authority::{AuthorityState, EffectsNotifyRead};
 use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
 };
-use crate::authority_server::{ValidatorService, MAX_PER_OBJECT_QUEUE_LENGTH};
 use crate::safe_client::SafeClient;
 use crate::test_authority_clients::LocalAuthorityClient;
 use crate::test_utils::{init_local_authorities, make_transfer_object_move_transaction};
+use crate::transaction_manager::MAX_PER_OBJECT_QUEUE_LENGTH;
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -557,7 +557,9 @@ async fn test_per_object_overload() {
             shared_counter_initial_version,
         )
         .build_and_sign(&key);
-    let res = ValidatorService::check_execution_overload(authorities[3].clone(), shared_txn.data());
+    let res = authorities[3]
+        .transaction_manager()
+        .check_execution_overload(shared_txn.data());
     let message = format!("{res:?}");
     assert!(
         message.contains("TooManyTransactionsPendingOnObject"),


### PR DESCRIPTION
## Description 

A function that operates on the first parameter as the primary entity is best defined inside that type.
This PR makes the following refactorings:
1. Move "handle_certificate" into AuthorityState, because it really belongs there.
2. Move the execution overload check into TransactionManager as it depends on its internal state.
3. Move the consensus overload check into ConsensusHandler.

Also cleaned up some strange Arc clones.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
