### PR TITLE
Make reputation score abstract

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -8,6 +8,7 @@ use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::AuthorityMetrics;
 use crate::checkpoints::CheckpointServiceNotify;
 use crate::consensus_throughput_calculator::ConsensusThroughputCalculator;
+use crate::consensus_types::consensus_output_api::ConsensusOutputAPI;
 use crate::scoring_decision::update_low_scoring_authorities;
 use crate::transaction_manager::TransactionManager;
 use arc_swap::ArcSwap;
@@ -225,7 +226,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
         update_low_scoring_authorities(
             self.low_scoring_authorities.clone(),
             &self.committee,
-            consensus_output.sub_dag.reputation_score.clone(),
+            consensus_output.reputation_score_sorted_desc(),
             &self.metrics,
             self.epoch_store
                 .protocol_config()

--- a/crates/sui-core/src/consensus_types/committee_api.rs
+++ b/crates/sui-core/src/consensus_types/committee_api.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_types::AuthorityIndex;
+use narwhal_config::committee::AuthorityIdentifier;
+use sui_types::base_types::AuthorityName;
+use sui_types::committee::StakeUnit;
+
+pub(crate) trait CommitteeAPI {
+    fn total_stake(&self) -> StakeUnit;
+    fn authority_pubkey_by_index(&self, index: AuthorityIndex) -> Option<AuthorityName>;
+    fn authority_hostname_by_index(&self, index: AuthorityIndex) -> Option<&str>;
+    fn authority_stake_by_index(&self, index: AuthorityIndex) -> StakeUnit;
+}
+
+impl CommitteeAPI for narwhal_config::Committee {
+    fn total_stake(&self) -> StakeUnit {
+        narwhal_config::Committee::total_stake(self)
+    }
+
+    fn authority_pubkey_by_index(&self, index: AuthorityIndex) -> Option<AuthorityName> {
+        let id = AuthorityIdentifier(index);
+        self.authority(&id).map(|authority| {
+            let name: AuthorityName = authority.protocol_key().into();
+            name
+        })
+    }
+
+    fn authority_hostname_by_index(&self, index: AuthorityIndex) -> Option<&str> {
+        let id = AuthorityIdentifier(index);
+        self.authority(&id).map(|authority| authority.hostname())
+    }
+
+    fn authority_stake_by_index(&self, index: AuthorityIndex) -> StakeUnit {
+        let id = AuthorityIdentifier(index);
+        self.authority(&id)
+            .map(|authority| authority.stake())
+            .unwrap_or(0)
+    }
+}

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_types::AuthorityIndex;
+
+pub(crate) trait ConsensusOutputAPI {
+    fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
+}
+
+impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
+    fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
+        if !self.sub_dag.reputation_score.final_of_schedule {
+            return None;
+        }
+        Some(
+            self.sub_dag
+                .reputation_score
+                .authorities_by_score_desc()
+                .into_iter()
+                .map(|(id, score)| (id.0, score))
+                .collect(),
+        )
+    }
+}

--- a/crates/sui-core/src/consensus_types/mod.rs
+++ b/crates/sui-core/src/consensus_types/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod committee_api;
+pub(crate) mod consensus_output_api;
+
+/// An unique integer ID for a validator used by consensus.
+/// In Narwhal, this is the inner value of the `AuthorityIdentifier` type.
+/// In Mysticeti, this is used the same way as the AuthorityIndex type there.
+pub type AuthorityIndex = u16;

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod checkpoints;
 pub mod consensus_adapter;
 pub mod consensus_handler;
 pub mod consensus_throughput_calculator;
+pub(crate) mod consensus_types;
 pub mod consensus_validator;
 pub mod db_checkpoint_handler;
 pub mod epoch;


### PR DESCRIPTION
## Description 

Starting a little bit on the consensus handler refactoring, and send out a small PR first just to make sure everyone is ok with the direction. As you can see in the PR, we are adding a bunch of types inside consensus-types as abstract trait types, including the Committee and ConsensusOutput, and then start implement functions on them for Narwhal.
The consensus handler code then calls these functions.
This PR focuses on abstracting the types needed by the reputation score updates.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
