### PR TITLE
[graphql/rpc] add estimated reward for Stake

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -52,6 +52,7 @@ use move_bytecode_utils::layout::TypeLayoutBuilder;
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout};
 use std::str::FromStr;
 use sui_indexer::{
+    apis::GovernanceReadApiV2,
     indexer_reader::IndexerReader,
     models_v2::{
         checkpoints::StoredCheckpoint, epoch::StoredEpochInfo, objects::StoredObject,
@@ -65,7 +66,8 @@ use sui_indexer::{
 };
 use sui_json_rpc::name_service::{Domain, NameRecord, NameServiceConfig};
 use sui_json_rpc_types::{
-    EventFilter as RpcEventFilter, ProtocolConfigResponse, SuiTransactionBlockEffects,
+    EventFilter as RpcEventFilter, ProtocolConfigResponse, Stake as SuiStake,
+    SuiTransactionBlockEffects,
 };
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_sdk::types::{
@@ -1248,43 +1250,45 @@ impl PgManager {
             object_ids: None,
             object_keys: None,
         };
-        let system_state = self.fetch_latest_sui_system_state().await?;
-        let current_epoch_id = system_state.epoch_id;
+
         let objs = self
             .multi_get_objs(first, after, last, before, Some(obj_filter))
             .await?;
 
         if let Some((stored_objs, has_next_page)) = objs {
             let mut connection = Connection::new(false, has_next_page);
-
             let mut edges = vec![];
+            let governance_api = GovernanceReadApiV2::new(self.inner.clone());
 
-            for stored_obj in stored_objs {
-                let object = sui_types::object::Object::try_from(stored_obj).map_err(|_| {
-                    Error::Internal("Error converting from StoredObject to Object".to_string())
-                })?;
-                let stake_object = StakedSui::try_from(&object).map_err(|_| {
-                    Error::Internal("Error converting from Object to StakedSui".to_string())
-                })?;
+            // convert the stored objects into staked sui type
+            let stakes = stored_objs
+                .into_iter()
+                .flat_map(|stored_obj| {
+                    let object = sui_types::object::Object::try_from(stored_obj)
+                        .map_err(|_| eprintln!("Error converting from StoredObject to Object"))
+                        .ok()?;
+                    let stake_object = StakedSui::try_from(&object)
+                        .map_err(|_| eprintln!("Error converting from Object to StakedSui"))
+                        .ok()?;
+                    Some(stake_object)
+                })
+                .collect::<Vec<_>>();
 
-                // TODO this only does active / pending stake status, but not unstaked,
-                // unstaked does not really make sense here, fullnode tracks deleted objects
-                let status = if current_epoch_id >= stake_object.activation_epoch() {
-                    StakeStatus::Active
-                } else {
-                    StakeStatus::Pending
-                };
-                let stake = Stake {
-                    id: ID(stake_object.id().to_string()),
-                    active_epoch_id: Some(stake_object.activation_epoch()),
-                    estimated_reward: None, // TODO once we have a good working governance API, we should fix this
-                    principal: Some(BigInt::from(stake_object.principal())),
-                    request_epoch_id: Some(stake_object.activation_epoch().saturating_sub(1)),
-                    status: Some(status),
-                    staked_sui_id: stake_object.id(),
-                };
+            // retrieve the delegated stakes
+            // at the first invocation, it will likely fail because data is not cached
+            let delegated_stakes = governance_api
+                .get_delegated_stakes(stakes)
+                .await
+                .map_err(|e| Error::Internal(format!("Error fetching delegated stakes. {e}")))?;
 
-                let cursor = stake.staked_sui_id.to_string();
+            let stakes = delegated_stakes
+                .into_iter()
+                .flat_map(|x| x.stakes)
+                .collect::<Vec<_>>();
+
+            for stk in stakes {
+                let cursor = stk.staked_sui_id.to_string();
+                let stake = Stake::from(stk);
                 edges.push(Edge::new(cursor, stake));
             }
             connection.edges.extend(edges);
@@ -1791,6 +1795,30 @@ impl TryFrom<StoredObject> for Coin {
             balance,
             move_obj: MoveObject { native_object },
         })
+    }
+}
+
+impl From<SuiStake> for Stake {
+    fn from(value: SuiStake) -> Self {
+        let mut reward = None;
+        let status = match value.status {
+            sui_json_rpc_types::StakeStatus::Pending => StakeStatus::Pending,
+            sui_json_rpc_types::StakeStatus::Active { estimated_reward } => {
+                reward = Some(estimated_reward.into());
+                StakeStatus::Active
+            }
+            sui_json_rpc_types::StakeStatus::Unstaked => todo!(),
+        };
+
+        Stake {
+            id: ID(value.staked_sui_id.to_string()),
+            active_epoch_id: Some(value.stake_active_epoch),
+            estimated_reward: reward,
+            principal: Some(value.principal.into()),
+            request_epoch_id: Some(value.stake_request_epoch),
+            status: Some(status),
+            staked_sui_id: value.staked_sui_id,
+        }
     }
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1807,7 +1807,7 @@ impl From<SuiStake> for Stake {
                 reward = Some(estimated_reward.into());
                 StakeStatus::Active
             }
-            sui_json_rpc_types::StakeStatus::Unstaked => todo!(),
+            sui_json_rpc_types::StakeStatus::Unstaked => StakeStatus::Unstaked,
         };
 
         Stake {

--- a/crates/sui-indexer/src/apis/governance_api_v2.rs
+++ b/crates/sui-indexer/src/apis/governance_api_v2.rs
@@ -22,7 +22,7 @@ use sui_types::{
 };
 
 #[derive(Clone)]
-pub(crate) struct GovernanceReadApiV2 {
+pub struct GovernanceReadApiV2 {
     inner: IndexerReader,
 }
 
@@ -89,7 +89,7 @@ impl GovernanceReadApiV2 {
         self.get_delegated_stakes(stakes).await
     }
 
-    async fn get_delegated_stakes(
+    pub async fn get_delegated_stakes(
         &self,
         stakes: Vec<StakedSui>,
     ) -> Result<Vec<DelegatedStake>, IndexerError> {

--- a/crates/sui-indexer/src/apis/mod.rs
+++ b/crates/sui-indexer/src/apis/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use coin_api_v2::CoinReadApiV2;
 pub(crate) use extended_api::ExtendedApi;
 pub(crate) use extended_api_v2::ExtendedApiV2;
 pub(crate) use governance_api::GovernanceReadApi;
-pub(crate) use governance_api_v2::GovernanceReadApiV2;
+pub use governance_api_v2::GovernanceReadApiV2;
 pub(crate) use indexer_api::IndexerApi;
 pub(crate) use indexer_api_v2::IndexerApiV2;
 pub(crate) use move_utils::MoveUtilsApi;


### PR DESCRIPTION
## Description 

This PR implements the estimated reward for Stake by leveraging indexer's governance api. 

## Test Plan 

Manually. See figure.
![image](https://github.com/MystenLabs/sui/assets/135084671/8971a693-d557-4a13-9ace-b5b44e2d68b5)


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
