### PR TITLE
Extract object loading from transaction input checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9753,8 +9753,10 @@ name = "simulacrum"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "fastcrypto",
+ "futures",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -11622,6 +11624,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
+ "once_cell",
  "prometheus",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -11630,6 +11633,7 @@ dependencies = [
  "sui-macros",
  "sui-protocol-config",
  "sui-simulator",
+ "sui-storage",
  "sui-test-transaction-builder",
  "sui-transaction-checks",
  "sui-types",

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+async-trait.workspace = true   
 anyhow.workspace = true
 bcs.workspace = true
 fastcrypto.workspace = true
@@ -17,6 +18,7 @@ rand.workspace = true
 serde.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
+futures.workspace = true
 
 move-bytecode-utils.workspace = true
 narwhal-config.workspace = true

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -717,6 +717,9 @@ impl AuthorityState {
         let input_object_kinds = tx_data.input_objects()?;
         let receiving_objects_refs = tx_data.receiving_objects();
 
+        // Note: the deny checks may do redundant package loads but:
+        // - they only load packages when there is an active package deny map
+        // - the loads are cached anyway
         sui_transaction_checks::deny::check_transaction_for_signing(
             tx_data,
             transaction.tx_signatures(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -743,7 +743,7 @@ impl AuthorityState {
         let (_gas_status, checked_input_objects) = sui_transaction_checks::check_transaction_input(
             epoch_store.protocol_config(),
             epoch_store.reference_gas_price(),
-            transaction.data().transaction_data(),
+            tx_data,
             input_objects,
             receiving_objects,
             &self.metrics.bytecode_verifier_metrics,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -138,6 +138,7 @@ use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::{StateAccumulator, WrappedObject};
 use crate::subscription_handler::SubscriptionHandler;
+use crate::transaction_input_loader::TransactionInputLoader;
 use crate::transaction_manager::TransactionManager;
 
 #[cfg(test)]
@@ -617,6 +618,7 @@ pub struct AuthorityState {
     pub secret: StableSyncAuthoritySigner,
 
     /// The database
+    input_loader: TransactionInputLoader,
     pub database: Arc<AuthorityStore>, // TODO: remove pub
 
     epoch_store: ArcSwap<AuthorityPerEpochStore>,
@@ -709,18 +711,42 @@ impl AuthorityState {
         transaction: VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<VerifiedSignedTransaction> {
-        let (_gas_status, input_objects) = sui_transaction_checks::check_transaction_input(
+        let tx_digest = transaction.digest();
+        let tx_data = &transaction.data().intent_message().value;
+
+        let input_object_kinds = tx_data.input_objects()?;
+        let receiving_objects_refs = tx_data.receiving_objects();
+
+        sui_transaction_checks::deny::check_transaction_for_signing(
+            tx_data,
+            transaction.tx_signatures(),
+            &input_object_kinds,
+            &receiving_objects_refs,
+            &self.transaction_deny_config,
             &self.database,
+        )?;
+
+        let (input_objects, receiving_objects) = self
+            .input_loader
+            .read_objects_for_signing(
+                tx_digest,
+                &input_object_kinds,
+                &receiving_objects_refs,
+                epoch_store.protocol_config(),
+                epoch_store.epoch(),
+            )
+            .await?;
+
+        let (_gas_status, checked_input_objects) = sui_transaction_checks::check_transaction_input(
             epoch_store.protocol_config(),
             epoch_store.reference_gas_price(),
-            epoch_store.epoch(),
             transaction.data().transaction_data(),
-            transaction.tx_signatures(),
-            &self.transaction_deny_config,
+            input_objects,
+            receiving_objects,
             &self.metrics.bytecode_verifier_metrics,
         )?;
 
-        let owned_objects = input_objects.filter_owned_objects();
+        let owned_objects = checked_input_objects.inner().filter_owned_objects();
 
         let signed_transaction = VerifiedSignedTransaction::new(
             epoch_store.epoch(),
@@ -926,9 +952,37 @@ impl AuthorityState {
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<(TransactionEffects, Option<ExecutionError>)> {
+        let tx_digest = certificate.digest();
+        let input_objects = {
+            let _scope = monitored_scope("Execution::load_input_objects");
+            let input_objects = &certificate.data().intent_message().value.input_objects()?;
+            if certificate
+                .data()
+                .intent_message()
+                .value
+                .is_end_of_epoch_tx()
+            {
+                self.input_loader
+                    .read_objects_for_synchronous_execution(
+                        tx_digest,
+                        input_objects,
+                        epoch_store.protocol_config(),
+                    )
+                    .await?
+            } else {
+                self.input_loader
+                    .read_objects_for_execution(
+                        &**epoch_store,
+                        tx_digest,
+                        input_objects,
+                        epoch_store.epoch(),
+                    )
+                    .await?
+            }
+        };
+
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
-        let tx_digest = *certificate.digest();
         debug!("execute_certificate_internal");
 
         // This acquires a lock on the tx digest to prevent multiple concurrent executions of the
@@ -937,9 +991,15 @@ impl AuthorityState {
         // may as well hold the lock and save the cpu time for other requests.
         let tx_guard = epoch_store.acquire_tx_guard(certificate).await?;
 
-        self.process_certificate(tx_guard, certificate, expected_effects_digest, epoch_store)
-            .await
-            .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
+        self.process_certificate(
+            tx_guard,
+            certificate,
+            input_objects,
+            expected_effects_digest,
+            epoch_store,
+        )
+        .await
+        .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for checking errors if the
@@ -1016,6 +1076,7 @@ impl AuthorityState {
         &self,
         tx_guard: CertTxGuard,
         certificate: &VerifiedExecutableTransaction,
+        input_objects: InputObjects,
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<(TransactionEffects, Option<ExecutionError>)> {
@@ -1057,7 +1118,7 @@ impl AuthorityState {
         // this function occur before we have written anything to the db, so we commit the tx
         // guard and rely on the client to retry the tx (if it was transient).
         let (inner_temporary_store, effects, execution_error_opt) = match self
-            .prepare_certificate(&execution_guard, certificate, epoch_store)
+            .prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
             .await
         {
             Err(e) => {
@@ -1279,6 +1340,7 @@ impl AuthorityState {
         &self,
         _execution_guard: &ExecutionLockReadGuard<'_>,
         certificate: &VerifiedExecutableTransaction,
+        input_objects: InputObjects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<(
         InnerTemporaryStore,
@@ -1290,15 +1352,13 @@ impl AuthorityState {
 
         // check_certificate_input also checks shared object locks when loading the shared objects.
         let (gas_status, input_objects) = sui_transaction_checks::check_certificate_input(
-            &self.database,
-            epoch_store.as_ref(),
             certificate,
+            input_objects,
             epoch_store.protocol_config(),
             epoch_store.reference_gas_price(),
-            epoch_store.epoch(),
         )?;
 
-        let owned_object_refs = input_objects.filter_owned_objects();
+        let owned_object_refs = input_objects.inner().filter_owned_objects();
         self.check_owned_locks(&owned_object_refs).await?;
         let tx_digest = *certificate.digest();
         let protocol_config = epoch_store.protocol_config();
@@ -1353,9 +1413,31 @@ impl AuthorityState {
             });
         }
 
+        let input_object_kinds = transaction.input_objects()?;
+        let receiving_object_refs = transaction.receiving_objects();
+
+        sui_transaction_checks::deny::check_transaction_for_signing(
+            &transaction,
+            &[],
+            &input_object_kinds,
+            &receiving_object_refs,
+            &self.transaction_deny_config,
+            &self.database,
+        )?;
+
+        let (input_objects, receiving_objects) = self
+            .input_loader
+            .read_objects_for_dry_run_exec(
+                &transaction_digest,
+                &input_object_kinds,
+                &receiving_object_refs,
+                epoch_store.protocol_config(),
+            )
+            .await?;
+
         // make a gas object if one was not provided
         let mut gas_object_refs = transaction.gas().to_vec();
-        let ((gas_status, input_objects), mock_gas) = if transaction.gas().is_empty() {
+        let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
             let sender = transaction.sender();
             // use a 1B sui coin
             const MIST_TO_SUI: u64 = 1_000_000_000;
@@ -1371,11 +1453,11 @@ impl AuthorityState {
             gas_object_refs = vec![gas_object_ref];
             (
                 sui_transaction_checks::check_transaction_input_with_given_gas(
-                    &self.database,
                     epoch_store.protocol_config(),
                     epoch_store.reference_gas_price(),
-                    epoch_store.epoch(),
                     &transaction,
+                    input_objects,
+                    receiving_objects,
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
                 )?,
@@ -1384,13 +1466,11 @@ impl AuthorityState {
         } else {
             (
                 sui_transaction_checks::check_transaction_input(
-                    &self.database,
                     epoch_store.protocol_config(),
                     epoch_store.reference_gas_price(),
-                    epoch_store.epoch(),
                     &transaction,
-                    &[],
-                    &self.transaction_deny_config,
+                    input_objects,
+                    receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                 )?,
                 None,
@@ -1420,7 +1500,7 @@ impl AuthorityState {
                     .epoch_start_config()
                     .epoch_data()
                     .epoch_start_timestamp(),
-                input_objects,
+                checked_input_objects,
                 gas_object_refs,
                 gas_status,
                 kind,
@@ -1526,13 +1606,25 @@ impl AuthorityState {
             Owner::AddressOwner(sender),
             TransactionDigest::genesis(),
         );
-        let (gas_object_ref, input_objects) = sui_transaction_checks::check_dev_inspect_input(
-            &self.database,
-            protocol_config,
-            &transaction_kind,
-            gas_object,
-            epoch_store.epoch(),
-        )?;
+
+        let input_object_kinds = transaction_kind.input_objects()?;
+        let receiving_object_refs = transaction_kind.receiving_objects();
+        let (input_objects, receiving_objects) = self
+            .input_loader
+            .read_objects_for_dev_inspect(
+                &input_object_kinds,
+                &receiving_object_refs,
+                protocol_config,
+            )
+            .await?;
+        let (gas_object_ref, checked_input_objects) =
+            sui_transaction_checks::check_dev_inspect_input(
+                protocol_config,
+                &transaction_kind,
+                input_objects,
+                receiving_objects,
+                gas_object,
+            )?;
 
         let gas_budget = max_tx_gas;
         let data = TransactionData::new(
@@ -1542,6 +1634,7 @@ impl AuthorityState {
             gas_price,
             gas_budget,
         );
+
         let transaction_digest = TransactionDigest::new(default_hash(&data));
         let transaction_kind = data.into_kind();
         let silent = true;
@@ -1564,7 +1657,7 @@ impl AuthorityState {
                 .epoch_start_config()
                 .epoch_data()
                 .epoch_start_timestamp(),
-            input_objects,
+            checked_input_objects,
             vec![gas_object_ref],
             gas_status,
             transaction_kind,
@@ -2083,10 +2176,12 @@ impl AuthorityState {
             indirect_objects_threshold,
             archive_readers,
         );
+        let input_loader = TransactionInputLoader::new(store.clone());
         let state = Arc::new(AuthorityState {
             name,
             secret,
             epoch_store: ArcSwap::new(epoch_store.clone()),
+            input_loader,
             database: store,
             indexes,
             subscription_handler: Arc::new(SubscriptionHandler::new(prometheus_registry)),
@@ -4128,8 +4223,22 @@ impl AuthorityState {
             .database
             .execution_lock_for_executable_transaction(&executable_tx)
             .await?;
+
+        let input_objects = self
+            .input_loader
+            .read_objects_for_synchronous_execution(
+                tx_digest,
+                &executable_tx
+                    .data()
+                    .intent_message()
+                    .value
+                    .input_objects()?,
+                epoch_store.protocol_config(),
+            )
+            .await?;
+
         let (temporary_store, effects, _execution_error_opt) = self
-            .prepare_certificate(&execution_guard, &executable_tx, epoch_store)
+            .prepare_certificate(&execution_guard, &executable_tx, input_objects, epoch_store)
             .await?;
         let system_obj = get_sui_system_state(&temporary_store.written)
             .expect("change epoch tx must write to system object");
@@ -4614,7 +4723,7 @@ impl NodeStateDump {
             input_objects: inner_temporary_store
                 .input_objects
                 .values()
-                .cloned()
+                .map(|o| (**o).clone())
                 .collect(),
             computed_effects: effects.clone(),
             expected_effects_digest,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,8 +20,8 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module, BackingPackageStore, ChildObjectResolver, MarkerTableQuery, MarkerValue, ObjectKey,
-    ObjectStore, PackageObjectArc,
+    get_module, BackingPackageStore, ChildObjectResolver, MarkerValue, ObjectKey, ObjectStore,
+    PackageObjectArc,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -421,11 +421,11 @@ impl AuthorityStore {
         }
     }
 
-    pub fn is_shared_object_deleted(
+    pub fn get_last_shared_object_deletion_info(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
-    ) -> SuiResult<bool> {
+    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>> {
         let object_key = ObjectKey::max_for_id(object_id);
         let marker_key = (epoch_id, object_key);
 
@@ -436,16 +436,19 @@ impl AuthorityStore {
             .skip_prior_to(&marker_key)?
             .next();
         match marker_entry {
-            Some(((epoch, key), marker)) => {
+            // Make sure the object was deleted or wrapped.
+            Some(((epoch, key), MarkerValue::SharedDeleted(digest))) => {
                 // Make sure object id matches and version is >= `version`
                 let object_id_matches = key.0 == *object_id;
                 // Make sure we don't have a stale epoch for some reason (e.g., a revert)
                 let epoch_data_ok = epoch == epoch_id;
-                // Make sure the object was deleted or wrapped.
-                let mark_data_ok = matches!(marker, MarkerValue::SharedDeleted(_));
-                Ok(object_id_matches && epoch_data_ok && mark_data_ok)
+                if object_id_matches && epoch_data_ok {
+                    Ok(Some((key.1, digest)))
+                } else {
+                    Ok(None)
+                }
             }
-            None => Ok(false),
+            _ => Ok(None),
         }
     }
 
@@ -1639,6 +1642,18 @@ impl AuthorityStore {
             .get_latest_object_ref_or_tombstone(object_id)
     }
 
+    /// Returns the latest object reference if and only if the object is still live (i.e. it does
+    /// not return tombstones)
+    pub fn get_latest_object_ref(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<Option<ObjectRef>, SuiError> {
+        match self.get_latest_object_ref_or_tombstone(object_id)? {
+            Some(objref) if objref.2.is_alive() => Ok(Some(objref)),
+            _ => Ok(None),
+        }
+    }
+
     /// Returns the latest object we have for this object_id in the objects table.
     ///
     /// If no entry for the object_id is found, return None.
@@ -1964,33 +1979,6 @@ impl AuthorityStore {
             .collect();
         info!("Removing all versions of object: {:?}", entries);
         self.perpetual_tables.objects.multi_remove(entries).unwrap();
-    }
-}
-
-impl MarkerTableQuery for AuthorityStore {
-    fn have_received_object_at_version(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-        epoch_id: EpochId,
-    ) -> Result<bool, SuiError> {
-        self.have_received_object_at_version(object_id, version, epoch_id)
-    }
-
-    fn get_deleted_shared_object_previous_tx_digest(
-        &self,
-        object_id: &ObjectID,
-        version: &SequenceNumber,
-        epoch_id: EpochId,
-    ) -> Result<Option<TransactionDigest>, SuiError> {
-        Ok(self.get_deleted_shared_object_previous_tx_digest(object_id, version, epoch_id)?)
-    }
-    fn is_shared_object_deleted(
-        &self,
-        object_id: &ObjectID,
-        epoch_id: EpochId,
-    ) -> Result<bool, SuiError> {
-        self.is_shared_object_deleted(object_id, epoch_id)
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1644,7 +1644,7 @@ impl AuthorityStore {
 
     /// Returns the latest object reference if and only if the object is still live (i.e. it does
     /// not return tombstones)
-    pub fn get_latest_object_ref(
+    pub fn get_latest_object_ref_if_alive(
         &self,
         object_id: ObjectID,
     ) -> Result<Option<ObjectRef>, SuiError> {

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod streamer;
 pub mod subscription_handler;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
+mod transaction_input_loader;
 mod transaction_manager;
 pub mod transaction_orchestrator;
 pub mod verify_indexes;

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -1,0 +1,348 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::authority_store::AuthorityStore;
+use itertools::izip;
+use once_cell::unsync::OnceCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{
+    base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, TransactionDigest},
+    error::{SuiError, SuiResult, UserInputError},
+    fp_ensure,
+    storage::{BackingPackageStore, GetSharedLocks, ObjectKey, ObjectStore},
+    transaction::{
+        InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
+        ReceivingObjectReadResult, ReceivingObjectReadResultKind, ReceivingObjects,
+    },
+};
+
+pub(crate) struct TransactionInputLoader {
+    store: Arc<AuthorityStore>,
+}
+
+impl TransactionInputLoader {
+    pub fn new(store: Arc<AuthorityStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl TransactionInputLoader {
+    /// Read the inputs for a transaction that the validator was asked to sign.
+    /// tx_digest is provided so that the inputs can be cached with the tx_digest and returned with
+    /// a single hash map lookup when notify_read_objects_for_execution is called later.
+    pub async fn read_objects_for_signing(
+        &self,
+        _tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_objects: &[ObjectRef],
+        protocol_config: &ProtocolConfig,
+        epoch_id: EpochId,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        fp_ensure!(
+            receiving_objects.len() + input_object_kinds.len()
+                <= protocol_config.max_input_objects() as usize,
+            UserInputError::SizeLimitExceeded {
+                limit: "maximum input and receiving objects in a transaction".to_string(),
+                value: protocol_config.max_input_objects().to_string()
+            }
+            .into()
+        );
+
+        let mut results = vec![None; input_object_kinds.len()];
+        let mut object_keys = Vec::with_capacity(input_object_kinds.len());
+        let mut fetch_indices = Vec::with_capacity(input_object_kinds.len());
+        let mut missing_shared_objects = Vec::new();
+
+        for (i, kind) in input_object_kinds.iter().enumerate() {
+            let obj_ref = match kind {
+                // Packages are loaded one at a time via the cache
+                InputObjectKind::MovePackage(id) => {
+                    let package = self.store.get_package_object(id)?.map(|o| o.into());
+                    if package.is_none() {
+                        return Err(SuiError::from(kind.object_not_found_error()));
+                    }
+                    results[i] = Some(ObjectReadResult {
+                        input_object_kind: *kind,
+                        object: ObjectReadResultKind::Object(package.unwrap()),
+                    });
+                    continue;
+                }
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    let objref = self.store.get_latest_object_ref(*id)?;
+                    if objref.is_none() {
+                        missing_shared_objects.push((i, *id));
+                        continue;
+                    }
+                    objref
+                }
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => Some(*objref),
+            }
+            .ok_or_else(|| SuiError::from(kind.object_not_found_error()))?;
+
+            object_keys.push(ObjectKey::from(obj_ref));
+            fetch_indices.push(i);
+        }
+
+        let objects = self.store.multi_get_object_by_key(&object_keys)?;
+        for (index, object) in fetch_indices.into_iter().zip(objects.into_iter()) {
+            let object = object.ok_or_else(|| {
+                SuiError::from(input_object_kinds[index].object_not_found_error())
+            })?;
+
+            results[index] = Some(ObjectReadResult {
+                input_object_kind: input_object_kinds[index],
+                object: ObjectReadResultKind::Object(Arc::new(object)),
+            });
+        }
+
+        for (i, id) in missing_shared_objects {
+            if let Some((version, digest)) = self
+                .store
+                .get_last_shared_object_deletion_info(&id, epoch_id)?
+            {
+                results[i] = Some(ObjectReadResult {
+                    input_object_kind: input_object_kinds[i],
+                    object: ObjectReadResultKind::DeletedSharedObject(version, digest),
+                });
+            } else {
+                return Err(SuiError::from(
+                    input_object_kinds[i].object_not_found_error(),
+                ));
+            }
+        }
+
+        // Load receiving objects
+        let mut receiving_results = Vec::with_capacity(receiving_objects.len());
+        for objref in receiving_objects {
+            let (object_id, version, _) = objref;
+            fp_ensure!(
+                *version < SequenceNumber::MAX,
+                UserInputError::InvalidSequenceNumber.into()
+            );
+
+            if self
+                .store
+                .have_received_object_at_version(object_id, *version, epoch_id)?
+            {
+                receiving_results.push(ReceivingObjectReadResult::new(
+                    *objref,
+                    ReceivingObjectReadResultKind::PreviouslyReceivedObject,
+                ));
+                continue;
+            }
+
+            let Some(object) = self.store.get_object(object_id)? else {
+                return Err(UserInputError::ObjectNotFound {
+                    object_id: *object_id,
+                    version: Some(*version),
+                }
+                .into());
+            };
+
+            receiving_results.push(ReceivingObjectReadResult::new(*objref, object.into()));
+        }
+
+        Ok((
+            results
+                .into_iter()
+                .map(Option::unwrap)
+                .collect::<Vec<_>>()
+                .into(),
+            receiving_results.into(),
+        ))
+    }
+
+    /// Reads input objects assuming a synchronous context such as the end of epoch transaction.
+    /// By "synchronous" we mean that it is safe to read the latest version of all shared objects,
+    /// as opposed to relying on the shared input version assignment.
+    pub async fn read_objects_for_synchronous_execution(
+        &self,
+        tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        protocol_config: &ProtocolConfig,
+    ) -> SuiResult<InputObjects> {
+        self.read_objects_for_synchronous_execution_impl(
+            Some(tx_digest),
+            input_object_kinds,
+            &[],
+            protocol_config,
+        )
+        .await
+        .map(|r| r.0)
+    }
+
+    /// Read input objects for a dry run execution.
+    pub async fn read_objects_for_dry_run_exec(
+        &self,
+        tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_objects: &[ObjectRef],
+        protocol_config: &ProtocolConfig,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        self.read_objects_for_synchronous_execution_impl(
+            Some(tx_digest),
+            input_object_kinds,
+            receiving_objects,
+            protocol_config,
+        )
+        .await
+    }
+
+    /// Read input objects for dev inspect
+    pub async fn read_objects_for_dev_inspect(
+        &self,
+        input_object_kinds: &[InputObjectKind],
+        receiving_objects: &[ObjectRef],
+        protocol_config: &ProtocolConfig,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        self.read_objects_for_synchronous_execution_impl(
+            None,
+            input_object_kinds,
+            receiving_objects,
+            protocol_config,
+        )
+        .await
+    }
+
+    /// Read the inputs for a transaction that is ready to be executed.
+    ///
+    /// shared_lock_store is used to resolve the versions of any shared input objects.
+    ///
+    /// This function panics if any inputs are not available, as TransactionManager should already
+    /// have verified that the transaction is ready to be executed.
+    ///
+    /// The tx_digest is provided here to support the following optimization (not yet implemented):
+    /// All the owned input objects will likely have been loaded during transaction signing, and
+    /// can be stored as a group with the transaction_digest as the key, allowing the lookup to
+    /// proceed with only a single hash map lookup. (additional lookups may be necessary for shared
+    /// inputs, since the versions are not known at signing time).
+    pub async fn read_objects_for_execution(
+        &self,
+        shared_lock_store: &dyn GetSharedLocks,
+        tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        epoch_id: EpochId,
+    ) -> SuiResult<InputObjects> {
+        let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
+
+        let mut results = vec![None; input_object_kinds.len()];
+        let mut object_keys = Vec::with_capacity(input_object_kinds.len());
+        let mut fetch_indices = Vec::with_capacity(input_object_kinds.len());
+
+        for (i, input) in input_object_kinds.iter().enumerate() {
+            match input {
+                InputObjectKind::MovePackage(id) => {
+                    let package = self.store.get_package_object(id)?.unwrap_or_else(|| {
+                        panic!(
+                            "Executable transaction {:?} depends on non-existent package {:?}",
+                            tx_digest, id
+                        )
+                    });
+
+                    results[i] = Some(ObjectReadResult {
+                        input_object_kind: *input,
+                        object: ObjectReadResultKind::Object(package.into()),
+                    });
+                }
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => object_keys.push(objref.into()),
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    let shared_locks = shared_locks_cell.get_or_try_init(|| {
+                        Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
+                            shared_lock_store
+                                .get_shared_locks(tx_digest)?
+                                .into_iter()
+                                .collect(),
+                        )
+                    })?;
+                    // If we can't find the locked version, it means
+                    // 1. either we have a bug that skips shared object version assignment
+                    // 2. or we have some DB corruption
+                    let version = shared_locks.get(id).unwrap_or_else(|| {
+                        panic!(
+                            "Shared object locks should have been set. tx_digest: {:?}, obj id: {:?}",
+                            tx_digest, id
+                        )
+                    });
+                    object_keys.push(ObjectKey(*id, *version));
+                    fetch_indices.push(i);
+                }
+            }
+        }
+
+        let objects = self.store.multi_get_object_by_key(&object_keys)?;
+
+        for (object, input, key, index) in izip!(
+            objects.into_iter(),
+            input_object_kinds,
+            object_keys.into_iter(),
+            fetch_indices.into_iter()
+        ) {
+            results[index] = Some(match (object, input) {
+                (Some(obj), input_object_kind) => ObjectReadResult {
+                    input_object_kind: *input_object_kind,
+                    object: obj.into(),
+                },
+                (None, InputObjectKind::SharedMoveObject { id, .. }) => {
+                    // Check if the object was deleted by a concurrently certified tx
+                    let version = key.1;
+                    if let Some(dependency) = self.store.get_deleted_shared_object_previous_tx_digest(id, &version, epoch_id)? {
+                        ObjectReadResult {
+                            input_object_kind: *input,
+                            object: ObjectReadResultKind::DeletedSharedObject(version, dependency),
+                        }
+                    } else {
+                        panic!("All dependencies of tx {:?} should have been executed now, but Shared Object id: {}, version: {} is absent in epoch {}", tx_digest, *id, version, epoch_id);
+                    }
+                },
+                _ => panic!("All dependencies of tx {:?} should have been executed now, but obj {:?} is absent", tx_digest, key),
+            });
+        }
+
+        Ok(results
+            .into_iter()
+            .map(Option::unwrap)
+            .collect::<Vec<_>>()
+            .into())
+    }
+}
+
+// private methods
+impl TransactionInputLoader {
+    async fn read_objects_for_synchronous_execution_impl(
+        &self,
+        _tx_digest: Option<&TransactionDigest>,
+        input_object_kinds: &[InputObjectKind],
+        receiving_objects: &[ObjectRef],
+        protocol_config: &ProtocolConfig,
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        fp_ensure!(
+            receiving_objects.len() + input_object_kinds.len()
+                <= protocol_config.max_input_objects() as usize,
+            UserInputError::SizeLimitExceeded {
+                limit: "maximum input and receiving objects in a transaction".to_string(),
+                value: protocol_config.max_input_objects().to_string()
+            }
+            .into()
+        );
+
+        let mut results = Vec::with_capacity(input_object_kinds.len());
+        for kind in input_object_kinds {
+            let obj = match kind {
+                InputObjectKind::MovePackage(id) => self
+                    .store
+                    .get_package_object(id)?
+                    .map(|o| o.object().clone()),
+
+                InputObjectKind::SharedMoveObject { id, .. } => self.store.get_object(id)?,
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
+                    self.store.get_object_by_key(&objref.0, objref.1)?
+                }
+            }
+            .ok_or_else(|| SuiError::from(kind.object_not_found_error()))?;
+            results.push(ObjectReadResult::new(*kind, obj.into()));
+        }
+        Ok((results.into(), vec![].into()))
+    }
+}

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -249,7 +249,10 @@ impl TransactionInputLoader {
                     });
                     continue;
                 }
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => object_keys.push(objref.into()),
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
+                    object_keys.push(objref.into());
+                    fetches.push((i, input));
+                }
                 InputObjectKind::SharedMoveObject { id, .. } => {
                     let shared_locks = shared_locks_cell.get_or_try_init(|| {
                         Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -245,6 +245,7 @@ impl TransactionInputLoader {
                         input_object_kind: *input,
                         object: ObjectReadResultKind::Object(package.into()),
                     });
+                    continue;
                 }
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => object_keys.push(objref.into()),
                 InputObjectKind::SharedMoveObject { id, .. } => {

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -17,6 +17,7 @@ use sui_types::{
         ReceivingObjectReadResult, ReceivingObjectReadResultKind, ReceivingObjects,
     },
 };
+use tracing::instrument;
 
 pub(crate) struct TransactionInputLoader {
     store: Arc<AuthorityStore>,
@@ -32,6 +33,7 @@ impl TransactionInputLoader {
     /// Read the inputs for a transaction that the validator was asked to sign.
     /// tx_digest is provided so that the inputs can be cached with the tx_digest and returned with
     /// a single hash map lookup when notify_read_objects_for_execution is called later.
+    #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_signing(
         &self,
         _tx_digest: &TransactionDigest,
@@ -148,6 +150,7 @@ impl TransactionInputLoader {
     /// Reads input objects assuming a synchronous context such as the end of epoch transaction.
     /// By "synchronous" we mean that it is safe to read the latest version of all shared objects,
     /// as opposed to relying on the shared input version assignment.
+    #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_synchronous_execution(
         &self,
         tx_digest: &TransactionDigest,
@@ -165,6 +168,7 @@ impl TransactionInputLoader {
     }
 
     /// Read input objects for a dry run execution.
+    #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_dry_run_exec(
         &self,
         tx_digest: &TransactionDigest,
@@ -182,6 +186,7 @@ impl TransactionInputLoader {
     }
 
     /// Read input objects for dev inspect
+    #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_dev_inspect(
         &self,
         input_object_kinds: &[InputObjectKind],
@@ -209,6 +214,7 @@ impl TransactionInputLoader {
     /// can be stored as a group with the transaction_digest as the key, allowing the lookup to
     /// proceed with only a single hash map lookup. (additional lookups may be necessary for shared
     /// inputs, since the versions are not known at signing time).
+    #[instrument(level = "trace", skip_all)]
     pub async fn read_objects_for_execution(
         &self,
         shared_lock_store: &dyn GetSharedLocks,

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -14,12 +14,14 @@ sui-core = { workspace = true, features = ["test-utils"] }
 sui-test-transaction-builder.workspace = true
 sui-transaction-checks.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
+sui-storage.workspace = true
 
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
 futures.workspace = true
 prometheus.workspace = true
+once_cell.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -4,6 +4,7 @@
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::ModuleId;
+use once_cell::unsync::OnceCell;
 use prometheus::core::{Atomic, AtomicU64};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -14,10 +15,11 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::object::{Object, Owner};
 use sui_types::storage::{
     get_module_by_id, load_package_object_from_object_store, BackingPackageStore,
-    ChildObjectResolver, GetSharedLocks, MarkerTableQuery, ObjectStore, PackageObjectArc,
-    ParentSync,
+    ChildObjectResolver, GetSharedLocks, ObjectStore, PackageObjectArc, ParentSync,
 };
+use sui_types::transaction::{InputObjectKind, InputObjects, ObjectReadResult};
 
+// TODO: We won't need a special purpose InMemoryObjectStore once the InMemoryCache is ready.
 #[derive(Clone)]
 pub(crate) struct InMemoryObjectStore {
     objects: Arc<HashMap<ObjectID, Object>>,
@@ -34,6 +36,78 @@ impl InMemoryObjectStore {
 
     pub(crate) fn get_num_object_reads(&self) -> u64 {
         self.num_object_reads.get()
+    }
+
+    // TODO: remove this when TransactionInputLoader is able to use the ExecutionCache trait
+    // note: does not support shared object deletion.
+    pub(crate) fn read_objects_for_execution(
+        &self,
+        shared_locks: &dyn GetSharedLocks,
+        tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+    ) -> SuiResult<InputObjects> {
+        let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
+        let mut input_objects = Vec::new();
+        for kind in input_object_kinds {
+            let obj: Option<Arc<_>> = match kind {
+                InputObjectKind::MovePackage(id) => self.get_package_object(id)?.map(|o| o.into()),
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => self
+                    .get_object_by_key(&objref.0, objref.1)?
+                    .map(|o| o.into()),
+
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    let shared_locks = shared_locks_cell.get_or_try_init(|| {
+                        Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
+                            shared_locks
+                                .get_shared_locks(tx_digest)?
+                                .into_iter()
+                                .collect(),
+                        )
+                    })?;
+                    let version = shared_locks.get(id).unwrap_or_else(|| {
+                        panic!(
+                            "Shared object locks should have been set. tx_digest: {:?}, obj id: {:?}",
+                            tx_digest, id
+                        )
+                    });
+
+                    self.get_object_by_key(id, *version)?.map(|o| o.into())
+                }
+            };
+
+            input_objects.push(ObjectReadResult::new(
+                *kind,
+                obj.ok_or_else(|| kind.object_not_found_error())?.into(),
+            ));
+        }
+
+        Ok(input_objects.into())
+    }
+
+    pub(crate) fn read_objects_for_synchronous_execution(
+        &self,
+        input_object_kinds: &[InputObjectKind],
+    ) -> SuiResult<InputObjects> {
+        let mut input_objects = Vec::new();
+        for kind in input_object_kinds {
+            let obj: Option<Arc<_>> = match kind {
+                InputObjectKind::MovePackage(id) => self.get_package_object(id)?.map(|o| o.into()),
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => self
+                    .get_object_by_key(&objref.0, objref.1)?
+                    .map(|o| o.into()),
+
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    self.get_object(id)?.map(|o| o.into())
+                }
+            };
+
+            input_objects.push(ObjectReadResult::new(
+                *kind,
+                obj.ok_or_else(|| kind.object_not_found_error())?.into(),
+            ));
+        }
+
+        Ok(input_objects.into())
     }
 }
 
@@ -99,34 +173,6 @@ impl GetModule for InMemoryObjectStore {
 
     fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
         get_module_by_id(self, id)
-    }
-}
-
-impl MarkerTableQuery for InMemoryObjectStore {
-    fn have_received_object_at_version(
-        &self,
-        _object_id: &ObjectID,
-        _version: VersionNumber,
-        _epoch_id: EpochId,
-    ) -> Result<bool, SuiError> {
-        // Currently the workload doesn't yet support receiving objects.
-        unimplemented!()
-    }
-    fn get_deleted_shared_object_previous_tx_digest(
-        &self,
-        _object_id: &ObjectID,
-        _version: &SequenceNumber,
-        _epoch_id: EpochId,
-    ) -> Result<Option<TransactionDigest>, SuiError> {
-        // Currently the workload doesn't yet support deleted shared objects
-        unimplemented!()
-    }
-    fn is_shared_object_deleted(
-        &self,
-        _object_id: &ObjectID,
-        _epoch_id: EpochId,
-    ) -> Result<bool, SuiError> {
-        unimplemented!()
     }
 }
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -1589,6 +1589,7 @@ mod tests {
     use prometheus::Registry;
     use std::collections::BTreeMap;
     use std::env::temp_dir;
+    use std::sync::Arc;
     use sui_types::base_types::{ObjectInfo, ObjectType, SuiAddress};
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEvents;
@@ -1624,7 +1625,7 @@ mod tests {
                     previous_transaction: object.previous_transaction,
                 },
             ));
-            object_map.insert(object.id(), object.clone());
+            object_map.insert(object.id(), Arc::new(object.clone()));
             written_objects.insert(object.data.id(), object);
         }
         let object_index_changes = ObjectIndexChanges {
@@ -1671,7 +1672,7 @@ mod tests {
         let mut deleted_objects = vec![];
         for (id, object) in object_map.iter().take(3) {
             deleted_objects.push((address, *id));
-            written_objects.insert(object.data.id(), object.clone());
+            written_objects.insert(object.data.id(), (**object).clone());
         }
         let object_index_changes = ObjectIndexChanges {
             deleted_owners: deleted_objects,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -407,7 +407,7 @@ mod test {
     use sui_types::in_memory_storage::InMemoryStorage;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::sui_system_state::SuiSystemStateTrait;
-    use sui_types::transaction::InputObjects;
+    use sui_types::transaction::CheckedInputObjects;
 
     #[test]
     fn roundtrip() {
@@ -447,7 +447,7 @@ mod test {
         let epoch = EpochData::new_test();
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, _) = transaction_data.execution_parts();
-        let input_objects = InputObjects::new(vec![], vec![]);
+        let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
 
         let (_inner_temp_store, effects, _execution_error) = executor
             .execute_transaction_to_effects(

--- a/crates/sui-transaction-checks/src/deny.rs
+++ b/crates/sui-transaction-checks/src/deny.rs
@@ -27,7 +27,7 @@ macro_rules! deny_if_true {
 pub fn check_transaction_for_signing(
     tx_data: &TransactionData,
     tx_signatures: &[GenericSignature],
-    input_objects: &[InputObjectKind],
+    input_object_kinds: &[InputObjectKind],
     receiving_objects: &[ObjectRef],
     filter_config: &TransactionDenyConfig,
     package_store: &impl BackingPackageStore,
@@ -36,7 +36,7 @@ pub fn check_transaction_for_signing(
 
     check_signers(filter_config, tx_data)?;
 
-    check_input_objects(filter_config, input_objects)?;
+    check_input_objects(filter_config, input_object_kinds)?;
 
     check_package_dependencies(filter_config, tx_data, package_store)?;
 
@@ -126,7 +126,7 @@ fn check_signers(filter_config: &TransactionDenyConfig, tx_data: &TransactionDat
 
 fn check_input_objects(
     filter_config: &TransactionDenyConfig,
-    input_objects: &[InputObjectKind],
+    input_object_kinds: &[InputObjectKind],
 ) -> SuiResult {
     let deny_map = filter_config.get_object_deny_set();
     let shared_object_disabled = filter_config.shared_object_disabled();
@@ -134,14 +134,14 @@ fn check_input_objects(
         // No need to iterate through the input objects if no relevant policy is set.
         return Ok(());
     }
-    for object_kind in input_objects {
-        let id = object_kind.object_id();
+    for input_object_kind in input_object_kinds {
+        let id = input_object_kind.object_id();
         deny_if_true!(
             deny_map.contains(&id),
             format!("Access to input object {:?} is temporarily disabled", id)
         );
         deny_if_true!(
-            shared_object_disabled && object_kind.is_shared_object(),
+            shared_object_disabled && input_object_kind.is_shared_object(),
             "Usage of shared object in transactions is temporarily disabled"
         );
     }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -7,25 +7,17 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    use once_cell::sync::OnceCell;
-    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::collections::{BTreeMap, HashSet};
     use std::sync::Arc;
-    use sui_config::transaction_deny_config::TransactionDenyConfig;
     use sui_protocol_config::ProtocolConfig;
-    use sui_types::base_types::{ObjectID, ObjectRef};
-    use sui_types::committee::EpochId;
-    use sui_types::digests::TransactionDigest;
+    use sui_types::base_types::ObjectRef;
     use sui_types::error::{UserInputError, UserInputResult};
     use sui_types::executable_transaction::VerifiedExecutableTransaction;
-    use sui_types::execution::DeletedSharedObjects;
     use sui_types::metrics::BytecodeVerifierMetrics;
-    use sui_types::signature::GenericSignature;
-    use sui_types::storage::MarkerTableQuery;
-    use sui_types::storage::ObjectStore;
-    use sui_types::storage::{BackingPackageStore, GetSharedLocks};
     use sui_types::transaction::{
-        InputObjectKind, InputObjects, TransactionData, TransactionDataAPI, TransactionKind,
-        VersionedProtocolMessage,
+        CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
+        ReceivingObjectReadResult, ReceivingObjects, TransactionData, TransactionDataAPI,
+        TransactionKind, VersionedProtocolMessage,
     };
     use sui_types::{
         base_types::{SequenceNumber, SuiAddress},
@@ -40,12 +32,22 @@ mod checked {
     use tracing::error;
     use tracing::instrument;
 
+    trait IntoChecked {
+        fn into_checked(self) -> CheckedInputObjects;
+    }
+
+    impl IntoChecked for InputObjects {
+        fn into_checked(self) -> CheckedInputObjects {
+            CheckedInputObjects::new_with_checked_transaction_inputs(self)
+        }
+    }
+
     // Entry point for all checks related to gas.
     // Called on both signing and execution.
     // On success the gas part of the transaction (gas data and gas coins)
     // is verified and good to go
     pub fn get_gas_status(
-        objects: &[Object],
+        objects: &InputObjects,
         gas: &[ObjectRef],
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
@@ -63,114 +65,68 @@ mod checked {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn check_transaction_input<S>(
-        store: &S,
+    pub fn check_transaction_input(
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        epoch_id: EpochId,
         transaction: &TransactionData,
-        tx_signatures: &[GenericSignature],
-        transaction_deny_config: &TransactionDenyConfig,
+        input_objects: InputObjects,
+        receiving_objects: ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
-    ) -> SuiResult<(SuiGasStatus, InputObjects)>
-    where
-        S: BackingPackageStore + ObjectStore + MarkerTableQuery,
-    {
+    ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
         transaction.check_version_supported(protocol_config)?;
         transaction.validity_check(protocol_config)?;
-        let receiving_objects = transaction.receiving_objects();
-        let input_objects = transaction.input_objects()?;
-        crate::deny::check_transaction_for_signing(
-            transaction,
-            tx_signatures,
-            &input_objects,
-            &receiving_objects,
-            transaction_deny_config,
-            &store,
-        )?;
-
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
 
-        let inputs = check_input_objects(store, &input_objects, protocol_config, epoch_id)?;
-        let objects: Vec<Object> = inputs.iter().map(|(_, o)| o.clone()).collect();
-
+        check_input_objects(&input_objects, protocol_config)?;
         let gas_status = get_gas_status(
-            &objects,
+            &input_objects,
             transaction.gas(),
             protocol_config,
             reference_gas_price,
             transaction,
         )?;
-        let input_objects = check_objects(transaction, inputs, Vec::new())?;
-        check_receiving_objects(
-            store,
-            &receiving_objects,
-            &input_objects,
-            protocol_config,
-            epoch_id,
-        )?;
-        Ok((gas_status, input_objects))
+        check_objects(transaction, &input_objects)?;
+        check_receiving_objects(&input_objects, &receiving_objects)?;
+        Ok((gas_status, input_objects.into_checked()))
     }
 
-    pub fn check_transaction_input_with_given_gas<S>(
-        store: &S,
+    pub fn check_transaction_input_with_given_gas(
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        epoch_id: EpochId,
         transaction: &TransactionData,
+        mut input_objects: InputObjects,
+        receiving_objects: ReceivingObjects,
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
-    ) -> SuiResult<(SuiGasStatus, InputObjects)>
-    where
-        S: ObjectStore + BackingPackageStore + MarkerTableQuery,
-    {
+    ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
         transaction.check_version_supported(protocol_config)?;
         transaction.validity_check_no_gas_check(protocol_config)?;
         check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
-        let receiving_objects = transaction.receiving_objects();
-        let input_object_kinds = transaction.input_objects()?;
-        let mut inputs =
-            check_input_objects(store, &input_object_kinds, protocol_config, epoch_id)?;
+        check_input_objects(&input_objects, protocol_config)?;
 
         let gas_object_ref = gas_object.compute_object_reference();
-        inputs.push((
-            InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref),
-            gas_object,
-        ));
-        let objects: Vec<Object> = inputs.iter().map(|(_, o)| o.clone()).collect();
+        input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
 
         let gas_status = get_gas_status(
-            &objects,
+            &input_objects,
             &[gas_object_ref],
             protocol_config,
             reference_gas_price,
             transaction,
         )?;
-        let input_objects = check_objects(transaction, inputs, Vec::new())?;
-        check_receiving_objects(
-            store,
-            &receiving_objects,
-            &input_objects,
-            protocol_config,
-            epoch_id,
-        )?;
-        Ok((gas_status, input_objects))
+        check_objects(transaction, &input_objects)?;
+        check_receiving_objects(&input_objects, &receiving_objects)?;
+        Ok((gas_status, input_objects.into_checked()))
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn check_certificate_input<S, G>(
-        store: &S,
-        shared_lock_store: &G,
+    pub fn check_certificate_input(
         cert: &VerifiedExecutableTransaction,
+        input_objects: InputObjects,
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
-        epoch_id: EpochId,
-    ) -> SuiResult<(SuiGasStatus, InputObjects)>
-    where
-        S: ObjectStore + BackingPackageStore + MarkerTableQuery,
-        G: GetSharedLocks,
-    {
+    ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
         // This should not happen - validators should not have signed the txn in the first place.
         assert!(
             cert.data()
@@ -182,51 +138,30 @@ mod checked {
         );
 
         let tx_data = &cert.data().intent_message().value;
-        let input_object_kinds = tx_data.input_objects()?;
-        let (input_object_data, deleted_shared_objects) = if tx_data.is_end_of_epoch_tx() {
-            // When changing the epoch, we update a the system object, which is shared, without going
-            // through sequencing, so we must bypass the sequence checks here.
-            (
-                check_input_objects(store, &input_object_kinds, protocol_config, epoch_id)?,
-                Vec::new(),
-            )
-        } else {
-            check_sequenced_input_objects(
-                store,
-                cert.digest(),
-                &input_object_kinds,
-                shared_lock_store,
-                epoch_id,
-            )?
-        };
-        let objects: Vec<Object> = input_object_data
-            .iter()
-            .map(|(_, obj)| obj.clone())
-            .collect();
+
+        check_input_objects(&input_objects, protocol_config)?;
         let gas_status = get_gas_status(
-            &objects,
+            &input_objects,
             tx_data.gas(),
             protocol_config,
             reference_gas_price,
             tx_data,
         )?;
-        let input_objects = check_objects(tx_data, input_object_data, deleted_shared_objects)?;
+        check_objects(tx_data, &input_objects)?;
         // NB: We do not check receiving objects when executing. Only at signing time do we check.
-        Ok((gas_status, input_objects))
+        Ok((gas_status, input_objects.into_checked()))
     }
 
     /// WARNING! This should only be used for the dev-inspect transaction. This transaction type
     /// bypasses many of the normal object checks
-    pub fn check_dev_inspect_input<S>(
-        store: &S,
+    pub fn check_dev_inspect_input(
         config: &ProtocolConfig,
         kind: &TransactionKind,
+        mut input_objects: InputObjects,
+        // TODO: check ReceivingObjects for dev inspect?
+        _receiving_objects: ReceivingObjects,
         gas_object: Object,
-        epoch_id: EpochId,
-    ) -> SuiResult<(ObjectRef, InputObjects)>
-    where
-        S: ObjectStore + BackingPackageStore + MarkerTableQuery,
-    {
+    ) -> SuiResult<(ObjectRef, CheckedInputObjects)> {
         let gas_object_ref = gas_object.compute_object_reference();
         kind.validity_check(config)?;
         if kind.is_system_tx() {
@@ -236,12 +171,14 @@ mod checked {
             ))
             .into());
         }
-        let mut input_objects = kind.input_objects()?;
-        let inputs = check_input_objects(store, &input_objects, config, epoch_id)?;
-        let mut objects: Vec<Object> = inputs.iter().map(|(_, o)| o.clone()).collect();
-
+        check_input_objects(&input_objects, config)?;
         let mut used_objects: HashSet<SuiAddress> = HashSet::new();
-        for object in &objects {
+        for input_object in input_objects.iter() {
+            let Some(object) = input_object.as_object() else {
+                // object was deleted
+                continue;
+            };
+
             if !object.is_immutable() {
                 fp_ensure!(
                     used_objects.insert(object.id().into()),
@@ -252,35 +189,19 @@ mod checked {
                 );
             }
         }
-        input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
-        objects.push(gas_object);
-        let input_objects =
-            InputObjects::new(input_objects.into_iter().zip(objects).collect(), Vec::new());
-        Ok((gas_object_ref, input_objects))
+
+        input_objects.push(ObjectReadResult::new(
+            InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref),
+            gas_object.into(),
+        ));
+
+        Ok((gas_object_ref, input_objects.into_checked()))
     }
 
-    fn check_receiving_objects<S>(
-        store: &S,
-        receiving_objects: &[ObjectRef],
+    fn check_receiving_objects(
         input_objects: &InputObjects,
-        protocol_config: &ProtocolConfig,
-        epoch_id: EpochId,
-    ) -> Result<(), SuiError>
-    where
-        S: ObjectStore + MarkerTableQuery,
-    {
-        // Count receiving objects towards the input object limit as they are passed in the PTB
-        // args and they will (most likely) incur an object load at runtime.
-        fp_ensure!(
-            receiving_objects.len() + input_objects.len()
-                <= protocol_config.max_input_objects() as usize,
-            UserInputError::SizeLimitExceeded {
-                limit: "maximum input and receiving objects in a transaction".to_string(),
-                value: protocol_config.max_input_objects().to_string()
-            }
-            .into()
-        );
-
+        receiving_objects: &ReceivingObjects,
+    ) -> Result<(), SuiError> {
         let mut objects_in_txn: HashSet<_> = input_objects
             .object_kinds()
             .map(|x| x.object_id())
@@ -293,32 +214,25 @@ mod checked {
         //
         // If there are any object IDs in common (either between receiving objects and input
         // objects) we return an error.
-        for (object_id, version, object_digest) in receiving_objects {
+        for ReceivingObjectReadResult {
+            object_ref: (object_id, version, object_digest),
+            object,
+        } in receiving_objects.iter()
+        {
             fp_ensure!(
                 *version < SequenceNumber::MAX,
                 UserInputError::InvalidSequenceNumber.into()
             );
 
-            let object = store.get_object(object_id)?;
+            let Some(object) = object.as_object() else {
+                // object was previously received
+                continue;
+            };
 
-            if !object.as_ref().is_some_and(|x| {
-                x.owner.is_address_owned()
-                    && x.version() == *version
-                    && x.digest() == *object_digest
-            }) && !store.have_received_object_at_version(object_id, *version, epoch_id)?
+            if !(object.owner.is_address_owned()
+                && object.version() == *version
+                && object.digest() == *object_digest)
             {
-                // Unable to load object
-                fp_ensure!(
-                    object.is_some(),
-                    UserInputError::ObjectNotFound {
-                        object_id: *object_id,
-                        version: Some(*version),
-                    }
-                    .into()
-                );
-
-                let object = object.expect("Safe to unwrap due to check in fp_unwrap");
-
                 // Version mismatch
                 fp_ensure!(
                     object.version() == *version,
@@ -392,17 +306,10 @@ mod checked {
         Ok(())
     }
 
-    pub fn check_input_objects<S>(
-        object_store: &S,
-        objects: &[InputObjectKind],
+    pub fn check_input_objects(
+        objects: &InputObjects,
         protocol_config: &ProtocolConfig,
-        epoch_id: EpochId,
-    ) -> Result<Vec<(InputObjectKind, Object)>, SuiError>
-    where
-        S: ObjectStore + BackingPackageStore + MarkerTableQuery,
-    {
-        let mut result = Vec::new();
-
+    ) -> SuiResult {
         fp_ensure!(
             objects.len() <= protocol_config.max_input_objects() as usize,
             UserInputError::SizeLimitExceeded {
@@ -412,97 +319,14 @@ mod checked {
             .into()
         );
 
-        for kind in objects {
-            let obj = match kind {
-                InputObjectKind::SharedMoveObject { id, .. } => {
-                    let res = object_store.get_object(id)?;
-                    if res.is_none() && object_store.is_shared_object_deleted(id, epoch_id)? {
-                        continue;
-                    }
-                    res
-                }
-                InputObjectKind::MovePackage(id) => object_store
-                    .get_package_object(id)?
-                    .map(|o| o.object().clone()),
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    object_store.get_object_by_key(&objref.0, objref.1)?
-                }
-            }
-            .ok_or_else(|| SuiError::from(kind.object_not_found_error()))?;
-            result.push((*kind, obj));
-        }
-        Ok(result)
-    }
-
-    /// When making changes, please see if get_input_object_keys() above needs
-    /// similar changes as well.
-    ///
-    /// Before this function is invoked, TransactionManager must ensure all depended
-    /// objects are present. Thus any missing object will panic.
-    pub fn check_sequenced_input_objects<S, G>(
-        store: &S,
-        digest: &TransactionDigest,
-        objects: &[InputObjectKind],
-        shared_lock_store: &G,
-        epoch_id: EpochId,
-    ) -> Result<(Vec<(InputObjectKind, Object)>, DeletedSharedObjects), SuiError>
-    where
-        S: ObjectStore + BackingPackageStore + MarkerTableQuery,
-        G: GetSharedLocks,
-    {
-        let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
-        let mut deleted_shared_objects = Vec::new();
-        let mut result = Vec::new();
-        for kind in objects.iter() {
-            match kind {
-                InputObjectKind::SharedMoveObject { id, mutable, .. } => {
-                    let shared_locks = shared_locks_cell.get_or_try_init(|| {
-                        Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
-                            shared_lock_store.get_shared_locks(digest)?.into_iter().collect(),
-                        )
-                    })?;
-                    // If we can't find the locked version, it means
-                    // 1. either we have a bug that skips shared object version assignment
-                    // 2. or we have some DB corruption
-                    let version = shared_locks.get(id).unwrap_or_else(|| {
-                        panic!(
-                            "Shared object locks should have been set. tx_digest: {:?}, obj id: {:?}",
-                            digest, id
-                        )
-                    });
-
-                    match store.get_object_by_key(id, *version)? {
-                        Some(obj) => result.push((*kind, obj)),
-                        None => {
-                            // If the object was deleted by a concurrently certified tx then return this separately
-                            if let Some(dependency) = store.get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)? {
-                                deleted_shared_objects.push((*id, *version, *mutable, dependency));
-                            } else {
-                                panic!("All dependencies of tx {:?} should have been executed now, but Shared Object id: {}, version: {} is absent in epoch {}", digest, *id, *version, epoch_id);
-                            }
-                        }
-                    };
-
-                }
-                InputObjectKind::MovePackage(id) => result.push((*kind, store.get_package_object(id)?.unwrap_or_else(|| {
-                    panic!("All dependencies of tx {:?} should have been executed now, but Move Package id: {} is absent", digest, id);
-                }).object().clone())),
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    result.push((*kind, store.get_object_by_key(&objref.0, objref.1)?.unwrap_or_else(|| {
-                        panic!("All dependencies of tx {:?} should have been executed now, but Immutable or Owned Object id: {}, version: {} is absent", digest, objref.0, objref.1);
-                    })))
-                }
-            };
-        }
-
-        Ok((result, deleted_shared_objects))
+        Ok(())
     }
 
     /// Check transaction gas data/info and gas coins consistency.
     /// Return the gas status to be used for the lifecycle of the transaction.
     #[instrument(level = "trace", skip_all)]
     fn check_gas(
-        objects: &[Object],
+        objects: &InputObjects,
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         gas: &[ObjectRef],
@@ -536,15 +360,12 @@ mod checked {
     /// Check all the objects used in the transaction against the database, and ensure
     /// that they are all the correct version and number.
     #[instrument(level = "trace", skip_all)]
-    pub fn check_objects(
-        transaction: &TransactionData,
-        inputs: Vec<(InputObjectKind, Object)>,
-        deleted_shared_objects: DeletedSharedObjects,
-    ) -> UserInputResult<InputObjects> {
+    fn check_objects(transaction: &TransactionData, objects: &InputObjects) -> UserInputResult<()> {
         // We require that mutable objects cannot show up more than once.
         let mut used_objects: HashSet<SuiAddress> = HashSet::new();
-        for (_, object) in inputs.iter() {
-            if !object.is_immutable() {
+        let mut deleted_shared_objects = Vec::new();
+        for object in objects.iter() {
+            if object.is_mutable() {
                 fp_ensure!(
                     used_objects.insert(object.id().into()),
                     UserInputError::MutableObjectUsedMoreThanOnce {
@@ -554,40 +375,50 @@ mod checked {
             }
         }
 
-        // Gather all objects and errors.
-        let mut all_objects = Vec::with_capacity(inputs.len());
-
-        for (object_kind, object) in inputs {
-            // We skip checking a deleted shared object because it no longer exists
-            if deleted_shared_objects
-                .iter()
-                .any(|obj| obj.0 == object.id())
-            {
-                continue;
-            }
-
-            // For Gas Object, we check the object is owned by gas owner
-            // TODO: this is a quadratic check and though limits are low we should do it differently
-            let owner_address = if transaction
-                .gas()
-                .iter()
-                .any(|obj_ref| *obj_ref.0 == *object.id())
-            {
-                transaction.gas_owner()
-            } else {
-                transaction.sender()
-            };
-            // Check if the object contents match the type of lock we need for
-            // this object.
-            let system_transaction = transaction.is_system_tx();
-            check_one_object(&owner_address, object_kind, &object, system_transaction)?;
-            all_objects.push((object_kind, object));
-        }
-        if !transaction.is_genesis_tx() && all_objects.is_empty() {
+        if !transaction.is_genesis_tx() && objects.is_empty() {
             return Err(UserInputError::ObjectInputArityViolation);
         }
 
-        Ok(InputObjects::new(all_objects, deleted_shared_objects))
+        for object in objects.iter() {
+            let input_object_kind = object.input_object_kind;
+
+            match &object.object {
+                ObjectReadResultKind::Object(object) => {
+                    // For Gas Object, we check the object is owned by gas owner
+                    // TODO: this is a quadratic check and though limits are low we should do it differently
+                    let owner_address = if transaction
+                        .gas()
+                        .iter()
+                        .any(|obj_ref| *obj_ref.0 == *object.id())
+                    {
+                        transaction.gas_owner()
+                    } else {
+                        transaction.sender()
+                    };
+                    // Check if the object contents match the type of lock we need for
+                    // this object.
+                    let system_transaction = transaction.is_system_tx();
+                    check_one_object(
+                        &owner_address,
+                        input_object_kind,
+                        object,
+                        system_transaction,
+                    )?;
+                }
+                // We skip checking a deleted shared object because it no longer exists
+                ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
+                    deleted_shared_objects.push((
+                        input_object_kind.object_id(),
+                        *seq,
+                        input_object_kind.is_mutable(),
+                        *digest,
+                    ));
+                    continue;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Check one object against a reference

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -413,7 +413,6 @@ mod checked {
                         input_object_kind.is_mutable(),
                         *digest,
                     ));
-                    continue;
                 }
             }
         }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -507,7 +507,12 @@ impl TransactionEffectsV2 {
         assert!(matches!(owner, Owner::AddressOwner(_)));
 
         for (id, _) in &self.unchanged_shared_objects {
-            assert!(unique_ids.insert(*id));
+            assert!(
+                unique_ids.insert(*id),
+                "Duplicate object id: {:?}\n{:#?}",
+                id,
+                self
+            );
         }
     }
 }

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -14,6 +14,7 @@ pub mod checked {
         gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
         object::Object,
         sui_serde::{BigInt, Readable},
+        transaction::ObjectReadResult,
     };
     use enum_dispatch::enum_dispatch;
     use itertools::MultiUnzip;
@@ -91,7 +92,11 @@ pub mod checked {
 
         // This is the only public API on SuiGasStatus, all other gas related operations should
         // go through `GasCharger`
-        pub fn check_gas_balance(&self, gas_objs: &[&Object], gas_budget: u64) -> UserInputResult {
+        pub fn check_gas_balance(
+            &self,
+            gas_objs: &[&ObjectReadResult],
+            gas_budget: u64,
+        ) -> UserInputResult {
             match self {
                 Self::V2(status) => status.check_gas_balance(gas_objs, gas_budget),
             }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -289,6 +289,10 @@ mod checked {
                     if !obj.is_address_owned() {
                         return Err(UserInputError::GasObjectNotOwnedObject { owner: obj.owner });
                     }
+                } else {
+                    // This case should never happen (because gas can't be a shared object), but we
+                    // handle this case for future-proofing
+                    return Err(UserInputError::MissingGasPayment);
                 }
             }
 

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub type WrittenObjects = BTreeMap<ObjectID, Object>;
-pub type ObjectMap = BTreeMap<ObjectID, Object>;
+pub type ObjectMap = BTreeMap<ObjectID, Arc<Object>>;
 pub type TxCoins = (ObjectMap, WrittenObjects);
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -11,7 +11,7 @@ use crate::crypto::{
     ToFromBytes,
 };
 use crate::digests::{CertificateDigest, SenderSignedDataDigest};
-use crate::execution::{DeletedSharedObjects, SharedInput};
+use crate::execution::SharedInput;
 use crate::message_envelope::{
     AuthenticatedMessage, Envelope, Message, TrustedEnvelope, VerifiedEnvelope,
 };
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use std::fmt::Write;
 use std::fmt::{Debug, Display, Formatter};
+use std::sync::Arc;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     hash::Hash,
@@ -2407,46 +2408,226 @@ impl InputObjectKind {
     pub fn is_shared_object(&self) -> bool {
         matches!(self, Self::SharedMoveObject { .. })
     }
+
+    pub fn is_mutable(&self) -> bool {
+        match self {
+            Self::MovePackage(..) => false,
+            Self::ImmOrOwnedMoveObject((_, _, _)) => true,
+            Self::SharedMoveObject { mutable, .. } => *mutable,
+        }
+    }
+}
+
+/// The result of reading an object for execution. Because shared objects may be deleted, one
+/// possible result of reading a shared object is that ObjectReadResultKind::Deleted is returned.
+#[derive(Clone, Debug)]
+pub struct ObjectReadResult {
+    pub input_object_kind: InputObjectKind,
+    pub object: ObjectReadResultKind,
+}
+
+#[derive(Clone, Debug)]
+pub enum ObjectReadResultKind {
+    Object(Arc<Object>),
+    // The version of the object that the transaction intended to read, and the digest of the tx
+    // that deleted it.
+    DeletedSharedObject(SequenceNumber, TransactionDigest),
+}
+
+impl From<Object> for ObjectReadResultKind {
+    fn from(object: Object) -> Self {
+        Self::Object(Arc::new(object))
+    }
+}
+
+impl From<Arc<Object>> for ObjectReadResultKind {
+    fn from(object: Arc<Object>) -> Self {
+        Self::Object(object)
+    }
+}
+
+impl ObjectReadResult {
+    pub fn new(input_object_kind: InputObjectKind, object: ObjectReadResultKind) -> Self {
+        if let (
+            InputObjectKind::ImmOrOwnedMoveObject(_),
+            ObjectReadResultKind::DeletedSharedObject(_, _),
+        ) = (&input_object_kind, &object)
+        {
+            panic!("only shared objects can be DeletedSharedObject");
+        }
+
+        Self {
+            input_object_kind,
+            object,
+        }
+    }
+
+    pub fn id(&self) -> ObjectID {
+        self.input_object_kind.object_id()
+    }
+
+    pub fn as_object(&self) -> Option<&Arc<Object>> {
+        match &self.object {
+            ObjectReadResultKind::Object(object) => Some(object),
+            ObjectReadResultKind::DeletedSharedObject(_, _) => None,
+        }
+    }
+
+    pub fn new_from_gas_object(gas: &Object) -> Self {
+        let objref = gas.compute_object_reference();
+        Self {
+            input_object_kind: InputObjectKind::ImmOrOwnedMoveObject(objref),
+            object: ObjectReadResultKind::Object(Arc::new(gas.clone())),
+        }
+    }
+
+    pub fn is_mutable(&self) -> bool {
+        match (&self.input_object_kind, &self.object) {
+            (InputObjectKind::MovePackage(_), _) => false,
+            (InputObjectKind::ImmOrOwnedMoveObject(_), ObjectReadResultKind::Object(object)) => {
+                !object.is_immutable()
+            }
+            (
+                InputObjectKind::ImmOrOwnedMoveObject(_),
+                ObjectReadResultKind::DeletedSharedObject(_, _),
+            ) => unreachable!(),
+            (InputObjectKind::SharedMoveObject { mutable, .. }, _) => *mutable,
+        }
+    }
+
+    pub fn is_shared_object(&self) -> bool {
+        self.input_object_kind.is_shared_object()
+    }
+
+    pub fn is_deleted_shared_object(&self) -> bool {
+        self.deletion_info().is_some()
+    }
+
+    pub fn deletion_info(&self) -> Option<(SequenceNumber, TransactionDigest)> {
+        match &self.object {
+            ObjectReadResultKind::DeletedSharedObject(v, tx) => Some((*v, *tx)),
+            _ => None,
+        }
+    }
+
+    /// Return the object ref iff the object is an owned object (i.e. not shared, not immutable).
+    pub fn get_owned_objref(&self) -> Option<ObjectRef> {
+        match (&self.input_object_kind, &self.object) {
+            (InputObjectKind::MovePackage(_), _) => None,
+            (
+                InputObjectKind::ImmOrOwnedMoveObject(objref),
+                ObjectReadResultKind::Object(object),
+            ) => {
+                if object.is_immutable() {
+                    None
+                } else {
+                    Some(*objref)
+                }
+            }
+            (
+                InputObjectKind::ImmOrOwnedMoveObject(_),
+                ObjectReadResultKind::DeletedSharedObject(_, _),
+            ) => unreachable!(),
+            (InputObjectKind::SharedMoveObject { .. }, _) => None,
+        }
+    }
+
+    pub fn is_owned(&self) -> bool {
+        self.get_owned_objref().is_some()
+    }
+
+    pub fn to_shared_input(&self) -> Option<SharedInput> {
+        match self.input_object_kind {
+            InputObjectKind::MovePackage(_) => None,
+            InputObjectKind::ImmOrOwnedMoveObject(_) => None,
+            InputObjectKind::SharedMoveObject { id, mutable, .. } => Some(match &self.object {
+                ObjectReadResultKind::Object(obj) => {
+                    SharedInput::Existing(obj.compute_object_reference())
+                }
+                ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
+                    SharedInput::Deleted((id, *seq, mutable, *digest))
+                }
+            }),
+        }
+    }
+
+    pub fn get_previous_transaction(&self) -> TransactionDigest {
+        match &self.object {
+            ObjectReadResultKind::Object(obj) => obj.previous_transaction,
+            ObjectReadResultKind::DeletedSharedObject(_, digest) => *digest,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct InputObjects {
-    objects: Vec<(InputObjectKind, Object)>,
-    deleted: DeletedSharedObjects,
+    objects: Vec<ObjectReadResult>,
+}
+
+// An InputObjects new-type that has been verified by sui-transaction-checks, and can be
+// safely passed to execution.
+pub struct CheckedInputObjects(InputObjects);
+
+// DO NOT CALL outside of sui-transaction-checks, genesis, or replay.
+//
+// CheckedInputObjects should really be defined in sui-transaction-checks so that we can
+// make public construction impossible. But we can't do that because it would result in circular
+// dependencies.
+impl CheckedInputObjects {
+    // Only called by sui-transaction-checks.
+    pub fn new_with_checked_transaction_inputs(inputs: InputObjects) -> Self {
+        Self(inputs)
+    }
+
+    // Only called when building the genesis transaction
+    pub fn new_for_genesis(input_objects: Vec<ObjectReadResult>) -> Self {
+        Self(InputObjects::new(input_objects))
+    }
+
+    // Only called from the replay tool.
+    pub fn new_for_replay(input_objects: InputObjects) -> Self {
+        Self(input_objects)
+    }
+
+    pub fn inner(&self) -> &InputObjects {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> InputObjects {
+        self.0
+    }
+}
+
+impl From<Vec<ObjectReadResult>> for InputObjects {
+    fn from(objects: Vec<ObjectReadResult>) -> Self {
+        Self::new(objects)
+    }
 }
 
 impl InputObjects {
-    pub fn new(objects: Vec<(InputObjectKind, Object)>, deleted: DeletedSharedObjects) -> Self {
-        Self { objects, deleted }
+    pub fn new(objects: Vec<ObjectReadResult>) -> Self {
+        Self { objects }
     }
 
     pub fn len(&self) -> usize {
-        self.objects.len() + self.deleted.len()
+        self.objects.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.objects.is_empty() && self.deleted.is_empty()
+        self.objects.is_empty()
     }
 
     pub fn contains_deleted_objects(&self) -> bool {
-        !self.deleted.is_empty()
+        self.objects
+            .iter()
+            .any(|obj| obj.is_deleted_shared_object())
     }
 
     pub fn filter_owned_objects(&self) -> Vec<ObjectRef> {
         let owned_objects: Vec<_> = self
             .objects
             .iter()
-            .filter_map(|(object_kind, object)| match object_kind {
-                InputObjectKind::MovePackage(_) => None,
-                InputObjectKind::ImmOrOwnedMoveObject(object_ref) => {
-                    if object.is_immutable() {
-                        None
-                    } else {
-                        Some(*object_ref)
-                    }
-                }
-                InputObjectKind::SharedMoveObject { .. } => None,
-            })
+            .filter_map(|obj| obj.get_owned_objref())
             .collect();
 
         trace!(
@@ -2460,47 +2641,63 @@ impl InputObjects {
     pub fn filter_shared_objects(&self) -> Vec<SharedInput> {
         self.objects
             .iter()
-            .filter(|(kind, _)| matches!(kind, InputObjectKind::SharedMoveObject { .. }))
-            .map(|(_, obj)| SharedInput::Existing(obj.compute_object_reference()))
-            .chain(self.deleted.iter().map(|info| SharedInput::Deleted(*info)))
+            .filter(|obj| obj.is_shared_object())
+            .map(|obj| {
+                obj.to_shared_input()
+                    .expect("already filtered for shared objects")
+            })
             .collect()
     }
 
     pub fn transaction_dependencies(&self) -> BTreeSet<TransactionDigest> {
-        let mut dependencies: BTreeSet<TransactionDigest> = self
-            .objects
+        self.objects
             .iter()
-            .map(|(_, obj)| obj.previous_transaction)
-            .collect();
-
-        for (_, _, _, digest) in &self.deleted {
-            dependencies.insert(*digest);
-        }
-
-        dependencies
+            .map(|obj| obj.get_previous_transaction())
+            .collect()
     }
 
     pub fn mutable_inputs(&self) -> BTreeMap<ObjectID, (VersionDigest, Owner)> {
         self.objects
             .iter()
-            .filter_map(|(kind, object)| match kind {
-                InputObjectKind::MovePackage(_) => None,
-                InputObjectKind::ImmOrOwnedMoveObject(object_ref) => {
-                    if object.is_immutable() {
-                        None
-                    } else {
-                        Some((object_ref.0, ((object_ref.1, object_ref.2), object.owner)))
+            .filter_map(
+                |ObjectReadResult {
+                     input_object_kind,
+                     object,
+                 }| match (input_object_kind, object) {
+                    (InputObjectKind::MovePackage(_), _) => None,
+                    (
+                        InputObjectKind::ImmOrOwnedMoveObject(object_ref),
+                        ObjectReadResultKind::Object(object),
+                    ) => {
+                        if object.is_immutable() {
+                            None
+                        } else {
+                            Some((object_ref.0, ((object_ref.1, object_ref.2), object.owner)))
+                        }
                     }
-                }
-                InputObjectKind::SharedMoveObject { mutable, .. } => {
-                    if *mutable {
-                        let oref = object.compute_object_reference();
-                        Some((oref.0, ((oref.1, oref.2), object.owner)))
-                    } else {
-                        None
+                    (
+                        InputObjectKind::ImmOrOwnedMoveObject(_),
+                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                    ) => {
+                        unreachable!()
                     }
-                }
-            })
+                    (
+                        InputObjectKind::SharedMoveObject { .. },
+                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                    ) => None,
+                    (
+                        InputObjectKind::SharedMoveObject { mutable, .. },
+                        ObjectReadResultKind::Object(object),
+                    ) => {
+                        if *mutable {
+                            let oref = object.compute_object_reference();
+                            Some((oref.0, ((oref.1, oref.2), object.owner)))
+                        } else {
+                            None
+                        }
+                    }
+                },
+            )
             .collect()
     }
 
@@ -2511,26 +2708,98 @@ impl InputObjects {
         let input_versions = self
             .objects
             .iter()
-            .filter_map(|(_, object)| object.data.try_as_move().map(MoveObject::version))
-            .chain(receiving_objects.iter().map(|object_ref| object_ref.1))
-            .chain(self.deleted.iter().map(|(_, version, _, _)| *version));
+            .filter_map(|object| match &object.object {
+                ObjectReadResultKind::Object(object) => {
+                    object.data.try_as_move().map(MoveObject::version)
+                }
+                ObjectReadResultKind::DeletedSharedObject(v, _) => Some(*v),
+            })
+            .chain(receiving_objects.iter().map(|object_ref| object_ref.1));
 
         SequenceNumber::lamport_increment(input_versions)
     }
 
-    pub fn into_objects(self) -> Vec<(InputObjectKind, Object)> {
-        self.objects
-    }
-
     pub fn object_kinds(&self) -> impl Iterator<Item = &InputObjectKind> {
-        self.objects.iter().map(|(kind, _)| kind)
+        self.objects.iter().map(
+            |ObjectReadResult {
+                 input_object_kind, ..
+             }| input_object_kind,
+        )
     }
 
-    pub fn into_object_map(self) -> BTreeMap<ObjectID, Object> {
+    pub fn into_object_map(self) -> BTreeMap<ObjectID, Arc<Object>> {
         self.objects
             .into_iter()
-            .map(|(_, object)| (object.id(), object))
+            .filter_map(|o| o.as_object().map(|object| (o.id(), object.clone())))
             .collect()
+    }
+
+    pub fn push(&mut self, object: ObjectReadResult) {
+        self.objects.push(object);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {
+        self.objects.iter()
+    }
+}
+
+// Result of attempting to read a receiving object (currently only at signing time).
+// Because an object may have been previously received and deleted, the result may be
+// ReceivingObjectReadResultKind::PreviouslyReceivedObject.
+#[derive(Clone, Debug)]
+pub enum ReceivingObjectReadResultKind {
+    Object(Arc<Object>),
+    // The version of the object that the transaction intended to read, and the digest of the tx
+    // that deleted it.
+    PreviouslyReceivedObject,
+}
+
+impl ReceivingObjectReadResultKind {
+    pub fn as_object(&self) -> Option<&Arc<Object>> {
+        match &self {
+            Self::Object(object) => Some(object),
+            Self::PreviouslyReceivedObject => None,
+        }
+    }
+}
+
+pub struct ReceivingObjectReadResult {
+    pub object_ref: ObjectRef,
+    pub object: ReceivingObjectReadResultKind,
+}
+
+impl ReceivingObjectReadResult {
+    pub fn new(object_ref: ObjectRef, object: ReceivingObjectReadResultKind) -> Self {
+        Self { object_ref, object }
+    }
+
+    pub fn is_previously_received(&self) -> bool {
+        matches!(
+            self.object,
+            ReceivingObjectReadResultKind::PreviouslyReceivedObject
+        )
+    }
+}
+
+impl From<Object> for ReceivingObjectReadResultKind {
+    fn from(object: Object) -> Self {
+        Self::Object(Arc::new(object))
+    }
+}
+
+pub struct ReceivingObjects {
+    pub objects: Vec<ReceivingObjectReadResult>,
+}
+
+impl ReceivingObjects {
+    pub fn iter(&self) -> impl Iterator<Item = &ReceivingObjectReadResult> {
+        self.objects.iter()
+    }
+}
+
+impl From<Vec<ReceivingObjectReadResult>> for ReceivingObjects {
+    fn from(objects: Vec<ReceivingObjectReadResult>) -> Self {
+        Self { objects }
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2749,8 +2749,7 @@ impl InputObjects {
 #[derive(Clone, Debug)]
 pub enum ReceivingObjectReadResultKind {
     Object(Arc<Object>),
-    // The version of the object that the transaction intended to read, and the digest of the tx
-    // that deleted it.
+    // The object was received by some other transaction, and we were not able to read it
     PreviouslyReceivedObject,
 }
 

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -43,7 +43,7 @@ mod checked {
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
-    use sui_types::transaction::InputObjects;
+    use sui_types::transaction::CheckedInputObjects;
     use sui_types::transaction::{
         Argument, AuthenticatorStateExpire, AuthenticatorStateUpdate, CallArg, ChangeEpoch,
         Command, EndOfEpochTransactionKind, GenesisTransaction, ObjectArg, ProgrammableTransaction,
@@ -60,7 +60,7 @@ mod checked {
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -78,6 +78,7 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        let input_objects = input_objects.into_inner();
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
@@ -197,9 +198,10 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let input_objects = input_objects.into_inner();
         let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -9,6 +9,7 @@ pub mod checked {
 
     use crate::sui_types::gas::SuiGasStatusAPI;
     use crate::temporary_store::TemporaryStore;
+    use std::ops::Deref;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::gas::{deduct_gas, GasCostSummary, SuiGasStatus};
     use sui_types::gas_model::gas_predicates::{
@@ -171,6 +172,7 @@ pub mod checked {
                         self.tx_digest
                     )
                 })
+                .deref()
                 .clone();
             // delete all gas objects except the primary_gas_object
             for (id, _version, _digest) in &self.gas_coins[1..] {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -7,6 +7,8 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::ops::Deref;
+use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::VersionDigest;
 use sui_types::committee::EpochId;
@@ -41,7 +43,7 @@ pub struct TemporaryStore<'backing> {
     // objects
     store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
-    input_objects: BTreeMap<ObjectID, Object>,
+    input_objects: BTreeMap<ObjectID, Arc<Object>>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
     mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
@@ -87,7 +89,7 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     // Helpers to access private fields
-    pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
+    pub fn objects(&self) -> &BTreeMap<ObjectID, Arc<Object>> {
         &self.input_objects
     }
 
@@ -134,7 +136,7 @@ impl<'backing> TemporaryStore<'backing> {
         }
         for object in to_be_updated {
             // The object must be mutated as it was present in the input objects
-            self.mutate_input_object(object);
+            self.mutate_input_object(object.deref().clone());
         }
     }
 
@@ -476,7 +478,7 @@ impl<'backing> TemporaryStore<'backing> {
         self.execution_results
             .written_objects
             .get(id)
-            .or_else(|| self.input_objects.get(id))
+            .or_else(|| self.input_objects.get(id).map(|o| o.deref()))
     }
 
     pub fn save_loaded_runtime_objects(

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -15,7 +15,7 @@ use sui_types::{
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::LimitsMetrics,
-    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -33,7 +33,7 @@ pub trait Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Transaction Inputs
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         // Gas related
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -59,7 +59,7 @@ pub trait Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Transaction Inputs
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         // Gas related
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
@@ -82,7 +82,7 @@ pub trait Executor {
         // Genesis State
         tx_context: &mut TxContext,
         // Transaction
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError>;
 

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -17,7 +17,7 @@ use sui_types::{
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -86,7 +86,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -124,7 +124,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -159,7 +159,7 @@ impl executor::Executor for Executor {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
         execute_genesis_state_update(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -17,7 +17,7 @@ use sui_types::{
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -86,7 +86,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -124,7 +124,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -159,7 +159,7 @@ impl executor::Executor for Executor {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
         execute_genesis_state_update(

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -17,7 +17,7 @@ use sui_types::{
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
-    transaction::{InputObjects, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
     type_resolver::LayoutResolver,
 };
 
@@ -86,7 +86,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -124,7 +124,7 @@ impl executor::Executor for Executor {
         certificate_deny_set: &HashSet<TransactionDigest>,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -159,7 +159,7 @@ impl executor::Executor for Executor {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
         execute_genesis_state_update(

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -38,7 +38,7 @@ mod checked {
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
-    use sui_types::transaction::InputObjects;
+    use sui_types::transaction::CheckedInputObjects;
     use sui_types::transaction::{
         Argument, CallArg, ChangeEpoch, Command, GenesisTransaction, ProgrammableTransaction,
         TransactionKind,
@@ -55,7 +55,7 @@ mod checked {
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -73,6 +73,7 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        let input_objects = input_objects.into_inner();
         let shared_object_refs = input_objects.filter_shared_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
         let mut temporary_store =
@@ -183,9 +184,10 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let input_objects = input_objects.into_inner();
         let mut temporary_store =
             TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
         let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -9,6 +9,7 @@ pub mod checked {
 
     use crate::sui_types::gas::SuiGasStatusAPI;
     use crate::temporary_store::TemporaryStore;
+    use std::ops::Deref;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::gas::{deduct_gas, GasCostSummary, SuiGasStatus};
     use sui_types::gas_model::gas_predicates::dont_charge_budget_on_storage_oog;
@@ -170,6 +171,7 @@ pub mod checked {
                         self.tx_digest
                     )
                 })
+                .deref()
                 .clone();
             // delete all gas objects except the primary_gas_object
             for (id, version, _digest) in &self.gas_coins[1..] {

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -43,7 +43,7 @@ mod checked {
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
-    use sui_types::transaction::InputObjects;
+    use sui_types::transaction::CheckedInputObjects;
     use sui_types::transaction::{
         Argument, AuthenticatorStateExpire, AuthenticatorStateUpdate, CallArg, ChangeEpoch,
         Command, EndOfEpochTransactionKind, GenesisTransaction, ObjectArg, ProgrammableTransaction,
@@ -60,7 +60,7 @@ mod checked {
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         gas_coins: Vec<ObjectRef>,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
@@ -78,6 +78,7 @@ mod checked {
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
+        let input_objects = input_objects.into_inner();
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
@@ -197,9 +198,10 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         move_vm: &Arc<MoveVM>,
         tx_context: &mut TxContext,
-        input_objects: InputObjects,
+        input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let input_objects = input_objects.into_inner();
         let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -9,6 +9,7 @@ pub mod checked {
 
     use crate::sui_types::gas::SuiGasStatusAPI;
     use crate::temporary_store::TemporaryStore;
+    use std::ops::Deref;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::gas::{deduct_gas, GasCostSummary, SuiGasStatus};
     use sui_types::gas_model::gas_predicates::{
@@ -171,6 +172,7 @@ pub mod checked {
                         self.tx_digest
                     )
                 })
+                .deref()
                 .clone();
             // delete all gas objects except the primary_gas_object
             for (id, _version, _digest) in &self.gas_coins[1..] {

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -7,6 +7,8 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::ops::Deref;
+use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::VersionDigest;
 use sui_types::committee::EpochId;
@@ -41,7 +43,7 @@ pub struct TemporaryStore<'backing> {
     // objects
     store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
-    input_objects: BTreeMap<ObjectID, Object>,
+    input_objects: BTreeMap<ObjectID, Arc<Object>>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
     mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
@@ -87,7 +89,7 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     // Helpers to access private fields
-    pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
+    pub fn objects(&self) -> &BTreeMap<ObjectID, Arc<Object>> {
         &self.input_objects
     }
 
@@ -134,7 +136,7 @@ impl<'backing> TemporaryStore<'backing> {
         }
         for object in to_be_updated {
             // The object must be mutated as it was present in the input objects
-            self.mutate_input_object(object);
+            self.mutate_input_object(object.deref().clone());
         }
     }
 
@@ -476,7 +478,7 @@ impl<'backing> TemporaryStore<'backing> {
         self.execution_results
             .written_objects
             .get(id)
-            .or_else(|| self.input_objects.get(id))
+            .or_else(|| self.input_objects.get(id).map(|o| o.deref()))
     }
 
     pub fn save_loaded_runtime_objects(


### PR DESCRIPTION
This PR
- Is primarily intended to support the creation of an in-memory object
  cache (coming soon).
- Makes it easier to use multi-gets for transaction loads.
- Simplifies handling of deleted shared objects and receivables.
- Will prevent inadvertently loading the same object multiple times.
- Will reduce the proliferation of special purpose traits (e.g.
  MarkerTableQuery which is removed in this PR).

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
