### PR TITLE
[graphql/rpc][easy] fix min_validator_count from system parameters

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1914,7 +1914,7 @@ impl TryFrom<NativeSuiSystemStateSummary> for SuiSystemStateSummary {
             system_parameters: Some(SystemParameters {
                 duration_ms: Some(BigInt::from(system_state.epoch_duration_ms)),
                 stake_subsidy_start_epoch: Some(system_state.stake_subsidy_start_epoch),
-                min_validator_count: Some(system_state.max_validator_count),
+                min_validator_count: Some(system_state.min_validator_count),
                 max_validator_count: Some(system_state.max_validator_count),
                 min_validator_joining_stake: Some(BigInt::from(
                     system_state.min_validator_joining_stake,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -8976,6 +8976,7 @@
           "inactivePoolsId",
           "inactivePoolsSize",
           "maxValidatorCount",
+          "minValidatorCount",
           "minValidatorJoiningStake",
           "pendingActiveValidatorsId",
           "pendingActiveValidatorsSize",
@@ -9073,6 +9074,14 @@
           },
           "maxValidatorCount": {
             "description": "Maximum number of active validators at any moment. We do not allow the number of validators in any epoch to go above this.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              }
+            ]
+          },
+          "minValidatorCount": {
+            "description": "Minimum number of active validators at any moment.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/BigInt_for_uint64"

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -16,6 +16,9 @@ use crate::SUI_SYSTEM_ADDRESS;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Minimum number of active validators at any moment.
+pub const MIN_VALIDATOR_COUNT: u64 = 4;
+
 /// Maximum number of active validators at any moment.
 /// We do not allow the number of validators in any epoch to go above this.
 pub const MAX_VALIDATOR_COUNT: u64 = 150;

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -8,6 +8,7 @@ use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata}
 use crate::crypto::verify_proof_of_possession;
 use crate::crypto::AuthorityPublicKeyBytes;
 use crate::error::SuiError;
+use crate::governance::MIN_VALIDATOR_COUNT;
 use crate::id::ID;
 use crate::multiaddr::Multiaddr;
 use crate::storage::ObjectStore;
@@ -725,6 +726,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                 .into_iter()
                 .map(|e| (e.key, e.value.contents))
                 .collect(),
+            min_validator_count: MIN_VALIDATOR_COUNT,
             max_validator_count,
             min_validator_joining_stake,
             validator_low_stake_threshold,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
@@ -231,7 +231,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV2 {
                 SystemParametersV2 {
                     stake_subsidy_start_epoch,
                     epoch_duration_ms,
-                    min_validator_count: _, // TODO: Add it to RPC layer in the future.
+                    min_validator_count,
                     max_validator_count,
                     min_validator_joining_stake,
                     validator_low_stake_threshold,
@@ -303,6 +303,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV2 {
                 .into_iter()
                 .map(|e| (e.key, e.value.contents))
                 .collect(),
+            min_validator_count,
             max_validator_count,
             min_validator_joining_stake,
             validator_low_stake_threshold,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -89,6 +89,11 @@ pub struct SuiSystemStateSummary {
     #[serde_as(as = "Readable<BigInt<u64>, _>")]
     pub stake_subsidy_start_epoch: u64,
 
+    /// Minimum number of active validators at any moment.
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub min_validator_count: u64,
+
     /// Maximum number of active validators at any moment.
     /// We do not allow the number of validators in any epoch to go above this.
     #[schemars(with = "BigInt<u64>")]
@@ -334,6 +339,7 @@ impl Default for SuiSystemStateSummary {
             epoch_start_timestamp_ms: 0,
             epoch_duration_ms: 0,
             stake_subsidy_start_epoch: 0,
+            min_validator_count: 0,
             max_validator_count: 0,
             min_validator_joining_stake: 0,
             validator_low_stake_threshold: 0,


### PR DESCRIPTION
## Description 

This PR fixes a bug where the `min_validator_count` was assigned the value from `max_validator_count`, leading to both min and max validator count fields to show the same value.

## Test Plan 

![image](https://github.com/MystenLabs/sui/assets/135084671/fe2dc019-11b5-4898-8779-cab497c07e70)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
