### PR TITLE
cherrypick fix

### DIFF
--- a/external-crates/move-execution/vm-rework/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move-execution/vm-rework/move-vm/runtime/src/interpreter.rs
@@ -141,6 +141,7 @@ impl Interpreter {
         }
     }
 
+    #[allow(unused_variables)]
     pub fn pre_entrypoint(
         plugins: &mut Vec<Box<dyn InterpreterHook>>,
         gas_meter: &mut impl GasMeter,
@@ -167,6 +168,7 @@ impl Interpreter {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     pub fn pre_fn(
         interpreter: &mut Interpreter,
         plugins: &mut Vec<Box<dyn InterpreterHook>>,
@@ -187,6 +189,7 @@ impl Interpreter {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     pub fn post_fn(
         _interpreter: &mut Interpreter,
         plugins: &mut Vec<Box<dyn InterpreterHook>>,
@@ -202,6 +205,7 @@ impl Interpreter {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     pub fn pre_instr(
         interpreter: &mut Interpreter,
         plugins: &mut Vec<Box<dyn InterpreterHook>>,
@@ -230,6 +234,7 @@ impl Interpreter {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     pub fn post_instr(
         interpreter: &mut Interpreter,
         plugins: &mut Vec<Box<dyn InterpreterHook>>,


### PR DESCRIPTION
## Description 

add allow-unused-variable to silence warnings that occur due to different compilation flags. This is fine as the allows are added to a wip branch vm-rework

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
