### PR TITLE
easy/chore: unwrap or default lints

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -22,7 +22,6 @@ move-clippy = [
     "-Aclippy::new_without_default",
     "-Aclippy::box_default",
     "-Aclippy::manual_slice_size_calculation",
-    "-Aclippy::unwrap-or-default",
     "-Aclippy::incorrect_partial_ord_impl_on_ord_type",
 ]
 

--- a/external-crates/move/move-analyzer/src/symbols.rs
+++ b/external-crates/move/move-analyzer/src/symbols.rs
@@ -527,10 +527,7 @@ impl UseDef {
             col_end,
         };
 
-        references
-            .entry(def_loc)
-            .or_insert_with(BTreeSet::new)
-            .insert(use_loc);
+        references.entry(def_loc).or_default().insert(use_loc);
         Self {
             col_start: use_start.character,
             col_end,
@@ -566,7 +563,7 @@ impl UseDefMap {
     }
 
     fn insert(&mut self, key: u32, val: UseDef) {
-        self.0.entry(key).or_insert_with(BTreeSet::new).insert(val);
+        self.0.entry(key).or_default().insert(val);
     }
 
     fn get(&self, key: u32) -> Option<BTreeSet<UseDef>> {
@@ -599,10 +596,7 @@ impl FunctionIdentTypeMap {
 impl Symbols {
     pub fn merge(&mut self, other: Self) {
         for (k, v) in other.references {
-            self.references
-                .entry(k)
-                .or_insert_with(BTreeSet::new)
-                .extend(v);
+            self.references.entry(k).or_default().extend(v);
         }
         self.file_use_defs.extend(other.file_use_defs);
         self.file_name_mapping.extend(other.file_name_mapping);

--- a/external-crates/move/move-binary-format/src/normalized.rs
+++ b/external-crates/move/move-binary-format/src/normalized.rs
@@ -462,7 +462,7 @@ impl Function {
                     .map(|bytecode| Bytecode::new(m, bytecode))
                     .collect()
             })
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let f = Function {
             visibility: def.visibility,

--- a/external-crates/move/move-borrow-graph/src/graph.rs
+++ b/external-crates/move/move-borrow-graph/src/graph.rs
@@ -68,7 +68,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
                     None => full_borrows.insert(borrower, edge.loc),
                     Some(f) => field_borrows
                         .entry(f.clone())
-                        .or_insert_with(BTreeMap::new)
+                        .or_default()
                         .insert(borrower, edge.loc),
                 };
             }

--- a/external-crates/move/move-bytecode-verifier/src/struct_defs.rs
+++ b/external-crates/move/move-bytecode-verifier/src/struct_defs.rs
@@ -126,7 +126,7 @@ impl<'a> StructDefGraphBuilder<'a> {
                 if let Some(struct_def_idx) = self.handle_to_def.get(sh_idx) {
                     neighbors
                         .entry(cur_idx)
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(*struct_def_idx);
                 }
             }
@@ -134,7 +134,7 @@ impl<'a> StructDefGraphBuilder<'a> {
                 if let Some(struct_def_idx) = self.handle_to_def.get(sh_idx) {
                     neighbors
                         .entry(cur_idx)
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(*struct_def_idx);
                 }
                 for t in inners {

--- a/external-crates/move/move-compiler/src/cfgir/cfg.rs
+++ b/external-crates/move/move-compiler/src/cfgir/cfg.rs
@@ -591,7 +591,7 @@ impl<'forward, Blocks: Deref<Target = BasicBlocks>> ReverseCFG<'forward, Blocks>
         for terminal_predecessor in &end_blocks {
             forward_successors
                 .entry(*terminal_predecessor)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(terminal);
         }
         forward_predecessor.insert(terminal, end_blocks);

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -265,7 +265,7 @@ pub fn program(
         for s in scripts {
             collected
                 .entry(s.function_name.value())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(s)
         }
         let mut keyed: BTreeMap<Symbol, E::Script> = BTreeMap::new();

--- a/external-crates/move/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/move-compiler/src/hlir/translate.rs
@@ -756,7 +756,7 @@ fn assign(
             context
                 .used_fields
                 .entry(s.value())
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .extend(tfields.iter().map(|(_, s, _)| *s));
 
             let bs = base_types(context, tbs);
@@ -776,7 +776,7 @@ fn assign(
             context
                 .used_fields
                 .entry(s.value())
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .extend(tfields.iter().map(|(_, s, _)| *s));
 
             let tmp = context.new_temp(loc, rvalue_ty.clone());
@@ -1362,7 +1362,7 @@ fn exp_impl(
             context
                 .used_fields
                 .entry(s.value())
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .extend(tfields.iter().map(|(_, s, _)| *s));
 
             let bs = base_types(context, tbs);
@@ -1447,7 +1447,7 @@ fn exp_impl(
                 context
                     .used_fields
                     .entry(struct_name.value())
-                    .or_insert_with(BTreeSet::new)
+                    .or_default()
                     .insert(f.value());
             }
             HE::Borrow(mut_, e, f)

--- a/external-crates/move/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/move-compiler/src/naming/translate.rs
@@ -621,7 +621,7 @@ fn use_funs(context: &mut Context, eufs: E::UseFuns) -> N::UseFuns {
         .flat_map(|e| explicit_use_fun(context, e))
         .collect();
     for (tn, method, nuf) in resolved_vec {
-        let methods = resolved.entry(tn.clone()).or_insert_with(UniqueMap::new);
+        let methods = resolved.entry(tn.clone()).or_default();
         let nuf_loc = nuf.loc;
         if let Err((_, prev)) = methods.add(method, nuf) {
             let msg = format!("Duplicate 'use fun' for '{}.{}'", tn, method);

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -492,7 +492,7 @@ impl CompilationEnv {
                 WarningFilter::All(_) => {
                     self.known_filters
                         .entry(KnownFilterInfo::new(FILTER_ALL, filter_attr_name))
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(filter);
                 }
                 WarningFilter::Category { name, .. } => {
@@ -501,7 +501,7 @@ impl CompilationEnv {
                     };
                     self.known_filters
                         .entry(KnownFilterInfo::new(n, filter_attr_name))
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(filter);
                 }
                 WarningFilter::Code {
@@ -516,7 +516,7 @@ impl CompilationEnv {
                     let known_filter_info = KnownFilterInfo::new(n, filter_attr_name);
                     self.known_filters
                         .entry(known_filter_info.clone())
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(filter);
                     self.known_filter_names
                         .insert((prefix, category, code), known_filter_info);

--- a/external-crates/move/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/move-compiler/src/typing/dependency_ordering.rs
@@ -131,14 +131,8 @@ impl<'a> Context<'a> {
             DepType::Use => Neighbor_::Dependency,
             DepType::Friend => Neighbor_::Friend,
         };
-        let current_neighbors = self
-            .neighbors_by_node
-            .entry(current.clone())
-            .or_insert_with(UniqueMap::new);
-        let current_used_addresses = self
-            .addresses_by_node
-            .entry(current.clone())
-            .or_insert_with(BTreeSet::new);
+        let current_neighbors = self.neighbors_by_node.entry(current.clone()).or_default();
+        let current_used_addresses = self.addresses_by_node.entry(current.clone()).or_default();
         current_neighbors.remove(&mident);
         current_neighbors.add(mident, sp(loc, neighbor_)).unwrap();
         current_used_addresses.insert(mident.value.address);
@@ -152,9 +146,9 @@ impl<'a> Context<'a> {
                 let m = self
                     .module_neighbors
                     .entry(node)
-                    .or_insert_with(BTreeMap::new)
+                    .or_default()
                     .entry(new_neighbor)
-                    .or_insert_with(BTreeMap::new);
+                    .or_default();
                 if m.contains_key(&dep_type) {
                     return;
                 }
@@ -175,7 +169,7 @@ impl<'a> Context<'a> {
     fn add_address_usage(&mut self, address: Address) {
         self.addresses_by_node
             .entry(self.current_node.clone().unwrap())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(address);
     }
 }

--- a/external-crates/move/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/move-compiler/src/typing/infinite_instantiations.rs
@@ -95,7 +95,7 @@ impl<'a> Context<'a> {
                     .for_each(|t| Self::add_tparam_edges(acc, tparam, info.clone(), t))
             }
             Param(tp) => {
-                let tp_neighbors = acc.entry(tp.clone()).or_insert_with(BTreeMap::new);
+                let tp_neighbors = acc.entry(tp.clone()).or_default();
                 match tp_neighbors.get(tparam) {
                     Some(EdgeInfo {
                         edge: Edge::Nested, ..

--- a/external-crates/move/move-compiler/src/typing/recursive_structs.rs
+++ b/external-crates/move/move-compiler/src/typing/recursive_structs.rs
@@ -36,7 +36,7 @@ impl Context {
         }
         self.struct_neighbors
             .entry(self.current_struct.unwrap())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(*sname, loc);
     }
 

--- a/external-crates/move/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/move-compiler/src/typing/translate.rs
@@ -1287,7 +1287,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                 context
                     .used_module_members
                     .entry(mident.value)
-                    .or_insert_with(BTreeSet::new)
+                    .or_default()
                     .insert(c.value());
             }
             (ty, TE::Constant(m, c))
@@ -2321,7 +2321,7 @@ fn module_call_impl(
     context
         .used_module_members
         .entry(m.value)
-        .or_insert_with(BTreeSet::new)
+        .or_default()
         .insert(f.value());
     call
 }
@@ -2554,7 +2554,7 @@ fn process_attributes(context: &mut Context, all_attributes: &Attributes) {
                     context
                         .used_module_members
                         .entry(mident.value)
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(name.value);
                 }
             }

--- a/external-crates/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
+++ b/external-crates/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
@@ -51,14 +51,14 @@ impl FunctionMarking {
     pub fn code_offset(&mut self, code_offset: CodeOffset, message: String) {
         self.code_offsets
             .entry(code_offset)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 
     pub fn type_param(&mut self, type_param_index: usize, message: String) {
         self.type_param_offsets
             .entry(type_param_index)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 }
@@ -74,14 +74,14 @@ impl StructMarking {
     pub fn field(&mut self, field_index: MemberCount, message: String) {
         self.fields
             .entry(field_index)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 
     pub fn type_param(&mut self, type_param_index: usize, message: String) {
         self.type_param_offsets
             .entry(type_param_index)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 }
@@ -102,7 +102,7 @@ impl MarkedSourceMapping {
     ) {
         self.function_marks
             .entry(function_definition_index.0)
-            .or_insert_with(FunctionMarking::new)
+            .or_default()
             .code_offset(code_offset, message)
     }
 
@@ -114,7 +114,7 @@ impl MarkedSourceMapping {
     ) {
         self.function_marks
             .entry(function_definition_index.0)
-            .or_insert_with(FunctionMarking::new)
+            .or_default()
             .type_param(type_param_offset, message)
     }
 
@@ -126,7 +126,7 @@ impl MarkedSourceMapping {
     ) {
         self.struct_marks
             .entry(struct_definition_index.0)
-            .or_insert_with(StructMarking::new)
+            .or_default()
             .field(field_index, message)
     }
 
@@ -138,7 +138,7 @@ impl MarkedSourceMapping {
     ) {
         self.struct_marks
             .entry(struct_definition_index.0)
-            .or_insert_with(StructMarking::new)
+            .or_default()
             .type_param(type_param_offset, message)
     }
 }

--- a/external-crates/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
+++ b/external-crates/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
@@ -72,10 +72,7 @@ impl StructMarking {
     }
 
     pub fn field(&mut self, field_index: MemberCount, message: String) {
-        self.fields
-            .entry(field_index)
-            .or_default()
-            .push(message)
+        self.fields.entry(field_index).or_default().push(message)
     }
 
     pub fn type_param(&mut self, type_param_index: usize, message: String) {

--- a/external-crates/move/move-model/src/builder/model_builder.rs
+++ b/external-crates/move/move-model/src/builder/model_builder.rs
@@ -177,7 +177,7 @@ impl<'env> ModelBuilder<'env> {
         // TODO: check whether overloads are distinguishable
         self.spec_fun_table
             .entry(name)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(entry);
     }
 

--- a/external-crates/move/move-model/src/builder/model_builder.rs
+++ b/external-crates/move/move-model/src/builder/model_builder.rs
@@ -175,10 +175,7 @@ impl<'env> ModelBuilder<'env> {
     /// Defines a spec function, adding it to the spec fun table.
     pub fn define_spec_fun(&mut self, name: QualifiedSymbol, entry: SpecFunEntry) {
         // TODO: check whether overloads are distinguishable
-        self.spec_fun_table
-            .entry(name)
-            .or_default()
-            .push(entry);
+        self.spec_fun_table.entry(name).or_default().push(entry);
     }
 
     /// Defines a spec variable.

--- a/external-crates/move/move-model/src/builder/module_builder.rs
+++ b/external-crates/move/move-model/src/builder/module_builder.rs
@@ -1271,18 +1271,14 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     {
         use SpecBlockContext::*;
         match context {
-            Function(name) => update(
-                self.fun_specs
-                    .entry(name.symbol)
-                    .or_insert_with(Spec::default),
-            ),
+            Function(name) => update(self.fun_specs.entry(name.symbol).or_default()),
             FunctionCode(name, spec_info) => update(
                 self.fun_specs
                     .entry(name.symbol)
-                    .or_insert_with(Spec::default)
+                    .or_default()
                     .on_impl
                     .entry(spec_info.offset)
-                    .or_insert_with(Spec::default),
+                    .or_default(),
             ),
             Schema(name) => update(
                 &mut self
@@ -1292,11 +1288,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     .expect("schema defined")
                     .spec,
             ),
-            Struct(name) => update(
-                self.struct_specs
-                    .entry(name.symbol)
-                    .or_insert_with(Spec::default),
-            ),
+            Struct(name) => update(self.struct_specs.entry(name.symbol).or_default()),
             Module => update(&mut self.module_spec),
         }
     }

--- a/external-crates/move/move-model/src/model.rs
+++ b/external-crates/move/move-model/src/model.rs
@@ -995,7 +995,7 @@ impl GlobalEnv {
         for memory in &inv.mem_usage {
             self.global_invariants_for_memory
                 .entry(memory.clone())
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(id);
         }
         self.global_invariants.insert(id, inv);
@@ -3665,7 +3665,7 @@ impl<'env> FunctionEnv<'env> {
                 let type_name = mid.qualified(sid);
                 modify_targets
                     .entry(type_name)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(target.clone());
             });
         }

--- a/external-crates/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/external-crates/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -867,7 +867,7 @@ fn create_domain_map(
     let mut default_domain = None;
 
     let mut insert_map = |elems: &Vec<ModelValue>, val: &ModelValue| -> Option<()> {
-        map.entry(elems[0].clone()).or_insert_with(BTreeMap::new);
+        map.entry(elems[0].clone()).or_default();
         map.get_mut(&elems[0])
             .unwrap()
             .insert(elems[1].extract_number()?, extract_bool(val)?);

--- a/external-crates/move/move-prover/bytecode/src/access_path_trie.rs
+++ b/external-crates/move/move-prover/bytecode/src/access_path_trie.rs
@@ -342,11 +342,11 @@ impl<T: FootprintDomain> AccessPathTrie<T> {
             weak_update = true
         };
 
-        let mut node = self.0.entry(root).or_insert_with(TrieNode::default);
+        let mut node = self.0.entry(root).or_default();
         for offset in offsets.into_iter() {
             // if one of the offsets is not statically known, we must do a weak update
             weak_update = weak_update || !offset.is_statically_known();
-            node = node.entry(offset).or_insert_with(TrieNode::default);
+            node = node.entry(offset).or_default();
         }
         if weak_update {
             node.join(&new_node);

--- a/external-crates/move/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/external-crates/move/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -174,7 +174,7 @@ impl Analyzer {
         for inst in func_insts {
             self.func_insts
                 .entry(inst)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(invariant.id);
         }
         if is_generic {

--- a/external-crates/move/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/external-crates/move/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -149,9 +149,8 @@ fn compute_disabled_invs_for_fun(
                 .get_function(caller_fun_id)
                 .get_called_functions();
             for called_fun_id in called_funs {
-                let disabled_invs_for_called = disabled_invs_for_fun
-                    .entry(called_fun_id)
-                    .or_insert_with(BTreeSet::new);
+                let disabled_invs_for_called =
+                    disabled_invs_for_fun.entry(called_fun_id).or_default();
                 // if caller has any disabled_invs that callee does not, add them to called
                 // and add called to the worklist for further processing
                 if !disabled_invs_for_caller.is_subset(disabled_invs_for_called) {
@@ -376,7 +375,7 @@ fn compute_funs_that_modify_inv(
                     funs_that_modify_some_inv.insert(fun_id);
                     let inv_set = invs_modified_by_fun
                         .entry(fun_id)
-                        .or_insert_with(BTreeSet::new);
+                        .or_default();
                     inv_set.insert(*inv_id);
                 }
             }

--- a/external-crates/move/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/external-crates/move/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -373,9 +373,7 @@ fn compute_funs_that_modify_inv(
                     let fun_id = fun_env.get_qualified_id();
                     fun_id_set.insert(fun_id);
                     funs_that_modify_some_inv.insert(fun_id);
-                    let inv_set = invs_modified_by_fun
-                        .entry(fun_id)
-                        .or_default();
+                    let inv_set = invs_modified_by_fun.entry(fun_id).or_default();
                     inv_set.insert(*inv_id);
                 }
             }

--- a/external-crates/move/move-prover/interpreter/src/concrete/value.rs
+++ b/external-crates/move/move-prover/interpreter/src/concrete/value.rs
@@ -1181,7 +1181,7 @@ impl GlobalState {
         self.touched_addresses.insert(addr);
         self.accounts
             .entry(addr)
-            .or_insert_with(AccountState::default)
+            .or_default()
             .put_resource(&key, object.val)
             .map(|val| TypedValue {
                 ty: Type::mk_struct(key),
@@ -1199,11 +1199,7 @@ impl GlobalState {
 
     /// Emit an event to the event store
     pub fn emit_event(&mut self, guid: Vec<u8>, seq: u64, msg: TypedValue) {
-        let res = self
-            .events
-            .entry(guid)
-            .or_insert_with(BTreeMap::new)
-            .insert(seq, msg);
+        let res = self.events.entry(guid).or_default().insert(seq, msg);
         if cfg!(debug_assertions) {
             assert!(res.is_none());
         }
@@ -1308,7 +1304,7 @@ impl EvalState {
         self.saved_memory
             .entry(label)
             .and_modify(|per_label_map| per_label_map.clear())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(partial_inst.ident, per_struct_map);
     }
 

--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -2537,7 +2537,7 @@ impl Loader {
         let info = cache
             .structs
             .entry(gidx)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfo::new);
 
@@ -2661,7 +2661,7 @@ impl Loader {
         let info = cache
             .structs
             .entry(gidx)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfo::new);
         info.struct_layout = Some(struct_layout.clone());
@@ -2759,7 +2759,7 @@ impl Loader {
         let info = cache
             .structs
             .entry(gidx)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfo::new);
         info.annotated_struct_layout = Some(struct_layout.clone());

--- a/external-crates/move/tools/move-cli/src/base/prove.rs
+++ b/external-crates/move/tools/move-cli/src/base/prove.rs
@@ -216,7 +216,7 @@ pub fn run_move_prover(
         let basedir = path
             .file_name()
             .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(String::new);
+            .unwrap_or_default();
         writeln!(
             message_writer,
             "{} proving {} modules from package `{}` in {:.3}s",

--- a/external-crates/move/tools/move-coverage/src/coverage_map.rs
+++ b/external-crates/move/tools/move-coverage/src/coverage_map.rs
@@ -155,10 +155,7 @@ impl ModuleCoverageMap {
     }
 
     pub fn insert_multi(&mut self, func_name: Identifier, pc: u64, count: u64) {
-        let func_entry = self
-            .function_maps
-            .entry(func_name)
-            .or_default();
+        let func_entry = self.function_maps.entry(func_name).or_default();
         let pc_entry = func_entry.entry(pc).or_insert(0);
         *pc_entry += count;
     }
@@ -169,10 +166,7 @@ impl ModuleCoverageMap {
 
     pub fn merge(&mut self, another: ModuleCoverageMap) {
         for (key, val) in another.function_maps {
-            self.function_maps
-                .entry(key)
-                .or_default()
-                .extend(val);
+            self.function_maps.entry(key).or_default().extend(val);
         }
     }
 
@@ -328,10 +322,7 @@ impl TraceMap {
         func_name: Identifier,
         pc: u64,
     ) {
-        let exec_entry = self
-            .exec_maps
-            .entry(exec_id.to_owned())
-            .or_default();
+        let exec_entry = self.exec_maps.entry(exec_id.to_owned()).or_default();
         exec_entry.push(TraceEntry {
             module_addr,
             module_name,

--- a/external-crates/move/tools/move-coverage/src/coverage_map.rs
+++ b/external-crates/move/tools/move-coverage/src/coverage_map.rs
@@ -158,7 +158,7 @@ impl ModuleCoverageMap {
         let func_entry = self
             .function_maps
             .entry(func_name)
-            .or_insert_with(FunctionCoverage::new);
+            .or_default();
         let pc_entry = func_entry.entry(pc).or_insert(0);
         *pc_entry += count;
     }
@@ -171,7 +171,7 @@ impl ModuleCoverageMap {
         for (key, val) in another.function_maps {
             self.function_maps
                 .entry(key)
-                .or_insert_with(FunctionCoverage::new)
+                .or_default()
                 .extend(val);
         }
     }
@@ -331,7 +331,7 @@ impl TraceMap {
         let exec_entry = self
             .exec_maps
             .entry(exec_id.to_owned())
-            .or_insert_with(Vec::new);
+            .or_default();
         exec_entry.push(TraceEntry {
             module_addr,
             module_name,

--- a/external-crates/move/tools/move-coverage/src/summary.rs
+++ b/external-crates/move/tools/move-coverage/src/summary.rs
@@ -292,10 +292,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
                             // move to branch info if there are more than one branches
                             if exits.len() > 1 {
                                 for (src, dst) in exits.into_iter() {
-                                    fn_branches
-                                        .entry(src)
-                                        .or_default()
-                                        .insert(dst);
+                                    fn_branches.entry(src).or_default().insert(dst);
                                 }
                             }
                         }

--- a/external-crates/move/tools/move-coverage/src/summary.rs
+++ b/external-crates/move/tools/move-coverage/src/summary.rs
@@ -294,7 +294,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
                                 for (src, dst) in exits.into_iter() {
                                     fn_branches
                                         .entry(src)
-                                        .or_insert_with(BTreeSet::new)
+                                        .or_default()
                                         .insert(dst);
                                 }
                             }
@@ -403,7 +403,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
             for (func_name, path) in path_store.into_iter() {
                 let path_count = func_path_cov_stats
                     .entry(func_name)
-                    .or_insert_with(BTreeMap::new)
+                    .or_default()
                     .entry(path)
                     .or_insert(0);
                 *path_count += 1;

--- a/external-crates/move/tools/move-unit-test/src/test_reporter.rs
+++ b/external-crates/move/tools/move-unit-test/src/test_reporter.rs
@@ -385,21 +385,21 @@ impl TestStatistics {
     pub fn test_failure(&mut self, test_failure: TestFailure, test_plan: &ModuleTestPlan) {
         self.failed
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(test_failure);
     }
 
     pub fn test_success(&mut self, test_info: TestRunInfo, test_plan: &ModuleTestPlan) {
         self.passed
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(test_info);
     }
 
     pub fn test_output(&mut self, test_name: TestName, test_plan: &ModuleTestPlan, output: String) {
         self.output
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(test_name, output);
     }
 


### PR DESCRIPTION
## Description 

Fixes clippy lints for unwrap or defaults

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
