### PR TITLE
[benchmark] Support benchmarking tx manager

### DIFF
--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
 #[command(
@@ -16,31 +16,33 @@ pub enum Command {
     NoMove {
         #[arg(
             long,
-            default_value_t = 1000000,
+            default_value_t = 500000,
             help = "Number of transactions to submit"
         )]
         tx_count: u64,
         #[arg(
             long,
-            default_value_t = false,
-            help = "Whether to include cert verification and tx manager in the benchmark"
+            default_value = "baseline",
+            ignore_case = true,
+            help = "Which component to benchmark"
         )]
-        end_to_end: bool,
+        component: Component,
     },
     #[command(name = "move")]
     Move {
         #[arg(
             long,
-            default_value_t = 1000000,
+            default_value_t = 500000,
             help = "Number of transactions to submit"
         )]
         tx_count: u64,
         #[arg(
             long,
-            default_value_t = false,
-            help = "Whether to include cert verification and tx manager in the benchmark"
+            default_value = "baseline",
+            ignore_case = true,
+            help = "Which component to benchmark"
         )]
-        end_to_end: bool,
+        component: Component,
         #[arg(
             long,
             default_value_t = 2,
@@ -64,4 +66,15 @@ pub enum Command {
         )]
         computation: u8,
     },
+}
+
+#[derive(Copy, Clone, ValueEnum)]
+pub enum Component {
+    /// Baseline includes the execution and storage layer only.
+    Baseline,
+    /// On top of Baseline, this schedules transactions through the transaction manager.
+    WithTxManager,
+    /// This goes through the `handle_certificate` entry point on authority_server, which includes
+    /// certificate verification, transaction manager, as well as a noop consensus layer.
+    ValidatorService,
 }

--- a/crates/sui-single-node-benchmark/src/main.rs
+++ b/crates/sui-single-node-benchmark/src/main.rs
@@ -18,18 +18,18 @@ async fn main() {
     match args {
         Command::NoMove {
             tx_count,
-            end_to_end,
-        } => benchmark_simple_transfer(tx_count, end_to_end).await,
+            component,
+        } => benchmark_simple_transfer(tx_count, component).await,
         Command::Move {
             tx_count,
-            end_to_end,
+            component,
             num_input_objects,
             num_dynamic_fields,
             computation,
         } => {
             benchmark_move_transactions(
                 tx_count,
-                end_to_end,
+                component,
                 num_input_objects,
                 num_dynamic_fields,
                 computation,

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_macros::sim_test;
+use sui_single_node_benchmark::command::Component;
 use sui_single_node_benchmark::execution::{
     benchmark_move_transactions, benchmark_simple_transfer,
 };
@@ -9,13 +10,15 @@ use sui_single_node_benchmark::execution::{
 #[sim_test]
 async fn benchmark_simple_transfer_smoke_test() {
     // This test makes sure that the benchmark runs.
-    benchmark_simple_transfer(10, false).await;
-    benchmark_simple_transfer(10, true).await;
+    benchmark_simple_transfer(10, Component::Baseline).await;
+    benchmark_simple_transfer(10, Component::WithTxManager).await;
+    benchmark_simple_transfer(10, Component::ValidatorService).await;
 }
 
 #[sim_test]
 async fn benchmark_move_transactions_smoke_test() {
     // This test makes sure that the benchmark runs.
-    benchmark_move_transactions(10, false, 2, 1, 1).await;
-    benchmark_move_transactions(10, true, 2, 1, 1).await;
+    benchmark_move_transactions(10, Component::Baseline, 2, 1, 1).await;
+    benchmark_move_transactions(10, Component::WithTxManager, 2, 1, 1).await;
+    benchmark_move_transactions(10, Component::ValidatorService, 2, 1, 1).await;
 }


### PR DESCRIPTION
## Description 

This PR extends the single-node-benchmark to be able to benchmark the TransactionManager.
Specifically it now supports 3 different components:
1. Execution and storage layer only
2. (1) + TxManager
3. ValidatorService, which is basically (2) + Cert verification

## Test Plan 

CI
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
