### PR TITLE
[mysticeti] add SuiBlockValidator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,15 +5461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minibytes"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860#383e7a26d7db4187a8115e95d5ce6d0138554860"
-dependencies = [
- "memmap2 0.7.1",
- "serde",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6457,41 +6448,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
- "parking_lot 0.12.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_yaml 0.9.21",
- "tabled",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "zeroize",
-]
-
-[[package]]
-name = "mysticeti-core"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860#383e7a26d7db4187a8115e95d5ce6d0138554860"
-dependencies = [
- "async-trait",
- "axum",
- "bincode",
- "blake2",
- "crc32fast",
- "digest 0.10.6",
- "ed25519-consensus",
- "eyre",
- "futures",
- "gettid",
- "hex",
- "hyper",
- "libc",
- "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
+ "minibytes",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10422,7 +10379,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "mysticeti-core",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14350,7 +14307,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
+ "minibytes",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14405,7 +14362,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
+ "mysticeti-core",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,9 +3889,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3904,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3914,15 +3914,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3931,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -3952,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -3963,15 +3963,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-timer"
@@ -3981,9 +3981,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4029,6 +4029,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gettid"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b20f40277dfb8a9dec7e2e945f6d8ff711e733c8f2a2c9b257562764b4c60d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5366,6 +5376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,6 +5449,24 @@ checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minibytes"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf#0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf"
+dependencies = [
+ "memmap2 0.7.1",
+ "serde",
+]
+
+[[package]]
+name = "minibytes"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860#383e7a26d7db4187a8115e95d5ce6d0138554860"
+dependencies = [
+ "memmap2 0.7.1",
+ "serde",
 ]
 
 [[package]]
@@ -6399,6 +6436,74 @@ dependencies = [
  "syn 1.0.107",
  "synstructure",
  "workspace-hack",
+]
+
+[[package]]
+name = "mysticeti-core"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf#0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bincode",
+ "blake2",
+ "crc32fast",
+ "digest 0.10.6",
+ "ed25519-consensus",
+ "eyre",
+ "futures",
+ "gettid",
+ "hex",
+ "hyper",
+ "libc",
+ "memmap2 0.7.1",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_yaml 0.9.21",
+ "tabled",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "zeroize",
+]
+
+[[package]]
+name = "mysticeti-core"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860#383e7a26d7db4187a8115e95d5ce6d0138554860"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bincode",
+ "blake2",
+ "crc32fast",
+ "digest 0.10.6",
+ "ed25519-consensus",
+ "eyre",
+ "futures",
+ "gettid",
+ "hex",
+ "hyper",
+ "libc",
+ "memmap2 0.7.1",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_yaml 0.9.21",
+ "tabled",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -9258,9 +9363,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -9297,13 +9402,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
- "syn 1.0.107",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -10317,6 +10422,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -10370,6 +10476,7 @@ dependencies = [
  "typed-store",
  "typed-store-derive",
  "workspace-hack",
+ "zeroize",
 ]
 
 [[package]]
@@ -12011,7 +12118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.8",
  "stable_deref_trait",
  "uuid",
 ]
@@ -12877,9 +12984,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -14111,6 +14218,7 @@ dependencies = [
  "generic-array",
  "getrandom 0.1.16",
  "getrandom 0.2.9",
+ "gettid",
  "ghash",
  "gimli",
  "git-version",
@@ -14233,7 +14341,8 @@ dependencies = [
  "md-5 0.9.1",
  "md5",
  "memchr",
- "memmap2",
+ "memmap2 0.5.8",
+ "memmap2 0.7.1",
  "memoffset 0.6.5",
  "memoffset 0.7.1",
  "merlin",
@@ -14241,6 +14350,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14295,6 +14405,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=383e7a26d7db4187a8115e95d5ce6d0138554860)",
  "named-lock",
  "nested",
  "newline-converter",
@@ -14793,9 +14904,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ expect-test = "1.4.0"
 eyre = "0.6.8"
 fdlimit = "0.2.1"
 fs_extra = "1.3.0"
-futures = "0.3.25"
+futures = "0.3.28"
 futures-core = "0.3.21"
 git-version = "0.3.5"
 glob = "0.3.1"
@@ -488,6 +488,7 @@ uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 webpki = { version = "0.101.0", package = "rustls-webpki", features = ["alloc", "std"] }
 x509-parser = "0.14.0"
 zstd = "0.12.3"
+zeroize = "1.6.0"
 versions = "4.1.0"
 
 # Move dependencies

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -81,6 +81,8 @@ sui-simulator.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
+zeroize.workspace = true
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use clap::*;
 use move_core_types::{
-    language_storage::TypeTag,
+    language_storage::{StructTag, TypeTag},
     value::{MoveStructLayout, MoveTypeLayout},
     vm_status::AbortLocation,
 };
@@ -12,6 +12,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
+use std::str::FromStr;
 use std::{fs::File, io::Write};
 use sui_types::effects::{
     IDOperation, ObjectIn, ObjectOut, TransactionEffects, UnchangedSharedKind,
@@ -61,7 +62,6 @@ fn get_registry() -> Result<Registry> {
     // or involving generics (see [serde_reflection documentation](https://novifinancial.github.io/serde-reflection/serde_reflection/index.html)).
     let (addr, kp): (_, AuthorityKeyPair) = get_key_pair();
     let (s_addr, s_kp): (_, AccountKeyPair) = get_key_pair();
-
     let pk: AuthorityPublicKeyBytes = kp.public().into();
     tracer.trace_value(&mut samples, &addr)?;
     tracer.trace_value(&mut samples, &kp)?;
@@ -132,6 +132,9 @@ fn get_registry() -> Result<Registry> {
 
     let ccd = CheckpointContentsDigest::random();
     tracer.trace_value(&mut samples, &ccd)?;
+
+    let struct_tag = StructTag::from_str("0x2::coin::Coin<0x2::sui::SUI>").unwrap();
+    tracer.trace_value(&mut samples, &struct_tag)?;
 
     let ccd = CheckpointDigest::random();
     tracer.trace_value(&mut samples, &ccd)?;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -294,6 +294,7 @@ futures-util = { version = "0.3", default-features = false, features = ["async-a
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
+gettid = { version = "0.1", default-features = false }
 ghash = { version = "0.5", default-features = false }
 gimli = { version = "0.27", default-features = false, features = ["read"] }
 git-version = { version = "0.3", default-features = false }
@@ -396,11 +397,13 @@ md-5-274715c4dabd11b0 = { package = "md-5", version = "0.9" }
 md-5-93f6ce9d446188ac = { package = "md-5", version = "0.10" }
 md5 = { version = "0.7" }
 memchr = { version = "2" }
+memmap2-ca01ad9e24f5d932 = { package = "memmap2", version = "0.7", default-features = false }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -450,6 +453,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -712,10 +716,10 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-core = { version = "0.1" }
 tracing-error = { version = "0.2" }
-tracing-log = { version = "0.1", default-features = false }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 tracing-opentelemetry = { version = "0.21" }
 tracing-serde = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "smallvec", "time"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
 treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
@@ -1096,6 +1100,7 @@ futures-util = { version = "0.3", default-features = false, features = ["async-a
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
+gettid = { version = "0.1", default-features = false }
 ghash = { version = "0.5", default-features = false }
 gimli = { version = "0.27", default-features = false, features = ["read"] }
 git-version = { version = "0.3", default-features = false }
@@ -1210,12 +1215,14 @@ md-5-274715c4dabd11b0 = { package = "md-5", version = "0.9" }
 md-5-93f6ce9d446188ac = { package = "md-5", version = "0.10" }
 md5 = { version = "0.7" }
 memchr = { version = "2" }
+memmap2-ca01ad9e24f5d932 = { package = "memmap2", version = "0.7", default-features = false }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1269,6 +1276,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1590,10 +1598,10 @@ tracing-appender = { version = "0.2", default-features = false }
 tracing-attributes = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1" }
 tracing-error = { version = "0.2" }
-tracing-log = { version = "0.1", default-features = false }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 tracing-opentelemetry = { version = "0.21" }
 tracing-serde = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "smallvec", "time"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
 treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
@@ -1677,7 +1685,7 @@ jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mach2 = { version = "0.4" }
-memmap2 = { version = "0.5", default-features = false }
+memmap2-d8f496e17d97b5cb = { package = "memmap2", version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -1716,7 +1724,7 @@ jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mach2 = { version = "0.4" }
-memmap2 = { version = "0.5", default-features = false }
+memmap2-d8f496e17d97b5cb = { package = "memmap2", version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -1753,7 +1761,7 @@ libc = { version = "0.2", default-features = false, features = ["extra_traits"] 
 linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memmap2 = { version = "0.5", default-features = false }
+memmap2-d8f496e17d97b5cb = { package = "memmap2", version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -1791,7 +1799,7 @@ libc = { version = "0.2", default-features = false, features = ["extra_traits"] 
 linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memmap2 = { version = "0.5", default-features = false }
+memmap2-d8f496e17d97b5cb = { package = "memmap2", version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -453,7 +453,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1222,7 +1222,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1276,7 +1276,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "383e7a26d7db4187a8115e95d5ce6d0138554860", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ allow = [
     "MPL-2.0",
     "ISC",
     "CC0-1.0",
+    "0BSD",
     "LicenseRef-ring",
     "BSL-1.0",
     "Unicode-DFS-2016",

--- a/narwhal/worker/src/client.rs
+++ b/narwhal/worker/src/client.rs
@@ -15,7 +15,6 @@ use tracing::info;
 use types::{Transaction, TxResponse};
 
 /// Uses a map to allow running multiple Narwhal instances in the same process.
-/// TODO: after Rust 1.66, use BTreeMap::new() instead of wrapping it in an Option.
 static LOCAL_NARWHAL_CLIENTS: Mutex<BTreeMap<Multiaddr, Arc<ArcSwap<LocalNarwhalClient>>>> =
     Mutex::new(BTreeMap::new());
 


### PR DESCRIPTION
## Description 

This PR imports mysticeti and implements `BlockValidator` for `SuiBlockValidator`. The former is the counterpart of `TransactionValidator` in narwhal, used to verify the block contents. The major verification logic is extracted into a shared function `validate_transactions`.

Also updated `futures` and `zeroize`'s config to align with mysticeti's. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
