### PR TITLE
move: source service watches multiple chains for upgrades

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -51,7 +51,7 @@ pub const TESTNET_WS_URL: &str = "wss://rpc.testnet.sui.io:443";
 pub const DEVNET_WS_URL: &str = "wss://rpc.devnet.sui.io:443";
 pub const LOCALNET_WS_URL: &str = "ws://127.0.0.1:9000";
 
-pub const WS_PING_INTERVAL_MS: u64 = 20_000;
+pub const WS_PING_INTERVAL: Duration = Duration::from_millis(20_000);
 
 pub fn host_port() -> String {
     match option_env!("HOST_PORT") {
@@ -399,7 +399,7 @@ pub async fn watch_for_upgrades(
     };
 
     let client: WsClient = WsClientBuilder::default()
-        .ping_interval(Duration::from_millis(WS_PING_INTERVAL_MS))
+        .ping_interval(WS_PING_INTERVAL)
         .build(websocket_url)
         .await?;
     let mut subscription: Subscription<SuiTransactionBlockEffects> = client

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use std::{ffi::OsString, fs, path::Path, process::Command};
 use tokio::sync::oneshot::Sender;
 
@@ -22,7 +23,7 @@ use jsonrpsee::core::params::ArrayParams;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 use url::Url;
 
 use move_compiler::compiled_unit::CompiledUnitEnum;
@@ -50,6 +51,8 @@ pub const TESTNET_WS_URL: &str = "wss://rpc.testnet.sui.io:443";
 pub const DEVNET_WS_URL: &str = "wss://rpc.devnet.sui.io:443";
 pub const LOCALNET_WS_URL: &str = "ws://127.0.0.1:9000";
 
+pub const WS_PING_INTERVAL_MS: u64 = 20_000;
+
 pub fn host_port() -> String {
     match option_env!("HOST_PORT") {
         Some(v) => v.to_string(),
@@ -57,12 +60,12 @@ pub fn host_port() -> String {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Config {
     pub packages: Vec<PackageSource>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "source", content = "values")]
 pub enum PackageSource {
     Repository(RepositorySource),
@@ -370,9 +373,11 @@ pub async fn verify_packages(config: &Config, dir: &Path) -> anyhow::Result<Netw
 pub async fn watch_for_upgrades(
     packages: Vec<PackageSource>,
     app_state: Arc<RwLock<AppState>>,
+    network: Network,
     channel: Option<Sender<SuiTransactionBlockEffects>>,
 ) -> anyhow::Result<()> {
     let mut watch_ids = ArrayParams::new();
+    let mut num_packages = 0;
     for s in packages {
         let packages = match s {
             PackageSource::Repository(RepositorySource { packages, .. }) => packages,
@@ -380,12 +385,23 @@ pub async fn watch_for_upgrades(
         };
         for p in packages {
             if let Some(id) = p.watch {
+                num_packages += 1;
                 watch_ids.insert(TransactionFilter::ChangedObject(id))?
             }
         }
     }
 
-    let client: WsClient = WsClientBuilder::default().build(LOCALNET_WS_URL).await?;
+    let websocket_url = match network {
+        Network::Mainnet => MAINNET_WS_URL,
+        Network::Testnet => TESTNET_WS_URL,
+        Network::Devnet => DEVNET_WS_URL,
+        Network::Localnet => LOCALNET_WS_URL,
+    };
+
+    let client: WsClient = WsClientBuilder::default()
+        .ping_interval(Duration::from_millis(WS_PING_INTERVAL_MS))
+        .build(websocket_url)
+        .await?;
     let mut subscription: Subscription<SuiTransactionBlockEffects> = client
         .subscribe(
             "suix_subscribeTransaction",
@@ -394,7 +410,7 @@ pub async fn watch_for_upgrades(
         )
         .await?;
 
-    info!("Listening for upgrades...");
+    info!("Listening for upgrades on {num_packages} package(s) on {websocket_url}...");
     loop {
         let result: Option<Result<SuiTransactionBlockEffects, _>> = subscription.next().await;
         match result {
@@ -417,7 +433,8 @@ pub async fn watch_for_upgrades(
                 info!("Saw failed transaction when listening to upgrades.")
             }
             None => {
-                bail!("Fatal: WebSocket connection lost while listening for upgrades. Shutting down server.")
+                error!("Fatal: WebSocket connection lost while listening for upgrades. Shutting down server.");
+                std::process::exit(1)
             }
         }
     }

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -10,7 +10,8 @@ use clap::Parser;
 use telemetry_subscribers::TelemetryConfig;
 
 use sui_source_validation_service::{
-    host_port, initialize, parse_config, serve, watch_for_upgrades, AppState,
+    host_port, initialize, parse_config, serve, watch_for_upgrades, AppState, DirectorySource,
+    Network, PackageSource, RepositorySource,
 };
 
 #[derive(Parser, Debug)]
@@ -29,13 +30,39 @@ pub async fn main() -> anyhow::Result<()> {
     info!("verification complete in {:?}", start.elapsed());
 
     let app_state = Arc::new(RwLock::new(AppState { sources }));
-    let app_state_copy = app_state.clone();
     let mut threads = vec![];
-    let watcher =
-        tokio::spawn(
-            async move { watch_for_upgrades(package_config.packages, app_state, None).await },
-        );
-    threads.push(watcher);
+    let networks_to_watch = vec![
+        Network::Mainnet,
+        Network::Testnet,
+        Network::Devnet,
+        Network::Localnet,
+    ];
+    // spawn a watcher thread for upgrades for each network
+    for network in networks_to_watch {
+        let app_state_copy = app_state.clone();
+        let packages: Vec<_> = package_config
+            .clone()
+            .packages
+            .into_iter()
+            .filter(|p| match p {
+                PackageSource::Repository(RepositorySource {
+                    network: Some(n), ..
+                })
+                | PackageSource::Directory(DirectorySource {
+                    network: Some(n), ..
+                }) => *n == network,
+                _ => false,
+            })
+            .collect();
+        if packages.is_empty() {
+            continue;
+        }
+        let watcher = tokio::spawn(async move {
+            watch_for_upgrades(packages, app_state_copy, network, None).await
+        });
+        threads.push(watcher);
+    }
+    let app_state_copy = app_state.clone();
     let server = tokio::spawn(async { serve(app_state_copy)?.await.map_err(anyhow::Error::from) });
     threads.push(server);
 

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -44,14 +44,17 @@ pub async fn main() -> anyhow::Result<()> {
             .clone()
             .packages
             .into_iter()
-            .filter(|p| match p {
-                PackageSource::Repository(RepositorySource {
-                    network: Some(n), ..
-                })
-                | PackageSource::Directory(DirectorySource {
-                    network: Some(n), ..
-                }) => *n == network,
-                _ => false,
+            .filter(|p| {
+                matches!(
+                    p,
+                    PackageSource::Repository(RepositorySource {
+                        network: Some(n),
+                        ..
+                    }) | PackageSource::Directory(DirectorySource {
+                        network: Some(n),
+                        ..
+                    }) if *n == network,
+                )
             })
             .collect();
         if packages.is_empty() {

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -93,7 +93,9 @@ async fn test_end_to_end() -> anyhow::Result<()> {
     let app_state = Arc::new(RwLock::new(AppState { sources }));
     let app_state_ref = app_state.clone();
     let (tx, rx) = oneshot::channel();
-    tokio::spawn(async move { watch_for_upgrades(config.packages, app_state, Some(tx)).await });
+    tokio::spawn(async move {
+        watch_for_upgrades(config.packages, app_state, Network::Localnet, Some(tx)).await
+    });
 
     // Set up to upgrade package.
     let package = effects


### PR DESCRIPTION
## Description 

This PR has the source service monitor all chains for upgrades; previously only the local network was monitored.

Note: I tested these changes for about ~1 week on a separate live instance to see stability / proneness to losing connections or erroring, and it has been stable.

## Test Plan 

Added tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
