### PR TITLE
[cli/keytool - easy] don't serialize mnemonic if it's empty

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -249,6 +249,7 @@ pub struct Key {
     public_base64_key: String,
     key_scheme: String,
     flag: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mnemonic: Option<String>,
     peer_id: Option<String>,
 }


### PR DESCRIPTION
## Description 

The `keytool list` does not show the mnemonic for obvious reasons, but the field appears empty for every keypair. Therefore, this field should not be serialized and shown. 

## Test Plan 
*Before*
<img width="910" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/d575990e-9983-49de-bdc7-d65e1dc03283">

*After*
<img width="910" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/248aee5f-4eda-459e-8880-7a817212587b">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The `keytool list` does not show the mnemonic for obvious reasons, but the field appears empty for every keypair. Therefore, this field should not be serialized and shown. 