### PR TITLE
fix: intepret zklogin address with padded address_seed field

### DIFF
--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -78,6 +78,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         metrics.clone(),
                         vec![],
                         ZkLoginEnv::Test,
+                        true,
                     ));
 
                     b.iter(|| {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -575,6 +575,7 @@ impl AuthorityPerEpochStore {
             signature_verifier_metrics,
             supported_providers,
             zklogin_env,
+            protocol_config.verify_legacy_zklogin_address(),
         );
 
         let authenticator_state_exists = epoch_start_configuration

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -117,6 +117,7 @@ struct ZkLoginParams {
     pub supported_providers: Vec<OIDCProvider>,
     /// The environment (prod/test) the code runs in. It decides which verifying key to use in fastcrypto.
     pub env: ZkLoginEnv,
+    pub verify_legacy_zklogin_address: bool,
 }
 
 impl SignatureVerifier {
@@ -126,6 +127,7 @@ impl SignatureVerifier {
         metrics: Arc<SignatureVerifierMetrics>,
         supported_providers: Vec<OIDCProvider>,
         env: ZkLoginEnv,
+        verify_legacy_zklogin_address: bool,
     ) -> Self {
         Self {
             committee,
@@ -147,6 +149,7 @@ impl SignatureVerifier {
             zk_login_params: ZkLoginParams {
                 supported_providers,
                 env,
+                verify_legacy_zklogin_address,
             },
         }
     }
@@ -156,6 +159,7 @@ impl SignatureVerifier {
         metrics: Arc<SignatureVerifierMetrics>,
         supported_providers: Vec<OIDCProvider>,
         zklogin_env: ZkLoginEnv,
+        verify_legacy_zklogin_address: bool,
     ) -> Self {
         Self::new_with_batch_size(
             committee,
@@ -163,6 +167,7 @@ impl SignatureVerifier {
             metrics,
             supported_providers,
             zklogin_env,
+            verify_legacy_zklogin_address,
         )
     }
 
@@ -346,6 +351,7 @@ impl SignatureVerifier {
                     jwks,
                     self.zk_login_params.supported_providers.clone(),
                     self.zk_login_params.env.clone(),
+                    self.zk_login_params.verify_legacy_zklogin_address,
                 );
                 signed_tx
                     .tx_signatures()
@@ -477,7 +483,7 @@ pub fn batch_verify_certificates(
     certs: &[CertifiedTransaction],
 ) -> Vec<SuiResult> {
     // certs.data() is assumed to be verified already by the caller.
-    let verify_params = VerifyParams::new(Default::default(), Vec::new(), Default::default());
+    let verify_params = VerifyParams::new(Default::default(), Vec::new(), Default::default(), true);
     match batch_verify(committee, certs, &[]) {
         Ok(_) => vec![Ok(()); certs.len()],
 

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -119,6 +119,7 @@ async fn test_async_verifier() {
         metrics,
         vec![],
         ZkLoginEnv::Test,
+        true,
     ));
 
     let tasks: Vec<_> = (0..32)

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -188,7 +188,7 @@ async fn test_zklogin_transaction_disabled() {
             .build(),
     )
     .await;
-    let (_, tx, _) = make_zklogin_tx();
+    let (_, tx, _) = make_zklogin_tx(false);
     assert_denied(&process_zklogin_tx(tx, &state).await);
 
     let (_, state1) = setup_test(
@@ -197,7 +197,7 @@ async fn test_zklogin_transaction_disabled() {
             .build(),
     )
     .await;
-    let (_, tx1, _) = make_zklogin_tx();
+    let (_, tx1, _) = make_zklogin_tx(false);
     assert_denied(&process_zklogin_tx(tx1, &state1).await);
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "28",
+              "maxSupportedProtocolVersion": "29",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,
@@ -1377,6 +1377,7 @@
                 "simplified_unwrap_then_delete": false,
                 "txn_base_cost_as_multiplier": false,
                 "upgraded_multisig_supported": false,
+                "verify_legacy_zklogin_address": false,
                 "zklogin_auth": false
               },
               "attributes": {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 28;
+const MAX_PROTOCOL_VERSION: u64 = 29;
 
 // Record history of protocol version allocations here:
 //
@@ -77,6 +77,8 @@ const MAX_PROTOCOL_VERSION: u64 = 28;
 // Version 26: New gas model version.
 //             Add support for receiving objects off of other objects in devnet only.
 // Version 28: Add sui::zklogin::verify_zklogin_id and related functions to sui framework.
+// Version 29: Add verify_legacy_zklogin_address flag to sui framework, this add ability to verify
+//             transactions from a legacy zklogin address.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -299,6 +301,10 @@ struct FeatureFlags {
     // If true, then use CertificateV2 in narwhal.
     #[serde(skip_serializing_if = "is_false")]
     narwhal_certificate_v2: bool,
+
+    // If true, allow verify with legacy zklogin address
+    #[serde(skip_serializing_if = "is_false")]
+    verify_legacy_zklogin_address: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -960,6 +966,10 @@ impl ProtocolConfig {
     pub fn narwhal_certificate_v2(&self) -> bool {
         self.feature_flags.narwhal_certificate_v2
     }
+
+    pub fn verify_legacy_zklogin_address(&self) -> bool {
+        self.feature_flags.verify_legacy_zklogin_address
+    }
 }
 
 #[cfg(not(msim))]
@@ -1534,6 +1544,9 @@ impl ProtocolConfig {
                         cfg.feature_flags.enable_effects_v2 = true;
                     }
                 }
+                29 => {
+                    cfg.feature_flags.verify_legacy_zklogin_address = true;
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.
@@ -1606,6 +1619,9 @@ impl ProtocolConfig {
     }
     pub fn set_narwhal_certificate_v2(&mut self, val: bool) {
         self.feature_flags.narwhal_certificate_v2 = val
+    }
+    pub fn set_verify_legacy_zklogin_address(&mut self, val: bool) {
+        self.feature_flags.verify_legacy_zklogin_address = val
     }
 }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
@@ -1,0 +1,207 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 29
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
+  zklogin_supported_providers:
+    - Facebook
+    - Google
+    - Twitch
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  verify_legacy_zklogin_address: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
@@ -1,0 +1,207 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 29
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
+  zklogin_supported_providers:
+    - Facebook
+    - Google
+    - Twitch
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  verify_legacy_zklogin_address: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
@@ -1,0 +1,210 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 29
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  narwhal_new_leader_election_schedule: true
+  zklogin_supported_providers:
+    - Facebook
+    - Google
+    - Twitch
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  enable_effects_v2: true
+  verify_legacy_zklogin_address: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 8
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 28
+  protocol_version: 29
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 28
+protocol_version: 29
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x67273cd3ed5bfbc6dcfc5cc292b67f56e5a1dc2d1ee415a7d355ad5c956ac226"
+            id: "0x658b0c687e422f01d00436d848ba37cc924a99615bdd0b1f7983eee908aa4d60"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xd1a6aebc3a3545153cf4c450b44253eb1208153bcc7a49a634ba85c3c0cb846e"
+      operation_cap_id: "0x4a06ba7302a9c4863f5166d4041e54490a20561034dc79d3c871f5e8a2b7bbd5"
       gas_price: 1000
       staking_pool:
-        id: "0x9541ca79d01eaa7fd999e6379c948a9078d3e28b63c6c0c0c94783e9ebe6a18f"
+        id: "0x38634ba6165019652230383c70f698a54606e8971c9f40a978e00dabea2b4b19"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x83f8c396cce12c9d3dc8f616838a1fdc1783239dfd1d4e97dc3778a9adb64f0d"
+          id: "0x3fa6f4d12a4876549548026a274b95d485107d2ceb0cddeaff4e09a160a27673"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x2439ac858660e5dafc11062dc8108ce1b6f92e52bd682b24b94fc193edc8ea77"
+            id: "0x0f73f6796f9f89ec37e041003917975423c2de610b5352e85c4678f197cfa3a2"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x1843ae4b9b86dd6d86c2ef1f6b62aa96ed9e5f5c94baa7c5e99ad33cb0219962"
+          id: "0x0ba371cca84a3712f4582f0dcc375f5f5cc49786676db04e9b336226ceea9b4d"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x13907f328840ecd7d2e35318ed2bd9a03efe261cc7e2973e6bea4036edd97304"
+      id: "0xe2ce386f770babc91fa60ab67a8f64b53f76ad7f2b74475487b5a59b9d50704e"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x75f62b0760b9c023034ef4377732d79f6749b89c58c2b21a76bafc478daf1178"
+    id: "0x686a0ee6de2455fca4bba285850d02f849f8cf8808ea8faba041744079c2b515"
     size: 1
   inactive_validators:
-    id: "0xce70b78d23277128ebe1acb52c7545e951b1f7e90589bd87a0111735beaf5740"
+    id: "0x88331a72af05e55312d3b0d1b561b8d4642a78a22170483171d0f1b5226eb97a"
     size: 0
   validator_candidates:
-    id: "0x57efea43a86b1996dfd92a3dad4c087c0d777f845ff8d79430d7b7a3bd097a65"
+    id: "0xed32965d7b51806a16b326226df9038cd18ec1f70d22ddbf47f73aa259f937b5"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xab499b6882efc22c3c1d4ddce9a4346989f7212c1457fd7d63a371b872ed31de"
+      id: "0xbccae2d0ff54175b1708b580d0e68c93fc65383015cd6d5202212d5bf00e0aa9"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x8adedb62f0b3cf690bedf888023d769862b3139c9234adfc213f55e3daa60873"
+      id: "0x9de9189bc53dffffae1a4cef3ddee392646b04c2440ea71a31dd4329d4b8800e"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x2bc37dd30b3f053ff47ef0ef4886ca167ebe5cf791574c57b0587b87b3151d69"
+      id: "0xd3ee91352a7e23913409c81d4dc5af944dc7e57dd806dcfb9fb363add9d22faf"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x8405dcf86babbc037bec669a16b4451444cb68a71494c7104a566ea56b6cf85a"
+    id: "0x6821c028816fb3f7538f92559635bcc419985d3bf1ad408b2abb66e686ecabbf"
   size: 0
 

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -24,6 +24,7 @@ pub struct VerifyParams {
     pub oidc_provider_jwks: ImHashMap<JwkId, JWK>,
     pub supported_providers: Vec<OIDCProvider>,
     pub zk_login_env: ZkLoginEnv,
+    pub verify_legacy_zklogin_address: bool,
 }
 
 impl VerifyParams {
@@ -31,11 +32,13 @@ impl VerifyParams {
         oidc_provider_jwks: ImHashMap<JwkId, JWK>,
         supported_providers: Vec<OIDCProvider>,
         zk_login_env: ZkLoginEnv,
+        verify_legacy_zklogin_address: bool,
     ) -> Self {
         Self {
             oidc_provider_jwks,
             supported_providers,
             zk_login_env,
+            verify_legacy_zklogin_address,
         }
     }
 }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -727,7 +727,7 @@ fn test_sponsored_transaction_message() {
     .unwrap();
 
     assert_eq!(
-        transaction.get_signer_sig_mapping().unwrap(),
+        transaction.get_signer_sig_mapping(true).unwrap(),
         BTreeMap::from([(sender, &sender_sig), (sponsor, &sponsor_sig)]),
     );
 

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -184,13 +184,47 @@ mod zk_login {
         SuiKeyPair::Ed25519(Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32])))
     }
 
-    pub fn make_zklogin_tx() -> (SuiAddress, Transaction, GenericSignature) {
-        let data = make_transaction_data(get_zklogin_user_address());
-
-        sign_zklogin_tx(data)
+    fn get_inputs_with_bad_address_seed() -> ZkLoginInputs {
+        thread_local! {
+        static ZKLOGIN_INPUTS: ZkLoginInputs = ZkLoginInputs::from_json("{\"proofPoints\":{\"a\":[\"10185507767637631461288631872420855392575502618230432798638077166913237487225\",\"486552727548963162216882318604712328033877312311180079292405972191227316846\",\"1\"],\"b\":[[\"1623053573270295461491876034060433315267271068599362032313214842804681292195\",\"1594254673256025153169642092795321274206140210044783261166689262134457223822\"],[\"929741208529428180185188361796488974664966086686436785158141177542057695691\",\"14730889823653262280085847538201539622182403254536943822643266539760211478223\"],[\"1\",\"0\"]],\"c\":[\"8378008976287778217679290603880929221536289895857224171038260777139834065550\",\"2647982871566280218690920336818257040745587756978173237549916715413265895543\",\"1\"]},\"issBase64Details\":{\"value\":\"wiaXNzIjoiaHR0cHM6Ly9pZC50d2l0Y2gudHYvb2F1dGgyIiw\",\"indexMod4\":2},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEifQ\"}", "380704556853533152350240698167704405529973457670972223618755249929828551006").unwrap();        }
+        ZKLOGIN_INPUTS.with(|a| a.clone())
     }
 
-    pub fn sign_zklogin_tx(data: TransactionData) -> (SuiAddress, Transaction, GenericSignature) {
+    pub fn get_legacy_zklogin_user_address() -> SuiAddress {
+        thread_local! {
+            static USER_ADDRESS: SuiAddress = {
+                // Derive user address manually: Blake2b_256 hash of [zklogin_flag || iss_bytes_length || iss_bytes || address seed in bytes])
+                let mut hasher = DefaultHash::default();
+                hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
+                let inputs = get_inputs_with_bad_address_seed();
+                let iss_bytes = inputs.get_iss().as_bytes();
+                hasher.update([iss_bytes.len() as u8]);
+                hasher.update(iss_bytes);
+                let bytes = big_int_str_to_bytes(inputs.get_address_seed()).unwrap();
+                // The bytes from example address seed is 31 bytes, padded with 0 to 32 bytes.
+                let mut padded = Vec::new();
+                padded.extend(vec![0; 32 - bytes.len()]);
+                padded.extend(bytes);
+                hasher.update(padded);
+                SuiAddress::from_bytes(hasher.finalize().digest).unwrap()
+            };
+        }
+        USER_ADDRESS.with(|a| *a)
+    }
+
+    pub fn make_zklogin_tx(legacy: bool) -> (SuiAddress, Transaction, GenericSignature) {
+        let data = if legacy {
+            make_transaction_data(get_legacy_zklogin_user_address())
+        } else {
+            make_transaction_data(get_zklogin_user_address())
+        };
+        sign_zklogin_tx(data, legacy)
+    }
+
+    pub fn sign_zklogin_tx(
+        data: TransactionData,
+        legacy: bool,
+    ) -> (SuiAddress, Transaction, GenericSignature) {
         // Sign the user transaction with the user's ephemeral key.
         //let tx = make_transaction(user_address, &user_key, Intent::sui_transaction());
 
@@ -205,9 +239,14 @@ mod zk_login {
             _ => panic!("Expected a signature"),
         };
 
+        let inputs = if legacy {
+            get_inputs_with_bad_address_seed()
+        } else {
+            get_inputs()
+        };
         // Construct the authenticator with all user submitted components.
         let authenticator = GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(
-            get_inputs(),
+            inputs,
             10,
             s.clone(),
         ));
@@ -217,8 +256,12 @@ mod zk_login {
             Intent::sui_transaction(),
             vec![authenticator.clone()],
         ));
-
-        (get_zklogin_user_address(), tx, authenticator)
+        let addr = if legacy {
+            get_legacy_zklogin_user_address()
+        } else {
+            get_zklogin_user_address()
+        };
+        (addr, tx, authenticator)
     }
 }
 

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -103,7 +103,11 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
     where
         T: Serialize,
     {
-        if author != self.try_into()? {
+        if aux_verify_data.verify_legacy_zklogin_address {
+            if author != self.try_into()? && author != SuiAddress::legacy_try_from(self)? {
+                return Err(SuiError::InvalidAddress);
+            }
+        } else if author != self.try_into()? {
             return Err(SuiError::InvalidAddress);
         }
 

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -871,6 +871,7 @@ impl KeyToolCommand {
                                 OIDCProvider::Google,
                             ],
                             ZkLoginEnv::Prod,
+                            true,
                         );
                         let res = zk.verify_authenticator(
                             &IntentMessage::new(Intent::sui_transaction(), tx_data.clone()),


### PR DESCRIPTION
## Description 

Make Sui derive zkLogin address with padded address_seed so the address derived in the legacy way can still send funds. 

## Test Plan 

unit test
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Make Sui to verify zkLogin legacy address (derived with padded address_seed). Upgrade protocol version to 29 to enable verify with legacy address. 