### PR TITLE
move: remove noisy trace logs in source service (easy)

### DIFF
--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -27,9 +27,7 @@ use mysten_metrics::RegistryService;
 use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
-use tower_http::trace::{DefaultOnResponse, TraceLayer};
-use tower_http::LatencyUnit;
-use tracing::{debug, error, info, Level};
+use tracing::{debug, error, info};
 use url::Url;
 
 use move_compiler::compiled_unit::CompiledUnitEnum;
@@ -617,16 +615,7 @@ pub fn start_prometheus_server(addr: TcpListener) -> RegistryService {
 
     let app = Router::new()
         .route(METRICS_ROUTE, get(mysten_metrics::metrics))
-        .layer(Extension(registry_service.clone()))
-        .layer(
-            ServiceBuilder::new().layer(
-                TraceLayer::new_for_http().on_response(
-                    DefaultOnResponse::new()
-                        .level(Level::INFO)
-                        .latency_unit(LatencyUnit::Seconds),
-                ),
-            ),
-        );
+        .layer(Extension(registry_service.clone()));
 
     tokio::spawn(async move {
         axum::Server::from_tcp(addr)


### PR DESCRIPTION
## Description 

`Info` log showing up every minute when the the service is scraped, noisy and not needed right now.

## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
