### PR TITLE
data sim 3/x: make test adapter executor parametric

### DIFF
--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -15,7 +15,6 @@ use sui_types::base_types::{SequenceNumber, SuiAddress};
 use sui_types::move_package::UpgradePolicy;
 use sui_types::object::{Object, Owner};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::storage::ObjectStore;
 use sui_types::transaction::{Argument, CallArg, ObjectArg};
 
 use crate::test_adapter::{FakeID, SuiTestAdapter};
@@ -254,9 +253,9 @@ impl SuiValue {
             None => bail!("INVALID TEST. Unknown object, object({})", fake_id),
         };
         let obj_res = if let Some(v) = version {
-            test_adapter.validator.database.get_object_by_key(&id, v)
+            test_adapter.executor.get_object_by_key(&id, v)
         } else {
-            test_adapter.validator.database.get_object(&id)
+            test_adapter.executor.get_object(&id)
         };
         let obj = match obj_res {
             Ok(Some(obj)) => obj,

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -138,7 +138,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 
     async fn advance_clock(
         &mut self,
-        duration: std::time::Duration,
+        _duration: std::time::Duration,
     ) -> anyhow::Result<TransactionEffects> {
         unimplemented!("advance_clock not supported")
     }
@@ -149,30 +149,10 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 
     async fn request_gas(
         &mut self,
-        address: SuiAddress,
-        amount: u64,
+        _address: SuiAddress,
+        _amount: u64,
     ) -> anyhow::Result<TransactionEffects> {
         unimplemented!("request_gas not supported")
-    }
-
-    async fn dev_inspect_transaction_block(
-        &self,
-        sender: SuiAddress,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-    ) -> SuiResult<DevInspectResults> {
-        unimplemented!("dev_inspect_transaction_block not supported")
-    }
-
-    async fn query_events(
-        &self,
-        query: EventFilter,
-        // If `Some`, the query will start from the next item after the specified cursor
-        cursor: Option<EventID>,
-        limit: usize,
-        descending: bool,
-    ) -> SuiResult<Vec<SuiEvent>> {
-        unimplemented!("query_events not supported")
     }
 }
 

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -131,6 +131,49 @@ impl TransactionalAdapter for ValidatorWithFullnode {
             .query_events(&self.kv_store, query, cursor, limit, descending)
             .await
     }
+
+    async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint> {
+        unimplemented!("create_checkpoint not supported")
+    }
+
+    async fn advance_clock(
+        &mut self,
+        duration: std::time::Duration,
+    ) -> anyhow::Result<TransactionEffects> {
+        unimplemented!("advance_clock not supported")
+    }
+
+    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
+        unimplemented!("advance_epoch not supported")
+    }
+
+    async fn request_gas(
+        &mut self,
+        address: SuiAddress,
+        amount: u64,
+    ) -> anyhow::Result<TransactionEffects> {
+        unimplemented!("request_gas not supported")
+    }
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> SuiResult<DevInspectResults> {
+        unimplemented!("dev_inspect_transaction_block not supported")
+    }
+
+    async fn query_events(
+        &self,
+        query: EventFilter,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<EventID>,
+        limit: usize,
+        descending: bool,
+    ) -> SuiResult<Vec<SuiEvent>> {
+        unimplemented!("query_events not supported")
+    }
 }
 
 impl ObjectStore for ValidatorWithFullnode {

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -9,11 +9,154 @@ pub mod test_adapter;
 
 use move_transactional_test_runner::framework::run_test_impl;
 use std::path::Path;
+use sui_types::storage::ObjectStore;
 use test_adapter::{SuiTestAdapter, PRE_COMPILED};
+
+use std::sync::Arc;
+use sui_core::authority::authority_test_utils::send_and_confirm_transaction_with_execution_error;
+use sui_core::authority::AuthorityState;
+use sui_json_rpc_types::DevInspectResults;
+use sui_json_rpc_types::EventFilter;
+use sui_json_rpc_types::SuiEvent;
+use sui_storage::key_value_store::TransactionKeyValueStore;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SuiAddress;
+use sui_types::base_types::VersionNumber;
+use sui_types::effects::TransactionEffects;
+use sui_types::error::ExecutionError;
+use sui_types::error::SuiError;
+use sui_types::error::SuiResult;
+use sui_types::event::EventID;
+use sui_types::messages_checkpoint::VerifiedCheckpoint;
+use sui_types::object::Object;
+use sui_types::transaction::Transaction;
+use sui_types::transaction::TransactionDataAPI;
+use sui_types::transaction::TransactionKind;
 
 #[cfg_attr(not(msim), tokio::main)]
 #[cfg_attr(msim, msim::main)]
 pub async fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     run_test_impl::<SuiTestAdapter>(path, Some(&*PRE_COMPILED)).await?;
     Ok(())
+}
+
+pub struct ValidatorWithFullnode {
+    pub validator: Arc<AuthorityState>,
+    pub fullnode: Arc<AuthorityState>,
+    pub kv_store: Arc<TransactionKeyValueStore>,
+}
+
+#[allow(unused_variables)]
+/// TODO: better name?
+#[async_trait::async_trait]
+pub trait TransactionalAdapterTestable: Send + Sync + ObjectStore {
+    async fn execute_txn(
+        &mut self,
+        transaction: Transaction,
+    ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)>;
+
+    async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint> {
+        unimplemented!("create_checkpoint not supported")
+    }
+
+    async fn advance_clock(
+        &mut self,
+        duration: std::time::Duration,
+    ) -> anyhow::Result<TransactionEffects> {
+        unimplemented!("advance_clock not supported")
+    }
+
+    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
+        unimplemented!("advance_epoch not supported")
+    }
+
+    async fn request_gas(
+        &mut self,
+        address: SuiAddress,
+        amount: u64,
+    ) -> anyhow::Result<TransactionEffects> {
+        unimplemented!("request_gas not supported")
+    }
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> SuiResult<DevInspectResults> {
+        unimplemented!("dev_inspect_transaction_block not supported")
+    }
+
+    async fn query_events(
+        &self,
+        query: EventFilter,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<EventID>,
+        limit: usize,
+        descending: bool,
+    ) -> SuiResult<Vec<SuiEvent>> {
+        unimplemented!("query_events not supported")
+    }
+}
+
+#[async_trait::async_trait]
+impl TransactionalAdapterTestable for ValidatorWithFullnode {
+    async fn execute_txn(
+        &mut self,
+        transaction: Transaction,
+    ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
+        let with_shared = transaction
+            .data()
+            .intent_message()
+            .value
+            .contains_shared_object();
+        let (_, effects, execution_error) = send_and_confirm_transaction_with_execution_error(
+            &self.validator,
+            Some(&self.fullnode),
+            transaction,
+            with_shared,
+        )
+        .await?;
+        Ok((effects.into_data(), execution_error))
+    }
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> SuiResult<DevInspectResults> {
+        self.fullnode
+            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .await
+    }
+
+    async fn query_events(
+        &self,
+        query: EventFilter,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: Option<EventID>,
+        limit: usize,
+        descending: bool,
+    ) -> SuiResult<Vec<SuiEvent>> {
+        self.validator
+            .query_events(&self.kv_store, query, cursor, limit, descending)
+            .await
+    }
+}
+
+impl ObjectStore for ValidatorWithFullnode {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+        self.validator.database.get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        self.validator
+            .database
+            .get_object_by_key(object_id, version)
+    }
 }

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -49,43 +49,33 @@ pub struct ValidatorWithFullnode {
 #[allow(unused_variables)]
 /// TODO: better name?
 #[async_trait::async_trait]
-pub trait TransactionalAdapterTestable: Send + Sync + ObjectStore {
+pub trait TransactionalAdapter: Send + Sync + ObjectStore {
     async fn execute_txn(
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)>;
 
-    async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint> {
-        unimplemented!("create_checkpoint not supported")
-    }
+    async fn create_checkpoint(&mut self) -> anyhow::Result<VerifiedCheckpoint>;
 
     async fn advance_clock(
         &mut self,
         duration: std::time::Duration,
-    ) -> anyhow::Result<TransactionEffects> {
-        unimplemented!("advance_clock not supported")
-    }
+    ) -> anyhow::Result<TransactionEffects>;
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
-        unimplemented!("advance_epoch not supported")
-    }
+    async fn advance_epoch(&mut self) -> anyhow::Result<()>;
 
     async fn request_gas(
         &mut self,
         address: SuiAddress,
         amount: u64,
-    ) -> anyhow::Result<TransactionEffects> {
-        unimplemented!("request_gas not supported")
-    }
+    ) -> anyhow::Result<TransactionEffects>;
 
     async fn dev_inspect_transaction_block(
         &self,
         sender: SuiAddress,
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
-    ) -> SuiResult<DevInspectResults> {
-        unimplemented!("dev_inspect_transaction_block not supported")
-    }
+    ) -> SuiResult<DevInspectResults>;
 
     async fn query_events(
         &self,
@@ -94,13 +84,11 @@ pub trait TransactionalAdapterTestable: Send + Sync + ObjectStore {
         cursor: Option<EventID>,
         limit: usize,
         descending: bool,
-    ) -> SuiResult<Vec<SuiEvent>> {
-        unimplemented!("query_events not supported")
-    }
+    ) -> SuiResult<Vec<SuiEvent>>;
 }
 
 #[async_trait::async_trait]
-impl TransactionalAdapterTestable for ValidatorWithFullnode {
+impl TransactionalAdapter for ValidatorWithFullnode {
     async fn execute_txn(
         &mut self,
         transaction: Transaction,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -4,7 +4,7 @@
 //! This module contains the transactional test runner instantiation for the Sui adapter
 
 use crate::{args::*, programmable_transaction_test_parser::parser::ParsedCommand};
-use crate::{TransactionalAdapterTestable, ValidatorWithFullnode};
+use crate::{TransactionalAdapter, ValidatorWithFullnode};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use bimap::btree::BiBTreeMap;
@@ -115,7 +115,7 @@ pub struct SuiTestAdapter<'a> {
     next_fake: (u64, u64),
     gas_price: u64,
     pub(crate) staged_modules: BTreeMap<Symbol, StagedPackage>,
-    pub(crate) executor: Box<dyn TransactionalAdapterTestable>,
+    pub(crate) executor: Box<dyn TransactionalAdapter>,
 }
 
 pub(crate) struct StagedPackage {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -4,6 +4,7 @@
 //! This module contains the transactional test runner instantiation for the Sui adapter
 
 use crate::{args::*, programmable_transaction_test_parser::parser::ParsedCommand};
+use crate::{TransactionalAdapterTestable, ValidatorWithFullnode};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use bimap::btree::BiBTreeMap;
@@ -38,10 +39,7 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use sui_core::authority::{
-    authority_test_utils::send_and_confirm_transaction_with_execution_error,
-    test_authority_builder::TestAuthorityBuilder, AuthorityState,
-};
+use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_framework::BuiltInFramework;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_json_rpc::api::QUERY_MAX_RESULT_LIMIT;
@@ -52,11 +50,13 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
+use sui_types::base_types::SequenceNumber;
+use sui_types::crypto::get_authority_key_pair;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::transaction::Command;
 use sui_types::transaction::ProgrammableTransaction;
 use sui_types::DEEPBOOK_PACKAGE_ID;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
-use sui_types::{base_types::SequenceNumber, effects::TransactionEffectsAPI};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, SUI_ADDRESS_LENGTH},
     crypto::{get_key_pair_from_rng, AccountKeyPair},
@@ -68,7 +68,6 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use sui_types::{clock::Clock, SUI_SYSTEM_ADDRESS};
-use sui_types::{crypto::get_authority_key_pair, storage::ObjectStore};
 use sui_types::{execution_status::ExecutionStatus, transaction::TransactionKind};
 use sui_types::{gas::GasCostSummary, object::GAS_VALUE_FOR_TESTING};
 use sui_types::{id::UID, DEEPBOOK_ADDRESS};
@@ -106,9 +105,6 @@ const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000;
 const GAS_FOR_TESTING: u64 = GAS_VALUE_FOR_TESTING;
 
 pub struct SuiTestAdapter<'a> {
-    pub(crate) validator: Arc<AuthorityState>,
-    pub(crate) kv_store: Arc<TransactionKeyValueStore>,
-    pub(crate) fullnode: Arc<AuthorityState>,
     pub(crate) compiled_state: CompiledState<'a>,
     /// For upgrades: maps an upgraded package name to the original package name.
     package_upgrade_mapping: BTreeMap<Symbol, Symbol>,
@@ -119,6 +115,7 @@ pub struct SuiTestAdapter<'a> {
     next_fake: (u64, u64),
     gas_price: u64,
     pub(crate) staged_modules: BTreeMap<Symbol, StagedPackage>,
+    pub(crate) executor: Box<dyn TransactionalAdapterTestable>,
 }
 
 pub(crate) struct StagedPackage {
@@ -356,9 +353,11 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         ));
 
         let mut test_adapter = Self {
-            validator,
-            kv_store,
-            fullnode,
+            executor: Box::new(ValidatorWithFullnode {
+                validator,
+                fullnode,
+                kv_store,
+            }),
             compiled_state: CompiledState::new(
                 named_address_mapping,
                 pre_compiled_deps,
@@ -1106,13 +1105,8 @@ impl<'a> SuiTestAdapter<'a> {
             .intent_message()
             .value
             .contains_shared_object();
-        let (txn, effects, error_opt) = send_and_confirm_transaction_with_execution_error(
-            &self.validator,
-            Some(&self.fullnode),
-            transaction,
-            with_shared,
-        )
-        .await?;
+        let (effects, error_opt) = self.executor.execute_txn(transaction).await?;
+        let digest = effects.transaction_digest();
         let mut created_ids: Vec<_> = effects
             .created()
             .iter()
@@ -1164,10 +1158,9 @@ impl<'a> SuiTestAdapter<'a> {
         match effects.status() {
             ExecutionStatus::Success { .. } => {
                 let events = self
-                    .validator
+                    .executor
                     .query_events(
-                        &self.kv_store,
-                        EventFilter::Transaction(*txn.digest()),
+                        EventFilter::Transaction(*digest),
                         None,
                         *QUERY_MAX_RESULT_LIMIT,
                         /* descending */ false,
@@ -1211,7 +1204,7 @@ impl<'a> SuiTestAdapter<'a> {
         gas_price: Option<u64>,
     ) -> anyhow::Result<TxnSummary> {
         let results = self
-            .fullnode
+            .executor
             .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
             .await?;
         let DevInspectResults {
@@ -1279,9 +1272,9 @@ impl<'a> SuiTestAdapter<'a> {
 
     fn get_object(&self, id: &ObjectID, version: Option<SequenceNumber>) -> anyhow::Result<Object> {
         let obj_res = if let Some(v) = version {
-            self.validator.database.get_object_by_key(id, v)
+            self.executor.get_object_by_key(id, v)
         } else {
-            self.validator.database.get_object(id)
+            self.executor.get_object(id)
         };
         match obj_res {
             Ok(Some(obj)) => Ok(obj),


### PR DESCRIPTION
## Description 

This makes the executor in adapter test runner parametric.
Subseq PR, will enable choosing the executor in the test file.
Executors include: validator (current approach) and an upcoming simulator

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
