### PR TITLE
[graphql][fix] object use object_id as cursor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,6 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      PG_DB_URL: ${{ secrets.INDEXER_V2_TEST_DB_URL }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -629,7 +629,9 @@ impl PgManager {
     }
 
     pub(crate) fn parse_obj_cursor(&self, cursor: &str) -> Result<Vec<u8>, Error> {
-        Ok(Digest::from_str(cursor)?.into_vec())
+        Ok(SuiAddress::from_str(cursor)
+            .map_err(|e| Error::InvalidCursor(e.to_string()))?
+            .into_vec())
     }
 
     pub(crate) fn parse_checkpoint_cursor(&self, cursor: &str) -> Result<i64, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -277,13 +277,13 @@ impl PgManager {
         if let Some(after) = after {
             let after = self.parse_obj_cursor(&after)?;
             query = query
-                .filter(objects::dsl::checkpoint_sequence_number.gt(after))
-                .order(objects::dsl::checkpoint_sequence_number.asc());
+                .filter(objects::dsl::object_id.gt(after))
+                .order(objects::dsl::object_id.asc());
         } else if let Some(before) = before {
             let before = self.parse_obj_cursor(&before)?;
             query = query
-                .filter(objects::dsl::checkpoint_sequence_number.lt(before))
-                .order(objects::dsl::checkpoint_sequence_number.desc());
+                .filter(objects::dsl::object_id.lt(before))
+                .order(objects::dsl::object_id.desc());
         }
 
         let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
@@ -530,7 +530,7 @@ impl PgManager {
                 .filter(checkpoints::dsl::sequence_number.gt(after))
                 .order(checkpoints::dsl::sequence_number.asc());
         } else if let Some(before) = before {
-            let before = self.parse_obj_cursor(&before)?;
+            let before = self.parse_checkpoint_cursor(&before)?;
             query = query
                 .filter(checkpoints::dsl::sequence_number.lt(before))
                 .order(checkpoints::dsl::sequence_number.desc());
@@ -591,13 +591,13 @@ impl PgManager {
         if let Some(after) = after {
             let after = self.parse_obj_cursor(&after)?;
             query = query
-                .filter(objects::dsl::checkpoint_sequence_number.gt(after))
-                .order(objects::dsl::checkpoint_sequence_number.asc());
+                .filter(objects::dsl::object_id.gt(after))
+                .order(objects::dsl::object_id.asc());
         } else if let Some(before) = before {
             let before = self.parse_obj_cursor(&before)?;
             query = query
-                .filter(objects::dsl::checkpoint_sequence_number.lt(before))
-                .order(objects::dsl::checkpoint_sequence_number.desc());
+                .filter(objects::dsl::object_id.lt(before))
+                .order(objects::dsl::object_id.desc());
         }
 
         let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
@@ -628,11 +628,8 @@ impl PgManager {
         Ok(tx_sequence_number)
     }
 
-    pub(crate) fn parse_obj_cursor(&self, cursor: &str) -> Result<i64, Error> {
-        let checkpoint_sequence_number = cursor
-            .parse::<i64>()
-            .map_err(|_| Error::InvalidCursor("obj".to_string()))?;
-        Ok(checkpoint_sequence_number)
+    pub(crate) fn parse_obj_cursor(&self, cursor: &str) -> Result<Vec<u8>, Error> {
+        Ok(Digest::from_str(cursor)?.into_vec())
     }
 
     pub(crate) fn parse_checkpoint_cursor(&self, cursor: &str) -> Result<i64, Error> {
@@ -956,11 +953,10 @@ impl PgManager {
             connection
                 .edges
                 .extend(stored_objs.into_iter().filter_map(|stored_obj| {
-                    let cursor = stored_obj.checkpoint_sequence_number.to_string();
                     Object::try_from(stored_obj)
                         .map_err(|e| eprintln!("Error converting object: {:?}", e))
                         .ok()
-                        .map(|obj| Edge::new(cursor, obj))
+                        .map(|obj| Edge::new(obj.address.to_string(), obj))
                 }));
             Ok(Some(connection))
         } else {
@@ -1084,11 +1080,10 @@ impl PgManager {
             connection
                 .edges
                 .extend(stored_objs.into_iter().filter_map(|stored_obj| {
-                    let cursor = stored_obj.checkpoint_sequence_number.to_string();
                     Coin::try_from(stored_obj)
                         .map_err(|e| eprintln!("Error converting object to coin: {:?}", e))
                         .ok()
-                        .map(|obj| Edge::new(cursor, obj))
+                        .map(|coin| Edge::new(coin.id.to_string(), coin))
                 }));
             Ok(Some(connection))
         } else {


### PR DESCRIPTION
## Description 

I will obfuscate this further, but wanted to address the glaring error of using checkpoint_sequence_number as a cursor for objects

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
