### PR TITLE
[move][lints] warn on uneeded return

### DIFF
--- a/external-crates/move/crates/move-compiler/src/linters/constant_naming.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/constant_naming.rs
@@ -6,11 +6,9 @@
 //! within a module against this convention.
 use crate::{
     diag,
-    diagnostics::{
-        codes::{custom, DiagnosticInfo, Severity},
-        WarningFilters,
-    },
+    diagnostics::{codes::DiagnosticInfo, WarningFilters},
     expansion::ast::ModuleIdent,
+    linters::StyleCodes,
     parser::ast::ConstantName,
     shared::CompilationEnv,
     typing::{
@@ -19,16 +17,8 @@ use crate::{
     },
 };
 
-use super::{LinterDiagnosticCategory, CONSTANT_NAMING_DIAG_CODE, LINT_WARNING_PREFIX};
-
 /// Diagnostic information for constant naming violations.
-const CONSTANT_NAMING_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Style as u8,
-    CONSTANT_NAMING_DIAG_CODE,
-    "constant should follow naming convention",
-);
+const CONSTANT_NAMING_DIAG: DiagnosticInfo = StyleCodes::ConstantNaming.diag_info();
 
 pub struct ConstantNamingVisitor;
 pub struct Context<'a> {

--- a/external-crates/move/crates/move-compiler/src/linters/constant_naming.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/constant_naming.rs
@@ -6,7 +6,7 @@
 //! within a module against this convention.
 use crate::{
     diag,
-    diagnostics::{codes::DiagnosticInfo, WarningFilters},
+    diagnostics::WarningFilters,
     expansion::ast::ModuleIdent,
     linters::StyleCodes,
     parser::ast::ConstantName,
@@ -16,9 +16,6 @@ use crate::{
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
 };
-
-/// Diagnostic information for constant naming violations.
-const CONSTANT_NAMING_DIAG: DiagnosticInfo = StyleCodes::ConstantNaming.diag_info();
 
 pub struct ConstantNamingVisitor;
 pub struct Context<'a> {
@@ -43,7 +40,7 @@ impl TypingVisitorContext for Context<'_> {
         if !is_valid_name(name) {
             let uid_msg =
                 format!("'{name}' should be ALL_CAPS. Or for error constants, use PascalCase",);
-            let diagnostic = diag!(CONSTANT_NAMING_DIAG, (cdef.loc, uid_msg));
+            let diagnostic = diag!(StyleCodes::ConstantNaming.diag_info(), (cdef.loc, uid_msg));
             self.env.add_diag(diagnostic);
         }
         false

--- a/external-crates/move/crates/move-compiler/src/linters/meaningless_math_operation.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/meaningless_math_operation.rs
@@ -7,26 +7,14 @@ use crate::{
     cfgir::ast as G,
     cfgir::visitor::{CFGIRVisitorConstructor, CFGIRVisitorContext},
     diag,
-    diagnostics::{
-        codes::{custom, DiagnosticInfo, Severity},
-        WarningFilters,
-    },
+    diagnostics::WarningFilters,
     hlir::ast::{self as H, Value_},
+    linters::StyleCodes,
     parser::ast::BinOp_,
     shared::CompilationEnv,
 };
 use move_core_types::u256::U256;
 use move_ir_types::location::Loc;
-
-use super::{LinterDiagnosticCategory, LINT_WARNING_PREFIX, MEANINGLESS_MATH_DIAG_CODE};
-
-const MEANINGLESS_MATH_OP_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Complexity as u8,
-    MEANINGLESS_MATH_DIAG_CODE,
-    "math operation can be simplified",
-);
 
 pub struct MeaninglessMathOperation;
 
@@ -67,7 +55,7 @@ impl CFGIRVisitorContext for Context<'_> {
         if let Some(meaningless_operand) = is_unchanged {
             let msg = "This operation has no effect and can be removed";
             self.env.add_diag(diag!(
-                MEANINGLESS_MATH_OP_DIAG,
+                StyleCodes::MeaninglessMath.diag_info(),
                 (exp.exp.loc, msg),
                 (meaningless_operand, "Because of this operand"),
             ));
@@ -83,7 +71,7 @@ impl CFGIRVisitorContext for Context<'_> {
         if let Some(zero_operand) = is_always_zero {
             let msg = "This operation is always zero and can be replaced with '0'";
             self.env.add_diag(diag!(
-                MEANINGLESS_MATH_OP_DIAG,
+                StyleCodes::MeaninglessMath.diag_info(),
                 (exp.exp.loc, msg),
                 (zero_operand, "Because of this operand"),
             ));
@@ -97,7 +85,7 @@ impl CFGIRVisitorContext for Context<'_> {
         if let Some(one_operand) = is_always_one {
             let msg = "This operation is always one and can be replaced with '1'";
             self.env.add_diag(diag!(
-                MEANINGLESS_MATH_OP_DIAG,
+                StyleCodes::MeaninglessMath.diag_info(),
                 (exp.exp.loc, msg),
                 (one_operand, "Because of this operand"),
             ));

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -4,12 +4,17 @@
 use move_symbol_pool::Symbol;
 
 use crate::{
-    cfgir::visitor::CFGIRVisitor, command_line::compiler::Visitor,
-    diagnostics::codes::WarningFilter, typing::visitor::TypingVisitor,
+    cfgir::visitor::CFGIRVisitor,
+    command_line::compiler::Visitor,
+    diagnostics::codes::WarningFilter,
+    diagnostics::codes::{custom, DiagnosticInfo, Severity},
+    typing::visitor::TypingVisitor,
 };
-pub mod constant_naming;
-pub mod meaningless_math_operation;
+
+mod constant_naming;
+mod meaningless_math_operation;
 mod unnecessary_while_loop;
+mod unneeded_return;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LintLevel {
@@ -32,38 +37,107 @@ pub enum LinterDiagnosticCategory {
     Sui = 99,
 }
 
+macro_rules! lints {
+    (
+        $(
+            ($enum_name:ident, $category:expr, $filter_name:expr, $code_msg:expr)
+        ),* $(,)?
+    ) => {
+        #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
+        #[repr(u8)]
+        pub enum StyleCodes {
+            DontStartAtZeroPlaceholder,
+            $(
+                $enum_name,
+            )*
+        }
+
+        impl StyleCodes {
+            const fn category_code_and_message(&self) -> (u8, u8, &'static str) {
+                let code = *self as u8;
+                debug_assert!(code > 0);
+                match self {
+                    Self::DontStartAtZeroPlaceholder =>
+                        panic!("ICE do not use placeholder error code"),
+                    $(Self::$enum_name => ($category as u8, code, $code_msg),)*
+                }
+            }
+
+            const fn category_code_and_filter_name(&self) -> (u8, u8, &'static str) {
+                let code = *self as u8;
+                debug_assert!(code > 0);
+                match self {
+                    Self::DontStartAtZeroPlaceholder =>
+                        panic!("ICE do not use placeholder error code"),
+                    $(Self::$enum_name => ($category as u8, code, $filter_name),)*
+                }
+            }
+
+            const fn diag_info(&self) -> DiagnosticInfo {
+                let (category, code, msg) = self.category_code_and_message();
+                custom(
+                    LINT_WARNING_PREFIX,
+                    Severity::Warning,
+                    category,
+                    code,
+                    msg,
+                )
+            }
+        }
+
+        const STYLE_WARNING_FILTERS: &[(u8, u8, &str)] = &[
+            $(
+                StyleCodes::$enum_name.category_code_and_filter_name(),
+            )*
+        ];
+    }
+}
+
+// Example usage:
+lints!(
+    (
+        ConstantNaming,
+        LinterDiagnosticCategory::Style,
+        "constant_naming",
+        "constant should follow naming convention"
+    ),
+    (
+        WhileTrueToLoop,
+        LinterDiagnosticCategory::Complexity,
+        "while_true",
+        "unnecessary 'while (true)', replace with 'loop'"
+    ),
+    (
+        MeaninglessMath,
+        LinterDiagnosticCategory::Complexity,
+        "unnecessary_math",
+        "math operator can be simplified"
+    ),
+    (
+        UnneededReturn,
+        LinterDiagnosticCategory::Style,
+        "unneeded_return",
+        "unneeded return"
+    ),
+);
+
 pub const ALLOW_ATTR_CATEGORY: &str = "lint";
 pub const LINT_WARNING_PREFIX: &str = "Lint ";
-pub const CONSTANT_NAMING_FILTER_NAME: &str = "constant_naming";
-pub const CONSTANT_NAMING_DIAG_CODE: u8 = 1;
-pub const WHILE_TRUE_TO_LOOP_FILTER_NAME: &str = "while_true";
-pub const WHILE_TRUE_TO_LOOP_DIAG_CODE: u8 = 4;
-pub const MEANINGLESS_MATH_FILTER_NAME: &str = "unnecessary_math";
-pub const MEANINGLESS_MATH_DIAG_CODE: u8 = 8;
 
 pub fn known_filters() -> (Option<Symbol>, Vec<WarningFilter>) {
     (
         Some(ALLOW_ATTR_CATEGORY.into()),
-        vec![
-            WarningFilter::code(
-                Some(LINT_WARNING_PREFIX),
-                LinterDiagnosticCategory::Style as u8,
-                CONSTANT_NAMING_DIAG_CODE,
-                Some(CONSTANT_NAMING_FILTER_NAME),
-            ),
-            WarningFilter::code(
-                Some(LINT_WARNING_PREFIX),
-                LinterDiagnosticCategory::Complexity as u8,
-                WHILE_TRUE_TO_LOOP_DIAG_CODE,
-                Some(WHILE_TRUE_TO_LOOP_FILTER_NAME),
-            ),
-            WarningFilter::code(
-                Some(LINT_WARNING_PREFIX),
-                LinterDiagnosticCategory::Complexity as u8,
-                MEANINGLESS_MATH_DIAG_CODE,
-                Some(MEANINGLESS_MATH_FILTER_NAME),
-            ),
-        ],
+        STYLE_WARNING_FILTERS
+            .iter()
+            .map(|(category, code, filter_name)| {
+                WarningFilter::code(
+                    Some(LINT_WARNING_PREFIX),
+                    *category,
+                    *code,
+                    Some(filter_name),
+                )
+            })
+            .collect(),
     )
 }
 
@@ -75,6 +149,7 @@ pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {
                 constant_naming::ConstantNamingVisitor.visitor(),
                 unnecessary_while_loop::WhileTrueToLoop.visitor(),
                 meaningless_math_operation::MeaninglessMathOperation.visitor(),
+                unneeded_return::UnneededReturnVisitor.visitor(),
             ]
         }
     }

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -93,7 +93,6 @@ macro_rules! lints {
     }
 }
 
-// Example usage:
 lints!(
     (
         ConstantNaming,

--- a/external-crates/move/crates/move-compiler/src/linters/unnecessary_while_loop.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unnecessary_while_loop.rs
@@ -3,27 +3,15 @@
 //! Aims to enhance code readability and adherence to Rust idioms.
 use crate::{
     diag,
-    diagnostics::{
-        codes::{custom, DiagnosticInfo, Severity},
-        WarningFilters,
-    },
+    diagnostics::WarningFilters,
     expansion::ast::Value_,
+    linters::StyleCodes,
     shared::CompilationEnv,
     typing::{
         ast::{self as T, UnannotatedExp_},
         visitor::{TypingVisitorConstructor, TypingVisitorContext},
     },
 };
-
-use super::{LinterDiagnosticCategory, LINT_WARNING_PREFIX, WHILE_TRUE_TO_LOOP_DIAG_CODE};
-
-const WHILE_TRUE_TO_LOOP_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Complexity as u8,
-    WHILE_TRUE_TO_LOOP_DIAG_CODE,
-    "unnecessary 'while (true)', replace with 'loop'",
-);
 
 pub struct WhileTrueToLoop;
 
@@ -56,7 +44,7 @@ impl TypingVisitorContext for Context<'_> {
         };
 
         let msg = "'while (true)' can be always replaced with 'loop'";
-        let mut diag = diag!(WHILE_TRUE_TO_LOOP_DIAG, (exp.exp.loc, msg));
+        let mut diag = diag!(StyleCodes::WhileTrueToLoop.diag_info(), (exp.exp.loc, msg));
         diag.add_note(
             "A 'loop' is more useful in these cases. Unlike 'while', 'loop' can have a \
             'break' with a value, e.g. 'let x = loop { break 42 };'",

--- a/external-crates/move/crates/move-compiler/src/linters/unneeded_return.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unneeded_return.rs
@@ -1,0 +1,219 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `UnneededReturnVisitor` enforces that users don't write `return <exp>` where `<exp>` is a
+//! value-like thing.
+
+use crate::{
+    diag,
+    diagnostics::WarningFilters,
+    expansion::ast::ModuleIdent,
+    linters::StyleCodes,
+    parser::ast::FunctionName,
+    shared::CompilationEnv,
+    typing::{
+        ast as T,
+        visitor::{TypingVisitorConstructor, TypingVisitorContext},
+    },
+};
+
+use move_ir_types::location::Loc;
+use move_proc_macros::growing_stack;
+
+use std::collections::VecDeque;
+
+pub struct UnneededReturnVisitor;
+
+pub struct Context<'a> {
+    env: &'a mut CompilationEnv,
+}
+
+impl TypingVisitorConstructor for UnneededReturnVisitor {
+    type Context<'a> = Context<'a>;
+
+    fn context<'a>(env: &'a mut CompilationEnv, _program: &T::Program) -> Self::Context<'a> {
+        Context { env }
+    }
+}
+
+impl TypingVisitorContext for Context<'_> {
+    fn visit_function_custom(
+        &mut self,
+        _module: ModuleIdent,
+        _function_name: FunctionName,
+        fdef: &mut T::Function,
+    ) -> bool {
+        if let T::FunctionBody_::Defined((_, seq)) = &mut fdef.body.value {
+            tail_block(self, seq);
+        };
+        true
+    }
+
+    fn add_warning_filter_scope(&mut self, filter: WarningFilters) {
+        self.env.add_warning_filter_scope(filter)
+    }
+
+    fn pop_warning_filter_scope(&mut self) {
+        self.env.pop_warning_filter_scope()
+    }
+}
+
+/// Recur down the tail (last) position of the sequence, looking for returns that
+/// might occur in the function's taul/return position..
+#[growing_stack]
+fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) {
+    let Some(last) = seq.back() else { return };
+    match &last.value {
+        T::SequenceItem_::Seq(exp) => tail(context, exp),
+        // These don't make sense and shouldn't occur, but are irrelevant to us.
+        T::SequenceItem_::Declare(_) | T::SequenceItem_::Bind(_, _, _) => (),
+    }
+}
+
+/// Recur down the tail (last) position of each expression, looking for returns that
+/// might occur in the function's taul/return position.
+#[growing_stack]
+fn tail(context: &mut Context, exp: &T::Exp) {
+    match &exp.exp.value {
+        T::UnannotatedExp_::IfElse(_, conseq, alt) => {
+            tail(context, conseq);
+            tail(context, alt);
+        }
+        T::UnannotatedExp_::Match(_, arms) => {
+            for arm in &arms.value {
+                tail(context, &arm.value.rhs);
+            }
+        }
+        T::UnannotatedExp_::VariantMatch(_, _, arms) => {
+            for (_, rhs) in arms {
+                tail(context, rhs);
+            }
+        }
+        T::UnannotatedExp_::NamedBlock(_, (_, seq)) => {
+            tail_block(context, seq);
+        }
+        T::UnannotatedExp_::Block((_, seq)) => {
+            tail_block(context, seq);
+        }
+        T::UnannotatedExp_::Return(rhs) => {
+            if returnable_value(context, rhs) {
+                report_unneeded_return(context, exp.exp.loc);
+            }
+        }
+
+        // These cases we don't care about, because they are:
+        // - loops
+        // - effects
+        // - values already
+        T::UnannotatedExp_::Builtin(_, _)
+        | T::UnannotatedExp_::Vector(_, _, _, _)
+        | T::UnannotatedExp_::While(_, _, _)
+        | T::UnannotatedExp_::Loop { .. }
+        | T::UnannotatedExp_::Assign(_, _, _)
+        | T::UnannotatedExp_::Mutate(_, _)
+        | T::UnannotatedExp_::Abort(_)
+        | T::UnannotatedExp_::Give(_, _)
+        | T::UnannotatedExp_::Continue(_)
+        | T::UnannotatedExp_::Unit { .. }
+        | T::UnannotatedExp_::Value(_)
+        | T::UnannotatedExp_::Move { .. }
+        | T::UnannotatedExp_::Copy { .. }
+        | T::UnannotatedExp_::Use(_)
+        | T::UnannotatedExp_::Constant(_, _)
+        | T::UnannotatedExp_::ModuleCall(_)
+        | T::UnannotatedExp_::Dereference(_)
+        | T::UnannotatedExp_::UnaryExp(_, _)
+        | T::UnannotatedExp_::BinopExp(_, _, _, _)
+        | T::UnannotatedExp_::Pack(_, _, _, _)
+        | T::UnannotatedExp_::PackVariant(_, _, _, _, _)
+        | T::UnannotatedExp_::ExpList(_)
+        | T::UnannotatedExp_::Borrow(_, _, _)
+        | T::UnannotatedExp_::TempBorrow(_, _)
+        | T::UnannotatedExp_::BorrowLocal(_, _)
+        | T::UnannotatedExp_::Cast(_, _)
+        | T::UnannotatedExp_::Annotate(_, _)
+        | T::UnannotatedExp_::ErrorConstant { .. }
+        | T::UnannotatedExp_::UnresolvedError => (),
+    }
+}
+
+/// Indicates if the expression is "value"-like, in that it produces a value. This is just to
+/// reduce noise for the lint, because things like `return loop { abort 0 }` is technically an
+/// unnecessary return, but we don't need to complain about weird code like that.
+#[growing_stack]
+fn returnable_value(context: &mut Context, exp: &T::Exp) -> bool {
+    match &exp.exp.value {
+        T::UnannotatedExp_::Return(rhs) => {
+            if returnable_value(context, rhs) {
+                report_unneeded_return(context, exp.exp.loc);
+            };
+            false
+        }
+
+        T::UnannotatedExp_::BinopExp(lhs, _, _, rhs) => {
+            returnable_value(context, lhs) && returnable_value(context, rhs)
+        }
+        T::UnannotatedExp_::ExpList(values) => values.iter().all(|v| match v {
+            T::ExpListItem::Single(exp, _) => returnable_value(context, exp),
+            T::ExpListItem::Splat(_, _, _) => false,
+        }),
+        T::UnannotatedExp_::Borrow(_, exp, _)
+        | T::UnannotatedExp_::Dereference(exp)
+        | T::UnannotatedExp_::UnaryExp(_, exp)
+        | T::UnannotatedExp_::TempBorrow(_, exp)
+        | T::UnannotatedExp_::Cast(exp, _)
+        | T::UnannotatedExp_::Annotate(exp, _) => returnable_value(context, exp),
+
+        T::UnannotatedExp_::Pack(_, _, _, _)
+        | T::UnannotatedExp_::PackVariant(_, _, _, _, _)
+        | T::UnannotatedExp_::Unit { .. }
+        | T::UnannotatedExp_::Value(_)
+        | T::UnannotatedExp_::Move { .. }
+        | T::UnannotatedExp_::Copy { .. }
+        | T::UnannotatedExp_::Use(_)
+        | T::UnannotatedExp_::Constant(_, _)
+        | T::UnannotatedExp_::ModuleCall(_)
+        | T::UnannotatedExp_::Builtin(_, _)
+        | T::UnannotatedExp_::BorrowLocal(_, _)
+        | T::UnannotatedExp_::ErrorConstant { .. }
+        | T::UnannotatedExp_::Vector(_, _, _, _) => true,
+
+        T::UnannotatedExp_::IfElse(_, _, _)
+        | T::UnannotatedExp_::Match(_, _)
+        | T::UnannotatedExp_::VariantMatch(_, _, _) => true,
+
+        // While loops can't yield values, so there should already be other errors.
+        T::UnannotatedExp_::While(_, _, _) => false,
+
+        // Non-while loops _can_ yield values, and should never appear after a return if the
+        // value is intended.
+        T::UnannotatedExp_::Loop { .. } => true,
+
+        T::UnannotatedExp_::NamedBlock(_, (_, seq)) | T::UnannotatedExp_::Block((_, seq)) => {
+            let Some(last) = seq.back() else { return false };
+            match &last.value {
+                T::SequenceItem_::Seq(exp) => returnable_value(context, exp),
+                T::SequenceItem_::Declare(_) | T::SequenceItem_::Bind(_, _, _) => false,
+            }
+        }
+
+        // These don't really make sense in return position, so there should already be other
+        // errors.
+        T::UnannotatedExp_::Assign(_, _, _)
+        | T::UnannotatedExp_::Mutate(_, _)
+        | T::UnannotatedExp_::Abort(_)
+        | T::UnannotatedExp_::Give(_, _)
+        | T::UnannotatedExp_::Continue(_) => false,
+        T::UnannotatedExp_::UnresolvedError => false,
+    }
+}
+
+fn report_unneeded_return(context: &mut Context, loc: Loc) {
+    context.env.add_diag(diag!(
+        StyleCodes::UnneededReturn.diag_info(),
+        (
+            loc,
+            "Remove unnecessary 'return', the expression is already in a 'return' position"
+        )
+    ));
+}

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -12,10 +12,7 @@ use crate::{
         codes::{Category, Declarations, DiagnosticsID, Severity, WarningFilter},
         Diagnostic, Diagnostics, DiagnosticsFormat, WarningFilters,
     },
-    editions::{
-        check_feature_or_error as edition_check_feature, feature_edition_error_msg, Edition,
-        FeatureGate, Flavor,
-    },
+    editions::{check_feature_or_error, feature_edition_error_msg, Edition, FeatureGate, Flavor},
     expansion::ast as E,
     hlir::ast as H,
     naming::ast as N,
@@ -588,7 +585,7 @@ impl CompilationEnv {
         feature: FeatureGate,
         loc: Loc,
     ) -> bool {
-        edition_check_feature(self, self.package_config(package).edition, feature, loc)
+        check_feature_or_error(self, self.package_config(package).edition, feature, loc)
     }
 
     // Returns an error string if if the feature isn't supported, or None otherwise.

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/allowed_unneeded_return.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/allowed_unneeded_return.move
@@ -1,0 +1,56 @@
+module 0x42::m;
+
+#[allow(lint(unneeded_return))]
+fun t0(): u64 { return 5 }
+
+#[allow(lint(unneeded_return))]
+fun t1(): u64 { return t0() }
+
+public struct S {  }
+
+#[allow(lint(unneeded_return))]
+fun t2(): S { return S { } }
+
+public enum E { V }
+
+#[allow(lint(unneeded_return))]
+fun t3(): E { return E::V }
+
+#[allow(lint(unneeded_return))]
+fun t4(): vector<u64> { return vector[1,2,3] }
+
+#[allow(lint(unneeded_return))]
+fun t5() { return () }
+
+#[allow(lint(unneeded_return))]
+fun t6(): u64 { let x = 0; return move x
+}
+
+#[allow(lint(unneeded_return))]
+fun t7(): u64 {
+    let x = 0;
+    return copy x
+}
+
+const VALUE: u64 = 0;
+
+#[allow(lint(unneeded_return))]
+fun t8(): u64 { return VALUE }
+
+#[allow(lint(unneeded_return))]
+fun t9(): u64 { return 5 + 2 }
+
+#[allow(lint(unneeded_return))]
+fun t10(): bool { return !true }
+
+#[allow(lint(unneeded_return))]
+fun t11(x: &u64): u64 { return *x }
+
+#[allow(lint(unneeded_return))]
+fun t12(x: u64): u128 { return x as u128 }
+
+#[allow(lint(unneeded_return))]
+fun t13(): u64 { return (0: u64) }
+
+#[allow(lint(unneeded_return))]
+fun t14(): u64 { return loop { break 5 } }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.exp
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.exp
@@ -1,0 +1,137 @@
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return.move:3:17
+  │
+3 │ fun t0(): u64 { return 5 }
+  │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return.move:5:17
+  │
+5 │ fun t1(): u64 { return t0() }
+  │                 ^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return.move:9:15
+  │
+9 │ fun t2(): S { return S { } }
+  │               ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:13:15
+   │
+13 │ fun t3(): E { return E::V }
+   │               ^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:15:25
+   │
+15 │ fun t4(): vector<u64> { return vector[1,2,3] }
+   │                         ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:17:12
+   │
+17 │ fun t5() { return () }
+   │            ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:19:28
+   │
+19 │ fun t6(): u64 { let x = 0; return move x
+   │                            ^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:24:5
+   │
+24 │     return copy x
+   │     ^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:29:17
+   │
+29 │ fun t8(): u64 { return VALUE }
+   │                 ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:33:5
+   │
+33 │     return &x
+   │     ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E07004]: invalid return of locally borrowed state
+   ┌─ tests/linter/move_2024/unneeded_return.move:33:5
+   │
+33 │     return &x
+   │     ^^^^^^^^^
+   │     │      │
+   │     │      It is still being borrowed by this reference
+   │     Invalid return. Local variable 'x' is still being borrowed.
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:36:18
+   │
+36 │ fun t10(): u64 { return 5 + 2 }
+   │                  ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:38:19
+   │
+38 │ fun t11(): bool { return !true }
+   │                   ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:40:25
+   │
+40 │ fun t12(x: &u64): u64 { return *x }
+   │                         ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:42:25
+   │
+42 │ fun t13(x: u64): u128 { return x as u128 }
+   │                         ^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:44:18
+   │
+44 │ fun t14(): u64 { return (0: u64) }
+   │                  ^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return.move:46:18
+   │
+46 │ fun t15(): u64 { return loop { break 5 } }
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.move
@@ -1,0 +1,46 @@
+module 0x42::m;
+
+fun t0(): u64 { return 5 }
+
+fun t1(): u64 { return t0() }
+
+public struct S {  }
+
+fun t2(): S { return S { } }
+
+public enum E { V }
+
+fun t3(): E { return E::V }
+
+fun t4(): vector<u64> { return vector[1,2,3] }
+
+fun t5() { return () }
+
+fun t6(): u64 { let x = 0; return move x
+}
+
+fun t7(): u64 {
+    let x = 0;
+    return copy x
+}
+
+const VALUE: u64 = 0;
+
+fun t8(): u64 { return VALUE }
+
+fun t9(): &u64 {
+    let x = 0;
+    return &x
+}
+
+fun t10(): u64 { return 5 + 2 }
+
+fun t11(): bool { return !true }
+
+fun t12(x: &u64): u64 { return *x }
+
+fun t13(x: u64): u128 { return x as u128 }
+
+fun t14(): u64 { return (0: u64) }
+
+fun t15(): u64 { return loop { break 5 } }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.exp
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.exp
@@ -1,0 +1,129 @@
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:4:17
+  │
+4 │     if (cond) { return 5 } else { abort 0 }
+  │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:4:35
+  │
+4 │     if (cond) { return 5 } else { abort 0 }
+  │                                   ^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:8:17
+  │
+8 │     if (cond) { return 5 } else { return 0 }
+  │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:8:35
+  │
+8 │     if (cond) { return 5 } else { return 0 }
+  │                                   ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+  │
+  = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:12:5
+   │
+12 │     return if (cond) { 5 } else { 0 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:16:5
+   │
+16 │     return if (cond) { return 5 } else { 0 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:20:5
+   │
+20 │     return if (cond) { 5 } else { return 0 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:29:5
+   │  
+29 │ ╭     return match (e) {
+30 │ │         E::V0 => 0,
+31 │ │         E::V1 => 1,
+32 │ │     }
+   │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │  
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:37:18
+   │
+37 │         E::V0 => return 0,
+   │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:44:18
+   │
+44 │         E::V0 => return 0,
+   │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:45:18
+   │
+45 │         E::V1 => return 1,
+   │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:51:18
+   │
+51 │         E::V0 => return 0,
+   │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:52:18
+   │
+52 │         E::V1 => abort 0,
+   │                  ^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:57:5
+   │  
+57 │ ╭     return match (e) {
+58 │ │         E::V0 => 0,
+59 │ │         E::V1 => abort 0,
+60 │ │     }
+   │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │  
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W04004]: unneeded return
+   ┌─ tests/linter/move_2024/unneeded_return_branch.move:64:5
+   │  
+64 │ ╭     return match (e) {
+65 │ │         E::V0 => if (true) { return 0 } else { 1 },
+66 │ │         E::V1 => 2,
+67 │ │     }
+   │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
+   │  
+   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.move
@@ -1,0 +1,68 @@
+module 0x42::m;
+
+fun t0(cond: bool): u64 {
+    if (cond) { return 5 } else { abort 0 }
+}
+
+fun t1(cond: bool): u64 {
+    if (cond) { return 5 } else { return 0 }
+}
+
+fun t2(cond: bool): u64 {
+    return if (cond) { 5 } else { 0 }
+}
+
+fun t3(cond: bool): u64 {
+    return if (cond) { return 5 } else { 0 }
+}
+
+fun t4(cond: bool): u64 {
+    return if (cond) { 5 } else { return 0 }
+}
+
+public enum E has drop {
+    V0,
+    V1
+}
+
+fun t5(e: E): u64{
+    return match (e) {
+        E::V0 => 0,
+        E::V1 => 1,
+    }
+}
+
+fun t6(e: E): u64{
+    match (e) {
+        E::V0 => return 0,
+        E::V1 => 1,
+    }
+}
+
+fun t7(e: E): u64 {
+    match (e) {
+        E::V0 => return 0,
+        E::V1 => return 1,
+    }
+}
+
+fun t8(e: E): u64{
+    match (e) {
+        E::V0 => return 0,
+        E::V1 => abort 0,
+    }
+}
+
+fun t9(e: E): u64 {
+    return match (e) {
+        E::V0 => 0,
+        E::V1 => abort 0,
+    }
+}
+
+fun t10(e: E): u64 {
+    return match (e) {
+        E::V0 => if (true) { return 0 } else { 1 },
+        E::V1 => 2,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_okay.exp
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_okay.exp
@@ -1,0 +1,54 @@
+warning[W09002]: unused variable
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:14:9
+   │
+14 │     let y = &mut x;
+   │         ^ Unused local variable 'y'. Consider removing or prefixing with an underscore: '_y'
+   │
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E04007]: incompatible types
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:15:14
+   │
+13 │     let mut x = 0;
+   │         ----- Given: integer
+14 │     let y = &mut x;
+15 │     return (*x = 1)
+   │              ^
+   │              │
+   │              Invalid mutation. Expected a mutable reference
+   │              Expected: '&mut _'
+
+error[E04007]: incompatible types
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:19:12
+   │
+19 │ fun t3() { 'a: { return { return 'a 0 } } }
+   │     --     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │     │      │
+   │     │      Invalid return expression
+   │     │      Given: integer
+   │     Expected: '()'
+
+error[E04014]: invalid loop control
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:23:19
+   │
+23 │ fun t4() { return continue }
+   │                   ^^^^^^^^ Invalid usage of 'continue'. 'continue' can only be used inside a loop body or lambda
+
+error[E04014]: invalid loop control
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:25:19
+   │
+25 │ fun t5() { return break }
+   │                   ^^^^^ Invalid usage of 'break'. 'break' can only be used inside a loop body or lambda
+
+error[E04014]: invalid loop control
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:27:20
+   │
+27 │ fun t6() { return (break + 5) }
+   │                    ^^^^^ Invalid usage of 'break'. 'break' can only be used inside a loop body or lambda
+
+error[E03005]: unbound unscoped name
+   ┌─ tests/linter/move_2024/unneeded_return_okay.move:29:19
+   │
+29 │ fun t7() { return unnamed_fun() }
+   │                   ^^^^^^^^^^^ Unbound function 'unnamed_fun' in current scope
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_okay.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_okay.move
@@ -1,0 +1,31 @@
+module 0x42::m;
+
+fun t0() { return abort 0 }
+
+// invalid type, so no lint
+fun t1() {
+    let mut x = 0;
+    return (x = 1)
+}
+
+// invalid syntax, so no lint
+fun t2() {
+    let mut x = 0;
+    let y = &mut x;
+    return (*x = 1)
+}
+
+// invalid type, so no lint
+fun t3() { 'a: { return { return 'a 0 } } }
+
+// the following are all invalid syntax, so no lint
+
+fun t4() { return continue }
+
+fun t5() { return break }
+
+fun t6() { return (break + 5) }
+
+fun t7() { return unnamed_fun() }
+
+fun t8(cond: bool) { return while (cond) { break } }

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_meaningless_math_operation.exp
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_meaningless_math_operation.exp
@@ -1,4 +1,4 @@
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:3:9
   │
 3 │         x * 1;
@@ -9,7 +9,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:4:9
   │
 4 │         1 * x;
@@ -20,7 +20,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:5:9
   │
 5 │         x / 1;
@@ -31,7 +31,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:6:9
   │
 6 │         x + 0;
@@ -42,7 +42,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:7:9
   │
 7 │         0 + x;
@@ -53,7 +53,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:8:9
   │
 8 │         x - 0;
@@ -64,7 +64,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:9:9
   │
 9 │         x << 0;
@@ -75,7 +75,7 @@ warning[Lint W01008]: math operation can be simplified
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:10:9
    │
 10 │         x << 0;
@@ -86,7 +86,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:14:9
    │
 14 │         x * 0;
@@ -97,7 +97,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:15:9
    │
 15 │         0 * x;
@@ -108,7 +108,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:16:9
    │
 16 │         0 / x;
@@ -119,7 +119,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:17:9
    │
 17 │         0 % x;
@@ -130,7 +130,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:18:9
    │
 18 │         x % 1;
@@ -141,7 +141,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:22:9
    │
 22 │         1 % x;
@@ -152,7 +152,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:27:9
    │
 26 │         let y = 1;
@@ -162,7 +162,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:28:9
    │
 28 │         x - (1 - 1);
@@ -173,7 +173,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:32:9
    │
 32 │         x * 1;
@@ -184,7 +184,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:33:9
    │
 33 │         x * 0;
@@ -195,7 +195,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:34:9
    │
 34 │         1 % x;
@@ -206,7 +206,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:38:9
    │
 38 │         x * 1;
@@ -217,7 +217,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:39:9
    │
 39 │         x * 0;
@@ -228,7 +228,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:40:9
    │
 40 │         1 % x;
@@ -239,7 +239,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:44:9
    │
 44 │         x * 1;
@@ -250,7 +250,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:45:9
    │
 45 │         x * 0;
@@ -261,7 +261,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:46:9
    │
 46 │         1 % x;
@@ -272,7 +272,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:50:9
    │
 50 │         x * 1;
@@ -283,7 +283,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:51:9
    │
 51 │         x * 0;
@@ -294,7 +294,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:52:9
    │
 52 │         1 % x;
@@ -305,7 +305,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:56:9
    │
 56 │         x * 1;
@@ -316,7 +316,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:57:9
    │
 57 │         x * 0;
@@ -327,7 +327,7 @@ warning[Lint W01008]: math operation can be simplified
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01008]: math operation can be simplified
+warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:58:9
    │
 58 │         1 % x;

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_while_loop.exp
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_while_loop.exp
@@ -1,4 +1,4 @@
-warning[Lint W01004]: unnecessary 'while (true)', replace with 'loop'
+warning[Lint W01002]: unnecessary 'while (true)', replace with 'loop'
   ┌─ tests/linter/true_positive_unnecessary_while_loop.move:3:9
   │
 3 │         while (true) {};
@@ -7,7 +7,7 @@ warning[Lint W01004]: unnecessary 'while (true)', replace with 'loop'
   = A 'loop' is more useful in these cases. Unlike 'while', 'loop' can have a 'break' with a value, e.g. 'let x = loop { break 42 };'
   = This warning can be suppressed with '#[allow(lint(while_true))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
-warning[Lint W01004]: unnecessary 'while (true)', replace with 'loop'
+warning[Lint W01002]: unnecessary 'while (true)', replace with 'loop'
   ┌─ tests/linter/true_positive_unnecessary_while_loop.move:4:9
   │
 4 │         while (true) { break }


### PR DESCRIPTION
## Description 

Check for and report unnecessary returns.

## Test Plan 

New test case added

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
