### PR TITLE
[compiler] Fix panic on public(script) after public(friend)

### DIFF
--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -1610,7 +1610,7 @@ fn function_(
     let attributes = flatten_attributes(context, AttributePosition::Function, pattributes);
     let warning_filter = warning_filter(context, &attributes);
     context.env.add_warning_filter_scope(warning_filter.clone());
-    let visibility = visibility(context, pvisibility);
+    let visibility = visibility(pvisibility);
     let (old_aliases, signature) = function_signature(context, psignature);
     let acquires = acquires
         .into_iter()
@@ -1647,16 +1647,13 @@ fn function_(
     (name, fdef)
 }
 
-fn visibility(context: &mut Context, pvisibility: P::Visibility) -> E::Visibility {
+fn visibility(pvisibility: P::Visibility) -> E::Visibility {
     match pvisibility {
         P::Visibility::Friend(loc) => E::Visibility::Friend(loc),
         P::Visibility::Internal => E::Visibility::Internal,
         P::Visibility::Package(loc) => E::Visibility::Package(loc),
         P::Visibility::Public(loc) => E::Visibility::Public(loc),
-        P::Visibility::Script(loc) => {
-            // assert!(!context.env.has_errors());
-            E::Visibility::Public(loc)
-        }
+        P::Visibility::Script(loc) => E::Visibility::Public(loc),
     }
 }
 

--- a/external-crates/move/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/move-compiler/src/expansion/translate.rs
@@ -1654,7 +1654,7 @@ fn visibility(context: &mut Context, pvisibility: P::Visibility) -> E::Visibilit
         P::Visibility::Package(loc) => E::Visibility::Package(loc),
         P::Visibility::Public(loc) => E::Visibility::Public(loc),
         P::Visibility::Script(loc) => {
-            assert!(!context.env.has_errors());
+            // assert!(!context.env.has_errors());
             E::Visibility::Public(loc)
         }
     }

--- a/external-crates/move/move-compiler/tests/move_check/parser/function_visibility_friend_script.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/function_visibility_friend_script.exp
@@ -1,0 +1,22 @@
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/parser/function_visibility_friend_script.move:2:20
+  │
+2 │     public(friend) public(script) fun f() {}
+  │     -------------- ^^^^^^^^^^^^^^ Duplicate visibility modifier
+  │     │               
+  │     Visibility modifier previously given here
+
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/parser/function_visibility_friend_script.move:2:20
+  │
+2 │     public(friend) public(script) fun f() {}
+  │                    ^^^^^^^^^^^^^^ 'public(script)' is deprecated in favor of the 'entry' modifier. Replace with 'public entry'
+
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/parser/function_visibility_friend_script.move:3:20
+  │
+3 │     public(script) public(friend) fun g() {}
+  │     -------------- ^^^^^^^^^^^^^^ Duplicate visibility modifier
+  │     │               
+  │     Visibility modifier previously given here
+

--- a/external-crates/move/move-compiler/tests/move_check/parser/function_visibility_friend_script.move
+++ b/external-crates/move/move-compiler/tests/move_check/parser/function_visibility_friend_script.move
@@ -1,0 +1,4 @@
+module 0x0::M {
+    public(friend) public(script) fun f() {}
+    public(script) public(friend) fun g() {}
+}


### PR DESCRIPTION
## Description 

Discovered an interesting panic while playing with function visibility modifiers:
```Move
module 0x0::test {
     public(friend) public(script) fun hey() {}
}
```

Compiler panics:
```
thread 'main2023-10-22T19:25:23.907561Z ERROR telemetry_subscribers: panicked at external-crates/move/move-compiler/src/expansion/translate.rs:1657:13:
assertion failed: !context.env.has_errors() panic.file="external-crates/move/move-compiler/src/expansion/translate.rs" panic.line=1657 panic.column=13
' panicked at external-crates/move/move-compiler/src/expansion/translate.rs:1657:13:
```

## Test Plan 

Adds a test for the scenario.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
