### PR TITLE
[graphql/rpc] limit num fragment defs

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -14,6 +14,7 @@ const MAX_QUERY_DEPTH: u32 = 10;
 const MAX_QUERY_NODES: u32 = 100;
 const MAX_DB_QUERY_COST: u64 = 50; // Max DB query cost (normally f64) truncated
 const MAX_QUERY_VARIABLES: u32 = 50;
+const MAX_QUERY_FRAGMENTS: u32 = 50;
 
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
@@ -50,6 +51,8 @@ pub struct Limits {
     pub(crate) max_db_query_cost: u64,
     #[serde(default)]
     pub(crate) max_query_variables: u32,
+    #[serde(default)]
+    pub(crate) max_query_fragments: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -147,6 +150,7 @@ impl Default for Limits {
             max_query_nodes: MAX_QUERY_NODES,
             max_db_query_cost: MAX_DB_QUERY_COST,
             max_query_variables: MAX_QUERY_VARIABLES,
+            max_query_fragments: MAX_QUERY_FRAGMENTS,
         }
     }
 }
@@ -240,6 +244,7 @@ mod tests {
                 max-query-nodes = 300
                 max-db-query-cost = 50
                 max-query-variables = 45
+                max-query-fragments = 32
             "#,
         )
         .unwrap();
@@ -250,6 +255,7 @@ mod tests {
                 max_query_nodes: 300,
                 max_db_query_cost: 50,
                 max_query_variables: 45,
+                max_query_fragments: 32,
             },
             ..Default::default()
         };
@@ -305,6 +311,7 @@ mod tests {
                 max-query-nodes = 320
                 max-db-query-cost = 20
                 max-query-variables = 34
+                max-query-fragments = 31
 
                 [experiments]
                 test-flag = true
@@ -318,6 +325,7 @@ mod tests {
                 max_query_nodes: 320,
                 max_db_query_cost: 20,
                 max_query_variables: 34,
+                max_query_fragments: 31,
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
             experiments: Experiments { test_flag: true },


### PR DESCRIPTION
## Description 

Bound the number of fragment definitions

## Test Plan 

Manual, coming up
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
