### PR TITLE
[chore/easy]: reduce duplication of prom server start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10874,7 +10874,6 @@ name = "sui-oracle"
 version = "1.12.0"
 dependencies = [
  "anyhow",
- "axum",
  "bcs",
  "chrono",
  "clap",

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -464,7 +464,9 @@ pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
     registry_service
 }
 
-async fn metrics(Extension(registry_service): Extension<RegistryService>) -> (StatusCode, String) {
+pub async fn metrics(
+    Extension(registry_service): Extension<RegistryService>,
+) -> (StatusCode, String) {
     let metrics_families = registry_service.gather_all();
     match TextEncoder.encode_to_string(&metrics_families) {
         Ok(metrics) => (StatusCode::OK, metrics),

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -4,9 +4,8 @@
 use clap::*;
 use prometheus::Registry;
 use sui_analytics_indexer::{
-    analytics_metrics::{start_prometheus_server, AnalyticsMetrics},
-    errors::AnalyticsIndexerError,
-    make_analytics_processor, AnalyticsIndexerConfig,
+    analytics_metrics::AnalyticsMetrics, errors::AnalyticsIndexerError, make_analytics_processor,
+    AnalyticsIndexerConfig,
 };
 use sui_indexer::framework::IndexerBuilder;
 use tracing::info;
@@ -19,7 +18,7 @@ async fn main() -> Result<(), AnalyticsIndexerError> {
 
     let config = AnalyticsIndexerConfig::parse();
     info!("Parsed config: {:#?}", config);
-    let registry_service = start_prometheus_server(
+    let registry_service = mysten_metrics::start_prometheus_server(
         format!(
             "{}:{}",
             config.client_metric_host, config.client_metric_port

--- a/crates/sui-oracle/Cargo.toml
+++ b/crates/sui-oracle/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2021"
 
 [dependencies]
-axum.workspace = true
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap.workspace = true
 prometheus = "0.13.3"

--- a/crates/sui-oracle/src/main.rs
+++ b/crates/sui-oracle/src/main.rs
@@ -1,11 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::{extract::Extension, http::StatusCode, routing::get, Router};
 use clap::Parser;
-use mysten_metrics::RegistryService;
-use prometheus::{Registry, TextEncoder};
-use std::net::SocketAddr;
+use mysten_metrics::start_prometheus_server;
 use std::path::PathBuf;
 use std::time::Duration;
 use sui_config::Config;
@@ -20,37 +17,6 @@ struct Args {
     pub oracle_config_path: PathBuf,
     #[clap(long)]
     pub client_config_path: PathBuf,
-}
-
-const METRICS_ROUTE: &str = "/metrics";
-pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
-    let registry = Registry::new();
-
-    let registry_service = RegistryService::new(registry);
-
-    let app = Router::new()
-        .route(METRICS_ROUTE, get(metrics))
-        .layer(Extension(registry_service.clone()));
-
-    tokio::spawn(async move {
-        axum::Server::bind(&addr)
-            .serve(app.into_make_service())
-            .await
-            .unwrap();
-    });
-    registry_service
-}
-
-// TODO dedup this function and move to mysten-metrics
-async fn metrics(Extension(registry_service): Extension<RegistryService>) -> (StatusCode, String) {
-    let metrics_families = registry_service.gather_all();
-    match TextEncoder.encode_to_string(&metrics_families) {
-        Ok(metrics) => (StatusCode::OK, metrics),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("unable to encode metrics: {error}"),
-        ),
-    }
 }
 
 #[tokio::main]

--- a/crates/sui-proxy/src/metrics.rs
+++ b/crates/sui-proxy/src/metrics.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use axum::{extract::Extension, http::StatusCode, routing::get, Router};
+use axum::{extract::Extension, routing::get, Router};
 use mysten_metrics::RegistryService;
-use prometheus::{Registry, TextEncoder};
+use prometheus::Registry;
 use std::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
@@ -20,7 +20,7 @@ pub fn start_prometheus_server(addr: TcpListener) -> RegistryService {
     let registry_service = RegistryService::new(registry);
 
     let app = Router::new()
-        .route(METRICS_ROUTE, get(metrics))
+        .route(METRICS_ROUTE, get(mysten_metrics::metrics))
         .layer(Extension(registry_service.clone()))
         .layer(
             ServiceBuilder::new().layer(
@@ -41,16 +41,4 @@ pub fn start_prometheus_server(addr: TcpListener) -> RegistryService {
     });
 
     registry_service
-}
-
-async fn metrics(Extension(registry_service): Extension<RegistryService>) -> (StatusCode, String) {
-    let mut metric_families = registry_service.gather_all();
-    metric_families.extend(prometheus::gather());
-    match TextEncoder.encode_to_string(&metric_families) {
-        Ok(metrics) => (StatusCode::OK, metrics),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("unable to encode metrics: {error}"),
-        ),
-    }
 }

--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use axum::{http::StatusCode, routing::get, Extension, Router};
+use axum::{routing::get, Extension, Router};
 use config::{AuthorityIdentifier, WorkerId};
-use mysten_metrics::spawn_logged_monitored_task;
+use mysten_metrics::{metrics, spawn_logged_monitored_task};
 use mysten_network::multiaddr::Multiaddr;
-use prometheus::{Registry, TextEncoder};
+use prometheus::Registry;
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
@@ -50,15 +50,4 @@ pub fn start_prometheus_server(addr: Multiaddr, registry: &Registry) -> JoinHand
         },
         "MetricsServerTask"
     )
-}
-
-async fn metrics(registry: Extension<Registry>) -> (StatusCode, String) {
-    let metrics_families = registry.gather();
-    match TextEncoder.encode_to_string(&metrics_families) {
-        Ok(metrics) => (StatusCode::OK, metrics),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("unable to encode metrics: {error}"),
-        ),
-    }
 }


### PR DESCRIPTION
## Description 

Follow up to https://github.com/MystenLabs/sui/pull/14111.
Turns out a lot of the code was duplicated across multiple crates.


## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
