### PR TITLE
[RFC] Add effects auxiliary data

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1053,6 +1053,7 @@ impl AuthorityStore {
             mutable_inputs,
             written,
             events,
+            aux_data,
             max_binary_format_version: _,
             loaded_runtime_objects: _,
             no_extraneous_module_bytes: _,
@@ -1210,6 +1211,13 @@ impl AuthorityStore {
             .map(|(i, e)| ((event_digest, i), e));
 
         write_batch.insert_batch(&self.perpetual_tables.events, events)?;
+
+        if let (Some(aux_data), Some(aux_data_digest)) = (aux_data, effects.aux_data_digest()) {
+            write_batch.insert_batch(
+                &self.perpetual_tables.aux_data,
+                [(aux_data_digest, aux_data)],
+            )?;
+        }
 
         let new_locks_to_init: Vec<_> = written
             .values()

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::SequenceNumber;
-use sui_types::digests::TransactionEventsDigest;
-use sui_types::effects::TransactionEffects;
+use sui_types::digests::{EffectsAuxDataDigest, TransactionEventsDigest};
+use sui_types::effects::{EffectsAuxDataInStorage, TransactionEffects};
 use sui_types::storage::MarkerValue;
 use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::util::{empty_compaction_filter, reference_count_merge_operator};
@@ -91,6 +91,9 @@ pub struct AuthorityPerpetualTables {
     // Also we need a pruning policy for this table. We can prune this table along with tx/effects.
     #[default_options_override_fn = "events_table_default_config"]
     pub(crate) events: DBMap<(TransactionEventsDigest, usize), Event>,
+
+    /// Auxiliary data in transaction effects.
+    pub(crate) aux_data: DBMap<EffectsAuxDataDigest, EffectsAuxDataInStorage>,
 
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
     /// Please do not add new accessors/callsites.

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -89,6 +89,7 @@ const MAX_PROTOCOL_VERSION: u64 = 31;
 //             In execution, has_public_transfer is recomputed when loading the object.
 //             Add support for shared obj deletion and receiving objects off of other objects in devnet only.
 // Version 31: Add support for shared object deletion in devnet only.
+//             Enable auxiliary data for effects v2 (devnet and testnet).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -335,6 +336,9 @@ struct FeatureFlags {
     // If true, recompute has_public_transfer from the type instead of what is stored in the object
     #[serde(skip_serializing_if = "is_false")]
     recompute_has_public_transfer_in_execution: bool,
+
+    #[serde(skip_serializing_if = "is_false")]
+    enable_effects_aux_data: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1032,6 +1036,10 @@ impl ProtocolConfig {
     pub fn throughput_aware_consensus_submission(&self) -> bool {
         self.feature_flags.throughput_aware_consensus_submission
     }
+
+    pub fn enable_effects_aux_data(&self) -> bool {
+        self.feature_flags.enable_effects_aux_data
+    }
 }
 
 #[cfg(not(msim))]
@@ -1640,6 +1648,9 @@ impl ProtocolConfig {
                     // Only enable shared object deletion on devnet
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.shared_object_deletion = true;
+                    }
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.enable_effects_aux_data = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_31.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_31.snap
@@ -34,6 +34,7 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
+  enable_effects_aux_data: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_31.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_31.snap
@@ -38,6 +38,7 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
+  enable_effects_aux_data: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1436,6 +1436,7 @@ mod bcs_signable {
 
     impl BcsSignable for crate::effects::TransactionEffects {}
     impl BcsSignable for crate::effects::TransactionEvents {}
+    impl BcsSignable for crate::effects::EffectsAuxDataInStorage {}
     impl BcsSignable for crate::transaction::TransactionData {}
     impl BcsSignable for crate::transaction::SenderSignedData {}
     impl BcsSignable for crate::object::Object {}

--- a/crates/sui-types/src/effects/effects_aux_data.rs
+++ b/crates/sui-types/src/effects/effects_aux_data.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base_types::ObjectRef;
+use crate::crypto::default_hash;
+use crate::digests::{EffectsAuxDataDigest, TransactionDigest};
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash)]
+pub struct EffectsAuxData<T> {
+    tx_digest: TransactionDigest,
+    version: u64,
+    inner: T,
+}
+
+/// Separating storage type and in-memory type allows for customized serde.
+pub type EffectsAuxDataInStorage = EffectsAuxData<Vec<u8>>;
+pub type EffectsAuxDataInMemory = EffectsAuxData<Vec<EffectsAuxDataEntry>>;
+
+#[derive(Serialize, Deserialize)]
+pub enum EffectsAuxDataEntry {
+    // Could either be children of read-only shared objects that are loaded at runtime,
+    // or objects that are successfully received at runtime but didn't materialize in the end (due to
+    // execution failure).
+    ReadOnlyRuntimeObjects(Vec<ObjectRef>),
+}
+
+impl EffectsAuxDataInStorage {
+    pub fn deserialize(self) -> anyhow::Result<EffectsAuxDataInMemory> {
+        let inner = match self.version {
+            1 => Self::deserialize_v1(&self.inner),
+            _ => Err(anyhow!(
+                "Unsupported EffectsAuxData version: {}",
+                self.version
+            )),
+        }?;
+        Ok(EffectsAuxDataInMemory {
+            tx_digest: self.tx_digest,
+            version: self.version,
+            inner,
+        })
+    }
+
+    pub fn digest(&self) -> EffectsAuxDataDigest {
+        EffectsAuxDataDigest::new(default_hash(self))
+    }
+
+    fn deserialize_v1(inner: &[u8]) -> anyhow::Result<Vec<EffectsAuxDataEntry>> {
+        bincode::deserialize(inner).map_err(|e| e.into())
+    }
+}
+
+impl EffectsAuxDataInMemory {
+    pub fn new(tx_digest: TransactionDigest, inner: Vec<EffectsAuxDataEntry>) -> Self {
+        Self {
+            tx_digest,
+            version: 1,
+            inner,
+        }
+    }
+
+    pub fn serialize(&self) -> anyhow::Result<EffectsAuxDataInStorage> {
+        let inner = match self.version {
+            1 => Self::serialize_v1(&self.inner),
+            _ => Err(anyhow!(
+                "Unsupported EffectsAuxData version: {}",
+                self.version
+            )),
+        }?;
+        Ok(EffectsAuxDataInStorage {
+            tx_digest: self.tx_digest,
+            version: self.version,
+            inner,
+        })
+    }
+
+    fn serialize_v1(inner: &[EffectsAuxDataEntry]) -> anyhow::Result<Vec<u8>> {
+        bincode::serialize(inner).map_err(|e| e.into())
+    }
+}

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -4,7 +4,7 @@
 use crate::base_types::{
     random_object_ref, EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
-use crate::digests::{ObjectDigest, TransactionEventsDigest};
+use crate::digests::{EffectsAuxDataDigest, ObjectDigest, TransactionEventsDigest};
 use crate::effects::{InputSharedObject, TransactionEffectsAPI};
 use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
@@ -148,7 +148,9 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     fn events_digest(&self) -> Option<&TransactionEventsDigest> {
         self.events_digest.as_ref()
     }
-
+    fn aux_data_digest(&self) -> Option<&EffectsAuxDataDigest> {
+        None
+    }
     fn dependencies(&self) -> &[TransactionDigest] {
         &self.dependencies
     }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -262,6 +262,10 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
         self.events_digest.as_ref()
     }
 
+    fn aux_data_digest(&self) -> Option<&EffectsAuxDataDigest> {
+        self.aux_data_digest.as_ref()
+    }
+
     fn dependencies(&self) -> &[TransactionDigest] {
         &self.dependencies
     }
@@ -349,6 +353,7 @@ impl TransactionEffectsV2 {
         changed_objects: BTreeMap<ObjectID, EffectsObjectChange>,
         gas_object: Option<ObjectID>,
         events_digest: Option<TransactionEventsDigest>,
+        aux_data_digest: Option<EffectsAuxDataDigest>,
         dependencies: Vec<TransactionDigest>,
     ) -> Self {
         let unchanged_shared_objects = shared_objects
@@ -391,7 +396,7 @@ impl TransactionEffectsV2 {
             gas_object_index,
             events_digest,
             dependencies,
-            aux_data_digest: None,
+            aux_data_digest,
         };
         #[cfg(debug_assertions)]
         result.check_invariant();

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use self::effects_v2::TransactionEffectsV2;
 use crate::base_types::{random_object_ref, ExecutionDigests, ObjectID, ObjectRef, SequenceNumber};
 use crate::committee::EpochId;
 use crate::crypto::{
     default_hash, AuthoritySignInfo, AuthorityStrongQuorumSignInfo, EmptySignInfo,
 };
 use crate::digests::{
-    ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
+    EffectsAuxDataDigest, ObjectDigest, TransactionDigest, TransactionEffectsDigest,
+    TransactionEventsDigest,
 };
+use crate::effects::effects_v2::TransactionEffectsV2;
 use crate::error::{SuiError, SuiResult};
 use crate::event::Event;
 use crate::execution::SharedInput;
@@ -21,6 +22,7 @@ use crate::message_envelope::{
 use crate::object::Owner;
 use crate::storage::WriteKind;
 use crate::transaction::{SenderSignedData, TransactionDataAPI, VersionedProtocolMessage};
+pub use effects_aux_data::{EffectsAuxDataEntry, EffectsAuxDataInMemory, EffectsAuxDataInStorage};
 use effects_v1::TransactionEffectsV1;
 pub use effects_v2::UnchangedSharedKind;
 use enum_dispatch::enum_dispatch;
@@ -30,6 +32,7 @@ use shared_crypto::intent::IntentScope;
 use std::collections::BTreeMap;
 use sui_protocol_config::ProtocolConfig;
 
+mod effects_aux_data;
 mod effects_v1;
 mod effects_v2;
 mod object_change;
@@ -166,6 +169,7 @@ impl TransactionEffects {
         changed_objects: BTreeMap<ObjectID, EffectsObjectChange>,
         gas_object: Option<ObjectID>,
         events_digest: Option<TransactionEventsDigest>,
+        aux_data_digest: Option<EffectsAuxDataDigest>,
         dependencies: Vec<TransactionDigest>,
     ) -> Self {
         Self::V2(TransactionEffectsV2::new(
@@ -178,6 +182,7 @@ impl TransactionEffects {
             changed_objects,
             gas_object,
             events_digest,
+            aux_data_digest,
             dependencies,
         ))
     }
@@ -372,6 +377,7 @@ pub trait TransactionEffectsAPI {
     fn gas_object(&self) -> (ObjectRef, Owner);
 
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
+    fn aux_data_digest(&self) -> Option<&EffectsAuxDataDigest>;
     fn dependencies(&self) -> &[TransactionDigest];
 
     fn transaction_digest(&self) -> &TransactionDigest;

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{SequenceNumber, VersionDigest};
-use crate::effects::TransactionEvents;
+use crate::effects::{EffectsAuxDataInStorage, TransactionEvents};
 use crate::execution::DynamicallyLoadedObjectMetadata;
 use crate::{
     base_types::ObjectID,
@@ -18,7 +18,7 @@ pub type WrittenObjects = BTreeMap<ObjectID, Object>;
 pub type ObjectMap = BTreeMap<ObjectID, Object>;
 pub type TxCoins = (ObjectMap, WrittenObjects);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct InnerTemporaryStore {
     pub input_objects: ObjectMap,
     pub mutable_inputs: BTreeMap<ObjectID, (VersionDigest, Owner)>,
@@ -26,6 +26,7 @@ pub struct InnerTemporaryStore {
     pub written: WrittenObjects,
     pub loaded_runtime_objects: BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata>,
     pub events: TransactionEvents,
+    pub aux_data: Option<EffectsAuxDataInStorage>,
     pub max_binary_format_version: u32,
     pub no_extraneous_module_bytes: bool,
     pub runtime_packages_loaded_from_db: BTreeMap<ObjectID, Object>,

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -151,6 +151,7 @@ impl<'backing> TemporaryStore<'backing> {
                 .map(|(id, (obj, _))| (id, obj))
                 .collect(),
             events: TransactionEvents { data: self.events },
+            aux_data: None,
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_runtime_objects: self.loaded_child_objects,
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),

--- a/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
@@ -113,6 +113,7 @@ impl<'backing> TemporaryStore<'backing> {
             events: TransactionEvents {
                 data: results.user_events,
             },
+            aux_data: None,
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_runtime_objects: self.loaded_runtime_objects,
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
@@ -226,6 +227,7 @@ impl<'backing> TemporaryStore<'backing> {
             } else {
                 Some(inner.events.digest())
             },
+            None,
             transaction_dependencies.into_iter().collect(),
         );
         (inner, effects)


### PR DESCRIPTION
## Description 

This PR introduces auxiliary data to transaction effects.
As a starter, it includes all read-only runtime objects loaded during execution (including read only shared child objects and receiving objects).
Note: This PR is not ready for merging yet, sending out early for demonstration. Eventually it needs to be gated by a protocol config flag.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
