### PR TITLE
Making sure that we don't prune the checkpoint corresponding to the highest executed watermark

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4223,7 +4223,6 @@ impl AuthorityState {
             .shutdown_execution_for_test();
     }
 
-    #[cfg(msim)]
     pub async fn prune_objects_and_compact_for_testing(&self) {
         let pruning_config = AuthorityStorePruningConfig {
             num_epochs_to_retain: 0,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4222,6 +4222,24 @@ impl AuthorityState {
             .execution_dispatcher
             .shutdown_execution_for_test();
     }
+
+    #[cfg(msim)]
+    pub async fn prune_objects_and_compact_for_testing(&self) {
+        let pruning_config = AuthorityStorePruningConfig {
+            num_epochs_to_retain: 0,
+            ..Default::default()
+        };
+        let _ = AuthorityStorePruner::prune_objects_for_eligible_epochs(
+            &self.database.perpetual_tables,
+            &self.checkpoint_store,
+            &self.database.objects_lock_table,
+            pruning_config,
+            AuthorityStorePruningMetrics::new_for_test(),
+            usize::MAX,
+        )
+        .await;
+        let _ = AuthorityStorePruner::compact(&self.database.perpetual_tables);
+    }
 }
 
 #[async_trait]

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -347,10 +347,11 @@ impl AuthorityStorePruner {
             };
             let checkpoint = ckpt.into_inner();
             // Skipping because  checkpoint's epoch or checkpoint number is too new.
-            // We have to respect the highest executed checkpoint watermark because there might be
-            // parts of the system that still require access to old object versions (i.e. state accumulator)
+            // We have to respect the highest executed checkpoint watermark (including the watermark itself)
+            // because there might be parts of the system that still require access to old object versions
+            // (i.e. state accumulator).
             if (current_epoch < checkpoint.epoch() + num_epochs_to_retain)
-                || (*checkpoint.sequence_number() > max_eligible_checkpoint)
+                || (*checkpoint.sequence_number() >= max_eligible_checkpoint)
             {
                 break;
             }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -351,7 +351,7 @@ impl AuthorityStorePruner {
             // because there might be parts of the system that still require access to old object versions
             // (i.e. state accumulator).
             if (current_epoch < checkpoint.epoch() + num_epochs_to_retain)
-                || (*checkpoint.sequence_number() >= max_eligible_checkpoint)
+                || (*checkpoint.sequence_number() > max_eligible_checkpoint)
             {
                 break;
             }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -351,7 +351,7 @@ impl AuthorityStorePruner {
             // because there might be parts of the system that still require access to old object versions
             // (i.e. state accumulator).
             if (current_epoch < checkpoint.epoch() + num_epochs_to_retain)
-                || (*checkpoint.sequence_number() > max_eligible_checkpoint)
+                || (*checkpoint.sequence_number() >= max_eligible_checkpoint)
             {
                 break;
             }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -587,11 +587,7 @@ impl CheckpointExecutor {
                     )
                     .await;
 
-                    #[cfg(msim)]
-                    {
-                        // Run pruner and compact RocksDb before accumulating state.
-                        self.prune_and_compact().await;
-                    }
+                    fail_point_async!("prune-and-compact");
 
                     // For finalizing the checkpoint, we need to pass in all checkpoint
                     // transaction effects, not just the change_epoch tx effects. However,
@@ -638,33 +634,6 @@ impl CheckpointExecutor {
             }
         }
         false
-    }
-
-    #[cfg(msim)]
-    async fn prune_and_compact(&self) {
-        use crate::authority::authority_store_pruner::{
-            AuthorityStorePruner, AuthorityStorePruningMetrics,
-        };
-        use sui_config::node::AuthorityStorePruningConfig;
-        use sui_storage::mutex_table::RwLockTable;
-
-        let metrics = AuthorityStorePruningMetrics::new(&Registry::default());
-        let lock_table = Arc::new(RwLockTable::new(1));
-        let pruning_config = AuthorityStorePruningConfig {
-            num_epochs_to_retain: 0,
-            ..Default::default()
-        };
-        info!("Starting object pruning");
-        let _ = AuthorityStorePruner::prune_objects_for_eligible_epochs(
-            &self.authority_store.perpetual_tables,
-            &self.checkpoint_store,
-            &lock_table,
-            pruning_config,
-            metrics,
-            usize::MAX,
-        )
-        .await;
-        let _ = AuthorityStorePruner::compact(&self.authority_store.perpetual_tables);
     }
 }
 

--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -83,6 +83,16 @@ fn register_fail_point_impl(
     })
 }
 
+fn clear_fail_point_impl(identifier: &'static str) {
+    with_fp_map(move |map| {
+        assert!(
+            map.remove(identifier).is_some(),
+            "fail point {:?} does not exist",
+            identifier
+        );
+    })
+}
+
 pub fn register_fail_point(identifier: &'static str, callback: impl Fn() + Sync + Send + 'static) {
     register_fail_point_impl(
         identifier,
@@ -113,6 +123,10 @@ pub fn register_fail_points(
     for id in identifiers {
         register_fail_point_impl(id, cb.clone());
     }
+}
+
+pub fn clear_fail_point(identifier: &'static str) {
+    clear_fail_point_impl(identifier);
 }
 
 #[cfg(any(msim, fail_points))]

--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -97,7 +97,7 @@ pub fn register_fail_point_async<F>(
     identifier: &'static str,
     callback: impl Fn() -> F + Sync + Send + 'static,
 ) where
-    F: Future<Output = ()> + Sync + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
 {
     register_fail_point_impl(identifier, Arc::new(move || Some(Box::pin(callback()))));
 }


### PR DESCRIPTION
This issue was found while working on pruning tombstone (#14373). Based on observation, the highest executed checkpoint's effects and objects are still used in the state accumulator, so we can't prune it.

It wasn't causing test issue before probably because we are using `ignore_range_deletions` option when issuing range deletes, so some of the objects are still available after pruning.

Send this PR out separately while I'm still making that PR work, and it seems unrelated to tombstones.

After adding a test path (basically doing a pruning and then compaction before state accumulation), here is the result:

Without the 1 line fix, 59 tests failed with missing object during state accumulation:
<img width="1302" alt="Screenshot 2023-10-24 at 3 02 03 PM" src="https://github.com/MystenLabs/sui/assets/9200652/c2c91a17-6d89-46f9-9f56-74da6c3534f6">

With the 1 line fix, all passed:
<img width="518" alt="Screenshot 2023-10-24 at 3 02 17 PM" src="https://github.com/MystenLabs/sui/assets/9200652/7e4edd8b-7086-4eb7-a35b-0303ce53d6d7">


## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
