### PR TITLE
sim data source 1/x: parametize rest api data source

### DIFF
--- a/crates/sui-rest-api/src/checkpoints.rs
+++ b/crates/sui-rest-api/src/checkpoints.rs
@@ -12,7 +12,6 @@ use axum::{
     Json, TypedHeader,
 };
 use serde::{Deserialize, Serialize};
-use sui_core::authority::AuthorityState;
 use sui_types::{
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     messages_checkpoint::{
@@ -23,7 +22,7 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use crate::{headers::Accept, AppError, Bcs};
+use crate::{node_state_getter::NodeStateGetter, headers::Accept, AppError, Bcs};
 
 pub const GET_LATEST_CHECKPOINT_PATH: &str = "/checkpoints";
 pub const GET_CHECKPOINT_PATH: &str = "/checkpoints/:checkpoint";
@@ -33,7 +32,7 @@ pub async fn get_full_checkpoint(
     //TODO support digest as well as sequence number
     Path(checkpoint_id): Path<CheckpointSequenceNumber>,
     TypedHeader(accept): TypedHeader<Accept>,
-    State(state): State<Arc<AuthorityState>>,
+    State(state): State<Arc<dyn NodeStateGetter>>,
 ) -> Result<Bcs<CheckpointData>, AppError> {
     if accept.as_str() != crate::APPLICATION_BCS {
         return Err(AppError(anyhow::anyhow!("invalid accept type")));
@@ -48,7 +47,6 @@ pub async fn get_full_checkpoint(
         .collect::<Vec<_>>();
 
     let transactions = state
-        .database
         .multi_get_transaction_blocks(&transaction_digests)?
         .into_iter()
         .map(|maybe_transaction| {
@@ -57,7 +55,6 @@ pub async fn get_full_checkpoint(
         .collect::<Result<Vec<_>>>()?;
 
     let effects = state
-        .database
         .multi_get_executed_effects(&transaction_digests)?
         .into_iter()
         .map(|maybe_effects| maybe_effects.ok_or_else(|| anyhow::anyhow!("missing effects")))
@@ -69,7 +66,6 @@ pub async fn get_full_checkpoint(
         .collect::<Vec<_>>();
 
     let events = state
-        .database
         .multi_get_events(&event_digests)?
         .into_iter()
         .map(|maybe_event| maybe_event.ok_or_else(|| anyhow::anyhow!("missing event")))
@@ -111,7 +107,6 @@ pub async fn get_full_checkpoint(
             .collect::<Vec<_>>();
 
         let input_objects = state
-            .database
             .multi_get_object_by_key(&input_object_keys)?
             .into_iter()
             .enumerate()
@@ -133,7 +128,6 @@ pub async fn get_full_checkpoint(
             .collect::<Vec<_>>();
 
         let output_objects = state
-            .database
             .multi_get_object_by_key(&output_object_keys)?
             .into_iter()
             .enumerate()
@@ -212,7 +206,7 @@ pub struct CheckpointTransaction {
 }
 
 pub async fn get_latest_checkpoint(
-    State(state): State<Arc<AuthorityState>>,
+    State(state): State<Arc<dyn NodeStateGetter>>,
 ) -> Result<Json<CertifiedCheckpointSummary>, AppError> {
     let latest_checkpoint_sequence_number = state.get_latest_checkpoint_sequence_number()?;
     let verified_summary =
@@ -223,7 +217,7 @@ pub async fn get_latest_checkpoint(
 pub async fn get_checkpoint(
     //TODO support digest as well as sequence number
     Path(checkpoint_id): Path<CheckpointSequenceNumber>,
-    State(state): State<Arc<AuthorityState>>,
+    State(state): State<Arc<dyn NodeStateGetter>>,
 ) -> Result<Json<CertifiedCheckpointSummary>, AppError> {
     let verified_summary = state.get_verified_checkpoint_by_sequence_number(checkpoint_id)?;
     Ok(Json(verified_summary.into()))

--- a/crates/sui-rest-api/src/checkpoints.rs
+++ b/crates/sui-rest-api/src/checkpoints.rs
@@ -22,7 +22,7 @@ use sui_types::{
     transaction::Transaction,
 };
 
-use crate::{node_state_getter::NodeStateGetter, headers::Accept, AppError, Bcs};
+use crate::{headers::Accept, node_state_getter::NodeStateGetter, AppError, Bcs};
 
 pub const GET_LATEST_CHECKPOINT_PATH: &str = "/checkpoints";
 pub const GET_CHECKPOINT_PATH: &str = "/checkpoints/:checkpoint";

--- a/crates/sui-rest-api/src/lib.rs
+++ b/crates/sui-rest-api/src/lib.rs
@@ -5,8 +5,8 @@ use axum::{http::StatusCode, routing::get, Router};
 
 mod checkpoints;
 mod client;
-mod node_state_getter;
 pub mod headers;
+mod node_state_getter;
 mod objects;
 
 pub use checkpoints::{CheckpointData, CheckpointTransaction};

--- a/crates/sui-rest-api/src/lib.rs
+++ b/crates/sui-rest-api/src/lib.rs
@@ -5,11 +5,13 @@ use axum::{http::StatusCode, routing::get, Router};
 
 mod checkpoints;
 mod client;
+mod node_state_getter;
 pub mod headers;
 mod objects;
 
 pub use checkpoints::{CheckpointData, CheckpointTransaction};
 pub use client::Client;
+use node_state_getter::NodeStateGetter;
 
 async fn health_check() -> StatusCode {
     StatusCode::OK
@@ -48,7 +50,7 @@ where
     }
 }
 
-pub fn rest_router(state: std::sync::Arc<sui_core::authority::AuthorityState>) -> Router {
+pub fn rest_router(state: std::sync::Arc<dyn NodeStateGetter>) -> Router {
     Router::new()
         .route("/", get(health_check))
         .route(
@@ -73,7 +75,7 @@ pub fn rest_router(state: std::sync::Arc<sui_core::authority::AuthorityState>) -
 
 pub async fn start_service(
     socket_address: std::net::SocketAddr,
-    state: std::sync::Arc<sui_core::authority::AuthorityState>,
+    state: std::sync::Arc<dyn NodeStateGetter>,
 ) {
     let app = rest_router(state);
 

--- a/crates/sui-rest-api/src/node_state_getter.rs
+++ b/crates/sui-rest-api/src/node_state_getter.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_core::authority::AuthorityState;
+use sui_types::{
+    base_types::{ObjectID, VersionNumber},
+    digests::{TransactionDigest, TransactionEventsDigest},
+    effects::{TransactionEffects, TransactionEvents},
+    error::{SuiError, SuiResult},
+    messages_checkpoint::{
+        CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
+    },
+    object::Object,
+    storage::{ObjectKey, ObjectStore},
+    transaction::VerifiedTransaction,
+};
+
+/// Trait for getting data from the node state.
+/// TODO: need a better name for this?
+pub trait NodeStateGetter: Sync + Send {
+    fn get_verified_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> SuiResult<VerifiedCheckpoint>;
+
+    fn get_latest_checkpoint_sequence_number(&self) -> SuiResult<CheckpointSequenceNumber>;
+
+    fn get_checkpoint_contents(
+        &self,
+        content_digest: CheckpointContentsDigest,
+    ) -> SuiResult<CheckpointContents>;
+
+    fn multi_get_transaction_blocks(
+        &self,
+        tx_digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<VerifiedTransaction>>>;
+
+    fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>>;
+
+    fn multi_get_events(
+        &self,
+        event_digests: &[TransactionEventsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEvents>>>;
+
+    fn multi_get_object_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>, SuiError>;
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError>;
+
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError>;
+}
+
+impl NodeStateGetter for AuthorityState {
+    fn get_verified_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> SuiResult<VerifiedCheckpoint> {
+        self.get_verified_checkpoint_by_sequence_number(sequence_number)
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> SuiResult<CheckpointSequenceNumber> {
+        self.get_latest_checkpoint_sequence_number()
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        content_digest: CheckpointContentsDigest,
+    ) -> SuiResult<CheckpointContents> {
+        self.get_checkpoint_contents(content_digest)
+    }
+
+    fn multi_get_transaction_blocks(
+        &self,
+        tx_digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<VerifiedTransaction>>> {
+        self.database.multi_get_transaction_blocks(tx_digests)
+    }
+
+    fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        self.database.multi_get_executed_effects(digests)
+    }
+
+    fn multi_get_events(
+        &self,
+        event_digests: &[TransactionEventsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEvents>>> {
+        self.database.multi_get_events(event_digests)
+    }
+
+    fn multi_get_object_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>, SuiError> {
+        self.database.multi_get_object_by_key(object_keys)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        self.database.get_object_by_key(object_id, version)
+    }
+
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+        self.database.get_object(object_id)
+    }
+}

--- a/crates/sui-rest-api/src/objects.rs
+++ b/crates/sui-rest-api/src/objects.rs
@@ -4,23 +4,20 @@
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
-use sui_core::authority::AuthorityState;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     object::Object,
-    storage::ObjectStore,
 };
 
-use crate::{AppError, Bcs};
+use crate::{node_state_getter::NodeStateGetter, AppError, Bcs};
 
 pub const GET_OBJECT_PATH: &str = "/objects/:object_id";
 
 pub async fn get_object(
     Path(object_id): Path<ObjectID>,
-    State(state): State<Arc<AuthorityState>>,
+    State(state): State<Arc<dyn NodeStateGetter>>,
 ) -> Result<Bcs<Object>, AppError> {
     let object = state
-        .database
         .get_object(&object_id)?
         .ok_or_else(|| anyhow::anyhow!("object not found"))?;
 
@@ -31,10 +28,9 @@ pub const GET_OBJECT_WITH_VERSION_PATH: &str = "/objects/:object_id/version/:ver
 
 pub async fn get_object_with_version(
     Path((object_id, version)): Path<(ObjectID, SequenceNumber)>,
-    State(state): State<Arc<AuthorityState>>,
+    State(state): State<Arc<dyn NodeStateGetter>>,
 ) -> Result<Bcs<Object>, AppError> {
     let object = state
-        .database
         .get_object_by_key(&object_id, version)?
         .ok_or_else(|| anyhow::anyhow!("object not found"))?;
 


### PR DESCRIPTION
## Description 

First part in a series of PRs to allow for simulated chain state which feeds into indexer etc and can be used for testing and experimentation 

## Test Plan 

NFC

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
