### PR TITLE
Allow passing in an aws endpoint for accelerated s3 downloads

### DIFF
--- a/crates/sui-storage/src/object_store/mod.rs
+++ b/crates/sui-storage/src/object_store/mod.rs
@@ -52,6 +52,10 @@ pub struct ObjectStoreConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[arg(long)]
     pub aws_secret_access_key: Option<String>,
+    /// When using Amazon S3 as the object store, set this to bucket endpoint
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[arg(long)]
+    pub aws_endpoint: Option<String>,
     /// When using Amazon S3 as the object store, set this to the region
     /// that goes with the specified bucket
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -124,6 +128,11 @@ impl ObjectStoreConfig {
         }
         if let Some(secret) = &self.aws_secret_access_key {
             builder = builder.with_secret_access_key(secret);
+        }
+        if let Some(endpoint) = &self.aws_endpoint {
+            builder = builder
+                .with_endpoint(endpoint)
+                .with_virtual_hosted_style_request(true);
         }
         // if let Some(profile) = &self.aws_profile {
         //     builder = builder.with_profile(profile);

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -939,7 +939,8 @@ pub async fn verify_archive(
     concurrency: usize,
     interactive: bool,
 ) -> Result<()> {
-    verify_archive_with_genesis_config(genesis, remote_store_config, concurrency, interactive).await
+    verify_archive_with_genesis_config(genesis, remote_store_config, concurrency, interactive, 10)
+        .await
 }
 
 pub async fn verify_archive_by_checksum(


### PR DESCRIPTION
## Description 

Allow passing in a custom endpoint for object store to start using accelerated s3 endpoint which is proven to be more reliable during archival verification
## Test Plan 

Ran an archive verification workflow with the cherry pick
