### PR TITLE
[GraphQL/Object] asStake is allowed to fail

### DIFF
--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -232,6 +232,10 @@ impl MoveObject {
         self.type_.is_coin()
     }
 
+    pub fn is_staked_sui(&self) -> bool {
+        self.type_.is_staked_sui()
+    }
+
     pub fn is_clock(&self) -> bool {
         self.type_.is(&crate::clock::Clock::type_())
     }


### PR DESCRIPTION
## Description

`as...` fields are special in that they are fallible conversion operators: It's a valid query to request stake-specific information on an object that isn't a `StakedSui`.

This PR changes the behaviour of the `asStake` to match this pattern. It also tweaks `asCoin` to follow a similar coding pattern.

## Test Plan

Tested with GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/e74fbcbe-b2a7-4929-b80f-905902c5df7b)

## Stack

- #14422 
- #14423 
- #14424 
- #14425