### PR TITLE
BackingPackageStore trait returns Arc

### DIFF
--- a/crates/simulacrum/src/store.rs
+++ b/crates/simulacrum/src/store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
@@ -242,8 +243,8 @@ impl BackingPackageStore for InMemoryStore {
     fn get_package_object(
         &self,
         package_id: &ObjectID,
-    ) -> sui_types::error::SuiResult<Option<Object>> {
-        Ok(self.get_object(package_id).cloned())
+    ) -> sui_types::error::SuiResult<Option<Arc<Object>>> {
+        Ok(self.get_object(package_id).map(|o| Arc::new(o.clone())))
     }
 }
 

--- a/crates/simulacrum/src/store.rs
+++ b/crates/simulacrum/src/store.rs
@@ -6,7 +6,7 @@ use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use std::collections::{BTreeMap, HashMap};
 use sui_config::genesis;
-use sui_types::storage::{get_module, get_package_object, PackageObjectArc};
+use sui_types::storage::{get_module, load_package_object_from_object_store, PackageObjectArc};
 use sui_types::{
     base_types::{AuthorityName, ObjectID, SequenceNumber, SuiAddress},
     committee::{Committee, EpochId},
@@ -243,7 +243,7 @@ impl BackingPackageStore for InMemoryStore {
         &self,
         package_id: &ObjectID,
     ) -> sui_types::error::SuiResult<Option<PackageObjectArc>> {
-        get_package_object(self, package_id)
+        load_package_object_from_object_store(self, package_id)
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,8 +20,8 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module, BackingPackageStore, ChildObjectResolver, MarkerTableQuery, MarkerValue, ObjectKey,
-    ObjectStore,
+    get_module, get_package_object, BackingPackageStore, ChildObjectResolver, MarkerTableQuery,
+    MarkerValue, ObjectKey, ObjectStore,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -1991,17 +1991,8 @@ impl MarkerTableQuery for AuthorityStore {
 }
 
 impl BackingPackageStore for AuthorityStore {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
-        let package = self.get_object(package_id)?;
-        if let Some(obj) = &package {
-            fp_ensure!(
-                obj.is_package(),
-                SuiError::BadObjectType {
-                    error: format!("Package expected, Move object found: {package_id}"),
-                }
-            );
-        }
-        Ok(package.map(Arc::new))
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
+        get_package_object(self, package_id)
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,8 +20,8 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module, get_package_object, BackingPackageStore, ChildObjectResolver, MarkerTableQuery,
-    MarkerValue, ObjectKey, ObjectStore,
+    get_module, load_package_object_from_object_store, BackingPackageStore, ChildObjectResolver,
+    MarkerTableQuery, MarkerValue, ObjectKey, ObjectStore,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -1992,7 +1992,7 @@ impl MarkerTableQuery for AuthorityStore {
 
 impl BackingPackageStore for AuthorityStore {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
-        get_package_object(self, package_id)
+        load_package_object_from_object_store(self, package_id)
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1991,7 +1991,7 @@ impl MarkerTableQuery for AuthorityStore {
 }
 
 impl BackingPackageStore for AuthorityStore {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         let package = self.get_object(package_id)?;
         if let Some(obj) = &package {
             fp_ensure!(
@@ -2001,7 +2001,7 @@ impl BackingPackageStore for AuthorityStore {
                 }
             );
         }
-        Ok(package)
+        Ok(package.map(Arc::new))
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -21,7 +21,7 @@ use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
     get_module, load_package_object_from_object_store, BackingPackageStore, ChildObjectResolver,
-    MarkerTableQuery, MarkerValue, ObjectKey, ObjectStore,
+    MarkerTableQuery, MarkerValue, ObjectKey, ObjectStore, PackageObjectArc,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -1088,7 +1088,7 @@ impl AuthorityStore {
 
         // We record any received or deleted objects since they could be pruned, and smear shared
         // object deletions in the marker table. For deleted entries in the marker table we need to
-        // make sure we don't accidentally overwite entries.
+        // make sure we don't accidentally overwrite entries.
         let markers_to_place = {
             let received = received_objects.iter().map(|(object_id, version, _)| {
                 (

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -265,11 +265,12 @@ async fn test_upgrade_package_happy_path() {
     let package = runner
         .authority_state
         .database
-        .get_package(&runner.package.0)
+        .get_package_object(&runner.package.0)
         .unwrap()
         .unwrap();
     let config = ProtocolConfig::get_for_max_version_UNSAFE();
     let normalized_modules = package
+        .move_package()
         .normalize(
             config.move_binary_format_version(),
             config.no_extraneous_module_bytes(),
@@ -838,12 +839,13 @@ async fn test_publish_override_happy_path() {
     let package = runner
         .authority_state
         .database
-        .get_package(&new_package.0)
+        .get_package_object(&new_package.0)
         .unwrap()
         .unwrap();
 
     // Make sure the linkage table points to the correct versions!
     let dep_ids_in_linkage_table: BTreeSet<_> = package
+        .move_package()
         .linkage_table()
         .values()
         .map(|up| up.upgraded_id)
@@ -890,12 +892,13 @@ async fn test_publish_transitive_happy_path() {
     let root_move_package = runner
         .authority_state
         .database
-        .get_package(&root_package.0)
+        .get_package_object(&root_package.0)
         .unwrap()
         .unwrap();
 
     // Make sure the linkage table points to the correct versions!
     let dep_ids_in_linkage_table: BTreeSet<_> = root_move_package
+        .move_package()
         .linkage_table()
         .values()
         .map(|up| up.upgraded_id)
@@ -980,12 +983,13 @@ async fn test_publish_transitive_override_happy_path() {
     let root_move_package = runner
         .authority_state
         .database
-        .get_package(&root_package.0)
+        .get_package_object(&root_package.0)
         .unwrap()
         .unwrap();
 
     // Make sure the linkage table points to the correct versions!
     let dep_ids_in_linkage_table: BTreeSet<_> = root_move_package
+        .move_package()
         .linkage_table()
         .values()
         .map(|up| up.upgraded_id)

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1726,7 +1726,7 @@ impl LocalExec {
 impl BackingPackageStore for LocalExec {
     /// In this case we might need to download a dependency package which was not present in the
     /// modified at versions list because packages are immutable
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         fn inner(self_: &LocalExec, package_id: &ObjectID) -> SuiResult<Option<Object>> {
             // If package not present fetch it from the network
             self_
@@ -1742,7 +1742,7 @@ impl BackingPackageStore for LocalExec {
                 package_id: *package_id,
                 result: res.clone(),
             });
-        res
+        res.map(|o| o.map(Arc::new))
     }
 }
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -41,6 +41,7 @@ use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
 use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_types::storage::{get_module, PackageObjectArc};
 use sui_types::{
     authenticator_state::get_authenticator_state_obj_initial_shared_version,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, VersionNumber},
@@ -1726,7 +1727,7 @@ impl LocalExec {
 impl BackingPackageStore for LocalExec {
     /// In this case we might need to download a dependency package which was not present in the
     /// modified at versions list because packages are immutable
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         fn inner(self_: &LocalExec, package_id: &ObjectID) -> SuiResult<Option<Object>> {
             // If package not present fetch it from the network
             self_
@@ -1742,7 +1743,7 @@ impl BackingPackageStore for LocalExec {
                 package_id: *package_id,
                 result: res.clone(),
             });
-        res.map(|o| o.map(Arc::new))
+        res.map(|o| o.map(PackageObjectArc::new))
     }
 }
 
@@ -1927,15 +1928,7 @@ impl ModuleResolver for LocalExec {
     /// We do not download
     fn get_module(&self, module_id: &ModuleId) -> SuiResult<Option<Vec<u8>>> {
         fn inner(self_: &LocalExec, module_id: &ModuleId) -> SuiResult<Option<Vec<u8>>> {
-            Ok(self_
-                .get_package(&ObjectID::from(*module_id.address()))
-                .map_err(ReplayEngineError::from)?
-                .and_then(|package| {
-                    package
-                        .serialized_module_map()
-                        .get(module_id.name().as_str())
-                        .cloned()
-                }))
+            get_module(self_, module_id)
         }
 
         let res = inner(self, module_id);

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -13,8 +13,8 @@ use sui_types::base_types::{
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::object::{Object, Owner};
 use sui_types::storage::{
-    get_module_by_id, get_package_object, BackingPackageStore, ChildObjectResolver, GetSharedLocks,
-    MarkerTableQuery, ObjectStore, ParentSync,
+    get_module_by_id, load_package_object_from_object_store, BackingPackageStore,
+    ChildObjectResolver, GetSharedLocks, MarkerTableQuery, ObjectStore, ParentSync,
 };
 
 #[derive(Clone)]
@@ -59,7 +59,7 @@ impl ObjectStore for InMemoryObjectStore {
 
 impl BackingPackageStore for InMemoryObjectStore {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
-        get_package_object(self, package_id)
+        load_package_object_from_object_store(self, package_id)
     }
 }
 

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -14,7 +14,8 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::object::{Object, Owner};
 use sui_types::storage::{
     get_module_by_id, load_package_object_from_object_store, BackingPackageStore,
-    ChildObjectResolver, GetSharedLocks, MarkerTableQuery, ObjectStore, ParentSync,
+    ChildObjectResolver, GetSharedLocks, MarkerTableQuery, ObjectStore, PackageObjectArc,
+    ParentSync,
 };
 
 #[derive(Clone)]

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -58,10 +58,10 @@ impl ObjectStore for InMemoryObjectStore {
 }
 
 impl BackingPackageStore for InMemoryObjectStore {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         Ok(self.get_object(package_id).unwrap().and_then(|o| {
             if o.is_package() {
-                Some(o.clone())
+                Some(Arc::new(o.clone()))
             } else {
                 None
             }

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -13,8 +13,8 @@ use sui_types::base_types::{
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::object::{Object, Owner};
 use sui_types::storage::{
-    get_module_by_id, BackingPackageStore, ChildObjectResolver, GetSharedLocks, MarkerTableQuery,
-    ObjectStore, ParentSync,
+    get_module_by_id, get_package_object, BackingPackageStore, ChildObjectResolver, GetSharedLocks,
+    MarkerTableQuery, ObjectStore, ParentSync,
 };
 
 #[derive(Clone)]
@@ -58,14 +58,8 @@ impl ObjectStore for InMemoryObjectStore {
 }
 
 impl BackingPackageStore for InMemoryObjectStore {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
-        Ok(self.get_object(package_id).unwrap().and_then(|o| {
-            if o.is_package() {
-                Some(Arc::new(o.clone()))
-            } else {
-                None
-            }
-        }))
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
+        get_package_object(self, package_id)
     }
 }
 

--- a/crates/sui-storage/src/package_object_cache.rs
+++ b/crates/sui-storage/src/package_object_cache.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::object::Object;
-use sui_types::storage::{get_module, get_module_by_id, BackingPackageStore, ObjectStore};
+use sui_types::storage::{
+    get_module, get_module_by_id, BackingPackageStore, ObjectStore, PackageObjectArc,
+};
 
 pub struct PackageObjectCache<S> {
     cache: RwLock<LruCache<ObjectID, Object>>,
@@ -49,19 +51,19 @@ impl<S: BackingPackageStore> ModuleResolver for PackageObjectCache<S> {
 
 // impl<S: ObjectStore + BackingPackageStore + ModuleResolver<Error = SuiError>> BackingPackageStore for PackageObjectCache<S> {
 impl<S: ObjectStore> BackingPackageStore for PackageObjectCache<S> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         // TODO: Here the use of `peek` doesn't update the internal use record,
         // and hence the LRU is really used as a capped map here.
         // This is OK because we won't typically have too many entries.
         // We cannot use `get` here because it requires a mut reference and that would
         // require unnecessary lock contention on the mutex, which defeats the purpose.
         if let Some(p) = self.cache.read().peek(package_id) {
-            return Ok(Some(Arc::new(p.clone())));
+            return Ok(Some(PackageObjectArc::new(p.clone())));
         }
         if let Some(p) = self.store.get_object(package_id)? {
             if p.is_package() {
                 self.cache.write().push(*package_id, p.clone());
-                Ok(Some(Arc::new(p)))
+                Ok(Some(PackageObjectArc::new(p)))
             } else {
                 Err(SuiError::UserInputError {
                     error: UserInputError::MoveObjectAsPackage {

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -4,7 +4,9 @@
 use crate::base_types::VersionNumber;
 use crate::committee::EpochId;
 use crate::inner_temporary_store::WrittenObjects;
-use crate::storage::{get_module, get_module_by_id, get_package_object, PackageObjectArc};
+use crate::storage::{
+    get_module, get_module_by_id, load_package_object_from_object_store, PackageObjectArc,
+};
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::{SuiError, SuiResult},
@@ -25,7 +27,7 @@ pub struct InMemoryStorage {
 
 impl BackingPackageStore for InMemoryStorage {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
-        get_package_object(self, package_id)
+        load_package_object_from_object_store(self, package_id)
     }
 }
 

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -15,6 +15,7 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 // TODO: We should use AuthorityTemporaryStore instead.
 // Keeping this functionally identical to AuthorityTemporaryStore is a pain.
@@ -24,8 +25,8 @@ pub struct InMemoryStorage {
 }
 
 impl BackingPackageStore for InMemoryStorage {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
-        Ok(self.persistent.get(package_id).cloned())
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+        Ok(self.persistent.get(package_id).cloned().map(Arc::new))
     }
 }
 

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -194,7 +194,7 @@ impl<S: ?Sized + BackingPackageStore> BackingPackageStore for &mut S {
     }
 }
 
-pub fn get_package_object(
+pub fn load_package_object_from_object_store(
     store: &impl ObjectStore,
     package_id: &ObjectID,
 ) -> SuiResult<Option<PackageObjectArc>> {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -47,6 +47,7 @@ mod checked {
     };
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution::ExecutionResults;
+    use sui_types::storage::PackageObjectArc;
     use sui_types::{
         balance::Balance,
         base_types::{MoveObjectType, ObjectID, SuiAddress, TxContext},
@@ -271,7 +272,7 @@ mod checked {
             let package = package_for_linkage(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            self.linkage_view.set_linkage(package.as_ref())
+            self.linkage_view.set_linkage(package.move_package())
         }
 
         /// Load a type using the context's current session.
@@ -999,11 +1000,11 @@ mod checked {
     fn package_for_linkage(
         linkage_view: &LinkageView,
         package_id: ObjectID,
-    ) -> VMResult<Arc<MovePackage>> {
+    ) -> VMResult<PackageObjectArc> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
-        match linkage_view.get_package(&package_id) {
+        match linkage_view.get_package_object(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
@@ -1039,11 +1040,13 @@ mod checked {
 
         // Set the defining package as the link context while loading the
         // struct
-        let original_address = linkage_view.set_linkage(package.as_ref()).map_err(|e| {
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message(e.to_string())
-                .finish(Location::Undefined)
-        })?;
+        let original_address = linkage_view
+            .set_linkage(package.move_package())
+            .map_err(|e| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(e.to_string())
+                    .finish(Location::Undefined)
+            })?;
 
         let runtime_id = ModuleId::new(original_address, module.clone());
         let data_store = SuiDataStore::new(linkage_view, new_packages);

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -271,7 +271,7 @@ mod checked {
             let package = package_for_linkage(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            self.linkage_view.set_linkage(&package)
+            self.linkage_view.set_linkage(package.as_ref())
         }
 
         /// Load a type using the context's current session.
@@ -999,7 +999,7 @@ mod checked {
     fn package_for_linkage(
         linkage_view: &LinkageView,
         package_id: ObjectID,
-    ) -> VMResult<MovePackage> {
+    ) -> VMResult<Arc<MovePackage>> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
@@ -1039,7 +1039,7 @@ mod checked {
 
         // Set the defining package as the link context while loading the
         // struct
-        let original_address = linkage_view.set_linkage(&package).map_err(|e| {
+        let original_address = linkage_view.set_linkage(package.as_ref()).map_err(|e| {
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                 .with_message(e.to_string())
                 .finish(Location::Undefined)

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -32,6 +32,7 @@ mod checked {
     };
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
+    use sui_types::storage::{get_package_objects, PackageObjectArc};
     use sui_types::{
         base_types::{
             MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
@@ -48,7 +49,6 @@ mod checked {
             normalize_deserialized_modules, MovePackage, UpgradeCap, UpgradePolicy, UpgradeReceipt,
             UpgradeTicket,
         },
-        storage::get_packages,
         transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
         transfer::RESOLVED_RECEIVING_STRUCT,
         SUI_FRAMEWORK_ADDRESS,
@@ -482,7 +482,8 @@ mod checked {
         // For newly published packages, runtime ID matches storage ID.
         let storage_id = runtime_id;
         let dependencies = fetch_packages(context, &dep_ids)?;
-        let package = context.new_package(&modules, dependencies.iter().map(|p| p.as_ref()))?;
+        let package =
+            context.new_package(&modules, dependencies.iter().map(|p| p.move_package()))?;
 
         // Here we optimistacally push the package that is being published/upgraded
         // and if there is an error of any kind (verification or module init) we
@@ -582,7 +583,7 @@ mod checked {
         let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
 
         let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
-        let runtime_id = current_package.original_package_id();
+        let runtime_id = current_package.move_package().original_package_id();
         substitute_package_id(&mut modules, runtime_id)?;
 
         // Upgraded packages share their predecessor's runtime ID but get a new storage ID.
@@ -591,9 +592,9 @@ mod checked {
         let dependencies = fetch_packages(context, &dep_ids)?;
         let package = context.upgrade_package(
             storage_id,
-            current_package.as_ref(),
+            current_package.move_package(),
             &modules,
-            dependencies.iter().map(|p| p.as_ref()),
+            dependencies.iter().map(|p| p.move_package()),
         )?;
 
         context.linkage_view.set_linkage(&package)?;
@@ -601,7 +602,12 @@ mod checked {
         context.linkage_view.reset_linkage();
         res?;
 
-        check_compatibility(context, &current_package, &modules, upgrade_ticket.policy)?;
+        check_compatibility(
+            context,
+            current_package.move_package(),
+            &modules,
+            upgrade_ticket.policy,
+        )?;
 
         context.write_package(package);
         Ok(vec![Value::Raw(
@@ -687,7 +693,7 @@ mod checked {
     fn fetch_package(
         context: &ExecutionContext<'_, '_, '_>,
         package_id: &ObjectID,
-    ) -> Result<Arc<MovePackage>, ExecutionError> {
+    ) -> Result<PackageObjectArc, ExecutionError> {
         let mut fetched_packages = fetch_packages(context, vec![package_id])?;
         assert_invariant!(
             fetched_packages.len() == 1,
@@ -704,9 +710,9 @@ mod checked {
     fn fetch_packages<'ctx, 'vm, 'state, 'a>(
         context: &'ctx ExecutionContext<'vm, 'state, 'a>,
         package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
-    ) -> Result<Vec<Arc<MovePackage>>, ExecutionError> {
+    ) -> Result<Vec<PackageObjectArc>, ExecutionError> {
         let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
-        match get_packages(&context.state_view, package_ids) {
+        match get_package_objects(&context.state_view, package_ids) {
             Err(e) => Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PublishUpgradeMissingDependency,
                 e,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
@@ -14,13 +13,12 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
-use sui_types::storage::get_module;
+use sui_types::storage::{get_module, PackageObjectArc};
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
     execution::SuiResolver,
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
-    object::Object,
     storage::BackingPackageStore,
 };
 
@@ -241,7 +239,7 @@ impl<'state> LinkageView<'state> {
         }
 
         let storage_id = ObjectID::from(*self.relocate(runtime_id)?.address());
-        let Some(package) = self.resolver.get_package(&storage_id)? else {
+        let Some(package) = self.resolver.get_package_object(&storage_id)? else {
             invariant_violation!("Missing dependent package in store: {storage_id}",)
         };
 
@@ -249,7 +247,7 @@ impl<'state> LinkageView<'state> {
             module_name,
             struct_name,
             package,
-        } in package.type_origin_table()
+        } in package.move_package().type_origin_table()
         {
             if module_name == runtime_id.name().as_str() && struct_name == struct_.as_str() {
                 self.add_type_origin(runtime_id.clone(), struct_.to_owned(), *package)?;
@@ -259,7 +257,7 @@ impl<'state> LinkageView<'state> {
 
         invariant_violation!(
             "{runtime_id}::{struct_} not found in type origin table in {storage_id} (v{})",
-            package.version(),
+            package.move_package().version(),
         )
     }
 }
@@ -317,7 +315,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
 }
 
 impl<'state> BackingPackageStore for LinkageView<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         self.resolver.get_package_object(package_id)
     }
 }

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
@@ -316,7 +317,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
 }
 
 impl<'state> BackingPackageStore for LinkageView<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         self.resolver.get_package_object(package_id)
     }
 }

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -8,6 +8,7 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::move_vm::MoveVM;
+use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
@@ -66,7 +67,7 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 }
 
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         self.0.get_package_object(package_id)
     }
 }

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -8,12 +8,10 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::move_vm::MoveVM;
-use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
-use sui_types::object::Object;
-use sui_types::storage::BackingPackageStore;
+use sui_types::storage::{BackingPackageStore, PackageObjectArc};
 use sui_types::{
     error::SuiError,
     object::{MoveObject, ObjectFormatOptions},
@@ -67,7 +65,7 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 }
 
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         self.0.get_package_object(package_id)
     }
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -34,6 +34,7 @@ mod checked {
         self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
     };
     use sui_protocol_config::ProtocolConfig;
+    use sui_types::storage::PackageObjectArc;
     use sui_types::{
         balance::Balance,
         base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
@@ -268,7 +269,7 @@ mod checked {
             let package = package_for_linkage(&self.session, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            set_linkage(&mut self.session, package.as_ref())
+            set_linkage(&mut self.session, package.move_package())
         }
 
         /// Set the link context for the session from the linkage information in the `package`.  Returns
@@ -1023,11 +1024,11 @@ mod checked {
     fn package_for_linkage(
         session: &Session<LinkageView>,
         package_id: ObjectID,
-    ) -> VMResult<Arc<MovePackage>> {
+    ) -> VMResult<PackageObjectArc> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
-        match session.get_resolver().get_package(&package_id) {
+        match session.get_resolver().get_package_object(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
@@ -1076,11 +1077,12 @@ mod checked {
 
                 // Set the defining package as the link context on the session while loading the
                 // struct
-                let original_address = set_linkage(session, package.as_ref()).map_err(|e| {
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(e.to_string())
-                        .finish(Location::Undefined)
-                })?;
+                let original_address =
+                    set_linkage(session, package.move_package()).map_err(|e| {
+                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                            .with_message(e.to_string())
+                            .finish(Location::Undefined)
+                    })?;
 
                 let runtime_id = ModuleId::new(original_address, module.clone());
                 let res = session.load_struct(&runtime_id, name);

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -268,7 +268,7 @@ mod checked {
             let package = package_for_linkage(&self.session, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            set_linkage(&mut self.session, &package)
+            set_linkage(&mut self.session, package.as_ref())
         }
 
         /// Set the link context for the session from the linkage information in the `package`.  Returns
@@ -1023,7 +1023,7 @@ mod checked {
     fn package_for_linkage(
         session: &Session<LinkageView>,
         package_id: ObjectID,
-    ) -> VMResult<MovePackage> {
+    ) -> VMResult<Arc<MovePackage>> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
@@ -1076,7 +1076,7 @@ mod checked {
 
                 // Set the defining package as the link context on the session while loading the
                 // struct
-                let original_address = set_linkage(session, &package).map_err(|e| {
+                let original_address = set_linkage(session, package.as_ref()).map_err(|e| {
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(e.to_string())
                         .finish(Location::Undefined)

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
@@ -349,7 +350,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
 }
 
 impl<'state> BackingPackageStore for LinkageView<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         self.resolver.get_package_object(package_id)
     }
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
@@ -14,13 +13,12 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
-use sui_types::storage::get_module;
+use sui_types::storage::{get_module, PackageObjectArc};
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
     execution::SuiResolver,
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
-    object::Object,
     storage::BackingPackageStore,
 };
 
@@ -304,7 +302,7 @@ impl<'state> LinkageResolver for LinkageView<'state> {
         }
 
         let storage_id = ObjectID::from(*self.relocate(runtime_id)?.address());
-        let Some(package) = self.resolver.get_package(&storage_id)? else {
+        let Some(package) = self.resolver.get_package_object(&storage_id)? else {
             invariant_violation!("Missing dependent package in store: {storage_id}",)
         };
 
@@ -312,7 +310,7 @@ impl<'state> LinkageResolver for LinkageView<'state> {
             module_name,
             struct_name,
             package,
-        } in package.type_origin_table()
+        } in package.move_package().type_origin_table()
         {
             if module_name == runtime_id.name().as_str() && struct_name == struct_.as_str() {
                 self.add_type_origin(runtime_id.clone(), struct_.to_owned(), *package)?;
@@ -322,7 +320,7 @@ impl<'state> LinkageResolver for LinkageView<'state> {
 
         invariant_violation!(
             "{runtime_id}::{struct_} not found in type origin table in {storage_id} (v{})",
-            package.version(),
+            package.move_package().version(),
         )
     }
 }
@@ -350,7 +348,7 @@ impl<'state> ModuleResolver for LinkageView<'state> {
 }
 
 impl<'state> BackingPackageStore for LinkageView<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         self.resolver.get_package_object(package_id)
     }
 }

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -11,6 +11,7 @@ use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
+use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
@@ -71,7 +72,7 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 }
 
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
         self.0.get_package_object(package_id)
     }
 }

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -11,12 +11,10 @@ use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::resolver::ResourceResolver;
 use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
-use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
-use sui_types::object::Object;
-use sui_types::storage::BackingPackageStore;
+use sui_types::storage::{BackingPackageStore, PackageObjectArc};
 use sui_types::{
     error::SuiError,
     object::{MoveObject, ObjectFormatOptions},
@@ -72,7 +70,7 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
 }
 
 impl<'state> BackingPackageStore for NullSuiResolver<'state> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Arc<Object>>> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
         self.0.get_package_object(package_id)
     }
 }


### PR DESCRIPTION
## Description 

This PR makes the BackingPackageStore trait ready to support object/package cache.
BackingPackageStore used to have two APIs, get_package and get_package_object. Both returns value (MovePackage and Object). This will make it very inefficient to support a package cache because we would have to clone all the time.
This PR makes it such that BackingPackageStore trait now only has one API, which is get_package_object. It returns an Arc of package object that can be passed around cheaply.
The primary change is in storage/src/mod.rs. All other changes are due to the API change.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
