### PR TITLE
remove expensive clone on hot execution path

### DIFF
--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -114,7 +114,7 @@ impl<'backing> TemporaryStore<'backing> {
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_runtime_objects: self.loaded_runtime_objects,
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
-            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.read().clone(),
+            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
         }
     }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -155,7 +155,7 @@ impl<'backing> TemporaryStore<'backing> {
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_runtime_objects: self.loaded_child_objects,
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
-            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.read().clone(),
+            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
         }
     }
 

--- a/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
@@ -113,7 +113,7 @@ impl<'backing> TemporaryStore<'backing> {
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_runtime_objects: self.loaded_runtime_objects,
             no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
-            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.read().clone(),
+            runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
         }
     }
 


### PR DESCRIPTION
## Description 

I tried to update the existing PR but was unable to, so this is meant to replace https://github.com/MystenLabs/sui/pull/13361 which show cased a major performance improvement by removing a clone in temporary store.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
