### PR TITLE
[GraphQL/EASY] Clean-up -- avoid clones

### DIFF
--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -64,16 +64,16 @@ impl Object {
         self.version
     }
 
-    async fn digest(&self) -> String {
-        self.digest.clone()
+    async fn digest(&self) -> &str {
+        &self.digest
     }
 
-    async fn storage_rebate(&self) -> Option<BigInt> {
-        self.storage_rebate.clone()
+    async fn storage_rebate(&self) -> Option<&BigInt> {
+        self.storage_rebate.as_ref()
     }
 
-    async fn bcs(&self) -> Option<Base64> {
-        self.bcs.clone()
+    async fn bcs(&self) -> Option<&Base64> {
+        self.bcs.as_ref()
     }
 
     async fn previous_transaction_block(

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -25,17 +25,11 @@ pub(crate) struct ProtocolConfigs {
 
 #[ComplexObject]
 impl ProtocolConfigs {
-    async fn config(&self, key: String) -> Result<Option<ProtocolConfigAttr>> {
-        match self.configs.iter().find(|config| config.key == key) {
-            Some(config) => Ok(Some(config.clone())),
-            None => Ok(None),
-        }
+    async fn config(&self, key: String) -> Option<&ProtocolConfigAttr> {
+        self.configs.iter().find(|config| config.key == key)
     }
 
-    async fn feature_flag(&self, key: String) -> Result<Option<ProtocolConfigFeatureFlag>> {
-        match self.feature_flags.iter().find(|config| config.key == key) {
-            Some(config) => Ok(Some(config.clone())),
-            None => Ok(None),
-        }
+    async fn feature_flag(&self, key: String) -> Option<&ProtocolConfigFeatureFlag> {
+        self.feature_flags.iter().find(|config| config.key == key)
     }
 }


### PR DESCRIPTION
## Description

Some GraphQL endpoint implementations were cloning existing fields to return, this is unnecessary -- we can just return a reference.

## Test Plan

Manually tested with GraphiQL

![Screenshot 2023-10-23 at 8 53 58 PM](https://github.com/MystenLabs/sui/assets/332275/87457fdc-ffbd-408e-81a7-419c4668126f)