### PR TITLE
[kv store] objects reader

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4184,6 +4184,14 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             .deprecated_get_transaction_checkpoint(&digest)
             .map(|maybe| maybe.map(|(_epoch, checkpoint)| checkpoint))
     }
+
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+        version: VersionNumber,
+    ) -> SuiResult<Option<Object>> {
+        self.database.get_object_by_key(&object_id, version)
+    }
 }
 
 #[cfg(msim)]

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -448,6 +448,8 @@ mod tests {
                 &self,
                 digest: TransactionDigest,
             ) -> SuiResult<Option<CheckpointSequenceNumber>>;
+
+            async fn get_object(&self, object_id: ObjectID, version: SequenceNumber) -> SuiResult<Option<Object>>;
         }
     }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -371,7 +371,8 @@ impl ReadApi {
             }
         }
 
-        let object_cache = ObjectProviderCache::new(self.state.clone());
+        let object_cache =
+            ObjectProviderCache::new((self.state.clone(), self.transaction_kv_store.clone()));
         if opts.show_balance_changes {
             let mut results = vec![];
             for resp in temp_response.values() {
@@ -781,7 +782,8 @@ impl ReadApiServer for ReadApi {
                 }
             }
 
-            let object_cache = ObjectProviderCache::new(self.state.clone());
+            let object_cache =
+                ObjectProviderCache::new((self.state.clone(), self.transaction_kv_store.clone()));
             if opts.show_balance_changes {
                 if let Some(effects) = &temp_response.effects {
                     let balance_changes = get_balance_changes_from_effect(

--- a/crates/sui-storage/src/bin/http_kv_tool.rs
+++ b/crates/sui-storage/src/bin/http_kv_tool.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use sui_storage::http_key_value_store::*;
 use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
+use sui_types::base_types::ObjectID;
 use sui_types::digests::{
     CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
 };
@@ -29,7 +30,7 @@ struct Options {
     #[arg(short, long)]
     seq: Vec<String>,
 
-    // must be either 'tx', 'fx', 'events', or 'ckpt_contents'
+    // must be either 'tx', 'fx','ob','events', or 'ckpt_contents'
     // default value of 'tx'
     #[arg(short, long, default_value = "tx")]
     type_: String,
@@ -140,6 +141,12 @@ async fn main() {
                 ckpt.as_ref().map(|c| c.digest());
                 println!("fetched ckpt summary: {:?} {:?}", digest, ckpt);
             }
+        }
+
+        "ob" => {
+            let object_id = ObjectID::from_str(&options.digest[0]).expect("invalid object id");
+            let object = kv.get_object(object_id, seqs[0].into()).await.unwrap();
+            println!("fetched object {:?}", object);
         }
 
         _ => {

--- a/crates/sui-storage/src/key_value_store.rs
+++ b/crates/sui-storage/src/key_value_store.rs
@@ -8,6 +8,7 @@ use crate::key_value_store_metrics::KeyValueStoreMetrics;
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Instant;
+use sui_types::base_types::{ObjectID, SequenceNumber, VersionNumber};
 use sui_types::digests::{
     CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
 };
@@ -16,6 +17,7 @@ use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
 };
+use sui_types::object::Object;
 use sui_types::transaction::Transaction;
 
 pub type KVStoreTransactionData = (
@@ -394,6 +396,14 @@ impl TransactionKeyValueStore {
             .deprecated_get_transaction_checkpoint(digest)
             .await
     }
+
+    pub async fn get_object(
+        &self,
+        object_id: ObjectID,
+        version: VersionNumber,
+    ) -> SuiResult<Option<Object>> {
+        self.inner.get_object(object_id, version).await
+    }
 }
 
 /// Immutable key/value store trait for storing/retrieving transactions, effects, and events.
@@ -421,6 +431,12 @@ pub trait TransactionKeyValueStoreTrait {
         &self,
         digest: TransactionDigest,
     ) -> SuiResult<Option<CheckpointSequenceNumber>>;
+
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<Option<Object>>;
 }
 
 /// A TransactionKeyValueStoreTrait that falls back to a secondary store for any key for which the
@@ -552,6 +568,18 @@ impl TransactionKeyValueStoreTrait for FallbackTransactionKVStore {
                 .fallback
                 .deprecated_get_transaction_checkpoint(digest)
                 .await?;
+        }
+        Ok(res)
+    }
+
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        let mut res = self.primary.get_object(object_id, version).await?;
+        if res.is_none() {
+            res = self.fallback.get_object(object_id, version).await?;
         }
         Ok(res)
     }

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -6,7 +6,7 @@ use futures::FutureExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{random_object_ref, ExecutionDigests};
+use sui_types::base_types::{random_object_ref, ExecutionDigests, ObjectID, VersionNumber};
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
@@ -24,6 +24,8 @@ use sui_types::transaction::Transaction;
 
 use sui_storage::key_value_store::*;
 use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
+use sui_types::object::Object;
+use sui_types::storage::ObjectKey;
 
 fn random_tx() -> Transaction {
     let (sender, key): (_, AccountKeyPair) = get_key_pair();
@@ -53,6 +55,7 @@ struct MockTxStore {
     checkpoint_summaries_by_digest: HashMap<CheckpointDigest, CertifiedCheckpointSummary>,
     checkpoint_contents_by_digest: HashMap<CheckpointContentsDigest, CheckpointContents>,
     tx_to_checkpoint: HashMap<TransactionDigest, CheckpointSequenceNumber>,
+    objects: HashMap<ObjectKey, Object>,
 
     next_seq_number: u64,
 }
@@ -215,6 +218,14 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         digest: TransactionDigest,
     ) -> SuiResult<Option<CheckpointSequenceNumber>> {
         Ok(self.tx_to_checkpoint.get(&digest).cloned())
+    }
+
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+        version: VersionNumber,
+    ) -> SuiResult<Option<Object>> {
+        Ok(self.objects.get(&ObjectKey(object_id, version)).cloned())
     }
 }
 


### PR DESCRIPTION
[cherry pick]
adds a fallback for showBalanceChanges queries in getTransactionBlock API
