### PR TITLE
[benchmark] Update Move workload

### DIFF
--- a/crates/sui-single-node-benchmark/move_package/sources/benchmark.move
+++ b/crates/sui-single-node-benchmark/move_package/sources/benchmark.move
@@ -16,16 +16,8 @@ module move_benchmark::benchmark {
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
-    public fun merge_input_coins(coins: vector<Coin<SUI>>, ctx: &mut TxContext): Coin<SUI> {
-        let result = coin::zero<SUI>(ctx);
-        let result_balance = coin::balance_mut(&mut result);
-        while (!vector::is_empty(&coins)) {
-            let coin = vector::pop_back(&mut coins);
-            let balance = coin::into_balance(coin);
-            balance::join(result_balance, balance);
-        };
-        vector::destroy_empty(coins);
-        result
+    public fun transfer_coin(coin: Coin<SUI>, ctx: &mut TxContext) {
+        transfer::public_transfer(coin, tx_context::sender(ctx));
     }
 
     public fun run_computation(num: u64) {

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -27,6 +27,13 @@ pub struct Command {
     pub checkpoint_size: usize,
     #[arg(
         long,
+        default_value_t = 2,
+        help = "Number of address owned input objects per transaction.\
+            This represents the amount of DB reads per transaction prior to execution."
+    )]
+    pub num_input_objects: u8,
+    #[arg(
+        long,
         default_value = "baseline",
         ignore_case = true,
         help = "Which component to benchmark"
@@ -63,13 +70,6 @@ pub enum Component {
 pub enum WorkloadKind {
     NoMove,
     Move {
-        #[arg(
-            long,
-            default_value_t = 2,
-            help = "Number of address owned input objects per transaction.\
-            This represents the amount of DB reads per transaction prior to execution."
-        )]
-        num_input_objects: u8,
         #[arg(
             long,
             default_value_t = 0,

--- a/crates/sui-single-node-benchmark/src/main.rs
+++ b/crates/sui-single-node-benchmark/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     let args = Command::parse();
     run_benchmark(
-        Workload::new(args.tx_count, args.workload),
+        Workload::new(args.tx_count, args.workload, args.num_input_objects),
         args.component,
         args.checkpoint_size,
     )

--- a/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
@@ -8,7 +8,9 @@ use std::collections::HashMap;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::{ObjectArg, Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
+use sui_types::transaction::{
+    Argument, CallArg, ObjectArg, Transaction, DEFAULT_VALIDATOR_GAS_PRICE,
+};
 
 pub struct MoveTxGenerator {
     move_package: ObjectID,
@@ -37,19 +39,23 @@ impl TxGenerator for MoveTxGenerator {
     fn generate_tx(&self, account: Account) -> Transaction {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            // PT command 1: Merge a vector of coins to a single coin.
-            let object_args = (0..self.num_input_objects - 1)
-                .map(|i| ObjectArg::ImmOrOwnedObject(account.gas_objects[(i + 1) as usize]));
-            let input_coins = builder.make_obj_vec(object_args).unwrap();
-            let merged_output = builder.programmable_move_call(
-                self.move_package,
-                Identifier::new("benchmark").unwrap(),
-                Identifier::new("merge_input_coins").unwrap(),
-                vec![],
-                vec![input_coins],
-            );
-            // PT command 2: Transfer the merged coin to the sender.
-            builder.transfer_arg(account.sender, merged_output);
+            // First transfer all input objects to the sender.
+            // Except the gas coin which can only be transferred directly, all other objects
+            // are transferred through Move.
+            builder.transfer_arg(account.sender, Argument::GasCoin);
+            for i in 1..self.num_input_objects {
+                builder
+                    .move_call(
+                        self.move_package,
+                        Identifier::new("benchmark").unwrap(),
+                        Identifier::new("transfer_coin").unwrap(),
+                        vec![],
+                        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                            account.gas_objects[i as usize],
+                        ))],
+                    )
+                    .unwrap();
+            }
 
             if !self.root_objects.is_empty() {
                 // PT command 3: Read all dynamic fields from the root object.
@@ -67,14 +73,16 @@ impl TxGenerator for MoveTxGenerator {
             }
 
             // PT command 4: Run some computation.
-            let computation_arg = builder.pure(self.computation as u64 * 100).unwrap();
-            builder.programmable_move_call(
-                self.move_package,
-                Identifier::new("benchmark").unwrap(),
-                Identifier::new("run_computation").unwrap(),
-                vec![],
-                vec![computation_arg],
-            );
+            if self.computation > 0 {
+                let computation_arg = builder.pure(self.computation as u64 * 100).unwrap();
+                builder.programmable_move_call(
+                    self.move_package,
+                    Identifier::new("benchmark").unwrap(),
+                    Identifier::new("run_computation").unwrap(),
+                    vec![],
+                    vec![computation_arg],
+                );
+            }
             builder.finish()
         };
         TestTransactionBuilder::new(

--- a/crates/sui-single-node-benchmark/src/tx_generator/non_move_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/non_move_tx_generator.rs
@@ -4,24 +4,33 @@
 use crate::mock_account::Account;
 use crate::tx_generator::TxGenerator;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::transaction::{Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{Argument, Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
 
-pub struct NonMoveTxGenerator {}
+pub struct NonMoveTxGenerator {
+    num_input_objects: u8,
+}
 
 impl NonMoveTxGenerator {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(num_input_objects: u8) -> Self {
+        Self { num_input_objects }
     }
 }
 
 impl TxGenerator for NonMoveTxGenerator {
     fn generate_tx(&self, account: Account) -> Transaction {
+        let mut pt = ProgrammableTransactionBuilder::new();
+        pt.transfer_arg(account.sender, Argument::GasCoin);
+        for i in 1..self.num_input_objects {
+            pt.transfer_object(account.sender, account.gas_objects[i as usize])
+                .unwrap();
+        }
         TestTransactionBuilder::new(
             account.sender,
             account.gas_objects[0],
             DEFAULT_VALIDATOR_GAS_PRICE,
         )
-        .transfer_sui(None, account.sender)
+        .programmable(pt.finish())
         .build_and_sign(account.keypair.as_ref())
     }
 

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -10,13 +10,15 @@ use std::sync::Arc;
 pub struct Workload {
     pub tx_count: u64,
     pub workload_kind: WorkloadKind,
+    pub num_input_objects: u8,
 }
 
 impl Workload {
-    pub fn new(tx_count: u64, workload_kind: WorkloadKind) -> Self {
+    pub fn new(tx_count: u64, workload_kind: WorkloadKind, num_input_objects: u8) -> Self {
         Self {
             tx_count,
             workload_kind,
+            num_input_objects,
         }
     }
 
@@ -25,28 +27,26 @@ impl Workload {
     }
 
     pub(crate) fn gas_object_num_per_account(&self) -> u64 {
-        match self.workload_kind {
-            WorkloadKind::NoMove => 1,
-            WorkloadKind::Move {
-                num_input_objects, ..
-            } => num_input_objects as u64,
-        }
+        self.num_input_objects as u64
     }
 
     pub(crate) async fn create_tx_generator(
         &self,
         ctx: &mut BenchmarkContext,
     ) -> Arc<dyn TxGenerator> {
+        assert!(
+            self.num_input_objects >= 1,
+            "Each transaction requires at least 1 input object"
+        );
         match self.workload_kind {
-            WorkloadKind::NoMove => Arc::new(NonMoveTxGenerator::new()),
+            WorkloadKind::NoMove => Arc::new(NonMoveTxGenerator::new(self.num_input_objects)),
             WorkloadKind::Move {
-                num_input_objects,
                 num_dynamic_fields,
                 computation,
             } => {
                 assert!(
-                    num_input_objects >= 1,
-                    "Each transaction requires at least 1 input object"
+                    self.num_input_objects >= 2,
+                    "Move transaction requires at least 2 input objects"
                 );
                 let move_package = ctx.publish_package().await;
                 let root_objects = ctx
@@ -54,7 +54,7 @@ impl Workload {
                     .await;
                 Arc::new(MoveTxGenerator::new(
                     move_package.0,
-                    num_input_objects,
+                    self.num_input_objects,
                     computation,
                     root_objects,
                 ))

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -11,7 +11,7 @@ use sui_single_node_benchmark::workload::Workload;
 async fn benchmark_simple_transfer_smoke_test() {
     // This test makes sure that the benchmark runs.
     for component in Component::iter() {
-        run_benchmark(Workload::new(10, WorkloadKind::NoMove), component, 1000).await;
+        run_benchmark(Workload::new(10, WorkloadKind::NoMove, 2), component, 1000).await;
     }
 }
 
@@ -23,10 +23,10 @@ async fn benchmark_move_transactions_smoke_test() {
             Workload::new(
                 10,
                 WorkloadKind::Move {
-                    num_input_objects: 2,
                     num_dynamic_fields: 1,
                     computation: 1,
                 },
+                2,
             ),
             component,
             1000,


### PR DESCRIPTION
## Description 

This PR updates the sui-single-node-benchmark's workload such that there is a fair comparison between non-Move and Move workload. Specifically it makes the num_input_objects a common parameter that can be specified in both non-Move and Move mode.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
