### PR TITLE
[narwhal] Temporarily disable NW Certificate V2

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -77,7 +77,6 @@ const MAX_PROTOCOL_VERSION: u64 = 28;
 // Version 26: New gas model version.
 //             Add support for receiving objects off of other objects in devnet only.
 // Version 28: Add sui::zklogin::verify_zklogin_id and related functions to sui framework.
-//             Use CertificateV2 in narwhal
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1530,10 +1529,9 @@ impl ProtocolConfig {
                     cfg.check_zklogin_id_cost_base = Some(200);
                     // zklogin::check_zklogin_issuer
                     cfg.check_zklogin_issuer_cost_base = Some(200);
-                    // Only enable effects v2 & nw certificate v2 on devnet.
+                    // Only enable effects v2 on devnet.
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.enable_effects_v2 = true;
-                        cfg.feature_flags.narwhal_certificate_v2 = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1604,6 +1604,9 @@ impl ProtocolConfig {
     pub fn set_receive_object_for_testing(&mut self, val: bool) {
         self.feature_flags.receive_objects = val
     }
+    pub fn set_narwhal_certificate_v2(&mut self, val: bool) {
+        self.feature_flags.narwhal_certificate_v2 = val
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_28.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_28.snap
@@ -36,7 +36,6 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   enable_effects_v2: true
-  narwhal_certificate_v2: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -32,21 +32,23 @@ BatchV2:
         TYPENAME: VersionedMetadata
 Certificate:
   ENUM:
-    1:
-      V2:
+    0:
+      V1:
         NEWTYPE:
-          TYPENAME: CertificateV2
+          TYPENAME: CertificateV1
 CertificateDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
-CertificateV2:
+CertificateV1:
   STRUCT:
     - header:
         TYPENAME: Header
-    - signature_verification_state:
-        TYPENAME: SignatureVerificationState
+    - aggregated_signature:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 48
     - signed_authorities: BYTES
     - metadata:
         TYPENAME: Metadata
@@ -86,14 +88,6 @@ MetadataV1:
     - created_at: U64
     - received_at:
         OPTION: U64
-SignatureVerificationState:
-  ENUM:
-    0:
-      Unsigned:
-        NEWTYPE:
-          TUPLEARRAY:
-            CONTENT: U8
-            SIZE: 48
 VersionedMetadata:
   ENUM:
     0:

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -493,8 +493,8 @@ async fn process_certificates_v1_helper(
         // should cancel processing for the entire batch of fetched certificates.
         all_certificates.push(
             validate_received_certificate_version(cert, protocol_config).map_err(|err| {
-                error!("{err}");
-                DagError::Canceled
+                error!("fetched certficate processing error: {err}");
+                DagError::InvalidCertificateVersion
             })?,
         );
     }
@@ -552,8 +552,8 @@ async fn process_certificates_v2_helper(
         all_certificates.push(
             validate_received_certificate_version(cert.clone(), protocol_config).map_err(
                 |err| {
-                    error!("{err}");
-                    DagError::Canceled
+                    error!("fetched certficate processing error: {err}");
+                    DagError::InvalidCertificateVersion
                 },
             )?,
         );

--- a/narwhal/primary/src/tests/certificate_tests.rs
+++ b/narwhal/primary/src/tests/certificate_tests.rs
@@ -11,7 +11,7 @@ use rand::{
     SeedableRng,
 };
 use std::num::NonZeroUsize;
-use test_utils::{get_protocol_config, latest_protocol_version, CommitteeFixture};
+use test_utils::{latest_protocol_version, CommitteeFixture};
 use types::{Certificate, CertificateAPI, SignatureVerificationState, Vote, VoteAPI};
 
 #[test]
@@ -40,7 +40,7 @@ fn test_empty_certificate_verification() {
 #[test]
 fn test_valid_certificate_v1_verification() {
     let fixture = CommitteeFixture::builder().build();
-    let cert_v1_protocol_config = get_protocol_config(27);
+    let cert_v1_protocol_config = latest_protocol_version();
     let committee = fixture.committee();
     let header = fixture.header(&cert_v1_protocol_config);
 
@@ -63,9 +63,11 @@ fn test_valid_certificate_v1_verification() {
 
 #[test]
 fn test_valid_certificate_v2_verification() {
+    let mut cert_v2_config = latest_protocol_version();
+    cert_v2_config.set_narwhal_certificate_v2(true);
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
-    let header = fixture.header(&latest_protocol_version());
+    let header = fixture.header(&cert_v2_config);
 
     let mut signatures = Vec::new();
 
@@ -76,8 +78,7 @@ fn test_valid_certificate_v2_verification() {
     }
 
     let certificate =
-        Certificate::new_unverified(&latest_protocol_version(), &committee, header, signatures)
-            .unwrap();
+        Certificate::new_unverified(&cert_v2_config, &committee, header, signatures).unwrap();
 
     let verified_certificate = certificate.verify(&committee, &fixture.worker_cache());
 

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -52,6 +52,9 @@ pub enum DagError {
     #[error("Invalid header digest")]
     InvalidHeaderDigest,
 
+    #[error("Invalid certificate version")]
+    InvalidCertificateVersion,
+
     #[error("Header {0} has bad worker IDs")]
     HeaderHasBadWorkerIds(HeaderDigest),
 

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -909,14 +909,6 @@ impl Certificate {
         }
     }
 
-    pub fn new_test_empty(protocol_config: &ProtocolConfig, author: AuthorityIdentifier) -> Self {
-        if protocol_config.narwhal_certificate_v2() {
-            CertificateV2::new_test_empty(author)
-        } else {
-            CertificateV1::new_test_empty(author)
-        }
-    }
-
     /// This function requires that certificate was verified against given committee
     pub fn signed_authorities(&self, committee: &Committee) -> Vec<PublicKey> {
         match self {
@@ -1075,17 +1067,6 @@ impl CertificateV1 {
         votes: Vec<(AuthorityIdentifier, Signature)>,
     ) -> DagResult<Certificate> {
         Self::new_unsafe(committee, header, votes, false)
-    }
-
-    pub fn new_test_empty(author: AuthorityIdentifier) -> Certificate {
-        let header = Header::V1(HeaderV1 {
-            author,
-            ..Default::default()
-        });
-        Certificate::V1(CertificateV1 {
-            header,
-            ..Default::default()
-        })
     }
 
     fn new_unsafe(
@@ -1344,17 +1325,6 @@ impl CertificateV2 {
         votes: Vec<(AuthorityIdentifier, Signature)>,
     ) -> DagResult<Certificate> {
         Self::new_unsafe(committee, header, votes, false)
-    }
-
-    pub fn new_test_empty(author: AuthorityIdentifier) -> Certificate {
-        let header = Header::V1(HeaderV1 {
-            author,
-            ..Default::default()
-        });
-        Certificate::V1(CertificateV1 {
-            header,
-            ..Default::default()
-        })
     }
 
     fn new_unsafe(


### PR DESCRIPTION
## Description 

- Disabled CertificateV2 temporarily for additional testing
- Removed unused Cert methods
- Fixed an issue where old certificate versions were not being gated properly and were being accepted by the network and causing panics. This was happening via the RequestVote missing parents codepath.

```
thread '{"timestamp":"2023-10-13T18:14:52.906206Z","level":"ERROR","fields":{"message":"panicked at narwhal/types/src/primary.rs:1024:9:\nnot implemented: CertificateV2 field! Use aggregated_signature.","panic.file":"narwhal/types/src/primary.rs","panic.line":1024,"panic.column":9},"target":"telemetry_subscribers","filename":"crates/telemetry-subscribers/src/lib.rs","line_number":201}
```