### PR TITLE
[Examples] Clean-up Move Warnings/Lints

### DIFF
--- a/examples/move/color_object/sources/example.move
+++ b/examples/move/color_object/sources/example.move
@@ -56,7 +56,7 @@ module color_object::example {
     }
 
     // === Tests ===
-    use sui::test_scenario as ts;
+    #[test_only] use sui::test_scenario as ts;
 
     // === Tests covered in Chapter 1 ===
 
@@ -76,17 +76,17 @@ module color_object::example {
         // Check that @not_owner does not own the just-created ColorObject.
         {
             ts::next_tx(&mut ts, bob);
-            assert!(!ts::has_most_recent_for_sender<ColorObject>(&mut ts), 0);
+            assert!(!ts::has_most_recent_for_sender<ColorObject>(&ts), 0);
         };
 
         // Check that owner indeed owns the just-created ColorObject.
         // Also checks the value fields of the object.
         {
             ts::next_tx(&mut ts, alice);
-            let object: ColorObject = ts::take_from_sender(&mut ts);
+            let object: ColorObject = ts::take_from_sender(&ts);
             let (red, green, blue) = get_color(&object);
             assert!(red == 255 && green == 0 && blue == 255, 0);
-            ts::return_to_sender(&mut ts, object);
+            ts::return_to_sender(&ts, object);
         };
 
         ts::end(ts);
@@ -121,22 +121,22 @@ module color_object::example {
 
         {
             ts::next_tx(&mut ts, owner);
-            let obj1: ColorObject = ts::take_from_sender_by_id(&mut ts, id1);
-            let obj2: ColorObject = ts::take_from_sender_by_id(&mut ts, id2);
+            let obj1: ColorObject = ts::take_from_sender_by_id(&ts, id1);
+            let obj2: ColorObject = ts::take_from_sender_by_id(&ts, id2);
             let (red, green, blue) = get_color(&obj1);
             assert!(red == 255 && green == 255 && blue == 255, 0);
 
             copy_into(&obj2, &mut obj1);
-            ts::return_to_sender(&mut ts, obj1);
-            ts::return_to_sender(&mut ts, obj2);
+            ts::return_to_sender(&ts, obj1);
+            ts::return_to_sender(&ts, obj2);
         };
 
         {
             ts::next_tx(&mut ts, owner);
-            let obj1: ColorObject = ts::take_from_sender_by_id(&mut ts, id1);
+            let obj1: ColorObject = ts::take_from_sender_by_id(&ts, id1);
             let (red, green, blue) = get_color(&obj1);
             assert!(red == 0 && green == 0 && blue == 0, 0);
-            ts::return_to_sender(&mut ts, obj1);
+            ts::return_to_sender(&ts, obj1);
         };
 
         ts::end(ts);
@@ -157,14 +157,14 @@ module color_object::example {
         // Delete the ColorObject we just created.
         {
             ts::next_tx(&mut ts, owner);
-            let object: ColorObject = ts::take_from_sender(&mut ts);
+            let object: ColorObject = ts::take_from_sender(&ts);
             delete(object);
         };
 
         // Verify that the object was indeed deleted.
         {
             ts::next_tx(&mut ts, owner);
-            assert!(!ts::has_most_recent_for_sender<ColorObject>(&mut ts), 0);
+            assert!(!ts::has_most_recent_for_sender<ColorObject>(&ts), 0);
         };
 
         ts::end(ts);
@@ -186,20 +186,20 @@ module color_object::example {
         // Transfer the object to recipient.
         {
             ts::next_tx(&mut ts, sender);
-            let object: ColorObject = ts::take_from_sender(&mut ts);
+            let object: ColorObject = ts::take_from_sender(&ts);
             transfer::public_transfer(object, recipient);
         };
 
         // Check that sender no longer owns the object.
         {
             ts::next_tx(&mut ts, sender);
-            assert!(!ts::has_most_recent_for_sender<ColorObject>(&mut ts), 0);
+            assert!(!ts::has_most_recent_for_sender<ColorObject>(&ts), 0);
         };
 
         // Check that recipient now owns the object.
         {
             ts::next_tx(&mut ts, recipient);
-            assert!(ts::has_most_recent_for_sender<ColorObject>(&mut ts), 0);
+            assert!(ts::has_most_recent_for_sender<ColorObject>(&ts), 0);
         };
 
         ts::end(ts);
@@ -222,13 +222,13 @@ module color_object::example {
         // take_owned does not work for immutable objects.
         {
             ts::next_tx(&mut ts, alice);
-            assert!(!ts::has_most_recent_for_sender<ColorObject>(&mut ts), 0);
+            assert!(!ts::has_most_recent_for_sender<ColorObject>(&ts), 0);
         };
 
         // Any sender can work.
         {
             ts::next_tx(&mut ts, bob);
-            let object: ColorObject = ts::take_immutable(&mut ts);
+            let object: ColorObject = ts::take_immutable(&ts);
             let (red, green, blue) = get_color(&object);
             assert!(red == 255 && green == 0 && blue == 255, 0);
             ts::return_immutable(object);

--- a/examples/move/dynamic_fields/sources/example.move
+++ b/examples/move/dynamic_fields/sources/example.move
@@ -4,7 +4,6 @@
 module dynamic_fields::example {
     use sui::dynamic_object_field as ofield;
     use sui::object::{Self, UID};
-    use sui::test_scenario;
 
     struct Parent has key {
         id: UID,
@@ -46,6 +45,9 @@ module dynamic_fields::example {
         let Child { id, count: _ } = reclaim_child(parent);
         object::delete(id);
     }
+
+    // === Tests ===
+    #[test_only] use sui::test_scenario;
 
     #[test]
     fun test_add_delete() {

--- a/examples/move/escrow/sources/example.move
+++ b/examples/move/escrow/sources/example.move
@@ -210,9 +210,9 @@ module escrow::example {
     }
 
     // === Tests ===
-    use sui::coin::{Self, Coin};
-    use sui::sui::SUI;
-    use sui::test_scenario::{Self as ts, Scenario};
+    #[test_only] use sui::coin::{Self, Coin};
+    #[test_only] use sui::sui::SUI;
+    #[test_only] use sui::test_scenario::{Self as ts, Scenario};
 
     #[test_only]
     fun test_coin(ts: &mut Scenario): Coin<SUI> {

--- a/examples/move/first_package/sources/example.move
+++ b/examples/move/first_package/sources/example.move
@@ -58,7 +58,7 @@ module first_package::example {
     }
 
     // === Tests ===
-    use sui::test_scenario as ts;
+    #[test_only] use sui::test_scenario as ts;
 
     #[test_only] const ADMIN: address = @0xAD;
     #[test_only] const ALICE: address = @0xA;
@@ -80,13 +80,13 @@ module first_package::example {
             ts::next_tx(&mut ts, ADMIN);
 
             // extract the Forge object
-            let forge: Forge = ts::take_from_sender(&mut ts);
+            let forge: Forge = ts::take_from_sender(&ts);
 
             // verify number of created swords
             assert!(swords_created(&forge) == 0, 1);
 
             // return the Forge object to the object pool
-            ts::return_to_sender(&mut ts, forge);
+            ts::return_to_sender(&ts, forge);
         };
 
         ts::end(ts);
@@ -105,18 +105,18 @@ module first_package::example {
         // second transaction executed by admin to create the sword
         {
             ts::next_tx(&mut ts, ADMIN);
-            let forge: Forge = ts::take_from_sender(&mut ts);
+            let forge: Forge = ts::take_from_sender(&ts);
             // create the sword and transfer it to the initial owner
             let sword = new_sword(&mut forge, 42, 7, ts::ctx(&mut ts));
             transfer::public_transfer(sword, ALICE);
-            ts::return_to_sender(&mut ts, forge);
+            ts::return_to_sender(&ts, forge);
         };
 
         // third transaction executed by the initial sword owner
         {
             ts::next_tx(&mut ts, ALICE);
             // extract the sword owned by the initial owner
-            let sword: Sword = ts::take_from_sender(&mut ts);
+            let sword: Sword = ts::take_from_sender(&ts);
             // transfer the sword to the final owner
             transfer::public_transfer(sword, BOB);
         };
@@ -125,11 +125,11 @@ module first_package::example {
         {
             ts::next_tx(&mut ts, BOB);
             // extract the sword owned by the final owner
-            let sword: Sword = ts::take_from_sender(&mut ts);
+            let sword: Sword = ts::take_from_sender(&ts);
             // verify that the sword has expected properties
             assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
             // return the sword to the object pool (it cannot be dropped)
-            ts::return_to_sender(&mut ts, sword)
+            ts::return_to_sender(&ts, sword)
         };
 
         ts::end(ts);

--- a/examples/move/hero/sources/example.move
+++ b/examples/move/hero/sources/example.move
@@ -322,7 +322,7 @@ module hero::example {
     }
 
     // === Tests ===
-    use sui::test_scenario as ts;
+    #[test_only] use sui::test_scenario as ts;
 
     #[test]
     fun slay_boar_test() {

--- a/examples/move/simple_warrior/sources/example.move
+++ b/examples/move/simple_warrior/sources/example.move
@@ -42,7 +42,7 @@ module simple_warrior::example {
     }
 
     // === Tests ===
-    use sui::test_scenario as ts;
+    #[test_only] use sui::test_scenario as ts;
 
     #[test]
     fun test_equip_empty() {

--- a/examples/move/trusted_swap/sources/example.move
+++ b/examples/move/trusted_swap/sources/example.move
@@ -86,7 +86,7 @@ module trusted_swap::example {
     }
 
     // === Tests ===
-    use sui::test_scenario as ts;
+    #[test_only] use sui::test_scenario as ts;
 
     #[test]
     fun successful_swap() {
@@ -115,8 +115,8 @@ module trusted_swap::example {
 
         {
             ts::next_tx(&mut ts, custodian);
-            let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
-            let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+            let s1 = ts::take_from_sender<SwapRequest>(&ts);
+            let s2 = ts::take_from_sender<SwapRequest>(&ts);
 
             let bal = execute_swap(s1, s2);
             let fee = coin::from_balance(bal, ts::ctx(&mut ts));
@@ -176,8 +176,8 @@ module trusted_swap::example {
 
         {
             ts::next_tx(&mut ts, custodian);
-            let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
-            let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+            let s1 = ts::take_from_sender<SwapRequest>(&ts);
+            let s2 = ts::take_from_sender<SwapRequest>(&ts);
             let _fee = execute_swap(s1, s2);
         };
 
@@ -208,8 +208,8 @@ module trusted_swap::example {
 
         {
             ts::next_tx(&mut ts, custodian);
-            let s1 = ts::take_from_sender<SwapRequest>(&mut ts);
-            let s2 = ts::take_from_sender<SwapRequest>(&mut ts);
+            let s1 = ts::take_from_sender<SwapRequest>(&ts);
+            let s2 = ts::take_from_sender<SwapRequest>(&ts);
             let _fee = execute_swap(s1, s2);
         };
 


### PR DESCRIPTION
## Description

Two new recent changes to the Move toolchain have introduced some warnings when building/testing the examples:

- The lint that picks up unnecessary `&mut`.
- Some change that means that imports are now being analysed even if they don't get used, which caused non-test builds to fail on imports of `test_scenario`.

This PR updates the examples to build and test cleanly.

## Test Plan

```
sui-framework-tests$ cargo nextest run
```