### PR TITLE
[transactional-tests] Fix struct parser

### DIFF
--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -6,7 +6,6 @@ use clap;
 use move_command_line_common::parser::{parse_u256, parse_u64};
 use move_command_line_common::values::{ParsableValue, ParsedValue};
 use move_command_line_common::{parser::Parser as MoveCLParser, values::ValueToken};
-use move_core_types::identifier::Identifier;
 use move_core_types::u256::U256;
 use move_core_types::value::{MoveStruct, MoveValue};
 use move_symbol_pool::Symbol;
@@ -376,20 +375,10 @@ impl ParsableValue for SuiExtraValueArgs {
         }
     }
 
-    fn concrete_struct(
-        _addr: move_core_types::account_address::AccountAddress,
-        _module: String,
-        _name: String,
-        values: std::collections::BTreeMap<String, Self::ConcreteValue>,
-    ) -> anyhow::Result<Self::ConcreteValue> {
-        Ok(SuiValue::MoveValue(MoveValue::Struct(
-            MoveStruct::WithFields(
-                values
-                    .into_iter()
-                    .map(|(f, v)| Ok((Identifier::new(f)?, v.assert_move_value())))
-                    .collect::<anyhow::Result<_>>()?,
-            ),
-        )))
+    fn concrete_struct(values: Vec<Self::ConcreteValue>) -> anyhow::Result<Self::ConcreteValue> {
+        Ok(SuiValue::MoveValue(MoveValue::Struct(MoveStruct::Runtime(
+            values.into_iter().map(|v| v.assert_move_value()).collect(),
+        ))))
     }
 
     fn into_concrete_value(


### PR DESCRIPTION
## Description 

- Struct value parsing was broken and incorrect, since it sorted the fields
- Replaced with a simple runtime struct representation parser

## Test Plan 

- Tested in an upcoming PR

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
