### PR TITLE
[graphql/rpc] change usage header checks

### DIFF
--- a/crates/sui-graphql-rpc/src/client/simple_client.rs
+++ b/crates/sui-graphql-rpc/src/client/simple_client.rs
@@ -61,6 +61,6 @@ async fn test_client() {
     "#;
     let res = client.execute(query.to_string(), vec![]).await.unwrap();
     let exp =
-        r#"{"data":{"chainIdentifier":"4c78adac"},"extensions":{"usage":{"nodes":1,"depth":1}}}"#;
+        r#"{"data":{"chainIdentifier":"4c78adac"}}"#;
     assert_eq!(&format!("{}", res), exp);
 }

--- a/crates/sui-graphql-rpc/src/client/simple_client.rs
+++ b/crates/sui-graphql-rpc/src/client/simple_client.rs
@@ -60,7 +60,6 @@ async fn test_client() {
         }
     "#;
     let res = client.execute(query.to_string(), vec![]).await.unwrap();
-    let exp =
-        r#"{"data":{"chainIdentifier":"4c78adac"}}"#;
+    let exp = r#"{"data":{"chainIdentifier":"4c78adac"}}"#;
     assert_eq!(&format!("{}", res), exp);
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -92,7 +92,6 @@ impl ServerBuilder {
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: axum::Extension<SuiGraphQLSchema>,
-    //usage: Option<TypedHeader<ShowUsage>>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> GraphQLResponse {

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -9,11 +9,12 @@ use crate::{
 use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
 use async_graphql::{EmptyMutation, EmptySubscription};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
-use axum::Router;
+use axum::http::HeaderMap;
 use axum::{
     extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo},
-    middleware, TypedHeader,
+    middleware,
 };
+use axum::{headers::Header, Router};
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
 use hyper::Server as HyperServer;
 use std::{any::Any, net::SocketAddr};
@@ -91,12 +92,13 @@ impl ServerBuilder {
 async fn graphql_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: axum::Extension<SuiGraphQLSchema>,
-    usage: Option<TypedHeader<ShowUsage>>,
+    //usage: Option<TypedHeader<ShowUsage>>,
+    headers: HeaderMap,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
     let mut req = req.into_inner();
-    if let Some(TypedHeader(usage)) = usage {
-        req.data.insert(usage)
+    if headers.contains_key(ShowUsage::name()) {
+        req.data.insert(ShowUsage)
     }
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address


### PR DESCRIPTION
## Description 

Previous logic was always yielding the headers even when not present. This seems like recent behavior.
Will dig in to see what changed but this new logic works well and is clearer

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
