### PR TITLE
[graphql] address epoch.transactionBlockConnection slow querying

### DIFF
--- a/crates/sui-graphql-rpc/examples/transaction_block_connection/before_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_connection/before_after_checkpoint.graphql
@@ -2,7 +2,7 @@
 {
   transactionBlockConnection(
     filter: {
-      afterCheckpoint:10,
+      afterCheckpoint: 10,
       beforeCheckpoint: 20
     }
   ) {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -369,8 +369,9 @@ impl PgManager {
                     .select(transactions::dsl::tx_sequence_number)
                     .into_boxed();
 
-                after_tx_seq_num = self.run_query_async(|conn| subquery.get_result::<i64>(conn).optional())
-                        .await?;
+                after_tx_seq_num = self
+                    .run_query_async(|conn| subquery.get_result::<i64>(conn).optional())
+                    .await?;
 
                 // Return early if we cannot find txs after the specified checkpoint
                 if after_tx_seq_num.is_none() {
@@ -385,8 +386,9 @@ impl PgManager {
                     .select(transactions::dsl::tx_sequence_number)
                     .into_boxed();
 
-                before_tx_seq_num = self.run_query_async(|conn| subquery.get_result::<i64>(conn).optional())
-                        .await?;
+                before_tx_seq_num = self
+                    .run_query_async(|conn| subquery.get_result::<i64>(conn).optional())
+                    .await?;
 
                 // Return early if we cannot find tx before the specified checkpoint
                 if before_tx_seq_num.is_none() {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -114,6 +114,8 @@ pub enum DbValidationError {
     LastBefore,
     #[error("Pagination is currently disabled on balances")]
     PaginationDisabledOnBalances,
+    #[error("after_checkpoint cannot be 0. To include 0, please leave after_checkpoint blank")]
+    AfterCheckpointCannotBeZero,
 }
 
 pub(crate) struct PgManager {
@@ -704,6 +706,11 @@ impl PgManager {
         if let (Some(before), Some(after)) = (filter.before_checkpoint, filter.after_checkpoint) {
             if before <= after {
                 return Err(DbValidationError::InvalidCheckpointOrder.into());
+            }
+        }
+        if let Some(after) = filter.after_checkpoint {
+            if after == 0 {
+                return Err(DbValidationError::AfterCheckpointCannotBeZero.into());
             }
         }
         self.validate_package_dependencies(

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -358,11 +358,52 @@ impl PgManager {
             .or(before)
             .map(|cursor| self.parse_tx_cursor(&cursor))
             .transpose()?;
-        if let Some(cursor) = cursor {
+
+        let mut after_tx_seq_num: Option<i64> = None;
+        let mut before_tx_seq_num: Option<i64> = None;
+        if let Some(filter) = &filter {
+            if let Some(checkpoint) = filter.after_checkpoint {
+                let subquery = transactions::dsl::transactions
+                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64))
+                    .order(transactions::dsl::tx_sequence_number.asc())
+                    .select(transactions::dsl::tx_sequence_number)
+                    .into_boxed();
+
+                after_tx_seq_num = Some(
+                    self.run_query_async(|conn| subquery.get_result::<i64>(conn))
+                        .await?,
+                );
+            }
+
+            if let Some(checkpoint) = filter.before_checkpoint {
+                let subquery = transactions::dsl::transactions
+                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64))
+                    .order(transactions::dsl::tx_sequence_number.desc())
+                    .select(transactions::dsl::tx_sequence_number)
+                    .into_boxed();
+
+                before_tx_seq_num = Some(
+                    self.run_query_async(|conn| subquery.get_result::<i64>(conn))
+                        .await?,
+                );
+            }
+        }
+        if let Some(cursor_val) = cursor {
             if descending_order {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor));
+                let filter_value =
+                    before_tx_seq_num.map_or(cursor_val, |b| std::cmp::min(b, cursor_val));
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(filter_value));
             } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor));
+                let filter_value =
+                    after_tx_seq_num.map_or(cursor_val, |a| std::cmp::max(a, cursor_val));
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(filter_value));
+            }
+        } else {
+            if let Some(av) = after_tx_seq_num {
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(av));
+            }
+            if let Some(bv) = before_tx_seq_num {
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(bv));
             }
         }
 
@@ -381,17 +422,6 @@ impl PgManager {
             if let Some(checkpoint) = filter.at_checkpoint {
                 query = query
                     .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
-            } else {
-                if let Some(checkpoint) = filter.after_checkpoint {
-                    query = query.filter(
-                        transactions::dsl::checkpoint_sequence_number.gt(checkpoint as i64),
-                    );
-                }
-                if let Some(checkpoint) = filter.before_checkpoint {
-                    query = query.filter(
-                        transactions::dsl::checkpoint_sequence_number.lt(checkpoint as i64),
-                    );
-                }
             }
             if let Some(transaction_ids) = filter.transaction_ids {
                 let digests = transaction_ids

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -13,8 +13,6 @@ use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
 use async_graphql::*;
 
-const CHECKPOINT_RANGE_BOUNDING: i64 = 100;
-
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct Epoch {
@@ -69,49 +67,14 @@ impl Epoch {
                 "Epoch should be able to find itself".to_string(),
             ))?;
 
-        let existing_filter = filter.unwrap_or_default();
-
-        // Upper bound in the absence of after or before to avoid inefficiently large queries
-        let (after_default, before_default) = if last.is_some() {
-            (
-                stored_epoch.last_checkpoint_id.map(|id| {
-                    std::cmp::max(
-                        id - CHECKPOINT_RANGE_BOUNDING,
-                        stored_epoch.first_checkpoint_id,
-                    ) as u64
-                }),
-                stored_epoch.last_checkpoint_id.map(|id| id as u64),
-            )
-        } else {
-            (
-                // Subtract and add 1 to include the first and last checkpoints
-                Some((stored_epoch.first_checkpoint_id - 1) as u64),
-                Some(
-                    (std::cmp::min(
-                        stored_epoch.first_checkpoint_id + CHECKPOINT_RANGE_BOUNDING,
-                        stored_epoch.last_checkpoint_id.map(|id| id + 1).unwrap_or(
-                            stored_epoch.first_checkpoint_id + CHECKPOINT_RANGE_BOUNDING,
-                        ),
-                    )) as u64,
-                ),
-            )
-        };
-
-        let nfilter = match (after.is_some(), before.is_some()) {
-            (true, _) | (_, true) => TransactionBlockFilter {
-                after_checkpoint: Some((stored_epoch.first_checkpoint_id - 1) as u64),
-                before_checkpoint: stored_epoch.last_checkpoint_id.map(|id| (id + 1) as u64),
-                ..existing_filter
-            },
-            _ => TransactionBlockFilter {
-                after_checkpoint: after_default,
-                before_checkpoint: before_default,
-                ..existing_filter
-            },
+        let new_filter = TransactionBlockFilter {
+            after_checkpoint: Some((stored_epoch.first_checkpoint_id - 1) as u64),
+            before_checkpoint: stored_epoch.last_checkpoint_id.map(|id| (id + 1) as u64),
+            ..filter.unwrap_or_default()
         };
 
         ctx.data_unchecked::<PgManager>()
-            .fetch_txs(first, after, last, before, Some(nfilter))
+            .fetch_txs(first, after, last, before, Some(new_filter))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -68,7 +68,11 @@ impl Epoch {
             ))?;
 
         let new_filter = TransactionBlockFilter {
-            after_checkpoint: Some((stored_epoch.first_checkpoint_id - 1) as u64),
+            after_checkpoint: if stored_epoch.first_checkpoint_id > 0 {
+                Some((stored_epoch.first_checkpoint_id - 1) as u64)
+            } else {
+                None
+            },
             before_checkpoint: stored_epoch.last_checkpoint_id.map(|id| (id + 1) as u64),
             ..filter.unwrap_or_default()
         };


### PR DESCRIPTION
## Description 

Modify querying mechanism for epoch.transactionBlockConnection per feedback. Query now completes under 2 seconds (previously would run >10 or forever). Previously, to fetch transactions for an epoch, we made a query for transactions whose checkpoint_sequence_number were between the first and last checkpoint ids of the epoch. Even though this filtering is done on an index, the filer causes some slowness if the distance between the two checkpoints are significant enough since we order the results by tx_sequence_number. This change fetches the first tx_sequence_number from the first checkpoint and the last tx_sequence_number from the last checkpoint, so now the filtering and ordering are both done on tx_sequence_number

## Test Plan 

manually run same queries

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
