### PR TITLE
add replay command to the CLI which point to existing replay commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9799,6 +9799,7 @@ dependencies = [
  "sui-move",
  "sui-move-build",
  "sui-protocol-config",
+ "sui-replay",
  "sui-sdk",
  "sui-simulator",
  "sui-source-validation",

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -364,7 +364,7 @@ pub async fn execute_replay_command(
 
             sandbox_state.check_effects()?;
 
-            info!("Execution finished successfully. Local and on-chain effects match.");
+            println!("Execution finished successfully. Local and on-chain effects match.");
             Some((1u64, 1u64))
         }
 

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -50,6 +50,7 @@ sui-move = { workspace = true, features = ["all"] }
 sui-move-build.workspace = true
 sui-protocol-config.workspace = true
 shared-crypto.workspace = true
+sui-replay.workspace = true
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -12,32 +12,36 @@ The Sui Client CLI installs when you install Sui. See the [Install Sui](install.
 
 The Sui Client CLI supports the following commands:
 
-| Command | Description |
-| --- | --- |
-| `active-address` | Default address used for commands when none specified. |
-| `active-env` | Default environment used for commands when none specified. |
-| `addresses` | Obtain the Addresses managed by the client. |
-| `call` | Call Move function. |
-| `dynamic-field` | Query a dynamic field by address. |
-| `envs` | List all Sui environments. |
-| `execute-signed-tx` | Execute a Signed Transaction. This is useful when the user prefers to sign elsewhere and use this command to execute. |
-| `gas` | Obtain all gas objects owned by the address. |
-| `help` | Print this message or the help of the given subcommand(s). |
-| `merge-coin` | Merge two coin objects into one coin. |
-| `new-address` | Generate new address and keypair with keypair scheme flag {ed25519 or secp256k1 or secp256r1} with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1 |
-| `new-env` | Add new Sui environment. |
-| `object` | Get object information. |
-| `objects` | Obtain all objects owned by the address. |
-| `pay` | Pay SUI to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts. |
-| `pay_all_sui` | Pay all residual SUI coins to the recipient with input coins, after deducting the gas cost. The input coins also include the coin for gas payment, so no extra gas coin is required. |
-| `pay_sui` | Pay SUI coins to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts. The input coins also include the coin for gas payment, so no extra gas coin is required. |
-| `publish` | Publish Move modules. |
-| `split-coin` | Split a coin object into multiple coins. |
-| `switch` | Switch active address and network. |
-| `transfer` | Transfer object. |
-| `transfer-sui` | Transfer SUI, and pay gas with the same SUI coin object. If amount is specified, transfers only the amount. If not specified, transfers the object. |
-| `upgrade` | Upgrade a Move module. |
-| `verify-source` | Verify local Move packages against on-chain packages, and optionally their dependencies. |
+| Command              | Description                                                                                                                                                                                                                                   |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `active-address`     | Default address used for commands when none specified.                                                                                                                                                                                        |
+| `active-env`         | Default environment used for commands when none specified.                                                                                                                                                                                    |
+| `addresses`          | Obtain the Addresses managed by the client.                                                                                                                                                                                                   |
+| `call`               | Call Move function.                                                                                                                                                                                                                           |
+| `dynamic-field`      | Query a dynamic field by address.                                                                                                                                                                                                             |
+| `envs`               | List all Sui environments.                                                                                                                                                                                                                    |
+| `execute-signed-tx`  | Execute a Signed Transaction. This is useful when the user prefers to sign elsewhere and use this command to execute.                                                                                                                         |
+| `gas`                | Obtain all gas objects owned by the address.                                                                                                                                                                                                  |
+| `help`               | Print this message or the help of the given subcommand(s).                                                                                                                                                                                    |
+| `merge-coin`         | Merge two coin objects into one coin.                                                                                                                                                                                                         |
+| `new-address`        | Generate new address and keypair with keypair scheme flag {ed25519 or secp256k1 or secp256r1} with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1 |
+| `new-env`            | Add new Sui environment.                                                                                                                                                                                                                      |
+| `object`             | Get object information.                                                                                                                                                                                                                       |
+| `objects`            | Obtain all objects owned by the address.                                                                                                                                                                                                      |
+| `pay`                | Pay SUI to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts.                                                                                                                |
+| `pay_all_sui`        | Pay all residual SUI coins to the recipient with input coins, after deducting the gas cost. The input coins also include the coin for gas payment, so no extra gas coin is required.                                                          |
+| `pay_sui`            | Pay SUI coins to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts. The input coins also include the coin for gas payment, so no extra gas coin is required.                 |
+| `publish`            | Publish Move modules.                                                                                                                                                                                                                         |
+| `split-coin`         | Split a coin object into multiple coins.                                                                                                                                                                                                      |
+| `switch`             | Switch active address and network.                                                                                                                                                                                                            |
+| `transfer`           | Transfer object.                                                                                                                                                                                                                              |
+| `transfer-sui`       | Transfer SUI, and pay gas with the same SUI coin object. If amount is specified, transfers only the amount. If not specified, transfers the object.                                                                                           |
+| `upgrade`            | Upgrade a Move module.                                                                                                                                                                                                                        |
+| `verify-source`      | Verify local Move packages against on-chain packages, and optionally their dependencies.                                                                                                                                                      |
+| `replay-transaction` | Replay a given transaction to view transaction effects. Set environment variable MOVE_VM_STEP=1 to debug.                                                                                                                                     |
+| `replay-batch`       | Replay transactions listed in a file.                                                                                                                                                                                                         |
+| `replay-checkpoint`  | Replay all transactions in a range of checkpoints.                                                                                                                                                                                            |
+\
 
 **Note:** The `clear`, `echo`, `env`, and `exit` commands exist only in the interactive shell.
 


### PR DESCRIPTION
## Description 

Adds 3 new CLI commands for replay which call into the existing replay commands. We've removed most of the optional parameters in leu of the defaults so that we provide a simple and straightforward user experience. Based on feedback if there is an ask to expose these we can add them in as needed. 

A follow-up PR will be added to reformat the output using the tabular structure instead of the existing println! statements.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
