### PR TITLE
[graphql/rpc] chore/easy: remove dead rpc 1.0 code

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/data_provider.rs
@@ -1,12 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::balance::Balance;
-use crate::types::checkpoint::Checkpoint;
-use crate::types::object::ObjectFilter;
+use crate::types::object::Object;
 use crate::types::protocol_config::ProtocolConfigs;
-use crate::types::{object::Object, sui_address::SuiAddress};
-use async_graphql::connection::Connection;
 use async_graphql::*;
 use async_trait::async_trait;
 use sui_json_rpc_types::SuiObjectDataOptions;
@@ -15,18 +11,6 @@ use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiSystemStateSu
 
 #[async_trait]
 pub(crate) trait DataProvider: Send + Sync {
-    async fn fetch_obj(&self, address: SuiAddress, version: Option<u64>) -> Result<Option<Object>>;
-
-    async fn fetch_owned_objs(
-        &self,
-        owner: &SuiAddress,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-        _filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>>;
-
     async fn get_object_with_options(
         &self,
         object_id: ObjectID,
@@ -38,27 +22,6 @@ pub(crate) trait DataProvider: Send + Sync {
         object_ids: Vec<ObjectID>,
         options: SuiObjectDataOptions,
     ) -> Result<Vec<Object>>;
-
-    async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance>;
-
-    async fn fetch_balance_connection(
-        &self,
-        address: &SuiAddress,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Connection<String, Balance>>;
-
-    async fn fetch_checkpoint_connection(
-        &self,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Connection<String, Checkpoint>>;
-
-    async fn fetch_chain_id(&self) -> Result<String>;
 
     async fn fetch_protocol_config(&self, version: Option<u64>) -> Result<ProtocolConfigs>;
 

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -5,16 +5,12 @@
 
 use crate::error::Error;
 use crate::types::address::Address;
-use crate::types::balance::Balance;
 use crate::types::base64::Base64;
 use crate::types::big_int::BigInt;
-use crate::types::checkpoint::Checkpoint;
-use crate::types::committee_member::CommitteeMember;
 use crate::types::date_time::DateTime;
 use crate::types::digest::Digest;
-use crate::types::end_of_epoch_data::EndOfEpochData;
 use crate::types::epoch::Epoch;
-use crate::types::object::{Object, ObjectFilter, ObjectKind};
+use crate::types::object::{Object, ObjectKind};
 use crate::types::protocol_config::{
     ProtocolConfigAttr, ProtocolConfigFeatureFlag, ProtocolConfigs,
 };
@@ -24,21 +20,13 @@ use crate::types::validator::Validator;
 use crate::types::validator_credentials::ValidatorCredentials;
 use crate::types::validator_set::ValidatorSet;
 
-use crate::types::gas::GasCostSummary;
-use async_graphql::connection::{Connection, Edge};
 use async_graphql::dataloader::*;
 use async_graphql::*;
 use async_trait::async_trait;
-use fastcrypto::traits::EncodeDecodeBase64;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::time::Duration;
-use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiPastObjectResponse, SuiRawData,
-    SuiTransactionBlockResponseOptions,
-};
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiRawData, SuiTransactionBlockResponseOptions};
 use sui_sdk::types::digests::TransactionDigest;
-use sui_sdk::types::sui_serde::BigInt as SerdeBigInt;
 use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_sdk::{
     types::{
@@ -50,7 +38,6 @@ use sui_sdk::{
 };
 
 use super::data_provider::DataProvider;
-use super::DEFAULT_PAGE_SIZE;
 
 // TODO: Ensure the logic is this file is for verification/experimentation only
 // and is not used in production
@@ -93,84 +80,6 @@ impl Loader<Digest> for SuiClientLoader {
 
 #[async_trait]
 impl DataProvider for SuiClient {
-    async fn fetch_obj(&self, address: SuiAddress, version: Option<u64>) -> Result<Option<Object>> {
-        let oid: NativeObjectID = address.into_array().as_slice().try_into()?;
-        let opts = SuiObjectDataOptions::full_content().with_bcs();
-
-        let g = match version {
-            Some(v) => match self
-                .read_api()
-                .try_get_parsed_past_object(oid, v.into(), opts)
-                .await?
-            {
-                SuiPastObjectResponse::VersionFound(x) => x,
-                _ => return Ok(None),
-            },
-            None => {
-                let val = self.read_api().get_object_with_options(oid, opts).await?;
-                if val.error.is_some() || val.data.is_none() {
-                    return Ok(None);
-                }
-                val.data.unwrap()
-            }
-        };
-        Ok(Some(convert_obj(&g)))
-    }
-
-    async fn fetch_owned_objs(
-        &self,
-        owner: &SuiAddress,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-        _filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
-        ensure_forward_pagination(&first, &after, &last, &before)?;
-
-        let count = first.map(|q| q as usize);
-        let native_owner = NativeSuiAddress::from(owner);
-        let query = SuiObjectResponseQuery::new_with_options(SuiObjectDataOptions::full_content());
-
-        let cursor = match after {
-            Some(q) => Some(
-                NativeObjectID::from_hex_literal(&q)
-                    .map_err(|w| Error::InvalidCursor(w.to_string()).extend())?,
-            ),
-            None => None,
-        };
-
-        let pg = self
-            .read_api()
-            .get_owned_objects(native_owner, Some(query), cursor, count)
-            .await?;
-
-        // TODO: support partial success/ failure responses
-        pg.data.iter().try_for_each(|n| {
-            if n.error.is_some() {
-                return Err(Error::CursorConnectionFetchFailed(
-                    n.error.as_ref().unwrap().to_string(),
-                )
-                .extend());
-            } else if n.data.is_none() {
-                return Err(Error::Internal(
-                    "Expected either data or error fields, received neither".to_string(),
-                )
-                .extend());
-            }
-            Ok(())
-        })?;
-        let mut connection = Connection::new(false, pg.has_next_page);
-
-        connection.edges.extend(pg.data.into_iter().map(|n| {
-            let g = n.data.unwrap();
-            let o = convert_obj(&g);
-
-            Edge::new(g.object_id.to_string(), o)
-        }));
-        Ok(connection)
-    }
-
     async fn get_object_with_options(
         &self,
         object_id: NativeObjectID,
@@ -211,99 +120,6 @@ impl DataProvider for SuiClient {
             objs.push(convert_obj(n.data.as_ref().unwrap()));
         }
         Ok(objs)
-    }
-
-    async fn fetch_balance(&self, address: &SuiAddress, type_: Option<String>) -> Result<Balance> {
-        let b = self
-            .coin_read_api()
-            .get_balance(address.into(), type_)
-            .await?;
-        Ok(convert_bal(b))
-    }
-
-    async fn fetch_balance_connection(
-        &self,
-        address: &SuiAddress,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Connection<String, Balance>> {
-        ensure_forward_pagination(&first, &after, &last, &before)?;
-
-        let count = first.unwrap_or(DEFAULT_PAGE_SIZE) as usize;
-        let offset = after
-            .map(|q| q.parse::<usize>().unwrap())
-            .unwrap_or(0_usize);
-
-        // This fetches all balances but we only want a slice
-        // The pagination logic here can break if data is added
-        // This is okay for now as we're only using this for testing
-        let balances = self
-            .coin_read_api()
-            .get_all_balances(NativeSuiAddress::from(address))
-            .await?;
-
-        let max = balances.len();
-
-        let bs = balances.into_iter().skip(offset).take(count);
-
-        let mut connection = Connection::new(false, offset + count < max);
-
-        connection
-            .edges
-            .extend(bs.into_iter().enumerate().map(|(i, b)| {
-                let balance = convert_bal(b);
-                Edge::new(format!("{:032}", offset + i), balance)
-            }));
-        Ok(connection)
-    }
-
-    // TODO: support backward pagination as fetching checkpoints
-    // API allows for it
-    async fn fetch_checkpoint_connection(
-        &self,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Connection<String, Checkpoint>> {
-        ensure_forward_pagination(&first, &after, &last, &before)?;
-
-        let count = first.map(|q| q as usize);
-        let after = after
-            .map(|x| x.parse::<u64>())
-            .transpose()
-            .map_err(|_| {
-                Error::InvalidCursor(
-                    "Cannot convert after parameter into u64 in the checkpoint connection"
-                        .to_string(),
-                )
-            })?
-            .map(SerdeBigInt::from);
-
-        let pg = self.read_api().get_checkpoints(after, count, false).await?;
-        let data: Result<Vec<_>, _> = pg.data.iter().map(convert_json_rpc_checkpoint).collect();
-
-        let checkpoints = data.map_err(|e| {
-            Error::Internal(format!(
-                "Cannot convert the JSON RPC checkpoint into GraphQL checkpoint type: {}",
-                e.message
-            ))
-        })?;
-
-        let mut connection = Connection::new(false, pg.has_next_page);
-        connection.edges.extend(
-            checkpoints
-                .iter()
-                .map(|x| Edge::new(x.sequence_number.to_string(), x.clone())),
-        );
-
-        Ok(connection)
-    }
-
-    async fn fetch_chain_id(&self) -> Result<String> {
-        Ok(self.read_api().get_chain_identifier().await?)
     }
 
     async fn fetch_protocol_config(&self, version: Option<u64>) -> Result<ProtocolConfigs> {
@@ -366,63 +182,6 @@ pub(crate) async fn lru_cache_data_loader(
     data_loader
 }
 
-pub(crate) fn convert_json_rpc_checkpoint(
-    c: &sui_json_rpc_types::Checkpoint,
-) -> Result<Checkpoint> {
-    let digest = c.digest.to_string();
-    let sequence_number = c.sequence_number;
-
-    let validator_signature = c.validator_signature.encode_base64();
-    let validator_signature = Some(Base64::from(validator_signature.into_bytes()));
-
-    let previous_checkpoint_digest = c.previous_digest.map(|x| x.to_string());
-    let network_total_transactions = Some(c.network_total_transactions);
-    let rolling_gas_summary = GasCostSummary::from(&c.epoch_rolling_gas_cost_summary);
-
-    let end_of_epoch_data = &c.end_of_epoch_data;
-    let end_of_epoch = end_of_epoch_data.clone().map(|e| {
-        let committees = e.next_epoch_committee;
-        let new_committee = if committees.is_empty() {
-            None
-        } else {
-            Some(
-                committees
-                    .iter()
-                    .map(|c| CommitteeMember {
-                        authority_name: Some(c.0.into_concise().to_string()),
-                        stake_unit: Some(c.1),
-                    })
-                    .collect::<Vec<_>>(),
-            )
-        };
-
-        EndOfEpochData {
-            new_committee,
-            next_protocol_version: Some(e.next_epoch_protocol_version.as_u64()),
-        }
-    });
-
-    let timestamp = i64::try_from(c.timestamp_ms).map_err(|_| {
-        Error::Internal(format!(
-            "Cannot convert start timestamp u64 ({}) of checkpoint ({sequence_number}) into i64 required by DateTime",
-            c.timestamp_ms
-        ))
-    })?;
-
-    Ok(Checkpoint {
-        digest,
-        sequence_number,
-        validator_signature,
-        timestamp: DateTime::from_ms(timestamp),
-        previous_checkpoint_digest,
-        live_object_set_digest: None, // TODO fix this
-        network_total_transactions,
-        rolling_gas_summary: Some(rolling_gas_summary),
-        epoch_id: c.epoch,
-        end_of_epoch,
-    })
-}
-
 pub(crate) fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
     Object {
         version: s.version.into(),
@@ -450,14 +209,6 @@ pub(crate) fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
             } => ObjectKind::Shared,
             NativeOwner::Immutable => ObjectKind::Immutable,
         }),
-    }
-}
-
-fn convert_bal(b: sui_json_rpc_types::Balance) -> Balance {
-    Balance {
-        coin_object_count: Some(b.coin_object_count as u64),
-        total_balance: Some(BigInt::from_str(&format!("{}", b.total_balance)).unwrap()),
-        coin_type: Some(b.coin_type),
     }
 }
 
@@ -607,22 +358,4 @@ impl From<&SuiAddress> for NativeSuiAddress {
     fn from(a: &SuiAddress) -> Self {
         NativeSuiAddress::try_from(a.as_slice()).unwrap()
     }
-}
-
-fn ensure_forward_pagination(
-    first: &Option<u64>,
-    after: &Option<String>,
-    last: &Option<u64>,
-    before: &Option<String>,
-) -> Result<()> {
-    if before.is_some() && after.is_some() {
-        return Err(Error::CursorNoBeforeAfter.extend());
-    }
-    if first.is_some() && last.is_some() {
-        return Err(Error::CursorNoFirstLast.extend());
-    }
-    if before.is_some() || last.is_some() {
-        return Err(Error::CursorNoReversePagination.extend());
-    }
-    Ok(())
 }

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -61,11 +61,11 @@ pub enum Error {
     #[error("'first' and 'last' must not be used together")]
     CursorNoFirstLast,
     #[error("reverse pagination is not supported")]
-    CursorNoReversePagination,
+    _CursorNoReversePagination,
     #[error("Invalid cursor: {0}")]
-    InvalidCursor(String),
+    _InvalidCursor(String),
     #[error("Data has changed since cursor was generated: {0}")]
-    CursorConnectionFetchFailed(String),
+    _CursorConnectionFetchFailed(String),
     #[error("Error received in multi-get query: {0}")]
     MultiGet(String),
     #[error("Internal error occurred while processing request: {0}")]
@@ -80,9 +80,9 @@ impl ErrorExtensions for Error {
             | Error::InvalidCheckpointQuery
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast
-            | Error::CursorNoReversePagination
-            | Error::InvalidCursor(_)
-            | Error::CursorConnectionFetchFailed(_)
+            | Error::_CursorNoReversePagination
+            | Error::_InvalidCursor(_)
+            | Error::_CursorConnectionFetchFailed(_)
             | Error::MultiGet(_)
             | Error::InvalidBase58(_)
             | Error::InvalidDigestLength { .. } => {


### PR DESCRIPTION
## Description 

Removes unused rpc 1.0 logic which we used for experimentation
This is a non-functional change

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
