### PR TITLE
[graphql/rpc] get schema from url

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -149,6 +149,7 @@ impl ServerBuilder {
 
         let app = axum::Router::new()
             .route("/", axum::routing::get(graphiql).post(graphql_handler))
+            .route("/schema", axum::routing::get(get_schema))
             .layer(axum::extract::Extension(schema))
             .layer(middleware::from_fn(check_version_middleware))
             .layer(middleware::from_fn(set_version_middleware));
@@ -161,6 +162,19 @@ impl ServerBuilder {
             .serve(app.into_make_service_with_connect_info::<SocketAddr>()),
         })
     }
+}
+
+async fn get_schema() -> impl axum::response::IntoResponse {
+    let schema = include_str!("../../schema/current_progress_schema.graphql").to_string();
+    let schema = format!(
+        r#"
+    <span style="white-space: pre;">{}
+    </span>  
+    "#,
+        schema
+    );
+
+    axum::response::Html(schema)
 }
 
 async fn graphql_handler(


### PR DESCRIPTION
## Description 

GET request on `{url}/schema` will now return the pretty schema,

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
