### PR TITLE
Re-enable CertV2 for faster NW Catchup in Devnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -79,6 +79,7 @@ const MAX_PROTOCOL_VERSION: u64 = 29;
 // Version 28: Add sui::zklogin::verify_zklogin_id and related functions to sui framework.
 // Version 29: Add verify_legacy_zklogin_address flag to sui framework, this add ability to verify
 //             transactions from a legacy zklogin address.
+//             Enable Narwhal CertificateV2
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1546,6 +1547,10 @@ impl ProtocolConfig {
                 }
                 29 => {
                     cfg.feature_flags.verify_legacy_zklogin_address = true;
+                    // Only enable nw certificate v2 on devnet.
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.narwhal_certificate_v2 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_29.snap
@@ -36,6 +36,7 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   enable_effects_v2: true
+  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -32,23 +32,21 @@ BatchV2:
         TYPENAME: VersionedMetadata
 Certificate:
   ENUM:
-    0:
-      V1:
+    1:
+      V2:
         NEWTYPE:
-          TYPENAME: CertificateV1
+          TYPENAME: CertificateV2
 CertificateDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
-CertificateV1:
+CertificateV2:
   STRUCT:
     - header:
         TYPENAME: Header
-    - aggregated_signature:
-        TUPLEARRAY:
-          CONTENT: U8
-          SIZE: 48
+    - signature_verification_state:
+        TYPENAME: SignatureVerificationState
     - signed_authorities: BYTES
     - metadata:
         TYPENAME: Metadata
@@ -88,6 +86,14 @@ MetadataV1:
     - created_at: U64
     - received_at:
         OPTION: U64
+SignatureVerificationState:
+  ENUM:
+    0:
+      Unsigned:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 48
 VersionedMetadata:
   ENUM:
     0:

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -20,7 +20,7 @@ use storage::CertificateStore;
 use storage::NodeStorage;
 
 use consensus::consensus::ConsensusRound;
-use test_utils::{latest_protocol_version, temp_dir, CommitteeFixture};
+use test_utils::{get_protocol_config, latest_protocol_version, temp_dir, CommitteeFixture};
 use tokio::{
     sync::{
         mpsc::{self, error::TryRecvError, Receiver, Sender},
@@ -186,7 +186,7 @@ struct BadHeader {
 // TODO: Remove after network has moved to CertificateV2
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn fetch_certificates_v1_basic() {
-    let cert_v1_protocol_config = latest_protocol_version();
+    let cert_v1_protocol_config = get_protocol_config(28);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
@@ -475,8 +475,7 @@ async fn fetch_certificates_v1_basic() {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn fetch_certificates_v2_basic() {
-    let mut cert_v2_config = latest_protocol_version();
-    cert_v2_config.set_narwhal_certificate_v2(true);
+    let cert_v2_config = latest_protocol_version();
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let worker_cache = fixture.worker_cache();
     let primary = fixture.authorities().next().unwrap();
@@ -774,7 +773,7 @@ async fn fetch_certificates_v2_basic() {
     // Send out a batch of certificate V1s.
     let mut certs = Vec::new();
     for cert in certificates.iter().skip(num_written).take(204) {
-        certs.push(fixture.certificate(&latest_protocol_version(), cert.header()));
+        certs.push(fixture.certificate(&get_protocol_config(28), cert.header()));
     }
     tx_fetch_resp
         .try_send(FetchCertificatesResponse {

--- a/narwhal/primary/src/tests/certificate_tests.rs
+++ b/narwhal/primary/src/tests/certificate_tests.rs
@@ -11,7 +11,7 @@ use rand::{
     SeedableRng,
 };
 use std::num::NonZeroUsize;
-use test_utils::{latest_protocol_version, CommitteeFixture};
+use test_utils::{get_protocol_config, latest_protocol_version, CommitteeFixture};
 use types::{Certificate, CertificateAPI, SignatureVerificationState, Vote, VoteAPI};
 
 #[test]
@@ -40,7 +40,7 @@ fn test_empty_certificate_verification() {
 #[test]
 fn test_valid_certificate_v1_verification() {
     let fixture = CommitteeFixture::builder().build();
-    let cert_v1_protocol_config = latest_protocol_version();
+    let cert_v1_protocol_config = get_protocol_config(28);
     let committee = fixture.committee();
     let header = fixture.header(&cert_v1_protocol_config);
 
@@ -63,8 +63,7 @@ fn test_valid_certificate_v1_verification() {
 
 #[test]
 fn test_valid_certificate_v2_verification() {
-    let mut cert_v2_config = latest_protocol_version();
-    cert_v2_config.set_narwhal_certificate_v2(true);
+    let cert_v2_config = latest_protocol_version();
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
     let header = fixture.header(&cert_v2_config);

--- a/narwhal/primary/src/tests/certifier_tests.rs
+++ b/narwhal/primary/src/tests/certifier_tests.rs
@@ -13,8 +13,8 @@ use primary::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
 use rand::{rngs::StdRng, SeedableRng};
 use std::num::NonZeroUsize;
-use test_utils::latest_protocol_version;
 use test_utils::CommitteeFixture;
+use test_utils::{get_protocol_config, latest_protocol_version};
 use tokio::sync::watch;
 use tokio::time::Duration;
 use types::{
@@ -25,7 +25,7 @@ use types::{
 // TODO: Remove after network has moved to CertificateV2
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn propose_header_and_form_certificate_v1() {
-    let cert_v1_protocol_config = latest_protocol_version();
+    let cert_v1_protocol_config = get_protocol_config(28);
     telemetry_subscribers::init_for_testing();
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -144,8 +144,7 @@ async fn propose_header_and_form_certificate_v1() {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn propose_header_and_form_certificate_v2() {
     telemetry_subscribers::init_for_testing();
-    let mut cert_v2_config = latest_protocol_version();
-    cert_v2_config.set_narwhal_certificate_v2(true);
+    let cert_v2_config = latest_protocol_version();
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
     let worker_cache = fixture.worker_cache();

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -20,8 +20,8 @@ use std::{
     time::Duration,
 };
 use test_utils::{
-    latest_protocol_version, make_optimal_signed_certificates, mock_signed_certificate,
-    CommitteeFixture,
+    get_protocol_config, latest_protocol_version, make_optimal_signed_certificates,
+    mock_signed_certificate, CommitteeFixture,
 };
 use tokio::sync::watch;
 use types::{
@@ -826,7 +826,7 @@ async fn sync_batches_drops_old() {
 
 #[tokio::test]
 async fn gc_suspended_certificates_v1() {
-    let cert_v1_config = latest_protocol_version();
+    let cert_v1_config = get_protocol_config(28);
     const NUM_AUTHORITIES: usize = 4;
     const GC_DEPTH: Round = 5;
 
@@ -946,8 +946,7 @@ async fn gc_suspended_certificates_v1() {
 
 #[tokio::test]
 async fn gc_suspended_certificates_v2() {
-    let mut cert_v2_config = latest_protocol_version();
-    cert_v2_config.set_narwhal_certificate_v2(true);
+    let cert_v2_config = latest_protocol_version();
     const NUM_AUTHORITIES: usize = 4;
     const GC_DEPTH: Round = 5;
 


### PR DESCRIPTION
## Test Plan 

150 Validators @ 200 TPS w/ 2 Hour downtime : https://metrics.sui.io/goto/TQ6QueGSR?orgId=1
120 Validators @ 200 TPS w/ 2 Hour downtime:  https://metrics.sui.io/goto/nJ6PJgnSR?orgId=1

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Enable CertV2 for faster NW Catchup in Devnet