### PR TITLE
[dapp-kit] do a little polishing on the hooks for inferring the active chain / exposing errors / etc.

### DIFF
--- a/.changeset/small-turtles-tie.md
+++ b/.changeset/small-turtles-tie.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Infer the active chain when signing transactions and expose some more descriptive errors

--- a/sdk/dapp-kit/src/hooks/wallet/useDisconnectWallet.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useDisconnectWallet.ts
@@ -9,8 +9,10 @@ import { WalletNotConnectedError } from '../../errors/walletErrors.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 import { useWalletStore } from './useWalletStore.js';
 
+type UseDisconnectWalletError = WalletNotConnectedError | Error;
+
 type UseDisconnectWalletMutationOptions = Omit<
-	UseMutationOptions<void, Error, void, unknown>,
+	UseMutationOptions<void, UseDisconnectWalletError, void, unknown>,
 	'mutationFn'
 >;
 

--- a/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
@@ -20,7 +20,7 @@ import { useCurrentWallet } from './useCurrentWallet.js';
 
 type UseSignAndExecuteTransactionBlockArgs = PartialBy<
 	SuiSignAndExecuteTransactionBlockInput,
-	'account'
+	'account' | 'chain'
 >;
 
 type UseSignAndExecuteTransactionBlockResult = SuiSignAndExecuteTransactionBlockOutput;
@@ -61,7 +61,7 @@ export function useSignAndExecuteTransactionBlock({
 			const signerAccount = signAndExecuteTransactionBlockArgs.account ?? currentAccount;
 			if (!signerAccount) {
 				throw new WalletNoAccountSelectedError(
-					'No wallet account is selected to sign the personal message with.',
+					'No wallet account is selected to sign and execute the transaction block with.',
 				);
 			}
 
@@ -75,6 +75,7 @@ export function useSignAndExecuteTransactionBlock({
 			return await walletFeature.signAndExecuteTransactionBlock({
 				...signAndExecuteTransactionBlockArgs,
 				account: signerAccount,
+				chain: signAndExecuteTransactionBlockArgs.chain ?? signerAccount.chains[0],
 			});
 		},
 		...mutationOptions,

--- a/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignTransactionBlock.ts
@@ -18,7 +18,7 @@ import type { PartialBy } from '../../types/utilityTypes.js';
 import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 
-type UseSignTransactionBlockArgs = PartialBy<SuiSignTransactionBlockInput, 'account'>;
+type UseSignTransactionBlockArgs = PartialBy<SuiSignTransactionBlockInput, 'account' | 'chain'>;
 
 type UseSignTransactionBlockResult = SuiSignTransactionBlockOutput;
 
@@ -58,7 +58,7 @@ export function useSignTransactionBlock({
 			const signerAccount = signTransactionBlockArgs.account ?? currentAccount;
 			if (!signerAccount) {
 				throw new WalletNoAccountSelectedError(
-					'No wallet account is selected to sign the personal message with.',
+					'No wallet account is selected to sign the transaction block with.',
 				);
 			}
 
@@ -72,6 +72,7 @@ export function useSignTransactionBlock({
 			return await walletFeature.signTransactionBlock({
 				...signTransactionBlockArgs,
 				account: signerAccount,
+				chain: signTransactionBlockArgs.chain ?? signerAccount.chains[0],
 			});
 		},
 		...mutationOptions,

--- a/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSwitchAccount.ts
@@ -16,13 +16,10 @@ type SwitchAccountArgs = {
 
 type SwitchAccountResult = void;
 
+type UseSwitchAccountError = WalletNotConnectedError | WalletAccountNotFoundError | Error;
+
 type UseSwitchAccountMutationOptions = Omit<
-	UseMutationOptions<
-		SwitchAccountResult,
-		WalletNotConnectedError | WalletAccountNotFoundError | Error,
-		SwitchAccountArgs,
-		unknown
-	>,
+	UseMutationOptions<SwitchAccountResult, UseSwitchAccountError, SwitchAccountArgs, unknown>,
 	'mutationFn'
 >;
 


### PR DESCRIPTION
## Description 

This PR does a little polish on the signing hooks for a few things I noticed were off. The most notable change here is that we're making the `chain` arg optional as we should just infer the active chain from the account. This keeps parity with the wallet-kit implementation

## Test Plan 
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
