### PR TITLE
[graphql/impl] remove non core gql folks from from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ CHANGELOG.md
 /crates/sui-framework/src/natives/ @oxade
 
 # GraphQL RPC working group
-/crates/sui-graphql-rpc/ @oxade @amnn @wlmyng @bmwill @longbowlu @gegaowp @Jordan-mysten @laura-makdah @stefan-mysten
+/crates/sui-graphql-rpc/ @oxade @amnn @wlmyng @stefan-mysten
 
 # Notify Narwhal changes to interested folks.
 /narwhal/crypto/ @joyqvq @kchalkias


### PR DESCRIPTION
## Description 

Since the basic integration & design has been decided, no need to add noise for non-core graphql devs

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
