### PR TITLE
[graphql/rpc] easy: add initial server config struct and file loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10354,6 +10354,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml 0.8.26",
  "sui-indexer",
  "sui-json-rpc-types",
  "sui-sdk",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -26,6 +26,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+serde_yaml.workspace = true
 telemetry-subscribers.workspace = true
 tracing.workspace = true
 tokio.workspace = true

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -155,8 +155,7 @@ struct ServerConfig {
 impl ServerConfig {
     pub fn from_yaml(path: &str) -> Self {
         let contents = std::fs::read_to_string(path).unwrap();
-        let config = serde_yaml::from_str::<Self>(&contents).unwrap();
-        config
+        serde_yaml::from_str::<Self>(&contents).unwrap()
     }
 
     pub fn to_yaml_file(&self, path: PathBuf) {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, path::PathBuf};
 
 use async_graphql::*;
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,7 @@ const MAX_QUERY_DEPTH: u32 = 10;
 const MAX_QUERY_NODES: u32 = 100;
 
 /// Configuration on connections for the RPC, passed in as command-line arguments.
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 pub struct ConnectionConfig {
     pub(crate) port: u16,
     pub(crate) host: String,
@@ -110,6 +111,57 @@ impl Default for Limits {
             max_query_depth: MAX_QUERY_DEPTH,
             max_query_nodes: MAX_QUERY_NODES,
         }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
+struct InternalFeatureConfig {
+    #[serde(default)]
+    pub(crate) query_limits_checker: bool,
+    #[serde(default)]
+    pub(crate) feature_gate: bool,
+    #[serde(default)]
+    pub(crate) logger: bool,
+    #[serde(default)]
+    pub(crate) query_timeout: bool,
+    #[serde(default)]
+    pub(crate) metrics: bool,
+}
+
+impl Default for InternalFeatureConfig {
+    fn default() -> Self {
+        Self {
+            query_limits_checker: true,
+            feature_gate: true,
+            logger: true,
+            query_timeout: true,
+            metrics: true,
+        }
+    }
+}
+
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq, Default)]
+struct ServerConfig {
+    #[serde(default)]
+    pub(crate) service: ServiceConfig,
+    #[serde(default)]
+    pub(crate) connection: ConnectionConfig,
+    #[serde(default)]
+    pub(crate) internal_features: InternalFeatureConfig,
+}
+
+#[allow(dead_code)]
+impl ServerConfig {
+    pub fn from_yaml(path: &str) -> Self {
+        let contents = std::fs::read_to_string(path).unwrap();
+        let config = serde_yaml::from_str::<Self>(&contents).unwrap();
+        config
+    }
+
+    pub fn to_yaml_file(&self, path: PathBuf) {
+        let config = serde_yaml::to_string(&self).unwrap();
+        std::fs::write(path, config).unwrap();
     }
 }
 


### PR DESCRIPTION
## Description 

Adds ServerConfig type which will be used to drive all server configs from a yaml file

## Test Plan 

TBD

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
