### PR TITLE
Remove module traits from AuthorityStore

### DIFF
--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -110,7 +110,8 @@ impl<R: ReadApiServer> IndexerApi<R> {
             type_: name_type,
             value,
         } = name;
-        let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.get_db())?;
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let layout = TypeLayoutBuilder::build_with_types(&name_type, epoch_store.module_cache())?;
         let sui_json_value = SuiJsonValue::new(value)?;
         let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
         Ok((name_type, name_bcs_value))

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -13,25 +13,19 @@ use crate::{
     transfer::Receiving,
 };
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::{
-    identifier::IdentStr,
-    resolver::{ModuleResolver, ResourceResolver},
-};
+use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
 use move_vm_types::loaded_data::runtime_types::Type;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
-pub trait SuiResolver:
-    ResourceResolver<Error = SuiError> + ModuleResolver<Error = SuiError> + BackingPackageStore
-{
+pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
 }
 
 impl<T> SuiResolver for T
 where
     T: ResourceResolver<Error = SuiError>,
-    T: ModuleResolver<Error = SuiError>,
     T: BackingPackageStore,
 {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore {
@@ -60,13 +54,8 @@ where
 }
 
 /// View of the store necessary to produce the layouts of types.
-pub trait TypeLayoutStore: BackingPackageStore + ModuleResolver<Error = SuiError> {}
-impl<T> TypeLayoutStore for T
-where
-    T: BackingPackageStore,
-    T: ModuleResolver<Error = SuiError>,
-{
-}
+pub trait TypeLayoutStore: BackingPackageStore {}
+impl<T> TypeLayoutStore for T where T: BackingPackageStore {}
 
 #[derive(Debug)]
 pub enum ExecutionResults {

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::ModuleId;
 pub use object_store_trait::ObjectStore;
 pub use read_store::ReadStore;
@@ -462,11 +461,7 @@ impl Display for DeleteKind {
 }
 
 pub trait BackingStore:
-    BackingPackageStore
-    + ChildObjectResolver
-    + GetModule<Error = SuiError, Item = CompiledModule>
-    + ObjectStore
-    + ParentSync
+    BackingPackageStore + ChildObjectResolver + ObjectStore + ParentSync
 {
     fn as_object_store(&self) -> &dyn ObjectStore;
 }
@@ -475,7 +470,6 @@ impl<T> BackingStore for T
 where
     T: BackingPackageStore,
     T: ChildObjectResolver,
-    T: GetModule<Error = SuiError, Item = CompiledModule>,
     T: ObjectStore,
     T: ParentSync,
 {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -13,6 +13,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
+use sui_types::storage::get_module;
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
@@ -310,7 +311,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
     type Error = SuiError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_module(id)
+        get_module(self, id)
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -1179,28 +1177,5 @@ impl<'backing> ParentSync for TemporaryStore<'backing> {
         _object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
         unreachable!("Never called in newer protocol versions")
-    }
-}
-
-impl<'backing> GetModule for TemporaryStore<'backing> {
-    type Error = SuiError;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, module_id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        if let Some(obj) = self.execution_results.written_objects.get(package_id) {
-            Ok(Some(
-                obj.data
-                    .try_as_package()
-                    .expect("Bad object type--expected package")
-                    .deserialize_module(
-                        &module_id.name().to_owned(),
-                        self.protocol_config.move_binary_format_version(),
-                        self.protocol_config.no_extraneous_module_bytes(),
-                    )?,
-            ))
-        } else {
-            self.store.get_module_by_id(module_id)
-        }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -3,8 +3,8 @@
 
 use crate::gas_charger::GasCharger;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::StructTag;
+use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -1100,35 +1100,6 @@ impl<'backing> BackingPackageStore for TemporaryStore<'backing> {
                 }
                 obj
             })
-        }
-    }
-}
-
-impl<'backing> ModuleResolver for TemporaryStore<'backing> {
-    type Error = SuiError;
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        let package_obj;
-        let package = match self.read_object(package_id) {
-            Some(object) => object,
-            None => match self.store.get_package_object(package_id)? {
-                Some(object) => {
-                    package_obj = object;
-                    &package_obj
-                }
-                None => {
-                    return Ok(None);
-                }
-            },
-        };
-        match &package.data {
-            Data::Package(c) => Ok(c
-                .serialized_module_map()
-                .get(module_id.name().as_str())
-                .cloned()),
-            _ => Err(SuiError::BadObjectType {
-                error: "Expected module object".to_string(),
-            }),
         }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -4,8 +4,8 @@
 use crate::programmable_transactions::context::load_type_from_struct;
 use crate::programmable_transactions::linkage_view::LinkageView;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::StructTag;
+use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
@@ -68,14 +68,6 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl<'state> ModuleResolver for NullSuiResolver<'state> {
-    type Error = SuiError;
-
-    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.get_module(id)
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -13,6 +13,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
+use sui_types::storage::get_module;
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
@@ -343,7 +344,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
     type Error = SuiError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_module(id)
+        get_module(self, id)
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -3,8 +3,8 @@
 
 use crate::gas_charger::GasCharger;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::StructTag;
+use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -996,35 +996,6 @@ impl<'backing> BackingPackageStore for TemporaryStore<'backing> {
                 }
                 obj
             })
-        }
-    }
-}
-
-impl<'backing> ModuleResolver for TemporaryStore<'backing> {
-    type Error = SuiError;
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        let package_obj;
-        let package = match self.read_object(package_id) {
-            Some(object) => object,
-            None => match self.store.get_package_object(package_id)? {
-                Some(object) => {
-                    package_obj = object;
-                    &package_obj
-                }
-                None => {
-                    return Ok(None);
-                }
-            },
-        };
-        match &package.data {
-            Data::Package(c) => Ok(c
-                .serialized_module_map()
-                .get(module_id.name().as_str())
-                .cloned()),
-            _ => Err(SuiError::BadObjectType {
-                error: "Expected module object".to_string(),
-            }),
         }
     }
 }

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -1075,28 +1073,5 @@ impl<'backing> ParentSync for TemporaryStore<'backing> {
         object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
         self.store.get_latest_parent_entry_ref_deprecated(object_id)
-    }
-}
-
-impl<'backing> GetModule for TemporaryStore<'backing> {
-    type Error = SuiError;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, module_id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        if let Some((obj, _)) = self.written.get(package_id) {
-            Ok(Some(
-                obj.data
-                    .try_as_package()
-                    .expect("Bad object type--expected package")
-                    .deserialize_module(
-                        &module_id.name().to_owned(),
-                        self.protocol_config.move_binary_format_version(),
-                        self.protocol_config.no_extraneous_module_bytes(),
-                    )?,
-            ))
-        } else {
-            self.store.get_module_by_id(module_id)
-        }
     }
 }

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -7,8 +7,8 @@ use crate::programmable_transactions::{
     linkage_view::{LinkageInfo, LinkageView},
 };
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::{StructTag, TypeTag};
+use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use sui_types::base_types::ObjectID;
@@ -73,14 +73,6 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl<'state> ModuleResolver for NullSuiResolver<'state> {
-    type Error = SuiError;
-
-    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.get_module(id)
     }
 }
 

--- a/sui-execution/vm-rework/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -13,6 +13,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
+use sui_types::storage::get_module;
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
@@ -310,7 +311,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
     type Error = SuiError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_module(id)
+        get_module(self, id)
     }
 }
 

--- a/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
@@ -3,8 +3,8 @@
 
 use crate::gas_charger::GasCharger;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::StructTag;
+use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -964,35 +964,6 @@ impl<'backing> BackingPackageStore for TemporaryStore<'backing> {
                 }
                 obj
             })
-        }
-    }
-}
-
-impl<'backing> ModuleResolver for TemporaryStore<'backing> {
-    type Error = SuiError;
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        let package_obj;
-        let package = match self.read_object(package_id) {
-            Some(object) => object,
-            None => match self.store.get_package_object(package_id)? {
-                Some(object) => {
-                    package_obj = object;
-                    &package_obj
-                }
-                None => {
-                    return Ok(None);
-                }
-            },
-        };
-        match &package.data {
-            Data::Package(c) => Ok(c
-                .serialized_module_map()
-                .get(module_id.name().as_str())
-                .cloned()),
-            _ => Err(SuiError::BadObjectType {
-                error: "Expected module object".to_string(),
-            }),
         }
     }
 }

--- a/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/temporary_store.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
@@ -1043,28 +1041,5 @@ impl<'backing> ParentSync for TemporaryStore<'backing> {
         _object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
         unreachable!("Never called in newer protocol versions")
-    }
-}
-
-impl<'backing> GetModule for TemporaryStore<'backing> {
-    type Error = SuiError;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, module_id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
-        let package_id = &ObjectID::from(*module_id.address());
-        if let Some(obj) = self.execution_results.written_objects.get(package_id) {
-            Ok(Some(
-                obj.data
-                    .try_as_package()
-                    .expect("Bad object type--expected package")
-                    .deserialize_module(
-                        &module_id.name().to_owned(),
-                        self.protocol_config.move_binary_format_version(),
-                        self.protocol_config.no_extraneous_module_bytes(),
-                    )?,
-            ))
-        } else {
-            self.store.get_module_by_id(module_id)
-        }
     }
 }

--- a/sui-execution/vm-rework/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/vm-rework/sui-adapter/src/type_layout_resolver.rs
@@ -4,8 +4,8 @@
 use crate::programmable_transactions::context::load_type_from_struct;
 use crate::programmable_transactions::linkage_view::LinkageView;
 use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::language_storage::StructTag;
+use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
@@ -68,14 +68,6 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl<'state> ModuleResolver for NullSuiResolver<'state> {
-    type Error = SuiError;
-
-    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.get_module(id)
     }
 }
 


### PR DESCRIPTION
## Description 

AuthorityStore should not care about Move modules. This can be done because we can retrieve modules as long as a type has BackingPackageStore trait which could fetch package objects.
Doing so forces us to not depend on the store directly as a module store.
This allowed me discover a place in RPC/indexerv0 where we forgot to use the module cache but went to the store directly. Fixed it.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
