### PR TITLE
Fix initialization of ConsensusStats after upgrades

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -125,6 +125,8 @@ pub struct ExecutionIndicesWithHash {
 /// stored on disk.
 #[enum_dispatch]
 pub trait ConsensusStatsAPI {
+    fn is_initialized(&self) -> bool;
+
     fn get_narwhal_certificates(&self, authority: usize) -> u64;
     fn inc_narwhal_certificates(&mut self, authority: usize) -> u64;
 
@@ -160,6 +162,10 @@ pub struct ConsensusStatsV1 {
 }
 
 impl ConsensusStatsAPI for ConsensusStatsV1 {
+    fn is_initialized(&self) -> bool {
+        !self.narwhal_certificates.is_empty()
+    }
+
     fn get_narwhal_certificates(&self, authority: usize) -> u64 {
         self.narwhal_certificates[authority]
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -77,9 +77,8 @@ impl<T, C> ConsensusHandler<T, C> {
         let mut last_consensus_stats = epoch_store
             .get_last_consensus_stats()
             .expect("Should be able to read last consensus index");
-        // last_consensus_stats is zero at the beginning of epoch for every field.
-        if last_consensus_stats.index.last_committed_round == 0 {
-            assert_eq!(last_consensus_stats.hash, 0);
+        // stats is empty at the beginning of epoch.
+        if !last_consensus_stats.stats.is_initialized() {
             last_consensus_stats.stats = ConsensusStats::new(committee.size());
         }
         let transaction_scheduler =


### PR DESCRIPTION
## Description 

Current logic does not initialize ConsensusStats for upgraded validators.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
