### PR TITLE
[Docs/Witness] Reword

### DIFF
--- a/docs/content/concepts/sui-move-concepts/patterns/witness.mdx
+++ b/docs/content/concepts/sui-move-concepts/patterns/witness.mdx
@@ -2,7 +2,7 @@
 title: Witness
 ---
 
-A witness is a pattern you use to confirm the ownership of a type. To do so, pass a `drop` instance of a type. `Coin` relies on this implementation.
+A witness is a type with `drop` that proves that its owner was present at the time of some privileged operation, for example having access to the "one-time witness" for a module proves that the code is being run at the time the module was first published. `Coin` uses this pattern to ensure its treasury is only created once.
 
 ```rust
 /// Module that defines a generic type `Guardian<T>` which can only be
@@ -51,5 +51,5 @@ module examples::peace_guardian {
 
 This pattern is used in these examples:
 
-    - Liquidity pool
-    - Regulated coin
+- Liquidity pool
+- Regulated coin


### PR DESCRIPTION
## Description

Witnesses are not about proving ownership -- they are proof that a thing happened, usually a privileged operation (that not anyone could witness).

Also fix the list formatting (was being interpreted as a code block).

## Test Plan

:eyes: