### PR TITLE
indexer v2 easy: clean up legacy schema

### DIFF
--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -234,22 +234,6 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    tx_indices (tx_sequence_number) {
-        tx_sequence_number -> Int8,
-        checkpoint_sequence_number -> Int8,
-        transaction_digest -> Bytea,
-        input_objects -> Array<Nullable<Bytea>>,
-        changed_objects -> Array<Nullable<Bytea>>,
-        senders -> Array<Nullable<Bytea>>,
-        payers -> Array<Nullable<Bytea>>,
-        recipients -> Array<Nullable<Bytea>>,
-        packages -> Array<Nullable<Bytea>>,
-        package_modules -> Array<Nullable<Text>>,
-        package_module_functions -> Array<Nullable<Text>>,
-    }
-}
-
 diesel::allow_tables_to_appear_in_same_query!(
     active_addresses,
     address_metrics,
@@ -270,8 +254,4 @@ diesel::allow_tables_to_appear_in_same_query!(
     tx_input_objects,
     tx_recipients,
     tx_senders,
-    tx_indices,
 );
-
-use diesel::sql_types::Text;
-diesel::sql_function! {fn query_cost(x : Text) ->Float8;}


### PR DESCRIPTION
## Description 

the schema v2 was used for graphql when it did not update to use latest schema, it should no longer be needed.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
