### PR TITLE
[move-compiler] implement nested module imports

### DIFF
--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -27,6 +27,7 @@ pub struct Edition {
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
 pub enum FeatureGate {
+    NestedUse,
     PublicPackage,
     PostFixAbilities,
     StructTypeVisibility,
@@ -101,6 +102,7 @@ static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
 const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
+    FeatureGate::NestedUse,
     FeatureGate::PublicPackage,
     FeatureGate::PostFixAbilities,
     FeatureGate::StructTypeVisibility,
@@ -182,6 +184,7 @@ impl Flavor {
 impl FeatureGate {
     fn error_prefix(&self) -> &'static str {
         match self {
+            FeatureGate::NestedUse => "Nested 'use' forms are ",
             FeatureGate::PublicPackage => "'public(package)' is",
             FeatureGate::PostFixAbilities => "Postfix abilities are",
             FeatureGate::StructTypeVisibility => "Struct visibility modifiers are",

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -184,7 +184,7 @@ impl Flavor {
 impl FeatureGate {
     fn error_prefix(&self) -> &'static str {
         match self {
-            FeatureGate::NestedUse => "Nested 'use' forms are ",
+            FeatureGate::NestedUse => "Nested 'use' forms are",
             FeatureGate::PublicPackage => "'public(package)' is",
             FeatureGate::PostFixAbilities => "Postfix abilities are",
             FeatureGate::StructTypeVisibility => "Struct visibility modifiers are",

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1184,159 +1184,166 @@ fn use_(
         loc,
         attributes,
     } = u;
-    if let P::Use::Modules(uses) = u {
-        for (use_entry, loc) in uses {
-            let use_decl = P::UseDecl {
-                use_: use_entry,
-                loc,
-                attributes: attributes.clone(),
+    let attributes = flatten_attributes(context, AttributePosition::Use, attributes);
+    match u {
+        P::Use::NestedModuleUses(address, use_decls) => {
+            for (module, use_) in use_decls {
+                let mident = sp(module.loc(), P::ModuleIdent_ { address, module });
+                module_use(context, acc, use_funs, mident, &attributes, use_);
+            }
+        }
+        P::Use::ModuleUse(mident, use_) => {
+            module_use(context, acc, use_funs, mident, &attributes, use_);
+        }
+        P::Use::Fun {
+            visibility,
+            function,
+            ty,
+            method,
+        } => {
+            context
+                .env
+                .check_feature(FeatureGate::DotCall, context.current_package, loc);
+            let is_public = match visibility {
+                P::Visibility::Public(vis_loc) => Some(vis_loc),
+                P::Visibility::Internal => None,
+                P::Visibility::Script(vis_loc)
+                | P::Visibility::Friend(vis_loc)
+                | P::Visibility::Package(vis_loc) => {
+                    let msg = "Invalid visibility for 'use fun' declaration";
+                    let vis_msg = format!(
+                        "Module level 'use fun' declarations can be '{}' for the module's types, \
+                    otherwise they must internal to declared scope.",
+                        P::Visibility::PUBLIC
+                    );
+                    context.env.add_diag(diag!(
+                        Declarations::InvalidUseFun,
+                        (loc, msg),
+                        (vis_loc, vis_msg)
+                    ));
+                    None
+                }
             };
-            use_(context, acc, use_funs, use_decl);
-        }
-    } else {
-        let attributes = flatten_attributes(context, AttributePosition::Use, attributes);
-        let unbound_module = |mident: &ModuleIdent| -> Diagnostic {
-            diag!(
-                NameResolution::UnboundModule,
-                (
-                    mident.loc,
-                    format!("Invalid 'use'. Unbound module: '{}'", mident),
-                )
-            )
-        };
-        macro_rules! add_module_alias {
-            ($ident:expr, $alias_opt:expr) => {{
-                let alias: Name = $alias_opt.unwrap_or_else(|| $ident.value.module.0.clone());
-                if let Err(()) =
-                    check_restricted_name_all_cases(context, NameCase::ModuleAlias, &alias)
-                {
-                    return;
-                }
-
-                if let Err(old_loc) = acc.add_module_alias(alias.clone(), $ident) {
-                    duplicate_module_alias(context, old_loc, alias)
-                }
-            }};
-        }
-        match u {
-            P::Use::Modules(_) => unreachable!(),
-
-            P::Use::Module(pmident, alias_opt) => {
-                let mident = module_ident(context, pmident);
-                if !context.module_members.contains_key(&mident) {
-                    context.env.add_diag(unbound_module(&mident));
-                    return;
-                };
-                add_module_alias!(mident, alias_opt.map(|m| m.0))
-            }
-            P::Use::Members(pmident, sub_uses) => {
-                let mident = module_ident(context, pmident);
-                let members = match context.module_members.get(&mident) {
-                    Some(members) => members,
-                    None => {
-                        context.env.add_diag(unbound_module(&mident));
-                        return;
-                    }
-                };
-                let mloc = *context.module_members.get_loc(&mident).unwrap();
-                let sub_uses_kinds = sub_uses
-                    .into_iter()
-                    .map(|(member, alia_opt)| {
-                        let kind = members.get(&member).cloned();
-                        (member, alia_opt, kind)
-                    })
-                    .collect::<Vec<_>>();
-
-                for (member, alias_opt, member_kind_opt) in sub_uses_kinds {
-                    if member.value.as_str() == ModuleName::SELF_NAME {
-                        add_module_alias!(mident, alias_opt);
-                        continue;
-                    }
-
-                    // check is member
-
-                    let member_kind = match member_kind_opt {
-                        None => {
-                            let msg = format!(
-                                "Invalid 'use'. Unbound member '{}' in module '{}'",
-                                member, mident
-                            );
-                            context.env.add_diag(diag!(
-                                NameResolution::UnboundModuleMember,
-                                (member.loc, msg),
-                                (mloc, format!("Module '{}' declared here", mident)),
-                            ));
-                            continue;
-                        }
-                        Some(m) => m,
-                    };
-
-                    let alias = alias_opt.unwrap_or(member);
-
-                    let alias = match check_valid_module_member_alias(context, member_kind, alias) {
-                        None => continue,
-                        Some(alias) => alias,
-                    };
-                    if let Err(old_loc) = acc.add_member_alias(alias, mident, member) {
-                        duplicate_module_member(context, old_loc, alias)
-                    }
-                    if matches!(member_kind, ModuleMemberKind::Function) {
-                        // remove any previously declared alias to keep in sync with the member alias
-                        // map
-                        use_funs.implicit.remove(&alias);
-                        // not a function declaration
-                        let is_public = None;
-                        // assume used. We will set it to false if needed when exiting this alias scope
-                        let kind = E::ImplicitUseFunKind::UseAlias { used: true };
-                        let implicit = E::ImplicitUseFunCandidate {
-                            loc: alias.loc,
-                            attributes: attributes.clone(),
-                            is_public,
-                            function: (mident, member),
-                            kind,
-                        };
-                        use_funs.implicit.add(alias, implicit).unwrap();
-                    }
-                }
-            }
-            P::Use::Fun {
-                visibility,
+            let explicit = ParserExplicitUseFun {
+                loc,
+                attributes,
+                is_public,
                 function,
                 ty,
                 method,
-            } => {
-                context
-                    .env
-                    .check_feature(FeatureGate::DotCall, context.current_package, loc);
-                let is_public = match visibility {
-                    P::Visibility::Public(vis_loc) => Some(vis_loc),
-                    P::Visibility::Internal => None,
-                    P::Visibility::Script(vis_loc)
-                    | P::Visibility::Friend(vis_loc)
-                    | P::Visibility::Package(vis_loc) => {
-                        let msg = "Invalid visibility for 'use fun' declaration";
-                        let vis_msg = format!(
-                        "Module level 'use fun' declarations can be '{}' for the module's types, \
-                        otherwise they must internal to declared scope.",
-                        P::Visibility::PUBLIC
-                    );
+            };
+            use_funs.explicit.push(explicit);
+        }
+    }
+}
+
+fn module_use(
+    context: &mut Context,
+    acc: &mut AliasMapBuilder,
+    use_funs: &mut UseFunsBuilder,
+    in_mident: P::ModuleIdent,
+    attributes: &E::Attributes,
+    muse: P::ModuleUse,
+) {
+    let unbound_module = |mident: &ModuleIdent| -> Diagnostic {
+        diag!(
+            NameResolution::UnboundModule,
+            (
+                mident.loc,
+                format!("Invalid 'use'. Unbound module: '{}'", mident),
+            )
+        )
+    };
+    macro_rules! add_module_alias {
+        ($ident:expr, $alias_opt:expr) => {{
+            let alias: Name = $alias_opt.unwrap_or_else(|| $ident.value.module.0.clone());
+            if let Err(()) = check_restricted_name_all_cases(context, NameCase::ModuleAlias, &alias)
+            {
+                return;
+            }
+
+            if let Err(old_loc) = acc.add_module_alias(alias.clone(), $ident) {
+                duplicate_module_alias(context, old_loc, alias)
+            }
+        }};
+    }
+    match muse {
+        P::ModuleUse::Module(alias_opt) => {
+            let mident = module_ident(context, in_mident);
+            if !context.module_members.contains_key(&mident) {
+                context.env.add_diag(unbound_module(&mident));
+                return;
+            };
+            add_module_alias!(mident, alias_opt.map(|m| m.0))
+        }
+        P::ModuleUse::Members(sub_uses) => {
+            let mident = module_ident(context, in_mident);
+            let members = match context.module_members.get(&mident) {
+                Some(members) => members,
+                None => {
+                    context.env.add_diag(unbound_module(&mident));
+                    return;
+                }
+            };
+            let mloc = *context.module_members.get_loc(&mident).unwrap();
+            let sub_uses_kinds = sub_uses
+                .into_iter()
+                .map(|(member, alia_opt)| {
+                    let kind = members.get(&member).cloned();
+                    (member, alia_opt, kind)
+                })
+                .collect::<Vec<_>>();
+
+            for (member, alias_opt, member_kind_opt) in sub_uses_kinds {
+                if member.value.as_str() == ModuleName::SELF_NAME {
+                    add_module_alias!(mident, alias_opt);
+                    continue;
+                }
+
+                // check is member
+
+                let member_kind = match member_kind_opt {
+                    None => {
+                        let msg = format!(
+                            "Invalid 'use'. Unbound member '{}' in module '{}'",
+                            member, mident
+                        );
                         context.env.add_diag(diag!(
-                            Declarations::InvalidUseFun,
-                            (loc, msg),
-                            (vis_loc, vis_msg)
+                            NameResolution::UnboundModuleMember,
+                            (member.loc, msg),
+                            (mloc, format!("Module '{}' declared here", mident)),
                         ));
-                        None
+                        continue;
                     }
+                    Some(m) => m,
                 };
-                let explicit = ParserExplicitUseFun {
-                    loc,
-                    attributes,
-                    is_public,
-                    function,
-                    ty,
-                    method,
+
+                let alias = alias_opt.unwrap_or(member);
+
+                let alias = match check_valid_module_member_alias(context, member_kind, alias) {
+                    None => continue,
+                    Some(alias) => alias,
                 };
-                use_funs.explicit.push(explicit);
+                if let Err(old_loc) = acc.add_member_alias(alias, mident, member) {
+                    duplicate_module_member(context, old_loc, alias)
+                }
+                if matches!(member_kind, ModuleMemberKind::Function) {
+                    // remove any previously declared alias to keep in sync with the member alias
+                    // map
+                    use_funs.implicit.remove(&alias);
+                    // not a function declaration
+                    let is_public = None;
+                    // assume used. We will set it to false if needed when exiting this alias scope
+                    let kind = E::ImplicitUseFunKind::UseAlias { used: true };
+                    let implicit = E::ImplicitUseFunCandidate {
+                        loc: alias.loc,
+                        attributes: attributes.clone(),
+                        is_public,
+                        function: (mident, member),
+                        kind,
+                    };
+                    use_funs.implicit.add(alias, implicit).unwrap();
+                }
             }
         }
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -433,21 +433,6 @@ fn parse_module_name(context: &mut Context) -> Result<ModuleName, Box<Diagnostic
 
 // Parse a module identifier:
 //      ModuleIdent = <LeadingNameAccess> "::" <ModuleName>
-fn parse_module_ident(context: &mut Context) -> Result<ModuleIdent, Box<Diagnostic>> {
-    let start_loc = context.tokens.start_loc();
-    let address = parse_leading_name_access(context)?;
-
-    consume_token_(
-        context.tokens,
-        Tok::ColonColon,
-        start_loc,
-        " after an address in a module identifier",
-    )?;
-    let module = parse_module_name(context)?;
-    let end_loc = context.tokens.previous_end_loc();
-    let loc = make_loc(context.tokens.file_hash(), start_loc, end_loc);
-    Ok(sp(loc, ModuleIdent_ { address, module }))
-}
 
 // Parse a module access (a variable, struct type, or function):
 //      NameAccessChain = <LeadingNameAccess> ( "::" <Identifier> ( "::" <Identifier> )? )?
@@ -2613,10 +2598,9 @@ fn parse_friend_decl(
 
 // Parse a use declaration:
 //      UseDecl =
-//          "use" <ModuleIdent> <UseAlias> ";" |
-//          "use" <ModuleIdent> :: <UseMember> ";" |
-//          "use" <ModuleIdent> :: "{" Comma<UseMember> "}" ";"
-//          "use" "fun" <NameAccessChain> "as" <Type> "." <Identifier> ";"
+//          "use" "fun" <NameAccessChain> "as" <Type> "." <Identifier> ";" |
+//          "use" <LeadingNameAccess> "::" "{" <Comma<UseModule>> "}" ";" |
+//          "use" <LeadingNameAccess> "::" <UseModule>> ";"
 fn parse_use_decl(
     attributes: Vec<Attributes>,
     start_loc: usize,
@@ -2668,28 +2652,36 @@ fn parse_use_decl(
                     .env
                     .add_diag(diag!(Syntax::InvalidModifier, (vis.loc().unwrap(), msg)));
             }
-            let ident = parse_module_ident(context)?;
-            let alias_opt = parse_use_alias(context)?;
-            match (&alias_opt, context.tokens.peek()) {
-                (None, Tok::ColonColon) => {
-                    consume_token(context.tokens, Tok::ColonColon)?;
-                    let sub_uses = match context.tokens.peek() {
-                        Tok::LBrace => parse_comma_list(
-                            context,
-                            Tok::LBrace,
-                            Tok::RBrace,
-                            parse_use_member,
-                            "a module member alias",
-                        )?,
-                        _ => vec![parse_use_member(context)?],
+            let address_start_loc = context.tokens.start_loc();
+            let address = parse_leading_name_access(context)?;
+            consume_token_(
+                context.tokens,
+                Tok::ColonColon,
+                start_loc,
+                " after an address in a use declaration",
+            )?;
+            match context.tokens.peek() {
+                Tok::LBrace => {
+                    let parse_inner = |ctxt: &mut Context<'_, '_, '_>| {
+                        let start_loc = ctxt.tokens.start_loc();
+                        let use_ = parse_use_module(None, address, ctxt)?;
+                        let end_loc = ctxt.tokens.previous_end_loc();
+                        let loc = make_loc(ctxt.tokens.file_hash(), start_loc, end_loc);
+                        Ok((use_, loc))
                     };
-                    Use::Members(ident, sub_uses)
+                    let use_decls = parse_comma_list(
+                        context,
+                        Tok::LBrace,
+                        Tok::RBrace,
+                        parse_inner,
+                        "a module use clause",
+                    )?;
+                    Use::Modules(use_decls)
                 }
-                _ => Use::Module(ident, alias_opt.map(ModuleName)),
+                _ => parse_use_module(Some(address_start_loc), address, context)?,
             }
         }
     };
-
     consume_token(context.tokens, Tok::Semicolon)?;
     let end_loc = context.tokens.previous_end_loc();
     let loc = make_loc(context.tokens.file_hash(), start_loc, end_loc);
@@ -2698,6 +2690,45 @@ fn parse_use_decl(
         loc,
         use_,
     })
+}
+
+// Parse a use declaration member:
+//      UseModule =
+//          <ModuleName> <UseAlias> |
+//          <ModuleName> "::" <UseMember> |
+//          <ModuleName> "::" "{" Comma<UseMember> "}"
+fn parse_use_module(
+    address_start_loc: Option<usize>,
+    address: LeadingNameAccess,
+    context: &mut Context,
+) -> Result<Use, Box<Diagnostic>> {
+    let start_loc = if let Some(sloc) = address_start_loc {
+        sloc
+    } else {
+        context.tokens.start_loc()
+    };
+    let module = parse_module_name(context)?;
+    let end_loc = context.tokens.previous_end_loc();
+    let loc = make_loc(context.tokens.file_hash(), start_loc, end_loc);
+    let module_ident = sp(loc, ModuleIdent_ { address, module });
+    let alias_opt = parse_use_alias(context)?;
+    match (&alias_opt, context.tokens.peek()) {
+        (None, Tok::ColonColon) => {
+            consume_token(context.tokens, Tok::ColonColon)?;
+            let sub_uses = match context.tokens.peek() {
+                Tok::LBrace => parse_comma_list(
+                    context,
+                    Tok::LBrace,
+                    Tok::RBrace,
+                    parse_use_member,
+                    "a module member alias",
+                )?,
+                _ => vec![parse_use_member(context)?],
+            };
+            Ok(Use::Members(module_ident, sub_uses))
+        }
+        _ => Ok(Use::Module(module_ident, alias_opt.map(ModuleName))),
+    }
 }
 
 // Parse an alias for a module member:

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use.move
@@ -1,0 +1,37 @@
+module 0x42::a {
+        
+    struct A has drop {} 
+
+    public fun foo(_a: A): u64 { 0 }
+
+    public fun bar(): A { A {} }
+
+}
+
+module 0x42::b {
+    struct B has drop {} 
+
+    public fun baz(): B { B {} }
+}
+
+module 0x42::c {
+    use 0x42::{a::{A, Self as g, foo as f}, b::{Self as q, B, baz as bar}};
+
+    fun use_a() {
+        let x: A = g::bar();
+        let _y = f(x);
+        let _g: q::B = bar();
+        let _h: B = bar();
+    }
+
+}
+
+module 0x42::d {
+    use 0x42::{a::{A, bar as foo}, a as g};
+
+    fun use_a() {
+        let x: A = foo();
+        let _y = g::foo(x);
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use_invalid.exp
@@ -1,0 +1,50 @@
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:18:59
+   │
+18 │     use 0x42::{a::{A, Self as q, foo as bar}, b::{Self as q, B, baz as bar}};
+   │                               -                           ^ Duplicate module alias 'q'. Module aliases must be unique within a given namespace
+   │                               │                            
+   │                               Alias previously defined here
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:18:72
+   │
+18 │     use 0x42::{a::{A, Self as q, foo as bar}, b::{Self as q, B, baz as bar}};
+   │                                         ---                            ^^^ Duplicate module member or alias 'bar'. Top level names in a namespace must be unique
+   │                                         │                               
+   │                                         Alias previously defined here
+
+error[E03003]: unbound module member
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:21:20
+   │
+21 │         let x: A = q::bar();
+   │                    ^^^^^^ Invalid module access. Unbound function 'bar' in module '0x42::b'
+
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:22:18
+   │
+22 │         let _y = f(x);
+   │                  ^ Unbound function 'f' in current scope
+
+warning[W09001]: unused alias
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:30:31
+   │
+30 │     use 0x42::{a::{A, Self as q, foo as f}, a as g};
+   │                               ^ Unused 'use' of alias 'q'. Consider removing it
+   │
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09001]: unused alias
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:30:41
+   │
+30 │     use 0x42::{a::{A, Self as q, foo as f}, a as g};
+   │                                         ^ Unused 'use' of alias 'f'. Consider removing it
+   │
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E03005]: unbound unscoped name
+   ┌─ tests/move_check/parser/nested_module_use_invalid.move:34:18
+   │
+34 │         let _y = bar(x);
+   │                  ^^^ Unbound function 'bar' in current scope
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/nested_module_use_invalid.move
@@ -1,0 +1,37 @@
+module 0x42::a {
+        
+    struct A has drop {} 
+
+    public fun foo(_a: A): u64 { 0 }
+
+    public fun bar(): A { A {} }
+
+}
+
+module 0x42::b {
+    struct B has drop {} 
+
+    public fun baz(): B { B {} }
+}
+
+module 0x42::c {
+    use 0x42::{a::{A, Self as q, foo as bar}, b::{Self as q, B, baz as bar}};
+
+    fun use_a() {
+        let x: A = q::bar();
+        let _y = f(x);
+        let _g: q::B = bar();
+        let _h: B = bar();
+    }
+
+}
+
+module 0x42::d {
+    use 0x42::{a::{A, Self as q, foo as f}, a as g};
+
+    fun use_a() {
+        let x: A = g::bar();
+        let _y = bar(x);
+    }
+
+}


### PR DESCRIPTION
## Description 

This allows users to import modules all in one line, as:

```
 use 0x42::{a::{A, Self as g, foo as f}, b::{Self as q, B, baz as bar}};
```

## Test Plan 

New test files

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
