### PR TITLE
[graphql][fix] missing type tag on MoveObject.contents resolver

### DIFF
--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -27,8 +27,9 @@ impl MoveObject {
         let resolver = ctx.data_unchecked::<PgManager>();
 
         if let Some(struct_tag) = self.native_object.data.struct_tag() {
+            let type_tag = TypeTag::Struct(Box::new(struct_tag));
             let type_layout = resolver
-                .build_with_types_in_blocking_task(TypeTag::Struct(Box::new(struct_tag)))
+                .build_with_types_in_blocking_task(type_tag.clone())
                 .await
                 .extend()?;
 


### PR DESCRIPTION
## Description 

Not sure how this passed, but MoveValue needs type_tag, which is not instantiated on resolver for Moveobject.contents

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
