### PR TITLE
[explorer] show source code for verified modules

### DIFF
--- a/apps/explorer/src/components/module/ModuleCodeTabs.tsx
+++ b/apps/explorer/src/components/module/ModuleCodeTabs.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/ui/Tabs';
+import { Text } from '@mysten/ui';
+
+import ModuleView from './ModuleView';
+import { useVerifiedSourceCode } from '~/hooks/useVerifiedSourceCode';
+import clsx from 'clsx';
+
+type ModuleCodeTabsProps = {
+	packageId: string;
+	moduleName: string;
+	moduleBytecode: string;
+	isCompact: boolean;
+};
+
+export function ModuleCodeTabs({
+	packageId,
+	moduleName,
+	moduleBytecode,
+	isCompact,
+}: ModuleCodeTabsProps) {
+	const { data: verifiedSourceCode } = useVerifiedSourceCode({
+		packageId,
+		moduleName,
+	});
+
+	return (
+		<Tabs defaultValue="bytecode" className="h-full grow overflow-auto border-gray-45 pt-5 md:pl-7">
+			<TabsList>
+				<TabsTrigger className="h-6" value="bytecode">
+					Bytecode
+				</TabsTrigger>
+				{verifiedSourceCode ? (
+					<TabsTrigger className="h-6" value="source">
+						Source
+						<div className="rounded bg-success-light px-1.5 py-1">
+							<Text variant="subtitle/medium" color="success-dark">
+								Verified
+							</Text>
+						</div>
+					</TabsTrigger>
+				) : null}
+			</TabsList>
+			<TabsContent value="bytecode">
+				<div className={clsx('overflow-auto', { 'h-verticalListLong': isCompact })}>
+					<ModuleView id={packageId} name={moduleName} code={moduleBytecode} />
+				</div>
+			</TabsContent>
+			{verifiedSourceCode ? (
+				<TabsContent value="source">
+					<div className={clsx('overflow-auto', { 'h-verticalListLong': isCompact })}>
+						<ModuleView id={packageId} name={moduleName} code={verifiedSourceCode} />
+					</div>
+				</TabsContent>
+			) : null}
+		</Tabs>
+	);
+}

--- a/apps/explorer/src/components/module/ModuleView.module.css
+++ b/apps/explorer/src/components/module/ModuleView.module.css
@@ -72,7 +72,7 @@ section .codeview pre {
 
 .codelinenumbers {
 	display: table-cell;
-	text-align: left;
+	text-align: right;
 	padding-right: 1em;
 	user-select: none;
 	opacity: 0.5;

--- a/apps/explorer/src/hooks/useVerifiedSourceCode.ts
+++ b/apps/explorer/src/hooks/useVerifiedSourceCode.ts
@@ -15,7 +15,11 @@ type UseVerifiedSourceCodeResponse = {
 	error?: string;
 };
 
-const networksWithSourceCodeVerification: Network[] = [Network.TESTNET, Network.MAINNET];
+const networksWithSourceCodeVerification: Network[] = [
+	Network.DEVNET,
+	Network.TESTNET,
+	Network.MAINNET,
+];
 
 /**
  * Hook that retrieves the source code for verified modules.
@@ -30,7 +34,7 @@ export function useVerifiedSourceCode({ packageId, moduleName }: UseVerifiedSour
 				`http://source.mystenlabs.com/api?network=${network.toLowerCase()}&address=${packageId}&module=${moduleName}`,
 			);
 			if (!response.ok) {
-				throw new Error(`Encountered un-expected response: ${response.status}`);
+				throw new Error(`Encountered unexpected response: ${response.status}`);
 			}
 
 			const jsonResponse: UseVerifiedSourceCodeResponse = await response.json();

--- a/apps/explorer/src/hooks/useVerifiedSourceCode.ts
+++ b/apps/explorer/src/hooks/useVerifiedSourceCode.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useSuiClientContext } from '@mysten/dapp-kit';
+import { useQuery } from '@tanstack/react-query';
+import { Network } from '~/utils/api/DefaultRpcClient';
+
+type UseVerifiedSourceCodeArgs = {
+	packageId: string;
+	moduleName: string;
+};
+
+type UseVerifiedSourceCodeResponse = {
+	source?: string;
+	error?: string;
+};
+
+const networksWithSourceCodeVerification: Network[] = [Network.TESTNET, Network.MAINNET];
+
+/**
+ * Hook that retrieves the source code for verified modules.
+ */
+export function useVerifiedSourceCode({ packageId, moduleName }: UseVerifiedSourceCodeArgs) {
+	const { network } = useSuiClientContext();
+
+	return useQuery({
+		queryKey: ['verified-source-code', packageId, moduleName, network],
+		queryFn: async () => {
+			const response = await fetch(
+				`http://source.mystenlabs.com/api?network=${network.toLowerCase()}&address=${packageId}&module=${moduleName}`,
+			);
+			if (!response.ok) {
+				throw new Error(`Encountered un-expected response: ${response.status}`);
+			}
+
+			const jsonResponse: UseVerifiedSourceCodeResponse = await response.json();
+			return jsonResponse.source || null;
+		},
+		enabled: networksWithSourceCodeVerification.includes(network as Network),
+	});
+}

--- a/apps/explorer/src/hooks/useVerifiedSourceCode.ts
+++ b/apps/explorer/src/hooks/useVerifiedSourceCode.ts
@@ -31,7 +31,7 @@ export function useVerifiedSourceCode({ packageId, moduleName }: UseVerifiedSour
 		queryKey: ['verified-source-code', packageId, moduleName, network],
 		queryFn: async () => {
 			const response = await fetch(
-				`http://source.mystenlabs.com/api?network=${network.toLowerCase()}&address=${packageId}&module=${moduleName}`,
+				`https://source.mystenlabs.com/api?network=${network.toLowerCase()}&address=${packageId}&module=${moduleName}`,
 			);
 			if (!response.ok) {
 				throw new Error(`Encountered unexpected response: ${response.status}`);

--- a/apps/explorer/src/hooks/useVerifiedSourceCode.ts
+++ b/apps/explorer/src/hooks/useVerifiedSourceCode.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import { useSuiClientContext } from '@mysten/dapp-kit';
 import { useQuery } from '@tanstack/react-query';
 import { Network } from '~/utils/api/DefaultRpcClient';
@@ -26,6 +27,7 @@ const networksWithSourceCodeVerification: Network[] = [
  */
 export function useVerifiedSourceCode({ packageId, moduleName }: UseVerifiedSourceCodeArgs) {
 	const { network } = useSuiClientContext();
+	const isEnabled = useFeatureIsOn('module-source-verification');
 
 	return useQuery({
 		queryKey: ['verified-source-code', packageId, moduleName, network],
@@ -40,6 +42,6 @@ export function useVerifiedSourceCode({ packageId, moduleName }: UseVerifiedSour
 			const jsonResponse: UseVerifiedSourceCodeResponse = await response.json();
 			return jsonResponse.source || null;
 		},
-		enabled: networksWithSourceCodeVerification.includes(network as Network),
+		enabled: isEnabled && networksWithSourceCodeVerification.includes(network as Network),
 	});
 }

--- a/apps/explorer/src/ui/Tabs.tsx
+++ b/apps/explorer/src/ui/Tabs.tsx
@@ -84,10 +84,12 @@ const TabsList = forwardRef<
 const TabsTrigger = forwardRef<
 	ElementRef<typeof TabsPrimitive.Trigger>,
 	ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->((props, ref) => {
+>(({ className, ...props }, ref) => {
 	const size = useContext(TabSizeContext);
 
-	return <TabsPrimitive.Trigger ref={ref} className={tabStyles({ size })} {...props} />;
+	return (
+		<TabsPrimitive.Trigger ref={ref} className={clsx(tabStyles({ size }), className)} {...props} />
+	);
 });
 
 const TabsContent = forwardRef<


### PR DESCRIPTION
## Description 
This PR implements phase 1 of our source code verification functionality according to https://www.notion.so/mystenlabs/Source-Code-Verification-1aaebb21554e466eaf70e19db2f66825.  To summarize, we're going to show a "Source [Verified]" tab for verified modules as determined by our new `source.mystenlabs.com/api` endpoint. I'll get sign off from @rvantonder and Sean before landing :)

Verified source tab:
https://explorer-git-wrobertson-sourcever-mysten-labs.vercel.app/object/0x0000000000000000000000000000000000000000000000000000000000000002

No source tab:
https://explorer-git-wrobertson-sourcever-mysten-labs.vercel.app/object/0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91

## Test Plan 
- Manual testing on devnet/testnet/mainnet against verified and non-verified modules
- Manual testing on mobile/desktop

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
