### PR TITLE
[sui-benchmark] run multiple traffic profiles on same benchmark

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use sui_core::test_utils::{make_pay_sui_transaction, make_transfer_sui_transaction};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::AccountKeyPair;
-use tracing::{debug, info};
+use tracing::info;
 
 /// Bank is used for generating gas for running the benchmark.
 #[derive(Clone)]
@@ -61,7 +61,7 @@ impl BenchmarkBank {
             )
             .await?;
 
-        debug!("Number of gas requests = {}", chunked_coin_configs.len());
+        info!("Number of gas requests = {}", chunked_coin_configs.len());
         for chunk in chunked_coin_configs {
             let gas_coins = self.pay_sui(chunk, &mut init_coin, gas_price).await?;
             new_gas_coins.extend(gas_coins);

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -965,7 +965,6 @@ async fn run_bench_worker(
     Some(worker)
 }
 
-
 /// Creates a new progress bar based on the provided duration. The method is agnostic to the actual
 /// usage - weather we want to track the overall benchmark duration or an individual benchmark run.
 fn create_progress_bar(duration: Interval) -> ProgressBar {

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -359,7 +359,16 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                     num_no_gas,
                                     num_in_flight,
                                     num_submitted,
-                                    bench_stats: BenchmarkStats {duration:stat_start_time.elapsed(),num_error_txes,num_success_txes,num_success_cmds,latency_ms:HistogramWrapper{histogram:latency_histogram.clone()}, total_gas_used },
+                                    bench_stats: BenchmarkStats {
+                                        duration:stat_start_time.elapsed(),
+                                        num_error_txes,
+                                        num_success_txes,
+                                        num_success_cmds,
+                                        latency_ms:HistogramWrapper{
+                                            histogram:latency_histogram.clone()
+                                        },
+                                        total_gas_used
+                                    },
                                 })
                                 .is_err()
                             {

--- a/crates/sui-benchmark/src/drivers/driver.rs
+++ b/crates/sui-benchmark/src/drivers/driver.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::drivers::Interval;
@@ -9,14 +10,14 @@ use crate::ValidatorProxy;
 use async_trait::async_trait;
 use prometheus::Registry;
 
-use crate::workloads::WorkloadInfo;
+use crate::workloads::{GroupID, WorkloadInfo};
 
 #[async_trait]
 pub trait Driver<T> {
     async fn run(
         &self,
         proxies: Vec<Arc<dyn ValidatorProxy + Send + Sync>>,
-        workloads: Vec<WorkloadInfo>,
+        workloads_by_group_id: BTreeMap<GroupID, Vec<WorkloadInfo>>,
         system_state_observer: Arc<SystemStateObserver>,
         registry: &Registry,
         show_progress: bool,

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use duration_str::parse;
+use std::fmt::Formatter;
 use std::{str::FromStr, time::Duration};
 
 pub mod bench_driver;
@@ -9,7 +10,7 @@ pub mod driver;
 use comfy_table::{Cell, Color, ContentArrangement, Row, Table};
 use hdrhistogram::{serialization::Serializer, Histogram};
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub enum Interval {
     Count(u64),
     Time(tokio::time::Duration),
@@ -30,9 +31,24 @@ impl FromStr for Interval {
         } else if let Ok(d) = parse(s) {
             Ok(Interval::Time(d))
         } else if "unbounded" == s {
-            Ok(Interval::Time(tokio::time::Duration::MAX))
+            Ok(Interval::Time(Duration::MAX))
         } else {
             Err("Required integer number of cycles or time duration".to_string())
+        }
+    }
+}
+
+impl std::fmt::Display for Interval {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Interval::Count(count) => f.write_str(format!("{}", count).as_str()),
+            Interval::Time(d) => {
+                if *d == Duration::MAX {
+                    f.write_str("unbounded")
+                } else {
+                    f.write_str(format!("{}sec", d.as_secs()).as_str())
+                }
+            }
         }
     }
 }

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -60,6 +60,14 @@ pub struct HistogramWrapper {
     histogram: Histogram<u64>,
 }
 
+impl Default for HistogramWrapper {
+    fn default() -> Self {
+        Self {
+            histogram: Histogram::new(0).unwrap(),
+        }
+    }
+}
+
 impl serde::Serialize for HistogramWrapper {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut vec = Vec::new();
@@ -111,7 +119,7 @@ impl StressStats {
 }
 
 /// Stores the final statistics of the test run.
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
 pub struct BenchmarkStats {
     pub duration: Duration,
     /// Number of transactions that ended in an error

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -189,24 +189,3 @@ pub enum RunSpec {
         duration: Vec<Interval>,
     },
 }
-
-/*
-
- 0    1         0   1    0   1   0    1
-100s 40s ---> 100s 40s 100s 40s 100s 40s
-100s 40s unbounded
-
-
-group the workload by the group id and order them in a list
-
-1. first spin up the workers of the groups starting from the lowest to highest 0 -> ...
-
-2. let the workers run until the next worker tasks have finished up (check by time and cancel them? or just wait for all tasks to finish)
-
-3. pick then next workers from next group. Spin them up and let them run. If the interval is "unbounded" then do not attempt ever to terminate them
-
-4. cycle through the workloads
-
-5. listen also to termination signals
-
-*/

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -5,6 +5,7 @@ use super::{
     workload::{Workload, WorkloadBuilder, MAX_GAS_FOR_TESTING},
     WorkloadBuilderInfo, WorkloadParams,
 };
+use crate::drivers::Interval;
 use crate::in_memory_wallet::move_call_pt_impl;
 use crate::in_memory_wallet::InMemoryWallet;
 use crate::system_state_observer::{SystemState, SystemStateObserver};
@@ -405,6 +406,8 @@ impl AdversarialWorkloadBuilder {
         num_workers: u64,
         in_flight_ratio: u64,
         adversarial_payload_cfg: AdversarialPayloadCfg,
+        duration: Interval,
+        group: u32,
     ) -> Option<WorkloadBuilderInfo> {
         let target_qps = (workload_weight * target_qps as f32) as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
@@ -416,6 +419,8 @@ impl AdversarialWorkloadBuilder {
                 target_qps,
                 num_workers,
                 max_ops,
+                duration,
+                group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 AdversarialWorkloadBuilder {

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::drivers::Interval;
 use crate::in_memory_wallet::InMemoryWallet;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
@@ -130,6 +131,8 @@ impl BatchPaymentWorkloadBuilder {
         num_workers: u64,
         in_flight_ratio: u64,
         batch_size: u32,
+        duration: Interval,
+        group: u32,
     ) -> Option<WorkloadBuilderInfo> {
         let target_qps = (workload_weight * target_qps as f32) as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
@@ -141,6 +144,8 @@ impl BatchPaymentWorkloadBuilder {
                 target_qps,
                 num_workers,
                 max_ops,
+                duration,
+                group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 BatchPaymentWorkloadBuilder {

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::{Workload, WorkloadBuilder};
@@ -92,6 +93,8 @@ impl DelegationWorkloadBuilder {
         target_qps: u64,
         num_workers: u64,
         in_flight_ratio: u64,
+        duration: Interval,
+        group: u32,
     ) -> Option<WorkloadBuilderInfo> {
         let target_qps = (workload_weight * target_qps as f32) as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
@@ -103,6 +106,8 @@ impl DelegationWorkloadBuilder {
                 target_qps,
                 num_workers,
                 max_ops,
+                duration,
+                group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 DelegationWorkloadBuilder { count: max_ops },

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -18,9 +18,11 @@ use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
 use workload::*;
 
+pub type GroupID = u32;
+
 #[derive(Debug, Clone)]
 pub struct WorkloadParams {
-    pub group: u32,
+    pub group: GroupID,
     pub target_qps: u64,
     pub num_workers: u64,
     pub max_ops: u64,

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -18,7 +18,7 @@ use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
 use workload::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WorkloadParams {
     pub group: u32,
     pub target_qps: u64,

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -12,6 +12,7 @@ pub mod workload_configuration;
 
 use std::sync::Arc;
 
+use crate::drivers::Interval;
 use crate::workloads::payload::Payload;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
@@ -19,9 +20,11 @@ use workload::*;
 
 #[derive(Debug)]
 pub struct WorkloadParams {
+    pub group: u32,
     pub target_qps: u64,
     pub num_workers: u64,
     pub max_ops: u64,
+    pub duration: Interval,
 }
 
 #[derive(Debug)]

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::util::publish_basics_package;
 use crate::workloads::payload::Payload;
@@ -90,6 +91,8 @@ impl SharedCounterWorkloadBuilder {
         shared_counter_hotness_factor: u32,
         shared_counter_max_tip_amount: u64,
         reference_gas_price: u64,
+        duration: Interval,
+        group: u32,
     ) -> Option<WorkloadBuilderInfo> {
         let target_qps = (workload_weight * target_qps as f32) as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
@@ -101,9 +104,11 @@ impl SharedCounterWorkloadBuilder {
             None
         } else {
             let workload_params = WorkloadParams {
+                group,
                 target_qps,
                 num_workers,
                 max_ops,
+                duration,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 SharedCounterWorkloadBuilder {
@@ -209,6 +214,7 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
                 .await
                 .0,
         );
+        info!("Basics package id {:?}", self.basics_package_id);
         if !self.counters.is_empty() {
             // We already initialized the workload with some counters
             return;

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -8,6 +8,7 @@ use tracing::error;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::drivers::Interval;
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::WorkloadBuilder;
@@ -100,6 +101,8 @@ impl TransferObjectWorkloadBuilder {
         num_workers: u64,
         in_flight_ratio: u64,
         num_transfer_accounts: u64,
+        duration: Interval,
+        group: u32,
     ) -> Option<WorkloadBuilderInfo> {
         let target_qps = (workload_weight * target_qps as f32) as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
@@ -111,6 +114,8 @@ impl TransferObjectWorkloadBuilder {
                 target_qps,
                 num_workers,
                 max_ops,
+                duration,
+                group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 TransferObjectWorkloadBuilder {

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -2,16 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bank::BenchmarkBank;
+use crate::drivers::Interval;
 use crate::options::{Opts, RunSpec};
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::batch_payment::BatchPaymentWorkloadBuilder;
 use crate::workloads::delegation::DelegationWorkloadBuilder;
 use crate::workloads::shared_counter::SharedCounterWorkloadBuilder;
 use crate::workloads::transfer_object::TransferObjectWorkloadBuilder;
-use crate::workloads::WorkloadInfo;
+use crate::workloads::{WorkloadBuilderInfo, WorkloadInfo};
 use anyhow::Result;
 use std::str::FromStr;
 use std::sync::Arc;
+use tracing::info;
 
 use super::adversarial::{AdversarialPayloadCfg, AdversarialWorkloadBuilder};
 
@@ -23,36 +25,65 @@ impl WorkloadConfiguration {
         opts: &Opts,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Result<Vec<WorkloadInfo>> {
+        let mut workload_builders = vec![];
+
+        // Create the workload builders for each Run spec
         match opts.run_spec.clone() {
             RunSpec::Bench {
-                target_qps,
-                num_workers,
-                in_flight_ratio,
+                num_of_benchmarks,
                 shared_counter,
                 transfer_object,
                 delegation,
                 batch_payment,
                 adversarial,
-                adversarial_cfg,
-                batch_payment_size,
                 shared_counter_hotness_factor,
                 shared_counter_max_tip,
-                ..
+                batch_payment_size,
+                adversarial_cfg,
+                target_qps,
+                num_workers,
+                in_flight_ratio,
+                duration,
             } => {
-                Self::build_workloads(
-                    num_workers,
-                    opts.num_transfer_accounts,
-                    shared_counter,
-                    transfer_object,
-                    delegation,
-                    batch_payment,
-                    adversarial,
-                    AdversarialPayloadCfg::from_str(&adversarial_cfg).unwrap(),
-                    batch_payment_size,
-                    shared_counter_hotness_factor,
-                    shared_counter_max_tip,
-                    target_qps,
-                    in_flight_ratio,
+                info!("Number of benchmarks to run: {}", num_of_benchmarks);
+
+                /*
+                // validate durations - should be in ascending order
+                let mut duration_copy = duration.clone();
+                assert_eq!(
+                    duration,
+                    duration_copy.sort(),
+                    "Duration values should be provided in ascending order"
+                );
+
+                 */
+
+                for workload_group in 0..num_of_benchmarks {
+                    let i = workload_group as usize;
+                    let builders = Self::create_workload_builders(
+                        workload_group,
+                        num_workers[i],
+                        opts.num_transfer_accounts,
+                        shared_counter[i],
+                        transfer_object[i],
+                        delegation[i],
+                        batch_payment[i],
+                        adversarial[i],
+                        AdversarialPayloadCfg::from_str(&adversarial_cfg[i]).unwrap(),
+                        batch_payment_size[i],
+                        shared_counter_hotness_factor[i],
+                        shared_counter_max_tip[i],
+                        target_qps[i],
+                        in_flight_ratio[i],
+                        duration[i],
+                        system_state_observer.clone(),
+                    )
+                    .await;
+                    workload_builders.extend(builders);
+                }
+
+                Self::build(
+                    workload_builders,
                     bank,
                     system_state_observer,
                     opts.gas_request_chunk_size,
@@ -62,7 +93,44 @@ impl WorkloadConfiguration {
         }
     }
 
-    pub async fn build_workloads(
+    pub async fn build(
+        workload_builders: Vec<Option<WorkloadBuilderInfo>>,
+        mut bank: BenchmarkBank,
+        system_state_observer: Arc<SystemStateObserver>,
+        gas_request_chunk_size: u64,
+    ) -> Result<Vec<WorkloadInfo>> {
+        // Generate the workloads and init them
+        let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
+        let (workload_params, workload_builders): (Vec<_>, Vec<_>) = workload_builders
+            .into_iter()
+            .flatten()
+            .map(|x| (x.workload_params, x.workload_builder))
+            .unzip();
+        let mut workloads = bank
+            .generate(
+                workload_builders,
+                reference_gas_price,
+                gas_request_chunk_size,
+            )
+            .await?;
+        for workload in workloads.iter_mut() {
+            workload
+                .init(bank.proxy.clone(), system_state_observer.clone())
+                .await;
+        }
+
+        Ok(workloads
+            .into_iter()
+            .zip(workload_params)
+            .map(|(workload, workload_params)| WorkloadInfo {
+                workload_params,
+                workload,
+            })
+            .collect())
+    }
+
+    pub async fn create_workload_builders(
+        workload_group: u32,
         num_workers: u64,
         num_transfer_accounts: u64,
         shared_counter_weight: u32,
@@ -76,10 +144,9 @@ impl WorkloadConfiguration {
         shared_counter_max_tip: u64,
         target_qps: u64,
         in_flight_ratio: u64,
-        mut bank: BenchmarkBank,
+        duration: Interval,
         system_state_observer: Arc<SystemStateObserver>,
-        chunk_size: u64,
-    ) -> Result<Vec<WorkloadInfo>> {
+    ) -> Vec<Option<WorkloadBuilderInfo>> {
         let total_weight = shared_counter_weight
             + transfer_object_weight
             + delegation_weight
@@ -95,6 +162,8 @@ impl WorkloadConfiguration {
             shared_counter_hotness_factor,
             shared_counter_max_tip,
             reference_gas_price,
+            duration,
+            workload_group,
         );
         workload_builders.push(shared_workload);
         let transfer_workload = TransferObjectWorkloadBuilder::from(
@@ -103,6 +172,8 @@ impl WorkloadConfiguration {
             num_workers,
             in_flight_ratio,
             num_transfer_accounts,
+            duration,
+            workload_group,
         );
         workload_builders.push(transfer_workload);
         let delegation_workload = DelegationWorkloadBuilder::from(
@@ -110,6 +181,8 @@ impl WorkloadConfiguration {
             target_qps,
             num_workers,
             in_flight_ratio,
+            duration,
+            workload_group,
         );
         workload_builders.push(delegation_workload);
         let batch_payment_workload = BatchPaymentWorkloadBuilder::from(
@@ -118,6 +191,8 @@ impl WorkloadConfiguration {
             num_workers,
             in_flight_ratio,
             batch_payment_size,
+            duration,
+            workload_group,
         );
         workload_builders.push(batch_payment_workload);
         let adversarial_workload = AdversarialWorkloadBuilder::from(
@@ -126,28 +201,11 @@ impl WorkloadConfiguration {
             num_workers,
             in_flight_ratio,
             adversarial_cfg,
+            duration,
+            workload_group,
         );
         workload_builders.push(adversarial_workload);
-        let (workload_params, workload_builders): (Vec<_>, Vec<_>) = workload_builders
-            .into_iter()
-            .flatten()
-            .map(|x| (x.workload_params, x.workload_builder))
-            .unzip();
-        let mut workloads = bank
-            .generate(workload_builders, reference_gas_price, chunk_size)
-            .await?;
-        for workload in workloads.iter_mut() {
-            workload
-                .init(bank.proxy.clone(), system_state_observer.clone())
-                .await;
-        }
-        Ok(workloads
-            .into_iter()
-            .zip(workload_params)
-            .map(|(workload, workload_params)| WorkloadInfo {
-                workload_params,
-                workload,
-            })
-            .collect())
+
+        workload_builders
     }
 }

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -30,7 +30,7 @@ impl WorkloadConfiguration {
         // Create the workload builders for each Run spec
         match opts.run_spec.clone() {
             RunSpec::Bench {
-                num_of_benchmarks,
+                num_of_benchmark_groups,
                 shared_counter,
                 transfer_object,
                 delegation,
@@ -45,9 +45,14 @@ impl WorkloadConfiguration {
                 in_flight_ratio,
                 duration,
             } => {
-                info!("Number of benchmarks to run: {}", num_of_benchmarks);
+                info!(
+                    "Number of benchmark groups to run: {}",
+                    num_of_benchmark_groups
+                );
 
-                for workload_group in 0..num_of_benchmarks {
+                // Creating the workload builders for each benchmark group. The workloads for each
+                // benchmark group will run in the same time for the same duration.
+                for workload_group in 0..num_of_benchmark_groups {
                     let i = workload_group as usize;
                     let builders = Self::create_workload_builders(
                         workload_group,

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -47,17 +47,6 @@ impl WorkloadConfiguration {
             } => {
                 info!("Number of benchmarks to run: {}", num_of_benchmarks);
 
-                /*
-                // validate durations - should be in ascending order
-                let mut duration_copy = duration.clone();
-                assert_eq!(
-                    duration,
-                    duration_copy.sort(),
-                    "Duration values should be provided in ascending order"
-                );
-
-                 */
-
                 for workload_group in 0..num_of_benchmarks {
                     let i = workload_group as usize;
                     let builders = Self::create_workload_builders(

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -74,7 +74,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_basic() {
-        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+        sui_protocol_config::ProtoqcolConfig::poison_get_for_min_version();
         let test_cluster = build_test_cluster(7, 0).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 15).await;
     }
@@ -492,6 +492,7 @@ mod test {
 
         // Run random payloads at 100% load
         let adversarial_cfg = AdversarialPayloadCfg::from_str("0-1.0").unwrap();
+        let duration = Interval::from_str("unbounded").unwrap();
 
         // TODO: re-enable this when we figure out why it is causing connection errors and making
         // tests run for ever
@@ -499,8 +500,10 @@ mod test {
 
         let shared_counter_hotness_factor = 50;
         let shared_counter_max_tip = 0;
+        let gas_request_chunk_size = 100;
 
-        let workloads = WorkloadConfiguration::build_workloads(
+        let workloads_builders = WorkloadConfiguration::create_workload_builders(
+            0,
             num_workers,
             num_transfer_accounts,
             shared_counter_weight,
@@ -514,9 +517,8 @@ mod test {
             shared_counter_max_tip,
             target_qps,
             in_flight_ratio,
-            bank,
+            duration,
             system_state_observer.clone(),
-            100,
         )
         .await
         .unwrap();

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -74,7 +74,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_basic() {
-        sui_protocol_config::ProtoqcolConfig::poison_get_for_min_version();
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
         let test_cluster = build_test_cluster(7, 0).await;
         test_simulated_load(TestInitData::new(&test_cluster).await, 15).await;
     }
@@ -519,6 +519,14 @@ mod test {
             in_flight_ratio,
             duration,
             system_state_observer.clone(),
+        )
+        .await;
+
+        let workloads = WorkloadConfiguration::build(
+            workloads_builders,
+            bank,
+            system_state_observer.clone(),
+            gas_request_chunk_size,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Description 

Modifying the sui-benchmark suite in order to allow us to run benchmarks with multiple traffic profiles instead of only one constant rate as we currently do. That will allow us to simulate load of variable traffic (and type of txes etc) instead of constant one. To achieve this the `Bench` cli subcommand was extended to provide all the arguments as vectors allowing us to set multiple "benchmark groups" , where the properties of each benchmark group are all the values of the specified vector position. More information about this on the `options.rs` file.

To achieve the above we build workloads for each "benchmark group" and then we initialise all those once. Then a bench workers schedule task has been introduced to coordinate running each benchmark group. Each group is defined to run for a specified `duration`. That allow us to do things like `run with 1K tx/s for 100 seconds, then run with 500 tx/s for 80seconds...` . Similarly we can configure further the groups to run a benchmark like `run with 1K tx/s for 100 seconds with 50% shared & 50% owned transactions , then run with 500 tx/s for 80 seconds with 80% own transactions and 20% adversarial transactions`.

Also, the benchmark groups will run in _a round robin fashion_. For example, if we do configure a benchmark with 3 groups, then after the last group is run, it will go again and start from the beginning - first group. That allow us with minimal configuration (just defining a few groups) to run repetitive traffic patterns and test the system's behaviour. If a group is defined with duration `unbounded` then that will run for the rest of the benchmark (so someone needs to be careful with the setup). From a software perspective the `BenchWorker`s created for each group are re-used during the round robin so no need to do any re-setup while running or spend excessive resources . The only thing that is managed is the tasks that are spawn and complete.

**Backwards compatibility:**  the cli parameter changes are backwards compatible so existing CI jobs won't break. Existing CI jobs will basically run with default settings having only one benchmark group.

## Test Plan 

An example of running a benchmark test that defines 2 benchmark groups where we want to test spiked traffic:
* 1000 tx/sec for 360sec (100% shared objects)
* 2000 tx/sec for 120sec (100% shared objects)

the **bench** sub-command line parameters look like:
```
--num-of-benchmark-groups 2 \
--in-flight-ratio 30,30 \
--num-workers 24,32 \
--target-qps 1000,2000 \
--shared-counter 100,100 \
--transfer-object 0,0 \
--delegation 0,0 \
--shared-counter-hotness-factor 50,50 \
--batch-payment 0,0 \
--batch-payment-size 100,100 \
--adversarial 0,0
--adversarial-cfg 0-1.0,0-1.0 \
--shared-counter-max-tip 0,0 \
--duration 360s,120s
```

as we can see on the above parameters we can configure all the arguments independently for each benchmark group and those will get respected on each run.

on the graph bellow we can see the `input traffic to consensus` is following the benchmark setup alternating between the 2 traffic profiles for the respective defined durations:

<img width="716" alt="Screenshot 2023-10-03 at 00 28 59" src="https://github.com/MystenLabs/sui/assets/17335598/86564a64-deac-4738-83b9-ffc7aeea6075">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
