### PR TITLE
[graphql/rpc] change expiration field in tx block

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -43,7 +43,7 @@ use sui_sdk::types::{
         CheckpointCommitment, CheckpointDigest, EndOfEpochData as NativeEndOfEpochData,
     },
     object::{Data, Object as SuiObject},
-    transaction::{SenderSignedData, TransactionDataAPI},
+    transaction::{SenderSignedData, TransactionDataAPI, TransactionExpiration},
 };
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
@@ -869,12 +869,18 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
             ))),
         }?;
 
+        let epoch_id = match sender_signed_data.intent_message().value.expiration() {
+            TransactionExpiration::None => None,
+            TransactionExpiration::Epoch(epoch_id) => Some(*epoch_id),
+        };
+
         Ok(Self {
             digest,
             effects,
             sender: Some(sender),
             bcs: Some(Base64::from(&tx.raw_transaction)),
             gas_input: Some(gas_input),
+            epoch_id,
         })
     }
 }


### PR DESCRIPTION
## Description 

Use the available data for the expiration field instead of using the get last system state.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
