### PR TITLE
[dapp-kit] only take Sui accounts when connecting to wallets that are multi-chain

### DIFF
--- a/.changeset/three-masks-fry.md
+++ b/.changeset/three-masks-fry.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Exclude non-Sui accounts from the accounts state when someone connects a multi-chain wallet

--- a/sdk/dapp-kit/src/hooks/wallet/useConnectWallet.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useConnectWallet.ts
@@ -41,10 +41,13 @@ export function useConnectWallet({
 		mutationKey: walletMutationKeys.connectWallet(mutationKey),
 		mutationFn: async ({ wallet, accountAddress, ...standardConnectInput }) => {
 			const connectResult = await wallet.features['standard:connect'].connect(standardConnectInput);
-			const selectedAccount = getSelectedAccount(connectResult.accounts, accountAddress);
+			const connectedSuiAccounts = connectResult.accounts.filter((account) =>
+				account.chains.some((chain) => chain.split(':')[0] === 'sui'),
+			);
+			const selectedAccount = getSelectedAccount(connectedSuiAccounts, accountAddress);
 
-			setWalletConnected(wallet, selectedAccount);
-			return connectResult;
+			setWalletConnected(wallet, connectedSuiAccounts, selectedAccount);
+			return { accounts: connectedSuiAccounts };
 		},
 		...mutationOptions,
 	});

--- a/sdk/dapp-kit/src/walletStore.ts
+++ b/sdk/dapp-kit/src/walletStore.ts
@@ -10,6 +10,7 @@ export type WalletActions = {
 	setAccountSwitched: (selectedAccount: WalletAccount) => void;
 	setWalletConnected: (
 		wallet: WalletWithRequiredFeatures,
+		connectedAccounts: readonly WalletAccount[],
 		selectedAccount: WalletAccount | null,
 	) => void;
 	updateWalletAccounts: (accounts: readonly WalletAccount[]) => void;
@@ -49,9 +50,9 @@ export function createWalletStore({ wallets, storage, storageKey }: WalletConfig
 				lastConnectedAccountAddress: null,
 				lastConnectedWalletName: null,
 				connectionStatus: 'disconnected',
-				setWalletConnected(wallet, selectedAccount) {
+				setWalletConnected(wallet, connectedAccounts, selectedAccount) {
 					set(() => ({
-						accounts: wallet.accounts,
+						accounts: connectedAccounts,
 						currentWallet: wallet,
 						currentAccount: selectedAccount,
 						lastConnectedWalletName: wallet.name,


### PR DESCRIPTION
## Description 
This PR resolves https://github.com/MystenLabs/sui/issues/11457 in dapp-kit. To summarize, when you connect a multi-chain wallet we were updating our `accounts` state to include non-Sui accounts. This PR adds some basic filtering so that our UI state excludes non-Sui wallets ⛓️ 

## Test Plan 
- Added a test
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
