### PR TITLE
[move-prover] Print warning about the level of Prover support for Sui

### DIFF
--- a/crates/sui-move/src/prove.rs
+++ b/crates/sui-move/src/prove.rs
@@ -93,7 +93,7 @@ impl Prover {
             ),
         );
 
-        eprintln!("WARNING: the level of Move Prover support for Sui is incomplete; use at your own risk as not everything is guaranteed to work (support for bug fixes and new features is also limited)");
+        eprintln!("WARNING: the level of Move Prover support for Sui is incomplete; use at your own risk as not everything is guaranteed to work (please file an issue if an update breaks existing usage but the level of current support is limited)");
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(
                 build_config,

--- a/crates/sui-move/src/prove.rs
+++ b/crates/sui-move/src/prove.rs
@@ -92,6 +92,7 @@ impl Prover {
             ),
         );
 
+        eprintln!("WARNING: the level of Move Prover support for Sui is currently limited; use at your own risk");
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(
                 build_config,

--- a/crates/sui-move/src/prove.rs
+++ b/crates/sui-move/src/prove.rs
@@ -9,6 +9,7 @@ use sui_types::sui_framework_address_concat_string;
 
 const SUI_NATIVE_TEMPLATE: &[u8] = include_bytes!("sui-natives.bpl");
 
+/// Run the Move Prover on the package at `path` (Warning: Move Prover support for Sui is currently limited)
 #[derive(Parser)]
 #[group(id = "sui-move-prover")]
 pub struct Prover {

--- a/crates/sui-move/src/prove.rs
+++ b/crates/sui-move/src/prove.rs
@@ -93,7 +93,7 @@ impl Prover {
             ),
         );
 
-        eprintln!("WARNING: the level of Move Prover support for Sui is currently limited; use at your own risk");
+        eprintln!("WARNING: the level of Move Prover support for Sui is incomplete; use at your own risk as not everything is guaranteed to work (support for bug fixes and new features is also limited)");
         let prover_result = std::thread::spawn(move || {
             prove::run_move_prover(
                 build_config,


### PR DESCRIPTION
## Description 

People keep trying to use Move Prover with Sui and there is currently no easily accessible place where the current level of support is mentioned. Adding a warning at the time when Prover is ran seems like a reasonable thing to do here.

## Test Plan 

Verified that the warning is printed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
A warning about current level of Move Prover support for Sui is now printed when the Prover is ran.