### PR TITLE
[graphql/rpc] render transaction kinds as strings temporarily

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -21,6 +21,10 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
+type AuthenticatorStateUpdate {
+	value: String!
+}
+
 type Balance {
 	coinType: String
 	coinObjectCount: Int
@@ -168,6 +172,10 @@ scalar DateTime
 type EndOfEpochData {
 	newCommittee: [CommitteeMember!]
 	nextProtocolVersion: Int
+}
+
+type EndOfEpochTransaction {
+	value: String!
 }
 
 type Epoch {
@@ -667,7 +675,7 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
-union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction | AuthenticatorStateUpdate | EndOfEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -28,8 +28,9 @@ use crate::{
         system_parameters::SystemParameters,
         transaction_block::{TransactionBlock, TransactionBlockEffects, TransactionBlockFilter},
         transaction_block_kind::{
-            ChangeEpochTransaction, ConsensusCommitPrologueTransaction, GenesisTransaction,
-            ProgrammableTransaction, TransactionBlockKind,
+            AuthenticatorStateUpdate, ChangeEpochTransaction, ConsensusCommitPrologueTransaction,
+            EndOfEpochTransaction, GenesisTransaction, ProgrammableTransaction,
+            TransactionBlockKind,
         },
         validator_set::ValidatorSet,
     },
@@ -1471,9 +1472,26 @@ impl From<&TransactionKind> for TransactionBlockKind {
                 };
                 TransactionBlockKind::GenesisTransaction(genesis)
             }
-            _ => TransactionBlockKind::ProgrammableTransactionBlock(ProgrammableTransaction {
-                value: "ProgrammableTransactionBlock".to_string(),
-            }),
+            // TODO: flesh out type
+            TransactionKind::ProgrammableTransaction(pt) => {
+                TransactionBlockKind::ProgrammableTransactionBlock(ProgrammableTransaction {
+                    value: format!("{:?}", pt),
+                })
+            }
+            // TODO: flesh out type
+            TransactionKind::AuthenticatorStateUpdate(asu) => {
+                TransactionBlockKind::AuthenticatorStateUpdateTransaction(
+                    AuthenticatorStateUpdate {
+                        value: format!("{:?}", asu),
+                    },
+                )
+            }
+            // TODO: flesh out type
+            TransactionKind::EndOfEpochTransaction(et) => {
+                TransactionBlockKind::EndOfEpochTransaction(EndOfEpochTransaction {
+                    value: format!("{:?}", et),
+                })
+            }
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -12,10 +12,25 @@ pub(crate) enum TransactionBlockKind {
     GenesisTransaction(GenesisTransaction),
     ChangeEpochTransaction(ChangeEpochTransaction),
     ProgrammableTransactionBlock(ProgrammableTransaction),
+    AuthenticatorStateUpdateTransaction(AuthenticatorStateUpdate),
+    EndOfEpochTransaction(EndOfEpochTransaction),
 }
 
+// TODO: flesh out the programmable transaction block type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 pub(crate) struct ProgrammableTransaction {
+    pub value: String,
+}
+
+// TODO: flesh out the authenticator state update type
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+pub(crate) struct AuthenticatorStateUpdate {
+    pub value: String,
+}
+
+// TODO: flesh out the end of epoch transaction type
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+pub(crate) struct EndOfEpochTransaction {
     pub value: String,
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -25,6 +25,10 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
+type AuthenticatorStateUpdate {
+	value: String!
+}
+
 type Balance {
 	coinType: String
 	coinObjectCount: Int
@@ -172,6 +176,10 @@ scalar DateTime
 type EndOfEpochData {
 	newCommittee: [CommitteeMember!]
 	nextProtocolVersion: Int
+}
+
+type EndOfEpochTransaction {
+	value: String!
 }
 
 type Epoch {
@@ -671,7 +679,7 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
-union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction | AuthenticatorStateUpdate | EndOfEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX
@@ -731,3 +739,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+


### PR DESCRIPTION
## Description 

While the types are being fleshed out, render the some transactions kinds as strings

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
