### PR TITLE
Fix `resolveRoyaltyRule` breaking

### DIFF
--- a/.changeset/nice-onions-listen.md
+++ b/.changeset/nice-onions-listen.md
@@ -1,0 +1,5 @@
+---
+'@mysten/kiosk': patch
+---
+
+Fixes resolve royalty rule from breaking.

--- a/sdk/kiosk/src/tx/rules/resolve.ts
+++ b/sdk/kiosk/src/tx/rules/resolve.ts
@@ -17,7 +17,7 @@ export function resolveRoyaltyRule(params: RuleResolvingParams) {
 	const [amount] = txb.moveCall({
 		target: `${packageId}::royalty_rule::fee_amount`,
 		typeArguments: [itemType],
-		arguments: [policyObj, objArg(txb, price ?? '')],
+		arguments: [policyObj, txb.pure.u64(price || '')],
 	});
 
 	// splits the coin.

--- a/sdk/kiosk/src/tx/rules/resolve.ts
+++ b/sdk/kiosk/src/tx/rules/resolve.ts
@@ -17,7 +17,7 @@ export function resolveRoyaltyRule(params: RuleResolvingParams) {
 	const [amount] = txb.moveCall({
 		target: `${packageId}::royalty_rule::fee_amount`,
 		typeArguments: [itemType],
-		arguments: [policyObj, txb.pure.u64(price || '')],
+		arguments: [policyObj, txb.pure.u64(price || '0')],
 	});
 
 	// splits the coin.


### PR DESCRIPTION
## Description 

Fixes `resolveRoyaltyRule` from breaking after 0.43 update.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
