### PR TITLE
[graphql/rpc] disable builder tests pending alt data source

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -133,6 +133,7 @@ mod tests {
     use std::time::Duration;
     use std::{env, sync::Arc};
 
+    #[ignore]
     #[tokio::test]
     async fn test_timeout() {
         struct TimedExecuteExt {
@@ -204,6 +205,7 @@ mod tests {
         assert_eq!(errs, vec![exp]);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_query_depth_limit() {
         async fn exec_query_depth_limit(depth: u32, query: &str) -> Response {
@@ -257,6 +259,7 @@ mod tests {
         assert_eq!(errs, vec!["Query is nested too deep.".to_string()]);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_query_node_limit() {
         async fn exec_query_node_limit(nodes: u32, query: &str) -> Response {
@@ -310,6 +313,7 @@ mod tests {
         assert_eq!(err, vec!["Query is too complex.".to_string()]);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_query_complexity_metrics() {
         let binding_address: SocketAddr = "0.0.0.0:9184".parse().unwrap();


### PR DESCRIPTION
## Description 

Disables tests which depend on DB while we develop data source for CI

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
