### PR TITLE
Use package cache in prod

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,8 +20,8 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module, load_package_object_from_object_store, BackingPackageStore, ChildObjectResolver,
-    MarkerTableQuery, MarkerValue, ObjectKey, ObjectStore, PackageObjectArc,
+    get_module, BackingPackageStore, ChildObjectResolver, MarkerTableQuery, MarkerValue, ObjectKey,
+    ObjectStore, PackageObjectArc,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -133,6 +133,8 @@ pub struct AuthorityStore {
     enable_epoch_sui_conservation_check: bool,
 
     metrics: AuthorityStoreMetrics,
+
+    package_cache: Arc<PackageObjectCache>,
 }
 
 pub type ExecutionLockReadGuard<'a> = RwLockReadGuard<'a, EpochId>;
@@ -244,6 +246,7 @@ impl AuthorityStore {
             indirect_objects_threshold,
             enable_epoch_sui_conservation_check,
             metrics: AuthorityStoreMetrics::new(registry),
+            package_cache: PackageObjectCache::new(),
         });
         // Only initialize an empty database.
         if store
@@ -1003,6 +1006,13 @@ impl AuthorityStore {
         // Commit.
         write_batch.write()?;
 
+        if transaction.transaction_data().is_change_epoch_tx() {
+            // At the end of epoch, since system packages may have been upgraded, force
+            // reload them in the cache.
+            self.package_cache
+                .force_reload_system_packages(BuiltInFramework::all_package_ids(), self);
+        }
+
         // test crashing before notifying
         fail_point_async!("crash");
 
@@ -1755,7 +1765,6 @@ impl AuthorityStore {
         let mut pending_objects = vec![];
         let mut count = 0;
         let mut size = 0;
-        let package_cache = PackageObjectCache::new(self.clone());
         let (mut total_sui, mut total_storage_rebate) = thread::scope(|s| {
             let pending_tasks = FuturesUnordered::new();
             for o in self.iter_live_object_set(false) {
@@ -1767,10 +1776,9 @@ impl AuthorityStore {
                         if count % 1_000_000 == 0 {
                             let mut task_objects = vec![];
                             mem::swap(&mut pending_objects, &mut task_objects);
-                            let package_cache_clone = package_cache.clone();
                             pending_tasks.push(s.spawn(move || {
                                 let mut layout_resolver =
-                                    executor.type_layout_resolver(Box::new(&package_cache_clone));
+                                    executor.type_layout_resolver(Box::new(self.as_ref()));
                                 let mut total_storage_rebate = 0;
                                 let mut total_sui = 0;
                                 for object in task_objects {
@@ -1992,7 +2000,7 @@ impl MarkerTableQuery for AuthorityStore {
 
 impl BackingPackageStore for AuthorityStore {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
-        load_package_object_from_object_store(self, package_id)
+        self.package_cache.get_package_object(package_id, self)
     }
 }
 

--- a/crates/sui-storage/src/package_object_cache.rs
+++ b/crates/sui-storage/src/package_object_cache.rs
@@ -2,68 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lru::LruCache;
-use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::GetModule;
-use move_core_types::language_storage::ModuleId;
-use move_core_types::resolver::ModuleResolver;
 use parking_lot::RwLock;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::{SuiError, SuiResult, UserInputError};
-use sui_types::object::Object;
-use sui_types::storage::{
-    get_module, get_module_by_id, BackingPackageStore, ObjectStore, PackageObjectArc,
-};
+use sui_types::storage::{ObjectStore, PackageObjectArc};
 
-pub struct PackageObjectCache<S> {
-    cache: RwLock<LruCache<ObjectID, Object>>,
-    store: Arc<S>,
+pub struct PackageObjectCache {
+    cache: RwLock<LruCache<ObjectID, PackageObjectArc>>,
 }
 
 const CACHE_CAP: usize = 1024 * 1024;
 
-impl<S> PackageObjectCache<S> {
-    pub fn new(store: Arc<S>) -> Arc<Self> {
+impl PackageObjectCache {
+    pub fn new() -> Arc<Self> {
         Arc::new(Self {
             cache: RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_CAP).unwrap())),
-            store,
         })
     }
-}
 
-impl<S: ObjectStore> GetModule for PackageObjectCache<S> {
-    type Error = SuiError;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>, Self::Error> {
-        get_module_by_id(self, id)
-    }
-}
-
-impl<S: BackingPackageStore> ModuleResolver for PackageObjectCache<S> {
-    type Error = SuiError;
-
-    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        get_module(&self.store, id)
-    }
-}
-
-// impl<S: ObjectStore + BackingPackageStore + ModuleResolver<Error = SuiError>> BackingPackageStore for PackageObjectCache<S> {
-impl<S: ObjectStore> BackingPackageStore for PackageObjectCache<S> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObjectArc>> {
+    pub fn get_package_object(
+        &self,
+        package_id: &ObjectID,
+        store: &impl ObjectStore,
+    ) -> SuiResult<Option<PackageObjectArc>> {
         // TODO: Here the use of `peek` doesn't update the internal use record,
         // and hence the LRU is really used as a capped map here.
         // This is OK because we won't typically have too many entries.
         // We cannot use `get` here because it requires a mut reference and that would
         // require unnecessary lock contention on the mutex, which defeats the purpose.
         if let Some(p) = self.cache.read().peek(package_id) {
-            return Ok(Some(PackageObjectArc::new(p.clone())));
+            return Ok(Some(p.clone()));
         }
-        if let Some(p) = self.store.get_object(package_id)? {
+        if let Some(p) = store.get_object(package_id)? {
             if p.is_package() {
+                let p = PackageObjectArc::new(p);
                 self.cache.write().push(*package_id, p.clone());
-                Ok(Some(PackageObjectArc::new(p)))
+                Ok(Some(p))
             } else {
                 Err(SuiError::UserInputError {
                     error: UserInputError::MoveObjectAsPackage {
@@ -73,6 +49,24 @@ impl<S: ObjectStore> BackingPackageStore for PackageObjectCache<S> {
             }
         } else {
             Ok(None)
+        }
+    }
+
+    pub fn force_reload_system_packages(
+        &self,
+        system_package_ids: impl IntoIterator<Item = ObjectID>,
+        store: &impl ObjectStore,
+    ) {
+        for package_id in system_package_ids {
+            if let Some(p) = store
+                .get_object(&package_id)
+                .expect("Failed to update system packages")
+            {
+                assert!(p.is_package());
+                self.cache
+                    .write()
+                    .push(package_id, PackageObjectArc::new(p));
+            }
         }
     }
 }

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -151,6 +151,7 @@ pub trait Storage {
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;
 
+#[derive(Clone)]
 pub struct PackageObjectArc {
     package_object: Arc<Object>,
 }


### PR DESCRIPTION
## Description 

This PR puts the package cache into the AuthorityStore and uses it in the production path.
It improves single node benchmark baseline throughput by about 30-40%.
The only thing that's tricky is that we must force evict the system packages after the execution of epoch change transaction.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
