### PR TITLE
changes to the schema to allow a better view over transctions

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/package_handler.rs
@@ -64,7 +64,7 @@ impl PackageHandler {
     fn process_package(&mut self, epoch: u64, checkpoint: u64, timestamp_ms: u64, object: &Object) {
         if let sui_types::object::Data::Package(p) = &object.data {
             let package = MovePackageEntry {
-                object_id: p.id().to_string(),
+                package_id: p.id().to_string(),
                 checkpoint,
                 epoch,
                 timestamp_ms,

--- a/crates/sui-analytics-indexer/src/tables.rs
+++ b/crates/sui-analytics-indexer/src/tables.rs
@@ -48,6 +48,8 @@ pub(crate) struct TransactionEntry {
     // transaction info
     pub(crate) sender: String,
     pub(crate) transaction_kind: String,
+    pub(crate) is_system_txn: bool,
+    pub(crate) is_sponsored_tx: bool,
     pub(crate) transaction_count: u64,
     pub(crate) execution_success: bool,
     // object info
@@ -60,12 +62,20 @@ pub(crate) struct TransactionEntry {
     pub(crate) mutated: u64,
     pub(crate) deleted: u64,
     // PTB info
+    pub(crate) transfers: u64,
+    pub(crate) split_coins: u64,
+    pub(crate) merge_coins: u64,
+    pub(crate) publish: u64,
+    pub(crate) upgrade: u64,
+    // move_vec or default for future commands
+    pub(crate) others: u64,
     pub(crate) move_calls: u64,
     // pub(crate) packages: BTreeSet<String>,
     // commas separated list of packages used by the transaction.
     // Use as a simple way to query for transactions that use a specific package.
     pub(crate) packages: String,
     // gas info
+    pub(crate) gas_owner: String,
     pub(crate) gas_object_id: String,
     pub(crate) gas_object_sequence: u64,
     pub(crate) gas_object_digest: String,
@@ -196,7 +206,8 @@ pub(crate) struct MoveCallEntry {
 // A Move package. Pacakge id and MovePackage object bytes
 #[derive(Serialize, Clone)]
 pub(crate) struct MovePackageEntry {
-    pub(crate) object_id: String,
+    // indexes
+    pub(crate) package_id: String,
     pub(crate) checkpoint: u64,
     pub(crate) epoch: u64,
     pub(crate) timestamp_ms: u64,


### PR DESCRIPTION
## Description 

Knowing the commands in a programmable transaction, or more precisely certain commands can help in grouping and analyzing transactions. 
This change is a very simple way to do it.

## Test Plan 

Simply tested the pipeline on my machine and looked at the generated files

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
