### PR TITLE
[Docs] Guides Overview Tweaks

### DIFF
--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -5,11 +5,11 @@ sidebar_label: Overview
 
 import { Cards, Card } from "../site/src/components/Cards"
 
-Often, the best way to learn a new technology is through experience. The content in this section contains concrete examples to guide your development on the Sui network. Whether you're a web3 novice or a seasoned Sui pro, the guides in this section help you get the most of your Sui development experience.    
+Often, the best way to learn a new technology is through experience. The content in this section contains concrete examples to guide your development on the Sui network. Whether you're a web3 novice or a seasoned Sui pro, the guides in this section help you get the most out of your Sui development experience.
 
 ## Guides by role
 
-Get the guides relevant to how you plan to use Sui.  
+Instructions for common tasks, based on your role in the Sui ecosystem.
 <Cards>
 <Card title="Developer guides" href="/guides/developer">
 Guides for developers of all levels.
@@ -21,16 +21,16 @@ Guides for validators and node operators.
 
 ## Get started developing on Sui
 
-You must crawl before you can run. Start your Sui journey here.    
+You must crawl before you can run. Start your Sui journey here.
 <Cards>
 <Card title="Environment setup" href="/guides/developer/getting-started/sui-environment">
-Learn about the Sui monorepo and suggested development environment.
+Learn about Sui tools and the recommended development environment.
 </Card>
 <Card title="Install Sui" href="/guides/developer/getting-started/sui-install">
 Install Sui on your Windows, MacOS, or Linux system.
 </Card>
 <Card title="Your first app on Sui" href="/guides/developer/first-app">
-With Sui installed, you're ready to start developing. 
+With Sui installed, you're ready to start developing.
 </Card>
 </Cards>
 
@@ -41,7 +41,7 @@ Learn the basics of Sui and how they might differ from other blockchains.
 <Card title="Transactions on Sui" href="/guides/developer/sui-101/building-ptb">
 Transactions on Sui are more powerful than other blockchains. Learn why and how to use them.
 </Card>
-<Card title="Access time on chain" href="/guides/developer/sui-101/access-time"> 
+<Card title="Access time on chain" href="/guides/developer/sui-101/access-time">
 </Card>
 <Card title="Using events" href="/guides/developer/sui-101/using-events">
 Monitor the Sui network and programmatically react to on-chain events.
@@ -55,7 +55,7 @@ Processes and guides for validators and node operators on the Sui network.
 <Card title="Validator configuration" href="/guides/operator/validator-config">
 </Card>
 <Card title="Run a Sui Full node" href="/guides/operator/sui-full-node">
-Learn how to operate a Full node on Sui. 
+Learn how to operate a Full node on Sui.
 </Card>
 <Card title="Full node data management" href="/guides/operator/data-management">
 Optimize your Full node configuration for efficient node operation.


### PR DESCRIPTION
## Description

- Missing "out" in first paragraph.
- Rewording intro sentence for "Guides by role", which was hard to scan (for me).
- Remove references to the "monorepo" in the section about Environment set-up (environment set-up no longer requires forking the Sui repo).
- Clean-up whitespace (editor did this automatically).

## Test Plan

:eyes: