### PR TITLE
[dapp-kit] require sui:signTransactionBlock by default so only Sui-specific wallets show

### DIFF
--- a/.changeset/nice-dragons-warn.md
+++ b/.changeset/nice-dragons-warn.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Require wallets to have some default characteristics in order to be recognized

--- a/sdk/dapp-kit/src/components/WalletProvider.tsx
+++ b/sdk/dapp-kit/src/components/WalletProvider.tsx
@@ -37,11 +37,16 @@ type WalletProviderProps = {
 };
 
 const SUI_WALLET_NAME = 'Sui Wallet';
+
 const DEFUALT_STORAGE_KEY = 'sui-dapp-kit:wallet-connection-info';
+
+const DEFAULT_REQUIRED_FEATURES: (keyof WalletWithRequiredFeatures['features'])[] = [
+	'sui:signTransactionBlock',
+];
 
 export function WalletProvider({
 	preferredWallets = [SUI_WALLET_NAME],
-	requiredFeatures = [],
+	requiredFeatures = DEFAULT_REQUIRED_FEATURES,
 	storage = localStorage,
 	storageKey = DEFUALT_STORAGE_KEY,
 	enableUnsafeBurner = false,

--- a/sdk/dapp-kit/test/components/WalletProvider.test.tsx
+++ b/sdk/dapp-kit/test/components/WalletProvider.test.tsx
@@ -12,7 +12,7 @@ import {
 } from 'dapp-kit/src';
 
 import { createMockAccount } from '../mocks/mockAccount.js';
-import { superCoolFeature } from '../mocks/mockFeatures.js';
+import { suiFeatures, superCoolFeature } from '../mocks/mockFeatures.js';
 import { createWalletProviderContextWrapper, registerMockWallet } from '../test-utils.js';
 
 describe('WalletProvider', () => {
@@ -33,9 +33,18 @@ describe('WalletProvider', () => {
 	});
 
 	test('the list of wallets is ordered correctly by preference', () => {
-		const { unregister: unregister1 } = registerMockWallet({ walletName: 'Mock Wallet 1' });
-		const { unregister: unregister2 } = registerMockWallet({ walletName: 'Mock Wallet 2' });
-		const { unregister: unregister3 } = registerMockWallet({ walletName: 'Mock Wallet 3' });
+		const { unregister: unregister1 } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			features: suiFeatures,
+		});
+		const { unregister: unregister2 } = registerMockWallet({
+			walletName: 'Mock Wallet 2',
+			features: suiFeatures,
+		});
+		const { unregister: unregister3 } = registerMockWallet({
+			walletName: 'Mock Wallet 3',
+			features: suiFeatures,
+		});
 
 		const wrapper = createWalletProviderContextWrapper({
 			preferredWallets: ['Mock Wallet 2', 'Mock Wallet 1'],
@@ -63,9 +72,18 @@ describe('WalletProvider', () => {
 	});
 
 	test('unregistered wallets are removed from the list of wallets', async () => {
-		const { unregister: unregister1 } = registerMockWallet({ walletName: 'Mock Wallet 1' });
-		const { unregister: unregister2 } = registerMockWallet({ walletName: 'Mock Wallet 2' });
-		const { unregister: unregister3 } = registerMockWallet({ walletName: 'Mock Wallet 3' });
+		const { unregister: unregister1 } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			features: suiFeatures,
+		});
+		const { unregister: unregister2 } = registerMockWallet({
+			walletName: 'Mock Wallet 2',
+			features: suiFeatures,
+		});
+		const { unregister: unregister3 } = registerMockWallet({
+			walletName: 'Mock Wallet 3',
+			features: suiFeatures,
+		});
 
 		const wrapper = createWalletProviderContextWrapper();
 		const { result } = renderHook(() => useWallets(), { wrapper });
@@ -140,6 +158,7 @@ describe('WalletProvider', () => {
 			const { unregister, mockWallet } = registerMockWallet({
 				walletName: 'Mock Wallet 1',
 				accounts: [createMockAccount(), createMockAccount()],
+				features: suiFeatures,
 			});
 
 			const wrapper = createWalletProviderContextWrapper({


### PR DESCRIPTION
## Description 

As the title says ^

Before:
<img width="762" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/5c648a93-061a-41a0-8f0a-4eb9ef7590c3">

After:
<img width="818" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/95f05c24-dda2-49cb-8641-50f5be2a9ae8">


## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
