### PR TITLE
Add coin type and coin balance in pipeline v2 object table

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -117,6 +117,12 @@ impl ObjectHandler {
             has_public_transfer,
             storage_rebate: object.storage_rebate,
             bcs: Base64::encode(bcs::to_bytes(object).unwrap()),
+            coin_type: object.coin_type_maybe().map(|t| t.to_string()),
+            coin_balance: if object.coin_type_maybe().is_some() {
+                Some(object.get_coin_value_unsafe())
+            } else {
+                None
+            },
         };
         self.objects.push(entry);
     }

--- a/crates/sui-analytics-indexer/src/tables.rs
+++ b/crates/sui-analytics-indexer/src/tables.rs
@@ -171,6 +171,9 @@ pub(crate) struct ObjectEntry {
     // We represent them in base64 encoding so they work with the csv.
     // TODO: review and possibly move back to Vec<u8>
     pub(crate) bcs: String,
+
+    pub(crate) coin_type: Option<String>,
+    pub(crate) coin_balance: Option<u64>,
 }
 
 // Objects used and manipulated in a transaction.


### PR DESCRIPTION
## Description 

As title says, these fields are currently missing on the objects table

