### PR TITLE
wallet-ext: hidden assets ui improvements

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -13,6 +13,7 @@ import { useOnScreen } from '@mysten/core';
 import { useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { useHiddenAssets } from '../hidden-assets/HiddenAssetsProvider';
 import AssetsOptionsMenu from './AssetsOptionsMenu';
 import NonVisualAssets from './NonVisualAssets';
 import VisualAssets from './VisualAssets';
@@ -47,6 +48,7 @@ function NftsPage() {
 		if (!filterType) return ownedAssets?.visual;
 		return ownedAssets?.[filterType as AssetFilterTypes] ?? [];
 	}, [ownedAssets, filterType]);
+	const { hiddenAssetIds } = useHiddenAssets();
 
 	if (isInitialLoading) {
 		return (
@@ -62,8 +64,8 @@ function NftsPage() {
 	];
 
 	return (
-		<div className="flex flex-1 flex-col flex-nowrap items-center gap-4">
-			<PageTitle title="Assets" after={<AssetsOptionsMenu />} />
+		<div className="flex min-h-full flex-col flex-nowrap items-center gap-4">
+			<PageTitle title="Assets" after={hiddenAssetIds.length ? <AssetsOptionsMenu /> : null} />
 			{!!ownedAssets?.other.length && (
 				<FiltersPortal firstLastMargin tags={tags} callback={handleFilterChange} />
 			)}

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.tsx
@@ -48,7 +48,11 @@ export function PageMainLayout({
 			/>
 			<div className="relative flex flex-col flex-nowrap flex-grow overflow-hidden rounded-t-xl shadow-wallet-content">
 				<div className="flex flex-col flex-nowrap bg-white flex-grow overflow-y-auto overflow-x-hidden rounded-t-xl">
-					<main className={cn('flex-grow w-full', { 'p-5': bottomNavEnabled })}>
+					<main
+						className={cn('flex flex-col flex-grow w-full', {
+							'p-5': bottomNavEnabled,
+						})}
+					>
 						<PageMainLayoutContext.Provider value={titlePortalContainer}>
 							<ErrorBoundary>{children}</ErrorBoundary>
 						</PageMainLayoutContext.Provider>


### PR DESCRIPTION
## Description 

* hide hidden assets menu button when no hidden assets exist
* center empty message

before


https://github.com/MystenLabs/sui/assets/10210143/fbf47c0f-ae6e-4cdd-a45e-b3ff6c1ec03a


after 


https://github.com/MystenLabs/sui/assets/10210143/b7b5d9f9-ba29-41d9-ad6d-d347f686b19e



closes [APPS-1807](https://mysten.atlassian.net/browse/APPS-1807) 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
