### PR TITLE
[Narwhal] speed up batch processing of fetched certificates

### DIFF
--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -15,7 +15,6 @@ use narwhal_types::{validate_batch_version, BatchAPI};
 use narwhal_worker::TransactionValidator;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use tap::TapFallible;
-use tokio::runtime::Handle;
 use tracing::{info, warn};
 
 /// Allows verifying the validity of transactions
@@ -105,16 +104,12 @@ impl TransactionValidator for SuiTxValidator {
         // verify the certificate signatures as a batch
         let cert_count = cert_batch.len();
         let ckpt_count = ckpt_batch.len();
-        let epoch_store = self.epoch_store.clone();
-        Handle::current()
-            .spawn_blocking(move || {
-                epoch_store
-                    .signature_verifier
-                    .verify_certs_and_checkpoints(cert_batch, ckpt_batch)
-                    .tap_err(|e| warn!("batch verification error: {}", e))
-                    .wrap_err("Malformed batch (failed to verify)")
-            })
-            .await??;
+
+        self.epoch_store
+            .signature_verifier
+            .verify_certs_and_checkpoints(cert_batch, ckpt_batch)
+            .tap_err(|e| warn!("batch verification error: {}", e))
+            .wrap_err("Malformed batch (failed to verify)")?;
 
         // All checkpoint sigs have been verified, forward them to the checkpoint service
         for ckpt in ckpt_messages {

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -42,8 +42,6 @@ struct PrimaryNodeInner {
 }
 
 impl PrimaryNodeInner {
-    /// The default channel capacity.
-    pub const CHANNEL_CAPACITY: usize = 1_000;
     /// The window where the schedule change takes place in consensus. It represents number
     /// of committed sub dags.
     /// TODO: move this to node properties
@@ -212,7 +210,7 @@ impl PrimaryNodeInner {
         )
         .unwrap();
         let (tx_new_certificates, rx_new_certificates) =
-            metered_channel::channel(Self::CHANNEL_CAPACITY, &new_certificates_counter);
+            metered_channel::channel(primary::CHANNEL_CAPACITY, &new_certificates_counter);
 
         let committed_certificates_counter = IntGauge::new(
             PrimaryChannelMetrics::NAME_COMMITTED_CERTS,
@@ -220,7 +218,7 @@ impl PrimaryNodeInner {
         )
         .unwrap();
         let (tx_committed_certificates, rx_committed_certificates) =
-            metered_channel::channel(Self::CHANNEL_CAPACITY, &committed_certificates_counter);
+            metered_channel::channel(primary::CHANNEL_CAPACITY, &committed_certificates_counter);
 
         // Compute the public key of this authority.
         let name = keypair.public().clone();
@@ -307,7 +305,7 @@ impl PrimaryNodeInner {
         let channel_metrics = ChannelMetrics::new(registry);
 
         let (tx_sequence, rx_sequence) =
-            metered_channel::channel(Self::CHANNEL_CAPACITY, &channel_metrics.tx_sequence);
+            metered_channel::channel(primary::CHANNEL_CAPACITY, &channel_metrics.tx_sequence);
 
         // Check for any sub-dags that have been sent by consensus but were not processed by the executor.
         let restored_consensus_output = get_restored_consensus_output(

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -21,10 +21,9 @@ use std::{
 };
 use storage::CertificateStore;
 use sui_protocol_config::ProtocolConfig;
-use tokio::task::{spawn_blocking, JoinSet};
 use tokio::{
     sync::watch,
-    task::JoinHandle,
+    task::{spawn_blocking, JoinHandle, JoinSet},
     time::{sleep, timeout, Instant},
 };
 use tracing::{debug, error, instrument, trace, warn};

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -6,14 +6,12 @@ use crate::{metrics::PrimaryMetrics, synchronizer::Synchronizer};
 use anemo::Request;
 use config::{AuthorityIdentifier, Committee};
 use crypto::NetworkPublicKey;
-use fastcrypto::hash::Hash;
 use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use mysten_metrics::metered_channel::Receiver;
 use mysten_metrics::{monitored_future, monitored_scope, spawn_logged_monitored_task};
 use network::PrimaryToPrimaryRpc;
 use rand::{rngs::ThreadRng, seq::SliceRandom};
-use std::collections::HashSet;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
@@ -27,12 +25,11 @@ use tokio::{
     time::{sleep, timeout, Instant},
 };
 use tracing::{debug, error, instrument, trace, warn};
-use types::CertificateDigest;
 use types::{
     error::{DagError, DagResult},
     validate_received_certificate_version, Certificate, CertificateAPI,
     ConditionalBroadcastReceiver, FetchCertificatesRequest, FetchCertificatesResponse, HeaderAPI,
-    Round, SignatureVerificationState,
+    Round,
 };
 
 #[cfg(test)]
@@ -50,13 +47,6 @@ const PARALLEL_FETCH_REQUEST_ADDITIONAL_TIMEOUT: Duration = Duration::from_secs(
 // Batch size is chosen so that verifying a batch takes non-trival
 // time (verifying a batch of 200 certificates should take > 100ms).
 const VERIFY_CERTIFICATES_BATCH_SIZE: usize = 200;
-// Number of certificates to verify in a batch. Verifications in each batch run serially.
-// Batch size is chosen so that verifying a batch takes non-trival
-// time (verifying a batch of 50 certificates should take > 25ms).
-const VERIFY_CERTIFICATES_V2_BATCH_SIZE: usize = 50;
-// Number of rounds to force verfication of certificates by signature, to bound the maximum
-// number of certificates with bad signatures in storage.
-const CERTIFICATE_VERIFICATION_ROUND_INTERVAL: u64 = 50;
 
 #[derive(Clone, Debug)]
 pub enum CertificateFetcherCommand {
@@ -464,18 +454,32 @@ async fn process_certificates_helper(
             MAX_CERTIFICATES_TO_FETCH,
         ));
     }
+
+    // We should not be getting mixed versions of certificates from a
+    // validator, so any individual certificate with mismatched versions
+    // should cancel processing for the entire batch of fetched certificates.
+    let certificates = response
+        .certificates
+        .into_iter()
+        .map(|cert| {
+            validate_received_certificate_version(cert, protocol_config).map_err(|err| {
+                error!("fetched certficate processing error: {err}");
+                DagError::InvalidCertificateVersion
+            })
+        })
+        .collect::<DagResult<Vec<Certificate>>>()?;
+
     // In PrimaryReceiverHandler, certificates already in storage are ignored.
     // The check is unnecessary here, because there is no concurrent processing of older
     // certificates. For byzantine failures, the check will not be effective anyway.
-    let _verify_scope = monitored_scope("VerifyingFetchedCertificates");
+    let _scope = monitored_scope("ProcessingFetchedCertificates");
 
-    // Verify certificates in parallel. If we are using CertificateV2 only verify
-    // the tip of a certificate chain and verify the parent certificates of that tip
-    // indirectly.
     if protocol_config.narwhal_certificate_v2() {
-        process_certificates_v2_helper(protocol_config, response, synchronizer, metrics).await?;
+        synchronizer
+            .try_accept_fetched_certificates(certificates)
+            .await?;
     } else {
-        process_certificates_v1_helper(protocol_config, response, synchronizer, metrics).await?;
+        process_certificates_v1_helper(certificates, synchronizer, metrics).await?;
     }
 
     trace!("Fetched certificates have been processed");
@@ -483,25 +487,13 @@ async fn process_certificates_helper(
     Ok(())
 }
 
+// Verify certificates in parallel.
 async fn process_certificates_v1_helper(
-    protocol_config: &ProtocolConfig,
-    response: FetchCertificatesResponse,
+    certificates: Vec<Certificate>,
     synchronizer: &Synchronizer,
     metrics: Arc<PrimaryMetrics>,
 ) -> DagResult<()> {
-    let mut all_certificates = vec![];
-    for cert in response.certificates {
-        // We should not be getting mixed versions of certificates from a
-        // validator, so any individual certificate with mismatched versions
-        // should cancel processing for the entire batch of fetched certificates.
-        all_certificates.push(
-            validate_received_certificate_version(cert, protocol_config).map_err(|err| {
-                error!("fetched certficate processing error: {err}");
-                DagError::InvalidCertificateVersion
-            })?,
-        );
-    }
-    let verify_tasks = all_certificates
+    let verify_tasks = certificates
         .chunks(VERIFY_CERTIFICATES_BATCH_SIZE)
         .map(|certs| {
             let certs = certs.to_vec();
@@ -531,113 +523,6 @@ async fn process_certificates_v1_helper(
                 // so not stopping early.
                 warn!("Failed to accept fetched certificate: {e}");
             }
-        }
-        metrics
-            .certificate_fetcher_total_accept_us
-            .inc_by(now.elapsed().as_micros() as u64);
-    }
-
-    Ok(())
-}
-
-async fn process_certificates_v2_helper(
-    protocol_config: &ProtocolConfig,
-    response: FetchCertificatesResponse,
-    synchronizer: &Synchronizer,
-    metrics: Arc<PrimaryMetrics>,
-) -> DagResult<()> {
-    let mut all_certificates = vec![];
-    let mut all_parents = HashSet::<CertificateDigest>::new();
-    for cert in response.certificates {
-        all_parents.extend(cert.header().parents().iter());
-        // We should not be getting mixed versions of certificates from a
-        // validator, so any individual certificate with mismatched versions
-        // should cancel processing for the entire batch of fetched certificates.
-        all_certificates.push(
-            validate_received_certificate_version(cert, protocol_config).map_err(|err| {
-                error!("fetched certficate processing error: {err}");
-                DagError::InvalidCertificateVersion
-            })?,
-        );
-    }
-
-    let all_certificates_count = all_certificates.len() as u64;
-
-    // Identify leaf certs and preemptively set the parent certificates
-    // as verified indirectly. This is safe because any leaf certs that
-    // fail verification will cancel processing for all fetched certs.
-    let mut direct_verification_certs = Vec::new();
-    for (idx, c) in all_certificates.iter_mut().enumerate() {
-        if !all_parents.contains(&c.digest()) {
-            direct_verification_certs.push((idx, c.clone()));
-            continue;
-        }
-        if c.header().round() % CERTIFICATE_VERIFICATION_ROUND_INTERVAL == 0 {
-            direct_verification_certs.push((idx, c.clone()));
-            continue;
-        }
-        // TODO: add dedicated Certificate API for VerifiedIndirectly.
-        c.set_signature_verification_state(SignatureVerificationState::VerifiedIndirectly(
-            c.aggregated_signature()
-                .ok_or(DagError::InvalidSignature)?
-                .clone(),
-        ));
-    }
-    let direct_verification_count = direct_verification_certs.len() as u64;
-
-    // Create verify tasks only for leaf certs as parent certs can skip this completely.
-    let verify_tasks = direct_verification_certs
-        .chunks(VERIFY_CERTIFICATES_V2_BATCH_SIZE)
-        .map(|chunk| {
-            let certs = chunk.to_vec();
-            let sync = synchronizer.clone();
-            let metrics = metrics.clone();
-            spawn_blocking(move || {
-                let now = Instant::now();
-                let mut sanitized_certs = Vec::new();
-                for (idx, c) in certs {
-                    sanitized_certs.push((idx, sync.sanitize_certificate(c)?));
-                }
-                metrics
-                    .certificate_fetcher_total_verification_us
-                    .inc_by(now.elapsed().as_micros() as u64);
-                Ok::<Vec<(usize, Certificate)>, DagError>(sanitized_certs)
-            })
-        })
-        .collect_vec();
-
-    // We ensure sanitization of certificates completes for all leaves
-    // fetched certificates before accepting any certficates.
-    for task in verify_tasks.into_iter() {
-        // Any certificates that fail to be verified should cancel the entire
-        // batch of fetched certficates.
-        let idx_and_certs = task.await.map_err(|err| {
-            error!("Cancelling due to {err:?}");
-            DagError::Canceled
-        })??;
-        for (idx, cert) in idx_and_certs {
-            all_certificates[idx] = cert;
-        }
-    }
-
-    metrics
-        .fetched_certificates_verified_directly
-        .inc_by(direct_verification_count);
-    metrics
-        .fetched_certificates_verified_indirectly
-        .inc_by(all_certificates_count.saturating_sub(direct_verification_count));
-
-    // Accept verified certificates in the same order as received.
-    for cert in all_certificates {
-        let cert_digest = cert.digest();
-        let now = Instant::now();
-        if let Err(e) = synchronizer.try_accept_fetched_certificate(cert).await {
-            // It is possible that subsequent certificates are useful,
-            // so not stopping early.
-            warn!(
-                "Failed to accept fetched certificate {:?}: {e}",
-                cert_digest
-            );
         }
         metrics
             .certificate_fetcher_total_accept_us

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -76,7 +76,7 @@ use types::{
 pub mod primary_tests;
 
 /// The default channel capacity for each channel of the primary.
-pub const CHANNEL_CAPACITY: usize = 1_000;
+pub const CHANNEL_CAPACITY: usize = 10_000;
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
 pub const NUM_SHUTDOWN_RECEIVERS: u64 = 27;
@@ -841,8 +841,9 @@ impl PrimaryReceiverHandler {
         Ok(())
     }
 
-    /// Gets parent certificate digests not known before, in storage, among suspended certificates,
-    /// or being requested from other header proposers.
+    /// Gets parent certificate digests not known before.
+    /// Digests that are in storage, suspended, or being requested from other proposers
+    /// are considered to be known.
     async fn get_unknown_parent_digests(
         &self,
         header: &Header,

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -4,7 +4,7 @@
 
 use crate::consensus::LeaderSchedule;
 use crate::metrics::PrimaryMetrics;
-use config::{AuthorityIdentifier, Committee, Epoch, WorkerId};
+use config::{AuthorityIdentifier, Committee, WorkerId};
 use fastcrypto::hash::Hash as _;
 use mysten_metrics::metered_channel::{Receiver, Sender};
 use mysten_metrics::spawn_logged_monitored_task;
@@ -66,7 +66,7 @@ pub struct Proposer {
     /// Receiver for shutdown.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// Receives the parents to include in the next header (along with their round number) from core.
-    rx_parents: Receiver<(Vec<Certificate>, Round, Epoch)>,
+    rx_parents: Receiver<(Vec<Certificate>, Round)>,
     /// Receives the batches' digests from our workers.
     rx_our_digests: Receiver<OurDigestMessage>,
     /// Receives system messages to include in the next header.
@@ -124,7 +124,7 @@ impl Proposer {
         min_header_delay: Duration,
         header_resend_timeout: Option<Duration>,
         rx_shutdown: ConditionalBroadcastReceiver,
-        rx_parents: Receiver<(Vec<Certificate>, Round, Epoch)>,
+        rx_parents: Receiver<(Vec<Certificate>, Round)>,
         rx_our_digests: Receiver<OurDigestMessage>,
         rx_system_messages: Receiver<SystemMessage>,
         tx_headers: Sender<Header>,
@@ -637,23 +637,13 @@ impl Proposer {
                     }
                 },
 
-                Some((parents, round, epoch)) = self.rx_parents.recv() => {
+                Some((parents, round)) = self.rx_parents.recv() => {
                     debug!("Proposer received parents, round={} parent.round={} num_parents={}", self.round, round, parents.len());
-
-                    // If the core already moved to the next epoch we should pull the next
-                    // committee as well.
-
-                    match epoch.cmp(&self.committee.epoch()) {
-                        Ordering::Equal => {
-                            // we can proceed.
-                        }
-                        _ => continue
-                    }
 
                     // Sanity check: verify provided certs are of the correct round & epoch.
                     for parent in parents.iter() {
-                        if parent.round() != round || parent.epoch() != epoch {
-                            error!("Proposer received certificate {parent:?} that failed to match expected round {round} or epoch {epoch}. This should not be possible.");
+                        if parent.round() != round {
+                            error!("Proposer received certificate {parent:?} that failed to match expected round {round}. This should not be possible.");
                         }
                     }
 

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -54,6 +54,9 @@ pub mod synchronizer_tests;
 /// locally highest processed round.
 /// Expected max memory usage with 100 nodes: 100 nodes * 1000 rounds * 3.3KB per certificate = 330MB.
 const NEW_CERTIFICATE_ROUND_LIMIT: Round = 1000;
+/// During catchup, periodically batches ~2000 certificates can arrive for processing. So channel capacity
+/// should be much bigger than that.
+const PROCESS_CERTIFICATE_CHANNEL_CAPACITY: usize = 100000;
 
 struct Inner {
     /// The id of this primary.
@@ -346,13 +349,13 @@ impl Synchronizer {
         let (tx_own_certificate_broadcast, _rx_own_certificate_broadcast) =
             broadcast::channel(CHANNEL_CAPACITY);
         let (tx_certificate_acceptor, mut rx_certificate_acceptor) = channel_with_total(
-            CHANNEL_CAPACITY,
+            PROCESS_CERTIFICATE_CHANNEL_CAPACITY,
             &primary_channel_metrics.tx_certificate_acceptor,
             &primary_channel_metrics.tx_certificate_acceptor_total,
         );
 
         let (tx_batch_tasks, mut rx_batch_tasks) = channel_with_total(
-            CHANNEL_CAPACITY,
+            PROCESS_CERTIFICATE_CHANNEL_CAPACITY,
             &primary_channel_metrics.tx_batch_tasks,
             &primary_channel_metrics.tx_batch_tasks_total,
         );

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo::{rpc::Status, Network, Request, Response};
-use config::{AuthorityIdentifier, Committee, Epoch, WorkerCache};
+use config::{AuthorityIdentifier, Committee, WorkerCache};
 use crypto::NetworkPublicKey;
 use fastcrypto::hash::Hash as _;
 use futures::{stream::FuturesOrdered, StreamExt};
+use itertools::Itertools;
 use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_metrics::metered_channel::{channel_with_total, Sender};
 use mysten_metrics::{monitored_scope, spawn_logged_monitored_task};
@@ -27,6 +28,8 @@ use std::{
 };
 use storage::{CertificateStore, PayloadStore};
 use sui_protocol_config::ProtocolConfig;
+use tokio::task::spawn_blocking;
+use tokio::time::Instant;
 use tokio::{
     sync::{broadcast, oneshot, watch, MutexGuard},
     task::JoinSet,
@@ -54,63 +57,82 @@ pub mod synchronizer_tests;
 /// locally highest processed round.
 /// Expected max memory usage with 100 nodes: 100 nodes * 1000 rounds * 3.3KB per certificate = 330MB.
 const NEW_CERTIFICATE_ROUND_LIMIT: Round = 1000;
-/// During catchup, periodically batches ~2000 certificates can arrive for processing. So channel capacity
-/// should be much bigger than that.
-const PROCESS_CERTIFICATE_CHANNEL_CAPACITY: usize = 100000;
 
 struct Inner {
-    /// The id of this primary.
+    // The id of this primary.
     authority_id: AuthorityIdentifier,
-    /// Committee of the current epoch.
+    // Committee of the current epoch.
     committee: Committee,
     protocol_config: ProtocolConfig,
-    /// The worker information cache.
+    // The worker information cache.
     worker_cache: WorkerCache,
-    /// The depth of the garbage collector.
+    // The depth of the garbage collector.
     gc_depth: Round,
-    /// Highest round that has been GC'ed.
+    // Highest round that has been GC'ed.
     gc_round: AtomicU64,
-    /// Highest round of certificate accepted into the certificate store.
+    // Highest round of certificate accepted into the certificate store.
     highest_processed_round: AtomicU64,
-    /// Highest round of verfied certificate that has been received.
+    // Highest round of verfied certificate that has been received.
     highest_received_round: AtomicU64,
-    /// Client for fetching payloads.
+    // Client for fetching payloads.
     client: NetworkClient,
-    /// The persistent storage tables.
+    // The persistent storage tables.
     certificate_store: CertificateStore,
-    /// The persistent store of the available batch digests produced either via our own workers
-    /// or others workers.
+    // The persistent store of the available batch digests produced either via our own workers
+    // or others workers.
     payload_store: PayloadStore,
-    /// Send missing certificates to the `CertificateFetcher`.
+    // Send missing certificates to the `CertificateFetcher`.
     tx_certificate_fetcher: Sender<CertificateFetcherCommand>,
-    /// Send certificates to be accepted into a separate task that runs
-    /// `process_certificate_with_lock()` in a loop.
-    /// See comment above `process_certificate_with_lock()` for why this is necessary.
-    tx_certificate_acceptor: Sender<(Certificate, oneshot::Sender<DagResult<()>>, bool)>,
-    /// Output all certificates to the consensus layer. Must send certificates in causal order.
+    // Send certificates to be accepted into a separate task that runs
+    // `process_certificate_with_lock()` in a loop.
+    // See comment above `process_certificate_with_lock()` for why this is necessary.
+    tx_certificate_acceptor: Sender<(Vec<Certificate>, oneshot::Sender<DagResult<()>>, bool)>,
+    // Output all certificates to the consensus layer. Must send certificates in causal order.
     tx_new_certificates: Sender<Certificate>,
-    /// Send valid a quorum of certificates' ids to the `Proposer` (along with their round).
-    tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
-    /// Send own certificates to be broadcasted to all other peers.
+    // Send valid a quorum of certificates' ids to the `Proposer` (along with their round).
+    tx_parents: Sender<(Vec<Certificate>, Round)>,
+    // Send own certificates to be broadcasted to all other peers.
     tx_own_certificate_broadcast: broadcast::Sender<Certificate>,
-    /// Get a signal when the commit & gc round changes.
+    // Get a signal when the commit & gc round changes.
     rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
-    /// Genesis digests and contents.
+    // Genesis digests and contents.
     genesis: HashMap<CertificateDigest, Certificate>,
-    /// Contains Synchronizer specific metrics among other Primary metrics.
+    // Contains Synchronizer specific metrics among other Primary metrics.
     metrics: Arc<PrimaryMetrics>,
-    /// Background tasks broadcasting newly formed certificates.
+    // Background tasks broadcasting newly formed certificates.
     certificate_senders: Mutex<JoinSet<()>>,
-    /// A background task that synchronizes batches. A tuple of a header and the maximum accepted
-    /// age is sent over.
+    // A background task that synchronizes batches. A tuple of a header and the maximum accepted
+    // age is sent over.
     tx_batch_tasks: Sender<(Header, u64)>,
-    /// Aggregates certificates to use as parents for new headers.
+    // Aggregates certificates to use as parents for new headers.
     certificates_aggregators: Mutex<BTreeMap<Round, Box<CertificatesAggregator>>>,
-    /// State for tracking suspended certificates and when they can be accepted.
+    // State for tracking suspended certificates and when they can be accepted.
+    //
+    // TODO: tokio::sync::Mutex seems to be very slow to acquire here. Switch to parking_log::Mutex.
+    // This requires making sure no await is used inside accept_certificate_internal().
     state: tokio::sync::Mutex<State>,
 }
 
 impl Inner {
+    /// Checks if the certificate is valid and can potentially be accepted into the DAG.
+    fn sanitize_certificate(&self, certificate: Certificate) -> DagResult<Certificate> {
+        ensure!(
+            self.committee.epoch() == certificate.epoch(),
+            DagError::InvalidEpoch {
+                expected: self.committee.epoch(),
+                received: certificate.epoch()
+            }
+        );
+        // Ok to drop old certificate, because it will never be included into the consensus dag.
+        let gc_round = self.gc_round.load(Ordering::Acquire);
+        ensure!(
+            gc_round < certificate.round(),
+            DagError::TooOld(certificate.digest().into(), certificate.round(), gc_round)
+        );
+        // Verify the certificate (and the embedded header).
+        certificate.verify(&self.committee, &self.worker_cache)
+    }
+
     async fn append_certificate_in_aggregator(&self, certificate: Certificate) -> DagResult<()> {
         // Check if we have enough certificates to enter a new dag round and propose a header.
         let Some(parents) = self
@@ -124,7 +146,7 @@ impl Inner {
         };
         // Send it to the `Proposer`.
         self.tx_parents
-            .send((parents, certificate.round(), certificate.epoch()))
+            .send((parents, certificate.round()))
             .await
             .map_err(|_| DagError::ShuttingDown)
     }
@@ -158,19 +180,6 @@ impl Inner {
         debug!("Accepting certificate {:?}", certificate);
 
         let digest = certificate.digest();
-
-        // Validate that certificates are accepted in causal order.
-        // This should be relatively cheap because of certificate store caching.
-        if certificate.round() > self.gc_round.load(Ordering::Acquire) + 1 {
-            let existence = self
-                .certificate_store
-                .multi_contains(certificate.header().parents().iter())?;
-            for (digest, exists) in certificate.header().parents().iter().zip(existence.iter()) {
-                if !*exists {
-                    panic!("Parent {digest:?} not found for {certificate:?}!")
-                }
-            }
-        }
 
         if self.protocol_config.narwhal_certificate_v2()
             && !matches!(
@@ -336,7 +345,7 @@ impl Synchronizer {
         payload_store: PayloadStore,
         tx_certificate_fetcher: Sender<CertificateFetcherCommand>,
         tx_new_certificates: Sender<Certificate>,
-        tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
+        tx_parents: Sender<(Vec<Certificate>, Round)>,
         rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
         metrics: Arc<PrimaryMetrics>,
         primary_channel_metrics: &PrimaryChannelMetrics,
@@ -349,13 +358,13 @@ impl Synchronizer {
         let (tx_own_certificate_broadcast, _rx_own_certificate_broadcast) =
             broadcast::channel(CHANNEL_CAPACITY);
         let (tx_certificate_acceptor, mut rx_certificate_acceptor) = channel_with_total(
-            PROCESS_CERTIFICATE_CHANNEL_CAPACITY,
+            CHANNEL_CAPACITY,
             &primary_channel_metrics.tx_certificate_acceptor,
             &primary_channel_metrics.tx_certificate_acceptor_total,
         );
 
         let (tx_batch_tasks, mut rx_batch_tasks) = channel_with_total(
-            PROCESS_CERTIFICATE_CHANNEL_CAPACITY,
+            CHANNEL_CAPACITY,
             &primary_channel_metrics.tx_batch_tasks,
             &primary_channel_metrics.tx_batch_tasks_total,
         );
@@ -489,7 +498,7 @@ impl Synchronizer {
         spawn_logged_monitored_task!(
             async move {
                 loop {
-                    let Some((certificate, result_sender, early_suspend)) =
+                    let Some((certificates, result_sender, early_suspend)) =
                         rx_certificate_acceptor.recv().await
                     else {
                         debug!("Synchronizer is shutting down.");
@@ -497,13 +506,16 @@ impl Synchronizer {
                     };
 
                     if protocol_config.narwhal_certificate_v2() {
-                        assert!(
-                            matches!(
-                                certificate.signature_verification_state(),
-                                SignatureVerificationState::VerifiedDirectly(_)
-                                | SignatureVerificationState::VerifiedIndirectly(_)
-                            ),
-                        "Never accept certificates that have not been verified either directly or indirectly.");
+                        for certificate in &certificates {
+                            assert!(
+                                matches!(
+                                    certificate.signature_verification_state(),
+                                    SignatureVerificationState::VerifiedDirectly(_)
+                                    | SignatureVerificationState::VerifiedIndirectly(_)
+                                ),
+                                "Never accept certificates that have not been verified either directly or indirectly."
+                            );
+                        }
                     }
 
                     let Some(inner) = weak_inner.upgrade() else {
@@ -512,7 +524,7 @@ impl Synchronizer {
                     };
                     // Ignore error if receiver has been dropped.
                     let _ = result_sender.send(
-                        Self::process_certificate_with_lock(&inner, certificate, early_suspend)
+                        Self::process_certificate_with_lock(&inner, certificates, early_suspend)
                             .await,
                     );
                 }
@@ -599,7 +611,6 @@ impl Synchronizer {
         let _scope = monitored_scope("Synchronizer::try_accept_certificate");
         self.process_certificate_internal(certificate, true, true)
             .await
-            .map(|_| ())
     }
 
     /// Tries to accept a certificate from certificate fetcher.
@@ -612,21 +623,193 @@ impl Synchronizer {
         let _scope = monitored_scope("Synchronizer::try_accept_fetched_certificate");
         self.process_certificate_internal(certificate, false, false)
             .await
-            .map(|_| ())
+    }
+
+    /// Tries to accept a batch of certificates from certificate fetcher.
+    ///
+    /// The implementation takes advantage of input certificates being in a batch and
+    /// likely topologically sorted, to improve processing efficiency.
+    ///
+    /// NOTE: when making changes to this function, check if the same change needs to be made to
+    /// process_certificate_internal() which is non-batched.
+    pub async fn try_accept_fetched_certificates(
+        &self,
+        mut certificates: Vec<Certificate>,
+    ) -> DagResult<()> {
+        // Number of certificates to verify in a batch. Verifications in each batch run serially.
+        // Batch size is chosen so that verifying a batch takes non-trival
+        // time (verifying a batch of 50 certificates should take > 25ms).
+        const VERIFY_CERTIFICATES_V2_BATCH_SIZE: usize = 50;
+        // Number of rounds to force verfication of certificates by signature, to bound the maximum
+        // number of certificates with bad signatures in storage.
+        const CERTIFICATE_VERIFICATION_ROUND_INTERVAL: u64 = 50;
+
+        if certificates.is_empty() {
+            return Ok(());
+        }
+
+        let _scope = monitored_scope("Synchronizer::try_accept_fetched_certificates");
+
+        let mut highest_round = 0;
+        let mut all_digests = HashSet::<CertificateDigest>::new();
+        let mut all_parents = HashSet::<CertificateDigest>::new();
+        for cert in &certificates {
+            highest_round = highest_round.max(cert.header().round());
+            all_digests.insert(cert.digest());
+            all_parents.extend(cert.header().parents().iter());
+        }
+
+        // TODO: extract batch signature verification into a separate function.
+
+        // Identify leaf certs and preemptively set the parent certificates
+        // as verified indirectly. This is safe because any leaf certs that
+        // fail verification will cancel processing for all fetched certs.
+        let mut direct_verification_certs = Vec::new();
+        for (idx, c) in certificates.iter_mut().enumerate() {
+            if !all_parents.contains(&c.digest()) {
+                direct_verification_certs.push((idx, c.clone()));
+                continue;
+            }
+            if c.header().round() % CERTIFICATE_VERIFICATION_ROUND_INTERVAL == 0 {
+                direct_verification_certs.push((idx, c.clone()));
+                continue;
+            }
+            // TODO: add dedicated Certificate API for VerifiedIndirectly.
+            c.set_signature_verification_state(SignatureVerificationState::VerifiedIndirectly(
+                c.aggregated_signature()
+                    .ok_or(DagError::InvalidSignature)?
+                    .clone(),
+            ));
+        }
+
+        // Start verify tasks only for certificates requiring direct verifications.
+        let verify_tasks = direct_verification_certs
+            .chunks(VERIFY_CERTIFICATES_V2_BATCH_SIZE)
+            .map(|chunk| {
+                let certs = chunk.to_vec();
+                let inner = self.inner.clone();
+                spawn_blocking(move || {
+                    let now = Instant::now();
+                    let mut sanitized_certs = Vec::new();
+                    for (idx, c) in certs {
+                        sanitized_certs.push((idx, inner.sanitize_certificate(c)?));
+                    }
+                    inner
+                        .metrics
+                        .certificate_fetcher_total_verification_us
+                        .inc_by(now.elapsed().as_micros() as u64);
+                    Ok::<Vec<(usize, Certificate)>, DagError>(sanitized_certs)
+                })
+            })
+            .collect_vec();
+
+        // We ensure sanitization of certificates completes for all leaves
+        // fetched certificates before accepting any certficates.
+        for task in verify_tasks.into_iter() {
+            // Any certificates that fail to be verified should cancel the entire
+            // batch of fetched certficates.
+            let idx_and_certs = task.await.map_err(|err| {
+                error!("Cancelling due to {err:?}");
+                DagError::Canceled
+            })??;
+            for (idx, cert) in idx_and_certs {
+                certificates[idx] = cert;
+            }
+        }
+
+        let certificates_count = certificates.len() as u64;
+        let direct_verification_count = direct_verification_certs.len() as u64;
+        self.inner
+            .metrics
+            .fetched_certificates_verified_directly
+            .inc_by(direct_verification_count);
+        self.inner
+            .metrics
+            .fetched_certificates_verified_indirectly
+            .inc_by(certificates_count.saturating_sub(direct_verification_count));
+
+        let certificate_source = "other";
+        let highest_received_round = self
+            .inner
+            .highest_received_round
+            .fetch_max(highest_round, Ordering::AcqRel)
+            .max(highest_round);
+        self.inner
+            .metrics
+            .highest_received_round
+            .with_label_values(&[certificate_source])
+            .set(highest_received_round as i64);
+
+        // Let the proposer draw early conclusions from a certificate at this round and epoch, without its
+        // parents or payload (which we may not have yet).
+        //
+        // Since our certificate is well-signed, it shows a majority of honest signers stand at round r,
+        // so to make a successful proposal, our proposer must use parents at least at round r-1.
+        //
+        // This allows the proposer not to fire proposals at rounds strictly below the certificate we witnessed.
+        let minimal_round_for_parents = highest_received_round.saturating_sub(1);
+        self.inner
+            .tx_parents
+            .send((vec![], minimal_round_for_parents))
+            .await
+            .map_err(|_| DagError::ShuttingDown)?;
+
+        // Try to accept the verified certificates.
+        let _accept_scope =
+            monitored_scope("Synchronizer::try_accept_fetched_certificates::accept");
+
+        let max_age = self.inner.gc_depth.saturating_sub(1);
+        let highest_processed_round = self.inner.highest_processed_round.load(Ordering::Acquire);
+        for certificate in &certificates {
+            // Instruct workers to download any missing batches referenced in this certificate.
+            // Since this header got certified, we are sure that all the data it refers to (ie. its batches and its parents) are available.
+            // We can thus continue the processing of the certificate without blocking on batch synchronization.
+            let header = certificate.header().clone();
+            self.inner
+                .tx_batch_tasks
+                .send((header.clone(), max_age))
+                .await
+                .map_err(|_| DagError::ShuttingDown)?;
+
+            if highest_processed_round + NEW_CERTIFICATE_ROUND_LIMIT < certificate.round() {
+                self.inner
+                    .tx_certificate_fetcher
+                    .send(CertificateFetcherCommand::Ancestors(certificate.clone()))
+                    .await
+                    .map_err(|_| DagError::ShuttingDown)?;
+                return Err(DagError::TooNew(
+                    certificate.digest().into(),
+                    certificate.round(),
+                    highest_processed_round,
+                ));
+            }
+        }
+
+        let (sender, receiver) = oneshot::channel();
+        self.inner
+            .tx_certificate_acceptor
+            .send((certificates, sender, false))
+            .await
+            .expect("Synchronizer should shut down before certificate acceptor task.");
+        receiver
+            .await
+            .expect("Synchronizer should shut down before certificate acceptor task.")?;
+
+        Ok(())
     }
 
     /// Accepts a certificate produced by this primary. This is not expected to fail unless
     /// the primary is shutting down.
     pub async fn accept_own_certificate(&self, certificate: Certificate) -> DagResult<()> {
         // Process the new certificate.
-        let certificate = match self
+        match self
             .process_certificate_internal(certificate.clone(), false, false)
             .await
         {
-            Ok(processed_certificate) => Ok(processed_certificate),
-            result @ Err(DagError::ShuttingDown) => result,
+            Ok(_) => {}
+            _result @ Err(DagError::ShuttingDown) => return Err(DagError::ShuttingDown),
             Err(e) => panic!("Failed to process locally-created certificate: {e}"),
-        }?;
+        };
 
         // Broadcast the certificate.
         if self
@@ -679,38 +862,23 @@ impl Synchronizer {
 
     /// Checks if the certificate is valid and can potentially be accepted into the DAG.
     pub fn sanitize_certificate(&self, certificate: Certificate) -> DagResult<Certificate> {
-        ensure!(
-            self.inner.committee.epoch() == certificate.epoch(),
-            DagError::InvalidEpoch {
-                expected: self.inner.committee.epoch(),
-                received: certificate.epoch()
-            }
-        );
-        // Ok to drop old certificate, because it will never be included into the consensus dag.
-        let gc_round = self.inner.gc_round.load(Ordering::Acquire);
-        ensure!(
-            gc_round < certificate.round(),
-            DagError::TooOld(certificate.digest().into(), certificate.round(), gc_round)
-        );
-        // Verify the certificate (and the embedded header).
-        certificate.verify(&self.inner.committee, &self.inner.worker_cache)
+        self.inner.sanitize_certificate(certificate)
     }
 
-    // CertificateV2 maintains signature verification state. Therefore when this
-    // method is called with sanitize = true, the signature verification state may
-    // change which is why the updated certificate is returned.
+    /// NOTE: when making changes to this function, check if the same change needs to be made to
+    /// try_accept_fetched_certificates() which is the batched version.
     async fn process_certificate_internal(
         &self,
         mut certificate: Certificate,
-        sanitize: bool,
         early_suspend: bool,
-    ) -> DagResult<Certificate> {
+        sanitize: bool,
+    ) -> DagResult<()> {
         let _scope = monitored_scope("Synchronizer::process_certificate_internal");
         let digest = certificate.digest();
         if self.inner.certificate_store.contains(&digest)? {
             trace!("Certificate {digest:?} has already been processed. Skip processing.");
             self.inner.metrics.duplicate_certificates_processed.inc();
-            return Ok(certificate);
+            return Ok(());
         }
         // Ensure parents are checked if !early_suspend.
         // See comments above `try_accept_fetched_certificate()` for details.
@@ -762,7 +930,7 @@ impl Synchronizer {
         let minimal_round_for_parents = certificate.round().saturating_sub(1);
         self.inner
             .tx_parents
-            .send((vec![], minimal_round_for_parents, certificate.epoch()))
+            .send((vec![], minimal_round_for_parents))
             .await
             .map_err(|_| DagError::ShuttingDown)?;
 
@@ -794,13 +962,13 @@ impl Synchronizer {
         let (sender, receiver) = oneshot::channel();
         self.inner
             .tx_certificate_acceptor
-            .send((certificate.clone(), sender, early_suspend))
+            .send((vec![certificate], sender, early_suspend))
             .await
             .expect("Synchronizer should shut down before certificate acceptor task.");
         receiver
             .await
             .expect("Synchronizer should shut down before certificate acceptor task.")?;
-        Ok(certificate)
+        Ok(())
     }
 
     /// This function checks if a certificate has all parents and can be accepted into storage.
@@ -814,20 +982,27 @@ impl Synchronizer {
     #[instrument(level = "debug", skip_all)]
     async fn process_certificate_with_lock(
         inner: &Inner,
-        certificate: Certificate,
+        certificates: Vec<Certificate>,
         early_suspend: bool,
     ) -> DagResult<()> {
         let _scope = monitored_scope("Synchronizer::process_certificate_with_lock");
-        let digest = certificate.digest();
 
         // We re-check here in case we already have in pipeline the same certificate for processing
         // more that once.
-        if inner.certificate_store.contains(&digest)? {
-            debug!("Skip processing certificate {:?}", certificate);
+        let certificates = certificates
+            .into_iter()
+            .filter(|c| {
+                if inner.certificate_store.contains(&c.digest()).unwrap() {
+                    debug!("Skip processing certificate {:?}", c);
+                    inner.metrics.duplicate_certificates_processed.inc();
+                    return false;
+                }
+                true
+            })
+            .collect_vec();
+        if certificates.is_empty() {
             return Ok(());
         }
-
-        debug!("Processing certificate {:?} with lock", certificate);
 
         // The state lock must be held for the rest of the function, to ensure updating state,
         // writing certificates into storage and sending certificates to consensus are atomic.
@@ -836,56 +1011,62 @@ impl Synchronizer {
         // It is possible to reduce the critical section below, but it seems unnecessary for now.
         let mut state = inner.state.lock().await;
 
-        // Ensure parents are checked if !early_suspend.
-        // See comments above `try_accept_fetched_certificate()` for details.
-        if early_suspend {
-            // Re-check if the certificate has been suspended, which can happen before the lock is
-            // acquired.
-            if let Some(notify) = state.check_suspended(&digest) {
-                trace!("Certificate {digest:?} is still suspended. Skip processing.");
-                inner
-                    .metrics
-                    .certificates_suspended
-                    .with_label_values(&["dedup_locked"])
-                    .inc();
-                return Err(DagError::Suspended(notify));
-            }
-        }
+        for certificate in certificates {
+            debug!("Processing certificate {:?} with lock", certificate);
+            let digest = certificate.digest();
 
-        // Ensure either we have all the ancestors of this certificate, or the parents have been garbage collected.
-        // If we don't, the synchronizer will start fetching missing certificates.
-        if certificate.round() > inner.gc_round.load(Ordering::Acquire) + 1 {
-            let missing_parents = inner.get_missing_parents(&certificate).await?;
-            if !missing_parents.is_empty() {
-                debug!(
-                    "Processing certificate {:?} suspended: missing ancestors",
-                    certificate
-                );
-                inner
-                    .metrics
-                    .certificates_suspended
-                    .with_label_values(&["missing_parents"])
-                    .inc();
-                // There is no upper round limit to suspended certificates. Currently there is no
-                // memory usage issue and this will speed up catching up. But we can revisit later.
-                let notify = state.insert(certificate, missing_parents, !early_suspend);
-                inner
-                    .metrics
-                    .certificates_currently_suspended
-                    .set(state.num_suspended() as i64);
-                return Err(DagError::Suspended(notify));
+            // Ensure parents are checked if !early_suspend.
+            // See comments above `try_accept_fetched_certificate()` for details.
+            if early_suspend {
+                // Re-check if the certificate has been suspended, which can happen before the lock is
+                // acquired.
+                if let Some(notify) = state.check_suspended(&digest) {
+                    trace!("Certificate {digest:?} is still suspended. Skip processing.");
+                    inner
+                        .metrics
+                        .certificates_suspended
+                        .with_label_values(&["dedup_locked"])
+                        .inc();
+                    return Err(DagError::Suspended(notify));
+                }
             }
-        }
 
-        let suspended_certs = state.accept_children(certificate.round(), certificate.digest());
-        // Accept in causal order.
-        inner
-            .accept_certificate_internal(&state, certificate)
-            .await?;
-        for suspended in suspended_certs {
+            // Ensure either we have all the ancestors of this certificate, or the parents have been garbage collected.
+            // If we don't, the synchronizer will start fetching missing certificates.
+            if certificate.round() > inner.gc_round.load(Ordering::Acquire) + 1 {
+                let missing_parents = inner.get_missing_parents(&certificate).await?;
+                if !missing_parents.is_empty() {
+                    debug!(
+                        "Processing certificate {:?} suspended: missing ancestors",
+                        certificate
+                    );
+                    inner
+                        .metrics
+                        .certificates_suspended
+                        .with_label_values(&["missing_parents"])
+                        .inc();
+                    // There is no upper round limit to suspended certificates. Currently there is no
+                    // memory usage issue and this will speed up catching up. But we can revisit later.
+                    let notify = state.insert(certificate, missing_parents, !early_suspend);
+                    inner
+                        .metrics
+                        .certificates_currently_suspended
+                        .set(state.num_suspended() as i64);
+                    return Err(DagError::Suspended(notify));
+                }
+            }
+
+            // TODO: batch write accepted certificates.
+            let suspended_certs = state.accept_children(certificate.round(), certificate.digest());
+            // Accept in causal order.
             inner
-                .accept_suspended_certificate(&state, suspended)
+                .accept_certificate_internal(&state, certificate)
                 .await?;
+            for suspended in suspended_certs {
+                inner
+                    .accept_suspended_certificate(&state, suspended)
+                    .await?;
+            }
         }
 
         inner

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -783,32 +783,6 @@ async fn fetch_certificates_v2_basic() {
     sleep(Duration::from_secs(1)).await;
     verify_certificates_not_in_store(&certificate_store, &certificates[num_written..target_index]);
 
-    // Additional testcases cannot be added, because it seems impossible now to receive from
-    // the tx_fetch_resp channel after a certain number of messages.
-    // TODO: find the root cause of this issue.
-
-    // Send out a batch of certificates with good signatures for leaves,
-    // but bad signatures at other rounds including the verification round.
-    // let mut certs = Vec::new();
-    // for cert in certificates.iter().skip(num_written).take(200) {
-    //     let mut cert = cert.clone();
-    //     cert.set_signature_verification_state(SignatureVerificationState::Unverified(
-    //         AggregateSignatureBytes::default(),
-    //     ));
-    //     certs.push(cert);
-    // }
-    // for cert in certificates.iter().skip(num_written + 200).take(4) {
-    //     certs.push(cert.clone());
-    // }
-    // tx_fetch_resp
-    //     .try_send(FetchCertificatesResponse {
-    //         certificates: certs,
-    //     })
-    //     .unwrap();
-
-    // sleep(Duration::from_secs(1)).await;
-    // verify_certificates_not_in_store(&certificate_store, &certificates[num_written..target_index]);
-
     // Send out a batch of certificates with good signatures.
     // The certificates 4 + 62 + 58 + 204 = 328 should become available in store eventually.let mut certs = Vec::new();
     let mut certs = Vec::new();
@@ -828,4 +802,8 @@ async fn fetch_certificates_v2_basic() {
         310, // to be verified indirectly
     )
     .await;
+
+    // Additional testcases cannot be added, because it seems impossible now to receive from
+    // the tx_fetch_resp channel after a certain number of messages.
+    // TODO: find the root cause of this issue.
 }

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -159,7 +159,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
         .map(|h| fixture.certificate(&latest_protocol_version(), h))
         .collect();
 
-    let result = tx_parents.send((parents, 1, 0)).await;
+    let result = tx_parents.send((parents, 1)).await;
     assert!(result.is_ok());
 
     // THEN the header should contain max_num_of_batches
@@ -253,7 +253,7 @@ async fn equivocation_protection() {
         .map(|h| fixture.certificate(&latest_protocol_version(), h))
         .collect();
 
-    let result = tx_parents.send((parents, 1, 0)).await;
+    let result = tx_parents.send((parents, 1)).await;
     assert!(result.is_ok());
     assert!(rx_ack.await.is_ok());
 
@@ -327,7 +327,7 @@ async fn equivocation_protection() {
         .map(|h| fixture.certificate(&latest_protocol_version(), h))
         .collect();
 
-    let result = tx_parents.send((parents, 1, 0)).await;
+    let result = tx_parents.send((parents, 1)).await;
     assert!(result.is_ok());
     assert!(rx_ack.await.is_ok());
 

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -98,11 +98,11 @@ async fn accept_certificates() {
     // The first messages are the Synchronizer letting us know about the round of parent certificates
     for _i in 0..3 {
         let received = rx_parents.recv().await.unwrap();
-        assert_eq!(received, (vec![], 0, 0));
+        assert_eq!(received, (vec![], 0));
     }
     // the next message actually contains the parents
     let received = rx_parents.recv().await.unwrap();
-    assert_eq!(received, (certificates.clone(), 1, 0));
+    assert_eq!(received, (certificates.clone(), 1));
 
     // Ensure the Synchronizer sends the certificates to the consensus.
     for x in certificates.clone() {
@@ -330,7 +330,6 @@ async fn synchronizer_recover_basic() {
     // the recovery flow sends message that contains the parents
     let received = rx_parents.recv().await.unwrap();
     assert_eq!(received.1, 1);
-    assert_eq!(received.2, 0);
     assert_eq!(received.0.len(), certificates.len());
     for c in &certificates {
         assert!(received.0.contains(c));
@@ -453,13 +452,12 @@ async fn synchronizer_recover_partial_certs() {
 
     for _ in 0..2 {
         let received = rx_parents.recv().await.unwrap();
-        assert_eq!(received, (vec![], 0, 0));
+        assert_eq!(received, (vec![], 0));
     }
 
     // the recovery flow sends message that contains the parents
     let received = rx_parents.recv().await.unwrap();
     assert_eq!(received.1, 1);
-    assert_eq!(received.2, 0);
     assert_eq!(received.0.len(), certificates.len());
     for c in &certificates {
         assert!(received.0.contains(c));
@@ -581,7 +579,6 @@ async fn synchronizer_recover_previous_round() {
     let received = rx_parents.recv().await.unwrap();
     assert_eq!(received.0.len(), round_1_certificates.len());
     assert_eq!(received.1, 1);
-    assert_eq!(received.2, 0);
     for c in &round_1_certificates {
         assert!(received.0.contains(c));
     }

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -14,9 +14,10 @@ use store::{rocks::DBMap, Map};
 use sui_protocol_config::ProtocolConfig;
 use tracing::{debug, trace};
 use types::{
-    now, Batch, BatchAPI, BatchDigest, FetchBatchesRequest, FetchBatchesResponse, MetadataAPI,
-    PrimaryToWorker, RequestBatchesRequest, RequestBatchesResponse, WorkerBatchMessage,
-    WorkerOthersBatchMessage, WorkerSynchronizeMessage, WorkerToWorker, WorkerToWorkerClient,
+    now, validate_batch_version, Batch, BatchAPI, BatchDigest, FetchBatchesRequest,
+    FetchBatchesResponse, MetadataAPI, PrimaryToWorker, RequestBatchesRequest,
+    RequestBatchesResponse, WorkerBatchMessage, WorkerOthersBatchMessage, WorkerSynchronizeMessage,
+    WorkerToWorker, WorkerToWorkerClient,
 };
 
 use crate::{batch_fetcher::BatchFetcher, TransactionValidator};
@@ -208,6 +209,14 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
 
         let mut write_batch = self.store.batch();
         for batch in response.batches.iter_mut() {
+            // TODO: Remove once we have removed BatchV1 from the codebase.
+            validate_batch_version(batch, &self.protocol_config).map_err(|err| {
+                anemo::rpc::Status::new_with_message(
+                    StatusCode::BadRequest,
+                    format!("Invalid batch: {err}"),
+                )
+            })?;
+
             if !message.is_certified {
                 // This batch is not part of a certificate, so we need to validate it.
                 if let Err(err) = self
@@ -220,7 +229,6 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                         format!("Invalid batch: {err}"),
                     ));
                 }
-                tokio::task::yield_now().await;
             }
 
             let digest = batch.digest();


### PR DESCRIPTION
## Description 

Currently, certificates fetched during catchup are processed and accepted one-by-one, same as normal certificate handling. This turns out to be a throughput bottleneck for catching up. This PR includes one major and a few minor changes to improve the catchup throughput.

Main change: take the lock on `state` once per batch of certificates in `process_certificate_with_lock()`, instead of once per certificate. `tokio::sync::Mutex` seems to be really slow as the lock on `state`, taking 5 ~ 10s for 2000 lock operations.

Other changes:
- Increase channel size in Narwhal across the board from 1k to 10k, to avoid filling the channels too often. I did not see very noticeable memory usage increase.
- Avoid using blocking thread for verifying user signatures in transactions, which should be relatively fast.
- Cleanups.

## Test Plan 

### Private testnet

In catchup experiments with 5000 TPS and 150 validators, this seems to improve catchup speed from ~2/round to ~8/round.

Before:
Catching up after 1 hr of downtime never finished within the epoch:

![image](https://github.com/MystenLabs/sui/assets/81660174/bcdbd727-12f7-46dc-944a-b13f68cfbf10)

![image](https://github.com/MystenLabs/sui/assets/81660174/1933e6a4-e51b-4fcf-8df6-506cba67d6cd)

After:
Catching up after 1 hr of downtime took ~20 min:

![image](https://github.com/MystenLabs/sui/assets/81660174/7dd85846-5074-49a3-b85e-fa6213aebd30)

![image](https://github.com/MystenLabs/sui/assets/81660174/89725256-fb8e-4817-aed5-609d241c57d0)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
