### PR TITLE
[rgaphql/rpc] easy: re-enable cluster

### DIFF
--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -36,6 +36,9 @@ async fn main() {
         } => {
             let conn = ConnectionConfig::new(port, host, rpc_url, db_url, prom_host, prom_port);
             let service_config = service_config(config);
+            let _guard = telemetry_subscribers::TelemetryConfig::new()
+                .with_env()
+                .init();
 
             println!("Starting server...");
             start_example_server(conn, service_config).await.unwrap();

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -26,9 +26,6 @@ pub async fn start_example_server(
     service_config: ServiceConfig,
 ) -> Result<(), crate::error::Error> {
     println!("Starting server with config: {:?}", conn);
-    let _guard = telemetry_subscribers::TelemetryConfig::new()
-        .with_env()
-        .init();
 
     let sui_sdk_client_v0 = sui_sdk_client_v0(&conn.rpc_url).await;
     let data_provider: Box<dyn DataProvider> = Box::new(sui_sdk_client_v0.clone());

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//#[cfg(feature = "pg_integration")]
+#[cfg(feature = "pg_integration")]
 mod tests {
     use diesel::OptionalExtension;
     use diesel::RunQueryDsl;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -23,7 +23,6 @@ mod tests {
     use sui_types::digests::ChainIdentifier;
     use tokio::time::sleep;
 
-    #[ignore]
     #[tokio::test]
     #[serial]
     async fn test_simple_client_validator_cluster() {

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "pg_integration")]
+//#[cfg(feature = "pg_integration")]
 mod tests {
     use diesel::OptionalExtension;
     use diesel::RunQueryDsl;
@@ -26,6 +26,10 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_simple_client_validator_cluster() {
+        let _guard = telemetry_subscribers::TelemetryConfig::new()
+            .with_env()
+            .init();
+
         let connection_config = ConnectionConfig::ci_integration_test_cfg();
 
         let cluster = sui_graphql_rpc::cluster::start_cluster(connection_config, None).await;


### PR DESCRIPTION
## Description 

Now we have serialized tests, we can enable cluster db dependent tests

## Test Plan 

e2e test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
