### PR TITLE
[graphql/rpc] add id to stake

### DIFF
--- a/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -1,19 +1,30 @@
-{
+query stake_connection {
   address(
-    address: "0x5f63d0b78e14d054568564c34023cde0f862271d587df7bd308b1aa7c46b8940"
+    address: "0x341fa71e4e58d63668034125c3152f935b00b0bb5c68069045d8c646d017fae1"
   ) {
-    balanceConnection {
-      edges {
-        node {
-          coinType
-          totalBalance
-        }
-      }
+    location
+    balance(type: "0x2::sui::SUI") {
+      coinType
+      totalBalance
     }
     stakeConnection {
-      edges {
-        node {
-          status
+      nodes {
+        status
+        principal
+        activeEpoch {
+          epochId
+          referenceGasPrice
+          validatorSet {
+            activeValidators {
+              name
+              description
+              exchangeRatesSize
+            }
+            totalStake
+          }
+        }
+        requestEpoch {
+          epochId
         }
       }
     }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -637,6 +637,7 @@ type ServiceConfig {
 }
 
 type Stake {
+	id: ID!
 	estimatedReward: BigInt
 	principal: BigInt
 	status: StakeStatus

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1256,6 +1256,7 @@ impl PgManager {
                     StakeStatus::Pending
                 };
                 let stake = Stake {
+                    id: ID(stake_object.id().to_string()),
                     active_epoch_id: Some(stake_object.activation_epoch()),
                     estimated_reward: None, // TODO once we have a good working governance API, we should fix this
                     principal: Some(BigInt::from(stake_object.principal())),

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -89,6 +89,7 @@ impl MoveObject {
             StakeStatus::Pending
         };
         Ok(Some(Stake {
+            id: ID(stake.id().to_string()),
             active_epoch_id: Some(stake.activation_epoch()),
             estimated_reward: None,
             principal: Some(BigInt::from(stake.principal())),

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -17,6 +17,7 @@ pub(crate) enum StakeStatus {
 #[derive(Clone, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct Stake {
+    pub id: ID,
     #[graphql(skip)]
     pub active_epoch_id: Option<u64>,
     pub estimated_reward: Option<BigInt>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -641,6 +641,7 @@ type ServiceConfig {
 }
 
 type Stake {
+	id: ID!
 	estimatedReward: BigInt
 	principal: BigInt
 	status: StakeStatus


### PR DESCRIPTION
## Description 

This PR adds an ID field for the Stake object.

## Test Plan 

Manually through queries.
<img width="1728" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/e1016a90-8518-439f-bd4e-e6678d682457">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
