### PR TITLE
indexer v2: analytical endpoints, read path

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
@@ -22,3 +22,4 @@ CREATE TABLE move_call_metrics (
     count                       BIGINT      NOT NULL
 );
 CREATE INDEX move_call_metrics_checkpoint ON move_call_metrics (checkpoint_sequence_number);
+CREATE INDEX move_call_metrics_day ON move_call_metrics (day);

--- a/crates/sui-indexer/src/apis/extended_api_v2.rs
+++ b/crates/sui-indexer/src/apis/extended_api_v2.rs
@@ -79,26 +79,46 @@ impl ExtendedApiServer for ExtendedApiV2 {
     }
 
     async fn get_network_metrics(&self) -> RpcResult<NetworkMetrics> {
-        unimplemented!()
+        let network_metrics = self
+            .inner
+            .spawn_blocking(|this| this.get_latest_network_metrics())
+            .await?;
+        Ok(network_metrics)
     }
 
     async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics> {
-        unimplemented!()
+        let move_call_metrics = self
+            .inner
+            .spawn_blocking(|this| this.get_latest_move_call_metrics())
+            .await?;
+        Ok(move_call_metrics)
     }
 
     async fn get_latest_address_metrics(&self) -> RpcResult<AddressMetrics> {
-        unimplemented!()
+        let latest_address_metrics = self
+            .inner
+            .spawn_blocking(|this| this.get_latest_address_metrics())
+            .await?;
+        Ok(latest_address_metrics)
     }
 
     async fn get_checkpoint_address_metrics(&self, checkpoint: u64) -> RpcResult<AddressMetrics> {
-        unimplemented!()
+        let checkpoint_address_metrics = self
+            .inner
+            .spawn_blocking(move |this| this.get_checkpoint_address_metrics(checkpoint))
+            .await?;
+        Ok(checkpoint_address_metrics)
     }
 
     async fn get_all_epoch_address_metrics(
         &self,
         descending_order: Option<bool>,
     ) -> RpcResult<Vec<AddressMetrics>> {
-        unimplemented!()
+        let all_epoch_address_metrics = self
+            .inner
+            .spawn_blocking(move |this| this.get_all_epoch_address_metrics(descending_order))
+            .await?;
+        Ok(all_epoch_address_metrics)
     }
 
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>> {

--- a/crates/sui-indexer/src/apis/mod.rs
+++ b/crates/sui-indexer/src/apis/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) use coin_api::CoinReadApi;
 pub(crate) use coin_api_v2::CoinReadApiV2;
 pub(crate) use extended_api::ExtendedApi;
+pub(crate) use extended_api_v2::ExtendedApiV2;
 pub(crate) use governance_api::GovernanceReadApi;
 pub(crate) use governance_api_v2::GovernanceReadApiV2;
 pub(crate) use indexer_api::IndexerApi;

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -4,16 +4,23 @@
 use crate::{
     errors::IndexerError,
     models_v2::{
+        address_metrics::StoredAddressMetrics,
         checkpoints::StoredCheckpoint,
         display::StoredDisplay,
         epoch::StoredEpochInfo,
         events::StoredEvent,
+        move_call_metrics::QueriedMoveCallMetrics,
+        network_metrics::StoredNetworkMetrics,
         objects::{CoinBalance, ObjectRefColumn, StoredObject},
         packages::StoredPackage,
         transactions::StoredTransaction,
+        tx_count_metrics::StoredTxCountMetrics,
         tx_indices::TxSequenceNumber,
     },
-    schema_v2::{checkpoints, display, epochs, events, objects, packages, transactions},
+    schema_v2::{
+        address_metrics, checkpoints, display, epochs, events, move_call_metrics, network_metrics,
+        objects, packages, transactions, tx_count_metrics,
+    },
     types_v2::{IndexerResult, OwnerType},
     PgConnectionConfig, PgConnectionPoolConfig, PgPoolConnection,
 };
@@ -29,10 +36,11 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::{Arc, RwLock},
 };
-use sui_json_rpc_types::{Balance, Coin as SuiCoin};
 use sui_json_rpc_types::{
-    CheckpointId, EpochInfo, EventFilter, SuiEvent, SuiTransactionBlockResponse, TransactionFilter,
+    AddressMetrics, CheckpointId, EpochInfo, EventFilter, MoveCallMetrics, MoveFunctionName,
+    NetworkMetrics, SuiEvent, SuiTransactionBlockResponse, TransactionFilter,
 };
+use sui_json_rpc_types::{Balance, Coin as SuiCoin};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, VersionNumber},
     committee::EpochId,
@@ -1331,6 +1339,136 @@ impl IndexerReader {
         let coin_balances =
             self.run_query(|conn| diesel::sql_query(query).load::<CoinBalance>(conn))?;
         Ok(coin_balances.into_iter().map(|cb| cb.into()).collect())
+    }
+
+    pub fn get_latest_network_metrics(&self) -> IndexerResult<NetworkMetrics> {
+        let stored_network_metrics = self.run_query(|conn| {
+            network_metrics::table
+                .order(network_metrics::dsl::checkpoint.desc())
+                .first::<StoredNetworkMetrics>(conn)
+        })?;
+        Ok(stored_network_metrics.into())
+    }
+
+    pub fn get_latest_move_call_metrics(&self) -> IndexerResult<MoveCallMetrics> {
+        let latest_3d_move_call_metrics = self.run_query(|conn| {
+            move_call_metrics::table
+                .filter(move_call_metrics::dsl::day.eq(3))
+                .order(move_call_metrics::dsl::id.desc())
+                .limit(10)
+                .load::<QueriedMoveCallMetrics>(conn)
+        })?;
+        let latest_7d_move_call_metrics = self.run_query(|conn| {
+            move_call_metrics::table
+                .filter(move_call_metrics::dsl::day.eq(7))
+                .order(move_call_metrics::dsl::id.desc())
+                .limit(10)
+                .load::<QueriedMoveCallMetrics>(conn)
+        })?;
+        let latest_30d_move_call_metrics = self.run_query(|conn| {
+            move_call_metrics::table
+                .filter(move_call_metrics::dsl::day.eq(30))
+                .order(move_call_metrics::dsl::id.desc())
+                .limit(10)
+                .load::<QueriedMoveCallMetrics>(conn)
+        })?;
+
+        let latest_3_days: Vec<(MoveFunctionName, usize)> = latest_3d_move_call_metrics
+            .into_iter()
+            .map(|m| m.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        let latest_7_days: Vec<(MoveFunctionName, usize)> = latest_7d_move_call_metrics
+            .into_iter()
+            .map(|m| m.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        let latest_30_days: Vec<(MoveFunctionName, usize)> = latest_30d_move_call_metrics
+            .into_iter()
+            .map(|m| m.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        // sort by call count desc.
+        let rank_3_days = latest_3_days
+            .into_iter()
+            .sorted_by(|a, b| b.1.cmp(&a.1))
+            .collect::<Vec<_>>();
+        let rank_7_days = latest_7_days
+            .into_iter()
+            .sorted_by(|a, b| b.1.cmp(&a.1))
+            .collect::<Vec<_>>();
+        let rank_30_days = latest_30_days
+            .into_iter()
+            .sorted_by(|a, b| b.1.cmp(&a.1))
+            .collect::<Vec<_>>();
+        Ok(MoveCallMetrics {
+            rank_3_days,
+            rank_7_days,
+            rank_30_days,
+        })
+    }
+
+    pub fn get_latest_address_metrics(&self) -> IndexerResult<AddressMetrics> {
+        let stored_address_metrics = self.run_query(|conn| {
+            address_metrics::table
+                .order(address_metrics::dsl::checkpoint.desc())
+                .first::<StoredAddressMetrics>(conn)
+        })?;
+        Ok(stored_address_metrics.into())
+    }
+
+    pub fn get_checkpoint_address_metrics(
+        &self,
+        checkpoint_seq: u64,
+    ) -> IndexerResult<AddressMetrics> {
+        let stored_address_metrics = self.run_query(|conn| {
+            address_metrics::table
+                .filter(address_metrics::dsl::checkpoint.eq(checkpoint_seq as i64))
+                .first::<StoredAddressMetrics>(conn)
+        })?;
+        Ok(stored_address_metrics.into())
+    }
+
+    pub fn get_all_epoch_address_metrics(
+        &self,
+        descending_order: Option<bool>,
+    ) -> IndexerResult<Vec<AddressMetrics>> {
+        let is_descending = descending_order.unwrap_or_default();
+        let epoch_address_metrics_query = format!(
+            "WITH ranked_rows AS (
+                SELECT
+                  checkpoint, epoch, timestamp_ms, cumulative_addresses, cumulative_active_addresses, daily_active_addresses,
+                  row_number() OVER(PARTITION BY epoch ORDER BY checkpoint DESC) as row_num
+                FROM
+                  address_metrics
+              )
+              SELECT
+                checkpoint, epoch, timestamp_ms, cumulative_addresses, cumulative_active_addresses, daily_active_addresses
+              FROM ranked_rows
+              WHERE row_num = 1 ORDER BY epoch {}",
+              if is_descending { "DESC" } else { "ASC" },
+        );
+        let epoch_address_metrics = self.run_query(|conn| {
+            diesel::sql_query(epoch_address_metrics_query).load::<StoredAddressMetrics>(conn)
+        })?;
+
+        Ok(epoch_address_metrics
+            .into_iter()
+            .map(|stored_address_metrics| stored_address_metrics.into())
+            .collect())
+    }
+
+    pub fn get_total_transactions(&self) -> IndexerResult<i64> {
+        let latest_tx_count_metrics = self.run_query(|conn| {
+            tx_count_metrics::table
+                .order(tx_count_metrics::dsl::checkpoint_sequence_number.desc())
+                .first::<StoredTxCountMetrics>(conn)
+        })?;
+        // NOTE: tx are counted as:
+        // - if a tx is successful, it is counted as # of commands in the tx
+        // - otherwise, it is counted as 1.
+        Ok(
+            latest_tx_count_metrics.network_total_successful_transactions
+                + latest_tx_count_metrics.network_total_transaction_blocks
+                - latest_tx_count_metrics.network_total_successful_transaction_blocks,
+        )
     }
 }
 

--- a/crates/sui-indexer/src/indexer_v2.rs
+++ b/crates/sui-indexer/src/indexer_v2.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::apis::{
-    CoinReadApiV2, GovernanceReadApiV2, IndexerApiV2, MoveUtilsApiV2, ReadApiV2,
+    CoinReadApiV2, ExtendedApiV2, GovernanceReadApiV2, IndexerApiV2, MoveUtilsApiV2, ReadApiV2,
     TransactionBuilderApiV2,
 };
 use crate::errors::IndexerError;
@@ -124,6 +124,7 @@ pub async fn build_json_rpc_server(
     builder.register_module(GovernanceReadApiV2::new(reader.clone()))?;
     builder.register_module(ReadApiV2::new(reader.clone()))?;
     builder.register_module(CoinReadApiV2::new(reader.clone()))?;
+    builder.register_module(ExtendedApiV2::new(reader.clone()))?;
     // builder.register_module()...
 
     let default_socket_addr: SocketAddr = SocketAddr::new(

--- a/crates/sui-indexer/src/models_v2/address_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/address_metrics.rs
@@ -59,15 +59,15 @@ pub struct StoredAddressMetrics {
     pub daily_active_addresses: i64,
 }
 
-impl Into<AddressMetrics> for StoredAddressMetrics {
-    fn into(self) -> AddressMetrics {
-        AddressMetrics {
-            checkpoint: self.checkpoint as u64,
-            epoch: self.epoch as u64,
-            timestamp_ms: self.timestamp_ms as u64,
-            cumulative_addresses: self.cumulative_addresses as u64,
-            cumulative_active_addresses: self.cumulative_active_addresses as u64,
-            daily_active_addresses: self.daily_active_addresses as u64,
+impl From<StoredAddressMetrics> for AddressMetrics {
+    fn from(metrics: StoredAddressMetrics) -> Self {
+        Self {
+            checkpoint: metrics.checkpoint as u64,
+            epoch: metrics.epoch as u64,
+            timestamp_ms: metrics.timestamp_ms as u64,
+            cumulative_addresses: metrics.cumulative_addresses as u64,
+            cumulative_active_addresses: metrics.cumulative_active_addresses as u64,
+            daily_active_addresses: metrics.daily_active_addresses as u64,
         }
     }
 }

--- a/crates/sui-indexer/src/models_v2/address_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/address_metrics.rs
@@ -4,6 +4,9 @@
 use std::collections::HashMap;
 
 use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+
+use sui_json_rpc_types::AddressMetrics;
 
 use crate::schema_v2::{active_addresses, address_metrics, addresses};
 
@@ -39,15 +42,34 @@ impl From<StoredAddress> for StoredActiveAddress {
     }
 }
 
-#[derive(Clone, Debug, Default, Queryable, Insertable)]
+#[derive(Clone, Debug, Default, Queryable, Insertable, QueryableByName)]
 #[diesel(table_name = address_metrics)]
 pub struct StoredAddressMetrics {
+    #[diesel(sql_type = BigInt)]
     pub checkpoint: i64,
+    #[diesel(sql_type = BigInt)]
     pub epoch: i64,
+    #[diesel(sql_type = BigInt)]
     pub timestamp_ms: i64,
+    #[diesel(sql_type = BigInt)]
     pub cumulative_addresses: i64,
+    #[diesel(sql_type = BigInt)]
     pub cumulative_active_addresses: i64,
+    #[diesel(sql_type = BigInt)]
     pub daily_active_addresses: i64,
+}
+
+impl Into<AddressMetrics> for StoredAddressMetrics {
+    fn into(self) -> AddressMetrics {
+        AddressMetrics {
+            checkpoint: self.checkpoint as u64,
+            epoch: self.epoch as u64,
+            timestamp_ms: self.timestamp_ms as u64,
+            cumulative_addresses: self.cumulative_addresses as u64,
+            cumulative_active_addresses: self.cumulative_active_addresses as u64,
+            daily_active_addresses: self.daily_active_addresses as u64,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-indexer/src/models_v2/network_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/network_metrics.rs
@@ -4,6 +4,8 @@
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
 
+use sui_json_rpc_types::NetworkMetrics;
+
 use crate::schema_v2::network_metrics;
 
 #[derive(Clone, Debug, Default, Queryable, Insertable)]
@@ -23,4 +25,18 @@ pub struct StoredNetworkMetrics {
 pub struct RowCountEstimation {
     #[diesel(sql_type = BigInt)]
     pub estimated_count: i64,
+}
+
+impl Into<NetworkMetrics> for StoredNetworkMetrics {
+    fn into(self) -> NetworkMetrics {
+        NetworkMetrics {
+            current_checkpoint: self.checkpoint as u64,
+            current_epoch: self.epoch as u64,
+            current_tps: self.real_time_tps,
+            tps_30_days: self.peak_tps_30d,
+            total_addresses: self.total_addresses as u64,
+            total_objects: self.total_objects as u64,
+            total_packages: self.total_packages as u64,
+        }
+    }
 }

--- a/crates/sui-indexer/src/models_v2/network_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/network_metrics.rs
@@ -27,16 +27,16 @@ pub struct RowCountEstimation {
     pub estimated_count: i64,
 }
 
-impl Into<NetworkMetrics> for StoredNetworkMetrics {
-    fn into(self) -> NetworkMetrics {
-        NetworkMetrics {
-            current_checkpoint: self.checkpoint as u64,
-            current_epoch: self.epoch as u64,
-            current_tps: self.real_time_tps,
-            tps_30_days: self.peak_tps_30d,
-            total_addresses: self.total_addresses as u64,
-            total_objects: self.total_objects as u64,
-            total_packages: self.total_packages as u64,
+impl From<StoredNetworkMetrics> for NetworkMetrics {
+    fn from(metrics: StoredNetworkMetrics) -> Self {
+        Self {
+            current_checkpoint: metrics.checkpoint as u64,
+            current_epoch: metrics.epoch as u64,
+            current_tps: metrics.real_time_tps,
+            tps_30_days: metrics.peak_tps_30d,
+            total_addresses: metrics.total_addresses as u64,
+            total_objects: metrics.total_objects as u64,
+            total_packages: metrics.total_packages as u64,
         }
     }
 }


### PR DESCRIPTION
## Description 

Implement the read path of analytical endpoints of indexer v2, the read path.

the related write path PR is https://github.com/MystenLabs/sui/pull/14140

## Test Plan 
- locally populate the analytical tables from the write PR

cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url http://ewr-suifn-y71v1.devnet.sui.io:9000 --fullnode-sync-worker --reset-db --use-v2

cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url http://ewr-suifn-y71v1.devnet.sui.io:9000 --fullnode-sync-worker --reset-db --use-v2

- locally run json rpc server with this PR and test cmd like


curl --location http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_getMoveCallMetrics",
  "params": []
}'

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
