### PR TITLE
[Docs/Examples] Purge References to `sui_programmability`

### DIFF
--- a/docs/content/concepts/object-ownership/immutable.mdx
+++ b/docs/content/concepts/object-ownership/immutable.mdx
@@ -4,7 +4,7 @@ title: Immutable
 
 Objects in Sui can have different types of ownership, with two broad categories: immutable objects and mutable objects. An immutable object is an object that can't be mutated, transferred, or deleted. Immutable objects have no owner, so anyone can use them.
 
-## Create immutable object 
+## Create immutable object
 
 To convert an object into an immutable object, call the `public_freeze_object` function from the [transfer module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/transfer.move):
 
@@ -14,7 +14,7 @@ public native fun public_freeze_object<T: key>(obj: T);
 
 This call makes the specified object immutable. This is a non-reversible operation. You should freeze an object only when you are certain that you don't need to mutate it.
 
-You can see this function's use in one of the [color_object example module](https://github.com/MystenLabs/sui/blob/main/examples/sui-move/color_object/sources/example.move) tests. The test creates a new (owned) `ColorObject`, then calls `public_freeze_object` to turn it into an immutable object.
+You can see this function's use in one of the [color_object example module](https://github.com/MystenLabs/sui/blob/main/examples/move/color_object/sources/example.move) tests. The test creates a new (owned) `ColorObject`, then calls `public_freeze_object` to turn it into an immutable object.
 
 ```rust
 {
@@ -41,7 +41,7 @@ public entry fun create_immutable(red: u8, green: u8, blue: u8, ctx: &mut TxCont
 
 This function creates a new `ColorObject` and immediately makes it immutable before it has an owner.
 
-## Use immutable object 
+## Use immutable object
 
 After an object becomes immutable, the rules of who can use this object in Sui Move calls change:
 You can only pass an immutable object as a read-only, immutable reference to Sui Move entry functions as `&T`.
@@ -57,7 +57,7 @@ public entry fun copy_into(from: &ColorObject, into: &mut ColorObject);
 In this function, anyone can pass an immutable object as the first argument, `from`, but not the second argument.
 Because you can never mutate immutable objects, there's no data race, even when multiple transactions are using the same immutable object at the same time. Hence, the existence of immutable objects does not pose any requirement on consensus.
 
-## Test immutable object 
+## Test immutable object
 
 You can interact with immutable objects in unit tests using `test_scenario::take_immutable<T>` to take an immutable object wrapper from global storage, and `test_scenario::return_immutable` to return the wrapper back to the global storage.
 
@@ -113,7 +113,7 @@ public entry fun update(
 
 As you have learned, the function fails when the `ColorObject` is immutable.
 
-## On-chain interactions 
+## On-chain interactions
 
 First, view the objects you own:
 
@@ -126,7 +126,7 @@ sui client objects $ADDR
 Publish the `ColorObject` code on-chain using the Sui Client CLI:
 
 ```shell
-sui client publish $ROOT/sui_programmability/examples/objects_tutorial --gas-budget 10000
+sui client publish $ROOT/examples/move/color_object --gas-budget 10000
 ```
 
 Set the package object ID to the `$PACKAGE` environment variable as described in previous chapters. Then create a new `ColorObject`:

--- a/docs/content/concepts/object-ownership/immutable.mdx
+++ b/docs/content/concepts/object-ownership/immutable.mdx
@@ -126,13 +126,13 @@ sui client objects $ADDR
 Publish the `ColorObject` code on-chain using the Sui Client CLI:
 
 ```shell
-sui client publish $ROOT/examples/move/color_object --gas-budget 10000
+sui client publish $ROOT/examples/move/color_object --gas-budget <GAS-AMOUNT>
 ```
 
-Set the package object ID to the `$PACKAGE` environment variable as described in previous chapters. Then create a new `ColorObject`:
+Set the package object ID to the `$PACKAGE` environment variable, if you have it set. Then create a new `ColorObject`:
 
 ```shell
-sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" --function "create" --args 0 255 0
+sui client call --gas-budget <GAS-AMOUNT> --package $PACKAGE --module "color_object" --function "create" --args 0 255 0
 ```
 
 Set the newly created object ID to `$OBJECT`. To view the objects in the current active address:
@@ -144,7 +144,7 @@ sui client objects $ADDR
 You should see an object with the ID you used for `$OBJECT`. To turn it into an immutable object:
 
 ```shell
-sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" --function "freeze_object" --args \"$OBJECT\"
+sui client call --gas-budget <GAS-AMOUNT> --package $PACKAGE --module "color_object" --function "freeze_object" --args \"$OBJECT\"
 ```
 
 View the list of objects again:
@@ -168,7 +168,7 @@ Owner: Immutable
 If you try to mutate it:
 
 ```shell
-sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" --function "update" --args \"$OBJECT\" 0 0 0
+sui client call --gas-budget <GAS-AMOUNT> --package $PACKAGE --module "color_object" --function "update" --args \"$OBJECT\" 0 0 0
 ```
 
 The response indicates that you can't pass an immutable object to a mutable argument.

--- a/docs/content/concepts/sui-move-concepts/patterns/id-pointer.mdx
+++ b/docs/content/concepts/sui-move-concepts/patterns/id-pointer.mdx
@@ -106,8 +106,5 @@ module examples::lock_and_key {
 
 This pattern is used in these examples:
 
-- [Lock](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/basics/sources/lock.move)
-- [Escrow](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/defi/sources/escrow.move)
-- [Hero](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/games/sources/hero.move)
-- [Tic Tac Toe](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/games/sources/tic_tac_toe.move)
-- [Auction](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/nfts/sources/auction.move)
+- [Escrow](https://github.com/MystenLabs/sui/blob/main/examples/move/escrow/sources/example.move)
+- [Hero](https://github.com/MystenLabs/sui/blob/main/examples/move/hero/sources/example.move)

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -25,17 +25,17 @@ For example, the following `init` functions are all valid:
 
 While the `sui move` command does not support publishing explicitly, you can still test module initializers using the testing framework by dedicating the first transaction to executing the initializer function.
 
-Continuing the fantasy game example, the `init` function should create a `Forge` object. 
+Continuing the fantasy game example, the `init` function should create a `Forge` object.
 
 ``` rust
-    // Module initializer to be executed when this module is published
+    /// Module initializer to be executed when this module is published
     fun init(ctx: &mut TxContext) {
         let admin = Forge {
             id: object::new(ctx),
             swords_created: 0,
         };
-        // Transfer the Forge object to the module/package publisher
-        // (presumably the game admin)
+
+        // transfer the forge object to the module/package publisher
         transfer::transfer(admin, tx_context::sender(ctx));
     }
 ```
@@ -44,45 +44,55 @@ The tests you have so far call the `init` function, but the initializer function
 created swords at the end of the function:
 
 ``` rust
-    public entry fun sword_create(forge: &mut Forge, magic: u64, strength: u64, recipient: address, ctx: &mut TxContext) {
-        ...
+    /// Constructor for creating swords
+    public fun new_sword(
+        forge: &mut Forge,
+        magic: u64,
+        strength: u64,
+        ctx: &mut TxContext,
+    ): Sword {
         forge.swords_created = forge.swords_created + 1;
+        // ...
     }
 ```
 
 Now, create a function to test the module initialization:
 
 ``` rust
+    #[test_only] use sui::test_scenario as ts;
+
+    #[test_only] const ADMIN: address = @0xAD;
+
     #[test]
     public fun test_module_init() {
-        use sui::test_scenario;
+        let ts = ts::begin(@0x0);
 
-        // Create test address representing game admin
-        let admin = @0xBABE;
-
-        // First transaction to emulate module initialization
-        let scenario_val = test_scenario::begin(admin);
-        let scenario = &mut scenario_val;
+        // first transaction to emulate module initialization.
         {
-            init(test_scenario::ctx(scenario));
+            ts::next_tx(&mut ts, ADMIN);
+            init(ts::ctx(&mut ts));
         };
-        // Second transaction to check if the forge has been created
+
+        // second transaction to check if the forge has been created
         // and has initial value of zero swords created
-        test_scenario::next_tx(scenario, admin);
         {
-            // Extract the Forge object
-            let forge = test_scenario::take_from_sender<Forge>(scenario);
-            // Verify number of created swords
-            assert!(swords_created(&forge) == 0, 1);
-            // Return the Forge object to the object pool
-            test_scenario::return_to_sender(scenario, forge);
-        };
-        test_scenario::end(scenario_val);
-    }
+            ts::next_tx(&mut ts, ADMIN);
 
+            // extract the Forge object
+            let forge: Forge = ts::take_from_sender(&mut ts);
+
+            // verify number of created swords
+            assert!(swords_created(&forge) == 0, 1);
+
+            // return the Forge object to the object pool
+            ts::return_to_sender(&mut ts, forge);
+        };
+
+        ts::end(ts);
+    }
 ```
 
 As the new test function shows, the first transaction (explicitly) calls the initializer. The next transaction checks if the `Forge` object has been created and properly initialized.
 
 If you try to run tests on the whole package at this point, you encounter compilation errors in the existing tests because of the
-`sword_create` function signature change. The changes required for the tests to run again is an exercise left for you. If you need help, you can refer to the source code for the package (with all the tests properly adjusted) in [my_module.move](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples/move_tutorial/sources/my_module.move).
+`new_sword` function signature change. The changes required for the tests to run again is an exercise left for you. If you need help, you can refer to the source code for the package (with all the tests properly adjusted) in [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move).

--- a/docs/content/guides/developer/getting-started/sui-environment.mdx
+++ b/docs/content/guides/developer/getting-started/sui-environment.mdx
@@ -3,7 +3,7 @@ title: Sui Environment Setup
 description: Get the background information you need before you start developing on Sui. Learn the layout of the Sui monorepository and the suggested develoment environment for working with Move.
 ---
 
-Before you start developing with Sui and Move, you should familiarize yourself with how to contribute to Sui, how Sui is structured, what tools and SDKs exist, and what plugins are available to use in your IDE. 
+Before you start developing with Sui and Move, you should familiarize yourself with how to contribute to Sui, how Sui is structured, what tools and SDKs exist, and what plugins are available to use in your IDE.
 
 ## Fork the Sui repository {#fork}
 
@@ -20,7 +20,7 @@ To create a local Sui repository:
 
     ![Copy URL](./images/gh-url.png)
 
-1. Open a terminal or console on your system at the location you want to save the repository locally. Type `git clone ` and paste the URL you copied in the previous step and press `Enter`. 
+1. Open a terminal or console on your system at the location you want to save the repository locally. Type `git clone ` and paste the URL you copied in the previous step and press `Enter`.
 1. Type `cd sui` to make `sui` the active directory.
 
 You can use any [branching strategy](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) you prefer on your Sui fork. Make your changes locally and push to your repository, submitting PRs to the official Sui repository from your fork as needed.
@@ -34,7 +34,7 @@ Be sure to synchronize your fork frequently to keep it up-to-date with active de
 
 ## Using Sui from command line
 
-You can interact with the Sui network through two official SDKs (TypeScript SDK and Rust SDK), and by using the Sui CLI. For more details about using the Sui CLI, see [Install Sui](./sui-install.mdx) and the [Sui CLI](/references/cli.mdx) reference. 
+You can interact with the Sui network through two official SDKs (TypeScript SDK and Rust SDK), and by using the Sui CLI. For more details about using the Sui CLI, see [Install Sui](./sui-install.mdx) and the [Sui CLI](/references/cli.mdx) reference.
 
 ## Move IDEs and plugins
 
@@ -46,24 +46,24 @@ cargo install --git https://github.com/move-language/move move-analyzer --branch
 
 See more [IDE options](https://github.com/MystenLabs/awesome-move#ides) in the [Awesome Move](https://github.com/MystenLabs/awesome-move) documentation.
 
-After you install VS Code and the `move-analyzer` extension, see the [sui_programmability](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples) for Move code examples.
+After you install VS Code and the `move-analyzer` extension, check out the [Move code examples](https://github.com/MystenLabs/sui/tree/main/examples/move).
 
-To test or run a Move example on Sui, use the `sui move` command from the Sui CLI. 
+To test or run a Move example on Sui, use the `sui move` command from the Sui CLI.
 
 ## Sui repository and how to contribute
 
-The Sui repo is a monorepo, containing all the source code that is used to build and run the Sui network, as well as this documentation. 
+The Sui repo is a monorepo, containing all the source code that is used to build and run the Sui network, as well as this documentation.
 
-The root folder of the Sui monorepo has the following top-level folders: 
+The root folder of the Sui monorepo has the following top-level folders:
 
 - [apps](https://github.com/MystenLabs/sui/tree/main/apps): Contains the source code for the main web applications that Mysten Labs runs, such as the `suiexplorer.com` or the `Sui Wallet`.
-- [crates](https://github.com/MystenLabs/sui/tree/main/crates): Contains all the Rust crates that are part of the Sui system. 
+- [crates](https://github.com/MystenLabs/sui/tree/main/crates): Contains all the Rust crates that are part of the Sui system.
 - [dapps](https://github.com/MystenLabs/sui/tree/main/dapps): Contains some examples of decentralized applications built on top of Sui, such as Kiosk or Sponsored Transactions.
 - [dashboards](https://github.com/MystenLabs/sui/tree/main/dashboards): Currently empty.
 - [doc](https://github.com/MystenLabs/sui/tree/main/doc): Contains deprecated documentation related to Move and Sui.
 - [docker](https://github.com/MystenLabs/sui/tree/main/docker): Contains the docker files needed to spin up a node, an indexer, a Full node or other services.
 - [docs](https://github.com/MystenLabs/sui/tree/main/docs): Contains this documentation and the source for this site.
-- [examples](https://github.com/MystenLabs/sui/tree/main/examples): Contains examples of smart contracts written in Move.
+- [examples](https://github.com/MystenLabs/sui/tree/main/examples): Contains examples of apps written for Sui and smart contracts written in Move.
 - [external-crates](https://github.com/MystenLabs/sui/tree/main/external-crates): Contains the source code for the Move programming language.
 - [kiosk](https://github.com/MystenLabs/sui/tree/main/kiosk): Contains the source code of the Mysten Labs Kiosk extensions and rules, as well as examples.
 - [narwhal](https://github.com/MystenLabs/sui/tree/main/narwhal): Contains the source code of Narwhal and partially synchronous Bullshark, a DAG-based mempool, and efficient BFT consensus.
@@ -71,11 +71,10 @@ The root folder of the Sui monorepo has the following top-level folders:
 - [scripts](https://github.com/MystenLabs/sui/tree/main/scripts): Contains a number of scripts that are used internally.
 - [sdk](https://github.com/MystenLabs/sui/tree/main/sdk): Contains the source code for different tools and SDKs, such as the Sui TypeScript SDK, Kiosk SDK, BCS, zkLogin, dApp kit, and others.
 - [sui-execution](https://github.com/MystenLabs/sui/tree/main/sui-execution): Contains the source code responsible for abstracting access to the execution layer.
-- [sui_programmability/examples](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples): Contains lots of Move code examples, partitioned by category, that are provided for demonstration purposes only.
 
 The following primary directories offer a good starting point for exploring the Sui codebase:
 
-- [explorer](https://github.com/MystenLabs/sui/tree/main/apps/explorer) - Browser-based object explorer for the Sui network. See the deployed application [here](https://suiexplorer.com). 
+- [explorer](https://github.com/MystenLabs/sui/tree/main/apps/explorer) - Browser-based object explorer for the Sui network. See the deployed application [here](https://suiexplorer.com).
 - [move](https://github.com/MystenLabs/sui/tree/main/external-crates/move) - Move VM, compiler, and tools.
 - [narwhal](https://github.com/MystenLabs/sui/tree/main/narwhal) - Mempool and consensus.
 - [typescript-sdk](https://github.com/MystenLabs/sui/tree/main/sdk/typescript/) - the Sui TypeScript SDK.
@@ -86,7 +85,6 @@ The following primary directories offer a good starting point for exploring the 
 - [sui-framework](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework) - Move system packages (0x1, 0x2, 0x3, 0xdee9).
 - [sui-network](https://github.com/MystenLabs/sui/tree/main/crates/sui-network) - Networking interfaces.
 - [sui-node](https://github.com/MystenLabs/sui/tree/main/crates/sui-node) - Validator and Full node software.
-- [sui_programmability](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples) - Move code examples.
 - [sui-protocol-config](https://github.com/MystenLabs/sui/tree/main/crates/sui-protocol-config) - On-chain system configuration and limits.
 - [sui-sdk](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) - The Sui Rust SDK.
 - [sui-types](https://github.com/MystenLabs/sui/tree/main/crates/sui-types) - Sui object types, such as coins and gas.

--- a/docs/content/references/cli/client.mdx
+++ b/docs/content/references/cli/client.mdx
@@ -47,17 +47,17 @@ Commands:
 Options:
   	--client.config <CONFIG>  Sets the file storing the state of our user accounts (an empty one will be created if missing)
   	--json                	Return command outputs in json format
-  -y, --yes                	 
+  -y, --yes
   -h, --help                	Print help
 ```
 
 ## JSON output
 
-Append the `--json` flag to commands to format responses in JSON instead of the more human-friendly default Sui CLI output. This can be useful for extremely large datasets, for example, as those results can have a troublesome display on smaller screens. In these cases, the `--json` flag is useful. 
+Append the `--json` flag to commands to format responses in JSON instead of the more human-friendly default Sui CLI output. This can be useful for extremely large datasets, for example, as those results can have a troublesome display on smaller screens. In these cases, the `--json` flag is useful.
 
 ## Examples
 
-The following examples demonstrate some of the most often used commands. 
+The following examples demonstrate some of the most often used commands.
 
 ### List available network environments
 
@@ -95,7 +95,7 @@ If you run `sui client envs` after this command, you see the asterisk in the `ac
 
 ### Get current active environment
 
-Use the `sui client active-address` command to reveal the current address. The CLI uses the current active address to execute address-specific CLI commands (like `sui client objects`) when you don't provide them with a Sui address value. 
+Use the `sui client active-address` command to reveal the current address. The CLI uses the current active address to execute address-specific CLI commands (like `sui client objects`) when you don't provide them with a Sui address value.
 
 ```shell
 $ sui client active-address
@@ -104,12 +104,12 @@ $ sui client active-address
 
 ### Get objects owned by an address
 
-Use `sui client objects` to list summary information about the objects the current active address owns. You can provide a Sui address value to the command to list objects for a particular address. This example lists objects for the defined Sui address.  
+Use `sui client objects` to list summary information about the objects the current active address owns. You can provide a Sui address value to the command to list objects for a particular address. This example lists objects for the defined Sui address.
 
 ```
 $ sui client objects 0x36df11369cf00ecf0be68d6ba965b0abe2e883bc5245911e3a29ebfa0aaf6b69
 
-╭───────────────────────────────────────────────────────────────────────────────────────╮ 
+╭───────────────────────────────────────────────────────────────────────────────────────╮
 | ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
 │ │ objectId   │  0xfffbb30ccb631f15f6cd36700589fc9c31cb04af28a95f3ed26d62daf3acb57f  │ │       |
 │ │ version	   │  33363559                                                        	  │ │
@@ -127,7 +127,7 @@ $ sui client objects 0x36df11369cf00ecf0be68d6ba965b0abe2e883bc5245911e3a29ebfa0
 
 ### Get complete object information
 
-Use `sui client object <OBJECT-ID>` to output complete details for the object with the ID you provide. This example checks the details for a Coin object. 
+Use `sui client object <OBJECT-ID>` to output complete details for the object with the ID you provide. This example checks the details for a Coin object.
 
 ```
 $ sui client object 0xfffbb30ccb631f15f6cd36700589fc9c31cb04af28a95f3ed26d62daf3acb57f
@@ -181,16 +181,16 @@ $ sui client dynamic-field 0x5
 
 ## Publish a Move package
 
-One of the main uses of the `sui client` command is to publish smart contracts on the Sui network. This example switches the current environment to the Devnet network, then builds, tests, and publishes one of the existing Move examples available in the Sui repository: `https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples` 
+One of the main uses of the `sui client` command is to publish smart contracts on the Sui network. This example switches the current environment to the Devnet network, then builds, tests, and publishes one of the existing Move examples available in the Sui repository: `https://github.com/MystenLabs/sui/tree/main/examples/move`
 
-This example also makes use of `sui move` commands. To learn more about those commands, see [Sui Move CLI](./move.mdx). 
+This example also makes use of `sui move` commands. To learn more about those commands, see [Sui Move CLI](./move.mdx).
 
-1. Open a terminal or console to the root of your local Sui repository and navigate to the move_tutorial example. 
+1. Open a terminal or console to the root of your local Sui repository and navigate to the move_tutorial example.
     ```shell
-    cd sui_programmability/examples
-    cd move_tutorial
+    cd examples/move
+    cd first_package
     ```
-1. Switch to the Devnet network. This command uses an alias, so the `devnet` value might be different for you, depending on the alias name set in your configuration. 
+1. Switch to the Devnet network. This command uses an alias, so the `devnet` value might be different for you, depending on the alias name set in your configuration.
     ```shell
     sui client switch --env devnet
     ```
@@ -199,20 +199,19 @@ This example also makes use of `sui move` commands. To learn more about those co
     sui move build
     INCLUDING DEPENDENCY Sui
     INCLUDING DEPENDENCY MoveStdlib
-    BUILDING MyFirstPackage
+    BUILDING first_package
     ```
 1. Use `sui move test` to run the unit tests. The console responds with updates of its progress.
     ```shell
     sui move test
     INCLUDING DEPENDENCY Sui
     INCLUDING DEPENDENCY MoveStdlib
-    BUILDING MyFirstPackage
+    BUILDING first_package
     Running Move unit tests
-    [ PASS	] 0x0::my_module::test_module_init
-    [ PASS	] 0x0::my_module::test_sword_create
-    [ PASS	] 0x0::my_module::test_sword_transactions
-    Test result: OK. Total tests: 3; passed: 3; failed: 0
-    ```
+    [ PASS    ] 0x0::example::test_module_init
+    [ PASS    ] 0x0::example::test_sword_transactions
+    Test result: OK. Total tests: 2; passed: 2; failed: 0
+     ```
 1. Use the `sui client verify-bytecode-meter` to check if the module passes the bytecode meter. The console responds with the maximum allowed values as well as the amount the package uses.
     ```shell
     $ sui client verify-bytecode-meter
@@ -220,9 +219,9 @@ This example also makes use of `sui move` commands. To learn more about those co
     ╭──────────────────────────────────╮
     │ Module will pass metering check! │
     ├────────┬────────────┬────────────┤
-    │    	 │ Module 	  │ Function   │
-    │ Max	 │ 16000000   │ 16000000   │
-    │ Used   │ 5265   	  │ 5265   	   │
+    │        │ Module     │ Function   │
+    │ Max    │ 16000000   │ 16000000   │
+    │ Used   │ 4565       │ 4565       │
     ╰────────┴────────────┴────────────╯
     ```
 1. Use `sui client gas` to verify that the active address has a gas coin for paying gas. In the case of this example, the console responds with the information that the address is coinless.
@@ -250,7 +249,7 @@ This example also makes use of `sui move` commands. To learn more about those co
     │ 0x2f3799d094573b0958eef703b95996fe459bb00afc2d09866335c30cf480e522 │ 10000000000 │
     ╰────────────────────────────────────────────────────────────────────┴─────────────╯
     ```
-1. Use `sui client publish` to publish the package, being sure to set an appropriate value for the `gas-budget` flag. The console responds with the details of the publish. You can use `sui client object <OBJECT-ID>` to check the details of any of the objects from the process. 
+1. Use `sui client publish` to publish the package, being sure to set an appropriate value for the `gas-budget` flag. The console responds with the details of the publish. You can use `sui client object <OBJECT-ID>` to check the details of any of the objects from the process.
     ```shell
     $ sui client publish --gas-budget 5000000
 

--- a/docs/content/references/cli/move.mdx
+++ b/docs/content/references/cli/move.mdx
@@ -7,15 +7,15 @@ The Sui Move CLI provides several commands for working with Move source code. A 
 
 ## Commands
 
-Typing `sui move --help` into your terminal or console displays the following information on available commands. 
+Typing `sui move --help` into your terminal or console displays the following information on available commands.
 
 ```
 Usage: sui move [OPTIONS] <COMMAND>
 
 Commands:
-  build   	 
+  build
   coverage 	Inspect test coverage for this package. A previous test run with the `--coverage` flag must have previously been run
-  disassemble  
+  disassemble
   new      	Create a new Move package with name `name` at `path`. If `path` is not provided the package will be created in the directory `name`
   prove    	Run the Move Prover on the package at `path`. If no path is provided defaults to current directory. Use `.. prove .. -- <options>` to pass on options to the
                	prover
@@ -42,7 +42,7 @@ Options:
 
 ## Examples
 
-The following examples demonstrate some of the most often used commands. 
+The following examples demonstrate some of the most often used commands.
 
 ### Create a new Move project
 
@@ -84,7 +84,7 @@ BUILDING smart_contract_test
 Use `sui move test` to run the tests in a Move package.
 
 ```shell
-$ sui move test    	 
+$ sui move test
 UPDATING GIT DEPENDENCY https://github.com/MystenLabs/sui.git
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
@@ -95,87 +95,29 @@ Test result: OK. Total tests: 0; passed: 0; failed: 0
 
 ### Get test coverage for a module
 
-This example uses the `nfts` example from [sui_programmability folder](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples) in the Sui repository.
 
-To get the a summary of the test coverage, you must first run the `sui move test --coverage` command, and then the `sui move coverage summary` to get a summary of the test coverage in the `nfts` Move example project.
+This example uses [`first_package`](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package) Move package.
+
+To get the a summary of the test coverage, you must first run the `sui move test --coverage` command, and then the `sui move coverage summary --test` to get a summary of the test coverage in the example project.
 
 ```shell
 $ sui move test --coverage
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
-BUILDING NFTs
-warning[W09011]: unused constant
-   ┌─ ./tests/cross_chain_airdrop_tests.move:13:11
-   │
-13 │ 	const ETOKEN_ID_CLAIMED: u64 = 0;
-   │       	^^^^^^^^^^^^^^^^^ The constant 'ETOKEN_ID_CLAIMED' is never used. Consider removing it.
-   │
-   = This warning can be suppressed with '#[allow(unused_const)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09009]: unused struct field
-   ┌─ ./tests/cross_chain_airdrop_tests.move:24:9
-   │
-24 │     	id: UID,
-   │     	^^ The 'id' field of the 'Object' type is unused
-   │
-   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09011]: unused constant
-   ┌─ ./sources/geniteam.move:20:11
-   │
-20 │ 	const EMonsterCollectionNotOwnedByFarm: u64 = 2;
-   │       	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The constant 'EMonsterCollectionNotOwnedByFarm' is never used. Consider removing it.
-   │
-   = This warning can be suppressed with '#[allow(unused_const)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09011]: unused constant
-   ┌─ ./sources/geniteam.move:23:11
-   │
-23 │ 	const EInventoryNotOwnedByPlayer: u64 = 3;
-   │       	^^^^^^^^^^^^^^^^^^^^^^^^^^ The constant 'EInventoryNotOwnedByPlayer' is never used. Consider removing it.
-   │
-   = This warning can be suppressed with '#[allow(unused_const)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
+BUILDING first_package
 Running Move unit tests
-[ PASS	] 0x0::chat_tests::test_chat
-[ PASS	] 0x0::discount_coupon_tests::test_mint_then_transfer
-[ PASS	] 0x0::devnet_nftTests::mint_transfer_update
-[ PASS	] 0x0::cross_chain_airdrop_tests::test_claim_airdrop
-[ PASS	] 0x0::shared_auction_tests::simple_auction_test
-[ PASS	] 0x0::auction_tests::simple_auction_test
-[ PASS	] 0x0::cross_chain_airdrop_tests::test_double_claim
-Test result: OK. Total tests: 7; passed: 7; failed: 0
+[ PASS    ] 0x0::example::test_module_init
+[ PASS    ] 0x0::example::test_sword_transactions
+Test result: OK. Total tests: 2; passed: 2; failed: 0
 
-$ sui move coverage --summary
+$ sui move coverage summary --test
 +-------------------------+
 | Move Coverage Summary   |
 +-------------------------+
-Module 0000000000000000000000000000000000000000000000000000000000000000::auction_lib
->>> % Module coverage: 84.68
-Module 0000000000000000000000000000000000000000000000000000000000000000::auction
->>> % Module coverage: 89.09
-Module 0000000000000000000000000000000000000000000000000000000000000000::chat
->>> % Module coverage: 60.00
-Module 0000000000000000000000000000000000000000000000000000000000000000::erc721_metadata
->>> % Module coverage: 59.09
-Module 0000000000000000000000000000000000000000000000000000000000000000::cross_chain_airdrop
->>> % Module coverage: 91.43
-Module 0000000000000000000000000000000000000000000000000000000000000000::devnet_nft
->>> % Module coverage: 87.76
-Module 0000000000000000000000000000000000000000000000000000000000000000::discount_coupon
->>> % Module coverage: 54.55
-Module 0000000000000000000000000000000000000000000000000000000000000000::typed_id
->>> % Module coverage: 0.00
-Module 0000000000000000000000000000000000000000000000000000000000000000::geniteam
->>> % Module coverage: 0.00
-Module 0000000000000000000000000000000000000000000000000000000000000000::marketplace
->>> % Module coverage: 0.00
-Module 0000000000000000000000000000000000000000000000000000000000000000::num
->>> % Module coverage: 0.00
-Module 0000000000000000000000000000000000000000000000000000000000000000::shared_auction
->>> % Module coverage: 82.86
+Module 0000000000000000000000000000000000000000000000000000000000000000::example
+>>> % Module coverage: 92.81
 +-------------------------+
-| % Move Coverage: 40.36  |
+| % Move Coverage: 92.81  |
 +-------------------------+
 ```
 
@@ -184,7 +126,7 @@ Module 0000000000000000000000000000000000000000000000000000000000000000::shared_
 Each command has its own help section. For example `sui move build –help` displays the following prompt:
 
 ```shell
-$ sui move build --help    
+$ sui move build --help
 Usage: sui move build [OPTIONS]
 
 Options:


### PR DESCRIPTION
## Description

Examples in `sui_programmability` are out-of-date, and we should prefer referencing examples in `examples/move` instead.  This PR gets updates most references to `sui_programmability` in the docs, leaving only two to be picked up in follow-ups:

- Flash Lender
- Shared vs Owned Objects

Where in both these cases more examples need to be modernised and ported to `examples/move` to remove the existing reference.

## Test Plan

:eyes: