### PR TITLE
Move checkpoint_builder to sui-types

### DIFF
--- a/crates/simulacrum/src/store.rs
+++ b/crates/simulacrum/src/store.rs
@@ -374,7 +374,7 @@ pub struct KeyStore {
 }
 
 impl KeyStore {
-    pub fn from_newtork_config(
+    pub fn from_network_config(
         network_config: &sui_swarm_config::network_config::NetworkConfig,
     ) -> Self {
         use fastcrypto::traits::KeyPair;

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -38,6 +38,7 @@ pub mod digests;
 pub mod display;
 pub mod dynamic_field;
 pub mod effects;
+pub mod epoch_data;
 pub mod event;
 pub mod executable_transaction;
 pub mod execution;
@@ -56,6 +57,7 @@ pub mod messages_consensus;
 pub mod messages_grpc;
 pub mod messages_safe_client;
 pub mod metrics;
+pub mod mock_checkpoint_builder;
 pub mod move_package;
 pub mod multisig;
 pub mod multisig_legacy;
@@ -72,8 +74,6 @@ pub mod type_resolver;
 pub mod versioned;
 pub mod zk_login_authenticator;
 pub mod zk_login_util;
-
-pub mod epoch_data;
 
 #[cfg(any(test, feature = "test-utils"))]
 #[path = "./unit_tests/utils.rs"]


### PR DESCRIPTION
## Description 

Move checkpoint_builder to sui-types so that we could reuse it for other things, such as benchmarking.
Also added a validator key provider trait to hide how the underline key management works.

## Test Plan 

cargo build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
