### PR TITLE
[sui-tools] add sui-tool to sui-tools Dockerfile

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -20,7 +20,8 @@ RUN cargo build --profile ${PROFILE} \
     --bin sui \
     --bin sui-faucet \
     --bin stress \
-    --bin sui-cluster-test
+    --bin sui-cluster-test \
+    --bin sui-tool
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -30,6 +31,7 @@ COPY --from=builder /sui/target/release/sui /usr/local/bin
 COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
 COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
+COPY --from=builder /sui/target/release/sui-tool /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Description 

I'm working on improving the archive validator workflows by converting them to k8s cron job and including `sui-tool` in the `sui-tools` docker image would make this much easier to accomplish.

## Test Plan 

 See my comment below for my testing pains. Hoping someone here could help out.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
