### PR TITLE
[narwhal] remove the access to the deprecated cf sub_dag

### DIFF
--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -7,18 +7,12 @@ use std::collections::HashMap;
 use store::rocks::{open_cf, DBMap, MetricConf, ReadWriteOptions};
 use store::{reopen, Map, TypedStoreError};
 use tracing::debug;
-use types::{
-    CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2, Round,
-    SequenceNumber,
-};
+use types::{CommittedSubDag, ConsensusCommit, ConsensusCommitV2, Round, SequenceNumber};
 
 /// The persistent storage of the sequencer.
 pub struct ConsensusStore {
     /// The latest committed round of each validator.
     last_committed: DBMap<AuthorityIdentifier, Round>,
-    /// TODO: remove once released to validators
-    /// The global consensus sequence.
-    committed_sub_dags_by_index: DBMap<SequenceNumber, CommittedSubDagShell>,
     /// The global consensus sequence
     committed_sub_dags_by_index_v2: DBMap<SequenceNumber, ConsensusCommit>,
 }
@@ -27,12 +21,10 @@ impl ConsensusStore {
     /// Create a new consensus store structure by using already loaded maps.
     pub fn new(
         last_committed: DBMap<AuthorityIdentifier, Round>,
-        sequence: DBMap<SequenceNumber, CommittedSubDagShell>,
         committed_sub_dags_map: DBMap<SequenceNumber, ConsensusCommit>,
     ) -> Self {
         Self {
             last_committed,
-            committed_sub_dags_by_index: sequence,
             committed_sub_dags_by_index_v2: committed_sub_dags_map,
         }
     }
@@ -44,19 +36,17 @@ impl ConsensusStore {
             MetricConf::default(),
             &[
                 NodeStorage::LAST_COMMITTED_CF,
-                NodeStorage::SUB_DAG_INDEX_CF,
                 NodeStorage::COMMITTED_SUB_DAG_INDEX_CF,
             ],
         )
         .expect("Cannot open database");
-        let (last_committed_map, sub_dag_index_map, committed_sub_dag_map) = reopen!(&rocksdb, NodeStorage::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>, NodeStorage::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>, NodeStorage::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>);
-        Self::new(last_committed_map, sub_dag_index_map, committed_sub_dag_map)
+        let (last_committed_map, committed_sub_dag_map) = reopen!(&rocksdb, NodeStorage::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>, NodeStorage::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>);
+        Self::new(last_committed_map, committed_sub_dag_map)
     }
 
     /// Clear the store.
     pub fn clear(&self) -> StoreResult<()> {
         self.last_committed.unsafe_clear()?;
-        self.committed_sub_dags_by_index.unsafe_clear()?;
         self.committed_sub_dags_by_index_v2.unsafe_clear()?;
         Ok(())
     }
@@ -85,19 +75,7 @@ impl ConsensusStore {
 
     /// Gets the latest sub dag index from the store
     pub fn get_latest_sub_dag_index(&self) -> SequenceNumber {
-        if let Some(s) = self
-            .committed_sub_dags_by_index_v2
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(seq, _)| seq)
-        {
-            return s;
-        }
-
-        // TODO: remove once this has been released to the validators
-        // If nothing has been found on v2, just fallback on the previous storage
-        self.committed_sub_dags_by_index
+        self.committed_sub_dags_by_index_v2
             .unbounded_iter()
             .skip_to_last()
             .next()
@@ -108,25 +86,11 @@ impl ConsensusStore {
     /// Returns thet latest subdag committed. If none is committed yet, then
     /// None is returned instead.
     pub fn get_latest_sub_dag(&self) -> Option<ConsensusCommit> {
-        if let Some(sub_dag) = self
-            .committed_sub_dags_by_index_v2
+        self.committed_sub_dags_by_index_v2
             .unbounded_iter()
             .skip_to_last()
             .next()
             .map(|(_, sub_dag)| sub_dag)
-        {
-            return Some(sub_dag);
-        }
-
-        // TODO: remove once this has been released to the validators
-        // If nothing has been found to the v2 table, just fallback to the previous one. We expect this
-        // to happen only after validator has upgraded. After that point the v2 table will populated
-        // and an entry should be found there.
-        self.committed_sub_dags_by_index
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(_, sub_dag)| ConsensusCommit::V1(sub_dag))
     }
 
     /// Load all the sub dags committed with sequence number of at least `from`.
@@ -134,24 +98,12 @@ impl ConsensusStore {
         &self,
         from: &SequenceNumber,
     ) -> StoreResult<Vec<ConsensusCommit>> {
-        // TODO: remove once this has been released to the validators
-        // start from the previous table first to ensure we haven't missed anything.
-        let mut sub_dags = self
-            .committed_sub_dags_by_index
+        Ok(self
+            .committed_sub_dags_by_index_v2
             .unbounded_iter()
             .skip_to(from)?
-            .map(|(_, sub_dag)| ConsensusCommit::V1(sub_dag))
-            .collect::<Vec<ConsensusCommit>>();
-
-        sub_dags.extend(
-            self.committed_sub_dags_by_index_v2
-                .unbounded_iter()
-                .skip_to(from)?
-                .map(|(_, sub_dag)| sub_dag)
-                .collect::<Vec<ConsensusCommit>>(),
-        );
-
-        Ok(sub_dags)
+            .map(|(_, sub_dag)| sub_dag)
+            .collect::<Vec<ConsensusCommit>>())
     }
 
     /// Load consensus commit with a given sequence number.
@@ -191,12 +143,8 @@ impl ConsensusStore {
 mod test {
     use crate::ConsensusStore;
     use std::collections::HashMap;
-    use store::Map;
     use test_utils::{latest_protocol_version, CommitteeFixture};
-    use types::{
-        Certificate, CommittedSubDag, CommittedSubDagShell, ConsensusCommit, ConsensusCommitV2,
-        ReputationScores, TimestampMs,
-    };
+    use types::{Certificate, CommittedSubDag, ReputationScores};
 
     #[tokio::test]
     async fn test_read_latest_final_reputation_scores() {
@@ -255,65 +203,5 @@ mod test {
 
         assert!(commit.reputation_score().final_of_schedule);
         assert_eq!(commit.sub_dag_index(), 20)
-    }
-
-    #[tokio::test]
-    async fn test_v1_v2_backwards_compatibility() {
-        let store = ConsensusStore::new_for_tests();
-
-        // Create few sub dags of V1 and write in the committed_sub_dags_by_index storage
-        for i in 0..3 {
-            let s = CommittedSubDagShell {
-                certificates: vec![],
-                leader: Default::default(),
-                leader_round: 2,
-                sub_dag_index: i,
-                reputation_score: Default::default(),
-            };
-
-            store
-                .committed_sub_dags_by_index
-                .insert(&s.sub_dag_index, &s)
-                .unwrap();
-        }
-
-        // Create few sub dags of V2 and write in the committed_sub_dags_by_index_v2 storage
-        for i in 3..6 {
-            let s = ConsensusCommitV2 {
-                certificates: vec![],
-                leader: Default::default(),
-                leader_round: 2,
-                sub_dag_index: i,
-                reputation_score: Default::default(),
-                commit_timestamp: i,
-            };
-
-            store
-                .committed_sub_dags_by_index_v2
-                .insert(&s.sub_dag_index.clone(), &ConsensusCommit::V2(s))
-                .unwrap();
-        }
-
-        // Read from index 0, all the sub dags should be returned
-        let sub_dags = store.read_committed_sub_dags_from(&0).unwrap();
-
-        assert_eq!(sub_dags.len(), 6);
-
-        for (index, sub_dag) in sub_dags.iter().enumerate() {
-            assert_eq!(sub_dag.sub_dag_index(), index as u64);
-            if index < 3 {
-                assert_eq!(sub_dag.commit_timestamp(), 0);
-            } else {
-                assert_eq!(sub_dag.commit_timestamp(), index as TimestampMs);
-            }
-        }
-
-        // Read the last sub dag, and the sub dag with index 5 should be returned
-        let last_sub_dag = store.get_latest_sub_dag();
-        assert_eq!(last_sub_dag.unwrap().sub_dag_index(), 5);
-
-        // Read the last sub dag index
-        let index = store.get_latest_sub_dag_index();
-        assert_eq!(index, 5);
     }
 }

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -102,7 +102,9 @@ impl NodeStorage {
             payload_map,
             batch_map,
             last_committed_map,
-            sub_dag_index_map,
+            // table `sub_dag` is deprecated in favor of `committed_sub_dag`.
+            // This can be removed when DBMap supports removing tables.
+            _sub_dag_index_map,
             committed_sub_dag_map,
         ) = reopen!(&rocksdb,
             Self::LAST_PROPOSED_CF;<ProposerKey, Header>,
@@ -134,7 +136,6 @@ impl NodeStorage {
         let batch_store = batch_map;
         let consensus_store = Arc::new(ConsensusStore::new(
             last_committed_map,
-            sub_dag_index_map,
             committed_sub_dag_map,
         ));
 


### PR DESCRIPTION
## Description 

Removes access to `sub_dag` column family. It has been deprecated in favor of `submitted_sub_dag` several months ago. Notably we can't simply delete everything in the code because rocksdb wants us to be aware the CF exists.

## Test Plan 

1. all tests passed
2. sui genesis -f and then sui start from main. Ctrl+C, then sui start from this branch. Observe narwhal still runs without any issues.


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
remove the access to the deprecated cf sub_dag
