### PR TITLE
Revert "Enable effects v2 in protocol config (#13969)"

### DIFF
--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -13,7 +13,6 @@ use rand::SeedableRng;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
 use std::{fs::File, io::Write};
-use sui_types::effects::{IDOperation, ObjectIn, ObjectOut, TransactionEffects};
 use sui_types::execution_status::{
     CommandArgumentError, ExecutionFailureStatus, ExecutionStatus, PackageUpgradeError,
     TypeArgumentError,
@@ -159,11 +158,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<PackageUpgradeError>(&samples)?;
     tracer.trace_type::<TransactionExpiration>(&samples)?;
     tracer.trace_type::<EndOfEpochTransactionKind>(&samples)?;
-
-    tracer.trace_type::<IDOperation>(&samples)?;
-    tracer.trace_type::<ObjectIn>(&samples)?;
-    tracer.trace_type::<ObjectOut>(&samples)?;
-    tracer.trace_type::<TransactionEffects>(&samples)?;
 
     // uncomment once GenericSignature is added
     tracer.trace_type::<FullCheckpointContents>(&samples)?;

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -418,7 +418,7 @@ async fn test_upgrade_package_incorrect_digest() {
 async fn test_upgrade_package_compatibility_too_permissive() {
     let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-    let effects = runner
+    let TransactionEffects::V1(effects) = runner
         .run({
             let mut builder = ProgrammableTransactionBuilder::new();
             let cap = builder

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -253,14 +253,6 @@ ECMHLiveObjectSetDigest:
   STRUCT:
     - digest:
         TYPENAME: Digest
-EffectsObjectChange:
-  STRUCT:
-    - input_state:
-        TYPENAME: ObjectIn
-    - output_state:
-        TYPENAME: ObjectOut
-    - id_operation:
-        TYPENAME: IDOperation
 EmptySignInfo:
   STRUCT: []
 EndOfEpochData:
@@ -460,14 +452,6 @@ GenesisTransaction:
     - objects:
         SEQ:
           TYPENAME: GenesisObject
-IDOperation:
-  ENUM:
-    0:
-      None: UNIT
-    1:
-      Created: UNIT
-    2:
-      Deleted: UNIT
 Identifier:
   NEWTYPESTRUCT: STR
 Intent:
@@ -653,18 +637,6 @@ ObjectDigest:
 ObjectID:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
-ObjectIn:
-  ENUM:
-    0:
-      NotExist: UNIT
-    1:
-      Exist:
-        NEWTYPE:
-          TUPLE:
-            - TUPLE:
-                - TYPENAME: SequenceNumber
-                - TYPENAME: ObjectDigest
-            - TYPENAME: Owner
 ObjectInfoRequestKind:
   ENUM:
     0:
@@ -673,22 +645,6 @@ ObjectInfoRequestKind:
       PastObjectInfoDebug:
         NEWTYPE:
           TYPENAME: SequenceNumber
-ObjectOut:
-  ENUM:
-    0:
-      NotExist: UNIT
-    1:
-      ObjectWrite:
-        NEWTYPE:
-          TUPLE:
-            - TYPENAME: ObjectDigest
-            - TYPENAME: Owner
-    2:
-      PackageWrite:
-        NEWTYPE:
-          TUPLE:
-            - TYPENAME: SequenceNumber
-            - TYPENAME: ObjectDigest
 Owner:
   ENUM:
     0:
@@ -834,10 +790,6 @@ TransactionEffects:
       V1:
         NEWTYPE:
           TYPENAME: TransactionEffectsV1
-    1:
-      V2:
-        NEWTYPE:
-          TYPENAME: TransactionEffectsV2
 TransactionEffectsDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -916,38 +868,6 @@ TransactionEffectsV1:
     - dependencies:
         SEQ:
           TYPENAME: TransactionDigest
-TransactionEffectsV2:
-  STRUCT:
-    - status:
-        TYPENAME: ExecutionStatus
-    - executed_epoch: U64
-    - gas_used:
-        TYPENAME: GasCostSummary
-    - transaction_digest:
-        TYPENAME: TransactionDigest
-    - gas_object_index:
-        OPTION: U32
-    - events_digest:
-        OPTION:
-          TYPENAME: TransactionEventsDigest
-    - dependencies:
-        SEQ:
-          TYPENAME: TransactionDigest
-    - lamport_version:
-        TYPENAME: SequenceNumber
-    - changed_objects:
-        SEQ:
-          TUPLE:
-            - TYPENAME: ObjectID
-            - TYPENAME: EffectsObjectChange
-    - unchanged_shared_objects:
-        SEQ:
-          TUPLE:
-            - TYPENAME: ObjectID
-            - TYPENAME: UnchangedSharedKind
-    - aux_data_digest:
-        OPTION:
-          TYPENAME: Digest
 TransactionEventsDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -1042,14 +962,6 @@ TypedStoreError:
       MetricsReporting: UNIT
     5:
       RetryableTransactionError: UNIT
-UnchangedSharedKind:
-  ENUM:
-    0:
-      ReadOnlyRoot:
-        NEWTYPE:
-          TUPLE:
-            - TYPENAME: SequenceNumber
-            - TYPENAME: ObjectDigest
 UpgradeInfo:
   STRUCT:
     - upgraded_id:

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -638,43 +638,56 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
     type Error = SuiError;
 
     fn try_from(effect: TransactionEffects) -> Result<Self, Self::Error> {
-        Ok(SuiTransactionBlockEffects::V1(
-            SuiTransactionBlockEffectsV1 {
-                status: effect.status().clone().into(),
-                executed_epoch: effect.executed_epoch(),
-                modified_at_versions: effect
-                    .modified_at_versions()
-                    .into_iter()
-                    .map(|(object_id, sequence_number)| {
-                        SuiTransactionBlockEffectsModifiedAtVersions {
-                            object_id,
-                            sequence_number,
-                        }
-                    })
-                    .collect(),
-                gas_used: effect.gas_cost_summary().clone(),
-                shared_objects: to_sui_object_ref(
-                    effect
-                        .input_shared_objects()
+        let message_version = effect
+            .message_version()
+            .expect("TransactionEffects defines message_version()");
+
+        match message_version {
+            1 => Ok(SuiTransactionBlockEffects::V1(
+                SuiTransactionBlockEffectsV1 {
+                    status: effect.status().clone().into(),
+                    executed_epoch: effect.executed_epoch(),
+                    modified_at_versions: effect
+                        .modified_at_versions()
                         .into_iter()
-                        .map(|(obj_ref, _)| obj_ref)
+                        .map(|(object_id, sequence_number)| {
+                            SuiTransactionBlockEffectsModifiedAtVersions {
+                                object_id,
+                                sequence_number,
+                            }
+                        })
                         .collect(),
-                ),
-                transaction_digest: *effect.transaction_digest(),
-                created: to_owned_ref(effect.created()),
-                mutated: to_owned_ref(effect.mutated().to_vec()),
-                unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
-                deleted: to_sui_object_ref(effect.deleted().to_vec()),
-                unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted().to_vec()),
-                wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
-                gas_object: OwnedObjectRef {
-                    owner: effect.gas_object().1,
-                    reference: effect.gas_object().0.into(),
+                    gas_used: effect.gas_cost_summary().clone(),
+                    shared_objects: to_sui_object_ref(
+                        effect
+                            .input_shared_objects()
+                            .into_iter()
+                            .map(|(obj_ref, _)| obj_ref)
+                            .collect(),
+                    ),
+                    transaction_digest: *effect.transaction_digest(),
+                    created: to_owned_ref(effect.created()),
+                    mutated: to_owned_ref(effect.mutated().to_vec()),
+                    unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
+                    deleted: to_sui_object_ref(effect.deleted().to_vec()),
+                    unwrapped_then_deleted: to_sui_object_ref(
+                        effect.unwrapped_then_deleted().to_vec(),
+                    ),
+                    wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
+                    gas_object: OwnedObjectRef {
+                        owner: effect.gas_object().1,
+                        reference: effect.gas_object().0.into(),
+                    },
+                    events_digest: effect.events_digest().copied(),
+                    dependencies: effect.dependencies().to_vec(),
                 },
-                events_digest: effect.events_digest().copied(),
-                dependencies: effect.dependencies().to_vec(),
-            },
-        ))
+            )),
+
+            _ => Err(SuiError::UnexpectedVersion(format!(
+                "Support for TransactionEffects version {} not implemented",
+                message_version
+            ))),
+        }
     }
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1358,7 +1358,6 @@
                 "disable_invariant_violation_check_in_swap_loc": false,
                 "disallow_adding_abilities_on_upgrade": false,
                 "disallow_change_struct_type_params_on_upgrade": false,
-                "enable_effects_v2": false,
                 "enable_jwk_consensus_updates": false,
                 "end_of_epoch_transaction_supported": false,
                 "loaded_child_object_format": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -292,9 +292,6 @@ struct FeatureFlags {
     // Enable receiving sent objects
     #[serde(skip_serializing_if = "is_false")]
     receive_objects: bool,
-
-    #[serde(skip_serializing_if = "is_false")]
-    enable_effects_v2: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -945,10 +942,6 @@ impl ProtocolConfig {
     pub fn create_authenticator_state_in_genesis(&self) -> bool {
         self.enable_jwk_consensus_updates()
     }
-
-    pub fn enable_effects_v2(&self) -> bool {
-        self.feature_flags.enable_effects_v2
-    }
 }
 
 #[cfg(not(msim))]
@@ -1513,10 +1506,6 @@ impl ProtocolConfig {
                     cfg.check_zklogin_id_cost_base = Some(200);
                     // zklogin::check_zklogin_issuer
                     cfg.check_zklogin_issuer_cost_base = Some(200);
-                    // Only enable effects v2 on devnet.
-                    if chain != Chain::Mainnet && chain != Chain::Testnet {
-                        cfg.feature_flags.enable_effects_v2 = true;
-                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_27.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_27.snap
@@ -35,7 +35,6 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
-  enable_effects_v2: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -8,7 +8,9 @@ use crate::digests::TransactionEventsDigest;
 use crate::effects::{InputSharedObjectKind, TransactionEffectsAPI};
 use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
+use crate::message_envelope::Message;
 use crate::object::Owner;
+use crate::transaction::SenderSignedData;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter, Write};
@@ -91,6 +93,22 @@ impl TransactionEffectsV1 {
             dependencies,
         }
     }
+
+    pub fn new_with_tx_and_gas(tx: &SenderSignedData, gas_object: (ObjectRef, Owner)) -> Self {
+        Self {
+            transaction_digest: tx.digest(),
+            gas_object,
+            ..Default::default()
+        }
+    }
+
+    pub fn new_with_tx_and_status(tx: &SenderSignedData, status: ExecutionStatus) -> Self {
+        Self {
+            transaction_digest: tx.digest(),
+            status,
+            ..Default::default()
+        }
+    }
 }
 
 impl TransactionEffectsAPI for TransactionEffectsV1 {
@@ -102,9 +120,6 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     }
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
         self.modified_at_versions.clone()
-    }
-    fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)> {
-        unimplemented!("Only supposed by v2 and above");
     }
 
     fn input_shared_objects(&self) -> Vec<(ObjectRef, InputSharedObjectKind)> {

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -4,18 +4,16 @@
 use super::object_change::{IDOperation, ObjectIn, ObjectOut};
 use super::EffectsObjectChange;
 use crate::base_types::{
-    EpochId, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
-    VersionDigest,
+    EpochId, ObjectDigest, ObjectRef, SuiAddress, TransactionDigest, VersionDigest,
 };
 use crate::digests::{Digest, TransactionEventsDigest};
 use crate::effects::{InputSharedObjectKind, TransactionEffectsAPI};
 use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
-use crate::message_envelope::Message;
 use crate::object::{Owner, OBJECT_START_VERSION};
-use crate::transaction::SenderSignedData;
+use crate::{ObjectID, SequenceNumber};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
 
@@ -31,8 +29,7 @@ pub struct TransactionEffectsV2 {
     transaction_digest: TransactionDigest,
     /// The updated gas object reference, as an index into the `changed_objects` vector.
     /// Having a dedicated field for convenient access.
-    /// System transaction that don't require gas will leave this as None.
-    gas_object_index: Option<u32>,
+    gas_object_index: u16,
     /// The digest of the events emitted during execution,
     /// can be None if the transaction does not emit any event.
     events_digest: Option<TransactionEventsDigest>,
@@ -67,25 +64,13 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
         self.executed_epoch
     }
 
+    // TODO: Add a new API to return modified object refs.
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
         self.changed_objects
             .iter()
             .filter_map(|(id, change)| {
                 if let ObjectIn::Exist(((version, _digest), _owner)) = &change.input_state {
                     Some((*id, *version))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)> {
-        self.changed_objects
-            .iter()
-            .filter_map(|(id, change)| {
-                if let ObjectIn::Exist(((version, digest), owner)) = &change.input_state {
-                    Some(((*id, *version, *digest), *owner))
                 } else {
                     None
                 }
@@ -235,19 +220,12 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
     }
 
     fn gas_object(&self) -> (ObjectRef, Owner) {
-        if let Some(gas_object_index) = self.gas_object_index {
-            let entry = &self.changed_objects[gas_object_index as usize];
-            match entry.1.output_state {
-                ObjectOut::ObjectWrite((digest, owner)) => {
-                    ((entry.0, self.lamport_version, digest), owner)
-                }
-                _ => panic!("Gas object must be an ObjectWrite in changed_objects"),
+        let entry = &self.changed_objects[self.gas_object_index as usize];
+        match entry.1.output_state {
+            ObjectOut::ObjectWrite((digest, owner)) => {
+                ((entry.0, self.lamport_version, digest), owner)
             }
-        } else {
-            (
-                (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
-                Owner::AddressOwner(SuiAddress::default()),
-            )
+            _ => panic!("Gas object must be an ObjectWrite in changed_objects"),
         }
     }
 
@@ -330,88 +308,11 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
 }
 
 impl TransactionEffectsV2 {
-    pub fn new(
-        status: ExecutionStatus,
-        executed_epoch: EpochId,
-        gas_used: GasCostSummary,
-        shared_objects: Vec<ObjectRef>,
-        transaction_digest: TransactionDigest,
-        lamport_version: SequenceNumber,
-        changed_objects: BTreeMap<ObjectID, EffectsObjectChange>,
-        gas_object: Option<ObjectID>,
-        events_digest: Option<TransactionEventsDigest>,
-        dependencies: Vec<TransactionDigest>,
-    ) -> Self {
-        let unchanged_shared_objects = shared_objects
-            .into_iter()
-            .filter_map(|(id, version, digest)| {
-                if changed_objects.contains_key(&id) {
-                    None
-                } else {
-                    Some((id, UnchangedSharedKind::ReadOnlyRoot((version, digest))))
-                }
-            })
-            .collect();
-        let changed_objects: Vec<_> = changed_objects.into_iter().collect();
-
-        let gas_object_index = gas_object.map(|gas_id| {
-            changed_objects
-                .iter()
-                .position(|(id, _)| id == &gas_id)
-                .unwrap() as u32
-        });
-
-        let result = Self {
-            status,
-            executed_epoch,
-            gas_used,
-            transaction_digest,
-            lamport_version,
-            changed_objects,
-            unchanged_shared_objects,
-            gas_object_index,
-            events_digest,
-            dependencies,
-            aux_data_digest: None,
-        };
-        #[cfg(debug_assertions)]
-        result.check_invariant();
-
-        result
-    }
-
-    pub fn new_with_tx_and_gas(tx: &SenderSignedData, gas_object: (ObjectRef, Owner)) -> Self {
-        Self {
-            transaction_digest: tx.digest(),
-            lamport_version: gas_object.0 .1,
-            changed_objects: vec![(
-                gas_object.0 .0,
-                EffectsObjectChange {
-                    input_state: ObjectIn::Exist((
-                        (SequenceNumber::default(), ObjectDigest::MIN),
-                        gas_object.1,
-                    )),
-                    output_state: ObjectOut::ObjectWrite((gas_object.0 .2, gas_object.1)),
-                    id_operation: IDOperation::None,
-                },
-            )],
-            gas_object_index: Some(0),
-            ..Default::default()
-        }
-    }
-
-    pub fn new_with_tx_and_status(tx: &SenderSignedData, status: ExecutionStatus) -> Self {
-        Self {
-            transaction_digest: tx.digest(),
-            status,
-            ..Default::default()
-        }
-    }
-
+    #[cfg(debug_assertions)]
     /// This function demonstrates what's the invariant of the effects.
     /// It also documents the semantics of different combinations in object changes.
-    #[cfg(debug_assertions)]
-    fn check_invariant(&self) {
+    /// TODO: It will be called in the constructor of `TransactionEffectsV2` in the future.
+    fn _check_invariant(&self) {
         let mut unique_ids = HashSet::new();
         for (id, change) in &self.changed_objects {
             assert!(unique_ids.insert(*id));
@@ -437,9 +338,8 @@ impl TransactionEffectsV2 {
                 (ObjectIn::NotExist, ObjectOut::PackageWrite(_), IDOperation::Created) => {
                     // created Move package or user Move package upgrade.
                 }
-                (ObjectIn::Exist((_, old_owner)), ObjectOut::NotExist, IDOperation::None) => {
+                (ObjectIn::Exist(_), ObjectOut::NotExist, IDOperation::None) => {
                     // wrapped.
-                    assert!(!old_owner.is_shared(), "Cannot wrap shared object");
                 }
                 (ObjectIn::Exist(_), ObjectOut::NotExist, IDOperation::Deleted) => {
                     // deleted.
@@ -476,26 +376,8 @@ impl TransactionEffectsV2 {
     }
 }
 
-impl Default for TransactionEffectsV2 {
-    fn default() -> Self {
-        Self {
-            status: ExecutionStatus::Success,
-            executed_epoch: 0,
-            gas_used: GasCostSummary::default(),
-            transaction_digest: TransactionDigest::default(),
-            lamport_version: SequenceNumber::default(),
-            changed_objects: vec![],
-            unchanged_shared_objects: vec![],
-            gas_object_index: None,
-            events_digest: None,
-            dependencies: vec![],
-            aux_data_digest: None,
-        }
-    }
-}
-
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub(crate) enum UnchangedSharedKind {
+enum UnchangedSharedKind {
     /// Read-only shared objects from the input. We don't really need ObjectDigest
     /// for protocol correctness, but it will make it easier to verify untrusted read.
     ReadOnlyRoot(VersionDigest),

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use self::effects_v2::TransactionEffectsV2;
 use crate::base_types::{random_object_ref, ExecutionDigests, ObjectID, ObjectRef, SequenceNumber};
 use crate::committee::EpochId;
 use crate::crypto::{
     default_hash, AuthoritySignInfo, AuthorityStrongQuorumSignInfo, EmptySignInfo,
 };
-use crate::digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest};
+use crate::digests::{
+    ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
+};
 use crate::error::{SuiError, SuiResult};
 use crate::event::Event;
 use crate::execution_status::ExecutionStatus;
@@ -20,11 +21,13 @@ use crate::storage::WriteKind;
 use crate::transaction::{SenderSignedData, TransactionDataAPI, VersionedProtocolMessage};
 use effects_v1::TransactionEffectsV1;
 use enum_dispatch::enum_dispatch;
-pub use object_change::{EffectsObjectChange, IDOperation, ObjectIn, ObjectOut};
+pub use object_change::EffectsObjectChange;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 use std::collections::BTreeMap;
-use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
+
+use self::object_change::{IDOperation, ObjectIn, ObjectOut};
 
 mod effects_v1;
 mod effects_v2;
@@ -50,35 +53,34 @@ pub const APPROX_SIZE_OF_OWNER: usize = 48;
 /// The response from processing a transaction or a certified transaction
 #[enum_dispatch(TransactionEffectsAPI)]
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
 pub enum TransactionEffects {
     V1(TransactionEffectsV1),
-    V2(TransactionEffectsV2),
 }
 
 impl VersionedProtocolMessage for TransactionEffects {
     fn message_version(&self) -> Option<u64> {
         Some(match self {
             Self::V1(_) => 1,
-            Self::V2(_) => 2,
         })
     }
 
     fn check_version_supported(&self, protocol_config: &ProtocolConfig) -> SuiResult {
-        match self {
-            Self::V1(_) => Ok(()),
-            Self::V2(_) => {
-                if protocol_config.enable_effects_v2() {
-                    Ok(())
-                } else {
-                    Err(SuiError::WrongMessageVersion {
-                        error: format!(
-                            "TransactionEffectsV2 is not supported at protocol {:?}.",
-                            protocol_config.version
-                        ),
-                    })
-                }
-            }
+        let (message_version, supported) = match self {
+            Self::V1(_) => (1, SupportedProtocolVersions::new_for_message(1, u64::MAX)),
+            // Suppose we add V2 at protocol version 7, then we must change this to:
+            // Self::V1 => (1, SupportedProtocolVersions::new_for_message(1, u64::MAX)),
+            // Self::V2 => (2, SupportedProtocolVersions::new_for_message(7, u64::MAX)),
+        };
+
+        if supported.is_version_supported(protocol_config.version) {
+            Ok(())
+        } else {
+            Err(SuiError::WrongMessageVersion {
+                error: format!(
+                    "TransactionEffectsV{} is not supported at {:?}. (Supported range is {:?}",
+                    message_version, protocol_config.version, supported
+                ),
+            })
         }
     }
 }
@@ -154,25 +156,107 @@ impl TransactionEffects {
     /// Creates a TransactionEffects message from the results of execution, choosing the correct
     /// format for the current protocol version.
     pub fn new_from_execution_v2(
+        _protocol_version: ProtocolVersion,
         status: ExecutionStatus,
         executed_epoch: EpochId,
         gas_used: GasCostSummary,
         shared_objects: Vec<ObjectRef>,
         transaction_digest: TransactionDigest,
         lamport_version: SequenceNumber,
-        changed_objects: BTreeMap<ObjectID, EffectsObjectChange>,
-        gas_object: Option<ObjectID>,
+        object_changes: BTreeMap<ObjectID, EffectsObjectChange>,
+        gas_object: (ObjectRef, Owner),
         events_digest: Option<TransactionEventsDigest>,
         dependencies: Vec<TransactionDigest>,
     ) -> Self {
-        Self::V2(TransactionEffectsV2::new(
+        let mut created = vec![];
+        let mut mutated = vec![];
+        let mut unwrapped = vec![];
+        let mut deleted = vec![];
+        let mut unwrapped_then_deleted = vec![];
+        let mut wrapped = vec![];
+        // It is important that we constructs `modified_at_versions` and `deleted_at_versions`
+        // separately, and merge them latter to achieve the exact same order as in v1.
+        let mut modified_at_versions = vec![];
+        let mut deleted_at_versions = vec![];
+        for (id, change) in object_changes {
+            match change.input_state {
+                ObjectIn::Exist(((old_version, _), _)) => {
+                    match (change.output_state, change.id_operation) {
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::None) => {
+                            mutated.push(((id, lamport_version, new_digest), new_owner));
+                            modified_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::PackageWrite((new_version, new_digest)), IDOperation::None) => {
+                            mutated.push(((id, new_version, new_digest), Owner::Immutable));
+                            modified_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Deleted) => {
+                            deleted.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_DELETED,
+                            ));
+                            deleted_at_versions.push((id, old_version));
+                        }
+                        (ObjectOut::NotExist, IDOperation::None) => {
+                            wrapped.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_WRAPPED,
+                            ));
+                            deleted_at_versions.push((id, old_version));
+                        }
+                        _ => {
+                            unreachable!("Impossible combination of output state and id operation");
+                        }
+                    }
+                }
+                ObjectIn::NotExist => {
+                    match (change.output_state, change.id_operation) {
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::Created) => {
+                            created.push(((id, lamport_version, new_digest), new_owner));
+                        }
+                        (
+                            ObjectOut::PackageWrite((new_version, new_digest)),
+                            IDOperation::Created,
+                        ) => {
+                            created.push(((id, new_version, new_digest), Owner::Immutable));
+                        }
+                        (ObjectOut::ObjectWrite((new_digest, new_owner)), IDOperation::None) => {
+                            unwrapped.push(((id, lamport_version, new_digest), new_owner));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Deleted) => {
+                            unwrapped_then_deleted.push((
+                                id,
+                                lamport_version,
+                                ObjectDigest::OBJECT_DIGEST_DELETED,
+                            ));
+                        }
+                        (ObjectOut::NotExist, IDOperation::Created) => {
+                            // Created then wrapped.
+                        }
+                        _ => {
+                            unreachable!("Impossible combination of output state and id operation");
+                        }
+                    }
+                }
+            }
+        }
+        modified_at_versions.extend(deleted_at_versions);
+
+        Self::V1(TransactionEffectsV1::new(
             status,
             executed_epoch,
             gas_used,
+            modified_at_versions,
             shared_objects,
             transaction_digest,
-            lamport_version,
-            changed_objects,
+            created,
+            mutated,
+            unwrapped,
+            deleted,
+            unwrapped_then_deleted,
+            wrapped,
             gas_object,
             events_digest,
             dependencies,
@@ -186,7 +270,7 @@ impl TransactionEffects {
         }
     }
 
-    pub fn estimate_effects_size_upperbound_v1(
+    pub fn estimate_effects_size_upperbound(
         num_writes: usize,
         num_mutables: usize,
         num_deletes: usize,
@@ -204,26 +288,6 @@ impl TransactionEffects {
             + (APPROX_SIZE_OF_OWNER + APPROX_SIZE_OF_OBJECT_REF) * num_writes
             + (APPROX_SIZE_OF_OBJECT_REF * num_mutables)
             + (APPROX_SIZE_OF_OBJECT_REF * num_deletes);
-
-        let deps_size = 1_000 + APPROX_SIZE_OF_TX_DIGEST * num_deps;
-
-        fixed_sizes + approx_change_entry_size + deps_size
-    }
-
-    pub fn estimate_effects_size_upperbound_v2(
-        num_writes: usize,
-        num_modifies: usize,
-        num_deps: usize,
-    ) -> usize {
-        let fixed_sizes = APPROX_SIZE_OF_EXECUTION_STATUS
-            + APPROX_SIZE_OF_EPOCH_ID
-            + APPROX_SIZE_OF_GAS_COST_SUMMARY
-            + APPROX_SIZE_OF_OPT_TX_EVENTS_DIGEST;
-
-        // We store object ref and owner for both old objects and new objects.
-        let approx_change_entry_size = 1_000
-            + (APPROX_SIZE_OF_OWNER + APPROX_SIZE_OF_OBJECT_REF) * num_writes
-            + (APPROX_SIZE_OF_OWNER + APPROX_SIZE_OF_OBJECT_REF) * num_modifies;
 
         let deps_size = 1_000 + APPROX_SIZE_OF_TX_DIGEST * num_deps;
 
@@ -305,11 +369,11 @@ impl TransactionEffects {
     pub fn new_with_tx_and_gas(tx: &SenderSignedData, gas_object: (ObjectRef, Owner)) -> Self {
         // TODO: Figure out who is calling this and why.
         // This creates an inconsistent effects where gas object is not mutated.
-        TransactionEffects::V2(TransactionEffectsV2::new_with_tx_and_gas(tx, gas_object))
+        TransactionEffects::V1(TransactionEffectsV1::new_with_tx_and_gas(tx, gas_object))
     }
 
     pub fn new_with_tx_and_status(tx: &SenderSignedData, status: ExecutionStatus) -> Self {
-        TransactionEffects::V2(TransactionEffectsV2::new_with_tx_and_status(tx, status))
+        TransactionEffects::V1(TransactionEffectsV1::new_with_tx_and_status(tx, status))
     }
 }
 
@@ -324,12 +388,6 @@ pub trait TransactionEffectsAPI {
     fn into_status(self) -> ExecutionStatus;
     fn executed_epoch(&self) -> EpochId;
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)>;
-
-    /// Metadata of objects prior to modification. This includes any object that exists in the
-    /// store prior to this transaction and is modified in this transaction.
-    /// It includes objects that are mutated, wrapped and deleted.
-    /// This API is only available on effects v2 and above.
-    fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)>;
     /// Returns the list of shared objects used in the input, with full object reference
     /// and use kind. This is needed in effects because in transaction we only have object ID
     /// for shared objects. Their version and digest can only be figured out after sequencing.
@@ -342,12 +400,7 @@ pub trait TransactionEffectsAPI {
     fn deleted(&self) -> Vec<ObjectRef>;
     fn unwrapped_then_deleted(&self) -> Vec<ObjectRef>;
     fn wrapped(&self) -> Vec<ObjectRef>;
-
-    // TODO: We should consider having this function to return Option.
-    // When the gas object is not available (i.e. system transaction), we currently return
-    // dummy object ref and owner. This is not ideal.
     fn gas_object(&self) -> (ObjectRef, Owner);
-
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
     fn dependencies(&self) -> &[TransactionDigest];
 

--- a/crates/sui-types/src/effects/object_change.rs
+++ b/crates/sui-types/src/effects/object_change.rs
@@ -55,7 +55,7 @@ impl EffectsObjectChange {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum IDOperation {
+pub(crate) enum IDOperation {
     None,
     Created,
     Deleted,
@@ -65,14 +65,14 @@ pub enum IDOperation {
 /// it should be Exist, otherwise it's NonExist, e.g. wrapped objects should be
 /// NonExist.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum ObjectIn {
+pub(crate) enum ObjectIn {
     NotExist,
     /// The old version, digest and owner.
     Exist((VersionDigest, Owner)),
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum ObjectOut {
+pub(crate) enum ObjectOut {
     /// Same definition as in ObjectIn.
     NotExist,
     /// Any written object, including all of mutated, created, unwrapped today.

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -124,8 +124,7 @@ impl ExecutionResultsV2 {
         prev_tx: TransactionDigest,
     ) {
         for (id, mut obj) in self.written_objects.iter_mut() {
-            // TODO: We can now get rid of the following logic by passing in lamport version
-            // into the execution layer, and create new objects using the lamport version directly.
+            // TODO: All of the following is no longer necessary and can be simplified.
 
             // Update the version for the written object.
             match &mut obj.data {

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -442,7 +442,7 @@ impl<'backing> TemporaryStore<'backing> {
 
     pub fn estimate_effects_size_upperbound(&self) -> usize {
         // In the worst case, the number of deps is equal to the number of input objects
-        TransactionEffects::estimate_effects_size_upperbound_v1(
+        TransactionEffects::estimate_effects_size_upperbound(
             self.written.len(),
             self.mutable_input_refs.len(),
             self.deleted.len(),

--- a/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
@@ -20,7 +20,9 @@ use sui_types::storage::BackingStore;
 use sui_types::sui_system_state::{get_sui_system_state_wrapper, AdvanceEpochParams};
 use sui_types::type_resolver::LayoutResolver;
 use sui_types::{
-    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
+    base_types::{
+        ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
+    },
     effects::EffectsObjectChange,
     error::{ExecutionError, SuiError, SuiResult},
     fp_bail,
@@ -197,14 +199,24 @@ impl<'backing> TemporaryStore<'backing> {
         // we don't really care about the effects to gas, just use the input for it.
         // Gas coins are guaranteed to be at least size 1 and if more than 1
         // the first coin is where all the others are merged.
-        let gas_coin = gas_charger.gas_coin();
+        let updated_gas_object_info = if let Some(coin_id) = gas_charger.gas_coin() {
+            let object = &self.execution_results.written_objects[&coin_id];
+            (object.compute_object_reference(), object.owner)
+        } else {
+            (
+                (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
+                Owner::AddressOwner(SuiAddress::default()),
+            )
+        };
 
         let object_changes = self.get_object_changes();
 
         let lamport_version = self.lamport_timestamp;
+        let protocol_version = self.protocol_config.version;
         let inner = self.into_inner();
 
         let effects = TransactionEffects::new_from_execution_v2(
+            protocol_version,
             status,
             epoch,
             gas_cost_summary,
@@ -216,7 +228,7 @@ impl<'backing> TemporaryStore<'backing> {
             *transaction_digest,
             lamport_version,
             object_changes,
-            gas_coin,
+            updated_gas_object_info,
             if inner.events.data.is_empty() {
                 None
             } else {
@@ -376,7 +388,7 @@ impl<'backing> TemporaryStore<'backing> {
                 })
                 .count();
         // In the worst case, the number of deps is equal to the number of input objects
-        TransactionEffects::estimate_effects_size_upperbound_v1(
+        TransactionEffects::estimate_effects_size_upperbound(
             self.execution_results.written_objects.len(),
             self.mutable_input_refs.len(),
             num_deletes,


### PR DESCRIPTION
This reverts commit 91991daa4d3b0f58449c6ffce3cbb2d4d00007b1.

## Description 

The change was not gated properly. Reverting and redo it.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
