### PR TITLE
Fix determination of scripts in Move model to work for 32-byte addresses

### DIFF
--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -410,7 +410,7 @@ move-ir-compiler = { path = "../../external-crates/move/move-ir-compiler" }
 move-ir-to-bytecode = { path = "../../external-crates/move/move-ir-compiler/move-ir-to-bytecode" }
 move-ir-to-bytecode-syntax = { path = "../../external-crates/move/move-ir-compiler/move-ir-to-bytecode/syntax" }
 move-ir-types = { path = "../../external-crates/move/move-ir/types", default-features = false }
-move-model = { path = "../../external-crates/move/move-model", default-features = false }
+move-model = { path = "../../external-crates/move/move-model" }
 move-package = { path = "../../external-crates/move/tools/move-package", default-features = false }
 move-prover = { path = "../../external-crates/move/move-prover", default-features = false }
 move-prover-boogie-backend = { path = "../../external-crates/move/move-prover/boogie-backend", default-features = false }
@@ -1201,7 +1201,7 @@ move-ir-compiler = { path = "../../external-crates/move/move-ir-compiler" }
 move-ir-to-bytecode = { path = "../../external-crates/move/move-ir-compiler/move-ir-to-bytecode" }
 move-ir-to-bytecode-syntax = { path = "../../external-crates/move/move-ir-compiler/move-ir-to-bytecode/syntax" }
 move-ir-types = { path = "../../external-crates/move/move-ir/types", default-features = false }
-move-model = { path = "../../external-crates/move/move-model", default-features = false }
+move-model = { path = "../../external-crates/move/move-model" }
 move-package = { path = "../../external-crates/move/tools/move-package", default-features = false }
 move-proc-macros = { path = "../../external-crates/move/testing-infra/move-proc-macros", default-features = false }
 move-prover = { path = "../../external-crates/move/move-prover", default-features = false }

--- a/external-crates/move/move-model/Cargo.toml
+++ b/external-crates/move/move-model/Cargo.toml
@@ -36,3 +36,7 @@ move-prover-test-utils = { path = "../move-prover/test-utils" }
 [[test]]
 name = "testsuite"
 harness = false
+
+[features]
+default = ["address32"]
+address32 = ["move-core-types/address32"]

--- a/external-crates/move/move-model/src/ast.rs
+++ b/external-crates/move/move-model/src/ast.rs
@@ -34,6 +34,11 @@ use crate::{
     ty::{Type, TypeDisplayContext},
 };
 
+#[cfg(feature = "address32")]
+const MAX_ADDR_STRING: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+#[cfg(not(feature = "address32"))]
+const MAX_ADDR_STRING: &str = "ffffffffffffffffffffffffffffffff";
+
 // =================================================================================================
 /// # Declarations
 
@@ -1106,9 +1111,8 @@ impl ModuleName {
     /// Determine whether this is a script. The move-compiler infrastructure uses MAX_ADDR
     /// for pseudo modules created from scripts, so use this address to check.
     pub fn is_script(&self) -> bool {
-        static MAX_ADDR: Lazy<BigUint> = Lazy::new(|| {
-            BigUint::from_str_radix("ffffffffffffffffffffffffffffffff", 16).expect("valid hex")
-        });
+        static MAX_ADDR: Lazy<BigUint> =
+            Lazy::new(|| BigUint::from_str_radix(MAX_ADDR_STRING, 16).expect("valid hex"));
         self.0 == *MAX_ADDR
     }
 }

--- a/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_inline.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_inline.md
@@ -1,26 +1,20 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main"></a>
+<a name="main"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::main`
+# Script `main`
 
 
 
--  [Function `main`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main)
-    -  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
 
 
 <pre><code></code></pre>
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main"></a>
-
-## Function `main`
-
-
 <a name="@Explanation_of_the_algorithm_0"></a>
 
-### Explanation of the algorithm
+## Explanation of the algorithm
 
 ```
 code block
@@ -28,7 +22,7 @@ code block
 then <code>inline code</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
 </code></pre>
 
 
@@ -37,7 +31,7 @@ then <code>inline code</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>() { }
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
 </code></pre>
 
 

--- a/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_inline_no_fold.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_inline_no_fold.md
@@ -1,26 +1,20 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main"></a>
+<a name="main"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::main`
+# Script `main`
 
 
 
--  [Function `main`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main)
-    -  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
 
 
 <pre><code></code></pre>
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main"></a>
-
-## Function `main`
-
-
 <a name="@Explanation_of_the_algorithm_0"></a>
 
-### Explanation of the algorithm
+## Explanation of the algorithm
 
 ```
 code block
@@ -28,7 +22,7 @@ code block
 then <code>inline code</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
 </code></pre>
 
 
@@ -36,5 +30,5 @@ then <code>inline code</code>
 ##### Implementation
 
 
-<pre><code><b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>() { }
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
 </code></pre>

--- a/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_separate.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/code_block_test.spec_separate.md
@@ -1,26 +1,20 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main"></a>
+<a name="main"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::main`
+# Script `main`
 
 
 
--  [Function `main`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main)
-    -  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
+-  [Explanation of the algorithm](#@Explanation_of_the_algorithm_0)
 
 
 <pre><code></code></pre>
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main_main"></a>
-
-## Function `main`
-
-
 <a name="@Explanation_of_the_algorithm_0"></a>
 
-### Explanation of the algorithm
+## Explanation of the algorithm
 
 ```
 code block
@@ -28,7 +22,7 @@ code block
 then <code>inline code</code>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>()
+<pre><code><b>public</b> <b>fun</b> <a href="code_block_test.md#main">main</a>()
 </code></pre>
 
 
@@ -37,7 +31,7 @@ then <code>inline code</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="code_block_test.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_main">main</a>() { }
+<pre><code><b>fun</b> <a href="code_block_test.md#main">main</a>() { }
 </code></pre>
 
 

--- a/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_inline.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_inline.md
@@ -7,14 +7,12 @@
 
 This document contains the description of multiple move scripts.
 
-The script <code><a href="root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another">yet_another</a></code> is documented in its own file.
+The script <code><a href="root_template_script3.md#yet_another">yet_another</a></code> is documented in its own file.
 
 -  [Some Scripts](#@Some_Scripts_1)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
-        -  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
+    -  [Script `some`](#some)
 -  [Other Scripts](#@Other_Scripts_2)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
-        -  [Function `other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other)
+    -  [Script `other`](#other)
 -  [Some other scripts from a module](#@Some_other_scripts_from_a_module_3)
     -  [Module `0x1::OneTypeOfScript`](#0x1_OneTypeOfScript)
         -  [Function `script1`](#0x1_OneTypeOfScript_script1)
@@ -32,24 +30,19 @@ The script <code><a href="root_template_script3.md#0xfffffffffffffffffffffffffff
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+### Script `some`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-#### Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -58,7 +51,7 @@ This script does really nothing but just aborts.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>
@@ -87,24 +80,19 @@ This script does really nothing but just aborts.
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other"></a>
+<a name="other"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`
+### Script `other`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other"></a>
-
-#### Function `other`
-
 This script does also abort.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -113,7 +101,7 @@ This script does also abort.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 2
 }
 </code></pre>
@@ -267,6 +255,6 @@ This is another script
 
 -  [`0x1::AnotherTypeOfScript`](root.md#0x1_AnotherTypeOfScript)
 -  [`0x1::OneTypeOfScript`](root.md#0x1_OneTypeOfScript)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::yet_another`](root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another)
+-  [`other`](root.md#other)
+-  [`some`](root.md#some)
+-  [`yet_another`](root_template_script3.md#yet_another)

--- a/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_inline_no_fold.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_inline_no_fold.md
@@ -7,14 +7,12 @@
 
 This document contains the description of multiple move scripts.
 
-The script <code><a href="root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another">yet_another</a></code> is documented in its own file.
+The script <code><a href="root_template_script3.md#yet_another">yet_another</a></code> is documented in its own file.
 
 -  [Some Scripts](#@Some_Scripts_1)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
-        -  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
+    -  [Script `some`](#some)
 -  [Other Scripts](#@Other_Scripts_2)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
-        -  [Function `other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other)
+    -  [Script `other`](#other)
 -  [Some other scripts from a module](#@Some_other_scripts_from_a_module_3)
     -  [Module `0x1::OneTypeOfScript`](#0x1_OneTypeOfScript)
         -  [Function `script1`](#0x1_OneTypeOfScript_script1)
@@ -32,24 +30,19 @@ The script <code><a href="root_template_script3.md#0xfffffffffffffffffffffffffff
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+### Script `some`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-#### Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -57,7 +50,7 @@ This script does really nothing but just aborts.
 ##### Implementation
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>
@@ -81,24 +74,19 @@ This script does really nothing but just aborts.
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other"></a>
+<a name="other"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`
+### Script `other`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other"></a>
-
-#### Function `other`
-
 This script does also abort.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -106,7 +94,7 @@ This script does also abort.
 ##### Implementation
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 2
 }
 </code></pre>
@@ -243,6 +231,6 @@ This is another script
 
 -  [`0x1::AnotherTypeOfScript`](root.md#0x1_AnotherTypeOfScript)
 -  [`0x1::OneTypeOfScript`](root.md#0x1_OneTypeOfScript)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::yet_another`](root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another)
+-  [`other`](root.md#other)
+-  [`some`](root.md#some)
+-  [`yet_another`](root_template_script3.md#yet_another)

--- a/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_separate.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/root_template.spec_separate.md
@@ -7,15 +7,13 @@
 
 This document contains the description of multiple move scripts.
 
-The script <code><a href="root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another">yet_another</a></code> is documented in its own file.
+The script <code><a href="root_template_script3.md#yet_another">yet_another</a></code> is documented in its own file.
 
 -  [Some Scripts](#@Some_Scripts_1)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
-        -  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
+    -  [Script `some`](#some)
         -  [Specification](#@Specification_2)
 -  [Other Scripts](#@Other_Scripts_3)
-    -  [Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
-        -  [Function `other`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other)
+    -  [Script `other`](#other)
         -  [Specification](#@Specification_4)
 -  [Some other scripts from a module](#@Some_other_scripts_from_a_module_5)
     -  [Module `0x1::OneTypeOfScript`](#0x1_OneTypeOfScript)
@@ -34,24 +32,19 @@ The script <code><a href="root_template_script3.md#0xfffffffffffffffffffffffffff
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+### Script `some`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-#### Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -60,7 +53,7 @@ This script does really nothing but just aborts.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>
@@ -79,7 +72,7 @@ This script does really nothing but just aborts.
 ##### Function `some`
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -98,24 +91,19 @@ This script does really nothing but just aborts.
 
 
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other"></a>
+<a name="other"></a>
 
-### Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`
+### Script `other`
 
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other_other"></a>
-
-#### Function `other`
-
 This script does also abort.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -124,7 +112,7 @@ This script does also abort.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 2
 }
 </code></pre>
@@ -143,7 +131,7 @@ This script does also abort.
 ##### Function `other`
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other">other</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="root.md#other">other</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -287,6 +275,6 @@ This is another script
 
 -  [`0x1::AnotherTypeOfScript`](root.md#0x1_AnotherTypeOfScript)
 -  [`0x1::OneTypeOfScript`](root.md#0x1_OneTypeOfScript)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::other`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_other)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`](root.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some)
--  [`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::yet_another`](root_template_script3.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_yet_another)
+-  [`other`](root.md#other)
+-  [`some`](root.md#some)
+-  [`yet_another`](root_template_script3.md#yet_another)

--- a/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_inline.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_inline.md
@@ -1,25 +1,19 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+# Script `some`
 
 
 
--  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-## Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -28,7 +22,7 @@ This script does really nothing but just aborts.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>

--- a/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_inline_no_fold.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_inline_no_fold.md
@@ -1,25 +1,19 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+# Script `some`
 
 
 
--  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-## Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -27,7 +21,7 @@ This script does really nothing but just aborts.
 ##### Implementation
 
 
-<pre><code><b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>

--- a/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_separate.md
+++ b/external-crates/move/move-prover/move-docgen/tests/sources/some_script.spec_separate.md
@@ -1,25 +1,19 @@
 
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some"></a>
+<a name="some"></a>
 
-# Module `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff::some`
+# Script `some`
 
 
 
--  [Function `some`](#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some)
 
 
 <pre><code></code></pre>
 
 
-
-<a name="0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some_some"></a>
-
-## Function `some`
-
 This script does really nothing but just aborts.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer)
+<pre><code><b>public</b> <b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer)
 </code></pre>
 
 
@@ -28,7 +22,7 @@ This script does really nothing but just aborts.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="some_script.md#0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_some">some</a>&lt;T&gt;(_account: signer) {
+<pre><code><b>fun</b> <a href="some_script.md#some">some</a>&lt;T&gt;(_account: signer) {
     <b>abort</b> 1
 }
 </code></pre>


### PR DESCRIPTION
## Description 

Fixes an issue from #14112 where docgen was improperly formatting scripts since these are identified with an address of `MAX_ADDR` but to get this in `BigUint` which is what the Move model uses it passes the address value string.

## Test Plan 

Ran tests locally and updated.

