### PR TITLE
[Analytics] Make analytics pipelines run from any checkpoint to support backfill

### DIFF
--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -29,7 +29,6 @@ pub(crate) struct CSVWriter {
 impl CSVWriter {
     pub(crate) fn new(
         root_dir_path: &Path,
-        epoch: EpochId,
         file_type: FileType,
         start_checkpoint_seq_num: u64,
     ) -> Result<Self> {
@@ -37,14 +36,14 @@ impl CSVWriter {
         let writer = Self::make_writer(
             root_dir_path.to_path_buf(),
             file_type,
-            epoch,
+            0,
             checkpoint_range.clone(),
         )?;
         Ok(CSVWriter {
             root_dir_path: root_dir_path.to_path_buf(),
             file_type,
             writer,
-            epoch,
+            epoch: 0,
             checkpoint_range,
         })
     }


### PR DESCRIPTION
## Description 

This PR allows for us to run analytics pipeline from any given checkpoint passed in through the config. This is useful for testing purposes and for backfill we need to be able to run from an arbitrary checkpoint.

## Test Plan 

Ran locally, pipeline works as expected
