### PR TITLE
[CI] Ensure Move Tests are run when Move files change

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -11,8 +11,8 @@ outputs:
     description: True when changes happened to the Move code
     value: "${{ steps.diff.outputs.isMove }}"
   isReleaseNotesEligible:
-    description: True when changes happened in Release Notes eligible paths 
-    value: "${{ steps.diff.outputs.isReleaseNotesEligible }}"    
+    description: True when changes happened in Release Notes eligible paths
+    value: "${{ steps.diff.outputs.isReleaseNotesEligible }}"
 
 runs:
   using: composite
@@ -42,6 +42,7 @@ runs:
           - 'crates/sui-framework-tests/**'
           - 'crates/sui_move/**'
           - 'Cargo.toml'
+          - 'examples/**'
           - 'sui_programmability/**'
         isReleaseNotesEligible:
           - 'crates/**'

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -30,7 +30,6 @@ runs:
           - 'sui-execution/**'
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
-          - '.github/workflows/rust.yml'
           - '.github/workflows/external.yml'
         isDoc:
           - 'doc/**'

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -30,6 +30,7 @@ runs:
           - 'sui-execution/**'
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
+          - '.github/workflows/rust.yml'
           - '.github/workflows/external.yml'
         isDoc:
           - 'doc/**'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -228,7 +228,7 @@ jobs:
   move-test:
     needs: diff
     if: needs.diff.outputs.isRust == 'false' && needs.diff.outputs.isMove == 'true'
-    timeout-mins: 10
+    timeout-minutes: 10
     runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -221,6 +221,22 @@ jobs:
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh
+
+  # This job ensures that Move unit tests are run if there are changes
+  # to Move code but not Rust code (If there are Rust changes, they
+  # will be run as part of a larger test suite).
+  move-test:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'false' && needs.diff.outputs.isMove == 'true'
+    timeout-mins: 10
+    runs-on: [ubuntu-ghcloud]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/install-action@nextest
+      - name: Run move tests
+        run: |
+          cargo nextest run -p sui-framework-tests -- unit_tests::
+
   # # Disabled
   # rosetta-validation:
   #   needs: diff

--- a/examples/move/first_package/sources/example.move
+++ b/examples/move/first_package/sources/example.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Move change
 module first_package::example {
     use sui::object::{Self, UID};
     use sui::transfer;

--- a/examples/move/first_package/sources/example.move
+++ b/examples/move/first_package/sources/example.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Move change
 module first_package::example {
     use sui::object::{Self, UID};
     use sui::transfer;


### PR DESCRIPTION
## Description

Move tests are run as part of the Rust tests for the Sui Framework, but they should also be run when there are only Move changes.

Surfaced because a recent PR (#14429) Moved some Move tests causing CI to fail on `main`, and this wasn't picked up because diff tests hadn't been run.

## Test Plan

CI
