### PR TITLE
indexer v2 analytical: skip analyze on estimated count query

### DIFF
--- a/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
@@ -102,7 +102,6 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
 
     async fn get_estimated_count(&self, table: &str) -> IndexerResult<i64> {
         let row_count_estimation = read_only_blocking!(&self.blocking_cp, |conn| {
-            diesel::sql_query(format!("ANALYZE {};", table)).execute(conn)?;
             diesel::sql_query(format!(
                 "SELECT reltuples::bigint AS estimated_count FROM pg_class WHERE relname='{}';",
                 table


### PR DESCRIPTION
## Description 

turns out that although DB analyze samples, it is very slow and cause timeout.
see this in logs
```
2023-10-31T03:14:08.324921Z ERROR sui_indexer::processors_v2::processor_orchestrator_v2: Indexer move call metrics processor failed with error ErrorWithContext("Failed reading transactions from PostgresDB", PostgresReadError("canceling statement due to statement timeout")), retrying in 5s..
```

## Test Plan 

local verifies without DB analyze, the estimated count takes less than 100ms to finish
```
SELECT reltuples::bigint AS estimated_count FROM pg_class WHERE relname='objects';
 estimated_count
-----------------
        22882962
(1 row)

Time: 85.789 ms
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
