### PR TITLE
[GraphQL/MovePackage] Type Origins Field

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -393,6 +393,10 @@ type MovePackage {
 	"""
 	linkage: [Linkage!]
 	"""
+	The (previous) versions of this package that introduced its types.
+	"""
+	typeOrigins: [TypeOrigin!]
+	"""
 	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
 	name, followed by module bytes), in alphabetic order by module name.
 	"""
@@ -844,6 +848,24 @@ enum TransactionBlockKindInput {
 
 type TransactionSignature {
 	base64Sig: Base64!
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -397,6 +397,10 @@ type MovePackage {
 	"""
 	linkage: [Linkage!]
 	"""
+	The (previous) versions of this package that introduced its types.
+	"""
+	typeOrigins: [TypeOrigin!]
+	"""
 	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
 	name, followed by module bytes), in alphabetic order by module name.
 	"""
@@ -848,6 +852,24 @@ enum TransactionBlockKindInput {
 
 type TransactionSignature {
 	base64Sig: Base64!
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 type Validator {


### PR DESCRIPTION
## Description

Completing the set of "raw" fields for MovePackage with a field exposing type origins.

## Test Plan

Tested using GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/3c0fd67d-9d62-4236-90ee-2c3aff47b9f2)

## Stack

- #14422 
- #14423 
- #14424 