### PR TITLE
capture adapter state after transactional test

### DIFF
--- a/external-crates/move-execution/vm-rework/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move-execution/vm-rework/move-vm/runtime/src/interpreter.rs
@@ -587,12 +587,7 @@ impl Interpreter {
         ty_args: Vec<Type>,
     ) -> PartialVMResult<()> {
         let return_values = self.call_native_return_values(
-            resolver,
-            data_store,
-            gas_meter,
-            extensions,
-            function.clone(),
-            &ty_args,
+            resolver, data_store, gas_meter, extensions, function, &ty_args,
         )?;
         // Put return values on the top of the operand stack, where the caller will find them.
         // This is one of only two times the operand stack is shared across call stack frames; the other is in handling


### PR DESCRIPTION
## Description 

Split the test parsing logic from the expectation checking and capture the state of adapter after the the execution.
This state will be used to feed the simulator post processing engine

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
