### PR TITLE
[graphql/rpc] chore/easy: add TODO comments to callout we're moving away from sdk usage

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -55,6 +55,9 @@ use sui_sdk::{
 
 use super::data_provider::DataProvider;
 
+// TODO: Ensure the logic is this file is for verification/experimentation only
+// and is not used in production
+
 const RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD: Duration = Duration::from_millis(10_000);
 const MAX_CONCURRENT_REQUESTS: usize = 1_000;
 const DATA_LOADER_LRU_CACHE_SIZE: usize = 1_000;

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -83,6 +83,7 @@ impl Address {
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance(&self.address, type_)
             .await
@@ -96,6 +97,7 @@ impl Address {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Connection<String, Balance>> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance_connection(&self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -50,6 +50,7 @@ impl GasInput {
     }
 
     async fn gas_payment(&self, ctx: &Context<'_>) -> Result<Option<Vec<Object>>> {
+        // TODO: implement DB counterpart without using Sui SDK client
         let payment_objs = ctx
             .data_provider()
             .multi_get_object_with_options(
@@ -128,6 +129,7 @@ impl From<(&NativeGasCostSummary, &OwnedObjectRef)> for GasEffects {
 #[Object]
 impl GasEffects {
     async fn gas_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
+        // TODO: implement DB counterpart without using Sui SDK client
         let gas_obj = ctx
             .data_provider()
             .get_object_with_options(self.object_id, SuiObjectDataOptions::full_content())

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -114,6 +114,7 @@ impl Object {
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance(&self.address, type_)
             .await
@@ -127,6 +128,7 @@ impl Object {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Connection<String, Balance>> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance_connection(&self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -116,6 +116,7 @@ impl Owner {
     }
 
     pub async fn balance(&self, ctx: &Context<'_>, type_: Option<String>) -> Result<Balance> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance(&self.address, type_)
             .await
@@ -129,6 +130,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Connection<String, Balance>> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_balance_connection(&self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -30,6 +30,7 @@ pub(crate) struct ProtocolConfigs {
 impl ProtocolConfigs {
     async fn configs(&self, ctx: &Context<'_>) -> Result<Option<Vec<ProtocolConfigAttr>>> {
         Ok(Some(
+            // TODO: implement DB counterpart without using Sui SDK client
             ctx.data_provider()
                 .fetch_protocol_config(None)
                 .await?
@@ -42,6 +43,7 @@ impl ProtocolConfigs {
         ctx: &Context<'_>,
     ) -> Result<Option<Vec<ProtocolConfigFeatureFlag>>> {
         Ok(Some(
+            // TODO: implement DB counterpart without using Sui SDK client
             ctx.data_provider()
                 .fetch_protocol_config(None)
                 .await?
@@ -50,6 +52,7 @@ impl ProtocolConfigs {
     }
 
     async fn protocol_version(&self, ctx: &Context<'_>) -> Result<u64> {
+        // TODO: implement DB counterpart without using Sui SDK client
         Ok(ctx
             .data_provider()
             .fetch_protocol_config(None)

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -182,6 +182,7 @@ impl Query {
         ctx: &Context<'_>,
         protocol_version: Option<u64>,
     ) -> Result<ProtocolConfigs> {
+        // TODO: implement DB counterpart without using Sui SDK client
         ctx.data_provider()
             .fetch_protocol_config(protocol_version)
             .await

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -59,6 +59,7 @@ impl TransactionBlock {
             return Ok(None);
         }
         let gcs = self.effects.as_ref().unwrap().gas_effects.gcs;
+        // TODO: implement DB counterpart without using Sui SDK client
         let data_provider = ctx.data_provider();
         let system_state = data_provider.get_latest_sui_system_state().await?;
         let protocol_configs = data_provider.fetch_protocol_config(None).await?;


### PR DESCRIPTION
## Description 

Make it more explicit via comments that we're moving away from depending on RPC 1.0 SDK so we can migrate and cleanup as needed.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
