### PR TITLE
[graphql/rpc]add epoch doc comments

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -202,13 +202,37 @@ type EndOfEpochTransaction {
 }
 
 type Epoch {
+	"""
+	The epoch's id
+	"""
 	epochId: Int!
+	"""
+	The reference gas price for this epoch
+	"""
 	referenceGasPrice: BigInt
+	"""
+	Validator related properties, including the active validators
+	"""
 	validatorSet: ValidatorSet
+	"""
+	The epoch's starting timestamp
+	"""
 	startTimestamp: DateTime
+	"""
+	The epoch's ending timestamp
+	"""
 	endTimestamp: DateTime
+	"""
+	The epoch's corresponding protocol configuration, including the feature flags and the configuration options
+	"""
 	protocolConfigs: ProtocolConfigs
+	"""
+	The epoch's corresponding checkpoints
+	"""
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	"""
+	The epoch's corresponding transaction blocks
+	"""
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -203,11 +203,11 @@ type EndOfEpochTransaction {
 
 type Epoch {
 	"""
-	The epoch's id
+	The epoch's id as a sequence number that starts at 0 and it is incremented by one at every epoch change
 	"""
 	epochId: Int!
 	"""
-	The reference gas price for this epoch
+	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for
 	"""
 	referenceGasPrice: BigInt
 	"""

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -16,12 +16,12 @@ use async_graphql::*;
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct Epoch {
-    /// The epoch's id
+    /// The epoch's id as a sequence number that starts at 0 and it is incremented by one at every epoch change
     pub epoch_id: u64,
     /// The epoch's protocol version
     #[graphql(skip)]
     pub protocol_version: u64,
-    /// The reference gas price for this epoch
+    /// The minimum gas price that a quorum of validators are guaranteed to sign a transaction for
     pub reference_gas_price: Option<BigInt>,
     /// Validator related properties, including the active validators
     pub validator_set: Option<ValidatorSet>,

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -16,17 +16,24 @@ use async_graphql::*;
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct Epoch {
+    /// The epoch's id
     pub epoch_id: u64,
+    /// The epoch's protocol version
     #[graphql(skip)]
     pub protocol_version: u64,
+    /// The reference gas price for this epoch
     pub reference_gas_price: Option<BigInt>,
+    /// Validator related properties, including the active validators
     pub validator_set: Option<ValidatorSet>,
+    /// The epoch's starting timestamp
     pub start_timestamp: Option<DateTime>,
+    /// The epoch's ending timestamp
     pub end_timestamp: Option<DateTime>,
 }
 
 #[ComplexObject]
 impl Epoch {
+    /// The epoch's corresponding protocol configuration, including the feature flags and the configuration options
     async fn protocol_configs(&self, ctx: &Context<'_>) -> Result<Option<ProtocolConfigs>> {
         Ok(Some(
             ctx.data_unchecked::<PgManager>()
@@ -35,6 +42,7 @@ impl Epoch {
         ))
     }
 
+    /// The epoch's corresponding checkpoints
     async fn checkpoint_connection(
         &self,
         ctx: &Context<'_>,
@@ -49,6 +57,7 @@ impl Epoch {
             .extend()
     }
 
+    /// The epoch's corresponding transaction blocks
     async fn transaction_block_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -206,13 +206,37 @@ type EndOfEpochTransaction {
 }
 
 type Epoch {
+	"""
+	The epoch's id
+	"""
 	epochId: Int!
+	"""
+	The reference gas price for this epoch
+	"""
 	referenceGasPrice: BigInt
+	"""
+	Validator related properties, including the active validators
+	"""
 	validatorSet: ValidatorSet
+	"""
+	The epoch's starting timestamp
+	"""
 	startTimestamp: DateTime
+	"""
+	The epoch's ending timestamp
+	"""
 	endTimestamp: DateTime
+	"""
+	The epoch's corresponding protocol configuration, including the feature flags and the configuration options
+	"""
 	protocolConfigs: ProtocolConfigs
+	"""
+	The epoch's corresponding checkpoints
+	"""
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	"""
+	The epoch's corresponding transaction blocks
+	"""
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__test__schema_sdl_export.snap
@@ -207,11 +207,11 @@ type EndOfEpochTransaction {
 
 type Epoch {
 	"""
-	The epoch's id
+	The epoch's id as a sequence number that starts at 0 and it is incremented by one at every epoch change
 	"""
 	epochId: Int!
 	"""
-	The reference gas price for this epoch
+	The minimum gas price that a quorum of validators are guaranteed to sign a transaction for
 	"""
 	referenceGasPrice: BigInt
 	"""


### PR DESCRIPTION
## Description 

Adds doc comments for the `epoch` and `validatorSet` types.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
