### PR TITLE
[move 2024] let mut

### DIFF
--- a/external-crates/move/move-analyzer/src/symbols.rs
+++ b/external-crates/move/move-analyzer/src/symbols.rs
@@ -879,12 +879,12 @@ impl Symbolicator {
                 fun.signature
                     .parameters
                     .iter()
-                    .map(|(n, _)| n.value.name)
+                    .map(|(_, n, _)| n.value.name)
                     .collect(),
                 fun.signature
                     .parameters
                     .iter()
-                    .map(|(_, t)| t.clone())
+                    .map(|(_, _, t)| t.clone())
                     .collect(),
                 fun.signature.return_type.clone(),
                 fun.acquires
@@ -1091,7 +1091,7 @@ impl Symbolicator {
         // function body)
         let mut scope = OrdMap::new();
 
-        for (pname, ptype) in &fun.signature.parameters {
+        for (_, pname, ptype) in &fun.signature.parameters {
             self.add_type_id_use_def(ptype, references, use_defs);
 
             // add definition of the parameter

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -255,6 +255,8 @@ codes!(
             severity: Warning
         },
         InvalidMethodCall: { msg: "invalid method call", severity: BlockingError },
+        InvalidImmVariableUsage:
+            { msg: "invalid usage of immutable variable", severity: NonblockingError },
     ],
     // errors for ability rules. mostly typing/translate
     AbilitySafety: [
@@ -295,6 +297,7 @@ codes!(
         StructField: { msg: "unused struct field", severity: Warning },
         FunTypeParam: { msg: "unused function type parameter", severity: Warning },
         Constant: { msg: "unused constant", severity: Warning },
+        MutModifier: { msg: "unused 'mut' modifiers", severity: Warning },
     ],
     Attributes: [
         Duplicate: { msg: "invalid duplicate attribute", severity: NonblockingError },

--- a/external-crates/move/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/move-compiler/src/editions/mod.rs
@@ -32,6 +32,7 @@ pub enum FeatureGate {
     StructTypeVisibility,
     DotCall,
     PositionalFields,
+    LetMut,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -105,6 +106,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::StructTypeVisibility,
     FeatureGate::DotCall,
     FeatureGate::PositionalFields,
+    FeatureGate::LetMut,
 ];
 
 impl Edition {
@@ -185,6 +187,7 @@ impl FeatureGate {
             FeatureGate::StructTypeVisibility => "Struct visibility modifiers are",
             FeatureGate::DotCall => "Method syntax is",
             FeatureGate::PositionalFields => "Positional fields are",
+            FeatureGate::LetMut => "'mut' variable modifiers are",
         }
     }
 }

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -1675,9 +1675,9 @@ fn function_signature(
         .shadow_for_type_parameters(type_parameters.iter().map(|(name, _)| name));
     let parameters = pparams
         .into_iter()
-        .map(|(v, t)| (v, type_(context, t)))
+        .map(|(pmut, v, t)| (mutability(context, pmut), v, type_(context, t)))
         .collect::<Vec<_>>();
-    for (v, _) in &parameters {
+    for (_, v, _) in &parameters {
         check_valid_local_name(context, v)
     }
     let return_type = type_(context, pret_ty);
@@ -2618,9 +2618,10 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
     use E::LValue_ as EL;
     use P::Bind_ as PB;
     let b_ = match pb_ {
-        PB::Var(v) => {
+        PB::Var(pmut, v) => {
+            let emut = mutability(context, pmut);
             check_valid_local_name(context, &v);
-            EL::Var(sp(loc, E::ModuleAccess_::Name(v.0)), None)
+            EL::Var(emut, sp(loc, E::ModuleAccess_::Name(v.0)), None)
         }
         PB::Unpack(ptn, ptys_opt, pfields) => {
             let tn = name_access_chain(context, Access::ApplyNamed, *ptn)?;
@@ -2732,7 +2733,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                 }
                 _ => {
                     let tys_opt = optional_types(context, ptys_opt);
-                    EL::Var(en, tys_opt)
+                    EL::Var(E::Mutability::NotApplicable, en, tys_opt)
                 }
             }
         }
@@ -2782,6 +2783,21 @@ fn assign_unpack_fields(
         "assignment binding",
         afields,
     ))
+}
+
+fn mutability(context: &mut Context, pmut: Option<Loc>) -> E::Mutability {
+    let supports_let_mut = context
+        .env
+        .supports_feature(context.current_package, FeatureGate::LetMut);
+    match pmut {
+        Some(loc) => {
+            assert!(supports_let_mut, "ICE mut should not parse without let mut");
+            E::Mutability::Mut(loc)
+        }
+        None if supports_let_mut => E::Mutability::Imm,
+        // without let mut enabled, all locals are mutable and do not need the annotation
+        None => E::Mutability::NotApplicable,
+    }
 }
 
 //**************************************************************************************************
@@ -2944,10 +2960,10 @@ fn unbound_names_binds_with_range(
 fn unbound_names_bind(unbound: &mut BTreeSet<Name>, sp!(_, l_): &E::LValue) {
     use E::LValue_ as EL;
     match l_ {
-        EL::Var(sp!(_, E::ModuleAccess_::Name(n)), _) => {
+        EL::Var(_, sp!(_, E::ModuleAccess_::Name(n)), _) => {
             unbound.remove(n);
         }
-        EL::Var(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _) => {
+        EL::Var(_, sp!(_, E::ModuleAccess_::ModuleAccess(..)), _) => {
             // Qualified vars are not considered in unbound set.
         }
         EL::Unpack(_, _, efields) => match efields {
@@ -2970,10 +2986,10 @@ fn unbound_names_assigns(unbound: &mut BTreeSet<Name>, sp!(_, ls_): &E::LValueLi
 fn unbound_names_assign(unbound: &mut BTreeSet<Name>, sp!(_, l_): &E::LValue) {
     use E::LValue_ as EL;
     match l_ {
-        EL::Var(sp!(_, E::ModuleAccess_::Name(n)), _) => {
+        EL::Var(_, sp!(_, E::ModuleAccess_::Name(n)), _) => {
             unbound.insert(*n);
         }
-        EL::Var(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _) => {
+        EL::Var(_, sp!(_, E::ModuleAccess_::ModuleAccess(..)), _) => {
             // Qualified vars are not considered in unbound set.
         }
         EL::Unpack(_, _, efields) => match efields {

--- a/external-crates/move/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/move-compiler/src/hlir/translate.rs
@@ -327,7 +327,7 @@ fn function_signature(context: &mut Context, sig: N::FunctionSignature) -> H::Fu
     let parameters = sig
         .parameters
         .into_iter()
-        .map(|(v, tty)| {
+        .map(|(_, v, tty)| {
             let ty = single_type(context, tty);
             context.bind_local(v, ty.clone());
             (translate_var(v), ty)

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -6,7 +6,8 @@ use crate::{
     diagnostics::WarningFilters,
     expansion::ast::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes, Fields,
-        Friend, ImplicitUseFunCandidate, ModuleIdent, SpecId, Value, Value_, Visibility,
+        Friend, ImplicitUseFunCandidate, ModuleIdent, Mutability, SpecId, Value, Value_,
+        Visibility,
     },
     parser::ast::{
         Ability_, BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER,
@@ -147,7 +148,7 @@ pub enum StructFields {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FunctionSignature {
     pub type_parameters: Vec<TParam>,
-    pub parameters: Vec<(Var, Type)>,
+    pub parameters: Vec<(Mutability, Var, Type)>,
     pub return_type: Type,
 }
 
@@ -267,7 +268,11 @@ pub type Var = Spanned<Var_>;
 #[allow(clippy::large_enum_variant)]
 pub enum LValue_ {
     Ignore,
-    Var { var: Var, unused_binding: bool },
+    Var {
+        mut_: Mutability,
+        var: Var,
+        unused_binding: bool,
+    },
     Unpack(ModuleIdent, StructName, Option<Vec<Type>>, Fields<LValue>),
 }
 pub type LValue = Spanned<LValue_>;
@@ -1023,7 +1028,8 @@ impl AstDebug for FunctionSignature {
         } = self;
         type_parameters.ast_debug(w);
         w.write("(");
-        w.comma(parameters, |w, (v, st)| {
+        w.comma(parameters, |w, (mut_, v, st)| {
+            mut_.ast_debug(w);
             v.ast_debug(w);
             w.write(": ");
             st.ast_debug(w);
@@ -1455,9 +1461,11 @@ impl AstDebug for LValue_ {
         match self {
             L::Ignore => w.write("_"),
             L::Var {
+                mut_,
                 var,
                 unused_binding,
             } => {
+                mut_.ast_debug(w);
                 var.ast_debug(w);
                 if *unused_binding {
                     w.write("#unused");

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -6,11 +6,11 @@ use crate::{
     diagnostics::WarningFilters,
     expansion::ast::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes, Fields,
-        Friend, ImplicitUseFunCandidate, ModuleIdent, Mutability, SpecId, Value, Value_,
-        Visibility,
+        Friend, ImplicitUseFunCandidate, ModuleIdent, SpecId, Value, Value_, Visibility,
     },
     parser::ast::{
-        Ability_, BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER,
+        Ability_, BinOp, ConstantName, Field, FunctionName, Mutability, StructName, UnaryOp,
+        ENTRY_MODIFIER,
     },
     shared::{ast_debug::*, program_info::NamingProgramInfo, unique_map::UniqueMap, *},
 };
@@ -1029,7 +1029,9 @@ impl AstDebug for FunctionSignature {
         type_parameters.ast_debug(w);
         w.write("(");
         w.comma(parameters, |w, (mut_, v, st)| {
-            mut_.ast_debug(w);
+            if mut_.is_some() {
+                w.write("mut ");
+            }
             v.ast_debug(w);
             w.write(": ");
             st.ast_debug(w);
@@ -1465,7 +1467,9 @@ impl AstDebug for LValue_ {
                 var,
                 unused_binding,
             } => {
-                mut_.ast_debug(w);
+                if mut_.is_some() {
+                    w.write("mut ");
+                }
                 var.ast_debug(w);
                 if *unused_binding {
                     w.write("#unused");

--- a/external-crates/move/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/move-compiler/src/naming/resolve_use_funs.rs
@@ -278,7 +278,12 @@ fn first_arg_type(
     f: &FunctionName,
 ) -> (Loc, Option<N::Type>) {
     let finfo = context.info.function_info(m, f);
-    match finfo.signature.parameters.first().map(|(_, t)| t.clone()) {
+    match finfo
+        .signature
+        .parameters
+        .first()
+        .map(|(_, _, t)| t.clone())
+    {
         None => (finfo.defined_loc, None),
         Some(t) => (t.loc, Some(t)),
     }

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -8,11 +8,11 @@ use crate::{
     diag,
     diagnostics::{Diagnostic, WarningFilters},
     editions::Flavor,
-    expansion::ast::{AbilitySet, AttributeName_, Fields, ModuleIdent, Mutability, Visibility},
+    expansion::ast::{AbilitySet, AttributeName_, Fields, ModuleIdent, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
     },
-    parser::ast::{Ability_, FunctionName, StructName},
+    parser::ast::{Ability_, FunctionName, Mutability, StructName},
     shared::{
         known_attributes::{KnownAttribute, TestingAttribute},
         program_info::TypingProgramInfo,

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -395,7 +395,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
         let otw_msg = "One-time witness declared here";
         let mut diag = diag!(
             INIT_FUN_DIAG,
-            (parameters[0].1.loc, msg),
+            (parameters[0].2.loc, msg),
             (otw_loc, otw_msg),
         );
         diag.add_note(OTW_NOTE);

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -8,7 +8,7 @@ use crate::{
     diag,
     diagnostics::{Diagnostic, WarningFilters},
     editions::Flavor,
-    expansion::ast::{AbilitySet, AttributeName_, Fields, ModuleIdent, Visibility},
+    expansion::ast::{AbilitySet, AttributeName_, Fields, ModuleIdent, Mutability, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructFields, Type, TypeName_, Type_, Var,
     },
@@ -361,11 +361,11 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
     }
     let last_loc = parameters
         .last()
-        .map(|(_, sp!(loc, _))| *loc)
+        .map(|(_, _, sp!(loc, _))| *loc)
         .unwrap_or(name.loc());
     let tx_ctx_kind = parameters
         .last()
-        .map(|(_, last_param_ty)| tx_context_kind(last_param_ty))
+        .map(|(_, _, last_param_ty)| tx_context_kind(last_param_ty))
         .unwrap_or(TxContextKind::None);
     if tx_ctx_kind == TxContextKind::None {
         let msg = format!(
@@ -402,7 +402,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
         context.env.add_diag(diag)
     } else if parameters.len() > 1 {
         // if there is more than one parameter, the first must be the OTW
-        let (first_var, first_ty) = parameters.first().unwrap();
+        let (_, first_var, first_ty) = parameters.first().unwrap();
         let is_otw = matches!(
             first_ty.value.type_name(),
             Some(sp!(_, TypeName_::ModuleType(m, n)))
@@ -439,7 +439,7 @@ fn init_signature(context: &mut Context, name: FunctionName, signature: &Functio
         }
     } else if parameters.len() > 2 {
         // no init function can take more than 2 parameters (the OTW and the TxContext)
-        let (second_var, _) = &parameters[1];
+        let (_, second_var, _) = &parameters[1];
         context.env.add_diag(diag!(
             INIT_FUN_DIAG,
             (name.loc(), "Invalid 'init' function declaration"),
@@ -577,7 +577,7 @@ fn entry_signature(
         return_type,
     } = signature;
     let all_non_ctx_parameters = match parameters.last() {
-        Some((_, last_param_ty)) if tx_context_kind(last_param_ty) != TxContextKind::None => {
+        Some((_, _, last_param_ty)) if tx_context_kind(last_param_ty) != TxContextKind::None => {
             &parameters[0..parameters.len() - 1]
         }
         _ => parameters,
@@ -618,9 +618,9 @@ fn entry_param(
     context: &mut Context,
     entry_loc: Loc,
     name: FunctionName,
-    parameters: &[(Var, Type)],
+    parameters: &[(Mutability, Var, Type)],
 ) {
-    for (var, ty) in parameters {
+    for (_, var, ty) in parameters {
         entry_param_ty(context, entry_loc, name, var, ty);
     }
 }

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -5,13 +5,12 @@
 use crate::{
     debug_display, diag,
     diagnostics::{codes::NameResolution, Diagnostic},
-    expansion::ast::Mutability,
     expansion::ast::{AbilitySet, ModuleIdent, ModuleIdent_, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, ResolvedUseFuns, StructDefinition, StructTypeParameter,
         TParam, TParamID, TVar, Type, TypeName, TypeName_, Type_, UseFunKind, Var,
     },
-    parser::ast::{Ability_, ConstantName, Field, FunctionName, StructName},
+    parser::ast::{Ability_, ConstantName, Field, FunctionName, Mutability, StructName},
     shared::{program_info::*, unique_map::UniqueMap, *},
     FullyCompiledProgram,
 };
@@ -64,6 +63,7 @@ pub struct Context<'env> {
     pub env: &'env mut CompilationEnv,
 
     use_funs: Vec<UseFunsScope>,
+    pub current_package: Option<Symbol>,
     pub current_module: Option<ModuleIdent>,
     pub current_function: Option<FunctionName>,
     pub current_script_constants: Option<UniqueMap<ConstantName, ConstantInfo>>,
@@ -133,6 +133,7 @@ impl<'env> Context<'env> {
         Context {
             use_funs: vec![global_use_funs],
             subst: Subst::empty(),
+            current_package: None,
             current_module: None,
             current_function: None,
             current_script_constants: None,

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -53,10 +53,10 @@ enum LoopInfo_ {
     BreakType(Box<Type>),
 }
 
-struct Local {
-    mut_: Mutability,
-    ty: Type,
-    used_mut: Option<Loc>,
+pub struct Local {
+    pub mut_: Mutability,
+    pub ty: Type,
+    pub used_mut: Option<Loc>,
 }
 
 pub struct Context<'env> {
@@ -319,6 +319,10 @@ impl<'env> Context<'env> {
         let local = self.locals.get_mut(var).unwrap();
         local.used_mut = Some(loc);
         (decl_loc, local.mut_)
+    }
+
+    pub fn take_locals(&mut self) -> UniqueMap<Var, Local> {
+        std::mem::take(&mut self.locals)
     }
 
     pub fn is_current_module(&self, m: &ModuleIdent) -> bool {

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -315,7 +315,7 @@ impl<'env> Context<'env> {
 
     pub fn mark_mutable_usage(&mut self, loc: Loc, var: &Var) -> (Loc, Mutability) {
         // should not fail, already checked in naming
-        let decl_loc = *self.locals.get_loc(&var).unwrap();
+        let decl_loc = *self.locals.get_loc(var).unwrap();
         let local = self.locals.get_mut(var).unwrap();
         local.used_mut = Some(loc);
         (decl_loc, local.mut_)

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -855,11 +855,15 @@ pub fn make_method_call_type(
         });
         // if we found a function with the method name, it must have the wrong type
         if let Some((m, finfo)) = finfo_opt {
-            let (first_ty_loc, first_ty) =
-                match finfo.signature.parameters.first().map(|(_, _, t)| t.clone()) {
-                    None => (finfo.defined_loc, None),
-                    Some(t) => (t.loc, Some(t)),
-                };
+            let (first_ty_loc, first_ty) = match finfo
+                .signature
+                .parameters
+                .first()
+                .map(|(_, _, t)| t.clone())
+            {
+                None => (finfo.defined_loc, None),
+                Some(t) => (t.loc, Some(t)),
+            };
             let arg_msg = match first_ty {
                 Some(ty) => {
                     let tys_str = error_format(&ty, &Subst::empty());

--- a/external-crates/move/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/move-compiler/src/typing/dependency_ordering.rs
@@ -329,7 +329,7 @@ fn function(context: &mut Context, fdef: &T::Function) {
 }
 
 fn function_signature(context: &mut Context, sig: &N::FunctionSignature) {
-    types(context, sig.parameters.iter().map(|(_, st)| st));
+    types(context, sig.parameters.iter().map(|(_, _, st)| st));
     type_(context, &sig.return_type)
 }
 

--- a/external-crates/move/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/move-compiler/src/typing/expand.rs
@@ -25,7 +25,7 @@ pub fn function_body_(context: &mut Context, b_: &mut T::FunctionBody_) {
 }
 
 pub fn function_signature(context: &mut Context, sig: &mut FunctionSignature) {
-    for (_, st) in &mut sig.parameters {
+    for (_, _, st) in &mut sig.parameters {
         type_(context, st);
     }
     type_(context, &mut sig.return_type);

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -1545,7 +1545,9 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             let ty = sp(eloc, Type_::Ref(mut_, Box::new(er.ty.clone())));
             let eborrow = match er.exp {
                 sp!(_, TE::Use(v)) => {
-                    check_mutability(context, eloc, "mutable borrow", &v);
+                    if mut_ {
+                        check_mutability(context, eloc, "mutable borrow", &v);
+                    }
                     TE::BorrowLocal(mut_, v)
                 }
                 erexp => TE::TempBorrow(mut_, Box::new(T::exp(er.ty, erexp))),
@@ -2064,7 +2066,9 @@ fn exp_dotted_to_borrow(
             let sp!(ebloc, eb_) = eb.exp;
             let e_ = match eb_ {
                 TE::Use(v) => {
-                    check_mutability(context, loc, "mutable borrow", &v);
+                    if mut_ {
+                        check_mutability(context, loc, "mutable borrow", &v);
+                    }
                     TE::BorrowLocal(mut_, v)
                 }
                 eb_ => {

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -2572,7 +2572,7 @@ fn unused_let_muts(context: &mut Context) {
         let Mutability::Mut(mut_loc) = mut_ else { continue };
         if used_mut.is_none() {
             let decl_msg = format!("The variable '{}' is never used mutably", v.value.name);
-            let mut_msg = format!("Consider removing the 'mut' declaration here");
+            let mut_msg = "Consider removing the 'mut' declaration here";
             context.env.add_diag(diag!(
                 UnusedItem::MutModifier,
                 (v.loc, decl_msg),

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/parser/mut_field_pun_invalid_assign.move:6:13
+  │
+6 │         S { mut f } = s1;
+  │             ^^^
+  │             │
+  │             Unexpected 'mut'
+  │             Expected an identifier
+

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_assign.move
@@ -1,0 +1,8 @@
+module a::m {
+    public struct S { f: u64 }
+
+    public fun foo(s: S) {
+        let f = 0;
+        S { mut f } = s1;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/parser/mut_field_pun_invalid_pack.move:6:13
+  │
+6 │         S { mut f }
+  │             ^^^
+  │             │
+  │             Unexpected 'mut'
+  │             Expected an identifier
+

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_invalid_pack.move
@@ -1,0 +1,8 @@
+module a::m {
+    public struct S { f: u64 }
+
+    public fun foo(): S {
+        let f = 0;
+        S { mut f }
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_valid.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_field_pun_valid.move
@@ -1,0 +1,20 @@
+module a::m {
+    public struct S { f: u64 }
+
+    public fun foo(s1: S, s2: &mut S, s3: &S) {
+        let mut x = 0;
+        let S { mut f } = s1;
+        f = f + 1;
+        f;
+
+        let S { mut f } = s2;
+        f;
+        f = &mut x;
+        f;
+
+        let S { mut f } = s3;
+        f;
+        f = &x;
+        f;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_2024/parser/mut_keyword.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/mut_keyword.exp
@@ -1,9 +1,9 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/mut_keyword.move:5:20
+  ┌─ tests/move_2024/parser/mut_keyword.move:5:23
   │
 5 │     public fun foo(mut: &mut u64): &mut u64 {
-  │                    ^^^
-  │                    │
-  │                    Unexpected 'mut'
-  │                    Expected an identifier
+  │                       ^
+  │                       │
+  │                       Unexpected ':'
+  │                       Expected an identifier
 

--- a/external-crates/move/move-compiler/tests/move_2024/parser/new_keywords_restricted_ident.move
+++ b/external-crates/move/move-compiler/tests/move_2024/parser/new_keywords_restricted_ident.move
@@ -1,9 +1,9 @@
 module a::m {
     public fun foo(): u64 {
-        let `mut` = 0;
-        let `enum` = 0;
-        let `type` = 0;
-        let `match` = 0;
+        let mut `mut` = 0;
+        let mut `enum` = 0;
+        let mut `type` = 0;
+        let mut `match` = 0;
         `mut` +
         `enum`+
         `type` +

--- a/external-crates/move/move-compiler/tests/move_2024/typing/defines_primitive.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/defines_primitive.move
@@ -5,7 +5,7 @@ module a::m {
         let _: address = s.to_address();
         let _: u64 = 0u64.max(1);
 
-        let v = vector[];
+        let mut v = vector[];
         let _: u64 = v.length();
         v.push_back(S {});
         let _: &S = v.borrow(0);

--- a/external-crates/move/move-compiler/tests/move_2024/typing/dot_call_mut_ref.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/dot_call_mut_ref.move
@@ -5,12 +5,12 @@ public struct Y has drop { x: X }
 
 fun f(_self: &mut X) {}
 
-public fun foo(x: X, x2: &mut X) {
+public fun foo(mut x: X, x2: &mut X) {
     x.f();
     x2.f();
 }
 
-public fun bar(y: Y, y2: &mut Y) {
+public fun bar(mut y: Y, y2: &mut Y) {
     y.x.f();
     y2.x.f();
 }

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_assign.exp
@@ -1,0 +1,27 @@
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_assign.move:7:9
+  │
+3 │     public fun t(x: u64, s: S): u64  {
+  │                  - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+  ·
+7 │         x = y + 1;
+  │         ^ Invalid assignment of immutable variable 'x'
+
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_assign.move:8:9
+  │
+5 │         let S { f } = s;
+  │                 - To use the variable mutably, it must be declared 'mut', e.g. 'mut f'
+  ·
+8 │         f = f + 1;
+  │         ^ Invalid assignment of immutable variable 'f'
+
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_assign.move:9:9
+  │
+4 │         let y = 0;
+  │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut y'
+  ·
+9 │         y = x + f;
+  │         ^ Invalid assignment of immutable variable 'y'
+

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_assign.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_assign.move
@@ -1,0 +1,12 @@
+module a::m {
+    public struct S { f: u64 }
+    public fun t(x: u64, s: S): u64  {
+        let y = 0;
+        let S { f } = s;
+        // these three assignments necessiate mut annotations above
+        x = y + 1;
+        f = f + 1;
+        y = x + f;
+        y
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut.exp
@@ -1,0 +1,27 @@
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_borrow_mut.move:7:13
+  │
+3 │     public fun t(x: u64, s: S) {
+  │                  - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+  ·
+7 │         foo(&mut x);
+  │             ^^^^^^ Invalid mutable borrow of immutable variable 'x'
+
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_borrow_mut.move:8:13
+  │
+4 │         let y = 0;
+  │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut y'
+  ·
+8 │         foo(&mut y);
+  │             ^^^^^^ Invalid mutable borrow of immutable variable 'y'
+
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_borrow_mut.move:9:13
+  │
+5 │         let S { f } = s;
+  │                 - To use the variable mutably, it must be declared 'mut', e.g. 'mut f'
+  ·
+9 │         foo(&mut f);
+  │             ^^^^^^ Invalid mutable borrow of immutable variable 'f'
+

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut.move
@@ -1,0 +1,12 @@
+module a::m {
+    public struct S { f: u64 }
+    public fun t(x: u64, s: S) {
+        let y = 0;
+        let S { f } = s;
+        // these three borrows necessiate mut annotations above
+        foo(&mut x);
+        foo(&mut y);
+        foo(&mut f);
+    }
+    public fun foo<T>(_: &mut T) {}
+}

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut_dot_call.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut_dot_call.exp
@@ -1,0 +1,27 @@
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_borrow_mut_dot_call.move:8:9
+  │
+4 │     public fun t(x: S, r: R) {
+  │                  - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+  ·
+8 │         x.foo();
+  │         ^^^^^^^ Invalid mutable borrow of immutable variable 'x'
+
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_borrow_mut_dot_call.move:9:9
+  │
+5 │         let y = S { f: 0 };
+  │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut y'
+  ·
+9 │         y.foo();
+  │         ^^^^^^^ Invalid mutable borrow of immutable variable 'y'
+
+error[E04024]: invalid usage of immutable variable
+   ┌─ tests/move_2024/typing/let_mut_borrow_mut_dot_call.move:10:9
+   │
+ 6 │         let R { s } = r;
+   │                 - To use the variable mutably, it must be declared 'mut', e.g. 'mut s'
+   ·
+10 │         s.foo();
+   │         ^^^^^^^ Invalid mutable borrow of immutable variable 's'
+

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut_dot_call.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_borrow_mut_dot_call.move
@@ -1,0 +1,13 @@
+module a::m {
+    public struct S has drop { f: u64 }
+    public struct R has drop { s: S }
+    public fun t(x: S, r: R) {
+        let y = S { f: 0 };
+        let R { s } = r;
+        // these three borrows necessiate mut annotations above
+        x.foo();
+        y.foo();
+        s.foo();
+    }
+    public fun foo(_: &mut S) {}
+}

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_shadow.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_shadow.exp
@@ -1,0 +1,20 @@
+error[E04024]: invalid usage of immutable variable
+  ┌─ tests/move_2024/typing/let_mut_shadow.move:9:9
+  │
+3 │     public fun foo(x: u64) {
+  │                    - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+  ·
+9 │         x = x + 1;
+  │         ^ Invalid assignment of immutable variable 'x'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/let_mut_shadow.move:10:9
+   │
+ 3 │     public fun foo(x: u64) {
+   │                ---    --- Given: 'u64'
+   │                │       
+   │                Expected: '()'
+   ·
+10 │         x
+   │         ^ Invalid return expression
+

--- a/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_shadow.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/let_mut_shadow.move
@@ -1,0 +1,13 @@
+// double check mut respects shadowing
+module a::m {
+    public fun foo(x: u64) {
+        {
+            let mut x = 0;
+            x = x + 1;
+            bar(x)
+        };
+        x = x + 1;
+        x
+    }
+    fun bar(_: u64) {}
+}

--- a/external-crates/move/move-compiler/tests/move_2024/typing/unused_let_mut.exp
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/unused_let_mut.exp
@@ -1,0 +1,38 @@
+error[E04013]: invalid statement or expression in constant
+  ┌─ tests/move_2024/typing/unused_let_mut.move:5:9
+  │
+5 │         let mut x = 0;
+  │         ^^^^^^^^^^^^^ 'let' declarations are not supported in constants
+
+warning[W09012]: unused 'mut' modifiers
+  ┌─ tests/move_2024/typing/unused_let_mut.move:5:17
+  │
+5 │         let mut x = 0;
+  │             --- ^ The variable 'x' is never used mutably
+  │             │    
+  │             Consider removing the 'mut' declaration here
+
+warning[W09012]: unused 'mut' modifiers
+  ┌─ tests/move_2024/typing/unused_let_mut.move:9:24
+  │
+9 │     public fun foo(mut x: u64, s: S): u64 {
+  │                    --- ^ The variable 'x' is never used mutably
+  │                    │    
+  │                    Consider removing the 'mut' declaration here
+
+warning[W09012]: unused 'mut' modifiers
+   ┌─ tests/move_2024/typing/unused_let_mut.move:10:17
+   │
+10 │         let mut y = 0;
+   │             --- ^ The variable 'y' is never used mutably
+   │             │    
+   │             Consider removing the 'mut' declaration here
+
+warning[W09012]: unused 'mut' modifiers
+   ┌─ tests/move_2024/typing/unused_let_mut.move:11:21
+   │
+11 │         let S { mut f } = s;
+   │                 --- ^ The variable 'f' is never used mutably
+   │                 │    
+   │                 Consider removing the 'mut' declaration here
+

--- a/external-crates/move/move-compiler/tests/move_2024/typing/unused_let_mut.move
+++ b/external-crates/move/move-compiler/tests/move_2024/typing/unused_let_mut.move
@@ -1,0 +1,19 @@
+module a::m {
+    public struct S { f: u64 }
+
+    const C: u64 = {
+        let mut x = 0;
+        x
+    };
+
+    public fun foo(mut x: u64, s: S): u64 {
+        let mut y = 0;
+        let S { mut f } = s;
+        bar(&x);
+        bar(&y);
+        bar(&f);
+        x + y + f
+    }
+
+    public fun bar(_: &u64) {}
+}

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/assign_wrong_type.exp
@@ -6,5 +6,5 @@ error[E04007]: incompatible types
 6 │     x = false
   │     ^   ----- Given: 'bool'
   │     │    
-  │     Invalid assignment to local 'x'
+  │     Invalid assignment to variable 'x'
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_unpack_references_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_unpack_references_invalid.exp
@@ -6,7 +6,7 @@ error[E04007]: incompatible types
 9 │         f = 0;
   │         ^
   │         │
-  │         Invalid assignment to local 'f'
+  │         Invalid assignment to variable 'f'
   │         Given: integer
 
 error[E04007]: incompatible types
@@ -18,7 +18,7 @@ error[E04007]: incompatible types
 10 │         s2 = S { f: 0 }
    │         ^^   ---------- Given: '0x8675309::M::S'
    │         │     
-   │         Invalid assignment to local 's2'
+   │         Invalid assignment to variable 's2'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:17:9
@@ -28,7 +28,7 @@ error[E04007]: incompatible types
 17 │         f = 0;
    │         ^
    │         │
-   │         Invalid assignment to local 'f'
+   │         Invalid assignment to variable 'f'
    │         Given: integer
 
 error[E04007]: incompatible types
@@ -40,7 +40,7 @@ error[E04007]: incompatible types
 18 │         s2 = S { f: 0 }
    │         ^^   ---------- Given: '0x8675309::M::S'
    │         │     
-   │         Invalid assignment to local 's2'
+   │         Invalid assignment to variable 's2'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:26:9
@@ -50,7 +50,7 @@ error[E04006]: invalid subtype
 26 │         f = &0;
    │         ^   -- Given: '&{integer}'
    │         │    
-   │         Invalid assignment to local 'f'
+   │         Invalid assignment to variable 'f'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/assign_unpack_references_invalid.move:27:9
@@ -61,5 +61,5 @@ error[E04006]: invalid subtype
 27 │         s2 = &S { f: 0 }
    │         ^^   ----------- Given: '&0x8675309::M::S'
    │         │     
-   │         Invalid assignment to local 's2'
+   │         Invalid assignment to variable 's2'
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_wrong_arity.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_wrong_arity.exp
@@ -22,7 +22,7 @@ error[E04007]: incompatible types
 7 │         x = (0, 1, 2);
   │         ^   --------- Given: '({integer}, {integer}, {integer})'
   │         │    
-  │         Invalid assignment to local 'x'
+  │         Invalid assignment to variable 'x'
 
 error[E04005]: expected a single type
   ┌─ tests/move_check/typing/assign_wrong_arity.move:7:9

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_wrong_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_wrong_type.exp
@@ -69,7 +69,7 @@ error[E04007]: incompatible types
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │          ^
    │          │
-   │          Invalid assignment to local 'x'
+   │          Invalid assignment to variable 'x'
    │          Given: integer
 
 error[E04007]: incompatible types
@@ -81,7 +81,7 @@ error[E04007]: incompatible types
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │             ^                 ----- Given: 'bool'
    │             │                  
-   │             Invalid assignment to local 'b'
+   │             Invalid assignment to variable 'b'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/assign_wrong_type.move:27:18
@@ -93,7 +93,7 @@ error[E04007]: incompatible types
    │                 ---- Expected: 'address'
 26 │         let r = S{ g: 0 };
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-   │                  ^ Invalid assignment to local 'f'
+   │                  ^ Invalid assignment to variable 'f'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/assign_wrong_type.move:27:22
@@ -103,5 +103,5 @@ error[E04007]: incompatible types
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │                      ^                        ------- Given: '0x8675309::M::R'
    │                      │                         
-   │                      Invalid assignment to local 'r'
+   │                      Invalid assignment to variable 'r'
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/bind_unpack_references_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/bind_unpack_references_invalid.exp
@@ -6,7 +6,7 @@ error[E04007]: incompatible types
 7 │         f = 0;
   │         ^
   │         │
-  │         Invalid assignment to local 'f'
+  │         Invalid assignment to variable 'f'
   │         Given: integer
 
 error[E04007]: incompatible types
@@ -18,7 +18,7 @@ error[E04007]: incompatible types
 8 │         s2 = S { f: 0 }
   │         ^^   ---------- Given: '0x8675309::M::S'
   │         │     
-  │         Invalid assignment to local 's2'
+  │         Invalid assignment to variable 's2'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:13:9
@@ -28,7 +28,7 @@ error[E04007]: incompatible types
 13 │         f = 0;
    │         ^
    │         │
-   │         Invalid assignment to local 'f'
+   │         Invalid assignment to variable 'f'
    │         Given: integer
 
 error[E04007]: incompatible types
@@ -40,7 +40,7 @@ error[E04007]: incompatible types
 14 │         s2 = S { f: 0 }
    │         ^^   ---------- Given: '0x8675309::M::S'
    │         │     
-   │         Invalid assignment to local 's2'
+   │         Invalid assignment to variable 's2'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:20:9
@@ -50,7 +50,7 @@ error[E04006]: invalid subtype
 20 │         f = &0;
    │         ^   -- Given: '&{integer}'
    │         │    
-   │         Invalid assignment to local 'f'
+   │         Invalid assignment to variable 'f'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/bind_unpack_references_invalid.move:21:9
@@ -61,5 +61,5 @@ error[E04006]: invalid subtype
 21 │         s2 = &S { f: 0 }
    │         ^^   ----------- Given: '&0x8675309::M::S'
    │         │     
-   │         Invalid assignment to local 's2'
+   │         Invalid assignment to variable 's2'
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/recursive_local.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/recursive_local.exp
@@ -10,7 +10,7 @@ error[E04008]: invalid type. recursive type found
 4 │         let x;
   │             - Unable to infer the type. Recursive type found.
 5 │         x = (x, 0);
-  │         ^ Invalid assignment to local 'x'
+  │         ^ Invalid assignment to variable 'x'
 
 error[E04005]: expected a single type
   ┌─ tests/move_check/typing/recursive_local.move:5:9

--- a/external-crates/move/move-compiler/tests/move_check/typing/subtype_assign_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/subtype_assign_invalid.exp
@@ -15,7 +15,7 @@ error[E04006]: invalid subtype
 10 │         (x, y) = (&0, &0);
    │          ^        -- Given: '&{integer}'
    │          │         
-   │          Invalid assignment to local 'x'
+   │          Invalid assignment to variable 'x'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/subtype_assign_invalid.move:10:13
@@ -25,7 +25,7 @@ error[E04006]: invalid subtype
 10 │         (x, y) = (&0, &0);
    │             ^         -- Given: '&{integer}'
    │             │          
-   │             Invalid assignment to local 'y'
+   │             Invalid assignment to variable 'y'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/subtype_assign_invalid.move:13:10
@@ -35,7 +35,7 @@ error[E04006]: invalid subtype
 13 │         (x, y) = (&0, &0);
    │          ^        -- Given: '&{integer}'
    │          │         
-   │          Invalid assignment to local 'x'
+   │          Invalid assignment to variable 'x'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_check/typing/subtype_assign_invalid.move:16:13
@@ -45,5 +45,5 @@ error[E04006]: invalid subtype
 16 │         (x, y)= (&0, &0);
    │             ^        -- Given: '&{integer}'
    │             │         
-   │             Invalid assignment to local 'y'
+   │             Invalid assignment to variable 'y'
 

--- a/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_modify.move
+++ b/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_modify.move
@@ -10,7 +10,7 @@ public struct Y has copy, drop { x: X }
 public fun bump(self: &mut X) { self.count = self.count + 1 }
 public fun count(self: &X): u64 { self.count }
 
-public fun owned(x: X, y: Y) {
+public fun owned(mut x: X, mut y: Y) {
     assert!(x.count() == 0, 0);
     assert!(y.x.count() == 0, 0);
     x.bump();
@@ -33,8 +33,8 @@ public fun test() {
     let y = Y { x };
     owned(x, y);
 
-    let x = X { count: 0 };
-    let y = Y { x };
+    let mut x = X { count: 0 };
+    let mut y = Y { x };
     mut_ref(&mut x, &mut y);
 }
 

--- a/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_owned.move
+++ b/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_owned.move
@@ -25,8 +25,8 @@ public fun mut_ref(x: &mut X, y: &mut Y) {
 }
 
 public fun test() {
-    let x = X{};
-    let y = Y { x };
+    let mut x = X{};
+    let mut y = Y { x };
     ref(&x, &y);
     mut_ref(&mut x, &mut y);
     owned(x, y)

--- a/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_ref.move
+++ b/external-crates/move/move-compiler/transactional-tests/tests/functions/dot_call_ref.move
@@ -30,8 +30,8 @@ public fun tmp(x: &X, y: &Y) {
 }
 
 public fun test() {
-    let x = X{};
-    let y = Y { x };
+    let mut x = X{};
+    let mut y = Y { x };
     ref(&x, &y);
     mut_ref(&mut x, &mut y);
     owned(x, y)

--- a/external-crates/move/move-model/src/builder/exp_translator.rs
+++ b/external-crates/move/move-model/src/builder/exp_translator.rs
@@ -455,7 +455,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     /// enters them into the environment. Returns a vector for representing them in the target AST.
     pub fn analyze_and_add_params(
         &mut self,
-        params: &[(EA::Mutability, PA::Var, EA::Type)],
+        params: &[(PA::Mutability, PA::Var, EA::Type)],
         for_move_fun: bool,
     ) -> Vec<(Symbol, Type)> {
         params

--- a/external-crates/move/move-model/src/builder/exp_translator.rs
+++ b/external-crates/move/move-model/src/builder/exp_translator.rs
@@ -455,13 +455,13 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     /// enters them into the environment. Returns a vector for representing them in the target AST.
     pub fn analyze_and_add_params(
         &mut self,
-        params: &[(PA::Var, EA::Type)],
+        params: &[(EA::Mutability, PA::Var, EA::Type)],
         for_move_fun: bool,
     ) -> Vec<(Symbol, Type)> {
         params
             .iter()
             .enumerate()
-            .map(|(idx, (v, ty))| {
+            .map(|(idx, (_, v, ty))| {
                 let ty = self.translate_type(ty);
                 let sym = self.symbol_pool().make(v.0.value.as_str());
                 self.define_local(
@@ -991,7 +991,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     }
                     let bind_loc = self.to_loc(&list.value[0].loc);
                     match &list.value[0].value {
-                        EA::LValue_::Var(maccess, _) => {
+                        EA::LValue_::Var(_, maccess, _) => {
                             let name = match &maccess.value {
                                 EA::ModuleAccess_::Name(n) => n,
                                 EA::ModuleAccess_::ModuleAccess(_, n) => n,
@@ -1784,6 +1784,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             let loc = self.to_loc(&bind.loc);
             match &bind.value {
                 EA::LValue_::Var(
+                    _,
                     Spanned {
                         value: EA::ModuleAccess_::Name(n),
                         ..
@@ -1880,6 +1881,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             }
             match &bind.value {
                 EA::LValue_::Var(
+                    _,
                     Spanned {
                         value: EA::ModuleAccess_::Name(n),
                         ..


### PR DESCRIPTION
## Description 

- `mut` modifier on variable declarations is not required for Move 2024
- Unused `mut` modifiers are reported
- Added `S { mut f }` punning for variable declarations with unpack

## Test Plan 

- Added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Move 2024.alpha now requires `mut` on local variables that are assigned or borrowed mutably. This is done on local variable declarations, e.g. `let mut x = 0`. And can also be done when field punning, e.g. `let S { mut f } = s;`