### PR TITLE
move: create Arc app state for source service

### DIFF
--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::info;
 
 use clap::Parser;
@@ -25,7 +26,6 @@ pub async fn main() -> anyhow::Result<()> {
     let sources = initialize(&package_config, tmp_dir.path()).await?;
     info!("verification complete in {:?}", start.elapsed());
     info!("serving on {}", host_port());
-    serve(AppState { sources })?
-        .await
-        .map_err(anyhow::Error::from)
+    let app_state = Arc::new(AppState { sources });
+    serve(app_state)?.await.map_err(anyhow::Error::from)
 }

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -1,15 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
 use std::sync::Arc;
+use std::{path::PathBuf, sync::RwLock};
 use tracing::info;
 
 use clap::Parser;
 
 use telemetry_subscribers::TelemetryConfig;
 
-use sui_source_validation_service::{host_port, initialize, parse_config, serve, AppState};
+use sui_source_validation_service::{
+    host_port, initialize, parse_config, serve, watch_for_upgrades, AppState,
+};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -26,6 +28,8 @@ pub async fn main() -> anyhow::Result<()> {
     let sources = initialize(&package_config, tmp_dir.path()).await?;
     info!("verification complete in {:?}", start.elapsed());
     info!("serving on {}", host_port());
-    let app_state = Arc::new(AppState { sources });
-    serve(app_state)?.await.map_err(anyhow::Error::from)
+    let app_state = Arc::new(RwLock::new(AppState { sources }));
+    let app_state_copy = app_state.clone();
+    tokio::spawn(async move { watch_for_upgrades(&package_config, app_state).await });
+    serve(app_state_copy)?.await.map_err(anyhow::Error::from)
 }

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -86,7 +86,9 @@ async fn test_end_to_end() -> anyhow::Result<()> {
         })],
     };
     // Start watching for upgrades.
-    let t = tokio::spawn(async move { watch_for_upgrades(&config).await });
+    let sources = NetworkLookup::new();
+    let dummy_app_state = Arc::new(RwLock::new(AppState { sources }));
+    let t = tokio::spawn(async move { watch_for_upgrades(&config, dummy_app_state).await });
 
     // Set up to upgrade package.
     let package = effects

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -6,6 +6,7 @@ use reqwest::Client;
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::FileExt;
+use std::sync::{Arc, RwLock};
 use std::{collections::BTreeMap, path::PathBuf};
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
@@ -274,7 +275,8 @@ async fn test_api_route() -> anyhow::Result<()> {
     );
     let mut sources = NetworkLookup::new();
     sources.insert(Network::Localnet, test_lookup);
-    tokio::spawn(serve(AppState { sources }).expect("Cannot start service."));
+    let app_state = Arc::new(RwLock::new(AppState { sources }));
+    tokio::spawn(serve(app_state).expect("Cannot start service."));
 
     let client = Client::new();
 


### PR DESCRIPTION
## Description 

The source service has two long running threads:

- the server thread that serves source when requests come in
- a thread that monitors on-chain transactions for upgrades (`fn watch_for_upgrades`)

The second thread needs access to the server thread state, in order to invalidate (and later update) source code when it observes an on-chain upgrade. This PR simply does the plumbing to share the server state as a mutable reference in `watch_for_upgrades`. The state is not used yet, see follow up PRs for more.

## Test Plan 

N/A no functional changes

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
