### PR TITLE
[graphql/rpc] transaction block kind

### DIFF
--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
@@ -1,0 +1,35 @@
+{
+  object(
+    address: "0xd6b9c261ab53d636760a104e4ab5f46c2a3e9cda58bd392488fc4efa6e43728c"
+  ) {
+    previousTransactionBlock {
+      sender {
+        location
+      }
+      kind {
+        __typename
+        ... on ConsensusCommitPrologueTransaction {
+          timestamp
+          round
+          epoch {
+            epochId
+            referenceGasPrice
+          }
+        }
+        ... on ChangeEpochTransaction {
+          computationCharge
+          storageCharge
+          timestamp
+          storageRebate
+        }
+        ... on GenesisTransaction {
+          objects {
+            owner {
+              location
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -60,6 +60,14 @@ scalar Base64
 scalar BigInt
 
 
+type ChangeEpochTransaction {
+	timestamp: DateTime
+	storageCharge: BigInt
+	computationCharge: BigInt
+	storageRebate: BigInt
+	epoch: Epoch
+}
+
 type Checkpoint {
 	digest: String!
 	sequenceNumber: Int!
@@ -146,6 +154,12 @@ type CommitteeMember {
 	stakeUnit: Int
 }
 
+type ConsensusCommitPrologueTransaction {
+	round: Int
+	timestamp: DateTime
+	epoch: Epoch
+}
+
 scalar DateTime
 
 type EndOfEpochData {
@@ -221,6 +235,10 @@ type GasInput {
 	gasPayment: [Object!]
 	gasPrice: BigInt
 	gasBudget: BigInt
+}
+
+type GenesisTransaction {
+	objects: [Object!]
 }
 
 
@@ -499,6 +517,7 @@ type TransactionBlock {
 	sender: Address
 	bcs: Base64
 	gasInput: GasInput
+	kind: TransactionBlockKind
 	digest: String!
 	expiration: Epoch
 }
@@ -556,6 +575,8 @@ input TransactionBlockFilter {
 	changedObject: SuiAddress
 	transactionIds: [String!]
 }
+
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -238,7 +238,7 @@ type GasInput {
 }
 
 type GenesisTransaction {
-	objects: [Object!]
+	objects: [SuiAddress!]
 }
 
 

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -680,7 +680,7 @@ type ConsensusCommitPrologueTransaction {
 }
 
 type GenesisTransaction {
-  objects: [Object]
+  objects: [SuiAddress]
 }
 
 type ChangeEpochTransaction {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -18,6 +18,7 @@ use crate::{
         object::{Object, ObjectFilter, ObjectKind},
         sui_address::SuiAddress,
         transaction_block::{TransactionBlock, TransactionBlockEffects, TransactionBlockFilter},
+        transaction_block_kind::TransactionBlockKind,
     },
 };
 use async_graphql::connection::{Connection, Edge};
@@ -874,6 +875,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
             TransactionExpiration::Epoch(epoch_id) => Some(*epoch_id),
         };
 
+        let kind = TransactionBlockKind::from(sender_signed_data.transaction_data().kind());
         Ok(Self {
             digest,
             effects,
@@ -881,6 +883,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
             bcs: Some(Base64::from(&tx.raw_transaction)),
             gas_input: Some(gas_input),
             epoch_id,
+            kind: Some(kind),
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -990,7 +990,7 @@ impl From<&TransactionKind> for TransactionBlockKind {
                         x.objects
                             .clone()
                             .into_iter()
-                            .map(Object::from)
+                            .map(SuiAddress::from)
                             .collect::<Vec<_>>(),
                     ),
                 };
@@ -1003,21 +1003,12 @@ impl From<&TransactionKind> for TransactionBlockKind {
 
 // TODO fix this GenesisObject
 #[allow(unreachable_code)]
-impl From<GenesisObject> for Object {
+impl From<GenesisObject> for SuiAddress {
     fn from(value: GenesisObject) -> Self {
         match value {
-            GenesisObject::RawObject { data, owner } => Self {
-                owner: Some(
-                    SuiAddress::from_bytes(owner.get_owner_address().unwrap().to_vec()).unwrap(),
-                ),
-                storage_rebate: None,
-                bcs: None,
-                previous_transaction: None,
-                kind: None,
-                address: SuiAddress::from_bytes(data.id().into_bytes()).unwrap(),
-                version: unimplemented!(),
-                digest: unimplemented!(),
-            },
+            GenesisObject::RawObject { data, owner: _ } => {
+                SuiAddress::from_bytes(data.id().to_vec()).unwrap()
+            }
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -48,7 +48,7 @@ use sui_sdk::types::{
     },
     object::{Data, Object as SuiObject},
     transaction::{
-        GenesisObject, SenderSignedData, TransactionDataAPI, TransactionKind, TransactonExpiration,
+        GenesisObject, SenderSignedData, TransactionDataAPI, TransactionExpiration, TransactionKind,
     },
 };
 

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod storage_fund;
 pub(crate) mod sui_address;
 pub(crate) mod system_parameters;
 pub(crate) mod transaction_block;
+pub(crate) mod transaction_block_kind;
 pub(crate) mod validator;
 pub(crate) mod validator_credentials;
 pub(crate) mod validator_set;

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -13,6 +13,7 @@ use super::{
     epoch::Epoch,
     gas::{GasEffects, GasInput},
     sui_address::SuiAddress,
+    transaction_block_kind::TransactionBlockKind,
 };
 use async_graphql::*;
 use sui_json_rpc_types::{
@@ -31,6 +32,7 @@ pub(crate) struct TransactionBlock {
     pub gas_input: Option<GasInput>,
     #[graphql(skip)]
     pub epoch_id: Option<u64>,
+    pub kind: Option<TransactionBlockKind>,
 }
 
 impl From<SuiTransactionBlockResponse> for TransactionBlock {
@@ -48,6 +50,7 @@ impl From<SuiTransactionBlockResponse> for TransactionBlock {
             bcs: Some(Base64::from(&tx_block.raw_transaction)),
             gas_input,
             epoch_id: None,
+            kind: None, // TODO (stefan) fix this
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -1,17 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::rc::Rc;
-
-use super::{
-    big_int::BigInt, date_time::DateTime, epoch::Epoch, object::Object, sui_address::SuiAddress,
-};
+use super::{big_int::BigInt, date_time::DateTime, epoch::Epoch, object::Object};
 use crate::context_data::db_data_provider::PgManager;
 use async_graphql::{ComplexObject, Context, Result, ResultExt, SimpleObject, Union};
-use sui_sdk::types::transaction::{GenesisObject, TransactionKind};
 
 #[derive(Union, PartialEq, Clone, Eq)]
-pub enum TransactionBlockKind {
+pub(crate) enum TransactionBlockKind {
     ConsensusCommitPrologueTransaction(ConsensusCommitPrologueTransaction),
     GenesisTransaction(GenesisTransaction),
     ChangeEpochTransaction(ChangeEpochTransaction),
@@ -20,30 +15,30 @@ pub enum TransactionBlockKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
-pub struct ConsensusCommitPrologueTransaction {
+pub(crate) struct ConsensusCommitPrologueTransaction {
     #[graphql(skip)]
-    epoch_id: u64,
+    pub(crate) epoch_id: u64,
     // # TODO: This is the "leader round" -- does this line up with
     // # checkpoints? In which case, it may suffice to have a `Checkpoint`
     // # here.
-    round: Option<u64>,
-    timestamp: Option<DateTime>,
+    pub(crate) round: Option<u64>,
+    pub(crate) timestamp: Option<DateTime>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
-pub struct GenesisTransaction {
-    objects: Option<Vec<Object>>,
+pub(crate) struct GenesisTransaction {
+    pub(crate) objects: Option<Vec<Object>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
-pub struct ChangeEpochTransaction {
+pub(crate) struct ChangeEpochTransaction {
     #[graphql(skip)]
-    epoch_id: u64,
-    timestamp: Option<DateTime>,
-    storage_charge: Option<BigInt>,
-    computation_charge: Option<BigInt>,
-    storage_rebate: Option<BigInt>,
+    pub(crate) epoch_id: u64,
+    pub(crate) timestamp: Option<DateTime>,
+    pub(crate) storage_charge: Option<BigInt>,
+    pub(crate) computation_charge: Option<BigInt>,
+    pub(crate) storage_rebate: Option<BigInt>,
 }
 
 #[ComplexObject]
@@ -69,64 +64,5 @@ impl ChangeEpochTransaction {
             .extend()?;
 
         Ok(Some(epoch))
-    }
-}
-
-impl From<&TransactionKind> for TransactionBlockKind {
-    fn from(value: &TransactionKind) -> Self {
-        match value {
-            TransactionKind::ConsensusCommitPrologue(x) => {
-                let consensus = ConsensusCommitPrologueTransaction {
-                    epoch_id: x.epoch,
-                    round: Some(x.round),
-                    timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
-                };
-                TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
-            }
-            TransactionKind::ChangeEpoch(x) => {
-                let change = ChangeEpochTransaction {
-                    epoch_id: x.epoch,
-                    timestamp: DateTime::from_ms(x.epoch_start_timestamp_ms as i64),
-                    storage_charge: Some(BigInt::from(x.storage_charge)),
-                    computation_charge: Some(BigInt::from(x.computation_charge)),
-                    storage_rebate: Some(BigInt::from(x.storage_rebate)),
-                };
-                TransactionBlockKind::ChangeEpochTransaction(change)
-            }
-            TransactionKind::Genesis(x) => {
-                let genesis = GenesisTransaction {
-                    objects: Some(
-                        x.objects
-                            .clone()
-                            .into_iter()
-                            .map(Object::from)
-                            .collect::<Vec<_>>(),
-                    ),
-                };
-                TransactionBlockKind::GenesisTransaction(genesis)
-            }
-            _ => unimplemented!(),
-        }
-    }
-}
-
-// TODO fix this GenesisObject
-#[allow(unreachable_code)]
-impl From<GenesisObject> for Object {
-    fn from(value: GenesisObject) -> Self {
-        match value {
-            GenesisObject::RawObject { data, owner } => Self {
-                owner: Some(
-                    SuiAddress::from_bytes(owner.get_owner_address().unwrap().to_vec()).unwrap(),
-                ),
-                storage_rebate: None,
-                bcs: None,
-                previous_transaction: None,
-                kind: None,
-                address: SuiAddress::from_bytes(data.id().into_bytes()).unwrap(),
-                version: unimplemented!(),
-                digest: unimplemented!(),
-            },
-        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -110,6 +110,8 @@ impl From<&TransactionKind> for TransactionBlockKind {
     }
 }
 
+// TODO fix this GenesisObject
+#[allow(unreachable_code)]
 impl From<GenesisObject> for Object {
     fn from(value: GenesisObject) -> Self {
         match value {

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{big_int::BigInt, date_time::DateTime, epoch::Epoch, object::Object};
+use super::{big_int::BigInt, date_time::DateTime, epoch::Epoch, sui_address::SuiAddress};
 use crate::context_data::db_data_provider::PgManager;
 use async_graphql::{ComplexObject, Context, Result, ResultExt, SimpleObject, Union};
 
@@ -19,16 +19,13 @@ pub(crate) enum TransactionBlockKind {
 pub(crate) struct ConsensusCommitPrologueTransaction {
     #[graphql(skip)]
     pub(crate) epoch_id: u64,
-    // # TODO: This is the "leader round" -- does this line up with
-    // # checkpoints? In which case, it may suffice to have a `Checkpoint`
-    // # here.
     pub(crate) round: Option<u64>,
     pub(crate) timestamp: Option<DateTime>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct GenesisTransaction {
-    pub(crate) objects: Option<Vec<Object>>,
+    pub(crate) objects: Option<Vec<SuiAddress>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    big_int::BigInt, date_time::DateTime, epoch::Epoch, object::Object, sui_address::SuiAddress,
+};
+use crate::context_data::db_data_provider::PgManager;
+use async_graphql::{ComplexObject, Context, Result, ResultExt, SimpleObject, Union};
+use sui_sdk::types::transaction::{GenesisObject, TransactionKind};
+
+#[derive(Union, PartialEq, Clone, Eq)]
+pub enum TransactionBlockKind {
+    ConsensusCommitPrologueTransaction(ConsensusCommitPrologueTransaction),
+    GenesisTransaction(GenesisTransaction),
+    ChangeEpochTransaction(ChangeEpochTransaction),
+    // ProgrammableTransactionBlock(ProgrammableTransactionBlock),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[graphql(complex)]
+pub struct ConsensusCommitPrologueTransaction {
+    #[graphql(skip)]
+    epoch_id: u64,
+    // # TODO: This is the "leader round" -- does this line up with
+    // # checkpoints? In which case, it may suffice to have a `Checkpoint`
+    // # here.
+    round: Option<u64>,
+    timestamp: Option<DateTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+pub struct GenesisTransaction {
+    objects: Option<Vec<Object>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[graphql(complex)]
+pub struct ChangeEpochTransaction {
+    #[graphql(skip)]
+    epoch_id: u64,
+    timestamp: Option<DateTime>,
+    storage_charge: Option<BigInt>,
+    computation_charge: Option<BigInt>,
+    storage_rebate: Option<BigInt>,
+}
+
+#[ComplexObject]
+impl ConsensusCommitPrologueTransaction {
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        let epoch = ctx
+            .data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.epoch_id)
+            .await
+            .extend()?;
+
+        Ok(Some(epoch))
+    }
+}
+
+#[ComplexObject]
+impl ChangeEpochTransaction {
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        let epoch = ctx
+            .data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.epoch_id)
+            .await
+            .extend()?;
+
+        Ok(Some(epoch))
+    }
+}
+
+impl From<&TransactionKind> for TransactionBlockKind {
+    fn from(value: &TransactionKind) -> Self {
+        match value {
+            TransactionKind::ConsensusCommitPrologue(x) => {
+                let consensus = ConsensusCommitPrologueTransaction {
+                    epoch_id: x.epoch,
+                    round: Some(x.round),
+                    timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
+                };
+                TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
+            }
+            TransactionKind::ChangeEpoch(x) => {
+                let change = ChangeEpochTransaction {
+                    epoch_id: x.epoch,
+                    timestamp: DateTime::from_ms(x.epoch_start_timestamp_ms as i64),
+                    storage_charge: Some(BigInt::from(x.storage_charge)),
+                    computation_charge: Some(BigInt::from(x.computation_charge)),
+                    storage_rebate: Some(BigInt::from(x.storage_rebate)),
+                };
+                TransactionBlockKind::ChangeEpochTransaction(change)
+            }
+            TransactionKind::Genesis(x) => {
+                let genesis = GenesisTransaction {
+                    objects: Some(
+                        x.objects
+                            .clone()
+                            .into_iter()
+                            .map(Object::from)
+                            .collect::<Vec<_>>(),
+                    ),
+                };
+                TransactionBlockKind::GenesisTransaction(genesis)
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+impl From<GenesisObject> for Object {
+    fn from(value: GenesisObject) -> Self {
+        match value {
+            GenesisObject::RawObject { data, owner } => Self {
+                address: todo!(),
+                version: todo!(),
+                digest: todo!(),
+                storage_rebate: todo!(),
+                owner: Some(
+                    SuiAddress::from_bytes(owner.get_owner_address().unwrap().to_vec()).unwrap(),
+                ),
+                bcs: todo!(),
+                previous_transaction: todo!(),
+                kind: todo!(),
+            },
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -6,6 +6,7 @@ use crate::context_data::db_data_provider::PgManager;
 use async_graphql::{ComplexObject, Context, Result, ResultExt, SimpleObject, Union};
 
 #[derive(Union, PartialEq, Clone, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum TransactionBlockKind {
     ConsensusCommitPrologueTransaction(ConsensusCommitPrologueTransaction),
     GenesisTransaction(GenesisTransaction),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::rc::Rc;
+
 use super::{
     big_int::BigInt, date_time::DateTime, epoch::Epoch, object::Object, sui_address::SuiAddress,
 };
@@ -103,7 +105,7 @@ impl From<&TransactionKind> for TransactionBlockKind {
                 };
                 TransactionBlockKind::GenesisTransaction(genesis)
             }
-            _ => todo!(),
+            _ => unimplemented!(),
         }
     }
 }
@@ -112,16 +114,16 @@ impl From<GenesisObject> for Object {
     fn from(value: GenesisObject) -> Self {
         match value {
             GenesisObject::RawObject { data, owner } => Self {
-                address: todo!(),
-                version: todo!(),
-                digest: todo!(),
-                storage_rebate: todo!(),
                 owner: Some(
                     SuiAddress::from_bytes(owner.get_owner_address().unwrap().to_vec()).unwrap(),
                 ),
-                bcs: todo!(),
-                previous_transaction: todo!(),
-                kind: todo!(),
+                storage_rebate: None,
+                bcs: None,
+                previous_transaction: None,
+                kind: None,
+                address: SuiAddress::from_bytes(data.id().into_bytes()).unwrap(),
+                version: unimplemented!(),
+                digest: unimplemented!(),
             },
         }
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -242,7 +242,7 @@ type GasInput {
 }
 
 type GenesisTransaction {
-	objects: [Object!]
+	objects: [SuiAddress!]
 }
 
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -64,6 +64,14 @@ scalar Base64
 scalar BigInt
 
 
+type ChangeEpochTransaction {
+	timestamp: DateTime
+	storageCharge: BigInt
+	computationCharge: BigInt
+	storageRebate: BigInt
+	epoch: Epoch
+}
+
 type Checkpoint {
 	digest: String!
 	sequenceNumber: Int!
@@ -150,6 +158,12 @@ type CommitteeMember {
 	stakeUnit: Int
 }
 
+type ConsensusCommitPrologueTransaction {
+	round: Int
+	timestamp: DateTime
+	epoch: Epoch
+}
+
 scalar DateTime
 
 type EndOfEpochData {
@@ -225,6 +239,10 @@ type GasInput {
 	gasPayment: [Object!]
 	gasPrice: BigInt
 	gasBudget: BigInt
+}
+
+type GenesisTransaction {
+	objects: [Object!]
 }
 
 
@@ -503,6 +521,7 @@ type TransactionBlock {
 	sender: Address
 	bcs: Base64
 	gasInput: GasInput
+	kind: TransactionBlockKind
 	digest: String!
 	expiration: Epoch
 }
@@ -560,6 +579,8 @@ input TransactionBlockFilter {
 	changedObject: SuiAddress
 	transactionIds: [String!]
 }
+
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX


### PR DESCRIPTION
## Description 

Add `TransactionBlockKind` resolvers in Graphql. Not fully completed due to missing other types (Move stuff). 
Not clear how to handle the `GenesisObject` yet. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
