### PR TITLE
[Explorer]: Add suins address resolver on object page

### DIFF
--- a/apps/explorer/src/pages/object-result/views/ObjectView.tsx
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CoinFormat, useFormatCoin } from '@mysten/core';
+import { CoinFormat, useFormatCoin, useResolveSuiNSName } from '@mysten/core';
 import { ArrowUpRight16 } from '@mysten/icons';
 import { type ObjectOwner, type SuiObjectResponse } from '@mysten/sui.js/client';
 import {
@@ -149,6 +149,12 @@ function VersionCard({ version, digest }: { version?: string; digest: string }) 
 	);
 }
 
+function AddressOwner({ address }: { address: string }) {
+	const { data: suinsDomainName } = useResolveSuiNSName(address);
+
+	return <AddressLink address={address} label={suinsDomainName} />;
+}
+
 function OwnerCard({
 	objOwner,
 	display,
@@ -181,7 +187,7 @@ function OwnerCard({
 					) : 'ObjectOwner' in objOwner ? (
 						<ObjectLink objectId={objOwner.ObjectOwner} />
 					) : (
-						<AddressLink address={objOwner.AddressOwner} />
+						<AddressOwner address={objOwner.AddressOwner} />
 					)}
 				</Description>
 			)}


### PR DESCRIPTION
## Description 

- Add SUINS name resolver for object page
- https://mysten.atlassian.net/browse/APPS-1715

<img width="1409" alt="Screenshot 2023-10-25 at 8 56 14 PM" src="https://github.com/MystenLabs/sui/assets/127577476/27187e1a-b1ee-473c-94ab-801c02d6d975">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
