### PR TITLE
[GraphQL/EASY] Use crate's error type

### DIFF
--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -6,8 +6,8 @@ use super::move_value::MoveValue;
 use super::stake::StakeStatus;
 use super::{coin::Coin, object::Object};
 use crate::context_data::db_data_provider::PgManager;
+use crate::error::Error;
 use crate::types::stake::Stake;
-use async_graphql::Error;
 use async_graphql::*;
 use move_core_types::language_storage::TypeTag;
 use sui_types::governance::StakedSui;
@@ -22,7 +22,7 @@ pub(crate) struct MoveObject {
 #[allow(unused_variables)]
 #[Object]
 impl MoveObject {
-    async fn contents(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>, Error> {
+    async fn contents(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
         let resolver = ctx.data_unchecked::<PgManager>();
 
         if let Some(struct_tag) = self.native_object.data.struct_tag() {
@@ -33,7 +33,7 @@ impl MoveObject {
                     .data
                     .try_as_move()
                     .ok_or_else(|| {
-                        crate::error::Error::Internal(format!(
+                        Error::Internal(format!(
                             "Failed to convert native object to move object: {}",
                             self.native_object.id()
                         ))
@@ -72,14 +72,14 @@ impl MoveObject {
     }
 
     // TODO implement this properly, it is missing estimate reward
-    async fn as_stake(&self, ctx: &Context<'_>) -> Result<Option<Stake>, Error> {
+    async fn as_stake(&self, ctx: &Context<'_>) -> Result<Option<Stake>> {
         let stake =
-            StakedSui::try_from(&self.native_object).map_err(|e| Error::new(e.to_string()))?;
+            StakedSui::try_from(&self.native_object).map_err(|e| Error::Internal(e.to_string()))?;
         let latest_system_state = ctx
             .data_unchecked::<PgManager>()
             .fetch_latest_sui_system_state()
             .await
-            .map_err(|e| Error::new(e.to_string()))?;
+            .map_err(|e| Error::Internal(e.to_string()))?;
         let current_epoch_id = latest_system_state.epoch_id;
         let status = if current_epoch_id >= stake.activation_epoch() {
             StakeStatus::Active

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -5,9 +5,8 @@ use super::move_module::MoveModule;
 use super::object::Object;
 use crate::context_data::db_data_provider::validate_cursor_pagination;
 use crate::error::code::INTERNAL_SERVER_ERROR;
-use crate::error::graphql_error;
+use crate::error::{graphql_error, Error};
 use async_graphql::connection::{Connection, Edge};
-use async_graphql::Error;
 use async_graphql::*;
 use move_binary_format::CompiledModule;
 use sui_types::object::Object as NativeSuiObject;
@@ -24,8 +23,9 @@ pub(crate) struct MovePackage {
 #[allow(unused_variables)]
 #[Object]
 impl MovePackage {
-    async fn module(&self, name: String) -> Result<Option<MoveModule>, Error> {
-        let identifier = Identifier::new(name).map_err(|e| Error::new(e.to_string()))?;
+    async fn module(&self, name: String) -> Result<Option<MoveModule>> {
+        let identifier = Identifier::new(name).map_err(|e| Error::Internal(e.to_string()))?;
+
         let module = self.native_object.data.try_as_package().map(|x| {
             x.deserialize_module(
                 &identifier,


### PR DESCRIPTION
## Description

Use `sui_graphql_rpc::error::Error` instead of `async_graphql::Error`.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```