### PR TITLE
[Explorer]: add network outage banner for testnet

### DIFF
--- a/apps/explorer/src/components/Layout/PageLayout.tsx
+++ b/apps/explorer/src/components/Layout/PageLayout.tsx
@@ -3,7 +3,7 @@
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import { useAppsBackend, useElementDimensions } from '@mysten/core';
-import { LoadingIndicator } from '@mysten/ui';
+import { LoadingIndicator, Text } from '@mysten/ui';
 import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { type ReactNode, useRef } from 'react';
@@ -13,6 +13,8 @@ import Header from '../header/Header';
 import { useNetworkContext } from '~/context';
 import { Banner } from '~/ui/Banner';
 import { Network } from '~/utils/api/DefaultRpcClient';
+import { Link } from '~/ui/Link';
+import { ArrowUpRight12 } from '@mysten/icons';
 
 export type PageLayoutProps = {
 	gradient?: {
@@ -25,6 +27,30 @@ export type PageLayoutProps = {
 };
 
 const DEFAULT_HEADER_HEIGHT = 68;
+
+const suiVisionTestnetUrl = 'https://testnet.suivision.xyz/';
+const suiScanTestnetUrl = 'https://suiscan.xyz/testnet/home';
+
+function TestnetOutageBanner() {
+	return (
+		<div className="flex flex-wrap gap-4">
+			Sui Explorer&apos;s Testnet backend is undergoing maintenance. The following explorers may
+			provide more accurate data at this time:
+			<div className="flex gap-4">
+				<Link href={suiVisionTestnetUrl} after={<ArrowUpRight12 className="h-3 w-3 text-steel" />}>
+					<Text variant="bodySmall/medium" color="hero-darkest">
+						SuiVision
+					</Text>
+				</Link>
+				<Link href={suiScanTestnetUrl} after={<ArrowUpRight12 className="h-3 w-3 text-steel" />}>
+					<Text variant="bodySmall/medium" color="hero-darkest">
+						SuiScan
+					</Text>
+				</Link>
+			</div>
+		</div>
+	);
+}
 
 export function PageLayout({ gradient, content, loading, isError }: PageLayoutProps) {
 	const [network] = useNetworkContext();
@@ -49,9 +75,11 @@ export function PageLayout({ gradient, content, loading, isError }: PageLayoutPr
 	const [headerHeight] = useElementDimensions(headerRef, DEFAULT_HEADER_HEIGHT);
 
 	const networkDegradeBannerCopy =
-		network === Network.TESTNET
-			? 'Sui Explorer (Testnet) is currently under-going maintenance. Some data may be incorrect or missing.'
-			: "The explorer is running slower than usual. We're working to fix the issue and appreciate your patience.";
+		network === Network.TESTNET ? (
+			<TestnetOutageBanner />
+		) : (
+			"The explorer is running slower than usual. We're working to fix the issue and appreciate your patience."
+		);
 
 	return (
 		<div className="relative min-h-screen w-full">

--- a/apps/explorer/src/components/Layout/PageLayout.tsx
+++ b/apps/explorer/src/components/Layout/PageLayout.tsx
@@ -36,7 +36,7 @@ function TestnetOutageBanner() {
 		<div className="flex flex-wrap gap-4">
 			Sui Explorer&apos;s Testnet backend is undergoing maintenance. The following explorers may
 			provide more accurate data at this time:
-			<div className="flex gap-4">
+			<div className="flex gap-4 max-md:py-3">
 				<Link href={suiVisionTestnetUrl} after={<ArrowUpRight12 className="h-3 w-3 text-steel" />}>
 					<Text variant="bodySmall/medium" color="hero-darkest">
 						SuiVision


### PR DESCRIPTION
## Description 

https://mysten.atlassian.net/browse/APPS-1752

<img width="421" alt="Screenshot 2023-10-02 at 4 29 15 PM" src="https://github.com/MystenLabs/sui/assets/127577476/8bbae441-f45b-4d7e-b2c5-c575e76509ed">
<img width="1186" alt="Screenshot 2023-10-02 at 4 29 08 PM" src="https://github.com/MystenLabs/sui/assets/127577476/d36d80e4-fce2-45d7-b180-0d9385c6b63f">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
