### PR TITLE
[Docs/Install Sui] Tweak "Next Steps"

### DIFF
--- a/docs/content/guides/developer/getting-started/sui-install.mdx
+++ b/docs/content/guides/developer/getting-started/sui-install.mdx
@@ -27,12 +27,12 @@ Each Sui release provides a set of binaries for several operating systems. You c
 1. Click the release tagged **Latest** to open the release's page.
 1. In the **Assets** section of the release, select the .tgz compressed file that corresponds to your operating system.
 1. Double-click the downloaded file. If the file doesn't automatically expand, manually unzip the file.
-1. Open the expanded folder and double-click the appropriate binary to install, beginning with sui-`<OS>`-`<ARCHITECTURE>`:  
+1. Open the expanded folder and double-click the appropriate binary to install, beginning with sui-`<OS>`-`<ARCHITECTURE>`:
 
-    - sui-faucet-`<OS>`-`<ARCHITECTURE>`: Local faucet to mint coins on local network.  
-    - sui-indexer-`<OS>`-`<ARCHITECTURE>`: An indexer for a local Sui network.  
-    - sui-`<OS>`-`<ARCHITECTURE>`: Main Sui binary.  
-    - sui-node-`<OS>`-`<ARCHITECTURE>`: Run a local node.  
+    - sui-faucet-`<OS>`-`<ARCHITECTURE>`: Local faucet to mint coins on local network.
+    - sui-indexer-`<OS>`-`<ARCHITECTURE>`: An indexer for a local Sui network.
+    - sui-`<OS>`-`<ARCHITECTURE>`: Main Sui binary.
+    - sui-node-`<OS>`-`<ARCHITECTURE>`: Run a local node.
     - sui-test-validator-`<OS>`-`<ARCHITECTURE>`: Run test validators on a local network for development.
     - sui-tool-`<OS>`-`<ARCHITECTURE>`: Provides utilities for Sui.
 
@@ -209,7 +209,7 @@ sudo apt-get install build-essential
 
 </TabItem>
 
-<TabItem value="mac" label="macOS">  
+<TabItem value="mac" label="macOS">
 
 The prerequisites needed for the macOS operating system include:
 
@@ -304,16 +304,16 @@ Sui requires the following additional tools on computers running Windows.
 - The [LLVM Compiler Infrastructure](https://releases.llvm.org/). Look for a file with a name similar to LLVM-15.0.7-win64.exe for 64-bit Windows, or LLVM-15.0.7-win32.exe for 32-bit Windows.
 
 **Known issue** - The `sui console` command does not work in PowerShell.
-        
+
 </TabItem>
 
 </Tabs>
 
 ## Next steps {#next-steps}
 
-Now that you have Sui installed, it's time to start developing. Checkout the following topics to start working with Sui:
+Now that you have Sui installed, it's time to start developing. Check out the following topics to start working with Sui:
 
-- [Get coins](./get-coins.mdx) - Get some coins on a development network to start using Sui.
-- [Connect to a Sui network](./connect.mdx) - Learn about the available networks and connect to one.
-- [Sui CLI](/references/cli.mdx) - The Sui CLI is the most straightforward way to start exploring Sui networks.
-- [Build your first dApp](../first-app.mdx) - You have Sui, time to start your on-chain journey.
+- Read about the [Sui CLI](/references/cli.mdx), the most straightforward way to start exploring Sui networks.
+- [Learn about the available networks](./connect.mdx) and connect to one.
+- [Get some coins](./get-coins.mdx) on a development network.
+- [Build your first dApp](../first-app.mdx) to start your on-chain journey.


### PR DESCRIPTION
## Description

- Make the order of "Next Steps" match the order in the sidebar/IA.
- Reduce repetition of references to "start"-ing.
- Re-word bullet about the "Sui CLI" reference -- that page is not a guide, so it needs a different call-to-action from the other next steps (to make it clear what the action is -- i.e. just read this page).

## Test Plan

:eyes: