### PR TITLE
[move] improve better error message for const bindings

### DIFF
--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -182,7 +182,8 @@ codes!(
         InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
         InvalidRestrictedIdentifier:
             { msg: "invalid identifier escape", severity: NonblockingError },
-        NeedsTypeAnnotation: { msg: "Requires a type annotation 'name: type ='", severity: BlockingError }
+        NeedsTypeAnnotation: 
+            { msg: "Requires a type annotation 'name: type ='", severity: BlockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -182,7 +182,7 @@ codes!(
         InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
         InvalidRestrictedIdentifier:
             { msg: "invalid identifier escape", severity: NonblockingError },
-        NeedsTypeAnnotation: 
+        NeedsTypeAnnotation:
             { msg: "Requires a type annotation 'name: type ='", severity: BlockingError },
     ],
     // errors for any rules around declaration items

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -182,8 +182,6 @@ codes!(
         InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
         InvalidRestrictedIdentifier:
             { msg: "invalid identifier escape", severity: NonblockingError },
-        NeedsTypeAnnotation:
-            { msg: "Requires a type annotation 'name: type ='", severity: BlockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -182,6 +182,7 @@ codes!(
         InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
         InvalidRestrictedIdentifier:
             { msg: "invalid identifier escape", severity: NonblockingError },
+        NeedsTypeAnnotation: { msg: "Requires a type annotation 'name: type ='", severity: BlockingError }
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/external-crates/move/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/move-compiler/src/parser/lexer.rs
@@ -220,6 +220,10 @@ impl<'input> Lexer<'input> {
         self.prev_end
     }
 
+    pub fn current_token_loc(&self) -> Loc {
+        make_loc(self.file_hash(), self.cur_start, self.cur_end)
+    }
+
     /// Strips line and block comments from input source, and collects documentation comments,
     /// putting them into a map indexed by the span of the comment region. Comments in the original
     /// source will be replaced by spaces, such that positions of source items stay unchanged.

--- a/external-crates/move/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/move-compiler/src/parser/syntax.rs
@@ -84,6 +84,64 @@ fn add_type_args_ambiguity_label(loc: Loc, mut diag: Box<Diagnostic>) -> Box<Dia
     diag
 }
 
+// A macro for providing better diagnostics when we expect a specific token and find some other
+// pattern instead. For example, we can use this to handle the case when a const is missing its
+// type annotation as:
+//
+//  expect_token!(
+//      context.tokens,
+//      Tok::Colon,
+//      Tok::Equal => (Syntax::UnexpectedToken, name.loc(), "Add type annotation to this constant")
+//  )?;
+//
+// This macro will fall through to an unexpected token error, but may also define its own default
+// as well:
+//
+//  expect_token!(
+//      context.tokens,
+//      Tok::Colon,
+//      Tok::Equal => (Syntax::UnexpectedToken, name.loc(), "Add type annotation to this constant")
+//      _ => (Syntax::UnexpectedToken, name.loc(), "Misformed constant definition")
+//  )?;
+//
+//  NB(cgswords): we could make $expected a pat if we required users to pass in a name for it as
+//  well for the default-case error reporting.
+
+macro_rules! expect_token {
+    ($tokens:expr, $expected:expr, $($tok:pat => ($code:expr, $loc:expr, $msg:expr)),+) => {
+        {
+            let next = $tokens.peek();
+            match next {
+                _ if next == $expected => {
+                    $tokens.advance()?;
+                    Ok(())
+                },
+                $($tok => Err(Box::new(diag!($code, ($loc, $msg)))),)+
+                _ => {
+                    let expected = format!("'{}'{}", next, $expected);
+                    Err(unexpected_token_error_($tokens, $tokens.start_loc(), &expected))
+                },
+            }
+        }
+    };
+    ($tokens:expr,
+     $expected:expr,
+     $($tok:pat => ($code:expr, $loc:expr, $msg:expr)),+
+     _ => ($dcode:expr, $dloc:expr, $dmsg:expr)) => {
+        {
+            let next = {
+                $tokens.advance()?;
+                Ok(())
+            };
+            match next {
+                _ if next == $expected => Ok(()),
+                $($tok => Err(Box::new(diag!($code, ($loc, $msg)))),)+
+                _ => Err(Box::new(diag!($dcode, ($dloc, $dmsg)))),
+            }
+        }
+    }
+}
+
 //**************************************************************************************************
 // Miscellaneous Utilities
 //**************************************************************************************************
@@ -2435,12 +2493,16 @@ fn parse_constant_decl(
     }
     consume_token(context.tokens, Tok::Const)?;
     let name = ConstantName(parse_identifier(context)?);
-    if consume_token(context.tokens, Tok::Colon).is_err() {
-        return Err(Box::new(diag!(
-            Syntax::NeedsTypeAnnotation,
-            (name.loc(), "Add type annotation to this constant")
-        )));
-    }
+    expect_token!(
+        context.tokens,
+        Tok::Colon,
+        Tok::Equal =>
+        (
+            Syntax::UnexpectedToken,
+            context.tokens.current_token_loc(),
+            format!("Expected a type annotation for this constant, e.g. '{}: <type>'", name)
+        )
+    )?;
     let signature = parse_type(context)?;
     consume_token(context.tokens, Tok::Equal)?;
     let value = parse_exp(context)?;

--- a/external-crates/move/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/move-compiler/src/parser/syntax.rs
@@ -2435,7 +2435,12 @@ fn parse_constant_decl(
     }
     consume_token(context.tokens, Tok::Const)?;
     let name = ConstantName(parse_identifier(context)?);
-    consume_token(context.tokens, Tok::Colon)?;
+    if consume_token(context.tokens, Tok::Colon).is_err() {
+        return Err(Box::new(diag!(
+            Syntax::NeedsTypeAnnotation,
+            (name.loc(), "Add type annotation to this constant")
+        )));
+    }
     let signature = parse_type(context)?;
     consume_token(context.tokens, Tok::Equal)?;
     let value = parse_exp(context)?;

--- a/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.exp
@@ -1,0 +1,6 @@
+error[E01013]: Requires a type annotation 'name: type ='
+  ┌─ tests/move_check/parser/constant_type_annotation_invalid.move:2:11
+  │
+2 │     const EThreadMaxxed = 1;
+  │           ^^^^^^^^^^^^^ Add type annotation to this constant
+

--- a/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.exp
@@ -1,6 +1,6 @@
-error[E01013]: Requires a type annotation 'name: type ='
-  ┌─ tests/move_check/parser/constant_type_annotation_invalid.move:2:11
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/constant_type_annotation_invalid.move:2:25
   │
 2 │     const EThreadMaxxed = 1;
-  │           ^^^^^^^^^^^^^ Add type annotation to this constant
+  │                         ^ Expected a type annotation for this constant, e.g. 'EThreadMaxxed: <type>'
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.move
+++ b/external-crates/move/move-compiler/tests/move_check/parser/constant_type_annotation_invalid.move
@@ -1,0 +1,3 @@
+module 0x42::m {
+    const EThreadMaxxed = 1;
+}


### PR DESCRIPTION
## Description 

This adds a slightly more-informative error message to constant parsing failures based on feedback from @tedks 

## Test Plan 

Added a new test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
