### PR TITLE
sim data source 2/x: impl node state getter for simulacrum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11151,6 +11151,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bcs",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "simulacrum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11153,6 +11153,7 @@ dependencies = [
  "bcs",
  "reqwest",
  "serde",
+ "simulacrum",
  "sui-core",
  "sui-types",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -535,6 +535,7 @@ mysten-util-mem = { path = "crates/mysten-util-mem" }
 mysten-util-mem-derive = { path = "crates/mysten-util-mem-derive" }
 prometheus-closure-metric = { path = "crates/prometheus-closure-metric" }
 shared-crypto = { path = "crates/shared-crypto" }
+simulacrum = { path = "crates/simulacrum" }
 sui = { path = "crates/sui" }
 sui-adapter-transactional-tests = { path = "crates/sui-adapter-transactional-tests" }
 sui-analytics-indexer = { path = "crates/sui-analytics-indexer" }

--- a/crates/sui-rest-api/Cargo.toml
+++ b/crates/sui-rest-api/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 bcs.workspace = true
 reqwest.workspace = true
 axum.workspace = true
+simulacrum.workspace = true
 sui-types.workspace = true
 sui-core.workspace = true
 workspace-hack.workspace = true

--- a/crates/sui-rest-api/Cargo.toml
+++ b/crates/sui-rest-api/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 bcs.workspace = true
 reqwest.workspace = true
 axum.workspace = true
+rand.workspace = true
 simulacrum.workspace = true
 sui-types.workspace = true
 sui-core.workspace = true

--- a/crates/sui-rest-api/src/node_state_getter.rs
+++ b/crates/sui-rest-api/src/node_state_getter.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_core::authority::AuthorityState;
+use sui_types::error::UserInputError;
 use sui_types::{
     base_types::{ObjectID, VersionNumber},
     digests::{TransactionDigest, TransactionEventsDigest},
@@ -119,7 +120,7 @@ impl NodeStateGetter for AuthorityState {
     }
 }
 
-impl sui_rest_api::node_state_getter::NodeStateGetter for simulacrum::Simulacrum<StdRng> {
+impl<T: Sync + Send> NodeStateGetter for simulacrum::Simulacrum<T> {
     fn get_verified_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
@@ -195,7 +196,7 @@ impl sui_rest_api::node_state_getter::NodeStateGetter for simulacrum::Simulacrum
     fn get_object_by_key(
         &self,
         object_id: &ObjectID,
-        version: SequenceNumber,
+        version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
         Ok(self
             .store()
@@ -204,6 +205,6 @@ impl sui_rest_api::node_state_getter::NodeStateGetter for simulacrum::Simulacrum
     }
 
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        Objectstore::get_object(&self.store(), object_id)
+        ObjectStore::get_object(&self.store(), object_id)
     }
 }


### PR DESCRIPTION
## Description 

Continuation of https://github.com/MystenLabs/sui/pull/14164
This will allow the simulator feed data into indexer etc

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
