### PR TITLE
[graphql/rpc] cleanup duplicate logic in server creation

### DIFF
--- a/crates/sui-graphql-rpc/src/cluster.rs
+++ b/crates/sui-graphql-rpc/src/cluster.rs
@@ -3,7 +3,7 @@
 
 use crate::client::simple_client::SimpleClient;
 use crate::config::ConnectionConfig;
-use crate::config::ServiceConfig;
+use crate::config::ServerConfig;
 use crate::server::simple_server::start_example_server;
 use mysten_metrics::init_metrics;
 use rand::rngs::StdRng;
@@ -119,11 +119,14 @@ pub async fn serve_simulator(
 }
 
 async fn start_graphql_server(graphql_connection_config: ConnectionConfig) -> JoinHandle<()> {
+    let server_config = ServerConfig {
+        connection: graphql_connection_config,
+        ..ServerConfig::default()
+    };
+
     // Starts graphql server
     tokio::spawn(async move {
-        start_example_server(graphql_connection_config, ServiceConfig::default())
-            .await
-            .unwrap();
+        start_example_server(&server_config).await.unwrap();
     })
 }
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -86,6 +86,10 @@ impl ConnectionConfig {
     pub fn db_url(&self) -> String {
         self.db_url.clone()
     }
+
+    pub fn server_address(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
 }
 
 impl ServiceConfig {
@@ -173,11 +177,11 @@ impl Default for InternalFeatureConfig {
 #[derive(Serialize, Clone, Deserialize, Debug, Default)]
 pub struct ServerConfig {
     #[serde(default)]
-    pub(crate) service: ServiceConfig,
+    pub service: ServiceConfig,
     #[serde(default)]
-    pub(crate) connection: ConnectionConfig,
+    pub connection: ConnectionConfig,
     #[serde(default)]
-    pub(crate) internal_features: InternalFeatureConfig,
+    pub internal_features: InternalFeatureConfig,
     #[serde(default)]
     pub name_service: NameServiceConfig,
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -75,6 +75,7 @@ impl Server {
         builder = builder
             .max_query_depth(config.service.limits.max_query_depth)
             .max_query_nodes(config.service.limits.max_query_nodes)
+            .context_data(config.service.clone())
             .context_data(pg_conn_pool)
             .context_data(package_cache)
             .context_data(name_service_config)

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -1,62 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::{ConnectionConfig, ServiceConfig};
-use crate::context_data::db_data_provider::PgManager;
-use crate::context_data::package_cache::PackageCache;
-use crate::extensions::feature_gate::FeatureGate;
-use crate::extensions::logger::Logger;
-use crate::extensions::query_limits_checker::QueryLimitsChecker;
-use crate::extensions::timeout::Timeout;
-use crate::metrics::RequestMetrics;
-use crate::server::builder::ServerBuilder;
+use crate::config::ServerConfig;
+use crate::server::builder::Server;
 
-use prometheus::Registry;
-use std::default::Default;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use sui_json_rpc::name_service::NameServiceConfig;
+pub async fn start_example_server(server_config: &ServerConfig) -> Result<(), crate::error::Error> {
+    println!("Starting server with config: {:?}", server_config);
 
-static PROM_ADDR: &str = "0.0.0.0:9184";
+    let server = Server::from_config(server_config).await?;
 
-pub async fn start_example_server(
-    conn: ConnectionConfig,
-    service_config: ServiceConfig,
-) -> Result<(), crate::error::Error> {
-    println!("Starting server with config: {:?}", conn);
+    println!(
+        "Launch GraphiQL IDE at: http://{}",
+        server_config.connection.server_address()
+    );
 
-    // TODO (wlmyng): Allow users to choose which data sources to back graphql
-    let reader = PgManager::reader(conn.db_url).expect("Failed to create pg connection pool");
-    let pg_conn_pool = PgManager::new(reader.clone(), service_config.limits);
-    let package_cache = PackageCache::new(reader);
-    let name_service_config = NameServiceConfig::default();
-
-    let prom_addr: SocketAddr = PROM_ADDR.parse().unwrap();
-    let registry = start_prom(prom_addr);
-    let metrics = RequestMetrics::new(&registry);
-
-    let builder = ServerBuilder::new(conn.port, conn.host);
-    println!("Launch GraphiQL IDE at: http://{}", builder.address());
-
-    builder
-        .max_query_depth(service_config.limits.max_query_depth)
-        .max_query_nodes(service_config.limits.max_query_nodes)
-        .context_data(service_config)
-        .context_data(pg_conn_pool)
-        .context_data(package_cache)
-        .context_data(name_service_config)
-        .context_data(Arc::new(metrics))
-        .extension(QueryLimitsChecker::default())
-        .extension(FeatureGate)
-        .extension(Logger::default())
-        .extension(Timeout::default())
-        .build()?
-        .run()
-        .await
-}
-
-fn start_prom(binding_address: SocketAddr) -> Registry {
-    println!("Starting Prometheus HTTP endpoint at {}", binding_address);
-    let registry_service = mysten_metrics::start_prometheus_server(binding_address);
-    registry_service.default_registry()
+    server.run().await
 }


### PR DESCRIPTION
## Description 

Both server builder and example server have similar logic.
This PR condenses them

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
