### PR TITLE
[workspace-hack] use workspace-dotted format and a patch directive

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -6,6 +6,10 @@ hakari-package = "workspace-hack"
 # Format for `workspace-hack = ...` lines in other Cargo.tomls.
 dep-format-version = "4"
 
+# Output lines as `omicron-workspace-hack.workspace = true`. Requires
+# cargo-hakari 0.9.28 or above.
+workspace-hack-line-style = "workspace-dotted"
+
 # Setting workspace.resolver = "2" in the root Cargo.toml is HIGHLY recommended.
 # Hakari works much better with the new feature resolver.
 # For more about the new feature resolver, see:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -598,7 +598,7 @@ test-cluster = { path = "crates/test-cluster" }
 transaction-fuzzer = { path = "crates/transaction-fuzzer" }
 typed-store = { path = "crates/typed-store" }
 typed-store-derive = { path = "crates/typed-store-derive" }
-workspace-hack = { path = "crates/workspace-hack" }
+workspace-hack = "0.1.0"
 x = { path = "crates/x" }
 
 narwhal-config = { path = "narwhal/config" }
@@ -620,3 +620,11 @@ sui-execution = { path = "sui-execution" }
 # move-stdlib = { path = "external-crates/move/move-stdlib" }
 # move-vm-runtime = { path = "external-crates/move/move-vm/runtime" }
 # move-bytecode-verifier = { path = "external-crates/move/move-bytecode-verifier" }
+
+
+# Using the workspace-hack via this patch directive means that it only applies
+# while building within this workspace. If another workspace imports a crate
+# from here via a git dependency, it will not have the workspace-hack applied
+# to it.
+[patch.crates-io.workspace-hack]
+path = "crates/workspace-hack"

--- a/crates/anemo-benchmark/Cargo.toml
+++ b/crates/anemo-benchmark/Cargo.toml
@@ -13,7 +13,7 @@ mysten-network.workspace = true
 rand.workspace= true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [build-dependencies]
 anemo-build.workspace = true

--- a/crates/data-transform/Cargo.toml
+++ b/crates/data-transform/Cargo.toml
@@ -23,4 +23,4 @@ move-core-types.workspace = true
 move-bytecode-utils.workspace = true
 sui-json-rpc-types.workspace = true
 once_cell.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/mysten-common/Cargo.toml
+++ b/crates/mysten-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 tokio.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+workspace-hack.workspace = true

--- a/crates/mysten-metrics/Cargo.toml
+++ b/crates/mysten-metrics/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2021"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 tracing.workspace = true
 scopeguard.workspace = true
 prometheus.workspace = true
@@ -21,3 +20,4 @@ futures.workspace = true
 async-trait.workspace = true
 
 prometheus-closure-metric.workspace = true
+workspace-hack.workspace = true

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -24,4 +24,4 @@ tonic-health.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/mysten-util-mem-derive/Cargo.toml
+++ b/crates/mysten-util-mem-derive/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 proc-macro2.workspace = true
 syn.workspace = true
 synstructure.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/mysten-util-mem/Cargo.toml
+++ b/crates/mysten-util-mem/Cargo.toml
@@ -22,7 +22,7 @@ ed25519-consensus.workspace = true
 smallvec = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 once_cell.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [features]
 default = ["std", "hashbrown", "smallvec", "estimate-heapsize"]

--- a/crates/prometheus-closure-metric/Cargo.toml
+++ b/crates/prometheus-closure-metric/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 anyhow.workspace = true
 prometheus.workspace = true
 protobuf.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/shared-crypto/Cargo.toml
+++ b/crates/shared-crypto/Cargo.toml
@@ -11,5 +11,5 @@ serde.workspace = true
 serde_repr.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 eyre.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 bcs.workspace = true
+workspace-hack.workspace = true

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -31,4 +31,4 @@ sui-genesis-builder.workspace = true
 sui-execution.workspace = true
 sui-swarm-config.workspace = true
 sui-transaction-checks.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-adapter-transactional-tests/Cargo.toml
+++ b/crates/sui-adapter-transactional-tests/Cargo.toml
@@ -16,4 +16,4 @@ name = "tests"
 harness = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-analytics-indexer/Cargo.toml
+++ b/crates/sui-analytics-indexer/Cargo.toml
@@ -34,10 +34,10 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 mysten-metrics.workspace = true
 sui-indexer.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 telemetry-subscribers.workspace = true
 sui-rest-api.workspace = true
 sui-storage.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 

--- a/crates/sui-archival/Cargo.toml
+++ b/crates/sui-archival/Cargo.toml
@@ -23,7 +23,7 @@ sui-types.workspace = true
 sui-storage.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 tokio = { workspace = true, features = ["full"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-aws-orchestrator/Cargo.toml
+++ b/crates/sui-aws-orchestrator/Cargo.toml
@@ -31,7 +31,7 @@ sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 sui-node = { path = "../sui-node" }
 sui-swarm-config =  { path = "../sui-swarm-config" }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile = "3.6.0"

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -45,9 +45,9 @@ fastcrypto-zkp.workspace = true
 move-core-types.workspace = true
 mysten-metrics.workspace = true
 narwhal-node.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 test-cluster.workspace = true
 sysinfo.workspace = true
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-framework.workspace = true

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -38,5 +38,5 @@ sui-test-transaction-builder.workspace = true
 telemetry-subscribers.workspace = true
 
 test-cluster.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 move-core-types.workspace = true
+workspace-hack.workspace = true

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -26,7 +26,7 @@ sui-keys.workspace = true
 sui-protocol-config.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -78,7 +78,7 @@ sui-transaction-checks.workspace = true
 sui-simulator.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-cost/Cargo.toml
+++ b/crates/sui-cost/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2021"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 sui-types.workspace = true
 anyhow.workspace = true
 tokio = { workspace = true, features = ["full"] }
@@ -15,6 +14,7 @@ serde.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 bcs.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-enum-compat-util/Cargo.toml
+++ b/crates/sui-enum-compat-util/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 
 [dependencies]
 serde_yaml.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -42,7 +42,7 @@ typed-store.workspace = true
 typed-store-derive.workspace = true
 shared-crypto.workspace = true
 async-recursion.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 test-cluster.workspace = true

--- a/crates/sui-framework-snapshot/Cargo.toml
+++ b/crates/sui-framework-snapshot/Cargo.toml
@@ -17,7 +17,7 @@ git-version.workspace = true
 sui-framework.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-framework-tests/Cargo.toml
+++ b/crates/sui-framework-tests/Cargo.toml
@@ -25,4 +25,4 @@ move-package.workspace = true
 move-unit-test.workspace = true
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -17,7 +17,7 @@ sui-types.workspace = true
 
 move-binary-format.workspace = true
 move-core-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -28,7 +28,7 @@ sui-framework.workspace = true
 sui-framework-snapshot.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true
 

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -31,8 +31,6 @@ toml.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
 # TODO: put these behind feature flag to prevent leakage
 # Used for dummy data
 bcs.workspace = true
@@ -40,6 +38,7 @@ sui-sdk.workspace = true
 sui-json-rpc-types.workspace = true
 sui-indexer.workspace = true
 move-bytecode-utils.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -40,7 +40,6 @@ sui-open-rpc.workspace = true
 sui-sdk.workspace = true
 sui-types.workspace = true
 sui-protocol-config.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 telemetry-subscribers.workspace = true
 sui-rest-api.workspace = true
 
@@ -50,6 +49,7 @@ move-binary-format.workspace = true
 
 diesel_migrations.workspace = true
 cached.workspace = true
+workspace-hack.workspace = true
 
 [features]
 pg_integration = []

--- a/crates/sui-json-rpc-tests/Cargo.toml
+++ b/crates/sui-json-rpc-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -29,7 +29,7 @@ move-bytecode-utils.workspace = true
 mysten-metrics.workspace = true
 sui-types.workspace = true
 sui-json.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -46,10 +46,10 @@ sui-protocol-config.workspace = true
 sui-json-rpc-types.workspace = true
 sui-transaction-builder.workspace = true
 mysten-metrics.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 shared-crypto.workspace = true
 typed-store.workspace = true
 cached.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -20,7 +20,7 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 fastcrypto = { workspace = true }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 test-fuzz.workspace = true

--- a/crates/sui-keys/Cargo.toml
+++ b/crates/sui-keys/Cargo.toml
@@ -18,7 +18,7 @@ slip10_ed25519.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 shared-crypto.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-kvstore/Cargo.toml
+++ b/crates/sui-kvstore/Cargo.toml
@@ -23,4 +23,4 @@ sui-core.workspace = true
 sui-types.workspace = true
 sui-config.workspace = true
 sui-storage.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-macros/Cargo.toml
+++ b/crates/sui-macros/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 sui-proc-macros.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 once_cell.workspace = true
 futures.workspace = true
 tracing.workspace = true
+workspace-hack.workspace = true

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -22,4 +22,4 @@ strum_macros.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -26,7 +26,7 @@ move-core-types.workspace = true
 move-ir-types.workspace = true
 move-package.workspace = true
 move-symbol-pool.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 datatest-stable.workspace = true

--- a/crates/sui-network/Cargo.toml
+++ b/crates/sui-network/Cargo.toml
@@ -22,7 +22,6 @@ sui-config.workspace = true
 sui-swarm-config.workspace = true
 
 mysten-network.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 futures.workspace = true
@@ -31,6 +30,7 @@ rand.workspace = true
 anyhow.workspace = true
 prometheus.workspace = true
 mysten-metrics.workspace = true
+workspace-hack.workspace = true
 
 [build-dependencies]
 anemo-build.workspace = true

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -48,7 +48,7 @@ mysten-network.workspace = true
 telemetry-subscribers.workspace = true
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-open-rpc-macros/Cargo.toml
+++ b/crates/sui-open-rpc-macros/Cargo.toml
@@ -16,5 +16,5 @@ quote.workspace = true
 proc-macro2.workspace = true
 itertools.workspace = true
 derive-syn-parse.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 unescape.workspace = true
+workspace-hack.workspace = true

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 bcs.workspace = true
 versions.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/sui-oracle/Cargo.toml
+++ b/crates/sui-oracle/Cargo.toml
@@ -28,4 +28,4 @@ sui-sdk = { path = "../sui-sdk" }
 sui-types = { path = "../sui-types" }
 mysten-metrics = { path = "../mysten-metrics" }
 telemetry-subscribers.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -12,9 +12,9 @@ proc-macro = true
 [dependencies]
 quote.workspace = true
 syn = { version = "2", features = ["full", "fold", "extra-traits"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 proc-macro2.workspace = true
 sui-enum-compat-util.workspace = true
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim-macros.workspace = true

--- a/crates/sui-protocol-config-macros/Cargo.toml
+++ b/crates/sui-protocol-config-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 proc-macro2.workspace = true
 syn.workspace = true
 quote.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-protocol-config/Cargo.toml
+++ b/crates/sui-protocol-config/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 edition = "2021"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 serde.workspace = true
 tracing.workspace = true
 serde_with.workspace = true
 sui-protocol-config-macros.workspace = true
 schemars.workspace = true
 insta.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -42,7 +42,7 @@ http-body.workspace = true
 
 telemetry-subscribers.workspace = true
 fastcrypto.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 mime.workspace = true

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -45,4 +45,4 @@ sui-protocol-config.workspace = true
 sui-sdk.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-rest-api/Cargo.toml
+++ b/crates/sui-rest-api/Cargo.toml
@@ -13,7 +13,7 @@ reqwest.workspace = true
 axum.workspace = true
 sui-types.workspace = true
 sui-core.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/sui-rosetta/Cargo.toml
+++ b/crates/sui-rosetta/Cargo.toml
@@ -41,7 +41,7 @@ shared-crypto.workspace = true
 move-core-types.workspace = true
 
 telemetry-subscribers.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 sui-sdk.workspace = true

--- a/crates/sui-rpc-loadgen/Cargo.toml
+++ b/crates/sui-rpc-loadgen/Cargo.toml
@@ -29,9 +29,9 @@ sui-json-rpc.workspace = true
 sui-json-rpc-types.workspace = true
 strum.workspace = true
 shared-crypto.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 serde_json.workspace = true
 strum_macros.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 test-cluster.workspace = true

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -35,7 +35,7 @@ tracing.workspace = true
 move-core-types.workspace = true
 
 fastcrypto.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2021"
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 move-package.workspace = true
 
 sui-framework.workspace = true
@@ -23,6 +22,7 @@ telemetry-subscribers.workspace = true
 tower.workspace = true
 lru.workspace = true
 rand.workspace = true
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -18,8 +18,7 @@ futures.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing.workspace = true
-
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true

--- a/crates/sui-snapshot/Cargo.toml
+++ b/crates/sui-snapshot/Cargo.toml
@@ -27,7 +27,7 @@ sui-storage.workspace = true
 sui-protocol-config.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 tokio = { workspace = true, features = ["full"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -38,7 +38,7 @@ move-symbol-pool.workspace = true
 telemetry-subscribers.workspace = true
 tower.workspace = true
 tower-http.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/crates/sui-source-validation/Cargo.toml
+++ b/crates/sui-source-validation/Cargo.toml
@@ -24,7 +24,7 @@ move-compiler.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true
 move-symbol-pool.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -42,12 +42,12 @@ sui-json-rpc-types.workspace = true
 sui-protocol-config.workspace = true
 typed-store.workspace = true
 typed-store-derive.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 eyre.workspace = true
 lru.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/sui-surfer/Cargo.toml
+++ b/crates/sui-surfer/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 prometheus.workspace = true

--- a/crates/sui-swarm-config/Cargo.toml
+++ b/crates/sui-swarm-config/Cargo.toml
@@ -25,7 +25,7 @@ sui-config.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 sui-genesis-builder.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-swarm/Cargo.toml
+++ b/crates/sui-swarm/Cargo.toml
@@ -25,7 +25,7 @@ sui-types.workspace = true
 mysten-metrics.workspace = true
 mysten-network.workspace = true
 telemetry-subscribers.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-telemetry/Cargo.toml
+++ b/crates/sui-telemetry/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 serde.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 sui-core.workspace = true
+workspace-hack.workspace = true
 

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -16,4 +16,4 @@ sui-sdk.workspace = true
 sui-types.workspace = true
 
 move-core-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-test-validator/Cargo.toml
+++ b/crates/sui-test-validator/Cargo.toml
@@ -14,8 +14,8 @@ axum.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 http.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 sui-faucet.workspace = true
 sui-cluster-test.workspace = true
 telemetry-subscribers.workspace = true
+workspace-hack.workspace = true

--- a/crates/sui-tls/Cargo.toml
+++ b/crates/sui-tls/Cargo.toml
@@ -17,7 +17,6 @@ webpki.workspace = true
 x509-parser.workspace = true
 
 fastcrypto.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 # reqwest support
 reqwest.workspace = true
@@ -28,6 +27,7 @@ axum-server.workspace = true
 tokio-rustls.workspace = true
 tower-layer.workspace = true
 tokio.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -44,4 +44,4 @@ sui-sdk.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 sui-archival.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-transaction-builder/Cargo.toml
+++ b/crates/sui-transaction-builder/Cargo.toml
@@ -19,4 +19,4 @@ sui-json.workspace = true
 sui-protocol-config.workspace = true
 
 move-core-types.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-transaction-checks/Cargo.toml
+++ b/crates/sui-transaction-checks/Cargo.toml
@@ -13,5 +13,5 @@ sui-protocol-config.workspace = true
 sui-types.workspace = true
 tracing.workspace = true
 sui-execution.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 fastcrypto-zkp.workspace = true
+workspace-hack.workspace = true

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -35,11 +35,11 @@ sui-core = { workspace = true, features = ["test-utils"] }
 sui-framework.workspace = true
 sui-protocol-config.workspace = true
 sui-types = { workspace = true, features = ["test-utils"]}
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 sui-json-rpc-types.workspace = true
 sui-json-rpc.workspace = true
 sui-framework-snapshot.workspace = true
 sui-storage.workspace = true
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -59,10 +59,10 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 fastcrypto-zkp.workspace = true
 
 typed-store.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 derive_more.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/crates/sui-upgrade-compatibility-transactional-tests/Cargo.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/Cargo.toml
@@ -22,4 +22,4 @@ name = "tests"
 harness = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui-verifier-transactional-tests/Cargo.toml
+++ b/crates/sui-verifier-transactional-tests/Cargo.toml
@@ -16,4 +16,4 @@ name = "tests"
 harness = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -65,8 +65,8 @@ telemetry-subscribers.workspace = true
 
 move-core-types.workspace = true
 move-package.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 csv.workspace = true
+workspace-hack.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemalloc-ctl.workspace = true

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -16,7 +16,7 @@ prometheus.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [features]
 default = []

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -29,7 +29,7 @@ sui-sdk.workspace = true
 sui-test-transaction-builder.workspace = true
 
 move-binary-format.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 proptest.workspace = true
 proptest-derive.workspace = true
 rand.workspace = true
@@ -21,6 +20,7 @@ sui-core.workspace = true
 sui-protocol-config.workspace = true
 sui-types = { workspace = true, features = ["fuzzing"] }
 sui-move-build.workspace = true
+workspace-hack.workspace = true
 
 
 [dev-dependencies]

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -28,7 +28,7 @@ ouroboros.workspace = true
 rand.workspace = true
 async-trait.workspace = true
 itertools.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/narwhal/config/Cargo.toml
+++ b/narwhal/config/Cargo.toml
@@ -17,8 +17,8 @@ fastcrypto.workspace = true
 mysten-util-mem.workspace = true
 crypto = { path = "../crypto", package = "narwhal-crypto" }
 mysten-network.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 rand.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -20,13 +20,13 @@ crypto = { path = "../crypto", package = "narwhal-crypto" }
 storage = { path = "../storage", package = "narwhal-storage" }
 prometheus.workspace = true
 types = { path = "../types", package = "narwhal-types" }
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 cfg-if.workspace = true
 mysten-metrics.workspace = true
 store = { path = "../../crates/typed-store", package = "typed-store" }
 sui-protocol-config.workspace = true
 
 telemetry-subscribers.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/narwhal/crypto/Cargo.toml
+++ b/narwhal/crypto/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 
 [dependencies]
 fastcrypto.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 serde.workspace = true
 shared-crypto.workspace = true
 bcs.workspace = true
+workspace-hack.workspace = true
 
 [features]
 default = []

--- a/narwhal/executor/Cargo.toml
+++ b/narwhal/executor/Cargo.toml
@@ -32,7 +32,7 @@ mockall.workspace = true
 
 mysten-metrics.workspace = true
 store = { path = "../../crates/typed-store", package = "typed-store" }
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 indexmap.workspace = true

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -24,14 +24,13 @@ crypto = { path = "../crypto", package = "narwhal-crypto" }
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
-
 anemo.workspace = true
 anemo-tower.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 axum-server.workspace = true
 tower.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -42,10 +42,10 @@ sui-protocol-config.workspace = true
 mysten-metrics.workspace = true
 mysten-network.workspace = true
 telemetry-subscribers.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 anemo.workspace = true
 reqwest.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -35,7 +35,6 @@ storage = { path = "../storage", package = "narwhal-storage" }
 store = { path = "../../crates/typed-store", package = "typed-store" }
 sui-macros.workspace = true
 mysten-network.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 sui-protocol-config.workspace = true
 
 mysten-common.workspace = true
@@ -43,6 +42,7 @@ mysten-metrics.workspace = true
 
 anemo.workspace = true
 anemo-tower.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 dashmap.workspace = true

--- a/narwhal/storage/Cargo.toml
+++ b/narwhal/storage/Cargo.toml
@@ -18,11 +18,11 @@ types = { path = "../types", package = "narwhal-types" }
 store = { path = "../../crates/typed-store", package = "typed-store" }
 sui-macros.workspace = true
 config = { path = "../config", package = "narwhal-config" }
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 prometheus.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
 tap.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils", package = "narwhal-test-utils" }

--- a/narwhal/test-utils/Cargo.toml
+++ b/narwhal/test-utils/Cargo.toml
@@ -33,6 +33,6 @@ store = { path = "../../crates/typed-store", package = "typed-store" }
 telemetry-subscribers.workspace = true
 mysten-network.workspace = true
 sui-protocol-config.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 anemo.workspace = true
+workspace-hack.workspace = true

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -33,7 +33,6 @@ config = { path = "../config", package = "narwhal-config" }
 fastcrypto.workspace = true
 crypto = { path = "../crypto", package = "narwhal-crypto" }
 anemo.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 sui-protocol-config.workspace = true
 once_cell.workspace = true
 
@@ -42,6 +41,7 @@ mysten-metrics.workspace = true
 mysten-common.workspace = true
 mysten-network.workspace = true
 mysten-util-mem.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -37,8 +37,8 @@ consensus = { path = "../consensus", package = "narwhal-consensus" }
 anemo.workspace = true
 anemo-tower.workspace = true
 anyhow.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 eyre.workspace = true
+workspace-hack.workspace = true
 
 [dev-dependencies]
 arc-swap.workspace = true

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -34,9 +34,7 @@ move-bytecode-verifier-vm-rework = { path = "../external-crates/move-execution/v
 move-vm-runtime-latest = { path = "../external-crates/move/move-vm/runtime", package = "move-vm-runtime" }
 move-vm-runtime-v0 = { path = "../external-crates/move-execution/v0/move-vm/runtime" }
 move-vm-runtime-vm-rework = { path = "../external-crates/move-execution/vm-rework/move-vm/runtime" }
-# move-vm-runtime-$CUT = { path = "../external-crates/move-execution/$CUT/move-vm/runtime" }
-
-workspace-hack = { version = "0.1", path = "../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 cargo_metadata = "0.15.4"

--- a/sui-execution/cut/Cargo.toml
+++ b/sui-execution/cut/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.3.1", features = ["derive"] }
 thiserror.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
-workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -30,8 +30,7 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
-
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true

--- a/sui-execution/latest/sui-move-natives/Cargo.toml
+++ b/sui-execution/latest/sui-move-natives/Cargo.toml
@@ -24,4 +24,4 @@ move-vm-runtime = { path = "../../../external-crates/move/move-vm/runtime" }
 
 sui-protocol-config.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -17,4 +17,4 @@ move-abstract-stack.workspace = true
 move-bytecode-verifier = { path = "../../../external-crates/move/move-bytecode-verifier" }
 
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true

--- a/sui-execution/v0/sui-adapter/Cargo.toml
+++ b/sui-execution/v0/sui-adapter/Cargo.toml
@@ -31,8 +31,7 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
-
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true

--- a/sui-execution/v0/sui-move-natives/Cargo.toml
+++ b/sui-execution/v0/sui-move-natives/Cargo.toml
@@ -24,4 +24,4 @@ move-vm-runtime = { path = "../../../external-crates/move-execution/v0/move-vm/r
 
 sui-protocol-config.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true

--- a/sui-execution/v0/sui-verifier/Cargo.toml
+++ b/sui-execution/v0/sui-verifier/Cargo.toml
@@ -17,5 +17,5 @@ move-abstract-stack.workspace = true
 move-bytecode-verifier = { path = "../../../external-crates/move-execution/v0/move-bytecode-verifier", package = "move-bytecode-verifier-v0" }
 
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
 sui-protocol-config.workspace = true
+workspace-hack.workspace = true

--- a/sui-execution/vm-rework/sui-adapter/Cargo.toml
+++ b/sui-execution/vm-rework/sui-adapter/Cargo.toml
@@ -30,8 +30,7 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
-
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true

--- a/sui-execution/vm-rework/sui-move-natives/Cargo.toml
+++ b/sui-execution/vm-rework/sui-move-natives/Cargo.toml
@@ -24,4 +24,4 @@ move-vm-runtime = { path = "../../../external-crates/move-execution/vm-rework/mo
 
 sui-protocol-config.workspace = true
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true

--- a/sui-execution/vm-rework/sui-verifier/Cargo.toml
+++ b/sui-execution/vm-rework/sui-verifier/Cargo.toml
@@ -17,4 +17,4 @@ move-abstract-stack.workspace = true
 move-bytecode-verifier = { path = "../../../external-crates/move-execution/vm-rework/move-bytecode-verifier", package = "move-bytecode-verifier-vm-rework" }
 
 sui-types.workspace = true
-workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+workspace-hack.workspace = true


### PR DESCRIPTION
## Description 

Two changes:

Switch to the workspace-dotted format (.workspace = true) for
uniformity. This is new in cargo-hakari
0.9.28.

Use a patch directive, which means that the workspace-hack only
applies while building within this workspace. If another workspace
imports a crate from here via a git dependency, it will not have the
workspace-hack applied to it (instead, it will use [this empty crate](https://crates.io/crates/workspace-hack)
on crates.io).

Thank you to @sunshowers for the update to hakari and the suggestion!

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
