### PR TITLE
[benchmark] Benchmark checkpoint executor

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -622,7 +622,7 @@ pub struct AuthorityState {
     pub indexes: Option<Arc<IndexStore>>,
 
     pub subscription_handler: Arc<SubscriptionHandler>,
-    pub(crate) checkpoint_store: Arc<CheckpointStore>,
+    checkpoint_store: Arc<CheckpointStore>,
 
     committee_store: Arc<CommitteeStore>,
 
@@ -2960,8 +2960,8 @@ impl AuthorityState {
             .get_transactions(filter, cursor, limit, reverse)
     }
 
-    fn get_checkpoint_store(&self) -> Arc<CheckpointStore> {
-        self.checkpoint_store.clone()
+    pub fn get_checkpoint_store(&self) -> &Arc<CheckpointStore> {
+        &self.checkpoint_store
     }
 
     pub fn get_latest_checkpoint_sequence_number(&self) -> SuiResult<CheckpointSequenceNumber> {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -48,6 +48,8 @@ pub struct TestAuthorityBuilder<'a> {
     starting_objects: Option<&'a [Object]>,
     expensive_safety_checks: Option<ExpensiveSafetyCheckConfig>,
     disable_indexer: bool,
+    /// By default, we don't insert the genesis checkpoint, which isn't needed by most tests.
+    insert_genesis_checkpoint: bool,
 }
 
 impl<'a> TestAuthorityBuilder<'a> {
@@ -121,6 +123,11 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub fn disable_indexer(mut self) -> Self {
         self.disable_indexer = true;
+        self
+    }
+
+    pub fn insert_genesis_checkpoint(mut self) -> Self {
+        self.insert_genesis_checkpoint = true;
         self
     }
 
@@ -201,6 +208,13 @@ impl<'a> TestAuthorityBuilder<'a> {
         ));
 
         let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
+        if self.insert_genesis_checkpoint {
+            checkpoint_store.insert_genesis_checkpoint(
+                genesis.checkpoint(),
+                genesis.checkpoint_contents().clone(),
+                &epoch_store,
+            );
+        }
         let index_store = if self.disable_indexer {
             None
         } else {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -160,7 +160,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     );
 
     authority_state
-        .checkpoint_store
+        .get_checkpoint_store()
         .epoch_last_checkpoint_map
         .insert(
             &end_of_epoch_0_checkpoint.epoch,
@@ -168,7 +168,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
         )
         .unwrap();
     authority_state
-        .checkpoint_store
+        .get_checkpoint_store()
         .certified_checkpoints
         .insert(
             end_of_epoch_0_checkpoint.sequence_number(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -528,6 +528,7 @@ impl CheckpointStore {
         )?;
 
         let contents = full_contents.into_checkpoint_contents();
+        assert_eq!(&checkpoint.content_digest, contents.digest());
 
         batch.insert_batch(&self.checkpoint_content, [(contents.digest(), &contents)])?;
 

--- a/crates/sui-single-node-benchmark/README.md
+++ b/crates/sui-single-node-benchmark/README.md
@@ -19,27 +19,29 @@ or
 cargo run --release --bin sui-single-node-benchmark -- no-move
 
 ```
-By default, it generates 100,0000 transactions, which can be changed using --tx-count.
+By default, it generates 50,0000 transactions, which can be changed using --tx-count.
 
 ### Move benchmark workloads
 When running the Move benchmark, one can adjust the workload to stress test different parts
 of the execution engine:
 - `--num-input-objects`: this specifies number of address owned input objects read/mutated by each transaction. Default to 2.
-- `--num--dynamic-fields`: this specifies number of dynamic fields read by each transaction. Default to 0.
+- `--num-dynamic-fields`: this specifies number of dynamic fields read by each transaction. Default to 0.
 - `--computation`: this specifies computation intensity. An increase by 1 means 100 more loop iterations in Fibonacci computation. Default to 0.
 
 ### Components
 By default, the benchmark will use the `AuthorityState::try_execute_immediately` entry function,
-which includes the execution layer as well as the interaction with the DB.
-When `--end-to-end` option is specified, the benchmark will use the `ValidatorService::execute_certificate_for_testing` entry function,
-which covers the full flow of a validator processing a certificate, including
-certificate verification as well as transaction manager. It will also submit the transactions
-to a dummy consensus layer, which does nothing.
+which includes the execution layer as well as the interaction with the DB. This is equivalent to running:
+```
+cargo run --release --bin sui-single-node-benchmark -- --component baseline <move/no-move>
+```
+The benchmark supports various component:
+- `baseline`: this is the default component, which includes the execution layer as well as the interaction with the DB.
+- `with-tx-manager`: on top of baseline, it schedules transactions into the transaction manager, instead of executing them immediately. It also goes through the execution driver.
+- `validator-without-consensus`: in this mode, transactions are sent to the `handle_certificate` GRPC entry point of the validator service. On top of `with-tx-manager`, it also includes the verification of the certificate.
+- `validator-with-fake-consensus`: in this mode, on top of `validator-without-consensus`, it also submits the transactions to a simple consensus layer, which sequences transactions in the order as it receives it directly back to the store. It covers part of the cost in consensus handler. The commit size can be controlled with `--checkpoint-size`.
+- `txn-signing`: in this mode, instead of executing transactions, we only benchmark transactions signing.
+- `checkpoint-executor`: in this mode, we benchmark how long it takes for the checkpoint executor to execute all checkpoints (i.e. all transactions in them) for the entire epoch. We first construct transactions and effects by actually executing them, and revert them as if they were never executed, construct checkpoints using the results, and then start the checkpoint executor. The size of checkpoints can be controlled with `--checkpoint-size`.
+
 
 ### Profiling
 If you are interested in profiling Sui, you can start the benchmark, wait for it to print out "Started execution...", and then attach a profiler to the process.
-
-
-## Caveat / Future Work
-1. More knobs will be added to the benchmark to allow more fine-grained control over the workload. For example, number of objects written.
-2. Plan to cover more components eventually, such as the checkpoint builder and checkpoint executor.

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -21,6 +21,12 @@ pub struct Command {
     pub tx_count: u64,
     #[arg(
         long,
+        default_value_t = 100,
+        help = "Number of transactions in a consensus commit/checkpoint"
+    )]
+    pub checkpoint_size: usize,
+    #[arg(
+        long,
         default_value = "baseline",
         ignore_case = true,
         help = "Which component to benchmark"
@@ -47,9 +53,12 @@ pub enum Component {
     ValidatorWithFakeConsensus,
     /// Benchmark only validator signing component: `handle_transaction`.
     TxnSigning,
+    /// Benchmark the checkpoint executor by constructing a full epoch of checkpoints, execute
+    /// all transactions in them and measure time.
+    CheckpointExecutor,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone, Copy)]
 pub enum WorkloadKind {
     NoMove,
     Move {

--- a/crates/sui-single-node-benchmark/src/execution.rs
+++ b/crates/sui-single-node-benchmark/src/execution.rs
@@ -4,32 +4,34 @@
 use crate::benchmark_context::BenchmarkContext;
 use crate::command::Component;
 use crate::workload::Workload;
+use std::collections::BTreeMap;
 use sui_types::effects::TransactionEffectsAPI;
-use sui_types::transaction::Transaction;
+use sui_types::transaction::{CertifiedTransaction, Transaction};
 use tracing::info;
 
 /// Benchmark a given workload on a specified component.
 /// The different kinds of workloads and components can be found in command.rs.
-pub async fn run_benchmark(workload: Workload, component: Component) {
-    let mut ctx = BenchmarkContext::new(
-        workload.num_accounts(),
-        workload.gas_object_num_per_account(),
-        component,
-    )
-    .await;
+/// \checkpoint_size represents both the size of a consensus commit, and size of a checkpoint
+/// if we are benchmarking the checkpoint.
+pub async fn run_benchmark(workload: Workload, component: Component, checkpoint_size: usize) {
+    let mut ctx = BenchmarkContext::new(workload, component, checkpoint_size).await;
     let tx_generator = workload.create_tx_generator(&mut ctx).await;
     let transactions = ctx.generate_transactions(tx_generator).await;
-    benchmark_transactions(&ctx, transactions, component).await;
+    benchmark_transactions(&ctx, transactions, component, checkpoint_size).await;
 }
 
 async fn benchmark_transactions(
     ctx: &BenchmarkContext,
     transactions: Vec<Transaction>,
     component: Component,
+    checkpoint_size: usize,
 ) {
     match component {
         Component::TxnSigning => {
             benchmark_transaction_signing(ctx, transactions).await;
+        }
+        Component::CheckpointExecutor => {
+            benchmark_checkpoint_executor(ctx, transactions, checkpoint_size).await;
         }
         _ => {
             benchmark_transaction_execution(ctx, transactions).await;
@@ -40,20 +42,14 @@ async fn benchmark_transactions(
 /// Benchmark parallel execution of a vector of transactions and measure the TPS.
 async fn benchmark_transaction_execution(ctx: &BenchmarkContext, transactions: Vec<Transaction>) {
     let mut transactions = ctx.certify_transactions(transactions).await;
-
-    // Print out a sample transaction and its effects so that we can get a rough idea
-    // what we are measuring.
-    let sample_transaction = transactions.pop().unwrap();
-    info!("Sample transaction: {:?}", sample_transaction.data());
-    let effects = ctx
-        .validator()
-        .execute_tx_immediately(sample_transaction.into_unsigned())
-        .await;
-    info!("Sample effects: {:?}\n\n", effects);
-    assert!(effects.status().is_ok());
+    execute_sample_transaction(ctx, transactions.pop().unwrap()).await;
 
     let tx_count = transactions.len();
     let start_time = std::time::Instant::now();
+    info!(
+        "Started executing {} transactions. You can now attach a profiler",
+        transactions.len()
+    );
     ctx.execute_transactions(transactions).await;
     let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
     info!(
@@ -61,6 +57,21 @@ async fn benchmark_transaction_execution(ctx: &BenchmarkContext, transactions: V
         elapsed,
         tx_count as f64 / elapsed
     );
+}
+
+/// Print out a sample transaction and its effects so that we can get a rough idea
+/// what we are measuring.
+async fn execute_sample_transaction(
+    ctx: &BenchmarkContext,
+    sample_transaction: CertifiedTransaction,
+) {
+    info!("Sample transaction: {:?}", sample_transaction.data());
+    let effects = ctx
+        .validator()
+        .execute_tx_immediately(sample_transaction.into_unsigned())
+        .await;
+    info!("Sample effects: {:?}\n\n", effects);
+    assert!(effects.status().is_ok());
 }
 
 /// Benchmark parallel signing a vector of transactions and measure the TPS.
@@ -74,6 +85,66 @@ async fn benchmark_transaction_signing(ctx: &BenchmarkContext, transactions: Vec
     let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
     info!(
         "Transaction signing finished in {}s, TPS={}.",
+        elapsed,
+        tx_count as f64 / elapsed,
+    );
+}
+
+async fn benchmark_checkpoint_executor(
+    ctx: &BenchmarkContext,
+    transactions: Vec<Transaction>,
+    checkpoint_size: usize,
+) {
+    let mut transactions = ctx.certify_transactions(transactions).await;
+
+    execute_sample_transaction(ctx, transactions.pop().unwrap()).await;
+
+    info!("Executing all transactions to generate effects");
+    let tx_count = transactions.len();
+    let effects: BTreeMap<_, _> = ctx
+        .execute_transactions(transactions.clone())
+        .await
+        .into_iter()
+        .map(|e| (*e.transaction_digest(), e))
+        .collect();
+    info!("Reverting all transactions so that we could re-execute through checkpoint executor");
+    ctx.revert_transactions(effects.keys()).await;
+
+    info!("Building checkpoints");
+    let validator = ctx.validator();
+    let checkpoints = validator
+        .build_checkpoints(transactions, effects, checkpoint_size)
+        .await;
+    info!("Built {} checkpoints", checkpoints.len());
+    let (mut checkpoint_executor, checkpoint_sender) = validator.create_checkpoint_executor();
+    for (checkpoint, contents) in checkpoints {
+        let state = validator.get_validator();
+        state
+            .get_checkpoint_store()
+            .insert_verified_checkpoint(&checkpoint)
+            .unwrap();
+        state
+            .database
+            .multi_insert_transaction_and_effects(contents.iter())
+            .unwrap();
+        state
+            .get_checkpoint_store()
+            .insert_verified_checkpoint_contents(&checkpoint, contents)
+            .unwrap();
+        state
+            .get_checkpoint_store()
+            .update_highest_synced_checkpoint(&checkpoint)
+            .unwrap();
+        checkpoint_sender.send(checkpoint).unwrap();
+    }
+    let start_time = std::time::Instant::now();
+    info!("Starting checkpoint execution. You can now attach a profiler");
+    checkpoint_executor
+        .run_epoch(validator.get_epoch_store().clone())
+        .await;
+    let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
+    info!(
+        "Checkpoint execution finished in {}s, TPS={}.",
         elapsed,
         tx_count as f64 / elapsed,
     );

--- a/crates/sui-single-node-benchmark/src/lib.rs
+++ b/crates/sui-single-node-benchmark/src/lib.rs
@@ -4,6 +4,7 @@
 pub(crate) mod benchmark_context;
 pub mod command;
 pub mod execution;
+pub(crate) mod mock_account;
 pub(crate) mod mock_consensus;
 pub(crate) mod single_node;
 pub(crate) mod tx_generator;

--- a/crates/sui-single-node-benchmark/src/main.rs
+++ b/crates/sui-single-node-benchmark/src/main.rs
@@ -14,5 +14,10 @@ async fn main() {
         .init();
 
     let args = Command::parse();
-    run_benchmark(Workload::new(args.tx_count, args.workload), args.component).await;
+    run_benchmark(
+        Workload::new(args.tx_count, args.workload),
+        args.component,
+        args.checkpoint_size,
+    )
+    .await;
 }

--- a/crates/sui-single-node-benchmark/src/mock_account.rs
+++ b/crates/sui-single-node-benchmark/src/mock_account.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::stream::FuturesUnordered;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, SUI_ADDRESS_LENGTH};
+use sui_types::crypto::{get_account_key_pair, AccountKeyPair};
+use sui_types::object::Object;
+
+#[derive(Clone)]
+pub struct Account {
+    pub sender: SuiAddress,
+    pub keypair: Arc<AccountKeyPair>,
+    pub gas_objects: Arc<Vec<ObjectRef>>,
+}
+
+/// Generate \num_accounts accounts and for each account generate \gas_object_num_per_account gas objects.
+/// Return all accounts along with a flattened list of all gas objects as genesis objects.
+pub async fn batch_create_account_and_gas(
+    num_accounts: u64,
+    gas_object_num_per_account: u64,
+) -> (BTreeMap<SuiAddress, Account>, Vec<Object>) {
+    let tasks: FuturesUnordered<_> = (0..num_accounts)
+        .map(|idx| {
+            let starting_id = idx * gas_object_num_per_account;
+            tokio::spawn(async move {
+                let (sender, keypair) = get_account_key_pair();
+                let objects = (0..gas_object_num_per_account)
+                    .map(|i| new_gas_object(starting_id + i, sender))
+                    .collect::<Vec<_>>();
+                (sender, keypair, objects)
+            })
+        })
+        .collect();
+    let mut accounts = BTreeMap::new();
+    let mut genesis_gas_objects = vec![];
+    for task in tasks {
+        let (sender, keypair, gas_objects) = task.await.unwrap();
+        let gas_object_refs: Vec<_> = gas_objects
+            .iter()
+            .map(|o| o.compute_object_reference())
+            .collect();
+        accounts.insert(
+            sender,
+            Account {
+                sender,
+                keypair: Arc::new(keypair),
+                gas_objects: Arc::new(gas_object_refs),
+            },
+        );
+        genesis_gas_objects.extend(gas_objects);
+    }
+    (accounts, genesis_gas_objects)
+}
+
+fn new_gas_object(idx: u64, owner: SuiAddress) -> Object {
+    // Predictable and cheaper way of generating object IDs for benchmarking.
+    let mut id_bytes = [0u8; SUI_ADDRESS_LENGTH];
+    let idx_bytes = idx.to_le_bytes();
+    id_bytes[0] = 255;
+    id_bytes[1..idx_bytes.len() + 1].copy_from_slice(&idx_bytes);
+    let object_id = ObjectID::from_bytes(id_bytes).unwrap();
+    Object::with_id_owner_for_testing(object_id, owner)
+}

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -3,27 +3,35 @@
 
 use crate::command::Component;
 use crate::mock_consensus::{ConsensusMode, MockConsensusClient};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_core::authority::AuthorityState;
 use sui_core::authority_server::{ValidatorService, ValidatorServiceMetrics};
+use sui_core::checkpoints::checkpoint_executor::CheckpointExecutor;
 use sui_core::consensus_adapter::{
     ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
 };
+use sui_core::state_accumulator::StateAccumulator;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::committee::Committee;
-use sui_types::crypto::AccountKeyPair;
+use sui_types::crypto::{AccountKeyPair, AuthoritySignature, Signer};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::messages_checkpoint::{
+    EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,
+};
 use sui_types::messages_grpc::HandleTransactionResponse;
+use sui_types::mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider};
 use sui_types::object::Object;
 use sui_types::transaction::{
     CertifiedTransaction, Transaction, VerifiedCertificate, VerifiedTransaction,
     DEFAULT_VALIDATOR_GAS_PRICE,
 };
+use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct SingleValidator {
@@ -32,13 +40,25 @@ pub struct SingleValidator {
 }
 
 impl SingleValidator {
-    pub(crate) async fn new(genesis_objects: &[Object], consensus_mode: ConsensusMode) -> Self {
+    pub(crate) async fn new(
+        genesis_objects: &[Object],
+        component: Component,
+        checkpoint_size: usize,
+    ) -> Self {
         let validator = TestAuthorityBuilder::new()
             .disable_indexer()
             .with_starting_objects(genesis_objects)
+            // This is needed to properly run checkpoint executor.
+            .insert_genesis_checkpoint()
             .build()
             .await;
         let epoch_store = validator.epoch_store_for_testing().clone();
+        let consensus_mode = match component {
+            Component::ValidatorWithFakeConsensus => {
+                ConsensusMode::DirectSequencing(checkpoint_size)
+            }
+            _ => ConsensusMode::Noop,
+        };
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
             Box::new(MockConsensusClient::new(validator.clone(), consensus_mode)),
             validator.name,
@@ -64,17 +84,8 @@ impl SingleValidator {
         self.validator_service.validator_state()
     }
 
-    pub fn get_committee(&self) -> &Committee {
-        self.epoch_store.committee()
-    }
-
-    pub async fn get_latest_object_ref(&self, object_id: &ObjectID) -> ObjectRef {
-        self.get_validator()
-            .get_object(object_id)
-            .await
-            .unwrap()
-            .unwrap()
-            .compute_object_reference()
+    pub fn get_epoch_store(&self) -> &Arc<AuthorityPerEpochStore> {
+        &self.epoch_store
     }
 
     pub async fn execute_tx_immediately(&self, transaction: Transaction) -> TransactionEffects {
@@ -92,23 +103,26 @@ impl SingleValidator {
         effects
     }
 
+    /// Publish a package, returns the package object and the updated gas object.
     pub async fn publish_package(
         &self,
         path: PathBuf,
         sender: SuiAddress,
         keypair: &AccountKeyPair,
         gas: ObjectRef,
-    ) -> ObjectRef {
+    ) -> (ObjectRef, ObjectRef) {
         let transaction = TestTransactionBuilder::new(sender, gas, DEFAULT_VALIDATOR_GAS_PRICE)
             .publish(path)
             .build_and_sign(keypair);
         let effects = self.execute_tx_immediately(transaction).await;
-        effects
+        let package = effects
             .all_changed_objects()
             .into_iter()
             .filter_map(|(oref, owner, _)| owner.is_immutable().then_some(oref))
             .next()
-            .unwrap()
+            .unwrap();
+        let updated_gas = effects.gas_object().0;
+        (package, updated_gas)
     }
 
     pub async fn execute_transaction(
@@ -118,7 +132,10 @@ impl SingleValidator {
     ) -> TransactionEffects {
         assert!(!matches!(component, Component::TxnSigning));
         let effects = match component {
-            Component::Baseline => {
+            Component::Baseline | Component::CheckpointExecutor => {
+                // When benchmarking CheckpointExecutor, we need to execute transactions here
+                // in order to generate effects and construct checkpoints. Since the generation is
+                // not part of what we want to measure, we want it to be as fast as possible.
                 let cert = VerifiedExecutableTransaction::new_from_certificate(
                     VerifiedCertificate::new_unchecked(cert),
                 );
@@ -154,5 +171,84 @@ impl SingleValidator {
         self.validator_service
             .handle_transaction_for_testing(transaction)
             .await
+    }
+
+    pub(crate) async fn build_checkpoints(
+        &self,
+        transactions: Vec<CertifiedTransaction>,
+        mut all_effects: BTreeMap<TransactionDigest, TransactionEffects>,
+        checkpoint_size: usize,
+    ) -> Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)> {
+        let mut builder = MockCheckpointBuilder::new(
+            self.get_validator()
+                .get_checkpoint_store()
+                .get_latest_certified_checkpoint()
+                .unwrap(),
+        );
+        let mut checkpoints = vec![];
+        for transaction in transactions {
+            let effects = all_effects.remove(transaction.digest()).unwrap();
+            builder.push_transaction(
+                VerifiedTransaction::new_unchecked(transaction.clone().into_unsigned()),
+                effects.clone(),
+            );
+            if builder.size() == checkpoint_size {
+                let (checkpoint, _, full_contents) = builder.build(self, 0);
+                checkpoints.push((checkpoint, full_contents));
+            }
+        }
+        let gas_cost_summary = builder.epoch_rolling_gas_cost_summary();
+        let epoch_tx = VerifiedTransaction::new_change_epoch(
+            1,
+            self.epoch_store.protocol_version(),
+            gas_cost_summary.storage_cost,
+            gas_cost_summary.computation_cost,
+            gas_cost_summary.storage_rebate,
+            gas_cost_summary.non_refundable_storage_fee,
+            0,
+            vec![],
+        );
+        let epoch_effects = self
+            .execute_tx_immediately(epoch_tx.clone().into_inner())
+            .await;
+        builder.push_transaction(epoch_tx, epoch_effects);
+        let (checkpoint, _, full_contents) = builder.build_end_of_epoch(
+            self,
+            0,
+            1,
+            EndOfEpochData {
+                next_epoch_committee: self.get_committee().voting_rights.clone(),
+                next_epoch_protocol_version: self.get_epoch_store().protocol_version(),
+                epoch_commitments: vec![],
+            },
+        );
+        checkpoints.push((checkpoint, full_contents));
+        checkpoints
+    }
+
+    pub fn create_checkpoint_executor(
+        &self,
+    ) -> (CheckpointExecutor, broadcast::Sender<VerifiedCheckpoint>) {
+        let validator = self.get_validator();
+        let (ckpt_sender, ckpt_receiver) = broadcast::channel(1000000);
+        let checkpoint_executor = CheckpointExecutor::new_for_tests(
+            ckpt_receiver,
+            validator.get_checkpoint_store().clone(),
+            validator.db(),
+            validator.transaction_manager().clone(),
+            Arc::new(StateAccumulator::new(validator.db())),
+        );
+        (checkpoint_executor, ckpt_sender)
+    }
+}
+
+impl ValidatorKeypairProvider for SingleValidator {
+    fn get_validator_key(&self, name: &AuthorityName) -> &dyn Signer<AuthoritySignature> {
+        assert_eq!(name, &self.get_validator().name);
+        &*self.get_validator().secret
+    }
+
+    fn get_committee(&self) -> &Committee {
+        self.epoch_store.committee().as_ref()
     }
 }

--- a/crates/sui-single-node-benchmark/src/tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::mock_account::Account;
 pub use move_tx_generator::MoveTxGenerator;
 pub use non_move_tx_generator::NonMoveTxGenerator;
 pub use root_object_create_tx_generator::RootObjectCreateTxGenerator;
-use std::sync::Arc;
-use sui_types::base_types::{ObjectRef, SuiAddress};
-use sui_types::crypto::AccountKeyPair;
 use sui_types::transaction::Transaction;
 
 mod move_tx_generator;
@@ -14,14 +12,9 @@ mod non_move_tx_generator;
 mod root_object_create_tx_generator;
 
 pub(crate) trait TxGenerator: Send + Sync {
-    /// Given a sender address, a keypair for that address, and a list of gas objects owned
-    /// by this address, generate a single transaction.
-    fn generate_tx(
-        &self,
-        sender: SuiAddress,
-        keypair: Arc<AccountKeyPair>,
-        gas_objects: Arc<Vec<ObjectRef>>,
-    ) -> Transaction;
+    /// Given an account that contains a sender address, a keypair for that address,
+    /// and a list of gas objects owned by this address, generate a single transaction.
+    fn generate_tx(&self, account: Account) -> Transaction;
 
     fn name(&self) -> &'static str;
 }

--- a/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
@@ -1,13 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::mock_account::Account;
 use crate::tx_generator::TxGenerator;
 use move_core_types::identifier::Identifier;
 use std::collections::HashMap;
-use std::sync::Arc;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
-use sui_types::crypto::AccountKeyPair;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{ObjectArg, Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
 
@@ -35,17 +34,12 @@ impl MoveTxGenerator {
 }
 
 impl TxGenerator for MoveTxGenerator {
-    fn generate_tx(
-        &self,
-        sender: SuiAddress,
-        keypair: Arc<AccountKeyPair>,
-        gas_objects: Arc<Vec<ObjectRef>>,
-    ) -> Transaction {
+    fn generate_tx(&self, account: Account) -> Transaction {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
             // PT command 1: Merge a vector of coins to a single coin.
             let object_args = (0..self.num_input_objects - 1)
-                .map(|i| ObjectArg::ImmOrOwnedObject(gas_objects[(i + 1) as usize]));
+                .map(|i| ObjectArg::ImmOrOwnedObject(account.gas_objects[(i + 1) as usize]));
             let input_coins = builder.make_obj_vec(object_args).unwrap();
             let merged_output = builder.programmable_move_call(
                 self.move_package,
@@ -55,11 +49,11 @@ impl TxGenerator for MoveTxGenerator {
                 vec![input_coins],
             );
             // PT command 2: Transfer the merged coin to the sender.
-            builder.transfer_arg(sender, merged_output);
+            builder.transfer_arg(account.sender, merged_output);
 
             if !self.root_objects.is_empty() {
                 // PT command 3: Read all dynamic fields from the root object.
-                let root_object = self.root_objects.get(&sender).unwrap();
+                let root_object = self.root_objects.get(&account.sender).unwrap();
                 let root_object_arg = builder
                     .obj(ObjectArg::ImmOrOwnedObject(*root_object))
                     .unwrap();
@@ -83,9 +77,13 @@ impl TxGenerator for MoveTxGenerator {
             );
             builder.finish()
         };
-        TestTransactionBuilder::new(sender, gas_objects[0], DEFAULT_VALIDATOR_GAS_PRICE)
-            .programmable(pt)
-            .build_and_sign(keypair.as_ref())
+        TestTransactionBuilder::new(
+            account.sender,
+            account.gas_objects[0],
+            DEFAULT_VALIDATOR_GAS_PRICE,
+        )
+        .programmable(pt)
+        .build_and_sign(account.keypair.as_ref())
     }
 
     fn name(&self) -> &'static str {

--- a/crates/sui-single-node-benchmark/src/tx_generator/non_move_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/non_move_tx_generator.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::mock_account::Account;
 use crate::tx_generator::TxGenerator;
-use std::sync::Arc;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{ObjectRef, SuiAddress};
-use sui_types::crypto::AccountKeyPair;
 use sui_types::transaction::{Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
 
 pub struct NonMoveTxGenerator {}
@@ -17,15 +15,14 @@ impl NonMoveTxGenerator {
 }
 
 impl TxGenerator for NonMoveTxGenerator {
-    fn generate_tx(
-        &self,
-        sender: SuiAddress,
-        keypair: Arc<AccountKeyPair>,
-        gas_objects: Arc<Vec<ObjectRef>>,
-    ) -> Transaction {
-        TestTransactionBuilder::new(sender, gas_objects[0], DEFAULT_VALIDATOR_GAS_PRICE)
-            .transfer_sui(None, sender)
-            .build_and_sign(keypair.as_ref())
+    fn generate_tx(&self, account: Account) -> Transaction {
+        TestTransactionBuilder::new(
+            account.sender,
+            account.gas_objects[0],
+            DEFAULT_VALIDATOR_GAS_PRICE,
+        )
+        .transfer_sui(None, account.sender)
+        .build_and_sign(account.keypair.as_ref())
     }
 
     fn name(&self) -> &'static str {

--- a/crates/sui-single-node-benchmark/src/tx_generator/root_object_create_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/root_object_create_tx_generator.rs
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::mock_account::Account;
 use crate::tx_generator::TxGenerator;
-use std::sync::Arc;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
-use sui_types::crypto::AccountKeyPair;
+use sui_types::base_types::ObjectID;
 use sui_types::transaction::{CallArg, Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
 
 pub struct RootObjectCreateTxGenerator {
@@ -23,20 +22,19 @@ impl RootObjectCreateTxGenerator {
 }
 
 impl TxGenerator for RootObjectCreateTxGenerator {
-    fn generate_tx(
-        &self,
-        sender: SuiAddress,
-        keypair: Arc<AccountKeyPair>,
-        gas_objects: Arc<Vec<ObjectRef>>,
-    ) -> Transaction {
-        TestTransactionBuilder::new(sender, gas_objects[0], DEFAULT_VALIDATOR_GAS_PRICE)
-            .move_call(
-                self.move_package,
-                "benchmark",
-                "generate_dynamic_fields",
-                vec![CallArg::Pure(bcs::to_bytes(&self.child_per_root).unwrap())],
-            )
-            .build_and_sign(keypair.as_ref())
+    fn generate_tx(&self, account: Account) -> Transaction {
+        TestTransactionBuilder::new(
+            account.sender,
+            account.gas_objects[0],
+            DEFAULT_VALIDATOR_GAS_PRICE,
+        )
+        .move_call(
+            self.move_package,
+            "benchmark",
+            "generate_dynamic_fields",
+            vec![CallArg::Pure(bcs::to_bytes(&self.child_per_root).unwrap())],
+        )
+        .build_and_sign(account.keypair.as_ref())
     }
 
     fn name(&self) -> &'static str {

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -6,9 +6,10 @@ use crate::command::WorkloadKind;
 use crate::tx_generator::{MoveTxGenerator, NonMoveTxGenerator, TxGenerator};
 use std::sync::Arc;
 
+#[derive(Clone, Copy)]
 pub struct Workload {
-    tx_count: u64,
-    workload_kind: WorkloadKind,
+    pub tx_count: u64,
+    pub workload_kind: WorkloadKind,
 }
 
 impl Workload {

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -11,7 +11,7 @@ use sui_single_node_benchmark::workload::Workload;
 async fn benchmark_simple_transfer_smoke_test() {
     // This test makes sure that the benchmark runs.
     for component in Component::iter() {
-        run_benchmark(Workload::new(10, WorkloadKind::NoMove), component).await;
+        run_benchmark(Workload::new(10, WorkloadKind::NoMove), component, 1000).await;
     }
 }
 
@@ -29,6 +29,7 @@ async fn benchmark_move_transactions_smoke_test() {
                 },
             ),
             component,
+            1000,
         )
         .await;
     }


### PR DESCRIPTION
## Description 

This PR adds the ability to benchmark checkpoint executor.
The benchmark will first try to execute all transactions on the node, then revert them as if they were not yet executed, use the results to construct checkpoints, and then trigger the checkpoint executor.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
