### PR TITLE
[indexerv2] use canonical string with 0x prefix for types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11970,6 +11970,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "enum_dispatch",
+ "expect-test",
  "eyre",
  "fastcrypto",
  "fastcrypto-zkp",

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -79,7 +79,7 @@ impl TransactionHandler {
         let move_calls_vec = txn_data.move_calls();
         let packages: BTreeSet<_> = move_calls_vec
             .iter()
-            .map(|(package, _, _)| package.to_canonical_string(false))
+            .map(|(package, _, _)| package.to_canonical_string(/* with_prefix */ false))
             .collect();
         let packages = packages
             .iter()

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -79,7 +79,7 @@ impl TransactionHandler {
         let move_calls_vec = txn_data.move_calls();
         let packages: BTreeSet<_> = move_calls_vec
             .iter()
-            .map(|(package, _, _)| package.to_canonical_string())
+            .map(|(package, _, _)| package.to_canonical_string(false))
             .collect();
         let packages = packages
             .iter()

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -173,7 +173,7 @@ impl TryFrom<TypeTag> for MoveTypeSignature {
             T::Vector(v) => Self::Vector(Box::new(Self::try_from(*v)?)),
 
             T::Struct(s) => Self::Struct {
-                package: s.address.to_canonical_display().to_string(),
+                package: s.address.to_canonical_display(true).to_string(),
                 module: s.module.to_string(),
                 type_: s.name.to_string(),
                 type_parameters: s

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -173,7 +173,7 @@ impl TryFrom<TypeTag> for MoveTypeSignature {
             T::Vector(v) => Self::Vector(Box::new(Self::try_from(*v)?)),
 
             T::Struct(s) => Self::Struct {
-                package: format!("0x{}", s.address.to_canonical_string()),
+                package: s.address.to_canonical_string_with_prefix(),
                 module: s.module.to_string(),
                 type_: s.name.to_string(),
                 type_parameters: s

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -173,7 +173,7 @@ impl TryFrom<TypeTag> for MoveTypeSignature {
             T::Vector(v) => Self::Vector(Box::new(Self::try_from(*v)?)),
 
             T::Struct(s) => Self::Struct {
-                package: s.address.to_canonical_display(true).to_string(),
+                package: s.address.to_canonical_string(/* with_prefix */ true),
                 module: s.module.to_string(),
                 type_: s.name.to_string(),
                 type_parameters: s

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -173,7 +173,7 @@ impl TryFrom<TypeTag> for MoveTypeSignature {
             T::Vector(v) => Self::Vector(Box::new(Self::try_from(*v)?)),
 
             T::Struct(s) => Self::Struct {
-                package: s.address.to_canonical_string_with_prefix(),
+                package: s.address.to_canonical_display().to_string(),
                 module: s.module.to_string(),
                 type_: s.name.to_string(),
                 type_parameters: s

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -220,7 +220,7 @@ fn try_to_json_value(value: value::MoveValue) -> Result<Value> {
         V::U256(n) => Value::String(n.to_string()),
 
         V::Bool(b) => Value::Boolean(b),
-        V::Address(a) => Value::String(format!("0x{}", a.to_canonical_string())),
+        V::Address(a) => Value::String(a.to_canonical_string(true)),
 
         V::Vector(xs) => Value::List(
             xs.into_iter()
@@ -243,10 +243,7 @@ fn try_to_json_value(value: value::MoveValue) -> Result<Value> {
                 Value::String(extract_string(&type_, fields)?)
             } else if is_type(&type_, &SUI, MOD_OBJECT, TYP_UID) {
                 // 0x2::object::UID
-                Value::String(format!(
-                    "0x{}",
-                    extract_uid(&type_, fields)?.to_canonical_string()
-                ))
+                Value::String(extract_uid(&type_, fields)?.to_canonical_string(true))
             } else {
                 // Arbitrary structs
                 Value::Object(

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -220,7 +220,7 @@ fn try_to_json_value(value: value::MoveValue) -> Result<Value> {
         V::U256(n) => Value::String(n.to_string()),
 
         V::Bool(b) => Value::Boolean(b),
-        V::Address(a) => Value::String(a.to_canonical_string(true)),
+        V::Address(a) => Value::String(a.to_canonical_string(/* with_prefix */ true)),
 
         V::Vector(xs) => Value::List(
             xs.into_iter()
@@ -243,7 +243,9 @@ fn try_to_json_value(value: value::MoveValue) -> Result<Value> {
                 Value::String(extract_string(&type_, fields)?)
             } else if is_type(&type_, &SUI, MOD_OBJECT, TYP_UID) {
                 // 0x2::object::UID
-                Value::String(extract_uid(&type_, fields)?.to_canonical_string(true))
+                Value::String(
+                    extract_uid(&type_, fields)?.to_canonical_string(/* with_prefix */ true),
+                )
             } else {
                 // Arbitrary structs
                 Value::Object(

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -698,7 +698,7 @@ fn try_create_dynamic_field_info(
                 name,
                 bcs_name,
                 type_,
-                object_type: object_type.to_canonical_string(true),
+                object_type: object_type.to_canonical_string(/* with_prefix */ true),
                 object_id,
                 version,
                 digest,
@@ -709,8 +709,7 @@ fn try_create_dynamic_field_info(
             bcs_name,
             type_,
             object_type: move_object.into_type().into_type_params()[1]
-                .to_canonical_display(true)
-                .to_string(),
+                .to_canonical_string(/* with_prefix */ true),
             object_id: o.id(),
             version: o.version(),
             digest: o.digest(),

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -7,6 +7,7 @@ use crate::models_v2::display::StoredDisplay;
 use async_trait::async_trait;
 use itertools::Itertools;
 use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::language_storage::StructTag;
 use mysten_metrics::{get_metrics, spawn_monitored_task};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
@@ -694,11 +695,12 @@ fn try_create_dynamic_field_info(
             let version = object.version();
             let digest = object.digest();
             let object_type = object.data.type_().unwrap().clone();
+            let struct_tag: StructTag = object_type.into();
             DynamicFieldInfo {
                 name,
                 bcs_name,
                 type_,
-                object_type: object_type.to_string(),
+                object_type: struct_tag.to_canonical_string(),
                 object_id,
                 version,
                 digest,
@@ -708,7 +710,7 @@ fn try_create_dynamic_field_info(
             name,
             bcs_name,
             type_,
-            object_type: move_object.into_type().into_type_params()[1].to_string(),
+            object_type: move_object.into_type().into_type_params()[1].to_canonical_string(),
             object_id: o.id(),
             version: o.version(),
             digest: o.digest(),

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -700,7 +700,7 @@ fn try_create_dynamic_field_info(
                 name,
                 bcs_name,
                 type_,
-                object_type: struct_tag.to_canonical_string(),
+                object_type: struct_tag.to_canonical_string_with_prefix(),
                 object_id,
                 version,
                 digest,
@@ -710,7 +710,8 @@ fn try_create_dynamic_field_info(
             name,
             bcs_name,
             type_,
-            object_type: move_object.into_type().into_type_params()[1].to_canonical_string(),
+            object_type: move_object.into_type().into_type_params()[1]
+                .to_canonical_string_with_prefix(),
             object_id: o.id(),
             version: o.version(),
             digest: o.digest(),

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -698,7 +698,7 @@ fn try_create_dynamic_field_info(
                 name,
                 bcs_name,
                 type_,
-                object_type: object_type.to_canonical_string(),
+                object_type: object_type.to_canonical_string(true),
                 object_id,
                 version,
                 digest,
@@ -709,7 +709,7 @@ fn try_create_dynamic_field_info(
             bcs_name,
             type_,
             object_type: move_object.into_type().into_type_params()[1]
-                .to_canonical_display()
+                .to_canonical_display(true)
                 .to_string(),
             object_id: o.id(),
             version: o.version(),

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -7,7 +7,6 @@ use crate::models_v2::display::StoredDisplay;
 use async_trait::async_trait;
 use itertools::Itertools;
 use move_bytecode_utils::module_cache::GetModule;
-use move_core_types::language_storage::StructTag;
 use mysten_metrics::{get_metrics, spawn_monitored_task};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
@@ -695,12 +694,11 @@ fn try_create_dynamic_field_info(
             let version = object.version();
             let digest = object.digest();
             let object_type = object.data.type_().unwrap().clone();
-            let struct_tag: StructTag = object_type.into();
             DynamicFieldInfo {
                 name,
                 bcs_name,
                 type_,
-                object_type: struct_tag.to_canonical_string_with_prefix(),
+                object_type: object_type.to_canonical_string(),
                 object_id,
                 version,
                 digest,
@@ -711,7 +709,8 @@ fn try_create_dynamic_field_info(
             bcs_name,
             type_,
             object_type: move_object.into_type().into_type_params()[1]
-                .to_canonical_string_with_prefix(),
+                .to_canonical_display()
+                .to_string(),
             object_id: o.id(),
             version: o.version(),
             digest: o.digest(),

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -573,11 +573,11 @@ impl IndexerReader {
             return Ok(None);
         }
         match filter.unwrap() {
-            SuiObjectDataFilter::StructType (struct_tag ) => Ok(Some(vec![struct_tag.to_string()])),
+            SuiObjectDataFilter::StructType (struct_tag ) => Ok(Some(vec![struct_tag.to_canonical_string(/* with_prefix */ true)])),
             SuiObjectDataFilter::MatchAny(filters) => {
                 filters.iter().map(|filter| {
                     match filter {
-                        SuiObjectDataFilter::StructType (struct_tag ) => Ok(struct_tag.to_string()),
+                        SuiObjectDataFilter::StructType (struct_tag ) => Ok(struct_tag.to_canonical_string(/* with_prefix */ true)),
                         _ => Err(IndexerError::InvalidArgumentError(
                             "Invalid filter type. Only struct filters and MatchAny of struct filters are supported.".into(),
                         )),

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1314,7 +1314,7 @@ impl IndexerReader {
         &self,
         object_type: &move_core_types::language_storage::StructTag,
     ) -> Result<Option<sui_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
-        let object_type = object_type.to_canonical_display(true).to_string();
+        let object_type = object_type.to_canonical_string(/* with_prefix */ true);
         self.spawn_blocking(move |this| this.get_display_update_event(object_type))
             .await
     }

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1314,7 +1314,7 @@ impl IndexerReader {
         &self,
         object_type: &move_core_types::language_storage::StructTag,
     ) -> Result<Option<sui_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
-        let object_type = object_type.to_canonical_string_with_prefix();
+        let object_type = object_type.to_canonical_display().to_string();
         self.spawn_blocking(move |this| this.get_display_update_event(object_type))
             .await
     }

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1314,7 +1314,7 @@ impl IndexerReader {
         &self,
         object_type: &move_core_types::language_storage::StructTag,
     ) -> Result<Option<sui_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
-        let object_type = object_type.to_canonical_display().to_string();
+        let object_type = object_type.to_canonical_display(true).to_string();
         self.spawn_blocking(move |this| this.get_display_update_event(object_type))
             .await
     }

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1314,7 +1314,7 @@ impl IndexerReader {
         &self,
         object_type: &move_core_types::language_storage::StructTag,
     ) -> Result<Option<sui_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
-        let object_type = object_type.to_canonical_string();
+        let object_type = object_type.to_canonical_string_with_prefix();
         self.spawn_blocking(move |this| this.get_display_update_event(object_type))
             .await
     }

--- a/crates/sui-indexer/src/models_v2/display.rs
+++ b/crates/sui-indexer/src/models_v2/display.rs
@@ -20,7 +20,7 @@ impl StoredDisplay {
         let (ty, display_event) = DisplayVersionUpdatedEvent::try_from_event(event)?;
 
         Some(Self {
-            object_type: ty.to_canonical_string_with_prefix(),
+            object_type: ty.to_canonical_display().to_string(),
             id: display_event.id.bytes.to_vec(),
             version: display_event.version as i16,
             bcs: event.contents.clone(),

--- a/crates/sui-indexer/src/models_v2/display.rs
+++ b/crates/sui-indexer/src/models_v2/display.rs
@@ -20,7 +20,7 @@ impl StoredDisplay {
         let (ty, display_event) = DisplayVersionUpdatedEvent::try_from_event(event)?;
 
         Some(Self {
-            object_type: ty.to_canonical_display().to_string(),
+            object_type: ty.to_canonical_display(true).to_string(),
             id: display_event.id.bytes.to_vec(),
             version: display_event.version as i16,
             bcs: event.contents.clone(),

--- a/crates/sui-indexer/src/models_v2/display.rs
+++ b/crates/sui-indexer/src/models_v2/display.rs
@@ -20,7 +20,7 @@ impl StoredDisplay {
         let (ty, display_event) = DisplayVersionUpdatedEvent::try_from_event(event)?;
 
         Some(Self {
-            object_type: ty.to_canonical_string(),
+            object_type: ty.to_canonical_string_with_prefix(),
             id: display_event.id.bytes.to_vec(),
             version: display_event.version as i16,
             bcs: event.contents.clone(),

--- a/crates/sui-indexer/src/models_v2/display.rs
+++ b/crates/sui-indexer/src/models_v2/display.rs
@@ -20,7 +20,7 @@ impl StoredDisplay {
         let (ty, display_event) = DisplayVersionUpdatedEvent::try_from_event(event)?;
 
         Some(Self {
-            object_type: ty.to_canonical_display(true).to_string(),
+            object_type: ty.to_canonical_string(/* with_prefix */ true),
             id: display_event.id.bytes.to_vec(),
             version: display_event.version as i16,
             bcs: event.contents.clone(),

--- a/crates/sui-indexer/src/models_v2/events.rs
+++ b/crates/sui-indexer/src/models_v2/events.rs
@@ -137,3 +137,36 @@ impl StoredEvent {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
+    use sui_types::event::Event;
+
+    #[test]
+    fn test_canonical_string_of_event_type() {
+        let tx_digest = TransactionDigest::default();
+        let event = Event {
+            package_id: ObjectID::random(),
+            transaction_module: Identifier::new("test").unwrap(),
+            sender: AccountAddress::random().into(),
+            type_: StructTag {
+                address: AccountAddress::TWO,
+                module: Identifier::new("test").unwrap(),
+                name: Identifier::new("test").unwrap(),
+                type_params: vec![],
+            },
+            contents: vec![],
+        };
+
+        let indexed_event = IndexedEvent::from_event(1, 1, 1, tx_digest, &event, 100);
+
+        let stored_event = StoredEvent::from(indexed_event);
+
+        assert_eq!(
+            stored_event.event_type,
+            "0x0000000000000000000000000000000000000000000000000000000000000002::test::test"
+        );
+    }
+}

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -74,7 +74,10 @@ impl From<IndexedObject> for StoredObject {
             checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
             owner_type: o.owner_type as i16,
             owner_id: o.owner_id.map(|id| id.to_vec()),
-            object_type: o.object.type_().map(|t| t.to_canonical_string(true)),
+            object_type: o
+                .object
+                .type_()
+                .map(|t| t.to_canonical_string(/* with_prefix */ true)),
             serialized_object: bcs::to_bytes(&o.object).unwrap(),
             coin_type: o.coin_type,
             coin_balance: o.coin_balance.map(|b| b as i64),
@@ -339,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_one_more_thing() {
+    fn test_vec_of_coin_sui_conversion() {
         // 0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>
         let vec_coins_type = TypeTag::Vector(Box::new(
             Coin::type_(TypeTag::Struct(Box::new(GAS::type_()))).into(),

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -74,7 +74,7 @@ impl From<IndexedObject> for StoredObject {
             checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
             owner_type: o.owner_type as i16,
             owner_id: o.owner_id.map(|id| id.to_vec()),
-            object_type: o.object.type_().map(|t| t.to_canonical_string()),
+            object_type: o.object.type_().map(|t| t.to_canonical_string(true)),
             serialized_object: bcs::to_bytes(&o.object).unwrap(),
             coin_type: o.coin_type,
             coin_balance: o.coin_balance.map(|b| b as i64),

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::language_storage::StructTag;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 
@@ -75,10 +74,7 @@ impl From<IndexedObject> for StoredObject {
             checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
             owner_type: o.owner_type as i16,
             owner_id: o.owner_id.map(|id| id.to_vec()),
-            object_type: o.object.type_().map(|t| {
-                let s: StructTag = t.clone().into();
-                s.to_canonical_string_with_prefix()
-            }),
+            object_type: o.object.type_().map(|t| t.to_canonical_string()),
             serialized_object: bcs::to_bytes(&o.object).unwrap(),
             coin_type: o.coin_type,
             coin_balance: o.coin_balance.map(|b| b as i64),
@@ -300,6 +296,15 @@ impl From<CoinBalance> for Balance {
 
 #[cfg(test)]
 mod tests {
+    use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
+    use sui_types::{
+        coin::Coin,
+        digests::TransactionDigest,
+        gas_coin::{GasCoin, GAS},
+        object::{Data, MoveObject, Owner},
+        Identifier, TypeTag,
+    };
+
     use super::*;
 
     #[test]
@@ -311,7 +316,7 @@ mod tests {
 
         match stored_obj.object_type {
             Some(t) => {
-                assert_eq!(t, "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>");
+                assert_eq!(t, "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>");
             }
             None => {
                 panic!("object_type should not be none");
@@ -331,5 +336,58 @@ mod tests {
             sui_coin.coin_type,
             "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
+    }
+
+    #[test]
+    fn test_one_more_thing() {
+        // 0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>
+        let vec_coins_type = TypeTag::Vector(Box::new(
+            Coin::type_(TypeTag::Struct(Box::new(GAS::type_()))).into(),
+        ));
+        let object_type = StructTag {
+            address: AccountAddress::from_hex_literal("0xe7").unwrap(),
+            module: Identifier::new("vec_coin").unwrap(),
+            name: Identifier::new("VecCoin").unwrap(),
+            type_params: vec![vec_coins_type],
+        };
+
+        let id = ObjectID::ZERO;
+        let gas = 10;
+
+        let contents = bcs::to_bytes(&vec![GasCoin::new(id, gas)]).unwrap();
+        let data = Data::Move(
+            unsafe {
+                MoveObject::new_from_execution_with_limit(
+                    object_type.into(),
+                    true,
+                    1.into(),
+                    contents,
+                    256,
+                )
+            }
+            .unwrap(),
+        );
+
+        let owner = AccountAddress::from_hex_literal("0x1").unwrap();
+
+        let object = Object {
+            owner: Owner::AddressOwner(owner.into()),
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
+        };
+
+        let indexed_obj = IndexedObject::from_object(1, object, None);
+
+        let stored_obj = StoredObject::from(indexed_obj);
+
+        match stored_obj.object_type {
+            Some(t) => {
+                assert_eq!(t, "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>");
+            }
+            None => {
+                panic!("object_type should not be none");
+            }
+        }
     }
 }

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -79,7 +79,6 @@ impl From<IndexedObject> for StoredObject {
                 let s: StructTag = t.clone().into();
                 s.to_canonical_string()
             }),
-            // object_type: o.object.type_().map(|t| t.to_string()),
             serialized_object: bcs::to_bytes(&o.object).unwrap(),
             coin_type: o.coin_type,
             coin_balance: o.coin_balance.map(|b| b as i64),

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -77,7 +77,7 @@ impl From<IndexedObject> for StoredObject {
             owner_id: o.owner_id.map(|id| id.to_vec()),
             object_type: o.object.type_().map(|t| {
                 let s: StructTag = t.clone().into();
-                s.to_canonical_string()
+                s.to_canonical_string_with_prefix()
             }),
             serialized_object: bcs::to_bytes(&o.object).unwrap(),
             coin_type: o.coin_type,
@@ -311,7 +311,7 @@ mod tests {
 
         match stored_obj.object_type {
             Some(t) => {
-                assert_eq!(t, "0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>");
+                assert_eq!(t, "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>");
             }
             None => {
                 panic!("object_type should not be none");
@@ -329,7 +329,7 @@ mod tests {
         let sui_coin = SuiCoin::try_from(stored_obj).unwrap();
         assert_eq!(
             sui_coin.coin_type,
-            "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
 }

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -194,7 +194,7 @@ impl IndexedEvent {
             senders: vec![event.sender],
             package: event.package_id,
             module: event.transaction_module.to_string(),
-            event_type: event.type_.to_canonical_display().to_string(),
+            event_type: event.type_.to_canonical_display(true).to_string(),
             bcs: event.contents.clone(),
             timestamp_ms,
         }
@@ -248,7 +248,7 @@ impl IndexedObject {
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
             .coin_type_maybe()
-            .map(|t| t.to_canonical_display().to_string());
+            .map(|t| t.to_canonical_display(true).to_string());
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unsafe())
         } else {

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -194,7 +194,7 @@ impl IndexedEvent {
             senders: vec![event.sender],
             package: event.package_id,
             module: event.transaction_module.to_string(),
-            event_type: event.type_.to_canonical_display(true).to_string(),
+            event_type: event.type_.to_canonical_string(/* with_prefix */ true),
             bcs: event.contents.clone(),
             timestamp_ms,
         }
@@ -248,7 +248,7 @@ impl IndexedObject {
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
             .coin_type_maybe()
-            .map(|t| t.to_canonical_display(true).to_string());
+            .map(|t| t.to_canonical_string(/* with_prefix */ true));
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unsafe())
         } else {

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -246,7 +246,7 @@ impl IndexedObject {
         df_info: Option<DynamicFieldInfo>,
     ) -> Self {
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
-        let coin_type = object.coin_type_maybe().map(|t| t.to_string());
+        let coin_type = object.coin_type_maybe().map(|t| t.to_canonical_string());
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unsafe())
         } else {

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -194,7 +194,7 @@ impl IndexedEvent {
             senders: vec![event.sender],
             package: event.package_id,
             module: event.transaction_module.to_string(),
-            event_type: event.type_.to_canonical_string_with_prefix(),
+            event_type: event.type_.to_canonical_display().to_string(),
             bcs: event.contents.clone(),
             timestamp_ms,
         }
@@ -248,7 +248,7 @@ impl IndexedObject {
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
             .coin_type_maybe()
-            .map(|t| t.to_canonical_string_with_prefix());
+            .map(|t| t.to_canonical_display().to_string());
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unsafe())
         } else {

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -194,7 +194,7 @@ impl IndexedEvent {
             senders: vec![event.sender],
             package: event.package_id,
             module: event.transaction_module.to_string(),
-            event_type: event.type_.to_string(),
+            event_type: event.type_.to_canonical_string_with_prefix(),
             bcs: event.contents.clone(),
             timestamp_ms,
         }
@@ -246,7 +246,9 @@ impl IndexedObject {
         df_info: Option<DynamicFieldInfo>,
     ) -> Self {
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
-        let coin_type = object.coin_type_maybe().map(|t| t.to_canonical_string());
+        let coin_type = object
+            .coin_type_maybe()
+            .map(|t| t.to_canonical_string_with_prefix());
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unsafe())
         } else {

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -70,6 +70,7 @@ criterion.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
 serde_yaml.workspace = true
+expect-test.workspace = true
 
 [[bench]]
 name = "accumulator_bench"

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -320,13 +320,9 @@ impl MoveObjectType {
         }
     }
 
-    /// Returns the string representation of this object's type using the canonical display.
-    /// full address with 0x prefix
+    /// Returns the string representation of this object's type using the canonical display.    
     pub fn to_canonical_string(&self, with_prefix: bool) -> String {
-        let canonical_string = StructTag::from(self.clone())
-            .to_canonical_display(with_prefix)
-            .to_string();
-        canonical_string
+        StructTag::from(self.clone()).to_canonical_string(with_prefix)
     }
 }
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -319,6 +319,15 @@ impl MoveObjectType {
             MoveObjectType_::Other(o) => s == o,
         }
     }
+
+    /// Returns the string representation of this object's type using the canonical display.
+    /// full address with 0x prefix
+    pub fn to_canonical_string(&self) -> String {
+        let canonical_string = StructTag::from(self.clone())
+            .to_canonical_display()
+            .to_string();
+        canonical_string
+    }
 }
 
 impl From<StructTag> for MoveObjectType {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -322,9 +322,9 @@ impl MoveObjectType {
 
     /// Returns the string representation of this object's type using the canonical display.
     /// full address with 0x prefix
-    pub fn to_canonical_string(&self) -> String {
+    pub fn to_canonical_string(&self, with_prefix: bool) -> String {
         let canonical_string = StructTag::from(self.clone())
-            .to_canonical_display()
+            .to_canonical_display(with_prefix)
             .to_string();
         canonical_string
     }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -278,7 +278,7 @@ mod tests {
         let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
@@ -291,7 +291,7 @@ mod tests {
         .expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
@@ -302,7 +302,7 @@ mod tests {
             parse_sui_struct_tag("0x2::coin::COIN<0x2::sui::SUI>").expect("should not error");
         assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
         );
     }
@@ -313,7 +313,7 @@ mod tests {
             .expect("should not error");
         assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
         );
     }
@@ -328,7 +328,7 @@ mod tests {
             "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
         );
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"
         );
     }
@@ -342,7 +342,7 @@ mod tests {
             "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
         );
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"            
         );
     }
@@ -358,7 +358,7 @@ mod tests {
             "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
         );
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
         );
     }
@@ -374,7 +374,7 @@ mod tests {
             "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
         );
         assert_eq!(
-            result.to_canonical_display().to_string(),
+            result.to_canonical_display(true).to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
         );
     }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -272,15 +272,17 @@ fn is_object_struct(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use expect_test::expect;
 
     #[test]
     fn test_parse_sui_struct_tag_short_account_addr() {
         let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
-        assert_eq!(result.to_string(), "0x2::sui::SUI");
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
@@ -289,33 +291,36 @@ mod tests {
             "0x00000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
         )
         .expect("should not error");
-        assert_eq!(result.to_string(), "0x2::sui::SUI");
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
     fn test_parse_sui_struct_with_type_param_short_addr() {
         let result =
             parse_sui_struct_tag("0x2::coin::COIN<0x2::sui::SUI>").expect("should not error");
-        assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
     fn test_parse_sui_struct_with_type_param_long_addr() {
         let result = parse_sui_struct_tag("0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>")
             .expect("should not error");
-        assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
@@ -323,28 +328,24 @@ mod tests {
         let result =
             parse_sui_struct_tag("0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>")
                 .expect("should not error");
-        assert_eq!(
-            result.to_string(),
-            "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
-        );
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
     fn test_complex_struct_tag_with_long_addr() {
         let result = parse_sui_struct_tag("0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>")    
             .expect("should not error");
-        assert_eq!(
-            result.to_string(),
-            "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
-        );
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"            
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
@@ -353,14 +354,12 @@ mod tests {
             "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>",
         )
         .expect("should not error");
-        assert_eq!(
-            result.to_string(),
-            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
-        );
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
     #[test]
@@ -369,13 +368,11 @@ mod tests {
             "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>",
         )
         .expect("should not error");
-        assert_eq!(
-            result.to_string(),
-            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
-        );
-        assert_eq!(
-            result.to_canonical_display(true).to_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
-        );
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_string());
+
+        let expected = expect![[""]];
+        expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -268,3 +268,31 @@ fn is_object_struct(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sui_struct_tag_short_account_addr() {
+        let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
+        assert_eq!(result.to_string(), "0x2::sui::SUI");
+        assert_eq!(
+            result.to_canonical_string(),
+            "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+        );
+    }
+
+    #[test]
+    fn test_parse_sui_struct_tag_long_account_addr() {
+        let result = parse_sui_struct_tag(
+            "0x00000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        )
+        .expect("should not error");
+        assert_eq!(result.to_string(), "0x2::sui::SUI");
+        assert_eq!(
+            result.to_canonical_string(),
+            "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+        );
+    }
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -278,10 +278,11 @@ mod tests {
     fn test_parse_sui_struct_tag_short_account_addr() {
         let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0x2::sui::SUI"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected =
+            expect!["0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -292,10 +293,11 @@ mod tests {
         )
         .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0x2::sui::SUI"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected =
+            expect!["0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -304,10 +306,10 @@ mod tests {
         let result =
             parse_sui_struct_tag("0x2::coin::COIN<0x2::sui::SUI>").expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0x2::coin::COIN<0x2::sui::SUI>"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -316,10 +318,10 @@ mod tests {
         let result = parse_sui_struct_tag("0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>")
             .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0x2::coin::COIN<0x2::sui::SUI>"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -329,10 +331,10 @@ mod tests {
             parse_sui_struct_tag("0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>")
                 .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -341,10 +343,10 @@ mod tests {
         let result = parse_sui_struct_tag("0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>")    
             .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect!["0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -355,10 +357,12 @@ mod tests {
         )
         .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect![
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
+        ];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 
@@ -369,10 +373,12 @@ mod tests {
         )
         .expect("should not error");
 
-        let expected = expect![[""]];
+        let expected = expect![
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
+        ];
         expected.assert_eq(&result.to_string());
 
-        let expected = expect![[""]];
+        let expected = expect!["0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"];
         expected.assert_eq(&result.to_canonical_string(/* with_prefix */ true));
     }
 }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -278,7 +278,7 @@ mod tests {
         let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_string_with_prefix(),
+            result.to_canonical_display().to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
@@ -291,8 +291,91 @@ mod tests {
         .expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_string_with_prefix(),
+            result.to_canonical_display().to_string(),
             "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+        );
+    }
+
+    #[test]
+    fn test_parse_sui_struct_with_type_param_short_addr() {
+        let result =
+            parse_sui_struct_tag("0x2::coin::COIN<0x2::sui::SUI>").expect("should not error");
+        assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        );
+    }
+
+    #[test]
+    fn test_parse_sui_struct_with_type_param_long_addr() {
+        let result = parse_sui_struct_tag("0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>")
+            .expect("should not error");
+        assert_eq!(result.to_string(), "0x2::coin::COIN<0x2::sui::SUI>");
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::coin::COIN<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        );
+    }
+
+    #[test]
+    fn test_complex_struct_tag_with_short_addr() {
+        let result =
+            parse_sui_struct_tag("0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>")
+                .expect("should not error");
+        assert_eq!(
+            result.to_string(),
+            "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
+        );
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"
+        );
+    }
+
+    #[test]
+    fn test_complex_struct_tag_with_long_addr() {
+        let result = parse_sui_struct_tag("0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>")    
+            .expect("should not error");
+        assert_eq!(
+            result.to_string(),
+            "0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>"
+        );
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x00000000000000000000000000000000000000000000000000000000000000e7::vec_coin::VecCoin<vector<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>>"            
+        );
+    }
+
+    #[test]
+    fn test_dynamic_field_short_addr() {
+        let result = parse_sui_struct_tag(
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>",
+        )
+        .expect("should not error");
+        assert_eq!(
+            result.to_string(),
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
+        );
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
+        );
+    }
+
+    #[test]
+    fn test_dynamic_field_long_addr() {
+        let result = parse_sui_struct_tag(
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>",
+        )
+        .expect("should not error");
+        assert_eq!(
+            result.to_string(),
+            "0x2::dynamic_field::Field<address, 0xdee9::custodian_v2::Account<0x234::coin::COIN>>"
+        );
+        assert_eq!(
+            result.to_canonical_display().to_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<address,0x000000000000000000000000000000000000000000000000000000000000dee9::custodian_v2::Account<0x0000000000000000000000000000000000000000000000000000000000000234::coin::COIN>>"            
         );
     }
 }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -278,8 +278,8 @@ mod tests {
         let result = parse_sui_struct_tag("0x2::sui::SUI").expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_string(),
-            "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            result.to_canonical_string_with_prefix(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
 
@@ -291,8 +291,8 @@ mod tests {
         .expect("should not error");
         assert_eq!(result.to_string(), "0x2::sui::SUI");
         assert_eq!(
-            result.to_canonical_string(),
-            "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            result.to_canonical_string_with_prefix(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
         );
     }
 }

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -204,31 +204,6 @@ fn to_sui_type_tag_string(value: &TypeTag) -> Result<String, fmt::Error> {
     }
 }
 
-pub fn to_sui_struct_tag_string_canonical(value: &StructTag) -> Result<String, fmt::Error> {
-    let mut f = String::new();
-    // trim leading zeros if address is in SUI_ADDRESSES
-    let address = value.address.to_canonical_string();
-
-    write!(f, "0x{}::{}::{}", address, value.module, value.name)?;
-    if let Some(first_ty) = value.type_params.first() {
-        write!(f, "<")?;
-        write!(f, "{}", to_sui_type_tag_string_canonical(first_ty)?)?;
-        for ty in value.type_params.iter().skip(1) {
-            write!(f, ", {}", to_sui_type_tag_string_canonical(ty)?)?;
-        }
-        write!(f, ">")?;
-    }
-    Ok(f)
-}
-
-fn to_sui_type_tag_string_canonical(value: &TypeTag) -> Result<String, fmt::Error> {
-    match value {
-        TypeTag::Vector(t) => Ok(format!("vector<{}>", to_sui_type_tag_string(t)?)),
-        TypeTag::Struct(s) => to_sui_struct_tag_string_canonical(s),
-        _ => Ok(value.to_string()),
-    }
-}
-
 impl<'de> DeserializeAs<'de, StructTag> for SuiStructTag {
     fn deserialize_as<D>(deserializer: D) -> Result<StructTag, D::Error>
     where

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -204,6 +204,31 @@ fn to_sui_type_tag_string(value: &TypeTag) -> Result<String, fmt::Error> {
     }
 }
 
+pub fn to_sui_struct_tag_string_canonical(value: &StructTag) -> Result<String, fmt::Error> {
+    let mut f = String::new();
+    // trim leading zeros if address is in SUI_ADDRESSES
+    let address = value.address.to_canonical_string();
+
+    write!(f, "0x{}::{}::{}", address, value.module, value.name)?;
+    if let Some(first_ty) = value.type_params.first() {
+        write!(f, "<")?;
+        write!(f, "{}", to_sui_type_tag_string_canonical(first_ty)?)?;
+        for ty in value.type_params.iter().skip(1) {
+            write!(f, ", {}", to_sui_type_tag_string_canonical(ty)?)?;
+        }
+        write!(f, ">")?;
+    }
+    Ok(f)
+}
+
+fn to_sui_type_tag_string_canonical(value: &TypeTag) -> Result<String, fmt::Error> {
+    match value {
+        TypeTag::Vector(t) => Ok(format!("vector<{}>", to_sui_type_tag_string(t)?)),
+        TypeTag::Struct(s) => to_sui_struct_tag_string_canonical(s),
+        _ => Ok(value.to_string()),
+    }
+}
+
 impl<'de> DeserializeAs<'de, StructTag> for SuiStructTag {
     fn deserialize_as<D>(deserializer: D) -> Result<StructTag, D::Error>
     where

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -181,7 +181,7 @@ pub fn to_sui_struct_tag_string(value: &StructTag) -> Result<String, fmt::Error>
     let address = if SUI_ADDRESSES.contains(&value.address) {
         value.address.short_str_lossless()
     } else {
-        value.address.to_canonical_string()
+        value.address.to_canonical_string(false)
     };
 
     write!(f, "0x{}::{}::{}", address, value.module, value.name)?;

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -181,7 +181,7 @@ pub fn to_sui_struct_tag_string(value: &StructTag) -> Result<String, fmt::Error>
     let address = if SUI_ADDRESSES.contains(&value.address) {
         value.address.short_str_lossless()
     } else {
-        value.address.to_canonical_string(false)
+        value.address.to_canonical_string(/* with_prefix */ false)
     };
 
     write!(f, "0x{}::{}::{}", address, value.module, value.name)?;

--- a/external-crates/move/crates/move-core-types/src/account_address.rs
+++ b/external-crates/move/crates/move-core-types/src/account_address.rs
@@ -59,10 +59,15 @@ impl AccountAddress {
         hex::encode(self.0)
     }
 
-    /// Return a canonical string representation of the address
-    /// With the prefix '0x'
-    pub fn to_canonical_string_with_prefix(&self) -> String {
-        format!("0x{}", self.to_canonical_string())
+    /// Implements Display for the address with the prefix 0x
+    pub fn to_canonical_display(&self) -> impl fmt::Display + '_ {
+        struct HexDisplay<'a>(&'a [u8]);
+        impl<'a> fmt::Display for HexDisplay<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "0x{}", hex::encode(self.0))
+            }
+        }
+        HexDisplay(&self.0)
     }
 
     pub fn short_str_lossless(&self) -> String {

--- a/external-crates/move/crates/move-core-types/src/account_address.rs
+++ b/external-crates/move/crates/move-core-types/src/account_address.rs
@@ -59,6 +59,12 @@ impl AccountAddress {
         hex::encode(self.0)
     }
 
+    /// Return a canonical string representation of the address
+    /// With the prefix '0x'
+    pub fn to_canonical_string_with_prefix(&self) -> String {
+        format!("0x{}", self.to_canonical_string())
+    }
+
     pub fn short_str_lossless(&self) -> String {
         let hex_str = hex::encode(self.0).trim_start_matches('0').to_string();
         if hex_str.is_empty() {

--- a/external-crates/move/crates/move-core-types/src/account_address.rs
+++ b/external-crates/move/crates/move-core-types/src/account_address.rs
@@ -55,19 +55,31 @@ impl AccountAddress {
     /// e.g., 0000000000000000000000000000000a, *not* 0x0000000000000000000000000000000a, 0xa, or 0xA
     /// Note: this function is guaranteed to be stable, and this is suitable for use inside
     /// Move native functions or the VM.
-    pub fn to_canonical_string(&self) -> String {
-        hex::encode(self.0)
+    /// However, one can pass with_prefix=true to get its representation with the 0x prefix.
+    pub fn to_canonical_string(&self, with_prefix: bool) -> String {
+        self.to_canonical_display(with_prefix).to_string()
     }
 
-    /// Implements Display for the address with the prefix 0x
-    pub fn to_canonical_display(&self) -> impl fmt::Display + '_ {
-        struct HexDisplay<'a>(&'a [u8]);
+    /// Implements Display for the address, with the prefix 0x if with_prefix is true.
+    pub fn to_canonical_display(&self, with_prefix: bool) -> impl fmt::Display + '_ {
+        struct HexDisplay<'a> {
+            data: &'a [u8],
+            with_prefix: bool,
+        }
+
         impl<'a> fmt::Display for HexDisplay<'a> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "0x{}", hex::encode(self.0))
+                if self.with_prefix {
+                    write!(f, "0x{}", hex::encode(self.data))
+                } else {
+                    write!(f, "{}", hex::encode(self.data))
+                }
             }
         }
-        HexDisplay(&self.0)
+        HexDisplay {
+            data: &self.0,
+            with_prefix,
+        }
     }
 
     pub fn short_str_lossless(&self) -> String {

--- a/external-crates/move/crates/move-core-types/src/language_storage.rs
+++ b/external-crates/move/crates/move-core-types/src/language_storage.rs
@@ -65,34 +65,25 @@ impl TypeTag {
     /// Struct types are represented as fully qualified type names; e.g.
     /// `00000000000000000000000000000001::string::String` or
     /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`
+    /// With or without the prefix 0x depending on the `with_prefix` flag.
     /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
     /// Note: this function is guaranteed to be stable, and this is suitable for use inside
     /// Move native functions or the VM. By contrast, the `Display` implementation is subject
     /// to change and should not be used inside stable code.
-    pub fn to_canonical_string(&self) -> String {
-        use TypeTag::*;
-        match self {
-            Bool => "bool".to_owned(),
-            U8 => "u8".to_owned(),
-            U16 => "u16".to_owned(),
-            U32 => "u32".to_owned(),
-            U64 => "u64".to_owned(),
-            U128 => "u128".to_owned(),
-            U256 => "u256".to_owned(),
-            Address => "address".to_owned(),
-            Signer => "signer".to_owned(),
-            Vector(t) => format!("vector<{}>", t.to_canonical_string()),
-            Struct(s) => s.to_canonical_string(),
-        }
+    pub fn to_canonical_string(&self, with_prefix: bool) -> String {
+        self.to_canonical_display(with_prefix).to_string()
     }
 
-    /// Return the canonical string representation of the TypeTag with prefix 0x
-    pub fn to_canonical_display(&self) -> impl std::fmt::Display + '_ {
-        struct CanonicalDisplay<'a>(&'a TypeTag);
+    /// Return the canonical string representation of the TypeTag conditionally with prefix 0x
+    pub fn to_canonical_display(&self, with_prefix: bool) -> impl std::fmt::Display + '_ {
+        struct CanonicalDisplay<'a> {
+            data: &'a TypeTag,
+            with_prefix: bool,
+        }
 
         impl std::fmt::Display for CanonicalDisplay<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                match self.0 {
+                match self.data {
                     TypeTag::Bool => write!(f, "bool"),
                     TypeTag::U8 => write!(f, "u8"),
                     TypeTag::U16 => write!(f, "u16"),
@@ -102,13 +93,18 @@ impl TypeTag {
                     TypeTag::U256 => write!(f, "u256"),
                     TypeTag::Address => write!(f, "address"),
                     TypeTag::Signer => write!(f, "signer"),
-                    TypeTag::Vector(t) => write!(f, "vector<{}>", t.to_canonical_display()),
-                    TypeTag::Struct(s) => write!(f, "{}", s.to_canonical_display()),
+                    TypeTag::Vector(t) => {
+                        write!(f, "vector<{}>", t.to_canonical_display(self.with_prefix))
+                    }
+                    TypeTag::Struct(s) => write!(f, "{}", s.to_canonical_display(self.with_prefix)),
                 }
             }
         }
 
-        CanonicalDisplay(self)
+        CanonicalDisplay {
+            data: self,
+            with_prefix,
+        }
     }
 
     /// Return the abstract size we use for gas metering
@@ -182,51 +178,39 @@ impl StructTag {
     /// `00000000000000000000000000000001::string::String`,
     /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`,
     /// or `0000000000000000000000000000000a::module_name2::type_name2<bool,u64,u128>.
+    /// With or without the prefix 0x depending on the `with_prefix` flag.
     /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
     /// Note: this function is guaranteed to be stable, and this is suitable for use inside
     /// Move native functions or the VM. By contrast, the `Display` implementation is subject
     /// to change and should not be used inside stable code.
-    pub fn to_canonical_string(&self) -> String {
-        let mut generics = String::new();
-        if let Some(first_ty) = self.type_params.first() {
-            generics.push('<');
-            generics.push_str(&first_ty.to_canonical_string());
-            for ty in self.type_params.iter().skip(1) {
-                generics.push(',');
-                generics.push_str(&ty.to_canonical_string())
-            }
-            generics.push('>');
-        }
-        format!(
-            "{}::{}::{}{}",
-            self.address.to_canonical_string(),
-            self.module,
-            self.name,
-            generics
-        )
+    pub fn to_canonical_string(&self, with_prefix: bool) -> String {
+        self.to_canonical_display(with_prefix).to_string()
     }
 
     /// Implements the canonical string representation of the StructTag with the prefix 0x
-    pub fn to_canonical_display(&self) -> impl std::fmt::Display + '_ {
-        struct CanonicalDisplay<'a>(&'a StructTag);
+    pub fn to_canonical_display(&self, with_prefix: bool) -> impl std::fmt::Display + '_ {
+        struct CanonicalDisplay<'a> {
+            data: &'a StructTag,
+            with_prefix: bool,
+        }
 
         impl std::fmt::Display for CanonicalDisplay<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(
                     f,
                     "{}::{}::{}",
-                    self.0.address.to_canonical_display(),
-                    self.0.module,
-                    self.0.name
+                    self.data.address.to_canonical_display(self.with_prefix),
+                    self.data.module,
+                    self.data.name
                 )?;
 
-                if let Some(first_ty) = self.0.type_params.first() {
+                if let Some(first_ty) = self.data.type_params.first() {
                     write!(f, "<")?;
-                    write!(f, "{}", first_ty.to_canonical_display())?;
-                    for ty in self.0.type_params.iter().skip(1) {
-                        // Note that unlike Display for StructTag, this follows the to_canonical_string() implementation.
-                        // As such, there is no space between the comma and canonical display of the TypeTag.
-                        write!(f, ",{}", ty.to_canonical_display())?;
+                    write!(f, "{}", first_ty.to_canonical_display(self.with_prefix))?;
+                    for ty in self.data.type_params.iter().skip(1) {
+                        // Note that unlike Display for StructTag, there is no space between the comma and canonical display.
+                        // This follows the original to_canonical_string() implementation.
+                        write!(f, ",{}", ty.to_canonical_display(self.with_prefix))?;
                     }
                     write!(f, ">")?;
                 }
@@ -234,7 +218,10 @@ impl StructTag {
             }
         }
 
-        CanonicalDisplay(self)
+        CanonicalDisplay {
+            data: self,
+            with_prefix,
+        }
     }
 
     /// Return the abstract size we use for gas metering

--- a/external-crates/move/crates/move-core-types/src/language_storage.rs
+++ b/external-crates/move/crates/move-core-types/src/language_storage.rs
@@ -86,6 +86,24 @@ impl TypeTag {
         }
     }
 
+    /// Return the canonical string representation of the type, including the prefix '0x'
+    pub fn to_canonical_string_with_prefix(&self) -> String {
+        use TypeTag::*;
+        match self {
+            Bool => "bool".to_owned(),
+            U8 => "u8".to_owned(),
+            U16 => "u16".to_owned(),
+            U32 => "u32".to_owned(),
+            U64 => "u64".to_owned(),
+            U128 => "u128".to_owned(),
+            U256 => "u256".to_owned(),
+            Address => "address".to_owned(),
+            Signer => "signer".to_owned(),
+            Vector(t) => format!("vector<{}>", t.to_canonical_string_with_prefix()),
+            Struct(s) => s.to_canonical_string_with_prefix(),
+        }
+    }
+
     /// Return the abstract size we use for gas metering
     /// This size might be imperfect but should be consistent across platforms
     /// TODO (ade): use macro to enfornce determinism
@@ -175,6 +193,27 @@ impl StructTag {
         format!(
             "{}::{}::{}{}",
             self.address.to_canonical_string(),
+            self.module,
+            self.name,
+            generics
+        )
+    }
+
+    /// Return the canonical string representation of the struct, including the prefix '0x'
+    pub fn to_canonical_string_with_prefix(&self) -> String {
+        let mut generics = String::new();
+        if let Some(first_ty) = self.type_params.first() {
+            generics.push('<');
+            generics.push_str(&first_ty.to_canonical_string_with_prefix());
+            for ty in self.type_params.iter().skip(1) {
+                generics.push(',');
+                generics.push_str(&ty.to_canonical_string_with_prefix())
+            }
+            generics.push('>');
+        }
+        format!(
+            "{}::{}::{}{}",
+            self.address.to_canonical_string_with_prefix(),
             self.module,
             self.name,
             generics

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1384,7 +1384,9 @@ impl<'a> fmt::Display for SubstTOML<'a> {
                 }
 
                 PM::SubstOrRename::Assign(account) => {
-                    f.write_str(&str_escape(&account.to_canonical_string(false))?)?;
+                    f.write_str(&str_escape(
+                        &account.to_canonical_string(/* with_prefix */ false),
+                    )?)?;
                 }
             }
 

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1384,7 +1384,7 @@ impl<'a> fmt::Display for SubstTOML<'a> {
                 }
 
                 PM::SubstOrRename::Assign(account) => {
-                    f.write_str(&str_escape(&account.to_canonical_string())?)?;
+                    f.write_str(&str_escape(&account.to_canonical_string(false))?)?;
                 }
             }
 

--- a/external-crates/move/crates/move-stdlib/src/natives/debug.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/debug.rs
@@ -470,7 +470,7 @@ mod testing {
             }
             MoveValue::Address(a) => {
                 let str = if canonicalize {
-                    a.to_canonical_string()
+                    a.to_canonical_string(false)
                 } else {
                     a.to_hex_literal()
                 };
@@ -478,7 +478,7 @@ mod testing {
             }
             MoveValue::Signer(s) => {
                 let str = if canonicalize {
-                    s.to_canonical_string()
+                    s.to_canonical_string(false)
                 } else {
                     s.to_hex_literal()
                 };

--- a/external-crates/move/crates/move-stdlib/src/natives/debug.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/debug.rs
@@ -470,7 +470,7 @@ mod testing {
             }
             MoveValue::Address(a) => {
                 let str = if canonicalize {
-                    a.to_canonical_string(false)
+                    a.to_canonical_string(/* with_prefix */ false)
                 } else {
                     a.to_hex_literal()
                 };
@@ -478,7 +478,7 @@ mod testing {
             }
             MoveValue::Signer(s) => {
                 let str = if canonicalize {
-                    s.to_canonical_string(false)
+                    s.to_canonical_string(/* with_prefix */ false)
                 } else {
                     s.to_hex_literal()
                 };

--- a/external-crates/move/crates/move-stdlib/src/natives/type_name.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/type_name.rs
@@ -41,7 +41,7 @@ fn native_get(
         context.type_to_type_tag(&ty_args[0])
     }?;
 
-    let type_name = type_tag.to_canonical_string();
+    let type_name = type_tag.to_canonical_string(false);
 
     // Charge base fee
     native_charge_gas_early_exit!(

--- a/external-crates/move/crates/move-stdlib/src/natives/type_name.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/type_name.rs
@@ -41,7 +41,7 @@ fn native_get(
         context.type_to_type_tag(&ty_args[0])
     }?;
 
-    let type_name = type_tag.to_canonical_string(false);
+    let type_name = type_tag.to_canonical_string(/* with_prefix */ false);
 
     // Charge base fee
     native_charge_gas_early_exit!(

--- a/external-crates/move/move-execution/v0/move-stdlib/src/natives/debug.rs
+++ b/external-crates/move/move-execution/v0/move-stdlib/src/natives/debug.rs
@@ -470,7 +470,7 @@ mod testing {
             }
             MoveValue::Address(a) => {
                 let str = if canonicalize {
-                    a.to_canonical_string()
+                    a.to_canonical_string(false)
                 } else {
                     a.to_hex_literal()
                 };
@@ -478,7 +478,7 @@ mod testing {
             }
             MoveValue::Signer(s) => {
                 let str = if canonicalize {
-                    s.to_canonical_string()
+                    s.to_canonical_string(false)
                 } else {
                     s.to_hex_literal()
                 };

--- a/external-crates/move/move-execution/v0/move-stdlib/src/natives/debug.rs
+++ b/external-crates/move/move-execution/v0/move-stdlib/src/natives/debug.rs
@@ -470,7 +470,7 @@ mod testing {
             }
             MoveValue::Address(a) => {
                 let str = if canonicalize {
-                    a.to_canonical_string(false)
+                    a.to_canonical_string(/* with_prefix */ false)
                 } else {
                     a.to_hex_literal()
                 };
@@ -478,7 +478,7 @@ mod testing {
             }
             MoveValue::Signer(s) => {
                 let str = if canonicalize {
-                    s.to_canonical_string(false)
+                    s.to_canonical_string(/* with_prefix */ false)
                 } else {
                     s.to_hex_literal()
                 };

--- a/external-crates/move/move-execution/v0/move-stdlib/src/natives/type_name.rs
+++ b/external-crates/move/move-execution/v0/move-stdlib/src/natives/type_name.rs
@@ -41,7 +41,7 @@ fn native_get(
         context.type_to_type_tag(&ty_args[0])
     }?;
 
-    let type_name = type_tag.to_canonical_string();
+    let type_name = type_tag.to_canonical_string(false);
 
     // Charge base fee
     native_charge_gas_early_exit!(

--- a/external-crates/move/move-execution/v0/move-stdlib/src/natives/type_name.rs
+++ b/external-crates/move/move-execution/v0/move-stdlib/src/natives/type_name.rs
@@ -41,7 +41,7 @@ fn native_get(
         context.type_to_type_tag(&ty_args[0])
     }?;
 
-    let type_name = type_tag.to_canonical_string(false);
+    let type_name = type_tag.to_canonical_string(/* with_prefix */ false);
 
     // Charge base fee
     native_charge_gas_early_exit!(


### PR DESCRIPTION
## Description 

1. introduces to_canonical_display -> impl Display for AccountAddress, TypeTag, and StructTag on the move crate
2. implements to_canonical_string for sui_types::MoveObjectType
3. test cases that verify Object -> IndexedObject -> StoredObject -> Object conversion does not lose or result in the incorrect type string/ display
4. test cases to verify that parse_sui_struct_tag still works correctly

## Test Plan 

unit tests on conversion from sui_types::Object to IndexedObject to StoredObject. The dynamic fields path is a bit challenging to write a unit test for

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
