### PR TITLE
move: factor out source service header middleware

### DIFF
--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -322,7 +322,7 @@ async fn test_api_route() -> anyhow::Result<()> {
         .await?;
 
     let expected =
-        expect!["Unsupported version 'bogus' specified in header X-Sui-Source-Validation-Version"];
+        expect!["Unsupported version 'bogus' specified in header x-sui-source-validation-version"];
     expected.assert_eq(&json.error);
 
     Ok(())


### PR DESCRIPTION
## Description 

Just factors out checking version headers to a middleware function. Previously we only had one route and checked the headers in line. Now I want to add a second `/list` route (see https://github.com/MystenLabs/sui/pull/14361) where the server can report which source paths are verified, so factoring out header checking to middleware.

## Test Plan 

Just factoring out a middleware layer, covered by existing test for header checks

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
