### PR TITLE
[SDK] Adds Receiving Object argument

### DIFF
--- a/sdk/typescript/src/bcs/index.ts
+++ b/sdk/typescript/src/bcs/index.ts
@@ -203,12 +203,12 @@ const SharedObjectRef = bcs.struct('SharedObjectRef', {
 const ObjectArg = bcs.enum('ObjectArg', {
 	ImmOrOwned: SuiObjectRef,
 	Shared: SharedObjectRef,
+	Receiving: SuiObjectRef,
 });
 
 const CallArg = bcs.enum('CallArg', {
 	Pure: bcs.vector(bcs.u8()),
 	Object: ObjectArg,
-	ObjVec: bcs.vector(ObjectArg),
 });
 
 const TypeTag: BcsType<TypeTag> = bcs.enum('TypeTag', {

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -20,6 +20,7 @@ const ObjectArg = union([
 			mutable: boolean(),
 		}),
 	}),
+	object({ Receiving: SuiObjectRef }),
 ]);
 
 export const PureCallArg = object({ Pure: array(integer()) });
@@ -70,6 +71,17 @@ export const Inputs = {
 			},
 		};
 	},
+	ReceivingObjectRef({ objectId, digest, version }: SuiObjectRef): ObjectCallArg {
+		return {
+			Object: {
+				Receiving: {
+					digest,
+					version,
+					objectId: normalizeSuiAddress(objectId),
+				},
+			},
+		};
+	},
 };
 
 export function getIdFromCallArg(arg: string | ObjectCallArg) {
@@ -78,6 +90,9 @@ export function getIdFromCallArg(arg: string | ObjectCallArg) {
 	}
 	if ('ImmOrOwned' in arg.Object) {
 		return normalizeSuiAddress(arg.Object.ImmOrOwned.objectId);
+	}
+	if ('Receiving' in arg.Object) {
+		return normalizeSuiAddress(arg.Object.Receiving.objectId);
 	}
 	return normalizeSuiAddress(arg.Object.Shared.objectId);
 }


### PR DESCRIPTION
## Description 

Follows the Transfer-to-Object specification and adds one more invariant to ObjectArg.

## Test Plan 

No tests just yet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- Adds support for transfer to object in sui.js