### PR TITLE
[Move/Tests] Ensure examples build outside of test mode

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -50,11 +50,14 @@ fn run_examples_move_unit_tests() {
         "nfts",
         "objects_tutorial",
     ] {
-        check_move_unit_tests({
+        let path = {
             let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             buf.extend(["..", "..", "sui_programmability", "examples", example]);
             buf
-        });
+        };
+
+        check_package_builds(path.clone());
+        check_move_unit_tests(path);
     }
 }
 
@@ -70,6 +73,7 @@ fn run_docs_examples_move_unit_tests() -> io::Result<()> {
     for entry in fs::read_dir(examples)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
+            check_package_builds(entry.path());
             check_move_unit_tests(entry.path());
         }
     }
@@ -80,11 +84,26 @@ fn run_docs_examples_move_unit_tests() -> io::Result<()> {
 #[test]
 #[cfg_attr(msim, ignore)]
 fn run_book_examples_move_unit_tests() {
-    check_move_unit_tests({
+    let path = {
         let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         buf.extend(["..", "..", "doc", "book", "examples"]);
         buf
-    });
+    };
+
+    check_package_builds(path.clone());
+    check_move_unit_tests(path);
+}
+
+/// Ensure packages build outside of test mode.
+fn check_package_builds(path: PathBuf) {
+    let mut config = BuildConfig::new_for_testing();
+    config.config.dev_mode = true;
+    config.run_bytecode_verifier = true;
+    config.print_diags_to_stderr = true;
+
+    config
+        .build(path.clone())
+        .unwrap_or_else(|e| panic!("Building package {}.\nWith error {e}", path.display()));
 }
 
 fn check_move_unit_tests(path: PathBuf) {


### PR DESCRIPTION
## Description

A recent change to the toolchain caused the examples to fail to build, because they `use`-d `test_scenario` without guarding the import with `#[test_only]` (fixed in #14512).

Previously this seemed to work because imports were largely ignored unless the imported value was referenced, and at that point, there may be an unbound reference issue.

Now, the imports seem to be eagerly resolved by the compiler, which causes a problem because `test_scenario` is itself a `#[test_only]` module.

This PR introduces an extra step to the CI support for Move tests to also try building example packages in non-test mode, to make sure that continues to work.

This extra step has only been introduced for example packages, because the system package builds are already covered by CI (they already need to build successfully for us to build the node software, CLI, etc).

## Test Plan

```
sui-framework-tests$ cargo nextest run
```