### PR TITLE
move (easy): source service uses smaller data dependency for watching upgrades

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -368,12 +368,12 @@ pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<Netw
 // falsely report outdated sources for a package. Pass an optional `channel` to observe the upgrade transaction(s).
 // The `channel` parameter exists for testing.
 pub async fn watch_for_upgrades(
-    config: &Config,
+    packages: Vec<PackageSources>,
     app_state: Arc<RwLock<AppState>>,
     channel: Option<Sender<SuiTransactionBlockEffects>>,
 ) -> anyhow::Result<()> {
     let mut watch_ids = ArrayParams::new();
-    for s in &config.packages {
+    for s in packages {
         let packages = match s {
             PackageSources::Repository(RepositorySource { packages, .. }) => packages,
             PackageSources::Directory(DirectorySource { packages, .. }) => packages,

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -32,7 +32,9 @@ pub async fn main() -> anyhow::Result<()> {
     let app_state_copy = app_state.clone();
     let mut threads = vec![];
     let watcher =
-        tokio::spawn(async move { watch_for_upgrades(&package_config, app_state, None).await });
+        tokio::spawn(
+            async move { watch_for_upgrades(package_config.packages, app_state, None).await },
+        );
     threads.push(watcher);
     let server = tokio::spawn(async { serve(app_state_copy)?.await.map_err(anyhow::Error::from) });
     threads.push(server);

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -93,7 +93,7 @@ async fn test_end_to_end() -> anyhow::Result<()> {
     let app_state = Arc::new(RwLock::new(AppState { sources }));
     let app_state_ref = app_state.clone();
     let (tx, rx) = oneshot::channel();
-    tokio::spawn(async move { watch_for_upgrades(&config, app_state, Some(tx)).await });
+    tokio::spawn(async move { watch_for_upgrades(config.packages, app_state, Some(tx)).await });
 
     // Set up to upgrade package.
     let package = effects


### PR DESCRIPTION
## Description 

See inline comment.

## Test Plan 

Updated tests, semantics-preserving change.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
