### PR TITLE
move: source service lists verified sources

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -100,14 +100,15 @@ pub struct Package {
     pub watch: Option<ObjectID>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct SourceInfo {
     pub path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
     // Is Some when content is hydrated from disk.
     pub source: Option<String>,
 }
 
-#[derive(Eq, PartialEq, Clone, Default, Deserialize, Debug, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Clone, Default, Serialize, Deserialize, Debug, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     #[default]
@@ -314,7 +315,10 @@ pub async fn clone_repositories(repos: Vec<&RepositorySource>, dir: &Path) -> an
     Ok(())
 }
 
-pub async fn initialize(config: &Config, dir: &Path) -> anyhow::Result<NetworkLookup> {
+pub async fn initialize(
+    config: &Config,
+    dir: &Path,
+) -> anyhow::Result<(NetworkLookup, NetworkLookup)> {
     let mut repos = vec![];
     for s in &config.packages {
         match s {
@@ -323,7 +327,31 @@ pub async fn initialize(config: &Config, dir: &Path) -> anyhow::Result<NetworkLo
         }
     }
     clone_repositories(repos, dir).await?;
-    verify_packages(config, dir).await
+    let sources = verify_packages(config, dir).await?;
+    let sources_list = sources_list(&sources).await;
+    Ok((sources, sources_list))
+}
+
+pub async fn sources_list(sources: &NetworkLookup) -> NetworkLookup {
+    let mut sources_list = NetworkLookup::new();
+    for (network, addresses) in sources {
+        let mut address_map = AddressLookup::new();
+        for (address, symbols) in addresses {
+            let mut symbol_map = SourceLookup::new();
+            for (symbol, source_info) in symbols {
+                symbol_map.insert(
+                    *symbol,
+                    SourceInfo {
+                        path: source_info.path.file_name().unwrap().into(),
+                        source: None,
+                    },
+                );
+            }
+            address_map.insert(*address, symbol_map);
+        }
+        sources_list.insert(network.clone(), address_map);
+    }
+    sources_list
 }
 
 pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<NetworkLookup> {
@@ -435,6 +463,7 @@ pub async fn watch_for_upgrades(
                 info!("Saw upgrade txn: {:?}", result);
                 let mut app_state = app_state.write().unwrap();
                 app_state.sources = NetworkLookup::new(); // Clear all sources.
+                app_state.sources_list = NetworkLookup::new(); // Clear all listed sources.
                 if let Some(channel) = channel {
                     channel.send(result).unwrap();
                     break Ok(());
@@ -456,6 +485,7 @@ pub async fn watch_for_upgrades(
 pub struct AppState {
     pub sources: NetworkLookup,
     pub metrics: Option<SourceServiceMetrics>,
+    pub sources_list: NetworkLookup,
 }
 
 pub fn serve(
@@ -587,8 +617,12 @@ async fn check_version_header<B>(
     response
 }
 
-async fn list_route(State(_app_state): State<Arc<RwLock<AppState>>>) -> impl IntoResponse {
-    (StatusCode::OK, "").into_response()
+async fn list_route(State(app_state): State<Arc<RwLock<AppState>>>) -> impl IntoResponse {
+    let app_state = app_state.read().unwrap();
+    (
+        StatusCode::OK,
+        Json(app_state.sources_list.clone()).into_response(),
+    )
 }
 
 pub struct SourceServiceMetrics {

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -40,7 +40,7 @@ pub async fn main() -> anyhow::Result<()> {
     let package_config = parse_config(args.config_path)?;
     let tmp_dir = tempfile::tempdir()?;
     let start = tokio::time::Instant::now();
-    let sources = initialize(&package_config, tmp_dir.path()).await?;
+    let (sources, sources_list) = initialize(&package_config, tmp_dir.path()).await?;
     info!("verification complete in {:?}", start.elapsed());
 
     let metrics_listener = std::net::TcpListener::bind(METRICS_HOST_PORT)?;
@@ -51,6 +51,7 @@ pub async fn main() -> anyhow::Result<()> {
     let app_state = Arc::new(RwLock::new(AppState {
         sources,
         metrics: Some(metrics),
+        sources_list,
     }));
     let mut threads = vec![];
     let networks_to_watch = vec![


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/14359

Implements `api/list` route that reports all verified sources served. This info is currently opaque (a client has to know or guess what's available based on the repos we index), but `api/list` exposes this info explicitly.

Currently we just report the filename path--in follow up I will update this to point to the original source URL (like `github.com/...`) but that requires a bit more lifting.

```json
{
  "mainnet": {
    "0000000000000000000000000000000000000000000000000000000000000001": {
      "address": {
        "path": "address.move"
      },
      "ascii": {
        "path": "ascii.move"
      },
      "bcs": {
        "path": "bcs.move"
      },
      ...
```

## Test Plan 

added test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
