### PR TITLE
[graphql] split queries into build and execution

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -45,6 +45,8 @@ use async_graphql::{
     ID,
 };
 use diesel::{
+    pg::Pg,
+    query_builder::{BoxedSelectStatement, FromClause},
     BoolExpressionMethods, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
     RunQueryDsl,
 };
@@ -61,6 +63,7 @@ use sui_indexer::{
         checkpoints, epochs, objects, transactions, tx_calls, tx_changed_objects, tx_input_objects,
         tx_recipients, tx_senders,
     },
+    types_v2::OwnerType,
     PgConnectionPoolConfig,
 };
 use sui_json_rpc::name_service::{Domain, NameRecord, NameServiceConfig};
@@ -114,243 +117,82 @@ pub enum DbValidationError {
     LastBefore,
     #[error("Pagination is currently disabled on balances")]
     PaginationDisabledOnBalances,
+    #[error(
+        "Cannot provide owner address for an owner that is not of owner type Address or Object"
+    )]
+    InvalidOwnerType,
 }
 
-pub(crate) struct PgManager {
-    pub inner: IndexerReader,
-    pub _limits: Limits,
-}
+type BalanceQuery<'a> = BoxedSelectStatement<
+    'a,
+    (
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    ),
+    FromClause<objects::table>,
+    Pg,
+    objects::dsl::coin_type,
+>;
 
-impl PgManager {
-    pub(crate) fn new(inner: IndexerReader, _limits: Limits) -> Self {
-        Self { inner, _limits }
+pub struct QueryBuilder;
+impl QueryBuilder {
+    fn get_tx_by_digest<'a>(digest: Vec<u8>) -> transactions::BoxedQuery<'a, Pg> {
+        transactions::dsl::transactions
+            .filter(transactions::dsl::transaction_digest.eq(digest))
+            .into_boxed()
     }
 
-    /// Create a new underlying reader, which is used by this type as well as other data providers.
-    pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader, Error> {
-        let mut config = PgConnectionPoolConfig::default();
-        config.set_pool_size(30);
-        IndexerReader::new_with_config(db_url, config)
-            .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
-    }
-
-    pub async fn run_query_async<T, E, F>(&self, query: F) -> Result<T, Error>
-    where
-        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
-        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
-        T: Send + 'static,
-    {
-        self.inner
-            .run_query_async(query)
-            .await
-            .map_err(|e| Error::Internal(e.to_string()))
-    }
-}
-
-/// Implement methods to query db and return StoredData
-impl PgManager {
-    async fn get_tx(&self, digest: Vec<u8>) -> Result<Option<StoredTransaction>, Error> {
-        self.run_query_async(|conn| {
-            transactions::dsl::transactions
-                .filter(transactions::dsl::transaction_digest.eq(digest))
-                .get_result::<StoredTransaction>(conn) // Expect exactly 0 to 1 result
-                .optional()
-        })
-        .await
-    }
-
-    async fn get_obj(
-        &self,
-        address: Vec<u8>,
-        version: Option<i64>,
-    ) -> Result<Option<StoredObject>, Error> {
+    fn get_obj<'a>(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'a, Pg> {
         let mut query = objects::dsl::objects.into_boxed();
         query = query.filter(objects::dsl::object_id.eq(address));
 
         if let Some(version) = version {
             query = query.filter(objects::dsl::object_version.eq(version));
         }
-
-        self.run_query_async(|conn| query.get_result::<StoredObject>(conn).optional())
-            .await
+        query
     }
 
-    pub async fn get_epoch(&self, epoch_id: Option<i64>) -> Result<Option<StoredEpochInfo>, Error> {
-        match epoch_id {
-            Some(epoch_id) => {
-                self.run_query_async(move |conn| {
-                    epochs::dsl::epochs
-                        .filter(epochs::dsl::epoch.eq(epoch_id))
-                        .get_result::<StoredEpochInfo>(conn)
-                        .optional()
-                })
-                .await
-            }
-            None => Some(
-                self.run_query_async(|conn| {
-                    epochs::dsl::epochs
-                        .order_by(epochs::dsl::epoch.desc())
-                        .limit(1)
-                        .first::<StoredEpochInfo>(conn)
-                })
-                .await,
-            )
-            .transpose(),
-        }
+    fn get_epoch<'a>(epoch_id: i64) -> epochs::BoxedQuery<'a, Pg> {
+        epochs::dsl::epochs
+            .filter(epochs::dsl::epoch.eq(epoch_id))
+            .into_boxed()
     }
 
-    async fn get_checkpoint(
-        &self,
-        digest: Option<Vec<u8>>,
-        sequence_number: Option<i64>,
-    ) -> Result<Option<StoredCheckpoint>, Error> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
-
-        match (digest, sequence_number) {
-            (Some(digest), None) => {
-                query = query.filter(checkpoints::dsl::checkpoint_digest.eq(digest));
-            }
-            (None, Some(sequence_number)) => {
-                query = query.filter(checkpoints::dsl::sequence_number.eq(sequence_number));
-            }
-            (None, None) => {
-                query = query
-                    .order_by(checkpoints::dsl::sequence_number.desc())
-                    .limit(1);
-            }
-            _ => (), // No-op if invalid input
-        }
-
-        self.run_query_async(|conn| query.get_result::<StoredCheckpoint>(conn).optional())
-            .await
+    fn get_latest_epoch<'a>() -> epochs::BoxedQuery<'a, Pg> {
+        epochs::dsl::epochs
+            .order_by(epochs::dsl::epoch.desc())
+            .limit(1)
+            .into_boxed()
     }
 
-    async fn get_chain_identifier(&self) -> Result<ChainIdentifier, Error> {
-        let result = self
-            .get_checkpoint(None, Some(0))
-            .await?
-            .ok_or_else(|| Error::Internal("Genesis checkpoint cannot be found".to_string()))?;
-
-        let digest = CheckpointDigest::try_from(result.checkpoint_digest).map_err(|e| {
-            Error::Internal(format!(
-                "Failed to convert checkpoint digest to CheckpointDigest. Error: {e}",
-            ))
-        })?;
-        Ok(ChainIdentifier::from(digest))
+    fn get_checkpoint_by_digest<'a>(digest: Vec<u8>) -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .filter(checkpoints::dsl::checkpoint_digest.eq(digest))
+            .into_boxed()
     }
 
-    async fn multi_get_coins(
-        &self,
-        address: Vec<u8>,
-        coin_type: Option<String>,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<(Vec<StoredObject>, bool)>, Error> {
-        let mut query = objects::dsl::objects.into_boxed();
-        query = query
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(1)); // Leverage index on objects table
-
-        if let Some(coin_type) = coin_type {
-            query = query.filter(objects::dsl::coin_type.eq(coin_type));
-        }
-
-        if let Some(after) = after {
-            let after = self.parse_obj_cursor(&after)?;
-            query = query
-                .filter(objects::dsl::object_id.gt(after))
-                .order(objects::dsl::object_id.asc());
-        } else if let Some(before) = before {
-            let before = self.parse_obj_cursor(&before)?;
-            query = query
-                .filter(objects::dsl::object_id.lt(before))
-                .order(objects::dsl::object_id.desc());
-        }
-
-        let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
-        query = query.limit(limit + 1);
-
-        let result: Option<Vec<StoredObject>> = self
-            .run_query_async(|conn| query.load(conn).optional())
-            .await?;
-
-        result
-            .map(|mut stored_objs| {
-                let has_next_page = stored_objs.len() as i64 > limit;
-                if has_next_page {
-                    stored_objs.pop();
-                }
-
-                Ok((stored_objs, has_next_page))
-            })
-            .transpose()
+    fn get_checkpoint_by_sequence_number<'a>(
+        sequence_number: i64,
+    ) -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
+            .into_boxed()
     }
 
-    async fn get_balance(
-        &self,
-        address: Vec<u8>,
-        coin_type: String,
-    ) -> Result<Vec<(Option<String>, Option<i64>, Option<String>)>, Error> {
-        let query = objects::dsl::objects
-            .group_by(objects::dsl::coin_type)
-            .select((
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::Text>>(
-                    "CAST(SUM(coin_balance) AS VARCHAR)",
-                ),
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "COUNT(*)",
-                ),
-                objects::dsl::coin_type,
-            ))
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(1))
-            .filter(objects::dsl::coin_type.eq(coin_type));
-
-        self.run_query_async(|conn| query.load(conn)).await
+    fn get_latest_checkpoint<'a>() -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .order_by(checkpoints::dsl::sequence_number.desc())
+            .limit(1)
+            .into_boxed()
     }
 
-    async fn multi_get_balances(
-        &self,
-        address: Vec<u8>,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Vec<(Option<String>, Option<i64>, Option<String>)>, Error> {
-        // Todo (wlmyng): paginating on balances does not really make sense
-        // We'll always need to calculate all balances first
-        if first.is_some() || after.is_some() || last.is_some() || before.is_some() {
-            return Err(DbValidationError::PaginationDisabledOnBalances.into());
-        }
-
-        let query = objects::dsl::objects
-            .group_by(objects::dsl::coin_type)
-            .select((
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::Text>>(
-                    "CAST(SUM(coin_balance) AS VARCHAR)",
-                ),
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "COUNT(*)",
-                ),
-                objects::dsl::coin_type,
-            ))
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(1))
-            .filter(objects::dsl::coin_type.is_not_null());
-
-        self.run_query_async(|conn| query.load(conn)).await
-    }
-
-    async fn multi_get_txs(
-        &self,
-        first: Option<u64>,
-        after: Option<String>,
-        last: Option<u64>,
-        before: Option<String>,
+    fn multi_get_txs<'a>(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
         filter: Option<TransactionBlockFilter>,
-    ) -> Result<Option<(Vec<StoredTransaction>, bool)>, Error> {
+    ) -> Result<transactions::BoxedQuery<'a, Pg>, Error> {
         let mut query = transactions::dsl::transactions.into_boxed();
 
         let descending_order = last.is_some();
@@ -421,7 +263,6 @@ impl PgManager {
             query = query.order(transactions::dsl::tx_sequence_number.asc());
         }
 
-        let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
         query = query.limit(limit + 1);
 
         if let Some(filter) = filter {
@@ -523,8 +364,349 @@ impl PgManager {
             }
         };
 
+        Ok(query)
+    }
+
+    fn multi_get_coins<'a>(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        address: Vec<u8>,
+        coin_type: String,
+    ) -> objects::BoxedQuery<'a, Pg> {
+        let mut query = objects::dsl::objects.into_boxed();
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(objects::dsl::object_id.lt(cursor));
+            } else {
+                query = query.filter(objects::dsl::object_id.gt(cursor));
+            }
+        }
+        if descending_order {
+            query = query.order(objects::dsl::object_id.desc());
+        } else {
+            query = query.order(objects::dsl::object_id.asc());
+        }
+        query = query.limit(limit + 1);
+
+        query = query
+            .filter(objects::dsl::owner_id.eq(address))
+            .filter(objects::dsl::owner_type.eq(1)) // Leverage index on objects table
+            .filter(objects::dsl::coin_type.eq(coin_type));
+        query
+    }
+
+    fn multi_get_objs<'a>(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<ObjectFilter>,
+        owner_type: Option<OwnerType>,
+    ) -> Result<objects::BoxedQuery<'a, Pg>, Error> {
+        let mut query = objects::dsl::objects.into_boxed();
+
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(objects::dsl::object_id.lt(cursor));
+            } else {
+                query = query.filter(objects::dsl::object_id.gt(cursor));
+            }
+        }
+
+        if descending_order {
+            query = query.order(objects::dsl::object_id.desc());
+        } else {
+            query = query.order(objects::dsl::object_id.asc());
+        }
+
+        query = query.limit(limit + 1);
+
+        if let Some(filter) = filter {
+            if let Some(object_ids) = filter.object_ids {
+                query = query.filter(
+                    objects::dsl::object_id.eq_any(
+                        object_ids
+                            .into_iter()
+                            .map(|id| id.into_vec())
+                            .collect::<Vec<_>>(),
+                    ),
+                );
+            }
+
+            if let Some(owner) = filter.owner {
+                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
+
+                match owner_type {
+                    Some(OwnerType::Address) => {
+                        query =
+                            query.filter(objects::dsl::owner_type.eq(OwnerType::Address as i16));
+                    }
+                    Some(OwnerType::Object) => {
+                        query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
+                    }
+                    None => {
+                        query = query.filter(objects::dsl::owner_type.between(1, 2));
+                    }
+                    _ => Err(DbValidationError::InvalidOwnerType)?,
+                }
+            }
+
+            if let Some(object_type) = filter.ty {
+                query = query.filter(objects::dsl::object_type.eq(object_type));
+            }
+        }
+
+        Ok(query)
+    }
+
+    fn multi_get_balances<'a>(address: Vec<u8>) -> BalanceQuery<'a> {
+        let query = objects::dsl::objects
+            .group_by(objects::dsl::coin_type)
+            .select((
+                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
+                    "CAST(SUM(coin_balance) AS BIGINT)",
+                ),
+                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
+                    "COUNT(*)",
+                ),
+                objects::dsl::coin_type,
+            ))
+            .filter(objects::dsl::owner_id.eq(address))
+            .filter(objects::dsl::owner_type.eq(1))
+            .filter(objects::dsl::coin_type.is_not_null())
+            .into_boxed();
+
+        query
+    }
+
+    fn get_balance<'a>(address: Vec<u8>, coin_type: String) -> BalanceQuery<'a> {
+        let query = QueryBuilder::multi_get_balances(address);
+        query.filter(objects::dsl::coin_type.eq(coin_type))
+    }
+
+    fn multi_get_checkpoints<'a>(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        epoch: Option<i64>,
+    ) -> checkpoints::BoxedQuery<'a, Pg> {
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(checkpoints::dsl::sequence_number.lt(cursor));
+            } else {
+                query = query.filter(checkpoints::dsl::sequence_number.gt(cursor));
+            }
+        }
+        if descending_order {
+            query = query.order(checkpoints::dsl::sequence_number.desc());
+        } else {
+            query = query.order(checkpoints::dsl::sequence_number.asc());
+        }
+        if let Some(epoch) = epoch {
+            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
+        }
+        query = query.limit(limit + 1);
+
+        query
+    }
+}
+
+pub(crate) struct PgManager {
+    pub inner: IndexerReader,
+    pub _limits: Limits,
+}
+
+impl PgManager {
+    pub(crate) fn new(inner: IndexerReader, _limits: Limits) -> Self {
+        Self { inner, _limits }
+    }
+
+    /// Create a new underlying reader, which is used by this type as well as other data providers.
+    pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader, Error> {
+        let mut config = PgConnectionPoolConfig::default();
+        config.set_pool_size(30);
+        IndexerReader::new_with_config(db_url, config)
+            .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
+    }
+
+    pub async fn run_query_async<T, E, F>(&self, query: F) -> Result<T, Error>
+    where
+        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
+        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
+        T: Send + 'static,
+    {
+        self.inner
+            .run_query_async(query)
+            .await
+            .map_err(|e| Error::Internal(e.to_string()))
+    }
+}
+
+/// Implement methods to query db and return StoredData
+impl PgManager {
+    async fn get_tx(&self, digest: Vec<u8>) -> Result<Option<StoredTransaction>, Error> {
+        self.run_query_async(|conn| {
+            QueryBuilder::get_tx_by_digest(digest)
+                .get_result::<StoredTransaction>(conn) // Expect exactly 0 to 1 result
+                .optional()
+        })
+        .await
+    }
+
+    async fn get_obj(
+        &self,
+        address: Vec<u8>,
+        version: Option<i64>,
+    ) -> Result<Option<StoredObject>, Error> {
+        self.run_query_async(move |conn| {
+            QueryBuilder::get_obj(address, version)
+                .get_result::<StoredObject>(conn)
+                .optional()
+        })
+        .await
+    }
+
+    pub async fn get_epoch(&self, epoch_id: Option<i64>) -> Result<Option<StoredEpochInfo>, Error> {
+        match epoch_id {
+            Some(epoch_id) => {
+                self.run_query_async(move |conn| {
+                    QueryBuilder::get_epoch(epoch_id)
+                        .get_result::<StoredEpochInfo>(conn)
+                        .optional()
+                })
+                .await
+            }
+            None => Some(
+                self.run_query_async(|conn| {
+                    QueryBuilder::get_latest_epoch().first::<StoredEpochInfo>(conn)
+                })
+                .await,
+            )
+            .transpose(),
+        }
+    }
+
+    async fn get_checkpoint(
+        &self,
+        digest: Option<Vec<u8>>,
+        sequence_number: Option<i64>,
+    ) -> Result<Option<StoredCheckpoint>, Error> {
+        let query = match (digest, sequence_number) {
+            (Some(digest), None) => QueryBuilder::get_checkpoint_by_digest(digest),
+            (None, Some(sequence_number)) => {
+                QueryBuilder::get_checkpoint_by_sequence_number(sequence_number)
+            }
+            (Some(_), Some(_)) => {
+                return Err(Error::InvalidCheckpointQuery);
+            }
+            _ => QueryBuilder::get_latest_checkpoint(),
+        };
+
+        self.run_query_async(|conn| query.get_result::<StoredCheckpoint>(conn).optional())
+            .await
+    }
+
+    async fn get_chain_identifier(&self) -> Result<ChainIdentifier, Error> {
+        let result = self
+            .get_checkpoint(None, Some(0))
+            .await?
+            .ok_or_else(|| Error::Internal("Genesis checkpoint cannot be found".to_string()))?;
+
+        let digest = CheckpointDigest::try_from(result.checkpoint_digest).map_err(|e| {
+            Error::Internal(format!(
+                "Failed to convert checkpoint digest to CheckpointDigest. Error: {e}",
+            ))
+        })?;
+        Ok(ChainIdentifier::from(digest))
+    }
+
+    async fn multi_get_coins(
+        &self,
+        address: Vec<u8>,
+        coin_type: Option<String>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Option<(Vec<StoredObject>, bool)>, Error> {
+        let descending_order = last.is_some();
+        let cursor = after
+            .or(before)
+            .map(|cursor| self.parse_obj_cursor(&cursor))
+            .transpose()?;
+        let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
+        let coin_type = coin_type.unwrap_or("0x2::sui::SUI".to_string());
+
+        let result: Option<Vec<StoredObject>> = self
+            .run_query_async(move |conn| {
+                QueryBuilder::multi_get_coins(cursor, descending_order, limit, address, coin_type)
+                    .load(conn)
+                    .optional()
+            })
+            .await?;
+
+        result
+            .map(|mut stored_objs| {
+                let has_next_page = stored_objs.len() as i64 > limit;
+                if has_next_page {
+                    stored_objs.pop();
+                }
+
+                Ok((stored_objs, has_next_page))
+            })
+            .transpose()
+    }
+
+    async fn get_balance(
+        &self,
+        address: Vec<u8>,
+        coin_type: String,
+    ) -> Result<(Option<i64>, Option<i64>, Option<String>), Error> {
+        self.run_query_async(move |conn| {
+            QueryBuilder::get_balance(address, coin_type).get_result(conn)
+        })
+        .await
+    }
+
+    async fn multi_get_balances(
+        &self,
+        address: Vec<u8>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Vec<(Option<i64>, Option<i64>, Option<String>)>, Error> {
+        // Todo (wlmyng): paginating on balances does not really make sense
+        // We'll always need to calculate all balances first
+        if first.is_some() || after.is_some() || last.is_some() || before.is_some() {
+            return Err(DbValidationError::PaginationDisabledOnBalances.into());
+        }
+
+        self.run_query_async(move |conn| QueryBuilder::multi_get_balances(address).load(conn))
+            .await
+    }
+
+    async fn multi_get_txs(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Option<(Vec<StoredTransaction>, bool)>, Error> {
+        let descending_order = last.is_some();
+        let cursor = after
+            .or(before)
+            .map(|cursor| self.parse_tx_cursor(&cursor))
+            .transpose()?;
+        let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
+
+        let query = QueryBuilder::multi_get_txs(cursor, descending_order, limit, filter)?;
+
         let result: Option<Vec<StoredTransaction>> = self
-            .run_query_async(|conn| {
+            .run_query_async(move |conn| {
                 query
                     .select(transactions::all_columns)
                     .load(conn)
@@ -552,34 +734,24 @@ impl PgManager {
         before: Option<String>,
         epoch: Option<u64>,
     ) -> Result<Option<(Vec<StoredCheckpoint>, bool)>, Error> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
-
         let descending_order = last.is_some();
         let cursor = after
             .or(before)
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
             .transpose()?;
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(checkpoints::dsl::sequence_number.lt(cursor));
-            } else {
-                query = query.filter(checkpoints::dsl::sequence_number.gt(cursor));
-            }
-        }
-        if descending_order {
-            query = query.order(checkpoints::dsl::sequence_number.desc());
-        } else {
-            query = query.order(checkpoints::dsl::sequence_number.asc());
-        }
-        if let Some(epoch) = epoch {
-            query = query.filter(checkpoints::dsl::epoch.eq(epoch as i64));
-        }
         let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
 
-        query = query.limit(limit + 1);
-
         let result: Option<Vec<StoredCheckpoint>> = self
-            .run_query_async(|conn| query.load(conn).optional())
+            .run_query_async(move |conn| {
+                QueryBuilder::multi_get_checkpoints(
+                    cursor,
+                    descending_order,
+                    limit,
+                    epoch.map(|e| e as i64),
+                )
+                .load(conn)
+                .optional()
+            })
             .await?;
 
         result
@@ -601,49 +773,20 @@ impl PgManager {
         last: Option<u64>,
         before: Option<String>,
         filter: Option<ObjectFilter>,
+        owner_type: Option<OwnerType>,
     ) -> Result<Option<(Vec<StoredObject>, bool)>, Error> {
-        let mut query = objects::dsl::objects.into_boxed();
-
-        if let Some(filter) = filter {
-            if let Some(object_ids) = filter.object_ids {
-                query = query.filter(
-                    objects::dsl::object_id.eq_any(
-                        object_ids
-                            .into_iter()
-                            .map(|id| id.into_vec())
-                            .collect::<Vec<_>>(),
-                    ),
-                );
-            }
-
-            if let Some(owner) = filter.owner {
-                query = query
-                    .filter(objects::dsl::owner_id.eq(owner.into_vec()))
-                    .filter(objects::dsl::owner_type.between(1, 2));
-            }
-
-            if let Some(object_type) = filter.ty {
-                query = query.filter(objects::dsl::object_type.eq(object_type));
-            }
-        }
-
-        if let Some(after) = after {
-            let after = self.parse_obj_cursor(&after)?;
-            query = query
-                .filter(objects::dsl::object_id.gt(after))
-                .order(objects::dsl::object_id.asc());
-        } else if let Some(before) = before {
-            let before = self.parse_obj_cursor(&before)?;
-            query = query
-                .filter(objects::dsl::object_id.lt(before))
-                .order(objects::dsl::object_id.desc());
-        }
-
+        let descending_order = last.is_some();
+        let cursor = after
+            .or(before)
+            .map(|cursor| self.parse_obj_cursor(&cursor))
+            .transpose()?;
         let limit = first.or(last).unwrap_or(DEFAULT_PAGE_SIZE) as i64;
-        query = query.limit(limit + 1);
+
+        let query =
+            QueryBuilder::multi_get_objs(cursor, descending_order, limit, filter, owner_type)?;
 
         let result: Option<Vec<StoredObject>> = self
-            .run_query_async(|conn| query.load(conn).optional())
+            .run_query_async(move |conn| query.load(conn).optional())
             .await?;
         result
             .map(|mut stored_objs| {
@@ -784,21 +927,14 @@ impl PgManager {
         digest: Option<&str>,
         sequence_number: Option<u64>,
     ) -> Result<Option<Checkpoint>, Error> {
-        let mut stored_checkpoint = None;
-
-        match (digest, sequence_number) {
-            (Some(digest), None) => {
-                let digest = Digest::from_str(digest)?.into_vec();
-                stored_checkpoint = self.get_checkpoint(Some(digest), None).await?;
-            }
-            (None, Some(sequence_number)) => {
-                stored_checkpoint = self
-                    .get_checkpoint(None, Some(sequence_number as i64))
-                    .await?;
-            }
-            _ => (), // No-op if invalid input
-        }
-
+        let stored_checkpoint = self
+            .get_checkpoint(
+                digest
+                    .map(|digest| Digest::from_str(digest).map(|digest| digest.into_vec()))
+                    .transpose()?,
+                sequence_number.map(|sequence_number| sequence_number as i64),
+            )
+            .await?;
         stored_checkpoint.map(Checkpoint::try_from).transpose()
     }
 
@@ -902,19 +1038,6 @@ impl PgManager {
         }))
     }
 
-    #[allow(dead_code)]
-    pub(crate) async fn fetch_owner(
-        &self,
-        address: SuiAddress,
-    ) -> Result<Option<SuiAddress>, Error> {
-        let address = address.into_vec();
-        let stored_obj = self.get_obj(address, None).await?;
-
-        Ok(stored_obj
-            .and_then(|obj| obj.owner_id.map(|id| SuiAddress::try_from(id).ok()))
-            .flatten())
-    }
-
     pub(crate) async fn fetch_obj(
         &self,
         address: SuiAddress,
@@ -987,7 +1110,7 @@ impl PgManager {
             self.validate_obj_filter(filter)?;
         }
         let objects = self
-            .multi_get_objs(first, after, last, before, filter)
+            .multi_get_objs(first, after, last, before, filter, None)
             .await?;
 
         if let Some((stored_objs, has_next_page)) = objects {
@@ -1047,18 +1170,18 @@ impl PgManager {
     ) -> Result<Option<Balance>, Error> {
         let address = address.into_vec();
         let coin_type = coin_type.unwrap_or("0x2::sui::SUI".to_string());
-        let balances = self.get_balance(address, coin_type).await?;
+        let result = self.get_balance(address, coin_type).await?;
 
-        if let Some((Some(balance), Some(count), coin_type)) = balances.first() {
-            let total_balance =
-                BigInt::from_str(balance).map_err(|e| Error::Internal(e.to_string()))?;
-            Ok(Some(Balance {
-                coin_object_count: Some(*count as u64),
-                total_balance: Some(total_balance),
-                coin_type: coin_type.clone(),
-            }))
-        } else {
-            Ok(None)
+        match result {
+            (Some(balance), Some(count), Some(coin_type)) => Ok(Some(Balance {
+                coin_object_count: Some(count as u64),
+                total_balance: Some(BigInt::from(balance)),
+                coin_type: Some(coin_type),
+            })),
+            (None, None, None) => Ok(None),
+            _ => Err(Error::Internal(
+                "Expected fields are missing on balance calculation".to_string(),
+            )),
         }
     }
 
@@ -1079,21 +1202,14 @@ impl PgManager {
         let mut connection = Connection::new(false, false);
         for (balance, count, coin_type) in balances {
             if let (Some(balance), Some(count), Some(coin_type)) = (balance, count, coin_type) {
-                match BigInt::from_str(&balance) {
-                    Ok(total_balance) => {
-                        connection.edges.push(Edge::new(
-                            coin_type.clone(),
-                            Balance {
-                                coin_object_count: Some(count as u64),
-                                total_balance: Some(total_balance),
-                                coin_type: Some(coin_type),
-                            },
-                        ));
-                    }
-                    Err(e) => {
-                        return Err(Error::Internal(e.to_string()));
-                    }
-                }
+                connection.edges.push(Edge::new(
+                    coin_type.clone(),
+                    Balance {
+                        coin_object_count: Some(count as u64),
+                        total_balance: Some(BigInt::from(balance)),
+                        coin_type: Some(coin_type),
+                    },
+                ));
             } else {
                 return Err(Error::Internal(
                     "Expected fields are missing on balance calculation".to_string(),
@@ -1258,7 +1374,14 @@ impl PgManager {
         };
 
         let objs = self
-            .multi_get_objs(first, after, last, before, Some(obj_filter))
+            .multi_get_objs(
+                first,
+                after,
+                last,
+                before,
+                Some(obj_filter),
+                Some(OwnerType::Address),
+            )
             .await?;
 
         if let Some((stored_objs, has_next_page)) = objs {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -117,9 +117,7 @@ pub enum DbValidationError {
     LastBefore,
     #[error("Pagination is currently disabled on balances")]
     PaginationDisabledOnBalances,
-    #[error(
-        "Invalid owner type. Must be Address or Object"
-    )]
+    #[error("Invalid owner type. Must be Address or Object")]
     InvalidOwnerType,
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -706,7 +706,14 @@ impl PgManager {
             }
         }
 
-        let query = QueryBuilder::multi_get_txs(cursor, descending_order, limit, filter, after_tx_seq_num, before_tx_seq_num)?;
+        let query = QueryBuilder::multi_get_txs(
+            cursor,
+            descending_order,
+            limit,
+            filter,
+            after_tx_seq_num,
+            before_tx_seq_num,
+        )?;
 
         let result: Option<Vec<StoredTransaction>> = self
             .run_query_async(move |conn| {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -391,7 +391,7 @@ impl QueryBuilder {
 
         query = query
             .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(1)); // Leverage index on objects table
+            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16)); // Leverage index on objects table
 
         if let Some(coin_type) = coin_type {
             query = query.filter(objects::dsl::coin_type.eq(coin_type));
@@ -448,7 +448,11 @@ impl QueryBuilder {
                         query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
                     }
                     None => {
-                        query = query.filter(objects::dsl::owner_type.between(1, 2));
+                        query = query.filter(
+                            objects::dsl::owner_type
+                                .eq(OwnerType::Address as i16)
+                                .or(objects::dsl::owner_type.eq(OwnerType::Object as i16)),
+                        );
                     }
                     _ => Err(DbValidationError::InvalidOwnerType)?,
                 }
@@ -475,7 +479,7 @@ impl QueryBuilder {
                 objects::dsl::coin_type,
             ))
             .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(1))
+            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
             .filter(objects::dsl::coin_type.is_not_null())
             .into_boxed();
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -118,7 +118,7 @@ pub enum DbValidationError {
     #[error("Pagination is currently disabled on balances")]
     PaginationDisabledOnBalances,
     #[error(
-        "Cannot provide owner address for an owner that is not of owner type Address or Object"
+        "Invalid owner type. Must be Address or Object"
     )]
     InvalidOwnerType,
 }


### PR DESCRIPTION
## Description 

Simple refactor that splits querying into two parts, building the query and actually executing it. This is done to support making an explain call on the query fragment before every query is actually executed

## Test Plan 

Manually ran all of our examples

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
