### PR TITLE
[graphql/rpc] easy/chore: fix type def & schema

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -244,17 +244,7 @@ type GenesisTransaction {
 
 
 
-type MoveObject {
-	contents: MoveValue
-	hasPublicTransfer: Boolean
-	asObject: Object
-	asCoin: Coin
-	asStakedSui: StakedSui
-}
-
-type MoveValue {
-	bcs: Base64!
-	data: \
+"""
 The contents of a Move Value, corresponding to the following recursive type:
 
 type MoveData =
@@ -266,7 +256,21 @@ type MoveData =
   | { Vector:  [MoveData] }
   | { Option:   MoveData? }
   | { Struct:  [{ name: string, value: MoveData }] }
-!
+
+"""
+scalar MoveData
+
+type MoveObject {
+	contents: MoveValue
+	hasPublicTransfer: Boolean
+	asObject: Object
+	asCoin: Coin
+	asStakedSui: StakedSui
+}
+
+type MoveValue {
+	bcs: Base64!
+	data: MoveData!
 }
 
 scalar NameService
@@ -657,20 +661,6 @@ type ValidatorSet {
 	inactivePoolsSize: Int
 	validatorCandidatesSize: Int
 }
-
-scalar \
-The contents of a Move Value, corresponding to the following recursive type:
-
-type MoveData =
-    { Address: SuiAddress }
-  | { UID:     SuiAddress }
-  | { Bool:    bool }
-  | { Number:  BigInt }
-  | { String:  string }
-  | { Vector:  [MoveData] }
-  | { Option:   MoveData? }
-  | { Struct:  [{ name: string, value: MoveData }] }
-
 
 schema {
 	query: Query

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -38,8 +38,8 @@ pub(crate) struct MoveValue {
 
 scalar!(
     MoveData,
-    r#"\
-The contents of a Move Value, corresponding to the following recursive type:
+    "MoveData",
+    r#"The contents of a Move Value, corresponding to the following recursive type:
 
 type MoveData =
     { Address: SuiAddress }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -248,17 +248,7 @@ type GenesisTransaction {
 
 
 
-type MoveObject {
-	contents: MoveValue
-	hasPublicTransfer: Boolean
-	asObject: Object
-	asCoin: Coin
-	asStakedSui: StakedSui
-}
-
-type MoveValue {
-	bcs: Base64!
-	data: \
+"""
 The contents of a Move Value, corresponding to the following recursive type:
 
 type MoveData =
@@ -270,7 +260,21 @@ type MoveData =
   | { Vector:  [MoveData] }
   | { Option:   MoveData? }
   | { Struct:  [{ name: string, value: MoveData }] }
-!
+
+"""
+scalar MoveData
+
+type MoveObject {
+	contents: MoveValue
+	hasPublicTransfer: Boolean
+	asObject: Object
+	asCoin: Coin
+	asStakedSui: StakedSui
+}
+
+type MoveValue {
+	bcs: Base64!
+	data: MoveData!
 }
 
 scalar NameService
@@ -661,20 +665,6 @@ type ValidatorSet {
 	inactivePoolsSize: Int
 	validatorCandidatesSize: Int
 }
-
-scalar \
-The contents of a Move Value, corresponding to the following recursive type:
-
-type MoveData =
-    { Address: SuiAddress }
-  | { UID:     SuiAddress }
-  | { Bool:    bool }
-  | { Number:  BigInt }
-  | { String:  string }
-  | { Vector:  [MoveData] }
-  | { Option:   MoveData? }
-  | { Struct:  [{ name: string, value: MoveData }] }
-
 
 schema {
 	query: Query


### PR DESCRIPTION
## Description 

The scalar `MoveData` wasn't properly defined

## Test Plan 

Unit

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
