### PR TITLE
Changes not pushed to earlier PR

### DIFF
--- a/docs/content/concepts/transactions.mdx
+++ b/docs/content/concepts/transactions.mdx
@@ -2,35 +2,35 @@
 title: Transactions
 ---
 
-All updates to the Sui database happen via a transaction. This topic describes the transaction types supported by Sui and explains how their execution changes the ledger.
+All updates to the Sui database happen via transactions. This topic describes the transaction types supported by Sui and explains how their execution changes the ledger.  There are only two kinds of transactions on Sui:
 
-## Programmable Transaction Blocks
-
-For more information on these transactions, see [Programmable Transaction Blocks](./transactions/prog-txn-blocks.mdx).
+- Programmable transaction blocks, which anyone can submit on the network.  For information on these transactions, see [Programmable Transaction Blocks](./transactions/prog-txn-blocks.mdx).
+- System transactions, which only validators can directly submit and are responsible for keeping the network running (changing epochs, starting checkpoints, and so on).
 
 ## Transaction metadata
 
 All Sui transactions have the following common metadata:
- * **Sender address:** The [address](guides/developer/getting-started/get-address.mdx) of the user sending this transaction.
- * **Gas input:** An object reference pointing to the object that will be used to pay for this transaction's execution and storage. This object must be owned by the user and must be of type `sui::coin::Coin<SUI>` (i.e., the Sui native currency).
- * **Gas price:** An unsigned integer specifying the number of native tokens per gas unit this transaction will pay. The gas price must always be nonzero.
- * **Maximum gas budget:** The maximum number of gas units that can be expended by executing this transaction. If this budget is exceeded, transaction execution will abort and have no effects other than debiting the gas input object. Consequently, the gas input object must have a value higher than the gas price multiplied by the max gas, and this product is the maximum amount that the gas input object will be debited for the transaction.
- * **Epoch:** The Sui epoch this transaction is intended for.
- * **Type:** A call, publish, or native transaction and its type-specific-data (see below).
- * **Authenticator:** A cryptographic signature and a public key that both verifies against the signature and is cryptographically committed to by the sender address.
- * **Expiration:** An epoch reference that sets a deadline after which validators will no longer consider the transaction valid. The optional expiration epoch reference enables users to define transactions that either execute and commit by a set time (current epoch less than or equal to expiration epoch), or never execute after the deadline passes. By default, there is no deadline for when a transaction must execute. 
+
+- **Sender address:** The [address](guides/developer/getting-started/get-address.mdx) of the user sending this transaction.
+- **Gas input:** An object reference pointing to the object that will be used to pay for this transaction's execution and storage. This object must be owned by the user and must be of type `sui::coin::Coin<SUI>` (i.e., the Sui native currency).
+- **Gas price:** An unsigned integer specifying the number of native tokens per gas unit this transaction will pay. The gas price must always be nonzero.
+- **Maximum gas budget:** The maximum number of gas units that can be expended by executing this transaction. If this budget is exceeded, transaction execution will abort and have no effects other than debiting the gas input object. Consequently, the gas input object must have a value higher than the gas price multiplied by the max gas, and this product is the maximum amount that the gas input object will be debited for the transaction.
+- **Epoch:** The Sui epoch this transaction is intended for.
+- **Type:** A call, publish, or native transaction and its type-specific-data (see below).
+- **Authenticator:** A cryptographic signature and a public key that both verifies against the signature and is cryptographically committed to by the sender address.
+- **Expiration:** An epoch reference that sets a deadline after which validators will no longer consider the transaction valid. The optional expiration epoch reference enables users to define transactions that either execute and commit by a set time (current epoch less than or equal to expiration epoch), or never execute after the deadline passes. By default, there is no deadline for when a transaction must execute. 
 
 ## Move call transaction
 
 This transaction type invokes a function in a published Move package with objects owned by the sender and pure values (e.g., integers) as inputs. Executing a function may read, write, mutate, and transfer these input objects, as well as other objects created during execution.
 
 In addition to the common metadata above, a call transaction includes the following fields:
- * **Package:** An object reference pointing to a previously published Move package object.
- * **Module:** A UTF-8 string specifying the name of a Move module in the package.
- * **Function:** A UTF-8 string specifying the name of a function inside the module. The function must be a valid entry point.
- * **Type Inputs:** A list of Move types that will be bound to the type parameters of the function.
- * **Object Inputs:** A list of unique object references pointing to objects that will be passed to this function. Each object must either be owned by the sender, immutable or shared. The gas input object from above cannot also appear as an object input.
- * **Pure Inputs:** A list of BCS-encoded values that will be bound to the parameters of the function. Pure inputs must be primitive types (i.e. addresses, object IDs, strings, bytes, integers, or booleans)--they cannot be objects.
+- **Package:** An object reference pointing to a previously published Move package object.
+- **Module:** A UTF-8 string specifying the name of a Move module in the package.
+- **Function:** A UTF-8 string specifying the name of a function inside the module. The function must be a valid entry point.
+- **Type Inputs:** A list of Move types that will be bound to the type parameters of the function.
+- **Object Inputs:** A list of unique object references pointing to objects that will be passed to this function. Each object must either be owned by the sender, immutable or shared. The gas input object from above cannot also appear as an object input.
+- **Pure Inputs:** A list of BCS-encoded values that will be bound to the parameters of the function. Pure inputs must be primitive types (i.e. addresses, object IDs, strings, bytes, integers, or booleans)--they cannot be objects.
 
 ## Move publish transaction
 
@@ -47,8 +47,8 @@ Native transactions are optimized versions of common Sui operations. Each native
 This transaction type transfers objects from the sender to the specified recipients.
 
 In addition to the common metadata above, a transfer object transaction includes the following fields:
- * Input: An object reference pointing to a mutable object owned by the sender. The object must be of type that allows for public transfers--that is, any type with the `store` ability. The gas input object from above cannot also appear as the object input.
- * Recipient: The address that will receive the object from this transfer.
+- Input: An object reference pointing to a mutable object owned by the sender. The object must be of type that allows for public transfers--that is, any type with the `store` ability. The gas input object from above cannot also appear as the object input.
+- Recipient: The address that will receive the object from this transfer.
 
 ### Transfer SUI
 
@@ -56,21 +56,21 @@ This transaction type is similar to the Transfer Object transaction type, but th
 Optionally, an amount can be specified for partial transfers.
 
 In addition to the common metadata above, a transfer SUI transaction includes the following fields:
- * Input: An object reference pointing to a `0x2::coin::Coin<0x2::sui::SUI>` object owned by the sender.
- * (Optional) Amount: An unsigned integer encoding the amount that the recipient will receive. The amount will be debited from the input object, wrapped in a freshly created coin object, and sent to the corresponding recipient address. The value of the input object must be greater than or equal to the amount specified.
- * Recipient: The address that will receive the coin from this transfer.
+- Input: An object reference pointing to a `0x2::coin::Coin<0x2::sui::SUI>` object owned by the sender.
+- (Optional) Amount: An unsigned integer encoding the amount that the recipient will receive. The amount will be debited from the input object, wrapped in a freshly created coin object, and sent to the corresponding recipient address. The value of the input object must be greater than or equal to the amount specified.
+- Recipient: The address that will receive the coin from this transfer.
 
 ## Transactions flow - example
 
 Here's an example showing how objects and transactions are connected to each other in Sui.
 
 In the following example there are two objects:
- * Object A is a coin of type SUI with a total balance of 5 SUI
- * Object B with 2 SUI coins that belongs to John
+- Object A is a coin of type SUI with a total balance of 5 SUI
+- Object B with 2 SUI coins that belongs to John
 
 Tom decides to send 1 SUI coin to Alice. In this case, Object A is the input to this transaction and 1 SUI coin is debited from this object. The output of the transaction is two objects: 
- * Object A with 4 SUI coins that still belongs to Tom
- * new created Object C with 1 SUI coin that belongs now to Alice
+- Object A with 4 SUI coins that still belongs to Tom
+- new created Object C with 1 SUI coin that belongs now to Alice
 
 At the same time, John decides to send 2 SUI coins to Anna. Because the relationship between objects and transactions is written in a directed acyclic graph (DAG), and both transactions interact with different objects, this transaction executes in parallel with the transaction that sends coins from Tom to Alice. This transaction changes only the owner of Object B from John to Anna.
 

--- a/docs/content/concepts/transactions.mdx
+++ b/docs/content/concepts/transactions.mdx
@@ -20,46 +20,6 @@ All Sui transactions have the following common metadata:
 - **Authenticator:** A cryptographic signature and a public key that both verifies against the signature and is cryptographically committed to by the sender address.
 - **Expiration:** An epoch reference that sets a deadline after which validators will no longer consider the transaction valid. The optional expiration epoch reference enables users to define transactions that either execute and commit by a set time (current epoch less than or equal to expiration epoch), or never execute after the deadline passes. By default, there is no deadline for when a transaction must execute. 
 
-## Move call transaction
-
-This transaction type invokes a function in a published Move package with objects owned by the sender and pure values (e.g., integers) as inputs. Executing a function may read, write, mutate, and transfer these input objects, as well as other objects created during execution.
-
-In addition to the common metadata above, a call transaction includes the following fields:
-- **Package:** An object reference pointing to a previously published Move package object.
-- **Module:** A UTF-8 string specifying the name of a Move module in the package.
-- **Function:** A UTF-8 string specifying the name of a function inside the module. The function must be a valid entry point.
-- **Type Inputs:** A list of Move types that will be bound to the type parameters of the function.
-- **Object Inputs:** A list of unique object references pointing to objects that will be passed to this function. Each object must either be owned by the sender, immutable or shared. The gas input object from above cannot also appear as an object input.
-- **Pure Inputs:** A list of BCS-encoded values that will be bound to the parameters of the function. Pure inputs must be primitive types (i.e. addresses, object IDs, strings, bytes, integers, or booleans)--they cannot be objects.
-
-## Move publish transaction
-
-This transaction type publishes a new Sui Move package as an immutable object. Once the package has been published, its public functions and types can be used by future packages, and its entry point functions can be called by future transactions.
-
-In addition to the common metadata above, a publish transaction includes Package Bytes: A list of Sui Move bytecode modules topologically sorted by their dependency relationship (i.e., leaves in the dependency graph must appear earlier in the list). These modules will be deserialized, verified, and linked against their dependencies. In addition, each module's initializer function will be invoked in the order specified by the list.
-
-## Native transaction
-
-Native transactions are optimized versions of common Sui operations. Each native transaction is semantically equivalent to a specific Move call but has a lower gas cost.
-
-### Transfer object
-
-This transaction type transfers objects from the sender to the specified recipients.
-
-In addition to the common metadata above, a transfer object transaction includes the following fields:
-- Input: An object reference pointing to a mutable object owned by the sender. The object must be of type that allows for public transfers--that is, any type with the `store` ability. The gas input object from above cannot also appear as the object input.
-- Recipient: The address that will receive the object from this transfer.
-
-### Transfer SUI
-
-This transaction type is similar to the Transfer Object transaction type, but the input object type must be a SUI coin--that is, an object of type `0x2::coin::Coin<0x2::sui::SUI>`. The benefit of this transaction type is that a separate coin object is not needed for gas. The gas payment is taken from the SUI coin being transferred.
-Optionally, an amount can be specified for partial transfers.
-
-In addition to the common metadata above, a transfer SUI transaction includes the following fields:
-- Input: An object reference pointing to a `0x2::coin::Coin<0x2::sui::SUI>` object owned by the sender.
-- (Optional) Amount: An unsigned integer encoding the amount that the recipient will receive. The amount will be debited from the input object, wrapped in a freshly created coin object, and sent to the corresponding recipient address. The value of the input object must be greater than or equal to the amount specified.
-- Recipient: The address that will receive the coin from this transfer.
-
 ## Transactions flow - example
 
 Here's an example showing how objects and transactions are connected to each other in Sui.

--- a/docs/content/sidebars/concepts.js
+++ b/docs/content/sidebars/concepts.js
@@ -45,19 +45,19 @@ const concepts = [
 							'concepts/dynamic-fields/dynamic-object-fields',
 							'concepts/dynamic-fields/tables-bags',
 							'concepts/dynamic-fields/events',
-							{
-								type: 'category',
-								label: 'Transfers',
-								link: {
-									type: 'doc',
-									id: 'concepts/dynamic-fields/transfers',
-								},
-								items: [
-									'concepts/dynamic-fields/transfers/custom-rules',
-									'concepts/dynamic-fields/transfers/transfer-to-object',
-								],
-							},
 							'concepts/dynamic-fields/versioning',
+						],
+					},
+					{
+						type: 'category',
+						label: 'Transfers',
+						link: {
+							type: 'doc',
+							id: 'concepts/dynamic-fields/transfers',
+						},
+						items: [
+							'concepts/dynamic-fields/transfers/custom-rules',
+							'concepts/dynamic-fields/transfers/transfer-to-object',
 						],
 					},
 				],


### PR DESCRIPTION
## Description 

Made these changes from your feedback on 14530, committed them, but failed to push.

## Test Plan 

Local

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
