### PR TITLE
[benchmark] Support two modes of consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11300,6 +11300,8 @@ dependencies = [
  "move-core-types",
  "move-package",
  "prometheus",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "sui-core",
  "sui-macros",
  "sui-protocol-config",

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1706,7 +1706,7 @@ impl AuthorityPerEpochStore {
     /// Important: This function can potentially be called in parallel and you can not rely on order of transactions to perform verification
     /// If this function return an error, transaction is skipped and is not passed to handle_consensus_transaction
     /// This function returns unit error and is responsible for emitting log messages for internal errors
-    pub(crate) fn verify_consensus_transaction(
+    fn verify_consensus_transaction(
         &self,
         transaction: SequencedConsensusTransaction,
         skipped_consensus_txns: &IntCounter,
@@ -1906,8 +1906,7 @@ impl AuthorityPerEpochStore {
     // VerifiedSequencedConsensusTransaction.
     // Also, ConsensusStats and hash will not be updated in the db with this function, unlike in
     // process_consensus_transactions_and_commit_boundary().
-    #[cfg(any(test, feature = "test-utils"))]
-    pub(crate) async fn process_consensus_transactions_for_tests<C: CheckpointServiceNotify>(
+    pub async fn process_consensus_transactions_for_tests<C: CheckpointServiceNotify>(
         self: &Arc<Self>,
         transactions: Vec<SequencedConsensusTransaction>,
         checkpoint_service: &Arc<C>,

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -15,6 +15,9 @@ async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
 futures.workspace = true
+prometheus.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing.workspace = true
@@ -22,7 +25,6 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 move-package.workspace = true
-prometheus.workspace = true
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-simulator.workspace = true

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::command::Component;
+use crate::mock_consensus::ConsensusMode;
 use crate::single_node::SingleValidator;
 use crate::tx_generator::TxGenerator;
 use futures::stream::FuturesUnordered;
@@ -68,7 +69,11 @@ impl BenchmarkContext {
         genesis_gas_objects.push(admin_gas_object);
 
         info!("Initializing validator");
-        let validator = SingleValidator::new(&genesis_gas_objects).await;
+        let consensus_mode = match benchmark_component {
+            Component::ValidatorWithFakeConsensus => ConsensusMode::DirectSequencing,
+            _ => ConsensusMode::Noop,
+        };
+        let validator = SingleValidator::new(&genesis_gas_objects, consensus_mode).await;
 
         Self {
             validator,

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{Parser, ValueEnum};
+use strum_macros::EnumIter;
 
 #[derive(Parser)]
 #[command(
@@ -68,13 +69,19 @@ pub enum Command {
     },
 }
 
-#[derive(Copy, Clone, ValueEnum)]
+#[derive(Copy, Clone, EnumIter, ValueEnum)]
 pub enum Component {
     /// Baseline includes the execution and storage layer only.
     Baseline,
     /// On top of Baseline, this schedules transactions through the transaction manager.
     WithTxManager,
     /// This goes through the `handle_certificate` entry point on authority_server, which includes
-    /// certificate verification, transaction manager, as well as a noop consensus layer.
-    ValidatorService,
+    /// certificate verification, transaction manager, as well as a noop consensus layer. The noop
+    /// consensus layer does absolutely nothing when receiving a transaction in consensus.
+    ValidatorWithoutConsensus,
+    /// Similar to ValidatorWithNoopConsensus, but the consensus layer contains a fake consensus
+    /// protocol that basically sequences transactions in order. It then verify the transaction
+    /// and store the sequenced transactions into the store. It covers the consensus-independent
+    /// portion of the code in consensus handler.
+    ValidatorWithFakeConsensus,
 }

--- a/crates/sui-single-node-benchmark/src/lib.rs
+++ b/crates/sui-single-node-benchmark/src/lib.rs
@@ -4,5 +4,6 @@
 pub(crate) mod benchmark_context;
 pub mod command;
 pub mod execution;
+pub(crate) mod mock_consensus;
 pub(crate) mod single_node;
 pub(crate) mod tx_generator;

--- a/crates/sui-single-node-benchmark/src/mock_consensus.rs
+++ b/crates/sui-single-node-benchmark/src/mock_consensus.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::IntCounter;
+use std::mem;
+use std::sync::Arc;
+use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use sui_core::authority::AuthorityState;
+use sui_core::checkpoints::CheckpointServiceNoop;
+use sui_core::consensus_adapter::SubmitToConsensus;
+use sui_core::consensus_handler::SequencedConsensusTransaction;
+use sui_types::error::SuiResult;
+use sui_types::messages_consensus::ConsensusTransaction;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+// TODO: Add tool args to parameterize this value.
+const CONSENSUS_COMMIT_SIZE: usize = 1000;
+
+pub(crate) struct MockConsensusClient {
+    tx_sender: mpsc::Sender<ConsensusTransaction>,
+    // TODO: May want to make sure we flush all pending transactions before benchmark ends.
+    _consensus_handle: JoinHandle<()>,
+}
+
+pub(crate) enum ConsensusMode {
+    // ConsensusClient does absolutely nothing when receiving a transaction
+    Noop,
+    // ConsensusClient directly sequences the transaction into the store.
+    DirectSequencing,
+}
+
+impl MockConsensusClient {
+    pub(crate) fn new(validator: Arc<AuthorityState>, consensus_mode: ConsensusMode) -> Self {
+        let (tx_sender, tx_receiver) = mpsc::channel(1000000);
+        let _consensus_handle = Self::run(validator, tx_receiver, consensus_mode);
+        Self {
+            tx_sender,
+            _consensus_handle,
+        }
+    }
+
+    pub(crate) fn run(
+        validator: Arc<AuthorityState>,
+        tx_receiver: mpsc::Receiver<ConsensusTransaction>,
+        consensus_mode: ConsensusMode,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move { Self::run_impl(validator, tx_receiver, consensus_mode).await })
+    }
+
+    async fn run_impl(
+        validator: Arc<AuthorityState>,
+        mut tx_receiver: mpsc::Receiver<ConsensusTransaction>,
+        consensus_mode: ConsensusMode,
+    ) {
+        let epoch_store = validator.epoch_store_for_testing().clone();
+        let checkpoint_service = Arc::new(CheckpointServiceNoop {});
+        let counter = IntCounter::new(
+            "skipped_consensus_txns",
+            "Total number of consensus transactions skipped",
+        )
+        .unwrap();
+        let mut transactions = vec![];
+        while let Some(tx) = tx_receiver.recv().await {
+            match consensus_mode {
+                ConsensusMode::Noop => {}
+                ConsensusMode::DirectSequencing => {
+                    transactions.push(SequencedConsensusTransaction::new_test(tx));
+                    if transactions.len() == CONSENSUS_COMMIT_SIZE {
+                        epoch_store
+                            .process_consensus_transactions_for_tests(
+                                mem::take(&mut transactions),
+                                &checkpoint_service,
+                                &validator.database,
+                                &counter,
+                            )
+                            .await
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SubmitToConsensus for MockConsensusClient {
+    async fn submit_to_consensus(
+        &self,
+        transaction: &ConsensusTransaction,
+        _epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        self.tx_sender.send(transaction.clone()).await.unwrap();
+        Ok(())
+    }
+}

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use strum::IntoEnumIterator;
 use sui_macros::sim_test;
 use sui_single_node_benchmark::command::Component;
 use sui_single_node_benchmark::execution::{
@@ -10,15 +11,15 @@ use sui_single_node_benchmark::execution::{
 #[sim_test]
 async fn benchmark_simple_transfer_smoke_test() {
     // This test makes sure that the benchmark runs.
-    benchmark_simple_transfer(10, Component::Baseline).await;
-    benchmark_simple_transfer(10, Component::WithTxManager).await;
-    benchmark_simple_transfer(10, Component::ValidatorService).await;
+    for component in Component::iter() {
+        benchmark_simple_transfer(10, component).await;
+    }
 }
 
 #[sim_test]
 async fn benchmark_move_transactions_smoke_test() {
     // This test makes sure that the benchmark runs.
-    benchmark_move_transactions(10, Component::Baseline, 2, 1, 1).await;
-    benchmark_move_transactions(10, Component::WithTxManager, 2, 1, 1).await;
-    benchmark_move_transactions(10, Component::ValidatorService, 2, 1, 1).await;
+    for component in Component::iter() {
+        benchmark_move_transactions(10, component, 2, 1, 1).await;
+    }
 }


### PR DESCRIPTION
## Description 

Try to exercise the consensus path in the single node benchmark.
There are two modes: noop and direct.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
