### PR TITLE
[graphql/rpc] chore/easy: remove rpc 1.0 fetch obj 

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/data_provider.rs
@@ -11,12 +11,6 @@ use sui_sdk::types::sui_system_state::sui_system_state_summary::SuiSystemStateSu
 
 #[async_trait]
 pub(crate) trait DataProvider: Send + Sync {
-    async fn get_object_with_options(
-        &self,
-        object_id: ObjectID,
-        options: SuiObjectDataOptions,
-    ) -> Result<Option<Object>>;
-
     async fn multi_get_object_with_options(
         &self,
         object_ids: Vec<ObjectID>,

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -80,22 +80,6 @@ impl Loader<Digest> for SuiClientLoader {
 
 #[async_trait]
 impl DataProvider for SuiClient {
-    async fn get_object_with_options(
-        &self,
-        object_id: NativeObjectID,
-        options: SuiObjectDataOptions,
-    ) -> Result<Option<Object>> {
-        let obj = self
-            .read_api()
-            .get_object_with_options(object_id, options)
-            .await?;
-
-        if obj.error.is_some() || obj.data.is_none() {
-            return Ok(None);
-        }
-        Ok(Some(convert_obj(&obj.data.unwrap())))
-    }
-
     async fn multi_get_object_with_options(
         &self,
         object_ids: Vec<NativeObjectID>,

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::context_data::context_ext::DataProviderContextExt;
+use crate::context_data::db_data_provider::PgManager;
 use crate::types::object::Object;
 use async_graphql::*;
 use sui_json_rpc_types::{OwnedObjectRef, SuiGasData, SuiObjectDataOptions};
@@ -130,11 +130,10 @@ impl From<(&NativeGasCostSummary, &OwnedObjectRef)> for GasEffects {
 impl GasEffects {
     async fn gas_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
         // TODO: implement DB counterpart without using Sui SDK client
-        let gas_obj = ctx
-            .data_provider()
-            .get_object_with_options(self.object_id, SuiObjectDataOptions::full_content())
-            .await?;
-        Ok(gas_obj)
+        ctx.data_unchecked::<PgManager>()
+            .fetch_obj(address, version)
+            .await
+            .extend()
     }
 
     async fn gas_summary(&self) -> Option<GasCostSummary> {


### PR DESCRIPTION
## Description 

Remove dependency on RPC 1.0 for obj fetch

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
