### PR TITLE
[graphql][easy][fix] remove some comments and fix owner enum variant

### DIFF
--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -10,7 +10,7 @@ use super::{
     epoch::Epoch,
     event::{Event, EventFilter},
     object::{Object, ObjectFilter},
-    owner::ObjectOwner,
+    owner::{ObjectOwner, Owner},
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
     sui_system_state_summary::SuiSystemStateSummary,
@@ -54,17 +54,9 @@ impl Query {
     // availableRange - pending impl. on IndexerV2
     // dryRunTransactionBlock
     // coinMetadata
-    // resolveNameServiceAddress
-    // event_connection -> TODO: need to define typings
 
-    async fn owner(&self, ctx: &Context<'_>, address: SuiAddress) -> Result<Option<ObjectOwner>> {
-        // Currently only an account address can own an object
-        let owner_address = ctx
-            .data_unchecked::<PgManager>()
-            .fetch_owner(address)
-            .await?;
-
-        Ok(owner_address.map(|o| ObjectOwner::Address(Address { address: o })))
+    async fn owner(&self, ctx: &Context<'_>, address: SuiAddress) -> Option<ObjectOwner> {
+        Some(ObjectOwner::Owner(Owner { address }))
     }
 
     async fn object(


### PR DESCRIPTION
## Description 

Fix Query.owner resolution to ObjectOwner::Owner variant to lazy render

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
