### PR TITLE
Enable transaction effects v2 on testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -77,10 +77,12 @@ const MAX_PROTOCOL_VERSION: u64 = 30;
 // Version 26: New gas model version.
 //             Add support for receiving objects off of other objects in devnet only.
 // Version 28: Add sui::zklogin::verify_zklogin_id and related functions to sui framework.
+//             Enable transaction effects v2 in devnet.
 // Version 29: Add verify_legacy_zklogin_address flag to sui framework, this add ability to verify
 //             transactions from a legacy zklogin address.
 // Version 30: Enable Narwhal CertificateV2
 //             Add support for random beacon.
+//             Enable transaction effects v2 in testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1589,6 +1591,10 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.narwhal_header_v2 = true;
                         cfg.feature_flags.random_beacon = true;
+                    }
+                    // Only enable effects v2 on devnet and testnet.
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.enable_effects_v2 = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
@@ -34,6 +34,7 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
+  enable_effects_v2: true
   verify_legacy_zklogin_address: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
## Description 

Enable transaction effects v2 on testnet as well.

## Test Plan 

It has been working well on devnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x ] breaking change for FNs (FN binary must upgrade)
- [x ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
