### PR TITLE
wallet-ext: qredo connect inputs rename organization to workspace

### DIFF
--- a/apps/wallet/src/background/qredo/types.ts
+++ b/apps/wallet/src/background/qredo/types.ts
@@ -7,6 +7,7 @@ export type QredoConnectIdentity = {
 	service: string;
 	apiUrl: string;
 	origin: string;
+	/** this was renamed to workspace in qredo side but keeping it as organization in wallet to avoid further changes */
 	organization: string;
 };
 

--- a/apps/wallet/src/background/qredo/utils.ts
+++ b/apps/wallet/src/background/qredo/utils.ts
@@ -45,7 +45,7 @@ export function validateInputOrThrow(input: QredoConnectInput) {
 		service,
 		apiUrl: apiUrl.toString(),
 		token,
-		organization: trimString(input.organization),
+		organization: trimString('organization' in input ? input.organization : input.workspace),
 	};
 }
 

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -73,8 +73,16 @@ export type QredoConnectInput = {
 	service: string;
 	apiUrl: string;
 	token: string;
-	organization: string;
-};
+} & (
+	| {
+			/** @deprecated renamed to workspace, please use that */
+			organization: string;
+	  }
+	| {
+			workspace: string;
+	  }
+);
+
 type QredoConnectFeature = {
 	'qredo:connect': {
 		version: '0.0.1';

--- a/apps/wallet/src/ui/app/pages/qredo-connect/QredoConnectInfoPage.tsx
+++ b/apps/wallet/src/ui/app/pages/qredo-connect/QredoConnectInfoPage.tsx
@@ -80,8 +80,8 @@ export function QredoConnectInfoPage() {
 								</div>
 							) : (
 								<LabelValuesContainer>
-									<LabelValueItem label="Service" value={data.service} />
-									<LabelValueItem label="Organization" value={data.organization || '-'} />
+									<LabelValueItem label="Service Name" value={data.service} />
+									<LabelValueItem label="Workspace" value={data.organization || '-'} />
 									<LabelValueItem label="Token" value={data.partialToken} />
 									<LabelValueItem label="API URL" value={data.apiUrl} />
 								</LabelValuesContainer>

--- a/apps/wallet/src/ui/app/pages/qredo-connect/components/SelectQredoAccountsSummaryCard.tsx
+++ b/apps/wallet/src/ui/app/pages/qredo-connect/components/SelectQredoAccountsSummaryCard.tsx
@@ -62,7 +62,7 @@ export function SelectQredoAccountsSummaryCard({
 	}, [qredoConnectedAccounts, data, onChange]);
 	return (
 		<SummaryCard
-			header="Select accounts"
+			header="Select Qredo accounts"
 			body={
 				<Loading loading={isLoading}>
 					{error ? (

--- a/sdk/wallet-kit/example/src/QredoConnectButton.tsx
+++ b/sdk/wallet-kit/example/src/QredoConnectButton.tsx
@@ -7,7 +7,7 @@ type QredoConnectInput = {
 	service: string;
 	apiUrl: string;
 	token: string;
-	organization: string;
+	workspace: string;
 };
 type QredoConnectFeature = {
 	'qredo:connect': {
@@ -42,7 +42,7 @@ export function QredoConnectButton() {
 						service: 'qredo-testing',
 						apiUrl: 'http://localhost:8080/connect/sui',
 						token: 'aToken',
-						organization: 'org1',
+						workspace: 'org1',
 					});
 				} catch (e) {
 					console.log(e);


### PR DESCRIPTION
## Description 

* connect inputs accept either of the fields for compatibility but workspace should be used
* other UI labels renames
* example app use workspace

| before | after |
| -- | -- |
| <img width="359" alt="Screenshot 2023-10-09 at 16 32 37" src="https://github.com/MystenLabs/sui/assets/10210143/fa989234-cb97-4d2b-9675-9d4c33fe88b6"> | <img width="359" alt="Screenshot 2023-10-09 at 16 17 16" src="https://github.com/MystenLabs/sui/assets/10210143/a738b0c0-4186-4bb3-81cb-d61e1fe71dba"> |
| <img width="359" alt="Screenshot 2023-10-09 at 16 32 41" src="https://github.com/MystenLabs/sui/assets/10210143/3d77e401-9f38-4a4d-a9e4-dc826b1ddedf"> | <img width="359" alt="Screenshot 2023-10-09 at 16 17 25" src="https://github.com/MystenLabs/sui/assets/10210143/1cb96586-5e4e-4126-9efb-0bf80132e271"> |

closes [APPS-1745](https://mysten.atlassian.net/browse/APPS-1745)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
