### PR TITLE
[execution] Recompute has_public_transfer on load

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1374,6 +1374,7 @@
                 "package_upgrades": true,
                 "random_beacon": false,
                 "receive_objects": false,
+                "recompute_has_public_transfer_in_execution": false,
                 "scoring_decision_with_validity_cutoff": true,
                 "simple_conservation_checks": false,
                 "simplified_unwrap_then_delete": false,

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_30.snap
@@ -31,6 +31,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
@@ -33,6 +33,7 @@ feature_flags:
   enable_effects_v2: true
   verify_legacy_zklogin_address: true
   throughput_aware_consensus_submission: true
+  recompute_has_public_transfer_in_execution: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
@@ -37,6 +37,7 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   throughput_aware_consensus_submission: true
+  recompute_has_public_transfer_in_execution: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -43,8 +43,8 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 pub struct MoveObject {
     /// The type of this object. Immutable
     type_: MoveObjectType,
-    /// Determines if it is usable with the TransferObject command
-    /// Derived from the type_
+    /// DEPRECATED this field is no longer used to determine whether a tx can transfer this
+    /// object. Instead, it is always calculated from the objects type when loaded in execution
     has_public_transfer: bool,
     /// Number that increases each time a tx takes this object as a mutable input
     /// This is a lamport timestamp, not a sequentially increasing version


### PR DESCRIPTION
## Description 

- has_public_transfer is conceptually static, but is not for core types due to in-place upgrades
- The flag originally existed to avoid having to load the VM in the very early days of Sui. This is no longer the case and the type is loaded anyway. So we should just recompute the flag.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
