### PR TITLE
[graphql/rpc] expose timeout in limits config

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -16,6 +16,8 @@ const MAX_DB_QUERY_COST: u64 = 50000; // Max DB query cost (normally f64) trunca
 const MAX_QUERY_VARIABLES: u32 = 50;
 const MAX_QUERY_FRAGMENTS: u32 = 50;
 
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 20_000;
+
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 pub struct ConnectionConfig {
@@ -53,6 +55,8 @@ pub struct Limits {
     pub(crate) max_query_variables: u32,
     #[serde(default)]
     pub(crate) max_query_fragments: u32,
+    #[serde(default)]
+    pub(crate) request_timeout_ms: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -151,6 +155,7 @@ impl Default for Limits {
             max_db_query_cost: MAX_DB_QUERY_COST,
             max_query_variables: MAX_QUERY_VARIABLES,
             max_query_fragments: MAX_QUERY_FRAGMENTS,
+            request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         }
     }
 }
@@ -245,6 +250,7 @@ mod tests {
                 max-db-query-cost = 50
                 max-query-variables = 45
                 max-query-fragments = 32
+                request-timeout-ms = 27000
             "#,
         )
         .unwrap();
@@ -256,6 +262,7 @@ mod tests {
                 max_db_query_cost: 50,
                 max_query_variables: 45,
                 max_query_fragments: 32,
+                request_timeout_ms: 27_000,
             },
             ..Default::default()
         };
@@ -312,6 +319,7 @@ mod tests {
                 max-db-query-cost = 20
                 max-query-variables = 34
                 max-query-fragments = 31
+                request-timeout-ms = 30000
 
                 [experiments]
                 test-flag = true
@@ -326,6 +334,7 @@ mod tests {
                 max_db_query_cost: 20,
                 max_query_variables: 34,
                 max_query_fragments: 31,
+                request_timeout_ms: 30_000,
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
             experiments: Experiments { test_flag: true },

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -9,49 +9,32 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
 
-// 10s
-const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(20_000);
-
-#[derive(Clone, Debug, Copy)]
-pub(crate) struct TimeoutConfig {
-    pub request_timeout: Duration,
-}
-
-impl Default for TimeoutConfig {
-    fn default() -> Self {
-        Self {
-            request_timeout: DEFAULT_REQUEST_TIMEOUT,
-        }
-    }
-}
+use crate::config::ServiceConfig;
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Timeout {
-    pub config: TimeoutConfig,
-}
+pub(crate) struct Timeout;
 
 impl ExtensionFactory for Timeout {
     fn create(&self) -> Arc<dyn Extension> {
-        Arc::new(TimeoutExtension {
-            config: self.config,
-        })
+        Arc::new(Timeout {})
     }
 }
 
-struct TimeoutExtension {
-    config: TimeoutConfig,
-}
-
 #[async_trait::async_trait]
-impl Extension for TimeoutExtension {
+impl Extension for Timeout {
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
-        timeout(self.config.request_timeout, next.run(ctx))
+        let cfg = ctx
+            .data::<ServiceConfig>()
+            .expect("No service config provided in schema data");
+        let request_timeout = Duration::from_millis(cfg.limits.request_timeout_ms);
+
+        timeout(request_timeout, next.run(ctx))
             .await
             .unwrap_or_else(|_| {
                 Response::from_errors(vec![ServerError::new(
                     format!(
                         "Request timed out. Limit: {}s",
-                        self.config.request_timeout.as_secs_f32()
+                        request_timeout.as_secs_f32()
                     ),
                     None,
                 )])

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -16,7 +16,7 @@ pub(crate) struct Timeout;
 
 impl ExtensionFactory for Timeout {
     fn create(&self) -> Arc<dyn Extension> {
-        Arc::new(Timeout {})
+        Arc::new(Timeout)
     }
 }
 


### PR DESCRIPTION
## Description 

Exposes request timeout setting in config.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
