### PR TITLE
[indexer] indexer api Part I

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http",
- "indexmap 2.0.1",
+ "indexmap 2.0.0",
  "lru 0.7.8",
  "mime",
  "multer",
@@ -725,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d74240f9daa8c1e8f73e9cfcc338d20a88d00bbeb83ded49ce8e5b4dcec0f5"
 dependencies = [
  "bytes",
- "indexmap 2.0.1",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
 ]
@@ -4551,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
@@ -13824,7 +13824,7 @@ dependencies = [
  "include_dir_macros",
  "indenter",
  "indexmap 1.9.3",
- "indexmap 2.0.1",
+ "indexmap 2.0.0",
  "indicatif",
  "inout",
  "inquire",

--- a/crates/sui-indexer/src/apis/mod.rs
+++ b/crates/sui-indexer/src/apis/mod.rs
@@ -5,6 +5,7 @@ pub(crate) use coin_api::CoinReadApi;
 pub(crate) use extended_api::ExtendedApi;
 pub(crate) use governance_api::GovernanceReadApi;
 pub(crate) use indexer_api::IndexerApi;
+pub(crate) use indexer_api_v2::IndexerApiV2;
 pub(crate) use move_utils::MoveUtilsApi;
 pub(crate) use read_api::ReadApi;
 pub(crate) use transaction_builder_api::TransactionBuilderApi;

--- a/crates/sui-indexer/src/apis/move_utils_v2.rs
+++ b/crates/sui-indexer/src/apis/move_utils_v2.rs
@@ -42,7 +42,7 @@ impl MoveUtilsServer for MoveUtilsApi {
     ) -> RpcResult<BTreeMap<String, SuiMoveNormalizedModule>> {
         let package = self
             .inner
-            .get_package_async(package_id)
+            .get_package_in_blocking_task(package_id)
             .await
             .map_err(|e| SuiRpcInputError::GenericNotFound(e.to_string()))?
             .ok_or_else(|| {

--- a/crates/sui-indexer/src/apis/read_api_v2.rs
+++ b/crates/sui-indexer/src/apis/read_api_v2.rs
@@ -117,7 +117,7 @@ impl ReadApiServer for ReadApiV2 {
         let options = options.unwrap_or_default();
         let txns = self
             .inner
-            .multi_get_transaction_block_response_async(digests, options)
+            .multi_get_transaction_block_response_in_blocking_task(digests, options)
             .await?;
 
         Ok(txns)
@@ -195,7 +195,7 @@ impl ReadApiServer for ReadApiV2 {
 
     async fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
         self.inner
-            .get_transaction_events_async(transaction_digest)
+            .get_transaction_events_in_blocking_task(transaction_digest)
             .await
             .map_err(Into::into)
     }

--- a/crates/sui-indexer/src/indexer_v2.rs
+++ b/crates/sui-indexer/src/indexer_v2.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::apis::IndexerApiV2;
 use crate::errors::IndexerError;
+use crate::indexer_reader::IndexerReader;
 use crate::metrics::IndexerMetrics;
 use crate::IndexerConfig;
 use anyhow::Result;
@@ -23,38 +25,16 @@ pub struct IndexerV2;
 const DOWNLOAD_QUEUE_SIZE: usize = 1000;
 
 impl IndexerV2 {
-    pub async fn start<S: IndexerStoreV2 + Sync + Send + Clone + 'static>(
+    pub async fn start_writer<S: IndexerStoreV2 + Sync + Send + Clone + 'static>(
         config: &IndexerConfig,
-        registry: &Registry,
         store: S,
         metrics: IndexerMetrics,
     ) -> Result<(), IndexerError> {
         info!(
-            "Sui indexer of version {:?} started...",
+            "Sui indexerV2 Writer (version {:?}) started...",
             env!("CARGO_PKG_VERSION")
         );
-        mysten_metrics::init_metrics(registry);
 
-        // For testing purposes, for the time being we allow an indexer to be a
-        // reader and writer at the same time
-        let _handle = if config.rpc_server_worker {
-            info!("Starting indexer reader");
-            let handle = build_json_rpc_server(registry, store.clone(), config, None)
-                .await
-                .expect("Json rpc server should not run into errors upon start.");
-            Some(tokio::spawn(async move { handle.stopped().await }))
-        } else {
-            None
-        };
-
-        if !config.fullnode_sync_worker {
-            if let Some(handle) = _handle {
-                handle.await.expect("Rpc server task failed");
-            }
-            return Ok(());
-        }
-
-        info!("Starting fullnode sync worker");
         // None will be returned when checkpoints table is empty.
         let last_seq_from_db = store
             .get_latest_tx_checkpoint_sequence_number()
@@ -90,17 +70,39 @@ impl IndexerV2 {
 
         Ok(())
     }
+
+    pub async fn start_reader(
+        config: &IndexerConfig,
+        registry: &Registry,
+        db_url: String,
+    ) -> Result<(), IndexerError> {
+        info!(
+            "Sui indexerV2 Reader (version {:?}) started...",
+            env!("CARGO_PKG_VERSION")
+        );
+        let indexer_reader = IndexerReader::new(db_url)?;
+        let handle = build_json_rpc_server(registry, indexer_reader, config, None)
+            .await
+            .expect("Json rpc server should not run into errors upon start.");
+        tokio::spawn(async move { handle.stopped().await })
+            .await
+            .expect("Rpc server task failed");
+
+        Ok(())
+    }
 }
 
-pub async fn build_json_rpc_server<S: IndexerStoreV2 + Sync + Send + 'static + Clone>(
+pub async fn build_json_rpc_server(
     prometheus_registry: &Registry,
-    _state: S,
+    reader: IndexerReader,
     config: &IndexerConfig,
     custom_runtime: Option<Handle>,
 ) -> Result<ServerHandle, IndexerError> {
-    let builder = JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry);
+    let mut builder = JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), prometheus_registry);
 
     // TODO: Register modules here
+
+    builder.register_module(IndexerApiV2::new(reader.clone()))?;
     // builder.register_module()...
 
     let default_socket_addr: SocketAddr = SocketAddr::new(

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -189,7 +189,6 @@ impl Indexer {
             "Sui indexer of version {:?} started...",
             env!("CARGO_PKG_VERSION")
         );
-        mysten_metrics::init_metrics(registry);
 
         if config.rpc_server_worker {
             info!("Starting indexer with only RPC server");

--- a/crates/sui-indexer/src/models_v2/tx_indices.rs
+++ b/crates/sui-indexer/src/models_v2/tx_indices.rs
@@ -4,6 +4,12 @@
 use crate::{schema_v2::tx_indices, types_v2::TxIndex};
 use diesel::prelude::*;
 
+#[derive(QueryableByName)]
+pub struct TxDigest {
+    #[diesel(sql_type = diesel::sql_types::Bytea)]
+    pub transaction_digest: Vec<u8>,
+}
+
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
 #[diesel(table_name = tx_indices)]
 pub struct StoredTxIndex {

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -45,3 +45,13 @@ pub struct Page<T, C> {
     pub next_cursor: Option<C>,
     pub has_next_page: bool,
 }
+
+impl<T, C> Page<T, C> {
+    pub fn empty() -> Self {
+        Self {
+            data: vec![],
+            next_cursor: None,
+            has_next_page: false,
+        }
+    }
+}


### PR DESCRIPTION
## Description 

(note: will merge this thing with `IndexerReader`)

1. separate the indexer writer & reader such that reader takes `PgIndexerStoreV2` instead of a trait
2. implement a few indexer api, including `query_transaction_blocks`, `get_dynamic_fields`, `get_owned_object` (does not support filter yet).

## Test Plan 

Tested locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
implement a few indexer api and separate the indexer writer & reader