### PR TITLE
[GraphQL/MoveObject] JSON field

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -306,6 +306,9 @@ type GenesisTransaction {
 
 
 
+"""
+Arbitrary JSON data.
+"""
 scalar JSON
 
 """

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -306,6 +306,8 @@ type GenesisTransaction {
 
 
 
+scalar JSON
+
 """
 Information used by a package to link to a specific version of its dependency.
 """
@@ -456,7 +458,25 @@ scalar MoveTypeSignature
 type MoveValue {
 	type: MoveType!
 	bcs: Base64!
+	"""
+	Structured contents of a Move value.
+	"""
 	data: MoveData!
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Empty optional values are represented by `null`.
+	
+	This form is offered as a less verbose convenience in cases where the layout of the type is
+	known by the client.
+	"""
+	json: JSON!
 }
 
 scalar NameService

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -177,6 +177,9 @@ scalar Base64
 # ISO-8601 Date and Time
 scalar DateTime
 
+# Arbitrary JSON data
+scalar JSON
+
 # Scalar representing the contents of a Move Value, corresponding to
 # the following recursive type:
 #
@@ -1073,6 +1076,7 @@ type MoveFunction {
 type MoveValue {
   type: MoveType!
   data: MoveData
+  json: JSON
 
   bcs: Base64
 }

--- a/crates/sui-graphql-rpc/src/types/json.rs
+++ b/crates/sui-graphql-rpc/src/types/json.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use async_graphql::*;
+
+/// Arbitrary JSON data.
+#[derive(Debug)]
+pub(crate) struct Json(Value);
+
+#[Scalar(name = "JSON")]
+impl ScalarType for Json {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        Ok(Self(value))
+    }
+
+    fn to_value(&self) -> Value {
+        self.0.clone()
+    }
+}
+
+impl From<Value> for Json {
+    fn from(value: Value) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for Json {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/json.rs
+++ b/crates/sui-graphql-rpc/src/types/json.rs
@@ -9,7 +9,7 @@ use async_graphql::*;
 #[derive(Debug)]
 pub(crate) struct Json(Value);
 
-#[Scalar(name = "JSON")]
+#[Scalar(name = "JSON", use_type_description = true)]
 impl ScalarType for Json {
     fn parse(value: Value) -> InputValueResult<Self> {
         Ok(Self(value))
@@ -17,6 +17,12 @@ impl ScalarType for Json {
 
     fn to_value(&self) -> Value {
         self.0.clone()
+    }
+}
+
+impl Description for Json {
+    fn description() -> &'static str {
+        "Arbitrary JSON data."
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod end_of_epoch_data;
 pub(crate) mod epoch;
 pub(crate) mod event;
 pub(crate) mod gas;
+pub(crate) mod json;
 pub(crate) mod move_module;
 pub(crate) mod move_object;
 pub(crate) mod move_package;

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -310,6 +310,8 @@ type GenesisTransaction {
 
 
 
+scalar JSON
+
 """
 Information used by a package to link to a specific version of its dependency.
 """
@@ -460,7 +462,25 @@ scalar MoveTypeSignature
 type MoveValue {
 	type: MoveType!
 	bcs: Base64!
+	"""
+	Structured contents of a Move value.
+	"""
 	data: MoveData!
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Empty optional values are represented by `null`.
+	
+	This form is offered as a less verbose convenience in cases where the layout of the type is
+	known by the client.
+	"""
+	json: JSON!
 }
 
 scalar NameService

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -310,6 +310,9 @@ type GenesisTransaction {
 
 
 
+"""
+Arbitrary JSON data.
+"""
 scalar JSON
 
 """

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -232,6 +232,10 @@ impl MoveObject {
         self.type_.is_coin()
     }
 
+    pub fn is_staked_sui(&self) -> bool {
+        self.type_.is_staked_sui()
+    }
+
     pub fn is_clock(&self) -> bool {
         self.type_.is(&crate::clock::Clock::type_())
     }


### PR DESCRIPTION
## Description

Implementing a feature request from @hayes-mysten to have a Move value representation that is more directly "JSON-like" (where Move concepts map to directly to their JSON counterpart without any extra boilerplate).

## Test Plan

New unit tests:

```
sui-graphql-rpc$ cargo nextest run -- types::move_value::tests
```

Tested on GraphiQL:

![image](https://github.com/MystenLabs/sui/assets/332275/50cbf433-4fbe-4e92-813a-faddf07c738a)

## Stack

- #14422 
- #14423 
- #14424 
- #14425
- #14485 