### PR TITLE
add telemetry layer for gas stats

### DIFF
--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -534,7 +534,7 @@ async fn test_leader_schedule_from_store() {
     assert_ne!(leader_2.id(), new_leader_2.id());
 }
 
-fn setup_tracing() -> TelemetryGuards {
+fn setup_tracing() -> Vec<TelemetryGuards> {
     // Setup tracing
     let tracing_level = "debug";
     let network_tracing_level = "info";

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -222,7 +222,7 @@ fn string_transaction(id: u32) -> String {
     format!("test transaction:{id}")
 }
 
-fn setup_tracing() -> TelemetryGuards {
+fn setup_tracing() -> Vec<TelemetryGuards> {
     // Setup tracing
     let tracing_level = "debug";
     let network_tracing_level = "info";

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -222,7 +222,7 @@ fn setup_telemetry(
     tracing_level: &str,
     network_tracing_level: &str,
     prom_registry: Option<&Registry>,
-) -> TelemetryGuards {
+) -> Vec<TelemetryGuards> {
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},quinn={network_tracing_level}");
 
     let config = telemetry_subscribers::TelemetryConfig::new()

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -791,7 +791,7 @@ impl AuthorityDetails {
     }
 }
 
-pub fn setup_tracing() -> TelemetryGuards {
+pub fn setup_tracing() -> Vec<TelemetryGuards> {
     // Setup tracing
     let tracing_level = "debug";
     let network_tracing_level = "info";


### PR DESCRIPTION
## Description 

Adds the ability for us to instantiate a telemetry config for emitting log lines with a given prefix to a local file 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
