### PR TITLE
chore/easy: fix some clippy lints in move

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -24,9 +24,6 @@ move-clippy = [
     "-Aclippy::manual_slice_size_calculation",
     "-Aclippy::unwrap-or-default",
     "-Aclippy::incorrect_partial_ord_impl_on_ord_type",
-    "-Aclippy::useless_attribute",
-    "-Aclippy::manual_while_let_some",
-    "-Aclippy::redundant_closure",
 ]
 
 [build]

--- a/external-crates/move/move-model/src/spec_translator.rs
+++ b/external-crates/move/move-model/src/spec_translator.rs
@@ -110,7 +110,7 @@ impl TranslatedSpec {
                         .mk_join_opt_bool(
                             Operation::And,
                             Some(exp.clone()),
-                            code.as_ref().map(|c| eq_code(c)),
+                            code.as_ref().map(eq_code),
                         )
                         .unwrap()
                 })
@@ -118,7 +118,7 @@ impl TranslatedSpec {
                     self.aborts_with
                         .iter()
                         .flat_map(|(_, codes)| codes.iter())
-                        .map(|c| eq_code(c)),
+                        .map(eq_code),
                 ),
         )
     }

--- a/external-crates/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/external-crates/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -707,8 +707,7 @@ impl TypeIdentToken {
 
         segments.reverse();
         let mut cursor = segments.pop().unwrap();
-        while !segments.is_empty() {
-            let next = segments.pop().unwrap();
+        while let Some(next) = segments.pop() {
             cursor = format!("ConcatVec({}, {})", cursor, next);
         }
         cursor

--- a/external-crates/move/move-prover/bytecode/src/graph.rs
+++ b/external-crates/move/move-prover/bytecode/src/graph.rs
@@ -86,8 +86,7 @@ impl<T: Ord + Copy + Debug> Graph<T> {
         let mut stack = vec![];
         visited.insert(self.entry, false);
         stack.push(self.entry);
-        while !stack.is_empty() {
-            let n = stack.pop().unwrap();
+        while let Some(n) = stack.pop() {
             if visited[&n] {
                 visited.entry(n).and_modify(|x| {
                     *x = false;
@@ -122,8 +121,7 @@ impl<T: Ord + Copy + Debug> Graph<T> {
             loop_body.insert(loop_latch);
             stack.push(loop_latch);
         }
-        while !stack.is_empty() {
-            let m = stack.pop().unwrap();
+        while let Some(m) = stack.pop() {
             for p in &self.predecessors[&m] {
                 if !loop_body.contains(p) {
                     loop_body.insert(*p);
@@ -194,8 +192,7 @@ impl<T: Ord + Copy + Debug> DomRelation<T> {
         let mut grey = BTreeSet::new();
         stack.push(graph.entry);
         visited.insert(graph.entry);
-        while !stack.is_empty() {
-            let curr = stack.pop().unwrap();
+        while let Some(curr) = stack.pop() {
             if grey.contains(&curr) {
                 let curr_num = self.postorder_num_to_node.len();
                 self.postorder_num_to_node.push(curr);

--- a/external-crates/move/move-prover/bytecode/src/mono_analysis.rs
+++ b/external-crates/move/move-prover/bytecode/src/mono_analysis.rs
@@ -218,8 +218,7 @@ impl<'a> Analyzer<'a> {
 
         // Next do todo-list for regular functions, while self.inst_opt contains the
         // specific instantiation.
-        while !self.todo_funs.is_empty() {
-            let (fun, variant, inst) = self.todo_funs.pop().unwrap();
+        while let Some((fun, variant, inst)) = self.todo_funs.pop() {
             self.inst_opt = Some(inst);
             self.analyze_fun(
                 self.targets
@@ -246,8 +245,7 @@ impl<'a> Analyzer<'a> {
         }
 
         // Finally do spec functions, after all regular functions and axioms are done.
-        while !self.todo_spec_funs.is_empty() {
-            let (fun, inst) = self.todo_spec_funs.pop().unwrap();
+        while let Some((fun, inst)) = self.todo_spec_funs.pop() {
             self.inst_opt = Some(inst);
             self.analyze_spec_fun(fun);
             let inst = std::mem::take(&mut self.inst_opt).unwrap();

--- a/external-crates/move/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/tools/move-cli/src/sandbox/utils/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
-#[allow(hidden_glob_reexports)]
+#![allow(hidden_glob_reexports)]
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;
 use anyhow::{bail, Result};
 use colored::Colorize;
@@ -391,8 +391,7 @@ pub(crate) fn explain_publish_error(
                 stack.push((code_cache.get_module(&dep)?, false));
             }
 
-            while !stack.is_empty() {
-                let (cur, is_exit) = stack.pop().unwrap();
+            while let Some((cur, is_exit)) = stack.pop() {
                 let cur_id = cur.self_id();
                 if is_exit {
                     state.insert(cur_id, false);


### PR DESCRIPTION
## Description 

Fixes some clippy lints ignored when [this](https://github.com/MystenLabs/sui/pull/14167) PR was inteoduced.
Others coming shortly.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
