### PR TITLE
Make effects v2 type private

### DIFF
--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -13,6 +13,9 @@ use rand::SeedableRng;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
 use std::{fs::File, io::Write};
+use sui_types::effects::{
+    IDOperation, ObjectIn, ObjectOut, TransactionEffects, UnchangedSharedKind,
+};
 use sui_types::execution_status::{
     CommandArgumentError, ExecutionFailureStatus, ExecutionStatus, PackageUpgradeError,
     TypeArgumentError,
@@ -41,12 +44,6 @@ use sui_types::{
     storage::DeleteKind,
     transaction::{
         Argument, CallArg, Command, EndOfEpochTransactionKind, ObjectArg, TransactionKind,
-    },
-};
-use sui_types::{
-    base_types::{random_object_ref, SequenceNumber},
-    effects::{
-        effects_v2::UnchangedSharedKind, IDOperation, ObjectIn, ObjectOut, TransactionEffects,
     },
 };
 use typed_store::rocks::TypedStoreError;
@@ -139,16 +136,6 @@ fn get_registry() -> Result<Registry> {
     let ccd = CheckpointDigest::random();
     tracer.trace_value(&mut samples, &ccd)?;
 
-    let usor = UnchangedSharedKind::ReadDeleted(SequenceNumber::from_u64(42));
-    let usow = UnchangedSharedKind::MutateDeleted(SequenceNumber::from_u64(42));
-    let usorr = {
-        let oref = random_object_ref();
-        UnchangedSharedKind::ReadOnlyRoot((oref.1, oref.2))
-    };
-    tracer.trace_value(&mut samples, &usor)?;
-    tracer.trace_value(&mut samples, &usow)?;
-    tracer.trace_value(&mut samples, &usorr)?;
-
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<Owner>(&samples)?;
     tracer.trace_type::<ExecutionStatus>(&samples)?;
@@ -178,6 +165,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<IDOperation>(&samples)?;
     tracer.trace_type::<ObjectIn>(&samples)?;
     tracer.trace_type::<ObjectOut>(&samples)?;
+    tracer.trace_type::<UnchangedSharedKind>(&samples)?;
     tracer.trace_type::<TransactionEffects>(&samples)?;
 
     // uncomment once GenericSignature is added

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -22,6 +22,7 @@ use crate::object::Owner;
 use crate::storage::WriteKind;
 use crate::transaction::{SenderSignedData, TransactionDataAPI, VersionedProtocolMessage};
 use effects_v1::TransactionEffectsV1;
+pub use effects_v2::UnchangedSharedKind;
 use enum_dispatch::enum_dispatch;
 pub use object_change::{EffectsObjectChange, IDOperation, ObjectIn, ObjectOut};
 use serde::{Deserialize, Serialize};
@@ -30,11 +31,7 @@ use std::collections::BTreeMap;
 use sui_protocol_config::ProtocolConfig;
 
 mod effects_v1;
-// TODO: effects_v2 needs to be public because we need to generate examples of `UnchangedSharedKind`
-// values in order to properly generate the layout for these in generate-format. We should look at
-// seeing if we can make this private and fix the issue with generate-format turn this module
-// private.
-pub mod effects_v2;
+mod effects_v2;
 mod object_change;
 
 // Since `std::mem::size_of` may not be stable across platforms, we use rough constants


### PR DESCRIPTION
## Description 

An attempt to keep effects v2 type private through `pub use`.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
