### PR TITLE
[GraphQL] Integrate PackageCache

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -385,12 +385,26 @@ type MoveType {
 	Structured representation of the type signature.
 	"""
 	signature: MoveTypeSignature!
+	"""
+	Structured representation of the "shape" of values that match this type.
+	"""
+	layout: MoveTypeLayout!
 }
 
 """
-The signature of a concrete Move Type (a type with all its type
-parameters instantiated with concrete types, that contains no
-references), corresponding to the following recursive type:
+The shape of a concrete Move Type (a type with all its type parameters instantiated with concrete types), corresponding to the following recursive type:
+
+type MoveTypeLayout =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: MoveTypeLayout }
+  | { struct: [{ name: string, layout: MoveTypeLayout }] }
+"""
+scalar MoveTypeLayout
+
+"""
+The signature of a concrete Move Type (a type with all its type parameters instantiated with concrete types, that contains no references), corresponding to the following recursive type:
 
 type MoveTypeSignature =
     "address"

--- a/crates/sui-graphql-rpc/src/context_data/mod.rs
+++ b/crates/sui-graphql-rpc/src/context_data/mod.rs
@@ -4,8 +4,7 @@
 pub(crate) mod data_provider;
 pub(crate) mod db_data_provider;
 pub mod db_query_cost;
-#[allow(dead_code)]
-pub(crate) mod package_cache; // TODO: Remove annotation once integrated
+pub(crate) mod package_cache;
 pub(crate) mod sui_sdk_data_provider;
 
 pub const DEFAULT_PAGE_SIZE: u64 = 10;

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -22,20 +22,13 @@ pub(crate) struct MoveObject {
 #[allow(unused_variables)]
 #[Object]
 impl MoveObject {
-    // TODO: This depends on having a module resolver so make more efficient
     async fn contents(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>, Error> {
         let resolver = ctx.data_unchecked::<PgManager>();
 
         if let Some(struct_tag) = self.native_object.data.struct_tag() {
             let type_tag = TypeTag::Struct(Box::new(struct_tag));
-            let type_layout = resolver
-                .build_with_types_in_blocking_task(type_tag.clone())
-                .await
-                .extend()?;
-
             return Ok(Some(MoveValue::new(
                 type_tag.to_string(),
-                type_layout,
                 self.native_object
                     .data
                     .try_as_move()

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -389,12 +389,26 @@ type MoveType {
 	Structured representation of the type signature.
 	"""
 	signature: MoveTypeSignature!
+	"""
+	Structured representation of the "shape" of values that match this type.
+	"""
+	layout: MoveTypeLayout!
 }
 
 """
-The signature of a concrete Move Type (a type with all its type
-parameters instantiated with concrete types, that contains no
-references), corresponding to the following recursive type:
+The shape of a concrete Move Type (a type with all its type parameters instantiated with concrete types), corresponding to the following recursive type:
+
+type MoveTypeLayout =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: MoveTypeLayout }
+  | { struct: [{ name: string, layout: MoveTypeLayout }] }
+"""
+scalar MoveTypeLayout
+
+"""
+The signature of a concrete Move Type (a type with all its type parameters instantiated with concrete types, that contains no references), corresponding to the following recursive type:
 
 type MoveTypeSignature =
     "address"
@@ -862,4 +876,3 @@ type ValidatorSet {
 schema {
 	query: Query
 }
-


### PR DESCRIPTION
## Description

Use PackageCache to calculate type layouts, and use this information to serve requests (derive type layouts from type tags, and returned structured representations of Move data).

This also eliminates some unused methods for fetching packages from the DB Data Provider.

Integration with GraphQL also requires introducing a new scalar type to represent `MoveTypeLayout`s, and a function to map from the native version of that type to the GraphQL version.

## Test Plan

Tested with GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/fe35bf17-3fae-4db2-b354-12fb6e03b6e0)


##  Stack

- #14376 
- #14377 
- #14378 
- #14319 