### PR TITLE
[graphql/rpc] easy: introduce db query cost limit to config

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -9,8 +9,10 @@ use sui_json_rpc::name_service::NameServiceConfig;
 
 use crate::functional_group::FunctionalGroup;
 
+// TODO: calculate proper cost limits
 const MAX_QUERY_DEPTH: u32 = 10;
 const MAX_QUERY_NODES: u32 = 100;
+const MAX_DB_QUERY_COST: u64 = 50; // Max DB query cost (normally f64) truncated
 
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
@@ -45,6 +47,8 @@ pub struct Limits {
     pub(crate) max_query_depth: u32,
     #[serde(default)]
     pub(crate) max_query_nodes: u32,
+    #[serde(default)]
+    pub(crate) max_db_query_cost: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -139,6 +143,7 @@ impl Default for Limits {
         Self {
             max_query_depth: MAX_QUERY_DEPTH,
             max_query_nodes: MAX_QUERY_NODES,
+            max_db_query_cost: MAX_DB_QUERY_COST,
         }
     }
 }
@@ -230,6 +235,7 @@ mod tests {
             r#" [limits]
                 max-query-depth = 100
                 max-query-nodes = 300
+                max-db-query-cost = 50
             "#,
         )
         .unwrap();
@@ -238,6 +244,7 @@ mod tests {
             limits: Limits {
                 max_query_depth: 100,
                 max_query_nodes: 300,
+                max_db_query_cost: 50,
             },
             ..Default::default()
         };
@@ -291,6 +298,7 @@ mod tests {
                 [limits]
                 max-query-depth = 42
                 max-query-nodes = 320
+                max-db-query-cost = 20
 
                 [experiments]
                 test-flag = true
@@ -302,6 +310,7 @@ mod tests {
             limits: Limits {
                 max_query_depth: 42,
                 max_query_nodes: 320,
+                max_db_query_cost: 20,
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
             experiments: Experiments { test_flag: true },

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
+    config::Limits,
     error::Error,
     types::{
         address::{Address, AddressTransactionBlockRelationship},
@@ -115,11 +116,12 @@ pub enum DbValidationError {
 
 pub(crate) struct PgManager {
     pub inner: IndexerReader,
+    pub _limits: Limits,
 }
 
 impl PgManager {
-    pub(crate) fn new(inner: IndexerReader) -> Self {
-        Self { inner }
+    pub(crate) fn new(inner: IndexerReader, _limits: Limits) -> Self {
+        Self { inner, _limits }
     }
 
     /// Create a new underlying reader, which is used by this type as well as other data providers.

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -8,6 +8,7 @@ pub struct RequestMetrics {
     pub(crate) num_nodes: Histogram,
     pub(crate) query_depth: Histogram,
     pub(crate) query_payload_size: Histogram,
+    pub(crate) _db_query_cost: Histogram,
 }
 
 // TODO: finetune buckets as we learn more about the distribution of queries
@@ -20,6 +21,9 @@ const QUERY_DEPTH_BUCKETS: &[f64] = &[
 const QUERY_PAYLOAD_SIZE_BUCKETS: &[f64] = &[
     100., 200., 400., 800., 1200., 1600., 2400., 3200., 4800., 6400., 9600., 12800., 25600.,
     51200., 102400.,
+];
+const DB_QUERY_COST_BUCKETS: &[f64] = &[
+    1., 2., 4., 8., 12., 16., 24., 32., 48., 64., 96., 128., 256., 512., 1024.,
 ];
 
 impl RequestMetrics {
@@ -43,6 +47,13 @@ impl RequestMetrics {
                 "query_payload_size",
                 "Size of the query payload string",
                 QUERY_PAYLOAD_SIZE_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            _db_query_cost: register_histogram_with_registry!(
+                "db_query_cost",
+                "Cost of a DB query",
+                DB_QUERY_COST_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -62,7 +62,7 @@ impl Server {
         let name_service_config = config.name_service.clone();
         let reader = PgManager::reader(config.connection.db_url.clone())
             .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
-        let pg_conn_pool = PgManager::new(reader.clone());
+        let pg_conn_pool = PgManager::new(reader.clone(), config.service.limits);
         let package_cache = PackageCache::new(reader);
 
         let prom_addr: SocketAddr = format!(
@@ -202,7 +202,7 @@ pub mod tests {
     use super::*;
     use crate::{
         cluster::SimulatorCluster,
-        config::{ConnectionConfig, ServiceConfig},
+        config::{ConnectionConfig, Limits, ServiceConfig},
         context_data::db_data_provider::PgManager,
         extensions::query_limits_checker::QueryLimitsChecker,
         extensions::timeout::{Timeout, TimeoutConfig},
@@ -268,7 +268,7 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader);
+            let pg_conn_pool = PgManager::new(reader, Limits::default());
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(pg_conn_pool)
                 .extension(TimedExecuteExt {
@@ -312,7 +312,7 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader);
+            let pg_conn_pool = PgManager::new(reader, Limits::default());
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(pg_conn_pool)
                 .max_query_depth(depth)
@@ -365,7 +365,7 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader);
+            let pg_conn_pool = PgManager::new(reader, Limits::default());
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
                 .context_data(pg_conn_pool)
                 .max_query_nodes(nodes)
@@ -421,7 +421,7 @@ pub mod tests {
 
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-        let pg_conn_pool = PgManager::new(reader);
+        let pg_conn_pool = PgManager::new(reader, service_config.limits);
         let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
             .max_query_depth(service_config.limits.max_query_depth)
             .max_query_nodes(service_config.limits.max_query_nodes)

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -33,7 +33,7 @@ pub async fn start_example_server(
 
     // TODO (wlmyng): Allow users to choose which data sources to back graphql
     let reader = PgManager::reader(conn.db_url).expect("Failed to create pg connection pool");
-    let pg_conn_pool = PgManager::new(reader.clone());
+    let pg_conn_pool = PgManager::new(reader.clone(), service_config.limits);
     let package_cache = PackageCache::new(reader);
     let name_service_config = NameServiceConfig::default();
 


### PR DESCRIPTION
## Description 

Adds DB query cost limit to the configs which will be enforced in subseq PRs

## Test Plan 

Existing 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
