### PR TITLE
[rust-sdk] allow rpc url without port

### DIFF
--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -31,4 +31,6 @@ pub enum Error {
     },
     #[error("Insufficient fund for address [{address}], requested amount: {amount}")]
     InsufficientFund { address: SuiAddress, amount: u128 },
+    #[error("Invalid URI: {0}")]
+    InvalidURI(String),
 }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -585,7 +585,7 @@ fn add_port_to_url(url: &str) -> Result<String, Error> {
         // split this into "scheme+host/authority+port and the rest
         // because we want to be able to just add the port, and then reconstruct
         // the whole URI without messing with the scheme/host/authority and the endpoints
-        let splits = uri.splitn(4, "/").collect::<Vec<_>>();
+        let splits = uri.splitn(4, '/').collect::<Vec<_>>();
         // if we have an endpoint path
         let (host, endpoint_path) = if splits.len() == 4 {
             (splits[2], splits[3])


### PR DESCRIPTION
## Description 

This PR adds support for allowing a RPC url without specifying a port number. If the URL scheme is `http`, then it will automatically add port `80` to the URL. If the URL scheme is `https`, it will automatically add port `443` to the URL, if a port number is not specified in the URL. 

Before:
`http://mydomain.com` -- not allowed, will fail
After:
`http://mydomain.com` -- allowed, the URL will become `http://mydomain.com:80` which will be accepted by the underlying `jsonrpsee` library.

Should fix and close #11120. 

## Test Plan 

Add several tests to cover for as many cases as possible. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR adds support for allowing a RPC url without specifying a port number. If the URL scheme is http, then it will automatically add port 80 to the URL. If the URL scheme is https, it will automatically add port 443 to the URL, if a port number is not specified in the URL.

Before:
http://mydomain.com -- not allowed, will fail
After:
http://mydomain.com -- allowed, the URL will become http://mydomain.com:80 which will be accepted by the underlying jsonrpsee library.
