### PR TITLE
move: source service invalidates data on upgrade txn

### DIFF
--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -31,7 +31,8 @@ pub async fn main() -> anyhow::Result<()> {
     let app_state = Arc::new(RwLock::new(AppState { sources }));
     let app_state_copy = app_state.clone();
     let mut threads = vec![];
-    let watcher = tokio::spawn(async move { watch_for_upgrades(&package_config, app_state).await });
+    let watcher =
+        tokio::spawn(async move { watch_for_upgrades(&package_config, app_state, None).await });
     threads.push(watcher);
     let server = tokio::spawn(async { serve(app_state_copy)?.await.map_err(anyhow::Error::from) });
     threads.push(server);

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -9,29 +9,31 @@ use std::os::unix::fs::FileExt;
 use std::sync::{Arc, RwLock};
 use std::{collections::BTreeMap, path::PathBuf};
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
-use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
 use sui_move_build::{BuildConfig, SuiPackageHooks};
 use sui_sdk::rpc_types::{
-    OwnedObjectRef, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockEffects,
-    SuiTransactionBlockEffectsV1,
+    OwnedObjectRef, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockEffectsV1,
 };
 use sui_sdk::types::base_types::ObjectID;
 use sui_sdk::types::object::Owner;
 use sui_sdk::types::transaction::TEST_ONLY_GAS_UNIT_FOR_PUBLISH;
 use sui_sdk::wallet_context::WalletContext;
+use tokio::sync::oneshot;
 
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use sui_source_validation_service::{
     host_port, initialize, serve, verify_packages, watch_for_upgrades, AppState, CloneCommand,
     Config, DirectorySource, ErrorResponse, Network, NetworkLookup, Package, PackageSources,
-    RepositorySource, SourceInfo, SourceResponse, SUI_SOURCE_VALIDATION_VERSION_HEADER,
+    RepositorySource, SourceInfo, SourceLookup, SourceResponse,
+    SUI_SOURCE_VALIDATION_VERSION_HEADER,
 };
 use test_cluster::TestClusterBuilder;
 
 const LOCALNET_PORT: u16 = 9000;
 const TEST_FIXTURES_DIR: &str = "tests/fixture";
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn test_end_to_end() -> anyhow::Result<()> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
@@ -86,9 +88,12 @@ async fn test_end_to_end() -> anyhow::Result<()> {
         })],
     };
     // Start watching for upgrades.
-    let sources = NetworkLookup::new();
-    let dummy_app_state = Arc::new(RwLock::new(AppState { sources }));
-    let t = tokio::spawn(async move { watch_for_upgrades(&config, dummy_app_state).await });
+    let mut sources = NetworkLookup::new();
+    sources.insert(Network::Localnet, SourceLookup::new());
+    let app_state = Arc::new(RwLock::new(AppState { sources }));
+    let app_state_ref = app_state.clone();
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move { watch_for_upgrades(&config, app_state, Some(tx)).await });
 
     // Set up to upgrade package.
     let package = effects
@@ -103,8 +108,14 @@ async fn test_end_to_end() -> anyhow::Result<()> {
     // Run the upgrade.
     run_upgrade(upgrade_pkg_path, cap, context, gas_obj_id, rgp).await?;
 
-    // Test expects to terminate when we observe an upgrade transaction.
-    t.await.unwrap()?;
+    // Test expects to observe an upgrade transaction.
+    let Ok(SuiTransactionBlockEffects::V1(effects)) = rx.await else {
+        panic!("No upgrade transaction observed")
+    };
+    assert!(effects.status.is_ok());
+    // Test expects `sources` of server state to be empty / cleared on upgrade.
+    let app_state_ref = app_state_ref.read().unwrap();
+    assert!(app_state_ref.sources.is_empty());
 
     ///////////////////////////
     // Test verify_packages


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/14106.

When we see a successful upgrade transaction on the network for monitored packages (e.g., sui-framework), the source service should not serve its existing knowledge of sources. I.e., the existing sources have changed in part or in whole, and we don't want to falsely report the sources for bytecode. 

This PR ensures that as soon as we observe an upgrade transaction, the `sources` reported are cleared and invalidated. It is basically the ultra conservative approach to ensure we don't report outdated sources. See inline comment on how we have to approach re-verifying sources when we know they have changed.

## Test Plan 

Added test to validate (a) successful upgrade transaction triggers in `watch_for_upgrades` and (b) such a transaction causes the sources to be cleared / invalidated until we reverify the sources.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
