### PR TITLE
easy/chore: remove unused unsafe function: `get_or_insert_unsafe`

### DIFF
--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -39,23 +39,6 @@ where
     /// Returns the raw value (serialized bytes) for the given key from the map, if it exists.
     fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    /// Returns the value for the given key from the map, if it exists
-    /// or the given default value if it does not.
-    /// This method is not thread safe
-    fn get_or_insert_unsafe<F: FnOnce() -> V>(
-        &self,
-        key: &K,
-        default: F,
-    ) -> Result<V, Self::Error> {
-        self.get(key).and_then(|optv| match optv {
-            Some(v) => Ok(v),
-            None => {
-                self.insert(key, &default())?;
-                self.get(key).transpose().expect("default just inserted")
-            }
-        })
-    }
-
     /// Inserts the given key-value pair into the map.
     fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error>;
 


### PR DESCRIPTION
## Description 

Closes https://github.com/MystenLabs/sui/issues/6010 which is also unused and potentially unsafe.

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
