### PR TITLE
Simplify zklogin SDK

### DIFF
--- a/.changeset/funny-flies-kiss.md
+++ b/.changeset/funny-flies-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zklogin': minor
+---
+
+Remove toBigIntBE, expose new `getExtendedEphemeralPublicKey` method. Methods now return base64-encoded strings instead of bigints.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -240,7 +240,7 @@ module.exports = {
 			},
 		},
 		{
-			files: ['sdk/ledgerjs-hw-app-sui/**/*', 'apps/wallet/**/*', 'sdk/zklogin/**/*'],
+			files: ['sdk/ledgerjs-hw-app-sui/**/*', 'apps/wallet/**/*'],
 			rules: {
 				// ledgerjs-hw-app-sui and wallet use Buffer
 				'no-restricted-globals': ['off'],

--- a/apps/wallet/src/background/accounts/zklogin/utils.ts
+++ b/apps/wallet/src/background/accounts/zklogin/utils.ts
@@ -7,7 +7,7 @@ import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
 import {
 	generateNonce,
 	generateRandomness,
-	toBigIntBE,
+	getExtendedEphemeralPublicKey,
 	type getZkLoginSignature,
 } from '@mysten/zklogin';
 import { randomBytes } from '@noble/hashes/utils';
@@ -157,9 +157,7 @@ export async function createPartialZkLoginSignature({
 		},
 		body: JSON.stringify({
 			jwt,
-			extendedEphemeralPublicKey: toBigIntBE(
-				Buffer.from(ephemeralPublicKey.toSuiBytes()),
-			).toString(),
+			extendedEphemeralPublicKey: getExtendedEphemeralPublicKey(ephemeralPublicKey),
 			maxEpoch,
 			jwtRandomness: jwtRandomness.toString(),
 			salt: userSalt.toString(),

--- a/sdk/typescript/src/zklogin/utils.ts
+++ b/sdk/typescript/src/zklogin/utils.ts
@@ -3,7 +3,25 @@
 
 import { hexToBytes } from '@noble/hashes/utils';
 
-export function toBigEndianBytes(num: bigint, width: number) {
+function findFirstNonZeroIndex(bytes: Uint8Array) {
+	for (let i = 0; i < bytes.length; i++) {
+		if (bytes[i] !== 0) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+export function toBigEndianBytes(num: bigint, width: number): Uint8Array {
 	const hex = num.toString(16);
-	return hexToBytes(hex.padStart(width * 2, '0').slice(-width * 2));
+	const bytes = hexToBytes(hex.padStart(width * 2, '0').slice(-width * 2));
+
+	const firstNonZeroIndex = findFirstNonZeroIndex(bytes);
+
+	if (firstNonZeroIndex === -1) {
+		return new Uint8Array([0]);
+	}
+
+	return bytes.slice(firstNonZeroIndex);
 }

--- a/sdk/typescript/test/unit/zklogin/address.test.ts
+++ b/sdk/typescript/test/unit/zklogin/address.test.ts
@@ -14,4 +14,13 @@ describe('zkLogin address', () => {
 			),
 		).toBe('0xf7badc2b245c7f74d7509a4aa357ecf80a29e7713fb4c44b0e7541ec43885ee1');
 	});
+
+	test('generates the correct address for a seed with leading zeros', () => {
+		expect(
+			computeZkLoginAddressFromSeed(
+				BigInt('380704556853533152350240698167704405529973457670972223618755249929828551006'),
+				'https://accounts.google.com',
+			),
+		).toBe('0xbd8b8ed42d90aebc71518385d8a899af14cef8b5a171c380434dd6f5bbfe7bf3');
+	});
 });

--- a/sdk/zklogin/src/address.ts
+++ b/sdk/zklogin/src/address.ts
@@ -8,7 +8,7 @@ import { lengthChecks } from './checks';
 import { JSONProcessor } from './jsonprocessor.js';
 import { genAddressSeed } from './utils.js';
 
-export function jwtToAddress(jwt: string, userSalt: bigint) {
+export function jwtToAddress(jwt: string, userSalt: string | bigint) {
 	const decodedJWT = decodeJwt(jwt);
 	if (!decodedJWT.iss) {
 		throw new Error('Missing iss');
@@ -41,7 +41,7 @@ export function jwtToAddress(jwt: string, userSalt: bigint) {
 export interface ComputeZkLoginAddressOptions {
 	claimName: string;
 	claimValue: string;
-	userSalt: bigint;
+	userSalt: string | bigint;
 	iss: string;
 	aud: string;
 }

--- a/sdk/zklogin/src/index.ts
+++ b/sdk/zklogin/src/index.ts
@@ -10,4 +10,4 @@ export { poseidonHash } from './poseidon.js';
 
 export { generateNonce, generateRandomness } from './nonce.js';
 
-export { hashASCIIStrToField, genAddressSeed, toBigIntBE } from './utils.js';
+export { hashASCIIStrToField, genAddressSeed, getExtendedEphemeralPublicKey } from './utils.js';

--- a/sdk/zklogin/src/nonce.ts
+++ b/sdk/zklogin/src/nonce.ts
@@ -1,23 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { toB64, toHEX } from '@mysten/bcs';
 import { PublicKey } from '@mysten/sui.js/cryptography';
 import { toBigEndianBytes } from '@mysten/sui.js/zklogin';
 import { randomBytes } from '@noble/hashes/utils';
 import { base64url } from 'jose';
 
 import { poseidonHash } from './poseidon.js';
-import { toBigIntBE } from './utils.js';
 
 const NONCE_LENGTH = 27;
 
-export function generateRandomness() {
-	// Once Node 20 enters LTS, we can just use crypto.getRandomValues(new Uint8Array(16)), but until then this improves compatibility:
-	return toBigIntBE(Buffer.from(randomBytes(16)));
+function toBigIntBE(bytes: Uint8Array) {
+	const hex = toHEX(bytes);
+	if (hex.length === 0) {
+		return BigInt(0);
+	}
+	return BigInt(`0x${hex}`);
 }
 
-export function generateNonce(publicKey: PublicKey, maxEpoch: number, randomness: bigint) {
-	const publicKeyBytes = toBigIntBE(Buffer.from(publicKey.toSuiBytes()));
+export function generateRandomness() {
+	// Once Node 20 enters LTS, we can just use crypto.getRandomValues(new Uint8Array(16)), but until then this improves compatibility:
+	return toB64(randomBytes(16));
+}
+
+export function generateNonce(publicKey: PublicKey, maxEpoch: number, randomness: bigint | string) {
+	const publicKeyBytes = toBigIntBE(publicKey.toSuiBytes());
 	const eph_public_key_0 = publicKeyBytes / 2n ** 128n;
 	const eph_public_key_1 = publicKeyBytes % 2n ** 128n;
 	const bigNum = poseidonHash([eph_public_key_0, eph_public_key_1, maxEpoch, randomness]);

--- a/sdk/zklogin/src/utils.ts
+++ b/sdk/zklogin/src/utils.ts
@@ -59,14 +59,14 @@ export function hashASCIIStrToField(str: string, maxSize: number) {
 }
 
 export function genAddressSeed(
-	salt: bigint,
+	salt: string | bigint,
 	name: string,
 	value: string,
 	aud: string,
 	max_name_length = MAX_KEY_CLAIM_NAME_LENGTH,
 	max_value_length = MAX_KEY_CLAIM_VALUE_LENGTH,
 	max_aud_length = MAX_AUD_VALUE_LENGTH,
-) {
+): bigint {
 	return poseidonHash([
 		hashASCIIStrToField(name, max_name_length),
 		hashASCIIStrToField(value, max_value_length),

--- a/sdk/zklogin/src/utils.ts
+++ b/sdk/zklogin/src/utils.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { toB64 } from '@mysten/bcs';
+import { PublicKey } from '@mysten/sui.js/cryptography';
+
 import { poseidonHash } from './poseidon.js';
 
 const MAX_KEY_CLAIM_NAME_LENGTH = 32;
@@ -8,12 +11,8 @@ export const MAX_KEY_CLAIM_VALUE_LENGTH = 115;
 export const MAX_AUD_VALUE_LENGTH = 145;
 const PACK_WIDTH = 248;
 
-export function toBigIntBE(buffer: Buffer) {
-	const hex = buffer.toString('hex');
-	if (hex.length === 0) {
-		return BigInt(0);
-	}
-	return BigInt(`0x${hex}`);
+export function getExtendedEphemeralPublicKey(publicKey: PublicKey) {
+	return toB64(publicKey.toSuiBytes());
 }
 
 /**


### PR DESCRIPTION
## Description 

This makes a couple changes to simplify usage of the zklogin SDK.
- Randomness now returns a base64-encoded string
- Expose new `getExtendedEphemeralPublicKey` helper that returns a base64-encoded string of the public key (this helper is really just a one-liner but it makes it obvious what you should do, so I think there's value in keeping it).
- Remove `toBigIntBE` as an export.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
