### PR TITLE
Pruning object tombstones

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -18,6 +18,7 @@ authority-store-pruning-config:
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   pruning-run-delay-seconds: 60
+  enable-pruning-tombstones: false
 
 protocol-key-pair:
   path: "protocol.key"

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -18,3 +18,4 @@ authority-store-pruning-config:
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   pruning-run-delay-seconds: 60
+  enable-pruning-tombstones: false

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -543,6 +543,7 @@ pub struct AuthorityStorePruningConfig {
     /// number of epochs to keep the latest version of transactions and effects for
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_epochs_to_retain_for_checkpoints: Option<u64>,
+    pub enable_pruning_tombstones: bool,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -559,6 +560,7 @@ impl Default for AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: None,
+            enable_pruning_tombstones: false,
         }
     }
 }
@@ -578,6 +580,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
+            enable_pruning_tombstones: false,
         }
     }
     pub fn fullnode_config() -> Self {
@@ -594,6 +597,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
+            enable_pruning_tombstones: false,
         }
     }
 
@@ -612,6 +616,10 @@ impl AuthorityStorePruningConfig {
                     n
                 }
             })
+    }
+
+    pub fn set_enable_pruning_tombstones(&mut self, enable_pruning_tombstones: bool) {
+        self.enable_pruning_tombstones = enable_pruning_tombstones;
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -117,12 +117,7 @@ impl AuthorityStorePruner {
                 live_object_keys_to_prune.push(ObjectKey(object_id, seq_number));
             }
 
-            // Indirect object is not being used when pruning tombstone is developed. Therefore, to not further
-            // complicate the code, tombstone pruning is only enabled when indirect object is not turned on.
-            // TODO: re-evaluate the need for indirect object.
-            if enable_pruning_tombstones
-                && (indirect_objects_threshold == 0 || indirect_objects_threshold == usize::MAX)
-            {
+            if enable_pruning_tombstones {
                 for deleted_object_ref in effects
                     .deleted()
                     .into_iter()

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -631,15 +631,9 @@ fn owned_object_transaction_locks_table_default_config() -> DBOptions {
 }
 
 fn objects_table_default_config() -> DBOptions {
-    DBOptions {
-        options: default_db_options()
-            .optimize_for_write_throughput()
-            .optimize_for_read(
-                read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024),
-            )
-            .options,
-        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(false),
-    }
+    default_db_options()
+        .optimize_for_write_throughput()
+        .optimize_for_read(read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024))
 }
 
 fn transactions_table_default_config() -> DBOptions {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -631,9 +631,15 @@ fn owned_object_transaction_locks_table_default_config() -> DBOptions {
 }
 
 fn objects_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_read(read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024))
+    DBOptions {
+        options: default_db_options()
+            .optimize_for_write_throughput()
+            .optimize_for_read(
+                read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024),
+            )
+            .options,
+        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(false),
+    }
 }
 
 fn transactions_table_default_config() -> DBOptions {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -247,6 +247,13 @@ impl<'a> TestAuthorityBuilder<'a> {
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
         let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
         let overload_threshold_config = self.overload_threshold_config.unwrap_or_default();
+        let mut pruning_config = AuthorityStorePruningConfig::default();
+        if epoch_store
+            .protocol_config()
+            .simplified_unwrap_then_delete()
+        {
+            pruning_config.set_enable_pruning_tombstones(true);
+        }
         let state = AuthorityState::new(
             name,
             secret,
@@ -257,7 +264,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             index_store,
             checkpoint_store,
             &registry,
-            AuthorityStorePruningConfig::default(),
+            pruning_config,
             genesis.objects(),
             &DBCheckpointConfig::default(),
             ExpensiveSafetyCheckConfig::new_enable_all(),

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -248,11 +248,11 @@ impl<'a> TestAuthorityBuilder<'a> {
         let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
         let overload_threshold_config = self.overload_threshold_config.unwrap_or_default();
         let mut pruning_config = AuthorityStorePruningConfig::default();
-        if epoch_store
+        if !epoch_store
             .protocol_config()
             .simplified_unwrap_then_delete()
         {
-            pruning_config.set_enable_pruning_tombstones(true);
+            pruning_config.set_enable_pruning_tombstones(false);
         }
         let state = AuthorityState::new(
             name,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -562,6 +562,14 @@ impl SuiNode {
             state_snapshot_handle.is_some(),
         )?;
 
+        let mut pruning_config = config.authority_store_pruning_config;
+        if epoch_store
+            .protocol_config()
+            .simplified_unwrap_then_delete()
+        {
+            pruning_config.set_enable_pruning_tombstones(true);
+        }
+
         let state = AuthorityState::new(
             config.protocol_public_key(),
             secret,
@@ -572,7 +580,7 @@ impl SuiNode {
             index_store.clone(),
             checkpoint_store.clone(),
             &prometheus_registry,
-            config.authority_store_pruning_config,
+            pruning_config,
             genesis.objects(),
             &db_checkpoint_config,
             config.expensive_safety_check_config.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -563,11 +563,11 @@ impl SuiNode {
         )?;
 
         let mut pruning_config = config.authority_store_pruning_config;
-        if epoch_store
+        if !epoch_store
             .protocol_config()
             .simplified_unwrap_then_delete()
         {
-            pruning_config.set_enable_pruning_tombstones(true);
+            pruning_config.set_enable_pruning_tombstones(false);
         }
 
         let state = AuthorityState::new(

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -58,6 +58,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -168,6 +169,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -278,6 +280,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -388,6 +391,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -498,6 +502,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -608,6 +613,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -718,6 +724,7 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
+      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -191,8 +191,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         }
     }
 
-    fn unsafe_add_deleted_object_for_testing(&mut self, object: ObjectRef) {
+    fn unsafe_add_deleted_live_object_for_testing(&mut self, object: ObjectRef) {
         self.modified_at_versions.push((object.0, object.1));
+    }
+
+    fn unsafe_add_object_tombstone_for_testing(&mut self, object: ObjectRef) {
         self.deleted.push(object);
     }
 }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -323,7 +323,24 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
         }
     }
 
-    fn unsafe_add_deleted_object_for_testing(&mut self, obj_ref: ObjectRef) {
+    fn unsafe_add_deleted_live_object_for_testing(&mut self, obj_ref: ObjectRef) {
+        self.changed_objects.push((
+            obj_ref.0,
+            EffectsObjectChange {
+                input_state: ObjectIn::Exist((
+                    (obj_ref.1, obj_ref.2),
+                    Owner::AddressOwner(SuiAddress::default()),
+                )),
+                output_state: ObjectOut::ObjectWrite((
+                    obj_ref.2,
+                    Owner::AddressOwner(SuiAddress::default()),
+                )),
+                id_operation: IDOperation::None,
+            },
+        ))
+    }
+
+    fn unsafe_add_object_tombstone_for_testing(&mut self, obj_ref: ObjectRef) {
         self.changed_objects.push((
             obj_ref.0,
             EffectsObjectChange {

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -397,7 +397,12 @@ pub trait TransactionEffectsAPI {
     fn transaction_digest_mut_for_testing(&mut self) -> &mut TransactionDigest;
     fn dependencies_mut_for_testing(&mut self) -> &mut Vec<TransactionDigest>;
     fn unsafe_add_input_shared_object_for_testing(&mut self, kind: InputSharedObject);
-    fn unsafe_add_deleted_object_for_testing(&mut self, obj_ref: ObjectRef);
+
+    // Adding an old version of a live object.
+    fn unsafe_add_deleted_live_object_for_testing(&mut self, obj_ref: ObjectRef);
+
+    // Adding a tombstone for a deleted object.
+    fn unsafe_add_object_tombstone_for_testing(&mut self, obj_ref: ObjectRef);
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Description 

This PR implements the main logic of pruning sui object tombstones.

Given the fact that we are using range deletes and `ignore_range_deletions` read option to improve read performance, it makes tombstone deletion tricky because once a tombstone is deleted, we need to make sure that all prior versions of the object must also be deleted. Otherwise, it'll leak object. To not hurt performance much (pending performance evaluation), we decided to use scan-and-point-delete when encounter an object tombstone. In this case, we guarantee that all prior versions are not visible to readers after the deletion.

The tombstone pruning logic currently is only tested in unit test. I wanted to enable it in integration test, but the PR becomes messy. It will come up in a follow up PR.

## Test Plan 

Unit test: this PR
Integration test: follow up PR
cluster test for performance testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
