### PR TITLE
explorer: fix crashing when searching with 0x0000000...

### DIFF
--- a/apps/ui/src/Combobox.tsx
+++ b/apps/ui/src/Combobox.tsx
@@ -188,7 +188,7 @@ export function Combobox({ value, onValueChange, children }: Props) {
 				setVisible,
 			}}
 		>
-			<Command className="relative w-full" shouldFilter={false}>
+			<Command className="relative w-full" shouldFilter={false} filter={() => 1}>
 				{children}
 			</Command>
 		</ComboboxContext.Provider>


### PR DESCRIPTION
## Description 

* it seems that cmdk command still does some filtering/sorting (even with shouldFilter=false) and invokes the default scoring functions that with 0x00000 and then adding more 0 delays exponentially until it crashes

<img width="971" alt="Screenshot 2023-10-09 at 14 26 59" src="https://github.com/MystenLabs/sui/assets/10210143/1c675d01-a2aa-4ed0-8f3d-dad527ef2372">


* this just uses a custom filter function to avoid using the default one for scoring


Before


https://github.com/MystenLabs/sui/assets/10210143/81adea75-aa4a-4f60-bb3f-a129f9779819


After


https://github.com/MystenLabs/sui/assets/10210143/bcb71aba-b68b-4983-9de0-82b8a09e5342



closes [APPS-1772](https://mysten.atlassian.net/browse/APPS-1772)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
