### PR TITLE
[GraphQL/Object] Implement asMoveObject

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -453,6 +453,7 @@ type Object implements ObjectOwner {
 	previousTransactionBlock: TransactionBlock
 	kind: ObjectKind
 	owner: Owner
+	asMoveObject: MoveObject
 	asMovePackage: MovePackage
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -76,7 +76,7 @@ use sui_sdk::types::{
         CheckpointCommitment, CheckpointDigest, EndOfEpochData as NativeEndOfEpochData,
     },
     move_package::MovePackage as SuiMovePackage,
-    object::{Data, Object as SuiObject},
+    object::Object as SuiObject,
     sui_system_state::sui_system_state_summary::{
         SuiSystemStateSummary as NativeSuiSystemStateSummary, SuiValidatorSummary,
     },
@@ -1565,14 +1565,10 @@ impl TryFrom<StoredObject> for Object {
             ));
         }
 
-        let bcs = match object.data {
-            // Do we BCS serialize packages?
-            Data::Package(package) => Base64::from(
-                bcs::to_bytes(&package)
-                    .map_err(|e| Error::Internal(format!("Failed to serialize package: {e}")))?,
-            ),
-            Data::Move(move_object) => Base64::from(&move_object.into_contents()),
-        };
+        let bcs = Base64::from(
+            bcs::to_bytes(&object)
+                .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))?,
+        );
 
         Ok(Self {
             address: SuiAddress::from_array(***object_id),

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -13,9 +13,8 @@ use super::{
     transaction_block::TransactionBlock,
 };
 use crate::context_data::db_data_provider::PgManager;
+use crate::error::{code, graphql_error};
 use crate::types::base64::Base64;
-use sui_types::digests::TransactionDigest as NativeSuiTransactionDigest;
-use sui_types::move_package::MovePackage as NativeSuiMovePackage;
 use sui_types::object::{Data as NativeSuiObjectData, Object as NativeSuiObject};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -99,23 +98,24 @@ impl Object {
     }
 
     async fn as_move_package(&self) -> Result<Option<MovePackage>> {
-        if let Some(bcs) = &self.bcs {
-            let bytes = bcs.0.as_slice();
+        let Some(bcs) = &self.bcs else {
+            return Ok(None);
+        };
 
-            let package = bcs::from_bytes::<NativeSuiMovePackage>(bytes)
-                .map_err(|e| Error::from(format!("Failed to deserialize package: {}", e)))?;
+        let native_object: NativeSuiObject = bcs::from_bytes(&bcs.0[..]).map_err(|_| {
+            graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                format!("Failed to deserialize object with ID: {}", self.address),
+            )
+        })?;
 
-            Ok(Some(MovePackage {
-                native_object: NativeSuiObject::new_package_from_data(
-                    NativeSuiObjectData::Package(package),
-                    self.previous_transaction
-                        .map(|x| NativeSuiTransactionDigest::new(x.into_array()))
-                        .ok_or(Error::new("Object must have a previous transaction digest"))?,
-                ),
-            }))
-        } else {
-            Ok(None)
-        }
+        Ok(
+            if matches!(native_object.data, NativeSuiObjectData::Package(_)) {
+                Some(MovePackage { native_object })
+            } else {
+                None
+            },
+        )
     }
 
     // =========== Owner interface methods =============
@@ -230,15 +230,12 @@ impl From<&NativeSuiObject> for Object {
             panic!("Immutable or Shared object should not have an owner_id");
         }
 
-        let bcs = match &o.data {
-            // Do we BCS serialize packages?
-            NativeSuiObjectData::Package(package) => Base64::from(
-                bcs::to_bytes(package)
-                    .expect("Failed to serialize package")
-                    .to_vec(),
-            ),
-            NativeSuiObjectData::Move(move_object) => Base64::from(move_object.contents()),
-        };
+        let bcs = Base64::from(
+            bcs::to_bytes(o)
+                // TODO: Shouldn't panic here.
+                .expect("Failed to serialize object")
+                .to_vec(),
+        );
 
         Self {
             address: SuiAddress::from_array(o.id().into_bytes()),

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -64,16 +64,16 @@ impl Object {
         self.version
     }
 
-    async fn digest(&self) -> String {
-        self.digest.clone()
+    async fn digest(&self) -> &str {
+        &self.digest
     }
 
-    async fn storage_rebate(&self) -> Option<BigInt> {
-        self.storage_rebate.clone()
+    async fn storage_rebate(&self) -> Option<&BigInt> {
+        self.storage_rebate.as_ref()
     }
 
-    async fn bcs(&self) -> Option<Base64> {
-        self.bcs.clone()
+    async fn bcs(&self) -> Option<&Base64> {
+        self.bcs.as_ref()
     }
 
     async fn previous_transaction_block(

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -25,17 +25,11 @@ pub(crate) struct ProtocolConfigs {
 
 #[ComplexObject]
 impl ProtocolConfigs {
-    async fn config(&self, key: String) -> Result<Option<ProtocolConfigAttr>> {
-        match self.configs.iter().find(|config| config.key == key) {
-            Some(config) => Ok(Some(config.clone())),
-            None => Ok(None),
-        }
+    async fn config(&self, key: String) -> Option<&ProtocolConfigAttr> {
+        self.configs.iter().find(|config| config.key == key)
     }
 
-    async fn feature_flag(&self, key: String) -> Result<Option<ProtocolConfigFeatureFlag>> {
-        match self.feature_flags.iter().find(|config| config.key == key) {
-            Some(config) => Ok(Some(config.clone())),
-            None => Ok(None),
-        }
+    async fn feature_flag(&self, key: String) -> Option<&ProtocolConfigFeatureFlag> {
+        self.feature_flags.iter().find(|config| config.key == key)
     }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -457,6 +457,7 @@ type Object implements ObjectOwner {
 	previousTransactionBlock: TransactionBlock
 	kind: ObjectKind
 	owner: Owner
+	asMoveObject: MoveObject
 	asMovePackage: MovePackage
 	location: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection


### PR DESCRIPTION
## Description

Now that the BCS representation of an `Object` does not lose information about whether it's a `MovePackage` or `MoveObject`, it becomes possible to implement `asMoveObject`, which this PR does.

## Test Plan

Manually tested with GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/0ea58cf7-21dc-4177-9b3f-84ee56e110f2)


## Stack

- #14376 
- #14377