### PR TITLE
jsonrpc: fix missing data when using query_transaction

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4209,6 +4209,20 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
     ) -> SuiResult<Option<Object>> {
         self.database.get_object_by_key(&object_id, version)
     }
+
+    async fn multi_get_transaction_checkpoint(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<CheckpointSequenceNumber>>> {
+        let res = self
+            .database
+            .deprecated_multi_get_transaction_checkpoint(digests)?;
+
+        Ok(res
+            .into_iter()
+            .map(|maybe| maybe.map(|(_epoch, checkpoint)| checkpoint))
+            .collect())
+    }
 }
 
 #[cfg(msim)]

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -450,6 +450,11 @@ mod tests {
             ) -> SuiResult<Option<CheckpointSequenceNumber>>;
 
             async fn get_object(&self, object_id: ObjectID, version: SequenceNumber) -> SuiResult<Option<Object>>;
+
+            async fn multi_get_transaction_checkpoint(
+                &self,
+                digests: &[TransactionDigest],
+            ) -> SuiResult<Vec<Option<CheckpointSequenceNumber>>>;
         }
     }
 

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -227,6 +227,16 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
     ) -> SuiResult<Option<Object>> {
         Ok(self.objects.get(&ObjectKey(object_id, version)).cloned())
     }
+
+    async fn multi_get_transaction_checkpoint(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<CheckpointSequenceNumber>>> {
+        Ok(digests
+            .iter()
+            .map(|digest| self.tx_to_checkpoint.get(digest).cloned())
+            .collect())
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description 

    Fixes an issue where data could be missing when using query_transaction
    when the transaction data itself isn't present on the node, due to
    pruning, requiring us to fallback to the kvstore.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
