### PR TITLE
[chore] disable the throughput aware consensus submission

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -86,7 +86,6 @@ const MAX_PROTOCOL_VERSION: u64 = 30;
 //             Enable transaction effects v2 in testnet.
 //             Deprecate supported oauth providers from protocol config and rely on node config
 //             instead.
-//             Enable throughput aware submission for Devnet & Testnet
 //             In execution, has_public_transfer is recomputed when loading the object.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1623,10 +1622,6 @@ impl ProtocolConfig {
                     // signature verifier will use the fetched jwk map to determine
                     // whether the provider is supported based on node config.
                     cfg.feature_flags.zklogin_supported_providers = BTreeSet::default();
-
-                    if chain != Chain::Mainnet {
-                        cfg.feature_flags.throughput_aware_consensus_submission = true;
-                    }
 
                     cfg.feature_flags.recompute_has_public_transfer_in_execution = true;
                 }

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_30.snap
@@ -33,7 +33,6 @@ feature_flags:
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
-  throughput_aware_consensus_submission: true
   recompute_has_public_transfer_in_execution: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_30.snap
@@ -36,7 +36,6 @@ feature_flags:
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
-  throughput_aware_consensus_submission: true
   recompute_has_public_transfer_in_execution: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
## Description 

Disabling the throughput aware consensus submission for all environments

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
