### PR TITLE
[dapp-kit] execute from dApp rather than wallet when using useSignAndExecuteTransactionBlock

### DIFF
--- a/.changeset/dull-dryers-smash.md
+++ b/.changeset/dull-dryers-smash.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+execute transaction from dApp rather than wallet in useSignAndExecuteTransactionBlock

--- a/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useSignAndExecuteTransactionBlock.ts
@@ -15,6 +15,7 @@ import {
 	WalletNotConnectedError,
 } from '../../errors/walletErrors.js';
 import type { PartialBy } from '../../types/utilityTypes.js';
+import { useSuiClient } from '../useSuiClient.js';
 import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 
@@ -39,43 +40,71 @@ type UseSignAndExecuteTransactionBlockMutationOptions = Omit<
 		unknown
 	>,
 	'mutationFn'
->;
+> & {
+	executeFromWallet?: boolean;
+};
 
 /**
  * Mutation hook for prompting the user to sign and execute a transaction block.
  */
 export function useSignAndExecuteTransactionBlock({
 	mutationKey,
+	executeFromWallet,
 	...mutationOptions
 }: UseSignAndExecuteTransactionBlockMutationOptions = {}) {
 	const currentWallet = useCurrentWallet();
 	const currentAccount = useCurrentAccount();
+	const client = useSuiClient();
 
 	return useMutation({
 		mutationKey: walletMutationKeys.signAndExecuteTransactionBlock(mutationKey),
-		mutationFn: async (signAndExecuteTransactionBlockArgs) => {
+		mutationFn: async ({ requestType, options, ...signTransactionBlockArgs }) => {
 			if (!currentWallet) {
 				throw new WalletNotConnectedError('No wallet is connected.');
 			}
 
-			const signerAccount = signAndExecuteTransactionBlockArgs.account ?? currentAccount;
+			const signerAccount = signTransactionBlockArgs.account ?? currentAccount;
 			if (!signerAccount) {
 				throw new WalletNoAccountSelectedError(
 					'No wallet account is selected to sign and execute the transaction block with.',
 				);
 			}
 
-			const walletFeature = currentWallet.features['sui:signAndExecuteTransactionBlock'];
+			if (executeFromWallet) {
+				const walletFeature = currentWallet.features['sui:signAndExecuteTransactionBlock'];
+				if (!walletFeature) {
+					throw new WalletFeatureNotSupportedError(
+						"This wallet doesn't support the `signAndExecuteTransactionBlock` feature.",
+					);
+				}
+
+				return walletFeature.signAndExecuteTransactionBlock({
+					...signTransactionBlockArgs,
+					account: signerAccount,
+					chain: signTransactionBlockArgs.chain ?? signerAccount.chains[0],
+					requestType,
+					options,
+				});
+			}
+
+			const walletFeature = currentWallet.features['sui:signTransactionBlock'];
 			if (!walletFeature) {
 				throw new WalletFeatureNotSupportedError(
 					"This wallet doesn't support the `signAndExecuteTransactionBlock` feature.",
 				);
 			}
 
-			return await walletFeature.signAndExecuteTransactionBlock({
-				...signAndExecuteTransactionBlockArgs,
+			const { signature, transactionBlockBytes } = await walletFeature.signTransactionBlock({
+				...signTransactionBlockArgs,
 				account: signerAccount,
-				chain: signAndExecuteTransactionBlockArgs.chain ?? signerAccount.chains[0],
+				chain: signTransactionBlockArgs.chain ?? signerAccount.chains[0],
+			});
+
+			return client.executeTransactionBlock({
+				transactionBlock: transactionBlockBytes,
+				signature,
+				requestType,
+				options,
 			});
 		},
 		...mutationOptions,

--- a/sdk/dapp-kit/test/test-utils.tsx
+++ b/sdk/dapp-kit/test/test-utils.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiClient } from '@mysten/sui.js/client';
+import { getFullnodeUrl, SuiClient } from '@mysten/sui.js/client';
 import type { IdentifierRecord, ReadonlyWalletAccount } from '@mysten/wallet-standard';
 import { getWallets } from '@mysten/wallet-standard';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -20,11 +20,12 @@ export function createSuiClientContextWrapper(client: SuiClient) {
 
 export function createWalletProviderContextWrapper(
 	providerProps: Omit<ComponentProps<typeof WalletProvider>, 'children'> = {},
+	suiClient: SuiClient = new SuiClient({ url: getFullnodeUrl('localnet') }),
 ) {
 	const queryClient = new QueryClient();
 	return function WalletProviderContextWrapper({ children }: { children: React.ReactNode }) {
 		return (
-			<SuiClientProvider>
+			<SuiClientProvider networks={{ test: suiClient }}>
 				<QueryClientProvider client={queryClient}>
 					<WalletProvider {...providerProps}>{children}</WalletProvider>;
 				</QueryClientProvider>


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
