### PR TITLE
[move] cgswords/const in const nits

### DIFF
--- a/external-crates/move/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -95,9 +95,7 @@ fn optimize_exp(consts: &UniqueMap<ConstantName, Value>, e: &mut Exp) -> bool {
         | E::Unreachable => false,
 
         e_ @ E::Constant(_) => {
-            let name = if let E::Constant(name) = e_ {
-                name
-            } else {
+            let E::Constant(name) = e_ else {
                 unreachable!()
             };
             if let Some(value) = consts.get(name) {

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -338,11 +338,7 @@ impl<'env> Context<'env> {
     }
 
     pub fn current_package(&self) -> Option<Symbol> {
-        if let Some(mident) = &self.current_module {
-            self.module_info(mident).package
-        } else {
-            None
-        }
+        self.current_module.as_ref().and_then(|mident| self.module_info(mident).package)
     }
 
     // `loc` indicates the location that caused the add to occur

--- a/external-crates/move/move-compiler/src/typing/core.rs
+++ b/external-crates/move/move-compiler/src/typing/core.rs
@@ -338,7 +338,9 @@ impl<'env> Context<'env> {
     }
 
     pub fn current_package(&self) -> Option<Symbol> {
-        self.current_module.as_ref().and_then(|mident| self.module_info(mident).package)
+        self.current_module
+            .as_ref()
+            .and_then(|mident| self.module_info(mident).package)
     }
 
     // `loc` indicates the location that caused the add to occur


### PR DESCRIPTION
## Description 

Follow up on small nits on PR that accidentally didn't get landed.

## Test Plan 

Same as before.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
