### PR TITLE
[graphql] resolvers for Query type

### DIFF
--- a/crates/sui-graphql-rpc/examples/checkpoint/checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint/checkpoint.graphql
@@ -1,0 +1,57 @@
+# Latest checkpoint
+{
+  checkpoint {
+    digest, sequenceNumber, validatorSignature, previousCheckpointDigest, networkTotalTransactions, rollingGasSummary {
+      computationCost
+      storageCost
+      storageRebate
+      nonRefundableStorageFee
+    }, epoch {
+      systemStateVersion
+      referenceGasPrice
+      startTimestamp
+    }, endOfEpoch {
+      nextProtocolVersion
+    }
+  }
+}
+
+# At a particular sequence number
+{
+  checkpoint(id: {
+    sequenceNumber:10
+  }) {
+    digest, sequenceNumber, validatorSignature, previousCheckpointDigest, networkTotalTransactions, rollingGasSummary {
+      computationCost
+      storageCost
+      storageRebate
+      nonRefundableStorageFee
+    }, epoch {
+      systemStateVersion
+      referenceGasPrice
+      startTimestamp
+    }, endOfEpoch {
+      nextProtocolVersion
+    }
+  }
+}
+
+# At a particular digest
+{
+  checkpoint(id: {
+    digest:"GaDeWEfbSQCQ8FBQHUHVdm4KjrnbgMqEZPuhStoq5njU"
+  }) {
+    digest, sequenceNumber, validatorSignature, previousCheckpointDigest, networkTotalTransactions, rollingGasSummary {
+      computationCost
+      storageCost
+      storageRebate
+      nonRefundableStorageFee
+    }, epoch {
+      systemStateVersion
+      referenceGasPrice
+      startTimestamp
+    }, endOfEpoch {
+      nextProtocolVersion
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/checkpoint_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/checkpoint_connection.graphql
@@ -1,0 +1,44 @@
+# Fetch some default amount of checkpoints, ascending
+{
+  checkpointConnection {
+    nodes {
+      digest
+      sequenceNumber
+      validatorSignature
+      previousCheckpointDigest
+      networkTotalTransactions
+      rollingGasSummary {
+        computationCost
+        storageCost
+        storageRebate
+        nonRefundableStorageFee
+      }
+      epoch {
+        systemStateVersion
+        referenceGasPrice
+        startTimestamp
+      }
+      endOfEpoch {
+        nextProtocolVersion
+      }
+    }
+  }
+}
+
+# Fetch first 10 after the cursor - note that cursor will be opaque
+{
+  checkpointConnection(first:10, after:"11") {
+    nodes {
+      digest
+    }
+  }
+}
+
+# Fetch last 20 before the cursor
+{
+  checkpointConnection(first:20, before:"100") {
+    nodes {
+      digest
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/epoch/epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/epoch.graphql
@@ -1,0 +1,13 @@
+# Latest epoch
+{
+  epoch {
+    epochId, referenceGasPrice
+  }
+}
+
+# Data for a particular epoch
+{
+  epoch(id:124) {
+    epochId, referenceGasPrice
+  }
+}

--- a/crates/sui-graphql-rpc/examples/object/object.graphql
+++ b/crates/sui-graphql-rpc/examples/object/object.graphql
@@ -1,0 +1,17 @@
+{
+  object(
+    address: "0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91"
+  ) {
+    location
+    version
+    digest
+    storageRebate
+    owner {
+      defaultNameServiceName
+    }
+    previousTransactionBlock {
+      digest
+    }
+    kind
+  }
+}

--- a/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
@@ -1,0 +1,20 @@
+{
+  objectConnection {
+    nodes {
+      version
+      digest
+      storageRebate
+      previousTransactionBlock {
+        digest, sender {
+          defaultNameServiceName
+        }, gasInput {
+          gasPrice
+          gasBudget
+        }
+      }
+    }
+    pageInfo {
+      endCursor
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
@@ -18,3 +18,8 @@
     }
   }
 }
+
+# Filter on owner
+
+
+# Filter on objectIds

--- a/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
@@ -27,9 +27,7 @@
     edges {
       node {
         storageRebate
-        bcs
         kind
-        defaultNameServiceName
       }
     }
   }
@@ -43,9 +41,7 @@
     edges {
       node {
         storageRebate
-        bcs
         kind
-        defaultNameServiceName
       }
     }
   }

--- a/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
@@ -20,6 +20,33 @@
 }
 
 # Filter on owner
-
+{
+  objectConnection(filter:{
+    owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
+  }) {
+    edges {
+      node {
+        storageRebate
+        bcs
+        kind
+        defaultNameServiceName
+      }
+    }
+  }
+}
 
 # Filter on objectIds
+{
+  objectConnection(filter:{
+    objectIds: ["0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"]
+  }) {
+    edges {
+      node {
+        storageRebate
+        bcs
+        kind
+        defaultNameServiceName
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/owner/owner.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/owner.graphql
@@ -1,0 +1,5 @@
+{
+  owner(address:"0x931f293ce7f65fd5ebe9542653e1fd92fafa03dda563e13b83be35da8a2eecbe"){
+    location
+  }
+}

--- a/crates/sui-graphql-rpc/examples/transaction_block_connection/transaction_block_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_connection/transaction_block_connection.graphql
@@ -1,0 +1,33 @@
+# Fetch some default amount of transactions, ascending
+{
+  transactionBlockConnection {
+    nodes {
+      digest
+      effects {
+        gasEffects {
+          gasObject {
+            version
+            digest
+          }
+          gasSummary {
+            computationCost
+            storageCost
+            storageRebate
+            nonRefundableStorageFee
+          }
+        }
+        errors
+      }
+      sender {
+        location
+      }
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+    pageInfo {
+      endCursor
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/transaction_block_connection/transaction_block_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_connection/transaction_block_connection.graphql
@@ -31,3 +31,216 @@
     }
   }
 }
+
+# Filtering on package
+{
+  transactionBlockConnection(
+    filter: {
+      package: "0x0000000000000000000000000000000000000000000000000000000000000003"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filtering on package and module
+{
+  transactionBlockConnection(
+    filter: {
+      package: "0x0000000000000000000000000000000000000000000000000000000000000003",
+      module:"sui_system"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filtering on package, module and function
+{
+  transactionBlockConnection(
+    filter: {
+      package: "0x0000000000000000000000000000000000000000000000000000000000000003",
+      module:"sui_system",
+      function:"request_withdraw_stake"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on TransactionKind (only SYSTEM_TX or PROGRAMMABLE_TX)
+{
+  transactionBlockConnection(
+    filter: {
+      kind:SYSTEM_TX
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on before_ and after_checkpoint. If both are provided, before must be greater than after
+{
+  transactionBlockConnection(
+    filter: {
+      afterCheckpoint:10,
+      beforeCheckpoint: 20
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on sign or sentAddress
+{
+  transactionBlockConnection(
+    filter: {
+      sentAddress:"0x0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on recvAddress
+{
+  transactionBlockConnection(
+    filter: {
+      recvAddress:"0x0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on paidAddress
+{
+  transactionBlockConnection(
+    filter: {
+      paidAddress:"0x0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on inputObject
+{
+  transactionBlockConnection(
+    filter: {
+      inputObject:"0x0000000000000000000000000000000000000000000000000000000000000006"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on changedObject
+{
+  transactionBlockConnection(
+    filter: {
+      changedObject:"0x0000000000000000000000000000000000000000000000000000000000000006"
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}
+
+# Filter on transactionIds
+{
+  transactionBlockConnection(
+    filter: {
+      transactionIds:["DtQ6v6iJW4wMLgadENPUCEUS5t8AP7qvdG5jX84T1akR"]
+    }
+  ) {
+    nodes {
+      sender {
+        location
+      },
+      gasInput {
+        gasPrice
+        gasBudget
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -399,6 +399,8 @@ type Query {
 	checkpoint(id: CheckpointId): Checkpoint
 	transactionBlock(digest: String!): TransactionBlock
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	protocolConfig(protocolVersion: Int): ProtocolConfigs!
 }
 
@@ -537,13 +539,15 @@ input TransactionBlockFilter {
 	module: String
 	function: String
 	kind: TransactionBlockKindInput
-	checkpoint: Int
+	afterCheckpoint: Int
+	beforeCheckpoint: Int
 	signAddress: SuiAddress
 	sentAddress: SuiAddress
 	recvAddress: SuiAddress
 	paidAddress: SuiAddress
 	inputObject: SuiAddress
 	changedObject: SuiAddress
+	transactionIds: [String!]
 }
 
 enum TransactionBlockKindInput {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -12,12 +12,16 @@ use crate::{
         digest::Digest,
         epoch::Epoch,
         gas::{GasCostSummary, GasInput},
-        object::{Object, ObjectKind},
+        object::{Object, ObjectFilter, ObjectKind},
         sui_address::SuiAddress,
-        transaction_block::{TransactionBlock, TransactionBlockEffects},
+        transaction_block::{TransactionBlock, TransactionBlockEffects, TransactionBlockFilter},
     },
 };
-use diesel::{ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl};
+use async_graphql::connection::{Connection, Edge};
+use diesel::{
+    ExpressionMethods, JoinOnDsl, OptionalExtension, PgArrayExpressionMethods, PgConnection,
+    QueryDsl, RunQueryDsl,
+};
 use std::str::FromStr;
 use sui_indexer::{
     indexer_reader::IndexerReader,
@@ -25,7 +29,7 @@ use sui_indexer::{
         checkpoints::StoredCheckpoint, epoch::StoredEpochInfo, objects::StoredObject,
         transactions::StoredTransaction,
     },
-    schema_v2::{checkpoints, epochs, objects, transactions},
+    schema_v2::{checkpoints, epochs, objects, transactions, tx_indices},
     PgConnectionPoolConfig,
 };
 use sui_json_rpc_types::SuiTransactionBlockEffects;
@@ -80,6 +84,22 @@ impl PgManager {
         .await
     }
 
+    async fn get_obj(
+        &self,
+        address: Vec<u8>,
+        version: Option<i64>,
+    ) -> Result<Option<StoredObject>, Error> {
+        let mut query = objects::dsl::objects.into_boxed();
+        query = query.filter(objects::dsl::object_id.eq(address));
+
+        if let Some(version) = version {
+            query = query.filter(objects::dsl::object_version.eq(version));
+        }
+
+        self.run_query_async(|conn| query.get_result::<StoredObject>(conn).optional())
+            .await
+    }
+
     async fn get_epoch(&self, epoch_id: Option<i64>) -> Result<Option<StoredEpochInfo>, Error> {
         match epoch_id {
             Some(epoch_id) => {
@@ -130,25 +150,222 @@ impl PgManager {
             .await
     }
 
-    async fn get_obj(
+    async fn multi_get_txs(
         &self,
-        address: Vec<u8>,
-        version: Option<i64>,
-    ) -> Result<Option<StoredObject>, Error> {
-        let mut query = objects::dsl::objects.into_boxed();
-        query = query.filter(objects::dsl::object_id.eq(address));
-
-        if let Some(version) = version {
-            query = query.filter(objects::dsl::object_version.eq(version));
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Option<(Vec<StoredTransaction>, bool)>, Error> {
+        let mut query =
+            transactions::dsl::transactions
+                .inner_join(tx_indices::dsl::tx_indices.on(
+                    transactions::dsl::tx_sequence_number.eq(tx_indices::dsl::tx_sequence_number),
+                ))
+                .into_boxed();
+        if let Some(after) = after {
+            let after = self.parse_tx_cursor(&after)?;
+            query = query
+                .filter(transactions::dsl::tx_sequence_number.gt(after))
+                .order(transactions::dsl::tx_sequence_number.asc());
+        } else if let Some(before) = before {
+            let before = self.parse_tx_cursor(&before)?;
+            query = query
+                .filter(transactions::dsl::tx_sequence_number.lt(before))
+                .order(transactions::dsl::tx_sequence_number.desc());
         }
 
-        self.run_query_async(|conn| query.get_result::<StoredObject>(conn).optional())
-            .await
+        if let Some(filter) = filter {
+            // Filters for transaction table
+            if let Some(kind) = filter.kind {
+                query = query.filter(transactions::dsl::transaction_kind.eq(kind as i16));
+            }
+            if let Some(checkpoint) = filter.checkpoint {
+                query = query
+                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
+            }
+
+            // Filters for tx_indices table
+            match (filter.package, filter.module, filter.function) {
+                (Some(p), None, None) => {
+                    query = query.filter(
+                        tx_indices::dsl::packages.contains(vec![Some(p.into_array().to_vec())]),
+                    );
+                }
+                (Some(p), Some(m), None) => {
+                    query = query.filter(
+                        tx_indices::dsl::package_modules
+                            .contains(vec![Some(format!("{}::{}", p, m))]),
+                    );
+                }
+                (Some(p), Some(m), Some(f)) => {
+                    query = query.filter(
+                        tx_indices::dsl::package_module_functions
+                            .contains(vec![Some(format!("{}::{}::{}", p, m, f))]),
+                    );
+                }
+                _ => {}
+            }
+            if let Some(sender) = filter.sent_address {
+                query = query.filter(tx_indices::dsl::senders.contains(vec![sender.into_vec()]));
+            }
+            if let Some(receiver) = filter.recv_address {
+                query =
+                    query.filter(tx_indices::dsl::recipients.contains(vec![receiver.into_vec()]));
+            }
+            // TODO: sign_, paid_address, input_, changed_object
+        };
+
+        let limit = first.or(last).unwrap_or(10) as i64;
+        query = query.limit(limit + 1);
+
+        let result: Option<Vec<StoredTransaction>> = self
+            .run_query_async(|conn| {
+                query
+                    .select(transactions::all_columns)
+                    .load(conn)
+                    .optional()
+            })
+            .await?;
+
+        result
+            .map(|mut stored_txs| {
+                let has_next_page = stored_txs.len() as i64 > limit;
+                if has_next_page {
+                    stored_txs.pop();
+                }
+
+                Ok((stored_txs, has_next_page))
+            })
+            .transpose()
+    }
+
+    async fn multi_get_checkpoints(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Option<(Vec<StoredCheckpoint>, bool)>, Error> {
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+
+        if let Some(after) = after {
+            let after = self.parse_checkpoint_cursor(&after)?;
+            query = query
+                .filter(checkpoints::dsl::sequence_number.gt(after))
+                .order(checkpoints::dsl::sequence_number.asc());
+        } else if let Some(before) = before {
+            let before = self.parse_obj_cursor(&before)?;
+            query = query
+                .filter(checkpoints::dsl::sequence_number.lt(before))
+                .order(checkpoints::dsl::sequence_number.desc());
+        }
+
+        let limit = first.or(last).unwrap_or(10) as i64;
+        query = query.limit(limit + 1);
+
+        let result: Option<Vec<StoredCheckpoint>> = self
+            .run_query_async(|conn| query.load(conn).optional())
+            .await?;
+
+        result
+            .map(|mut stored_checkpoints| {
+                let has_next_page = stored_checkpoints.len() as i64 > limit;
+                if has_next_page {
+                    stored_checkpoints.pop();
+                }
+
+                Ok((stored_checkpoints, has_next_page))
+            })
+            .transpose()
+    }
+
+    async fn multi_get_objs(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Result<Option<(Vec<StoredObject>, bool)>, Error> {
+        let mut query = objects::dsl::objects.into_boxed();
+
+        if let Some(filter) = filter {
+            if let Some(object_ids) = filter.object_ids {
+                query = query.filter(
+                    objects::dsl::object_id.eq_any(
+                        object_ids
+                            .into_iter()
+                            .map(|id| id.into_vec())
+                            .collect::<Vec<_>>(),
+                    ),
+                );
+            }
+
+            if let Some(_object_keys) = filter.object_keys {
+                // TODO: Temporary table? Probably better than a long list of ORs
+            }
+
+            if let Some(owner) = filter.owner {
+                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
+            }
+        }
+
+        if let Some(after) = after {
+            let after = self.parse_obj_cursor(&after)?;
+            query = query
+                .filter(objects::dsl::checkpoint_sequence_number.gt(after))
+                .order(objects::dsl::checkpoint_sequence_number.asc());
+        } else if let Some(before) = before {
+            let before = self.parse_obj_cursor(&before)?;
+            query = query
+                .filter(objects::dsl::checkpoint_sequence_number.lt(before))
+                .order(objects::dsl::checkpoint_sequence_number.desc());
+        }
+
+        let limit = first.or(last).unwrap_or(10) as i64;
+        query = query.limit(limit + 1);
+
+        let result: Option<Vec<StoredObject>> = self
+            .run_query_async(|conn| query.load(conn).optional())
+            .await?;
+        result
+            .map(|mut stored_objs| {
+                let has_next_page = stored_objs.len() as i64 > limit;
+                if has_next_page {
+                    stored_objs.pop();
+                }
+
+                Ok((stored_objs, has_next_page))
+            })
+            .transpose()
     }
 }
 
 /// Implement methods to be used by graphql resolvers
 impl PgManager {
+    pub(crate) fn parse_tx_cursor(&self, cursor: &str) -> Result<i64, Error> {
+        let tx_sequence_number = cursor
+            .parse::<i64>()
+            .map_err(|_| Error::Internal("Invalid transaction cursor".to_string()))?;
+        Ok(tx_sequence_number)
+    }
+
+    pub(crate) fn parse_obj_cursor(&self, cursor: &str) -> Result<i64, Error> {
+        let checkpoint_sequence_number = cursor
+            .parse::<i64>()
+            .map_err(|_| Error::Internal("Invalid object cursor".to_string()))?;
+        Ok(checkpoint_sequence_number)
+    }
+
+    pub(crate) fn parse_checkpoint_cursor(&self, cursor: &str) -> Result<i64, Error> {
+        let sequence_number = cursor
+            .parse::<i64>()
+            .map_err(|_| Error::Internal("Invalid checkpoint cursor".to_string()))?;
+        Ok(sequence_number)
+    }
+
     pub(crate) async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>, Error> {
         let digest = Digest::from_str(digest)?.into_vec();
 
@@ -227,6 +444,35 @@ impl PgManager {
         Ok(ChainIdentifier::from(digest).to_string())
     }
 
+    pub(crate) async fn fetch_txs(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Option<Connection<String, TransactionBlock>>, Error> {
+        let transactions = self
+            .multi_get_txs(first, after, last, before, filter)
+            .await?;
+
+        if let Some((stored_txs, has_next_page)) = transactions {
+            let mut connection = Connection::new(false, has_next_page);
+            connection
+                .edges
+                .extend(stored_txs.into_iter().filter_map(|stored_tx| {
+                    let cursor = stored_tx.tx_sequence_number.to_string();
+                    TransactionBlock::try_from(stored_tx)
+                        .map_err(|e| eprintln!("Error converting transaction: {:?}", e))
+                        .ok()
+                        .map(|tx| Edge::new(cursor, tx))
+                }));
+            Ok(Some(connection))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub(crate) async fn fetch_owner(
         &self,
         address: SuiAddress,
@@ -251,6 +497,67 @@ impl PgManager {
         let stored_obj = self.get_obj(address, version).await?;
 
         stored_obj.map(Object::try_from).transpose()
+    }
+
+    pub(crate) async fn fetch_objs(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Result<Option<Connection<String, Object>>, Error> {
+        let objects = self
+            .multi_get_objs(first, after, last, before, filter)
+            .await?;
+
+        if let Some((stored_objs, has_next_page)) = objects {
+            let mut connection = Connection::new(false, has_next_page);
+            connection
+                .edges
+                .extend(stored_objs.into_iter().filter_map(|stored_obj| {
+                    let cursor = stored_obj.checkpoint_sequence_number.to_string();
+                    Object::try_from(stored_obj)
+                        .map_err(|e| eprintln!("Error converting object: {:?}", e))
+                        .ok()
+                        .map(|obj| Edge::new(cursor, obj))
+                }));
+            Ok(Some(connection))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) async fn fetch_checkpoints(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Option<Connection<String, Checkpoint>>, Error> {
+        let checkpoints = self
+            .multi_get_checkpoints(first, after, last, before)
+            .await?;
+
+        if let Some((stored_checkpoints, has_next_page)) = checkpoints {
+            let mut connection = Connection::new(false, has_next_page);
+            connection
+                .edges
+                .extend(
+                    stored_checkpoints
+                        .into_iter()
+                        .filter_map(|stored_checkpoint| {
+                            let cursor = stored_checkpoint.sequence_number.to_string();
+                            Checkpoint::try_from(stored_checkpoint)
+                                .map_err(|e| eprintln!("Error converting checkpoint: {:?}", e))
+                                .ok()
+                                .map(|checkpoint| Edge::new(cursor, checkpoint))
+                        }),
+                );
+            Ok(Some(connection))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -283,6 +590,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
     type Error = Error;
 
     fn try_from(tx: StoredTransaction) -> Result<Self, Self::Error> {
+        // TODO (wlmyng): Split the below into resolver methods
         let digest = Digest::try_from(tx.transaction_digest.as_slice())?;
 
         let sender_signed_data: SenderSignedData =
@@ -328,6 +636,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
 impl TryFrom<StoredObject> for Object {
     type Error = Error;
 
+    // TODO (wlmyng): Refactor into resolvers once we retire sui-sdk data provider
     fn try_from(o: StoredObject) -> Result<Self, Self::Error> {
         let version = o.object_version as u64;
         let (object_id, _sequence_number, digest) = &o.get_object_ref()?;

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -354,7 +354,9 @@ impl PgManager {
             }
 
             if let Some(owner) = filter.owner {
-                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
+                query = query
+                    .filter(objects::dsl::owner_id.eq(owner.into_vec()))
+                    .filter(objects::dsl::owner_type.between(1, 2));
             }
         }
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -43,6 +43,10 @@ pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerErr
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Requires package and module")]
+    RequiresPackageAndModule,
+    #[error("Requires package")]
+    RequiresPackage,
     #[error("Provide one of digest or sequence_number, not both")]
     InvalidCheckpointQuery,
     #[error("String is not valid base58: {0}")]
@@ -68,7 +72,9 @@ pub enum Error {
 impl ErrorExtensions for Error {
     fn extend(&self) -> async_graphql::Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            Error::InvalidCheckpointQuery
+            Error::RequiresPackageAndModule
+            | Error::RequiresPackage
+            | Error::InvalidCheckpointQuery
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast
             | Error::CursorNoReversePagination

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -5,6 +5,8 @@ use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, ServerError
 use async_graphql_axum::GraphQLResponse;
 use sui_indexer::errors::IndexerError;
 
+use crate::context_data::db_data_provider::DbValidationError;
+
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
 /// `<https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes>`
@@ -43,10 +45,8 @@ pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerErr
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Requires package and module")]
-    RequiresPackageAndModule,
-    #[error("Requires package")]
-    RequiresPackage,
+    #[error(transparent)]
+    DbValidation(#[from] DbValidationError),
     #[error("Provide one of digest or sequence_number, not both")]
     InvalidCheckpointQuery,
     #[error("String is not valid base58: {0}")]
@@ -72,8 +72,7 @@ pub enum Error {
 impl ErrorExtensions for Error {
     fn extend(&self) -> async_graphql::Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            Error::RequiresPackageAndModule
-            | Error::RequiresPackage
+            Error::DbValidation(_)
             | Error::InvalidCheckpointQuery
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -117,15 +117,18 @@ async fn graphiql() -> impl axum::response::IntoResponse {
 mod tests {
     use super::*;
     use crate::{
-        context_data::{data_provider::DataProvider, sui_sdk_data_provider::sui_sdk_client_v0},
+        context_data::{
+            data_provider::DataProvider, db_data_provider::PgManager,
+            sui_sdk_data_provider::sui_sdk_client_v0,
+        },
         extensions::timeout::{Timeout, TimeoutConfig},
     };
     use async_graphql::{
         extensions::{Extension, ExtensionContext, NextExecute},
         Response,
     };
-    use std::sync::Arc;
     use std::time::Duration;
+    use std::{env, sync::Arc};
 
     #[tokio::test]
     async fn test_timeout() {
@@ -157,8 +160,16 @@ mod tests {
         async fn test_timeout(delay: Duration, timeout: Duration) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
+            let db_url = env::var("PG_DB_URL").expect("PG_DB_URL must be set");
+            let pg_conn_pool = PgManager::new(db_url, None)
+                .map_err(|e| {
+                    println!("Failed to create pg connection pool: {}", e);
+                    e
+                })
+                .unwrap();
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(data_provider)
+                .context_data(pg_conn_pool)
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
                 })
@@ -195,8 +206,16 @@ mod tests {
         async fn exec_query_depth_limit(depth: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
+            let db_url = env::var("PG_DB_URL").expect("PG_DB_URL must be set");
+            let pg_conn_pool = PgManager::new(db_url, None)
+                .map_err(|e| {
+                    println!("Failed to create pg connection pool: {}", e);
+                    e
+                })
+                .unwrap();
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(data_provider)
+                .context_data(pg_conn_pool)
                 .max_query_depth(depth)
                 .build_schema();
             schema.execute(query).await
@@ -240,8 +259,16 @@ mod tests {
         async fn exec_query_node_limit(nodes: u32, query: &str) -> Response {
             let sdk = sui_sdk_client_v0("https://fullnode.testnet.sui.io:443/").await;
             let data_provider: Box<dyn DataProvider> = Box::new(sdk);
+            let db_url = env::var("PG_DB_URL").expect("PG_DB_URL must be set");
+            let pg_conn_pool = PgManager::new(db_url, None)
+                .map_err(|e| {
+                    println!("Failed to create pg connection pool: {}", e);
+                    e
+                })
+                .unwrap();
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(data_provider)
+                .context_data(pg_conn_pool)
                 .max_query_nodes(nodes)
                 .build_schema();
             schema.execute(query).await

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -153,14 +153,6 @@ impl Query {
         before: Option<String>,
         filter: Option<TransactionBlockFilter>,
     ) -> Result<Option<Connection<String, TransactionBlock>>> {
-        if let Some(filter) = &filter {
-            validate_package_dependencies(
-                filter.package.as_ref(),
-                filter.module.as_ref(),
-                filter.function.as_ref(),
-            )?;
-        }
-
         ctx.data_unchecked::<PgManager>()
             .fetch_txs(first, after, last, before, filter)
             .await
@@ -176,14 +168,6 @@ impl Query {
         before: Option<String>,
         filter: Option<ObjectFilter>,
     ) -> Result<Option<Connection<String, Object>>> {
-        if let Some(filter) = &filter {
-            validate_package_dependencies(
-                filter.package.as_ref(),
-                filter.module.as_ref(),
-                filter.ty.as_ref(),
-            )?;
-        }
-
         ctx.data_unchecked::<PgManager>()
             .fetch_objs(first, after, last, before, filter)
             .await
@@ -199,19 +183,4 @@ impl Query {
             .fetch_protocol_config(protocol_version)
             .await
     }
-}
-
-pub(crate) fn validate_package_dependencies(
-    package: Option<&SuiAddress>,
-    module: Option<&String>,
-    function: Option<&String>,
-) -> Result<()> {
-    if function.is_some() {
-        if package.is_none() || module.is_none() {
-            return Err(Error::RequiresPackageAndModule.extend());
-        }
-    } else if module.is_some() && package.is_none() {
-        return Err(Error::RequiresPackage.extend());
-    }
-    Ok(())
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -7,11 +7,11 @@ use super::{
     address::Address,
     checkpoint::{Checkpoint, CheckpointId},
     epoch::Epoch,
-    object::Object,
+    object::{Object, ObjectFilter},
     owner::ObjectOwner,
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
-    transaction_block::TransactionBlock,
+    transaction_block::{TransactionBlock, TransactionBlockFilter},
 };
 use crate::{
     config::ServiceConfig,
@@ -138,12 +138,56 @@ impl Query {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Option<Connection<String, Checkpoint>>> {
-        let result = ctx
-            .data_provider()
-            .fetch_checkpoint_connection(first, after, last, before)
-            .await?;
+        ctx.data_unchecked::<PgManager>()
+            .fetch_checkpoints(first, after, last, before)
+            .await
+            .extend()
+    }
 
-        Ok(Some(result))
+    async fn transaction_block_connection(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Option<Connection<String, TransactionBlock>>> {
+        if let Some(filter) = &filter {
+            validate_package_dependencies(
+                filter.package.as_ref(),
+                filter.module.as_ref(),
+                filter.function.as_ref(),
+            )?;
+        }
+
+        ctx.data_unchecked::<PgManager>()
+            .fetch_txs(first, after, last, before, filter)
+            .await
+            .extend()
+    }
+
+    async fn object_connection(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<ObjectFilter>,
+    ) -> Result<Option<Connection<String, Object>>> {
+        if let Some(filter) = &filter {
+            validate_package_dependencies(
+                filter.package.as_ref(),
+                filter.module.as_ref(),
+                filter.ty.as_ref(),
+            )?;
+        }
+
+        ctx.data_unchecked::<PgManager>()
+            .fetch_objs(first, after, last, before, filter)
+            .await
+            .extend()
     }
 
     async fn protocol_config(
@@ -155,4 +199,19 @@ impl Query {
             .fetch_protocol_config(protocol_version)
             .await
     }
+}
+
+pub(crate) fn validate_package_dependencies(
+    package: Option<&SuiAddress>,
+    module: Option<&String>,
+    function: Option<&String>,
+) -> Result<()> {
+    if function.is_some() {
+        if package.is_none() || module.is_none() {
+            return Err(Error::RequiresPackageAndModule.extend());
+        }
+    } else if module.is_some() && package.is_none() {
+        return Err(Error::RequiresPackage.extend());
+    }
+    Ok(())
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -143,7 +143,8 @@ pub(crate) struct TransactionBlockFilter {
     pub function: Option<String>,
 
     pub kind: Option<TransactionBlockKindInput>,
-    pub checkpoint: Option<u64>,
+    pub after_checkpoint: Option<u64>,
+    pub before_checkpoint: Option<u64>,
 
     pub sign_address: Option<SuiAddress>,
     pub sent_address: Option<SuiAddress>,
@@ -152,4 +153,6 @@ pub(crate) struct TransactionBlockFilter {
 
     pub input_object: Option<SuiAddress>,
     pub changed_object: Option<SuiAddress>,
+
+    pub transaction_ids: Option<Vec<String>>,
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -403,6 +403,8 @@ type Query {
 	checkpoint(id: CheckpointId): Checkpoint
 	transactionBlock(digest: String!): TransactionBlock
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	protocolConfig(protocolVersion: Int): ProtocolConfigs!
 }
 
@@ -541,13 +543,15 @@ input TransactionBlockFilter {
 	module: String
 	function: String
 	kind: TransactionBlockKindInput
-	checkpoint: Int
+	afterCheckpoint: Int
+	beforeCheckpoint: Int
 	signAddress: SuiAddress
 	sentAddress: SuiAddress
 	recvAddress: SuiAddress
 	paidAddress: SuiAddress
 	inputObject: SuiAddress
 	changedObject: SuiAddress
+	transactionIds: [String!]
 }
 
 enum TransactionBlockKindInput {


### PR DESCRIPTION
## Description 

Implements postgres resolvers for Query type, except for the following:
1. availableRange - pending impl. on IndexerV2
2. dryRunTransactionBlock
3. coinMetadata -> need to be added to DB
4. resolveNameServiceAddress
5. event_connection -> TODO: need to define typings

transactionBlockConnection
* can support all transactionBlockFilter except the post-MVP ones
objectConnection
* Does not support filtering by package::module::type as the column is missing on object table
* Does not support querying by objectKeys = (objectId, version) either, as we do not have an object history table


## Test Plan 

1. Manual queries, which were then added to the examples dir
2. snapshot tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
