### PR TITLE
[Wallet]: Add asset pages for DEFI swap

### DIFF
--- a/apps/wallet/src/ui/app/pages/swap/BaseAssets.tsx
+++ b/apps/wallet/src/ui/app/pages/swap/BaseAssets.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useSortedCoinsByCategories } from '_app/hooks/useSortedCoinsByCategories';
+import Loading from '_components/loading';
+import Overlay from '_components/overlay';
+import { filterAndSortTokenBalances } from '_helpers';
+import { useActiveAddress, useCoinsReFetchingConfig } from '_hooks';
+import { TokenRow } from '_pages/home/tokens/TokensDetails';
+import { useSuiClientQuery } from '@mysten/dapp-kit';
+import { useNavigate } from 'react-router-dom';
+
+export function BaseAssets() {
+	const navigate = useNavigate();
+	const selectedAddress = useActiveAddress();
+	const { staleTime, refetchInterval } = useCoinsReFetchingConfig();
+
+	const { data: coins, isLoading } = useSuiClientQuery(
+		'getAllBalances',
+		{ owner: selectedAddress! },
+		{
+			enabled: !!selectedAddress,
+			refetchInterval,
+			staleTime,
+			select: filterAndSortTokenBalances,
+		},
+	);
+
+	const { recognized } = useSortedCoinsByCategories(coins ?? []);
+
+	return (
+		<Overlay showModal title="Select a Coin" closeOverlay={() => navigate(-1)}>
+			<Loading loading={isLoading}>
+				<div className="flex flex-shrink-0 justify-start flex-col w-full">
+					{recognized?.map((coinBalance, index) => {
+						return (
+							<TokenRow
+								borderBottom={index !== recognized.length - 1}
+								key={coinBalance.coinType}
+								as="button"
+								coinBalance={coinBalance}
+								onClick={() => {
+									navigate(
+										`/swap?${new URLSearchParams({ type: coinBalance.coinType }).toString()}`,
+									);
+								}}
+							/>
+						);
+					})}
+				</div>
+			</Loading>
+		</Overlay>
+	);
+}

--- a/apps/wallet/src/ui/app/pages/swap/QuoteAssets.tsx
+++ b/apps/wallet/src/ui/app/pages/swap/QuoteAssets.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { coinsMap } from '_app/hooks/useDeepBook';
+import Overlay from '_components/overlay';
+import { useActiveAddress, useCoinsReFetchingConfig } from '_hooks';
+import { TokenRow } from '_pages/home/tokens/TokensDetails';
+import { useSuiClientQuery } from '@mysten/dapp-kit';
+import { useSearchParams } from 'react-router-dom';
+
+const recognizedCoins = Object.values(coinsMap);
+
+function QuoteAsset({
+	coinType,
+	borderBottom,
+	onClick,
+}: {
+	coinType: string;
+	onClick: (coinType: string) => void;
+	borderBottom?: boolean;
+}) {
+	const accountAddress = useActiveAddress();
+	const [searchParams] = useSearchParams();
+	const activeCoinType = searchParams.get('type');
+
+	const { staleTime, refetchInterval } = useCoinsReFetchingConfig();
+
+	const { data: coinBalance } = useSuiClientQuery(
+		'getBalance',
+		{ coinType: coinType, owner: accountAddress! },
+		{ enabled: !!accountAddress, refetchInterval, staleTime },
+	);
+
+	if (!coinBalance || coinBalance.coinType === activeCoinType) {
+		return null;
+	}
+
+	return (
+		<TokenRow
+			as="button"
+			borderBottom={borderBottom}
+			coinBalance={coinBalance}
+			onClick={() => {
+				onClick(coinType);
+			}}
+		/>
+	);
+}
+
+export function QuoteAssets({
+	setOpen,
+	isOpen,
+	onRowClick,
+}: {
+	setOpen: (isOpen: boolean) => void;
+	isOpen: boolean;
+	onRowClick: (coinType: string) => void;
+}) {
+	return (
+		<Overlay showModal={isOpen} title="Select a Coin" closeOverlay={() => setOpen(false)}>
+			<div className="flex flex-shrink-0 justify-start flex-col w-full">
+				{recognizedCoins.map((coinType, index) => (
+					<QuoteAsset
+						key={coinType}
+						borderBottom={index !== recognizedCoins.length - 1}
+						coinType={coinType}
+						onClick={onRowClick}
+					/>
+				))}
+			</div>
+		</Overlay>
+	);
+}

--- a/apps/wallet/src/ui/app/pages/swap/utils.ts
+++ b/apps/wallet/src/ui/app/pages/swap/utils.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { coinsMap } from '_app/hooks/useDeepBook';
+
+export const DEFAULT_MAX_SLIPPAGE_PERCENTAGE = 0.5;
+export const FEES_PERCENTAGE = 0.03;
+
+export const initialValues = {
+	amount: '',
+	isPayAll: false,
+	quoteAssetType: coinsMap.USDC,
+	allowedMaxSlippagePercentage: DEFAULT_MAX_SLIPPAGE_PERCENTAGE,
+};
+
+export type FormValues = typeof initialValues;

--- a/apps/wallet/src/ui/app/pages/swap/validation.ts
+++ b/apps/wallet/src/ui/app/pages/swap/validation.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createTokenValidation } from '_shared/validation';
+import * as Yup from 'yup';
+
+export function validate(...args: Parameters<typeof createTokenValidation>) {
+	return Yup.object({
+		amount: createTokenValidation(...args),
+	});
+}


### PR DESCRIPTION
## Description 

- Portions of DEFI swap page

<img width="478" alt="Screenshot 2023-10-02 at 3 56 01 PM" src="https://github.com/MystenLabs/sui/assets/127577476/aa8bb1ee-b236-454c-a6be-21c3c0b6e311">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
