### PR TITLE
[GraphQL/MovePackage] BCS field

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -370,6 +370,11 @@ type MoveObject {
 type MovePackage {
 	module(name: String!): MoveModule
 	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	bcs: Base64
 	asObject: Object
 }
 

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -977,6 +977,8 @@ type MovePackage {
     before: String,
   ): MoveModuleConnection
 
+  bcs: Base64
+
   asObject: Object!
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -374,6 +374,11 @@ type MoveObject {
 type MovePackage {
 	module(name: String!): MoveModule
 	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	bcs: Base64
 	asObject: Object
 }
 
@@ -876,3 +881,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+


### PR DESCRIPTION
## Description

Field to get the BCS representation of a package's modules.  The decision to only output the modules, rather than the whole package struct was done to match the format that modules take when they are passed in to the network, during publish and upgrade transactions.

## Test Plan

Tested in GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/69b02a0a-0a8a-4381-a946-9b90f4d28c1b)

And using cURL:

```
curl -LX POST "http://127.0.0.1:9001" \
    --data-raw '{
      "query": "{ object(address: \"0x2\") { asMovePackage { bcs } } }"
    }' \
  | jq  -r .data.object.asMovePackage.bcs
  | base64 -d
  | hexdump -C
```

## Stack

- #14422 