### PR TITLE
[Wallet]: Input with action btn decoupled from formik

### DIFF
--- a/apps/wallet/src/ui/app/shared/InputWithAction.tsx
+++ b/apps/wallet/src/ui/app/shared/InputWithAction.tsx
@@ -5,6 +5,7 @@ import NumberInput from '_components/number-input';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { useField, useFormikContext } from 'formik';
 import type { ComponentProps } from 'react';
+import { forwardRef } from 'react';
 
 import Alert from '../components/alert';
 import { Pill, type PillProps } from './Pill';
@@ -35,6 +36,14 @@ const styles = cva(
 	},
 );
 
+type ActionButtonProps = {
+	actionText: string;
+	onActionClicked?: PillProps['onClick'];
+	actionType?: PillProps['type'];
+	name: string;
+	actionDisabled?: boolean | 'auto';
+};
+
 export type InputWithActionProps = VariantProps<typeof styles> &
 	(
 		| (Omit<ComponentProps<'input'>, 'className' | 'type'> & {
@@ -43,13 +52,8 @@ export type InputWithActionProps = VariantProps<typeof styles> &
 		| (Omit<ComponentProps<typeof NumberInput>, 'form' | 'field' | 'meta'> & {
 				type: 'numberInput';
 		  })
-	) & {
-		actionText: string;
-		onActionClicked?: PillProps['onClick'];
-		actionType?: PillProps['type'];
-		name: string;
-		actionDisabled?: boolean | 'auto';
-	};
+	) &
+	ActionButtonProps;
 
 export function InputWithAction({
 	actionText,
@@ -114,3 +118,58 @@ export function InputWithAction({
 		</>
 	);
 }
+
+type InputWithActionZodFormProps = VariantProps<typeof styles> &
+	(Omit<ComponentProps<'input'>, 'className' | 'type'> & {
+		type?: 'text' | 'number' | 'password' | 'email';
+	}) &
+	ActionButtonProps & {
+		errorString?: string;
+	};
+
+export const InputWithActionButton = forwardRef<HTMLInputElement, InputWithActionZodFormProps>(
+	(
+		{
+			actionText,
+			onActionClicked,
+			actionType = 'submit',
+			type,
+			disabled = false,
+			actionDisabled = false,
+			dark,
+			rounded,
+			errorString,
+			...props
+		},
+		forwardRef,
+	) => {
+		return (
+			<>
+				<div className="flex flex-row flex-nowrap items-center relative">
+					<input
+						{...props}
+						type={type}
+						className={styles({ rounded })}
+						disabled={disabled}
+						ref={forwardRef}
+					/>
+					<div className="flex items-center justify-end absolute right-0 max-w-[20%] mx-3 overflow-hidden">
+						<Pill
+							text={actionText}
+							type={actionType}
+							disabled={disabled}
+							onClick={onActionClicked}
+							dark={dark}
+						/>
+					</div>
+				</div>
+
+				{errorString ? (
+					<div className="mt-3">
+						<Alert>{errorString}</Alert>
+					</div>
+				) : null}
+			</>
+		);
+	},
+);


### PR DESCRIPTION
## Description 

- Decouple Formik from `InputWithActionButton`

![input](https://github.com/MystenLabs/sui/assets/127577476/7316fbb0-2383-464b-8d66-fd0a91ace059)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
