### PR TITLE
[Cleanup] remove remaining logic for input object fastpath

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -368,7 +368,6 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
                     let QuorumDriverResponse {
                         effects_cert,
                         events,
-                        ..
                     } = resp;
                     return Ok(ExecutionEffects::CertifiedTransactionEffects(
                         effects_cert.into(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -789,7 +789,6 @@ impl AuthorityState {
         // this function, in order to prevent a byzantine validator from
         // giving us incorrect effects.
         effects: &VerifiedCertifiedTransactionEffects,
-        _objects: Vec<Object>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         assert!(self.is_fullnode(epoch_store));

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -39,7 +39,7 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, IntCounter, IntCounterVec, IntGauge, Registry,
 };
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::string::ToString;
 use std::sync::Arc;
 use std::time::Duration;
@@ -389,7 +389,6 @@ struct ProcessCertificateState {
     non_retryable_stake: StakeUnit,
     non_retryable_errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
     retryable_errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
-    object_map: HashMap<TransactionEffectsDigest, HashSet<Object>>,
     // As long as none of the exit criteria are met we consider the state retryable
     // 1) >= 2f+1 signatures
     // 2) >= f+1 non-retryable errors
@@ -1573,16 +1572,11 @@ where
         &self,
         certificate: CertifiedTransaction,
     ) -> Result<
-        (
-            VerifiedCertifiedTransactionEffects,
-            TransactionEvents,
-            Vec<Object>,
-        ),
+        (VerifiedCertifiedTransactionEffects, TransactionEvents),
         AggregatorProcessCertificateError,
     > {
         let state = ProcessCertificateState {
             effects_map: MultiStakeAggregator::new(self.committee.clone()),
-            object_map: HashMap::new(),
             non_retryable_stake: 0,
             non_retryable_errors: vec![],
             retryable_errors: vec![],
@@ -1748,18 +1742,12 @@ where
         state: &mut ProcessCertificateState,
         response: SuiResult<HandleCertificateResponseV2>,
         name: AuthorityName,
-    ) -> SuiResult<
-        Option<(
-            VerifiedCertifiedTransactionEffects,
-            TransactionEvents,
-            Vec<Object>,
-        )>,
-    > {
+    ) -> SuiResult<Option<(VerifiedCertifiedTransactionEffects, TransactionEvents)>> {
         match response {
             Ok(HandleCertificateResponseV2 {
                 signed_effects,
                 events,
-                fastpath_input_objects,
+                ..
             }) => {
                 debug!(
                     ?tx_digest,
@@ -1768,7 +1756,7 @@ where
                 );
                 let effects_digest = *signed_effects.digest();
                 // Note: here we aggregate votes by the hash of the effects structure
-                let result = match state.effects_map.insert(
+                match state.effects_map.insert(
                     (signed_effects.epoch(), effects_digest),
                     signed_effects.clone(),
                 ) {
@@ -1796,25 +1784,10 @@ where
                         );
                         ct.verify(&committee).map(|ct| {
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
-                            let fastpath_input_objects =
-                                state.object_map.remove(&effects_digest).unwrap_or_default();
-                            Some((ct, events, fastpath_input_objects.into_iter().collect()))
+                            Some((ct, events))
                         })
                     }
-                };
-                if result.is_ok() {
-                    // We verified the objects' relevance and content's integrity in `safe_client.rs`
-                    // based on the effects. Only responses with legit objects will reach here.
-                    // Therefore, as long as we have quorum on effects, we have quorum on objects.
-                    // One thing to note is objects may be missing in some responses e.g. validators are on
-                    // different code versions, but this is fine as long as their content is correct.
-                    state
-                        .object_map
-                        .entry(effects_digest)
-                        .or_default()
-                        .extend(fastpath_input_objects.into_iter());
                 }
-                result
             }
             Err(err) => Err(err),
         }

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -148,7 +148,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
             return Ok(HandleCertificateResponseV2 {
                 signed_effects: response.signed_effects,
                 events: response.events,
-                fastpath_input_objects: vec![], // fastpath is unused for now
+                fastpath_input_objects: vec![], // unused field
             });
         }
         response.map_err(Into::into)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -366,7 +366,7 @@ impl ValidatorService {
             return Ok(Some(HandleCertificateResponseV2 {
                 signed_effects: signed_effects.into_inner(),
                 events,
-                fastpath_input_objects: vec![], // fastpath is unused for now
+                fastpath_input_objects: vec![], // unused field
             }));
         }
 
@@ -447,7 +447,7 @@ impl ValidatorService {
         Ok(Some(HandleCertificateResponseV2 {
             signed_effects: effects.into_inner(),
             events,
-            fastpath_input_objects: vec![], // fastpath is unused for now
+            fastpath_input_objects: vec![], // unused field
         }))
     }
 }

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -411,7 +411,7 @@ where
         let auth_agg = self.validators.load();
         let _cert_guard = GaugeGuard::acquire(&auth_agg.metrics.inflight_certificates);
         let tx_digest = *certificate.digest();
-        let (effects, events, objects) = auth_agg
+        let (effects, events) = auth_agg
             .process_certificate(certificate.clone())
             .instrument(tracing::debug_span!("aggregator_process_cert", ?tx_digest))
             .await
@@ -439,7 +439,6 @@ where
         let response = QuorumDriverResponse {
             effects_cert: effects,
             events,
-            objects,
         };
 
         Ok(response)
@@ -699,7 +698,6 @@ where
                     let response = QuorumDriverResponse {
                         effects_cert,
                         events,
-                        objects: vec![],
                     };
                     quorum_driver.notify(&transaction, &Ok(response), old_retry_times + 1);
                     return;

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -194,7 +194,7 @@ impl LocalAuthorityClient {
         Ok(HandleCertificateResponseV2 {
             signed_effects,
             events,
-            fastpath_input_objects: vec![],
+            fastpath_input_objects: vec![], // unused field
         })
     }
 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -712,20 +712,6 @@ impl TransactionManager {
         Ok(())
     }
 
-    /// Notifies TransactionManager that the given objects are available in the objects table.
-    /// Useful when transactions associated with the objects are not known, e.g. after checking
-    /// object availability from storage, or for testing.
-    pub(crate) fn _fastpath_objects_available(
-        &self,
-        input_keys: Vec<InputKey>,
-        epoch_store: &AuthorityPerEpochStore,
-    ) {
-        let mut inner = self.inner.write();
-        let _scope = monitored_scope("TransactionManager::objects_available::wlock");
-        self.objects_available_locked(&mut inner, epoch_store, input_keys, false);
-        inner.maybe_shrink_capacity();
-    }
-
     #[cfg(test)]
     pub(crate) fn objects_available(
         &self,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -31,7 +31,6 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::effects::{TransactionEffectsAPI, VerifiedCertifiedTransactionEffects};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::object::Object;
 use sui_types::quorum_driver_types::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
     FinalizedEffects, QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse,
@@ -223,11 +222,7 @@ where
             Ok(Err(err)) => Err(err),
             Ok(Ok(response)) => {
                 good_response_metrics.inc();
-                let QuorumDriverResponse {
-                    effects_cert,
-                    objects,
-                    ..
-                } = response;
+                let QuorumDriverResponse { effects_cert, .. } = response;
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
                         FinalizedEffects::new_from_effects_cert(effects_cert.into()),
@@ -245,7 +240,6 @@ where
                     &self.validator_state,
                     &executable_tx,
                     &effects_cert,
-                    objects,
                     &self.metrics,
                 )
                 .await
@@ -312,7 +306,6 @@ where
         validator_state: &Arc<AuthorityState>,
         transaction: &VerifiedExecutableTransaction,
         effects_cert: &VerifiedCertifiedTransactionEffects,
-        objects: Vec<Object>,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {
         let epoch_store = validator_state.load_epoch_store_one_call_per_task();
@@ -347,7 +340,6 @@ where
             validator_state.fullnode_execute_certificate_with_effects(
                 transaction,
                 effects_cert,
-                objects,
                 &epoch_store,
             ),
         )
@@ -391,14 +383,7 @@ where
     ) {
         loop {
             match effects_receiver.recv().await {
-                Ok(Ok((
-                    transaction,
-                    QuorumDriverResponse {
-                        effects_cert,
-                        objects,
-                        ..
-                    },
-                ))) => {
+                Ok(Ok((transaction, QuorumDriverResponse { effects_cert, .. }))) => {
                     let tx_digest = transaction.digest();
                     if let Err(err) = pending_transaction_log.finish_transaction(tx_digest) {
                         panic!(
@@ -436,7 +421,6 @@ where
                         &validator_state,
                         &executable_tx,
                         &effects_cert,
-                        objects,
                         &metrics,
                     )
                     .await;

--- a/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
@@ -142,7 +142,7 @@ impl StressTestRunner {
                 .programmable(pt)
                 .build(),
         );
-        let (effects, _, _) = self
+        let (effects, _) = self
             .test_cluster
             .execute_transaction_return_raw_effects(transaction)
             .await

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -848,7 +848,6 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         QuorumDriverResponse {
             effects_cert: certified_txn_effects,
             events: txn_events,
-            ..
         },
     ) = rx.recv().await.unwrap().unwrap();
     let (cte, events, is_executed_locally) = *res;
@@ -877,7 +876,6 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         QuorumDriverResponse {
             effects_cert: certified_txn_effects,
             events: txn_events,
-            ..
         },
     ) = rx.recv().await.unwrap().unwrap();
     let (cte, events, is_executed_locally) = *res;
@@ -1273,10 +1271,8 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
         QuorumDriverResponse {
             effects_cert: _certified_txn_effects,
             events: _txn_events,
-            objects,
         },
     ) = rx.recv().await.unwrap().unwrap();
-    assert!(objects.is_empty(), "{objects:?}");
     Ok(())
 }
 

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -14,7 +14,6 @@ use sui_types::event::Event;
 use sui_types::execution_status::{CommandArgumentError, ExecutionFailureStatus, ExecutionStatus};
 use sui_types::messages_grpc::ObjectInfoRequest;
 use sui_types::transaction::{CallArg, ObjectArg};
-use sui_types::SUI_CLOCK_OBJECT_ID;
 use test_cluster::TestClusterBuilder;
 
 /// Send a simple shared object transaction to Sui and ensures the client gets back a response.
@@ -206,21 +205,11 @@ async fn access_clock_object_test() {
     let start = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
-    let (effects, events, objects) = test_cluster
+    let (effects, events) = test_cluster
         .execute_transaction_return_raw_effects(transaction)
         .await
         .unwrap();
     assert!(effects.status().is_ok());
-
-    assert_eq!(
-        objects.first().unwrap().compute_object_reference(),
-        effects
-            .input_shared_objects()
-            .into_iter()
-            .find(|((id, _, _), _)| id == &SUI_CLOCK_OBJECT_ID)
-            .map(|(obj_ref, _)| obj_ref)
-            .unwrap()
-    );
 
     let finish = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -292,7 +281,7 @@ async fn shared_object_sync() {
             position_submit_certificate(&committee, name, create_counter_transaction.digest()) > 0
         });
 
-    let (effects, _, _) = test_cluster
+    let (effects, _) = test_cluster
         .submit_transaction_to_validators(create_counter_transaction.clone(), &slow_validators)
         .await
         .unwrap();
@@ -334,7 +323,7 @@ async fn shared_object_sync() {
     );
 
     // Let's submit the transaction to the original set of validators, except the first.
-    let (effects, _, _) = test_cluster
+    let (effects, _) = test_cluster
         .submit_transaction_to_validators(increment_counter_transaction.clone(), &validators[1..])
         .await
         .unwrap();
@@ -342,7 +331,7 @@ async fn shared_object_sync() {
 
     // Submit transactions to the out-of-date authority.
     // It will succeed because we share owned object certificates through narwhal
-    let (effects, _, _) = test_cluster
+    let (effects, _) = test_cluster
         .submit_transaction_to_validators(increment_counter_transaction, &validators[0..1])
         .await
         .unwrap();

--- a/crates/sui-e2e-tests/tests/shared_objects_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_version_tests.rs
@@ -8,7 +8,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
-use sui_types::object::{Object, Owner, OBJECT_START_VERSION};
+use sui_types::object::{Owner, OBJECT_START_VERSION};
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -116,7 +116,7 @@ impl TestEnvironment {
         &self,
         function: &'static str,
         arguments: Vec<CallArg>,
-    ) -> anyhow::Result<(TransactionEffects, TransactionEvents, Vec<Object>)> {
+    ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
         let transaction = self
             .test_cluster
             .test_transaction_builder()
@@ -135,7 +135,7 @@ impl TestEnvironment {
     }
 
     async fn create_counter(&self) -> (ObjectRef, Owner) {
-        let (fx, _, _) = self.move_call("create_counter", vec![]).await.unwrap();
+        let (fx, _) = self.move_call("create_counter", vec![]).await.unwrap();
         assert!(fx.status().is_ok());
 
         *fx.created()
@@ -145,7 +145,7 @@ impl TestEnvironment {
     }
 
     async fn create_shared_counter(&self) -> (ObjectRef, Owner) {
-        let (fx, _, _) = self
+        let (fx, _) = self
             .move_call("create_shared_counter", vec![])
             .await
             .unwrap();
@@ -161,7 +161,7 @@ impl TestEnvironment {
         &self,
         counter: ObjectRef,
     ) -> Result<(ObjectRef, Owner), ExecutionFailureStatus> {
-        let (fx, _, _) = self
+        let (fx, _) = self
             .move_call(
                 "share_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
@@ -181,7 +181,7 @@ impl TestEnvironment {
     }
 
     async fn increment_owned_counter(&self, counter: ObjectRef) -> (ObjectRef, Owner) {
-        let (fx, _, _) = self
+        let (fx, _) = self
             .move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
@@ -200,7 +200,7 @@ impl TestEnvironment {
         counter: ObjectID,
         initial_shared_version: SequenceNumber,
     ) -> anyhow::Result<(ObjectRef, Owner)> {
-        let (fx, _, _) = self
+        let (fx, _) = self
             .move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::SharedObject {

--- a/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
@@ -10,7 +10,7 @@ use sui_types::base_types::{ObjectID, ObjectRef};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::SuiError;
-use sui_types::object::{Object, Owner};
+use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg, Transaction};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
@@ -175,11 +175,12 @@ impl TestEnvironment {
             .build();
         self.test_cluster.wallet.sign_transaction(&transaction)
     }
+
     async fn move_call(
         &self,
         function: &'static str,
         arguments: Vec<CallArg>,
-    ) -> anyhow::Result<(TransactionEffects, TransactionEvents, Vec<Object>)> {
+    ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
         let transaction = self.create_move_call(function, arguments).await;
         self.test_cluster
             .execute_transaction_return_raw_effects(transaction)
@@ -187,7 +188,7 @@ impl TestEnvironment {
     }
 
     async fn start(&self) -> (ObjectRef, ObjectRef) {
-        let (fx, _, _) = self.move_call("start", vec![]).await.unwrap();
+        let (fx, _) = self.move_call("start", vec![]).await.unwrap();
         assert!(fx.status().is_ok());
 
         get_parent_and_child(fx.created())

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -13,7 +13,6 @@ use crate::effects::{
 };
 use crate::error::SuiError;
 use crate::messages_checkpoint::CheckpointSequenceNumber;
-use crate::object::Object;
 use crate::transaction::{Transaction, VerifiedTransaction};
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
@@ -107,7 +106,6 @@ pub struct QuorumDriverRequest {
 pub struct QuorumDriverResponse {
     pub effects_cert: VerifiedCertifiedTransactionEffects,
     pub events: TransactionEvents,
-    pub objects: Vec<Object>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
## Description 

It seems this optimization is unlikely to come back, so removing the remaining scaffolding.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
