### PR TITLE
[docs] fix typo in dapp-kit docs (createNetworkConfig vs. createNetworkConfigs)

### DIFF
--- a/sdk/dapp-kit/README.md
+++ b/sdk/dapp-kit/README.md
@@ -34,12 +34,12 @@ providers. The props available on the providers are covered in more detail in th
 pages.
 
 ```tsx
-import { createNetworkConfigs, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { type SuiClientOptions } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to
-const { networkConfig } = createNetworkConfigs({
+const { networkConfig } = createNetworkConfig({
 	localnet: { url: getFullnodeUrl('localnet') },
 	mainnet: { url: getFullnodeUrl('mainnet') },
 });

--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -32,12 +32,12 @@ providers. The props available on the providers are covered in more detail in th
 pages.
 
 ```tsx
-import { createNetworkConfigs, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { type SuiClientOptions } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to
-const { networkConfig } = createNetworkConfigs({
+const { networkConfig } = createNetworkConfig({
 	localnet: { url: getFullnodeUrl('localnet') },
 	mainnet: { url: getFullnodeUrl('mainnet') },
 });

--- a/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
+++ b/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
@@ -11,7 +11,7 @@ It accepts a list of network configs, which will be used to create `SuiClient` i
 currently active network.
 
 ```tsx
-import { createNetworkConfigs, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { type SuiClientOptions } from '@mysten/sui.js/client';
 
 // Config options for the networks you want to connect to
@@ -45,12 +45,12 @@ function App() {
 ## Using the SuiClientProvider as a controlled component
 
 ```tsx
-import { createNetworkConfigs, SuiClientProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider } from '@mysten/dapp-kit';
 import { type SuiClientOptions } from '@mysten/sui.js/client';
 import { useState } from 'react';
 
 // Config options for the networks you want to connect to
-const { networkConfig } = createNetworkConfigs({
+const { networkConfig } = createNetworkConfig({
 	localnet: { url: getFullnodeUrl('localnet') },
 	mainnet: { url: getFullnodeUrl('mainnet') },
 });
@@ -144,25 +144,25 @@ function NetworkSelector() {
 ## Using network specific configuration
 
 If your dApp runs on multiple networks, the IDs for packages, and potentially other configuration
-will change depending on which network is being used. You can use `createNetworkConfigs` to create
+will change depending on which network is being used. You can use `createNetworkConfig` to create
 per-network config which can be accessed from your components.
 
-the `createNetworkConfigs` function returns the provided config, along a few hooks you can use to
-get access the variables defined in your config.
+the `createNetworkConfig` function returns the provided config, along a few hooks you can use to get
+access the variables defined in your config.
 
 - `useNetworkConfig` returns the full network config object
 - `useNetworkVariables` returns the full variables object from the network config
 - `useNetworkVariable` returns a specific variable from the network config
 
 ```tsx
-import { createNetworkConfigs, SuiClientProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider } from '@mysten/dapp-kit';
 
-import { createNetworkConfigs, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
+import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { type SuiClientOptions } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to
-const { networkConfig, useNetworkVariable } = createNetworkConfigs({
+const { networkConfig, useNetworkVariable } = createNetworkConfig({
 	localnet: {
 		url: getFullnodeUrl('localnet'),
 		variables: {


### PR DESCRIPTION
## Description 

I noticed a tiny typo while reading the dapp-kit docs, the actual function is called `createNetworkConfig` and not `createNetworkConfigs` 😄 

## Test Plan 
- Eyes

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
