### PR TITLE
fix: include `pk` in `bls12381_*_verify` examples

### DIFF
--- a/doc/src/learn/cryptography/sui-move-signatures.md
+++ b/doc/src/learn/cryptography/sui-move-signatures.md
@@ -190,7 +190,7 @@ Public key in hex: $PK
     let msg = x"$MSG";
     let pk = x"$PK";
     let sig = x"$SIG";
-    let verified = bls12381::bls12381_min_sig_verify(&sig, &msg);
+    let verified = bls12381::bls12381_min_sig_verify(&sig, &pk, &msg);
     assert!(verified == true, 0);
 ```
 
@@ -217,6 +217,6 @@ Public key in hex: $PK
     let msg = x"$MSG";
     let pk = x"$PK";
     let sig = x"$SIG";
-    let verified = bls12381::bls12381_min_pk_verify(&sig, &msg);
+    let verified = bls12381::bls12381_min_pk_verify(&sig, &pk, &msg);
     assert!(verified == true, 0);
 ```


### PR DESCRIPTION

## Description 

I added the public keys as inputs to the examples for BLS verification, since they were missing.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
