### PR TITLE
[GraphQL/MovePackage] Linkage Field

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -315,7 +315,7 @@ type Linkage {
 	"""
 	originalId: SuiAddress!
 	"""
-	The ID on-chain of the version of the depedency that this package depends on.
+	The ID on-chain of the version of the dependency that this package depends on.
 	"""
 	upgradedId: SuiAddress!
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -307,6 +307,24 @@ type GenesisTransaction {
 
 
 """
+Information used by a package to link to a specific version of its dependency.
+"""
+type Linkage {
+	"""
+	The ID on-chain of the first version of the dependency.
+	"""
+	originalId: SuiAddress!
+	"""
+	The ID on-chain of the version of the depedency that this package depends on.
+	"""
+	upgradedId: SuiAddress!
+	"""
+	The version of the dependency that this package depends on.
+	"""
+	version: Int!
+}
+
+"""
 The contents of a Move Value, corresponding to the following recursive type:
 
 type MoveData =
@@ -370,6 +388,10 @@ type MoveObject {
 type MovePackage {
 	module(name: String!): MoveModule
 	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	"""
+	The transitive dependencies of this package.
+	"""
+	linkage: [Linkage!]
 	"""
 	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
 	name, followed by module bytes), in alphabetic order by module name.

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -977,9 +977,16 @@ type MovePackage {
     before: String,
   ): MoveModuleConnection
 
+  linkage: [Linkage!]
   bcs: Base64
 
   asObject: Object!
+}
+
+type Linkage {
+  originalId: SuiAddress!
+  upgradedId: SuiAddress!
+  version: Int!
 }
 
 type MoveModuleId {

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -28,7 +28,7 @@ struct Linkage {
     /// The ID on-chain of the first version of the dependency.
     original_id: SuiAddress,
 
-    /// The ID on-chain of the version of the depedency that this package depends on.
+    /// The ID on-chain of the version of the dependency that this package depends on.
     upgraded_id: SuiAddress,
 
     /// The version of the dependency that this package depends on.

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -4,20 +4,35 @@
 use super::base64::Base64;
 use super::move_module::MoveModule;
 use super::object::Object;
+use super::sui_address::SuiAddress;
 use crate::context_data::db_data_provider::validate_cursor_pagination;
 use crate::error::code::INTERNAL_SERVER_ERROR;
 use crate::error::{graphql_error, Error};
 use async_graphql::connection::{Connection, Edge};
 use async_graphql::*;
 use move_binary_format::CompiledModule;
-use sui_types::object::Object as NativeSuiObject;
-use sui_types::Identifier;
+use sui_types::{
+    move_package::MovePackage as NativeMovePackage, object::Object as NativeSuiObject, Identifier,
+};
 
 const DEFAULT_PAGE_SIZE: usize = 10;
 
 #[derive(Clone)]
 pub(crate) struct MovePackage {
     pub native_object: NativeSuiObject,
+}
+
+/// Information used by a package to link to a specific version of its dependency.
+#[derive(SimpleObject)]
+struct Linkage {
+    /// The ID on-chain of the first version of the dependency.
+    original_id: SuiAddress,
+
+    /// The ID on-chain of the version of the depedency that this package depends on.
+    upgraded_id: SuiAddress,
+
+    /// The version of the dependency that this package depends on.
+    version: u64,
 }
 
 #[allow(unreachable_code)]
@@ -135,20 +150,26 @@ impl MovePackage {
         Ok(None)
     }
 
+    /// The transitive dependencies of this package.
+    async fn linkage(&self) -> Result<Option<Vec<Linkage>>> {
+        let linkage = self
+            .as_native_package()?
+            .linkage_table()
+            .iter()
+            .map(|(&runtime_id, upgrade_info)| Linkage {
+                original_id: runtime_id.into(),
+                upgraded_id: upgrade_info.upgraded_id.into(),
+                version: upgrade_info.upgraded_version.value(),
+            })
+            .collect();
+
+        Ok(Some(linkage))
+    }
+
     /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
     /// name, followed by module bytes), in alphabetic order by module name.
     async fn bcs(&self) -> Result<Option<Base64>> {
-        let modules = self
-            .native_object
-            .data
-            .try_as_package()
-            .ok_or_else(|| {
-                Error::Internal(format!(
-                    "Failed to convert native object to move package: {}",
-                    self.native_object.id(),
-                ))
-            })?
-            .serialized_module_map();
+        let modules = self.as_native_package()?.serialized_module_map();
 
         let bcs = bcs::to_bytes(modules).map_err(|_| {
             Error::Internal(format!(
@@ -162,5 +183,16 @@ impl MovePackage {
 
     async fn as_object(&self) -> Option<Object> {
         Some(Object::from(&self.native_object))
+    }
+}
+
+impl MovePackage {
+    fn as_native_package(&self) -> Result<&NativeMovePackage> {
+        Ok(self.native_object.data.try_as_package().ok_or_else(|| {
+            Error::Internal(format!(
+                "Failed to convert native object to move package: {}",
+                self.native_object.id(),
+            ))
+        })?)
     }
 }

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use async_graphql::*;
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
+use sui_types::base_types::ObjectID;
 use thiserror::Error;
 
 const SUI_ADDRESS_LENGTH: usize = 32;
@@ -85,6 +86,12 @@ impl TryFrom<Vec<u8>> for SuiAddress {
 
 impl From<AccountAddress> for SuiAddress {
     fn from(value: AccountAddress) -> Self {
+        SuiAddress(value.into_bytes())
+    }
+}
+
+impl From<ObjectID> for SuiAddress {
+    fn from(value: ObjectID) -> Self {
         SuiAddress(value.into_bytes())
     }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -311,6 +311,24 @@ type GenesisTransaction {
 
 
 """
+Information used by a package to link to a specific version of its dependency.
+"""
+type Linkage {
+	"""
+	The ID on-chain of the first version of the dependency.
+	"""
+	originalId: SuiAddress!
+	"""
+	The ID on-chain of the version of the depedency that this package depends on.
+	"""
+	upgradedId: SuiAddress!
+	"""
+	The version of the dependency that this package depends on.
+	"""
+	version: Int!
+}
+
+"""
 The contents of a Move Value, corresponding to the following recursive type:
 
 type MoveData =
@@ -374,6 +392,10 @@ type MoveObject {
 type MovePackage {
 	module(name: String!): MoveModule
 	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	"""
+	The transitive dependencies of this package.
+	"""
+	linkage: [Linkage!]
 	"""
 	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
 	name, followed by module bytes), in alphabetic order by module name.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -319,7 +319,7 @@ type Linkage {
 	"""
 	originalId: SuiAddress!
 	"""
-	The ID on-chain of the version of the depedency that this package depends on.
+	The ID on-chain of the version of the dependency that this package depends on.
 	"""
 	upgradedId: SuiAddress!
 	"""


### PR DESCRIPTION
## Description

Lists the packages transitive dependencies.  Exposing this as its own field because the BCS representation of a package doesn't contain this information (it contains only the modules).

This maps how this field is represented in RPC 1.0

## Test Plan

Tested with GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/cb829b4c-e1c8-4c14-b331-1c386391a87e)

## Stack

- #14422 
- #14423 