### PR TITLE
[dapp-kit] expose theme types so people can declare external themes more easily

### DIFF
--- a/.changeset/pretty-poets-confess.md
+++ b/.changeset/pretty-poets-confess.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Expose types related to theming

--- a/sdk/dapp-kit/src/index.ts
+++ b/sdk/dapp-kit/src/index.ts
@@ -21,3 +21,5 @@ export * from './hooks/useSuiClientQuery.js';
 export * from './hooks/useSuiClientInfiniteQuery.js';
 export * from './themes/lightTheme.js';
 export * from './types.js';
+
+export type { Theme, ThemeVars, DynamicTheme } from './themes/themeContract.js';


### PR DESCRIPTION
## Description 

I was taking a stab at migrating SuiFrens to use dapp-kit, and I noticed none of the theme types were exposed.

[before] dAppTheme.ts
```
const theme = {}; // bleh
const theme: ComponentProps<typeof WalletProvider>['theme'] = {}; // bleh
```

[after] dAppTheme.ts
```
const theme: Theme = {...};
```

## Test Plan 
- CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
