### PR TITLE
move: better websocket error message for source service (easy)

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -422,7 +422,8 @@ pub async fn watch_for_upgrades(
             watch_ids,
             "suix_unsubscribeTransaction",
         )
-        .await?;
+        .await
+        .map_err(|e| anyhow!("Failed to open websocket connection for {}: {}", network, e))?;
 
     info!("Listening for upgrades on {num_packages} package(s) on {websocket_url}...");
     loop {


### PR DESCRIPTION
## Description 

Display the network when a websocket connection fails

## Test Plan 

N/A for debugging

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
