### PR TITLE
Transaction deferral system

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -13,7 +13,7 @@ use parking_lot::{Mutex, RwLockReadGuard, RwLockWriteGuard};
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::iter;
 use std::path::{Path, PathBuf};
@@ -115,6 +115,8 @@ pub enum ConsensusCertificateResult {
     Ignored,
     /// An executable transaction (can be a user tx or a system tx)
     SuiTransaction(VerifiedExecutableTransaction),
+    /// The transaction should be re-processed at a future commit, specified by the DeferralKey
+    Defered(DeferralKey),
     /// Everything else, e.g. AuthorityCapabilities, CheckpointSignatures, etc.
     ConsensusMessage,
 }
@@ -413,6 +415,121 @@ pub struct AuthorityEpochTables {
     /// This would normally be stored as (JwkId, JWK) -> u64, but we need to be able to scan to
     /// find all Jwks for a given round
     active_jwks: DBMap<(u64, (JwkId, JWK)), ()>,
+
+    /// Transactions that are being deferred until some future time
+    deferred_transactions: DBMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>>,
+}
+
+// DeferralKey requires both the round to which the tx should be deferred (so that we can
+// efficiently load all txns that are now ready), and the round from which it has been deferred (so
+// that multiple rounds can efficiently defer to the same future round).
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum DeferralKey {
+    RandomnessRound {
+        future_round: u64,
+        deferred_from_round: u64,
+    },
+
+    ConsensusRound {
+        future_round: u64,
+        deferred_from_round: u64,
+    },
+}
+
+impl DeferralKey {
+    fn new_for_randomness_round(future_round: u64, deferred_from_round: u64) -> Self {
+        Self::RandomnessRound {
+            future_round,
+            deferred_from_round,
+        }
+    }
+
+    fn new_for_consensus_round(future_round: u64, deferred_from_round: u64) -> Self {
+        Self::ConsensusRound {
+            future_round,
+            deferred_from_round,
+        }
+    }
+
+    fn range_for_randomness_round(future_round: u64) -> (Self, Self) {
+        (
+            Self::RandomnessRound {
+                future_round,
+                deferred_from_round: 0,
+            },
+            Self::RandomnessRound {
+                future_round: future_round.checked_add(1).unwrap(),
+                deferred_from_round: 0,
+            },
+        )
+    }
+
+    fn range_for_consensus_round(future_round: u64) -> (Self, Self) {
+        (
+            Self::ConsensusRound {
+                future_round,
+                deferred_from_round: 0,
+            },
+            Self::ConsensusRound {
+                future_round: future_round.checked_add(1).unwrap(),
+                deferred_from_round: 0,
+            },
+        )
+    }
+}
+
+#[tokio::test]
+async fn test_deferral_key_sort_order() {
+    use rand::prelude::*;
+
+    #[derive(DBMapUtils)]
+    struct TestDB {
+        deferred_certs: DBMap<DeferralKey, ()>,
+    }
+
+    // get a tempdir
+    let tempdir = tempfile::tempdir().unwrap();
+
+    let db = TestDB::open_tables_read_write(
+        tempdir.path().to_owned(),
+        MetricConf::with_db_name("test_db"),
+        None,
+        None,
+    );
+
+    for _ in 0..10000 {
+        let future_round = rand::thread_rng().gen_range(0..u64::MAX);
+        let current_round = rand::thread_rng().gen_range(0..u64::MAX);
+
+        let key = if rand::thread_rng().gen() {
+            DeferralKey::new_for_randomness_round(future_round, current_round)
+        } else {
+            DeferralKey::new_for_consensus_round(future_round, current_round)
+        };
+
+        db.deferred_certs.insert(&key, &()).unwrap();
+    }
+
+    // verify that all random round keys are sorted before all consensus round keys
+    let mut first_consensus_round_seen = false;
+    let mut previous_future_round = 0;
+    for (key, _) in db.deferred_certs.unbounded_iter() {
+        match key {
+            DeferralKey::ConsensusRound { future_round, .. } => {
+                if !first_consensus_round_seen {
+                    first_consensus_round_seen = true;
+                    previous_future_round = 0;
+                }
+                assert!(previous_future_round <= future_round);
+                previous_future_round = future_round;
+            }
+            DeferralKey::RandomnessRound { future_round, .. } => {
+                assert!(!first_consensus_round_seen);
+                assert!(previous_future_round <= future_round);
+                previous_future_round = future_round;
+            }
+        }
+    }
 }
 
 fn signed_transactions_table_default_config() -> DBOptions {
@@ -1130,6 +1247,70 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    fn defer_transactions(
+        &self,
+        batch: &mut DBBatch,
+        key: DeferralKey,
+        transactions: Vec<VerifiedSequencedConsensusTransaction>,
+    ) -> SuiResult {
+        batch.insert_batch(
+            &self.tables.deferred_transactions,
+            std::iter::once((key, transactions)),
+        )?;
+        Ok(())
+    }
+
+    fn load_deferred_transactions_for_randomness_round(
+        &self,
+        batch: &mut DBBatch,
+        randomness_round: u64,
+    ) -> SuiResult<Vec<VerifiedSequencedConsensusTransaction>> {
+        let (min, max) = DeferralKey::range_for_randomness_round(randomness_round);
+        self.load_deferred_transactions(batch, min, max)
+    }
+
+    fn load_deferred_transactions_for_consensus_round(
+        &self,
+        batch: &mut DBBatch,
+        consensus_round: u64,
+    ) -> SuiResult<Vec<VerifiedSequencedConsensusTransaction>> {
+        let (min, max) = DeferralKey::range_for_consensus_round(consensus_round);
+        self.load_deferred_transactions(batch, min, max)
+    }
+
+    // factoring of the above
+    fn load_deferred_transactions(
+        &self,
+        batch: &mut DBBatch,
+        min: DeferralKey,
+        max: DeferralKey,
+    ) -> SuiResult<Vec<VerifiedSequencedConsensusTransaction>> {
+        let txns: Vec<_> = self
+            .tables
+            .deferred_transactions
+            .iter_with_bounds(Some(min), Some(max))
+            .flat_map(|(_, txns)| txns)
+            .collect();
+
+        // verify that there are no duplicates - should be impossible due to
+        // is_consensus_message_processed
+        #[cfg(debug_assertions)]
+        {
+            let seen = HashSet::new();
+            for txn in &txns {
+                assert!(seen.insert(txn.0.key()));
+            }
+        }
+
+        batch.schedule_delete_range(&self.tables.deferred_transactions, &min, &max)?;
+        Ok(txns)
+    }
+
+    // Placeholder implementation
+    fn should_defer(&self, cert: &VerifiedExecutableTransaction) -> Option<DeferralKey> {
+        None
+    }
+
     /// Lock a sequence number for the shared objects of the input transaction based on the effects
     /// of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who catch up by state sync.
@@ -1823,12 +2004,24 @@ impl AuthorityPerEpochStore {
                 .into_iter()
                 .partition(|transaction| transaction.0.is_end_of_publish());
 
+        let mut batch = self.db_batch();
+
+        sequenced_transactions.extend(
+            self.load_deferred_transactions_for_consensus_round(&mut batch, commit_round)?
+                .into_iter(),
+        );
+
+        // TODO: load deferred random round transactions
+        // sequenced_transactions.extend(
+        //     self.load_deferred_transactions_for_randomness_round(&mut batch, random_round)?
+        //         .into_iter(),
+        // );
+
         PostConsensusTxReorder::reorder(
             &mut sequenced_transactions,
             self.protocol_config.consensus_transaction_ordering(),
         );
 
-        let mut batch = self.db_batch();
         let (transactions_to_schedule, notifications, lock_and_final_round) = self
             .process_consensus_transactions(
                 &mut batch,
@@ -1983,6 +2176,9 @@ impl AuthorityPerEpochStore {
             .await?
         };
 
+        let mut deferred_txns: BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>> =
+            BTreeMap::new();
+
         for tx in transactions {
             let key = tx.0.transaction.key();
             self.record_consensus_message_processed(batch, key.clone())?;
@@ -1999,9 +2195,21 @@ impl AuthorityPerEpochStore {
                     notifications.push(key);
                     verified_certificates.push(cert);
                 }
+                ConsensusCertificateResult::Defered(deferral_key) => {
+                    // Note: record_consensus_message_processed() must have been called for this
+                    // cert even though we are not processing it now!
+                    deferred_txns
+                        .entry(deferral_key)
+                        .or_default()
+                        .push(tx.clone());
+                }
                 ConsensusCertificateResult::ConsensusMessage => notifications.push(key),
                 ConsensusCertificateResult::Ignored => (),
             }
+        }
+
+        for (key, txns) in deferred_txns.into_iter() {
+            self.defer_transactions(batch, key, txns)?;
         }
 
         batch.insert_batch(
@@ -2149,6 +2357,15 @@ impl AuthorityPerEpochStore {
                     debug!("Ignoring consensus certificate for transaction {:?} because of end of epoch",
                     certificate.digest());
                     return Ok(ConsensusCertificateResult::Ignored);
+                }
+
+                if let Some(deferral_key) = self.should_defer(&certificate) {
+                    debug!(
+                        "Deferring consensus certificate for transaction {:?} until {:?}",
+                        certificate.digest(),
+                        deferral_key
+                    );
+                    return Ok(ConsensusCertificateResult::Defered(deferral_key));
                 }
 
                 if certificate.contains_shared_object() {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -28,7 +28,9 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use sui_types::authenticator_state::ActiveJwk;
 use sui_types::base_types::{AuthorityName, EpochId, TransactionDigest};
-use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::executable_transaction::{
+    TrustedExecutableTransaction, VerifiedExecutableTransaction,
+};
 use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
 };
@@ -533,10 +535,60 @@ pub struct SequencedConsensusTransaction {
     pub transaction: SequencedConsensusTransactionKind,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum SequencedConsensusTransactionKind {
     External(ConsensusTransaction),
     System(VerifiedExecutableTransaction),
+}
+
+impl Serialize for SequencedConsensusTransactionKind {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let serializable = SerializableSequencedConsensusTransactionKind::from(self);
+        serializable.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SequencedConsensusTransactionKind {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let serializable =
+            SerializableSequencedConsensusTransactionKind::deserialize(deserializer)?;
+        Ok(serializable.into())
+    }
+}
+
+// We can't serialize SequencedConsensusTransactionKind directly because it contains a
+// VerifiedExecutableTransaction, which is not serializable (by design). This wrapper allows us to
+// convert to a serializable format easily.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum SerializableSequencedConsensusTransactionKind {
+    External(ConsensusTransaction),
+    System(TrustedExecutableTransaction),
+}
+
+impl From<&SequencedConsensusTransactionKind> for SerializableSequencedConsensusTransactionKind {
+    fn from(kind: &SequencedConsensusTransactionKind) -> Self {
+        match kind {
+            SequencedConsensusTransactionKind::External(ext) => {
+                SerializableSequencedConsensusTransactionKind::External(ext.clone())
+            }
+            SequencedConsensusTransactionKind::System(txn) => {
+                SerializableSequencedConsensusTransactionKind::System(txn.clone().serializable())
+            }
+        }
+    }
+}
+
+impl From<SerializableSequencedConsensusTransactionKind> for SequencedConsensusTransactionKind {
+    fn from(kind: SerializableSequencedConsensusTransactionKind) -> Self {
+        match kind {
+            SerializableSequencedConsensusTransactionKind::External(ext) => {
+                SequencedConsensusTransactionKind::External(ext)
+            }
+            SerializableSequencedConsensusTransactionKind::System(txn) => {
+                SequencedConsensusTransactionKind::System(txn.into())
+            }
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Debug)]

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -525,6 +525,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SequencedConsensusTransaction {
     pub certificate_author_index: AuthorityIndex,
     pub certificate_author: AuthorityName,
@@ -532,6 +533,7 @@ pub struct SequencedConsensusTransaction {
     pub transaction: SequencedConsensusTransactionKind,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SequencedConsensusTransactionKind {
     External(ConsensusTransaction),
     System(VerifiedExecutableTransaction),
@@ -623,6 +625,7 @@ impl SequencedConsensusTransaction {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerifiedSequencedConsensusTransaction(pub SequencedConsensusTransaction);
 
 #[cfg(test)]

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -370,9 +370,7 @@ impl RocksDB {
     ) -> Result<Transaction<'_, rocksdb::OptimisticTransactionDB>, TypedStoreError> {
         match self {
             Self::OptimisticTransactionDB(db) => Ok(db.underlying.transaction()),
-            Self::DBWithThreadMode(_) => Err(TypedStoreError::RocksDBError(
-                "operation not supported".to_string(),
-            )),
+            Self::DBWithThreadMode(_) => panic!(),
         }
     }
 
@@ -388,9 +386,7 @@ impl RocksDB {
                     .underlying
                     .transaction_opt(&WriteOptions::default(), &tx_opts))
             }
-            Self::DBWithThreadMode(_) => Err(TypedStoreError::RocksDBError(
-                "operation not supported".to_string(),
-            )),
+            Self::DBWithThreadMode(_) => panic!(),
         }
     }
 
@@ -624,9 +620,7 @@ impl RocksDBBatch {
                 batch.delete_range_cf(cf, from, to);
                 Ok(())
             }
-            Self::Transactional(_) => Err(TypedStoreError::RocksDBError(
-                "operation not supported".to_string(),
-            )),
+            Self::Transactional(_) => panic!(),
         }
     }
 }


### PR DESCRIPTION
Transactions may be deferred in each consensus round by providing either the future consensus commit or future random round to which the commit should be deferred.

When the given round arrives, all transactions that were deferred to that point in time are loaded from the DB and added to the set of transactions that arrived in the most recent commit.