### PR TITLE
chore/easy: ord clippy lint

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -22,7 +22,6 @@ move-clippy = [
     "-Aclippy::new_without_default",
     "-Aclippy::box_default",
     "-Aclippy::manual_slice_size_calculation",
-    "-Aclippy::incorrect_partial_ord_impl_on_ord_type",
 ]
 
 [build]

--- a/external-crates/move/move-analyzer/src/symbols.rs
+++ b/external-crates/move/move-analyzer/src/symbols.rs
@@ -46,6 +46,8 @@
 //! definitions, the symbolicator builds a scope stack, entering encountered definitions and
 //! matching uses to a definition in the innermost scope.
 
+#![allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+
 use crate::{
     context::Context,
     diagnostics::{lsp_diagnostics, lsp_empty_diagnostics},
@@ -167,6 +169,7 @@ struct StructDef {
     field_defs: Vec<FieldDef>,
 }
 
+#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
 #[derive(Derivative, Debug, Clone, PartialEq, Eq)]
 #[derivative(PartialOrd, Ord)]
 pub struct FunctionDef {

--- a/external-crates/move/move-borrow-graph/src/references.rs
+++ b/external-crates/move/move-borrow-graph/src/references.rs
@@ -209,6 +209,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> PartialEq for BorrowEdge<Loc, Lbl> {
 
 impl<Loc: Copy, Lbl: Clone + Ord> Eq for BorrowEdge<Loc, Lbl> {}
 
+#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
 impl<Loc: Copy, Lbl: Clone + Ord> PartialOrd for BorrowEdge<Loc, Lbl> {
     fn partial_cmp(&self, other: &BorrowEdge<Loc, Lbl>) -> Option<Ordering> {
         BorrowEdgeNoLoc::new(self).partial_cmp(&BorrowEdgeNoLoc::new(other))

--- a/external-crates/move/move-compiler/src/shared/unique_set.rs
+++ b/external-crates/move/move-compiler/src/shared/unique_set.rs
@@ -117,6 +117,7 @@ impl<T: TName> PartialEq for UniqueSet<T> {
 }
 impl<T: TName> Eq for UniqueSet<T> {}
 
+#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
 impl<T: TName> PartialOrd for UniqueSet<T> {
     fn partial_cmp(&self, other: &UniqueSet<T>) -> Option<Ordering> {
         (self.0).0.keys().partial_cmp((other.0).0.keys())

--- a/external-crates/move/move-core/types/src/gas_algebra.rs
+++ b/external-crates/move/move-core/types/src/gas_algebra.rs
@@ -177,7 +177,7 @@ impl<U> Eq for GasQuantity<U> {}
 
 impl<U> PartialOrd for GasQuantity<U> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp_impl(other))
+        Some(std::cmp::Ord::cmp(self, other))
     }
 }
 


### PR DESCRIPTION
## Description 

This is the last cleanup for the outstanding lints from https://github.com/MystenLabs/sui/pull/14167
In order to preserve existing behavior, it was easier to selectively ignore the lints on specific files.

## Test Plan 

Existing
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
