### PR TITLE
[graphql] object.balance impl check self for balance

### DIFF
--- a/crates/sui-graphql-rpc/examples/object/balance.graphql
+++ b/crates/sui-graphql-rpc/examples/object/balance.graphql
@@ -1,0 +1,22 @@
+{
+  object(
+    address: "0x27ac4f3f3c3f77027871f390f9f31736a2fffffafeceb27fbf64cc2d7eb27397"
+  ) {
+    balance {
+      coinType {
+        repr
+      }
+      coinObjectCount
+      totalBalance
+    }
+    balanceConnection {
+      nodes {
+        coinType {
+          repr
+        }
+        coinObjectCount
+        totalBalance
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/sui_sdk_data_provider.rs
@@ -209,6 +209,7 @@ pub(crate) fn convert_obj(s: &sui_json_rpc_types::SuiObjectData) -> Object {
             } => ObjectKind::Shared,
             NativeOwner::Immutable => ObjectKind::Immutable,
         }),
+        balance: None,
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::big_int::BigInt;
+use super::{big_int::BigInt, move_type::MoveType};
 use crate::types::owner::Owner;
 use async_graphql::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 pub(crate) struct Balance {
-    pub(crate) coin_type: Option<String>, // TODO: replace with MoveType
+    pub(crate) coin_type: Option<MoveType>,
     pub(crate) coin_object_count: Option<u64>,
     pub(crate) total_balance: Option<BigInt>,
 }

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{code, graphql_error};
 
 /// Represents concrete types (no type parameters, no references)
-#[derive(SimpleObject)]
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct MoveType {
     /// Flat representation of the type signature, as a displayable string.

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -28,6 +28,7 @@ pub(crate) struct Object {
     pub bcs: Option<Base64>,
     pub previous_transaction: Option<Digest>,
     pub kind: Option<ObjectKind>,
+    pub balance: Option<Balance>, // TODO (wlmyng): A non-coin object has no balance, but may own coin objects
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
@@ -144,6 +145,10 @@ impl Object {
         ctx: &Context<'_>,
         type_: Option<String>,
     ) -> Result<Option<Balance>> {
+        if let Some(balance) = &self.balance {
+            return Ok(Some(balance.clone()));
+        }
+
         ctx.data_unchecked::<PgManager>()
             .fetch_balance(self.address, type_)
             .await
@@ -249,6 +254,7 @@ impl From<&NativeSuiObject> for Object {
             bcs: Some(bcs),
             previous_transaction: Some(Digest::from_array(o.previous_transaction.into_inner())),
             kind,
+            balance: None,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -13,6 +13,7 @@ use async_graphql::connection::Connection;
 use async_graphql::*;
 use sui_json_rpc::name_service::NameServiceConfig;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Interface)]
 #[graphql(
     field(name = "location", ty = "SuiAddress"),

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -30,7 +30,7 @@ type AuthenticatorStateUpdate {
 }
 
 type Balance {
-	coinType: String
+	coinType: MoveType
 	coinObjectCount: Int
 	totalBalance: BigInt
 }


### PR DESCRIPTION
## Description 

Object.balance should check if the object is a coin, and if so, return its own balance. Although, with send to object, it's now possible for objects to own other coin objects

Maybe something like
1. return sum of self.balance + fetched balance
2. If the type_ is provided (Some(type_)), check if self.balance.type matches the provided type.
3. If type_ is not provided (None), fetch the balance using self.balance.type as the type.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
