### PR TITLE
use the right schema on reset

### DIFF
--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -26,7 +26,7 @@ pub async fn start_test_indexer(
                 .get()
                 .map_err(|e| anyhow!("Fail to get pg_connection_pool {e}"))?,
             true,
-            false,
+            config.use_v2,
         )?;
     }
 


### PR DESCRIPTION
## Description 

`start_test_indexer` does not honor the schema choice, causing DB to get reset to v1 everytime.


## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
