### PR TITLE
[formal snapshots] Optimize and polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11619,6 +11619,7 @@ dependencies = [
  "itertools",
  "narwhal-storage",
  "narwhal-types",
+ "num_cpus",
  "object_store",
  "prometheus",
  "rocksdb",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+num_cpus.workspace = true
 bcs.workspace = true
 clap = { version = "4.1.4", features = ["derive"] }
 colored.workspace = true

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -471,7 +471,7 @@ impl ToolCommand {
                         panic!("Cannot generate default archive bucket for unknown network");
                     }
                 });
-                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or_else(|| {
+                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or({
                     if formal {
                         ObjectStoreType::GCS
                     } else {

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -14,6 +14,7 @@ use sui_config::genesis::Genesis;
 use sui_core::authority_client::AuthorityAPI;
 use sui_protocol_config::Chain;
 use sui_replay::{execute_replay_command, ReplayToolCommand};
+use telemetry_subscribers::Filters;
 
 use sui_types::{base_types::*, object::Owner};
 
@@ -217,8 +218,10 @@ pub enum ToolCommand {
         /// as index staging is not yet supported for formal snapshots.
         #[clap(long = "skip-indexes")]
         skip_indexes: bool,
-        #[clap(long = "num-parallel-downloads", default_value = "2")]
-        num_parallel_downloads: usize,
+        /// Number of parallel downloads to perform. Defaults to a reasonable
+        /// value based on number of available logical cores.
+        #[clap(long = "num-parallel-downloads")]
+        num_parallel_downloads: Option<usize>,
         /// If true, restore from formal (slim, DB agnostic) snapshot. Note that this is only supported
         /// for protocol versions supporting `commit_root_state_digest`. For mainnet, this is
         /// epoch 20+, and for testnet this is epoch 12+
@@ -251,6 +254,10 @@ pub enum ToolCommand {
         archive_bucket: Option<String>,
         #[clap(long = "archive-bucket-type", default_value = "s3")]
         archive_bucket_type: ObjectStoreType,
+        /// If false (default), log level will be overridden to "off",
+        /// and output will be reduced to necessary status information.
+        #[clap(long = "formal")]
+        verbose: bool,
     },
 
     #[clap(name = "replay")]
@@ -336,7 +343,7 @@ impl std::fmt::Display for OwnerOutput {
 
 impl ToolCommand {
     #[allow(clippy::format_in_format_args)]
-    pub async fn execute(self) -> Result<(), anyhow::Error> {
+    pub async fn execute(self, filters: Filters) -> Result<(), anyhow::Error> {
         match self {
             ToolCommand::FetchObject {
                 id,
@@ -454,7 +461,18 @@ impl ToolCommand {
                 snapshot_path,
                 archive_bucket,
                 archive_bucket_type,
+                verbose,
             } => {
+                if !verbose {
+                    filters
+                        .update_log("off")
+                        .expect("Failed to update log level");
+                }
+                let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
+                    num_cpus::get()
+                        .checked_sub(1)
+                        .expect("Failed to get number of CPUs")
+                });
                 let snapshot_bucket = snapshot_bucket.unwrap_or_else(|| match (formal, network) {
                     (true, Chain::Mainnet) => "mysten-mainnet-formal".to_string(),
                     (false, Chain::Mainnet) => "mysten-mainnet-snapshots".to_string(),
@@ -596,6 +614,7 @@ impl ToolCommand {
                         snapshot_store_config,
                         archive_store_config,
                         num_parallel_downloads,
+                        network,
                         verify,
                     )
                     .await?;

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -18,12 +18,14 @@ use std::{fs, io};
 use sui_config::{genesis::Genesis, NodeConfig};
 use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use sui_network::default_mysten_network_config;
+use sui_protocol_config::Chain;
 use sui_sdk::SuiClientBuilder;
+use sui_types::accumulator::Accumulator;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::multiaddr::Multiaddr;
 use sui_types::object::ObjectFormatOptions;
 use sui_types::{base_types::*, object::Owner};
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
@@ -54,7 +56,7 @@ use sui_types::messages_grpc::{
     TransactionStatus,
 };
 
-use tracing::{info, warn};
+use tracing::info;
 use typed_store::rocks::MetricConf;
 
 pub mod commands;
@@ -724,9 +726,11 @@ fn start_summary_sync(
             .await?;
         sync_progress_bar.finish_with_message("Checkpoint summary sync is complete");
 
+        // verify checkpoint summaries
         if verify {
-            // reset highest verified
             let v_start = s_start;
+            // update highest verified to be highest synced. We will move back
+            // iff parallel verification succeeds
             let latest_verified = checkpoint_store
                 .get_checkpoint_by_sequence_number(latest_synced)
                 .expect("Failed to get checkpoint")
@@ -794,9 +798,17 @@ pub async fn download_formal_snapshot(
     snapshot_store_config: ObjectStoreConfig,
     archive_store_config: ObjectStoreConfig,
     num_parallel_downloads: usize,
+    network: Chain,
     verify: bool,
 ) -> Result<(), anyhow::Error> {
+    eprintln!(
+        "Beginning formal snapshot restore to end of epoch {}, network: {:?}",
+        epoch, network,
+    );
     let path = path.join("staging").to_path_buf();
+    if path.exists() {
+        fs::remove_dir_all(path.clone())?;
+    }
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&path.join("store"), None));
     let genesis = Genesis::load(genesis).unwrap();
     let genesis_committee = genesis.committee()?;
@@ -827,11 +839,14 @@ pub async fn download_formal_snapshot(
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
     let perpetual_db_clone = perpetual_db.clone();
     let snapshot_dir = path.parent().unwrap().join("snapshot");
+    if snapshot_dir.exists() {
+        fs::remove_dir_all(snapshot_dir.clone())?;
+    }
     let snapshot_dir_clone = snapshot_dir.clone();
 
     // TODO if verify is false, we should skip generating these and
     // not pass in a channel to the reader
-    let (sender, receiver) = oneshot::channel();
+    let (sender, mut receiver) = mpsc::channel(num_parallel_downloads);
 
     let snapshot_handle = tokio::spawn(async move {
         let local_store_config = ObjectStoreConfig {
@@ -855,14 +870,14 @@ pub async fn download_formal_snapshot(
             .unwrap_or_else(|err| panic!("Failed during read: {}", err));
         Ok::<(), anyhow::Error>(())
     });
-    let accumulator = receiver.await?;
-    let tasks: Vec<_> = vec![Box::pin(snapshot_handle), Box::pin(summaries_handle)];
-    join_all(tasks)
+    let mut root_accumulator = Accumulator::default();
+    while let Some(partial_acc) = receiver.recv().await {
+        root_accumulator.union(&partial_acc);
+    }
+    summaries_handle
         .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .for_each(|result| result.expect("Task failed"));
+        .expect("Task join failed")
+        .expect("Summaries task failed");
 
     let last_checkpoint = checkpoint_store
         .get_highest_verified_checkpoint()?
@@ -886,25 +901,34 @@ pub async fn download_formal_snapshot(
             .last()
             .expect(
                 "End of epoch has no commitments. This likely means that the epoch \
-                you are attempting to restore from does not support state accumulation. \
-                If restoring from mainnet, `--epoch` must be > 20, and for testnet, \
-                `--epoch` must be > 12.",
+                you are attempting to restore from does not support end of epoch state \
+                digest commitment. If restoring from mainnet, `--epoch` must be > 20, \
+                and for testnet, `--epoch` must be > 12.",
             );
         match commitment {
             CheckpointCommitment::ECMHLiveObjectSetDigest(consensus_digest) => {
-                let local_digest: ECMHLiveObjectSetDigest = accumulator.digest().into();
+                let local_digest: ECMHLiveObjectSetDigest = root_accumulator.digest().into();
                 assert_eq!(
                     *consensus_digest, local_digest,
                     "End of epoch {} root state digest {} does not match \
                     local root state hash {} after restoring from formal snapshot",
                     epoch, consensus_digest.digest, local_digest.digest,
                 );
-                info!("Formal snapshot state verification complete!");
+                eprintln!("Formal snapshot state verification completed successfully!");
             }
         };
     } else {
-        warn!("Skipping snapshot verification");
+        eprintln!(
+            "WARNING: Skipping snapshot verification! \
+            This is highly discouraged unless you fully trust the source of this snapshot and its contents. 
+            If this was unintentional, rerun with `--verify` set to `true`"
+        );
     }
+
+    snapshot_handle
+        .await
+        .expect("Task join failed")
+        .expect("Snapshot restore task failed");
 
     // TODO we should ensure this map is being updated for all end of epoch
     // checkpoints during summary sync. This happens in `insert_{verified|certified}_checkpoint`
@@ -913,7 +937,7 @@ pub async fn download_formal_snapshot(
 
     setup_db_state(
         epoch,
-        accumulator,
+        root_accumulator,
         perpetual_db,
         checkpoint_store,
         committee_store,

--- a/crates/sui-tool/src/main.rs
+++ b/crates/sui-tool/src/main.rs
@@ -13,9 +13,9 @@ async fn main() {
     colored::control::set_virtual_terminal(true).unwrap();
 
     let cmd: ToolCommand = ToolCommand::parse();
-    let _guard = telemetry_subscribers::TelemetryConfig::new()
+    let (_guards, filters) = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
 
-    exit_main!(cmd.execute().await);
+    exit_main!(cmd.execute(filters).await);
 }


### PR DESCRIPTION
## Description 

- Optimize checkpoint summary sync + verification
  - Rather than blocking on verification during summary sync, which can be slow as it requires that we sync in order, instead sync all checkpoint summaries, and then locally verify.
  - This optimization moves checkpoint summary sync and verification from 3.5 hours to ~20 minutes, as measured against testnet `epoch_125` snapshot
- Optimize state accumulation
    - Parallel divide and conquer partial accumulators (per file partition), then union 
    - This speeds up accumulation from 3.2 hours to 20 minutes (for same benchmark as above)
-  Introduce early termination on snapshot verification failure
- Introduce `verbose` flag, which, when not set, sets log level to `off` for cleaner status output  
- Factor out snapshot accumulation and object download/bulk-load for easier readability


## Test Plan 

Ran formal snapshot restore from `sui-tool` and verified improvements

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
