### PR TITLE
[data-sim/graphql testing] easy: add trait for sim store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9479,6 +9479,7 @@ name = "simulacrum"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "fastcrypto",
  "move-binary-format",

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 bcs.workspace = true
 fastcrypto.workspace = true
 move-binary-format.workspace = true

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -35,8 +35,8 @@ use sui_types::{
 };
 
 use self::epoch_state::EpochState;
-pub use self::store::InMemoryStore;
 use self::store::KeyStore;
+pub use self::store::{InMemoryStore, SimulatorStore};
 use sui_types::mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider};
 
 mod epoch_state;
@@ -51,12 +51,12 @@ mod store;
 /// See [module level][mod] documentation for more details.
 ///
 /// [mod]: index.html
-pub struct Simulacrum<R = OsRng> {
+pub struct Simulacrum<R = OsRng, Store: SimulatorStore = InMemoryStore> {
     rng: R,
     keystore: KeyStore,
     #[allow(unused)]
     genesis: genesis::Genesis,
-    store: InMemoryStore,
+    store: Store,
     checkpoint_builder: MockCheckpointBuilder,
 
     // Epoch specific data

--- a/crates/simulacrum/src/store.rs
+++ b/crates/simulacrum/src/store.rs
@@ -409,3 +409,194 @@ impl KeyStore {
         self.account_keys.iter()
     }
 }
+
+#[async_trait::async_trait]
+pub trait SimulatorStore:
+    sui_types::storage::BackingPackageStore
+    + sui_types::storage::ObjectStore
+    + sui_types::storage::ReceivedMarkerQuery
+{
+    async fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<&VerifiedCheckpoint>;
+
+    async fn get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Option<&VerifiedCheckpoint>;
+
+    async fn get_highest_checkpint(&self) -> Option<&VerifiedCheckpoint>;
+    async fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<&CheckpointContents>;
+
+    async fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee>;
+
+    async fn get_transaction(&self, digest: &TransactionDigest) -> Option<&VerifiedTransaction>;
+
+    async fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<&TransactionEffects>;
+    async fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Option<&TransactionEvents>;
+
+    async fn get_object(&self, id: &ObjectID) -> Option<&Object>;
+    async fn get_object_at_version(
+        &self,
+        id: &ObjectID,
+        version: SequenceNumber,
+    ) -> Option<&Object>;
+
+    async fn get_system_state(&self) -> sui_types::sui_system_state::SuiSystemState;
+
+    async fn get_clock(&self) -> sui_types::clock::Clock;
+
+    async fn owned_objects(&self, owner: SuiAddress) -> Box<dyn Iterator<Item = &Object> + '_>;
+
+    async fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint);
+
+    async fn insert_checkpoint_contents(&mut self, contents: CheckpointContents);
+
+    async fn insert_committee(&mut self, committee: Committee);
+
+    async fn insert_executed_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        written_objects: BTreeMap<ObjectID, Object>,
+    );
+
+    async fn insert_transaction(&mut self, transaction: VerifiedTransaction);
+
+    async fn insert_transaction_effects(&mut self, effects: TransactionEffects);
+
+    async fn insert_events(&mut self, events: TransactionEvents);
+
+    async fn update_objects(
+        &mut self,
+        written_objects: BTreeMap<ObjectID, Object>,
+        deleted_objects: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    );
+}
+
+#[async_trait::async_trait]
+impl SimulatorStore for InMemoryStore {
+    async fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.get_checkpoint_by_sequence_number(sequence_number)
+    }
+
+    async fn get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.get_checkpoint_by_digest(digest)
+    }
+
+    async fn get_highest_checkpint(&self) -> Option<&VerifiedCheckpoint> {
+        self.get_highest_checkpint()
+    }
+
+    async fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<&CheckpointContents> {
+        self.get_checkpoint_contents(digest)
+    }
+
+    async fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee> {
+        self.get_committee_by_epoch(epoch)
+    }
+
+    async fn get_transaction(&self, digest: &TransactionDigest) -> Option<&VerifiedTransaction> {
+        self.get_transaction(digest)
+    }
+
+    async fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<&TransactionEffects> {
+        self.get_transaction_effects(digest)
+    }
+
+    async fn get_transaction_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Option<&TransactionEvents> {
+        self.get_transaction_events(digest)
+    }
+
+    async fn get_object(&self, id: &ObjectID) -> Option<&Object> {
+        self.get_object(id)
+    }
+
+    async fn get_object_at_version(
+        &self,
+        id: &ObjectID,
+        version: SequenceNumber,
+    ) -> Option<&Object> {
+        self.get_object_at_version(id, version)
+    }
+
+    async fn get_system_state(&self) -> sui_types::sui_system_state::SuiSystemState {
+        self.get_system_state()
+    }
+
+    async fn get_clock(&self) -> sui_types::clock::Clock {
+        self.get_clock()
+    }
+
+    async fn owned_objects(&self, owner: SuiAddress) -> Box<dyn Iterator<Item = &Object> + '_> {
+        Box::new(self.owned_objects(owner))
+    }
+
+    async fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        self.insert_checkpoint(checkpoint)
+    }
+
+    async fn insert_checkpoint_contents(&mut self, contents: CheckpointContents) {
+        self.insert_checkpoint_contents(contents)
+    }
+
+    async fn insert_committee(&mut self, committee: Committee) {
+        self.insert_committee(committee)
+    }
+
+    async fn insert_executed_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        written_objects: BTreeMap<ObjectID, Object>,
+    ) {
+        self.insert_executed_transaction(transaction, effects, events, written_objects)
+    }
+
+    async fn insert_transaction(&mut self, transaction: VerifiedTransaction) {
+        self.insert_transaction(transaction)
+    }
+
+    async fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
+        self.insert_transaction_effects(effects)
+    }
+
+    async fn insert_events(&mut self, events: TransactionEvents) {
+        self.insert_events(events)
+    }
+
+    async fn update_objects(
+        &mut self,
+        written_objects: BTreeMap<ObjectID, Object>,
+        deleted_objects: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    ) {
+        self.update_objects(written_objects, deleted_objects)
+    }
+}


### PR DESCRIPTION
## Description 

Just puts the sim store behind a trait so we can use persisted store (in upcoming PR) and other stores.


## Test Plan 

Manual, existing.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
