### PR TITLE
[graphql/rpc] add fragment limits inline

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, ServerError};
+use async_graphql::{ErrorExtensionValues, ErrorExtensions, Pos, Response, ServerError};
 use async_graphql_axum::GraphQLResponse;
 use sui_indexer::errors::IndexerError;
 use sui_json_rpc::name_service::DomainParseError;
@@ -39,6 +39,23 @@ pub(crate) fn graphql_error(code: &str, message: impl Into<String>) -> ServerErr
         message: message.into(),
         source: None,
         locations: vec![],
+        path: vec![],
+        extensions: Some(ext),
+    }
+}
+
+pub(crate) fn graphql_error_at_pos(
+    code: &str,
+    message: impl Into<String>,
+    pos: Pos,
+) -> ServerError {
+    let mut ext = ErrorExtensionValues::default();
+    ext.set("code", code);
+
+    ServerError {
+        message: message.into(),
+        source: None,
+        locations: vec![pos],
         path: vec![],
         extensions: Some(ext),
     }


### PR DESCRIPTION
## Description 

This counts fragments in the query complexity
Fragments can be defined but not used, causing them to still be parsed. We will limit these early on too in subseq PR.


## Test Plan 

Manual, coming next

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
