### PR TITLE
Mark packages as side-effect free

### DIFF
--- a/.changeset/lovely-ties-stare.md
+++ b/.changeset/lovely-ties-stare.md
@@ -1,0 +1,9 @@
+---
+'@mysten/wallet-standard': patch
+'@mysten/sui.js': patch
+'@mysten/zklogin': patch
+'@mysten/kiosk': patch
+'@mysten/bcs': patch
+---
+
+Mark packages as being side-effect free.

--- a/sdk/bcs/package.json
+++ b/sdk/bcs/package.json
@@ -15,6 +15,7 @@
 			"require": "./dist/index.js"
 		}
 	},
+	"sideEffects": false,
 	"files": [
 		"dist",
 		"src",

--- a/sdk/kiosk/package.json
+++ b/sdk/kiosk/package.json
@@ -7,6 +7,7 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
+	"sideEffects": false,
 	"files": [
 		"dist",
 		"src",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -5,6 +5,7 @@
 	"homepage": "https://sui-typescript-docs.vercel.app",
 	"version": "0.43.3",
 	"license": "Apache-2.0",
+	"sideEffects": false,
 	"files": [
 		"CHANGELOG.md",
 		"LICENSE",

--- a/sdk/wallet-standard/package.json
+++ b/sdk/wallet-standard/package.json
@@ -15,6 +15,7 @@
 			"require": "./dist/index.js"
 		}
 	},
+	"sideEffects": false,
 	"files": [
 		"dist",
 		"src",

--- a/sdk/zklogin/package.json
+++ b/sdk/zklogin/package.json
@@ -15,6 +15,7 @@
 			"require": "./dist/cjs/index.js"
 		}
 	},
+	"sideEffects": false,
 	"files": [
 		"CHANGELOG.md",
 		"dist",


### PR DESCRIPTION
## Description 

This marks some packages as side-effect free now that we shouldn't have any imports that create side-effects without exporting the references, which makes it work fine in testing.

I only marked packages that we are actively developing (which is why I didn't include wallet-kit and suins-toolkit packages) and that I was somewhat familiar with (which is why I didn't include ledger, deepbook, move-binary-format) as being side-effect free.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
