### PR TITLE
Move narwhal cert v2 and random beacon to a new protocol version.

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "29",
+              "maxSupportedProtocolVersion": "30",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 29;
+const MAX_PROTOCOL_VERSION: u64 = 30;
 
 // Record history of protocol version allocations here:
 //
@@ -79,7 +79,7 @@ const MAX_PROTOCOL_VERSION: u64 = 29;
 // Version 28: Add sui::zklogin::verify_zklogin_id and related functions to sui framework.
 // Version 29: Add verify_legacy_zklogin_address flag to sui framework, this add ability to verify
 //             transactions from a legacy zklogin address.
-//             Enable Narwhal CertificateV2
+// Version 30: Enable Narwhal CertificateV2
 //             Add support for random beacon.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -1577,7 +1577,8 @@ impl ProtocolConfig {
                 }
                 29 => {
                     cfg.feature_flags.verify_legacy_zklogin_address = true;
-
+                }
+                30 => {
                     // Only enable nw certificate v2 on devnet.
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.narwhal_certificate_v2 = true;

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_29.snap
@@ -204,5 +204,4 @@ execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
-random_beacon_reduction_allowed_delta: 800
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 29
+version: 30
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -34,8 +34,6 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
-  receive_objects: true
-  enable_effects_v2: true
   verify_legacy_zklogin_address: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -138,7 +136,6 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
-transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
@@ -207,4 +204,5 @@ execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_29.snap
@@ -204,5 +204,4 @@ execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
-random_beacon_reduction_allowed_delta: 800
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 29
+version: 30
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -34,8 +34,6 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
-  receive_objects: true
-  enable_effects_v2: true
   verify_legacy_zklogin_address: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -138,7 +136,6 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
-transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
@@ -207,4 +204,5 @@ execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 29
+version: 30
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -35,7 +35,10 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  narwhal_header_v2: true
+  random_beacon: true
   enable_effects_v2: true
+  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -207,4 +210,5 @@ execution_version: 1
 consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 29
+  protocol_version: 30
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 29
+protocol_version: 30
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x658b0c687e422f01d00436d848ba37cc924a99615bdd0b1f7983eee908aa4d60"
+            id: "0x7f2921e33815276557f7dfb8a0e683ed7387d246cb28ce17aadebbe56b7948ab"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x4a06ba7302a9c4863f5166d4041e54490a20561034dc79d3c871f5e8a2b7bbd5"
+      operation_cap_id: "0x018912fa2c86009c6aa7e83f6b82bcfd8ded243f43ccc8bcda6befa03c663f78"
       gas_price: 1000
       staking_pool:
-        id: "0x38634ba6165019652230383c70f698a54606e8971c9f40a978e00dabea2b4b19"
+        id: "0xec8d45e2235012a16d4fddc55d97717fb46e925fc7da9fb09bbe8e99e271738c"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x3fa6f4d12a4876549548026a274b95d485107d2ceb0cddeaff4e09a160a27673"
+          id: "0x743aa78783e30f0c8eedf8458c0d7b6341dfaddc91f9a47a1f719e66c4d1deb7"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x0f73f6796f9f89ec37e041003917975423c2de610b5352e85c4678f197cfa3a2"
+            id: "0x42a7c8ec76d7c36eb7559f0bc43f8cea0bc6497f9737c3828a6989ef57d15a07"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x0ba371cca84a3712f4582f0dcc375f5f5cc49786676db04e9b336226ceea9b4d"
+          id: "0x8df66c956a1c88a9326c9159953aa7c0801c940ff574fa89ddee3ac4e3c3d3f7"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xe2ce386f770babc91fa60ab67a8f64b53f76ad7f2b74475487b5a59b9d50704e"
+      id: "0x976b8b88ff131c400cc1f1cb279093fe63932eedf93efa176d020ce56011395d"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x686a0ee6de2455fca4bba285850d02f849f8cf8808ea8faba041744079c2b515"
+    id: "0xda6a5a42f65d6e074590529be4ec47ebd6a20ff668c26e9b367583d479540744"
     size: 1
   inactive_validators:
-    id: "0x88331a72af05e55312d3b0d1b561b8d4642a78a22170483171d0f1b5226eb97a"
+    id: "0x52b0eff93b53506b533ac0655efb4f448f56cc35297d22bf0385c4e73d3f4f23"
     size: 0
   validator_candidates:
-    id: "0xed32965d7b51806a16b326226df9038cd18ec1f70d22ddbf47f73aa259f937b5"
+    id: "0xbfba2893593ec2f9842f235d01bf39d8f9bc7ed5da49689059508f57fab9d039"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xbccae2d0ff54175b1708b580d0e68c93fc65383015cd6d5202212d5bf00e0aa9"
+      id: "0xf6cee91ff8c6a95411c207d3d56a3d8f7b122b29dd70ddaaa80567cb8a78da64"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x9de9189bc53dffffae1a4cef3ddee392646b04c2440ea71a31dd4329d4b8800e"
+      id: "0xb55c540000e0aca2e36e73328709bbcda6dddf287417c0bb81063e392f971063"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xd3ee91352a7e23913409c81d4dc5af944dc7e57dd806dcfb9fb363add9d22faf"
+      id: "0xfdbc8f735c9ecca61a5ff20899d5e39a8a8562a7cc6631db6c97dfb3837ca5eb"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x6821c028816fb3f7538f92559635bcc419985d3bf1ad408b2abb66e686ecabbf"
+    id: "0x14688c8e3d4965264c683b9024f36e90b9d0f6e6a6f972c5389cca2bd6e428ca"
   size: 0
 


### PR DESCRIPTION
These were mistakenly released on top of existing cherrypicked v29 in devnet.