### PR TITLE
[Explorer]: Add hover tooltip

### DIFF
--- a/apps/explorer/src/pages/object-result/views/ObjectView.tsx
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CoinFormat, useFormatCoin, useResolveSuiNSName } from '@mysten/core';
-import { ArrowUpRight16 } from '@mysten/icons';
+import { ArrowUpRight16, Info16 } from '@mysten/icons';
 import { type ObjectOwner, type SuiObjectResponse } from '@mysten/sui.js/client';
 import {
 	formatAddress,
@@ -135,13 +135,23 @@ function DescriptionCard({
 				<ObjectLink objectId={objectId} />
 			</Description>
 
-			<Description title="Type">
-				<Tooltip tip={<div className="flex flex-wrap break-all">{objectType}</div>}>
-					<ObjectLink
-						label={<div className="text-right">{normalizedStructTag}</div>}
-						objectId={`${address}?module=${module}`}
-					/>
-				</Tooltip>
+			<Description
+				title={
+					<div className="flex items-center gap-1">
+						<Text variant="pBodySmall/medium" color="steel-dark">
+							Type
+						</Text>
+
+						<Tooltip tip={<div className="flex flex-wrap break-all">{objectType}</div>}>
+							<Info16 />
+						</Tooltip>
+					</div>
+				}
+			>
+				<ObjectLink
+					label={<div className="text-right">{normalizedStructTag}</div>}
+					objectId={`${address}?module=${module}`}
+				/>
 			</Description>
 		</ObjectViewCard>
 	);

--- a/apps/explorer/src/pages/object-result/views/ObjectView.tsx
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.tsx
@@ -24,6 +24,7 @@ import { Link } from '~/ui/Link';
 import { ObjectVideoImage } from '~/ui/ObjectVideoImage';
 import { extractName, getDisplayUrl, parseImageURL, parseObjectType } from '~/utils/objectUtils';
 import { genFileTypeMsg, trimStdLibPrefix } from '~/utils/stringUtils';
+import { Tooltip } from '~/ui/Tooltip';
 
 interface HeroVideoImageProps {
 	title: string;
@@ -135,10 +136,12 @@ function DescriptionCard({
 			</Description>
 
 			<Description title="Type">
-				<ObjectLink
-					label={<div className="text-right">{normalizedStructTag}</div>}
-					objectId={`${address}?module=${module}`}
-				/>
+				<Tooltip tip={<div className="flex flex-wrap break-all">{objectType}</div>}>
+					<ObjectLink
+						label={<div className="text-right">{normalizedStructTag}</div>}
+						objectId={`${address}?module=${module}`}
+					/>
+				</Tooltip>
 			</Description>
 		</ObjectViewCard>
 	);

--- a/apps/explorer/src/ui/Description.tsx
+++ b/apps/explorer/src/ui/Description.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { type ReactNode } from 'react';
 
 interface DescriptionProps {
-	title: string;
+	title: ReactNode;
 	children: ReactNode;
 	titleVariant?: TextProps['variant'];
 	titleColor?: TextProps['color'];


### PR DESCRIPTION
## Description 

Add hover tooltip for object type


<img width="529" alt="Screenshot 2023-10-30 at 9 35 28 AM" src="https://github.com/MystenLabs/sui/assets/127577476/7131c44e-ad9d-4366-987b-49d284370437">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
