### PR TITLE
[dapp-kit] don't apply CSS resets to custom triggers in the connect modal

### DIFF
--- a/.changeset/orange-insects-wave.md
+++ b/.changeset/orange-insects-wave.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Fix bug where style resets were being applied to custom trigger buttons

--- a/sdk/dapp-kit/src/components/ConnectButton.tsx
+++ b/sdk/dapp-kit/src/components/ConnectButton.tsx
@@ -6,6 +6,7 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { useCurrentAccount } from '../hooks/wallet/useCurrentAccount.js';
 import { AccountDropdownMenu } from './AccountDropdownMenu.js';
 import { ConnectModal } from './connect-modal/ConnectModal.js';
+import { StyleMarker } from './styling/StyleMarker.js';
 import { Button } from './ui/Button.js';
 
 type ConnectButtonProps = {
@@ -20,6 +21,12 @@ export function ConnectButton({
 	return currentAccount ? (
 		<AccountDropdownMenu currentAccount={currentAccount} />
 	) : (
-		<ConnectModal trigger={<Button {...buttonProps}>{connectText}</Button>} />
+		<ConnectModal
+			trigger={
+				<StyleMarker>
+					<Button {...buttonProps}>{connectText}</Button>
+				</StyleMarker>
+			}
+		/>
 	);
 }

--- a/sdk/dapp-kit/src/components/connect-modal/ConnectModal.tsx
+++ b/sdk/dapp-kit/src/components/connect-modal/ConnectModal.tsx
@@ -97,9 +97,7 @@ export function ConnectModal({ trigger, open, defaultOpen, onOpenChange }: Conne
 
 	return (
 		<Dialog.Root open={open ?? isModalOpen} onOpenChange={handleOpenChange}>
-			<StyleMarker>
-				<Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
-			</StyleMarker>
+			<Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
 			<Dialog.Portal>
 				<StyleMarker>
 					<Dialog.Overlay className={styles.overlay}>


### PR DESCRIPTION
## Description 
I noticed a hack in one of our dApps that works around a CSS ordering issue with dApp-kit styles + application styles. I don't think we should apply style resets to custom trigger buttons; we should only apply the style marker to the button provided by `ConnectButton`.

Hacky workaround pattern:
```
      <Button
        className="flex-1"
        variant="outline"
        onClick={() => {
          setOpen(true);
        }}
      >
        <div className="flex gap-4 items-center">
          <div>Connect Wallet</div>
        </div>
      </Button>
      <ConnectModal
        trigger={<></>}
        open={open}
        onOpenChange={(open) => setOpen(open)}
      />
```

Ideal pattern:
```
      <ConnectModal
        trigger={
          <Button
            className="flex-1"
            variant="outline"
          >
            <div className="flex gap-4 items-center">
              <div>Connect Wallet</div>
            </div>
          </Button>
        }
      />
```

## Test Plan 
- Made a custom button and tested that no resets were being applied
- Tested that the current ConnectButton button component still has resets

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
