### PR TITLE
[graphql/rpc] chore/easy: build server from config

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -31,6 +31,13 @@ pub enum Command {
         /// DB URL to connect to
         #[clap(long)]
         db_url: Option<String>,
+        /// Port to bind the prom server to
+        #[clap(short, long)]
+        prom_port: Option<u16>,
+        /// Host to bind the prom server to
+        #[clap(long)]
+        prom_host: Option<String>,
+
         /// Path to TOML file containing configuration for service.
         #[clap(short, long)]
         config: Option<PathBuf>,

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -29,8 +29,10 @@ async fn main() {
             host,
             config,
             db_url,
+            prom_host,
+            prom_port,
         } => {
-            let conn = ConnectionConfig::new(port, host, rpc_url, db_url);
+            let conn = ConnectionConfig::new(port, host, rpc_url, db_url, prom_host, prom_port);
             let service_config = service_config(config);
 
             println!("Starting server...");

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -62,7 +62,7 @@ impl Domain {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NameServiceConfig {
     pub package_address: SuiAddress,
     pub registry_id: ObjectID,


### PR DESCRIPTION
## Description 

Allows one build a server from a config file


## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
