### PR TITLE
[sui-mode][move-compiler] Fixed init bug. Improved other cases

### DIFF
--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.exp
@@ -1,6 +1,11 @@
-processed 1 task
+processed 2 tasks
 
 task 0 'publish'. lines 6-23:
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 4613200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 1 'publish'. lines 25-43:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4932400,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.mvir
@@ -7,7 +7,7 @@
 module 0x0.m {
     import 0x2.tx_context;
 
-    struct M has drop { value: u64 }
+    struct M has store, drop { value: u64 }
 
     init(_ctx: &mut tx_context.TxContext) {
         label l0:
@@ -18,6 +18,26 @@ module 0x0.m {
         label l0:
         _ = M { value: 7 };
         _ = M { value: 42 };
+        return;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+
+    struct Other has drop { value: bool }
+    struct M has drop { value: Self.Other }
+
+    init(_ctx: &mut tx_context.TxContext) {
+        label l0:
+        return;
+    }
+
+    foo() {
+        label l0:
+        _ = M { value: Other { value: false } };
+        _ = M { value: Other { value: false } };
         return;
     }
 }

--- a/external-crates/move/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/typing.rs
@@ -466,7 +466,7 @@ fn check_otw_type(
     sdef: &N::StructDefinition,
     usage_loc: Option<Loc>,
 ) {
-    const OTW_USAGE: &str = "Possible attempted usage as a one-time witness here";
+    const OTW_USAGE: &str = "Attempted usage as a one-time witness here";
     if context.one_time_witness.is_some() {
         return;
     }

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_many_wrong_parameters.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_many_wrong_parameters.exp
@@ -1,0 +1,40 @@
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:2:9
+  │
+2 │     fun init(_: who::X, _: who::Y, _: who::Z) {}
+  │         ^^^^                       - 'init' functions can have at most two parameters
+  │         │                           
+  │         Invalid 'init' function declaration
+
+error[E03002]: unbound module
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:2:17
+  │
+2 │     fun init(_: who::X, _: who::Y, _: who::Z) {}
+  │                 ^^^ Unbound module alias 'who'
+
+error[E03002]: unbound module
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:2:28
+  │
+2 │     fun init(_: who::X, _: who::Y, _: who::Z) {}
+  │                            ^^^ Unbound module alias 'who'
+
+error[E03002]: unbound module
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:2:39
+  │
+2 │     fun init(_: who::X, _: who::Y, _: who::Z) {}
+  │                                       ^^^ Unbound module alias 'who'
+
+error[Sui E02003]: invalid 'init' function
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:7:9
+  │
+7 │     fun init(_: Who, _: u64, _: &mut sui::tx_context::TxContext) {}
+  │         ^^^^                 - 'init' functions can have at most two parameters
+  │         │                     
+  │         Invalid 'init' function declaration
+
+error[E03004]: unbound type
+  ┌─ tests/sui_mode/one_time_witness/init_many_wrong_parameters.move:7:17
+  │
+7 │     fun init(_: Who, _: u64, _: &mut sui::tx_context::TxContext) {}
+  │                 ^^^ Unbound type 'Who' in current scope
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_many_wrong_parameters.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_many_wrong_parameters.move
@@ -1,0 +1,12 @@
+module a::m {
+    fun init(_: who::X, _: who::Y, _: who::Z) {}
+}
+
+module a::beep {
+    struct BEEP has drop {}
+    fun init(_: Who, _: u64, _: &mut sui::tx_context::TxContext) {}
+}
+
+module sui::tx_context {
+    struct TxContext {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_unbound_type.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_unbound_type.exp
@@ -1,0 +1,12 @@
+error[E03002]: unbound module
+  ┌─ tests/sui_mode/one_time_witness/init_unbound_type.move:2:20
+  │
+2 │     fun init(_ctx: who::TxContext) {}
+  │                    ^^^ Unbound module alias 'who'
+
+error[E03004]: unbound type
+  ┌─ tests/sui_mode/one_time_witness/init_unbound_type.move:7:17
+  │
+7 │     fun init(_: Who, _ctx: &mut sui::tx_context::TxContext) {}
+  │                 ^^^ Unbound type 'Who' in current scope
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_unbound_type.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/init_unbound_type.move
@@ -1,0 +1,12 @@
+module a::m {
+    fun init(_ctx: who::TxContext) {}
+}
+
+module a::beep {
+    struct BEEP has drop {}
+    fun init(_: Who, _ctx: &mut sui::tx_context::TxContext) {}
+}
+
+module sui::tx_context {
+    struct TxContext {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
@@ -7,7 +7,7 @@ error[Sui E02004]: invalid one-time witness declaration
   │            Invalid one-time witness declaration
 6 │ 
 7 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
-  │                    - Possible attempted usage as a one-time witness here
+  │                    - Attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/many_fields_invalid.exp
@@ -2,12 +2,12 @@ error[Sui E02004]: invalid one-time witness declaration
   ┌─ tests/sui_mode/one_time_witness/many_fields_invalid.move:5:12
   │
 5 │     struct M has drop { some_field: bool, some_field2: bool  }
-  │            ^                              ----------- One-time witness types must have no fields, or exactly one field of type 'bool'
+  │            ^                              ----------- Found more than one field. One-time witness types must have no fields, or exactly one field of type 'bool'
   │            │                               
   │            Invalid one-time witness declaration
 6 │ 
 7 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
-  │                    - Used as a one-time witness here
+  │                    - Possible attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type.move
@@ -3,7 +3,7 @@
 module a::m {
     use sui::tx_context;
 
-    struct M has drop { value: u64 }
+    struct M has store, drop { value: u64 }
 
     fun init(_ctx: &mut tx_context::TxContext) {
     }
@@ -14,6 +14,13 @@ module a::m {
     }
 }
 
+module 0::beep {
+  struct BEEP has store { boop: sui::table::Table<u8, bool> }
+}
+
 module sui::tx_context {
     struct TxContext has drop {}
+}
+module sui::table {
+    struct Table<phantom K, phantom V> has store {}
 }

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field.move
@@ -1,0 +1,12 @@
+module a::beep {
+    struct BEEP has drop {
+        f0: u64,
+        f1: bool,
+    }
+    fun init(_ctx: &mut sui::tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
@@ -1,0 +1,27 @@
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.move:2:12
+  │
+2 │     struct BEEP has drop {
+  │            ^^^^ Invalid one-time witness declaration
+3 │         f0: u64,
+  │         -- One-time witness types must have no fields, or exactly one field of type 'bool'
+  ·
+6 │     fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
+  │                 ---- Used as a one-time witness here
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+
+error[Sui E02004]: invalid one-time witness declaration
+  ┌─ tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.move:2:12
+  │
+2 │     struct BEEP has drop {
+  │            ^^^^ Invalid one-time witness declaration
+3 │         f0: u64,
+4 │         f1: bool,
+  │         -- One-time witness types must have no fields, or exactly one field of type 'bool'
+5 │     }
+6 │     fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
+  │                 ---- Used as a one-time witness here
+  │
+  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
+

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
@@ -7,21 +7,7 @@ error[Sui E02004]: invalid one-time witness declaration
   │         -- One-time witness types must have no fields, or exactly one field of type 'bool'
   ·
 6 │     fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
-  │                 ---- Used as a one-time witness here
-  │
-  = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
-
-error[Sui E02004]: invalid one-time witness declaration
-  ┌─ tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.move:2:12
-  │
-2 │     struct BEEP has drop {
-  │            ^^^^ Invalid one-time witness declaration
-3 │         f0: u64,
-4 │         f1: bool,
-  │         -- One-time witness types must have no fields, or exactly one field of type 'bool'
-5 │     }
-6 │     fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
-  │                 ---- Used as a one-time witness here
+  │                 ---- Possible attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.exp
@@ -7,7 +7,7 @@ error[Sui E02004]: invalid one-time witness declaration
   │         -- One-time witness types must have no fields, or exactly one field of type 'bool'
   ·
 6 │     fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
-  │                 ---- Possible attempted usage as a one-time witness here
+  │                 ---- Attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.move
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_and_extra_field_with_init.move
@@ -1,0 +1,12 @@
+module a::beep {
+    struct BEEP has drop {
+        f0: u64,
+        f1: bool,
+    }
+    fun init(_: BEEP, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
@@ -7,7 +7,7 @@ error[Sui E02004]: invalid one-time witness declaration
   │            Invalid one-time witness declaration
 7 │ 
 8 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
-  │                    - Possible attempted usage as a one-time witness here
+  │                    - Attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 

--- a/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
+++ b/external-crates/move/move-compiler/tests/sui_mode/one_time_witness/wrong_field_type_with_init.exp
@@ -7,7 +7,7 @@ error[Sui E02004]: invalid one-time witness declaration
   │            Invalid one-time witness declaration
 7 │ 
 8 │     fun init(_otw: M, _ctx: &mut tx_context::TxContext) {
-  │                    - Used as a one-time witness here
+  │                    - Possible attempted usage as a one-time witness here
   │
   = One-time witness types are structs with the following requirements: their name is the upper-case version of the module's name, they have no fields (or a single boolean field), they have no type parameters, and they have only the 'drop' ability.
 


### PR DESCRIPTION
## Description 

- Fixed bug with OTW checks
- Improved init error messages

## Test Plan 

- Added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

This release fixes a bug in the Sui mode of the Move compiler that categorized certain structs erroneously as one-time witnesses. 
