### PR TITLE
[governance_api_v2] fix subtle bug that leads to a panic when an activation_epoch is 0

### DIFF
--- a/crates/sui-indexer/src/apis/governance_api_v2.rs
+++ b/crates/sui-indexer/src/apis/governance_api_v2.rs
@@ -147,7 +147,7 @@ impl GovernanceReadApiV2 {
                 delegations.push(sui_json_rpc_types::Stake {
                     staked_sui_id: stake.id(),
                     // TODO: this might change when we implement warm up period.
-                    stake_request_epoch: stake.activation_epoch() - 1,
+                    stake_request_epoch: stake.activation_epoch().saturating_sub(1),
                     stake_active_epoch: stake.activation_epoch(),
                     principal: stake.principal(),
                     status,


### PR DESCRIPTION
## Description 

This fixes a bug that leads to a panic when an `activation_epoch` is 0.

## Test Plan 

Manual queries

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
