### PR TITLE
indexer v2 analytical: partial tx fetching and fixes

### DIFF
--- a/crates/sui-indexer/src/models_v2/address_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/address_metrics.rs
@@ -103,3 +103,9 @@ pub fn dedup_addresses(addrs_to_commit: Vec<AddressInfoToCommit>) -> Vec<StoredA
     }
     compressed_addr_map.values().cloned().collect()
 }
+
+#[derive(Clone, Debug)]
+pub struct TxTimestampInfo {
+    pub tx_seq: i64,
+    pub timestamp_ms: i64,
+}

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use diesel::prelude::*;
+
 use move_bytecode_utils::module_cache::GetModule;
 use sui_json_rpc_types::BalanceChange;
 use sui_json_rpc_types::ObjectChange;
@@ -35,6 +36,18 @@ pub struct StoredTransaction {
     pub balance_changes: Vec<Option<Vec<u8>>>,
     pub events: Vec<Option<Vec<u8>>>,
     pub transaction_kind: i16,
+}
+
+#[derive(Clone, Debug, Queryable)]
+pub struct StoredTransactionTimestamp {
+    pub tx_sequence_number: i64,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Clone, Debug, Queryable)]
+pub struct StoredTransactionCheckpoint {
+    pub tx_sequence_number: i64,
+    pub checkpoint_sequence_number: i64,
 }
 
 impl From<&IndexedTransaction> for StoredTransaction {

--- a/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
@@ -58,27 +58,26 @@ where
 
             // +1 b/c get_tx_indices_in_checkpoint_range is left-inclusive, right-exclusive,
             // but we want left-exclusive, right-inclusive, as latest_address_metrics has been processed.
-            let txs = self
+            let tx_timestamps = self
                 .store
-                .get_transactions_in_checkpoint_range(
+                .get_tx_timestamps_in_checkpoint_range(
                     latest_address_metrics.checkpoint + 1,
                     end_cp.sequence_number + 1,
                 )
                 .await?;
-            let start_tx_seq = txs
+            let start_tx_seq = tx_timestamps
                 .first()
                 .ok_or(IndexerError::PostgresReadError(
                     "Cannot read first tx from PG for address metrics".to_string(),
                 ))?
                 .tx_sequence_number;
-            let end_tx_seq = txs
+            let end_tx_seq = tx_timestamps
                 .last()
                 .ok_or(IndexerError::PostgresReadError(
                     "Cannot read last tx from PG for address metrics".to_string(),
                 ))?
                 .tx_sequence_number;
-
-            let tx_timestamp_map = txs
+            let tx_timestamp_map = tx_timestamps
                 .iter()
                 .map(|tx| (tx.tx_sequence_number, tx.timestamp_ms))
                 .collect::<HashMap<_, _>>();

--- a/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
@@ -61,24 +61,24 @@ where
                 .iter()
                 .map(|cp| (cp.sequence_number, cp.epoch))
                 .collect::<HashMap<_, _>>();
-            let txs = self
+            let tx_checkpoints = self
                 .store
-                .get_transactions_in_checkpoint_range(
+                .get_tx_checkpoints_in_checkpoint_range(
                     last_end_cp_seq + 1,
                     end_cp.sequence_number + 1,
                 )
                 .await?;
-            let tx_cp_map = txs
+            let tx_cp_map = tx_checkpoints
                 .iter()
                 .map(|tx| (tx.tx_sequence_number, tx.checkpoint_sequence_number))
                 .collect::<HashMap<_, _>>();
-            let start_tx_seq = txs
+            let start_tx_seq = tx_checkpoints
                 .first()
                 .ok_or(IndexerError::PostgresReadError(
                     "Cannot read first tx from PG for move call metrics".to_string(),
                 ))?
                 .tx_sequence_number;
-            let end_tx_seq = txs
+            let end_tx_seq = tx_checkpoints
                 .last()
                 .ok_or(IndexerError::PostgresReadError(
                     "Cannot read last tx from PG for move call metrics".to_string(),

--- a/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
+++ b/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
@@ -25,9 +25,9 @@ where
     pub async fn run_forever(&mut self) {
         info!("Processor orchestrator started...");
         // TODO(gegaowp): add metrics for each processor to monitor health and progress
-        loop {
-            let network_metrics_processor = NetworkMetricsProcessor::new(self.store.clone());
-            let network_metrics_handle = tokio::task::spawn(async move {
+        let network_metrics_processor = NetworkMetricsProcessor::new(self.store.clone());
+        let network_metrics_handle = tokio::task::spawn(async move {
+            loop {
                 let network_metrics_res = network_metrics_processor.start().await;
                 if let Err(e) = network_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -36,10 +36,12 @@ where
                         e
                     );
                 }
-            });
+            }
+        });
 
-            let addr_metrics_processor = AddressMetricsProcessor::new(self.store.clone());
-            let addr_metrics_handle = tokio::task::spawn(async move {
+        let addr_metrics_processor = AddressMetricsProcessor::new(self.store.clone());
+        let addr_metrics_handle = tokio::task::spawn(async move {
+            loop {
                 let addr_metrics_res = addr_metrics_processor.start().await;
                 if let Err(e) = addr_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -48,10 +50,12 @@ where
                         e
                     );
                 }
-            });
+            }
+        });
 
-            let move_call_metrics_processor = MoveCallMetricsProcessor::new(self.store.clone());
-            let move_call_metrics_handle = tokio::task::spawn(async move {
+        let move_call_metrics_processor = MoveCallMetricsProcessor::new(self.store.clone());
+        let move_call_metrics_handle = tokio::task::spawn(async move {
+            loop {
                 let move_call_metrics_res = move_call_metrics_processor.start().await;
                 if let Err(e) = move_call_metrics_res {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -60,21 +64,15 @@ where
                         e
                     );
                 }
-            });
-
-            let processor_orchestrator_res = try_join_all(vec![
-                network_metrics_handle,
-                addr_metrics_handle,
-                move_call_metrics_handle,
-            ])
-            .await;
-            if let Err(e) = processor_orchestrator_res {
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                error!(
-                    "Indexer processor orchestrator failed with error {:?}, retrying in 10s...",
-                    e
-                );
             }
-        }
+        });
+
+        try_join_all(vec![
+            network_metrics_handle,
+            addr_metrics_handle,
+            move_call_metrics_handle,
+        ])
+        .await
+        .expect("Processor orchestrator should not run into errors.");
     }
 }

--- a/crates/sui-indexer/src/store/indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/indexer_analytical_store.rs
@@ -7,7 +7,9 @@ use crate::models_v2::address_metrics::{StoredActiveAddress, StoredAddress, Stor
 use crate::models_v2::checkpoints::StoredCheckpoint;
 use crate::models_v2::move_call_metrics::{StoredMoveCall, StoredMoveCallMetrics};
 use crate::models_v2::network_metrics::StoredNetworkMetrics;
-use crate::models_v2::transactions::StoredTransaction;
+use crate::models_v2::transactions::{
+    StoredTransaction, StoredTransactionCheckpoint, StoredTransactionTimestamp,
+};
 use crate::models_v2::tx_count_metrics::StoredTxCountMetrics;
 use crate::models_v2::tx_indices::{StoredTxCalls, StoredTxRecipients, StoredTxSenders};
 use crate::types_v2::IndexerResult;
@@ -25,6 +27,16 @@ pub trait IndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransaction>>;
+    async fn get_tx_timestamps_in_checkpoint_range(
+        &self,
+        start_checkpoint: i64,
+        end_checkpoint: i64,
+    ) -> IndexerResult<Vec<StoredTransactionTimestamp>>;
+    async fn get_tx_checkpoints_in_checkpoint_range(
+        &self,
+        start_checkpoint: i64,
+        end_checkpoint: i64,
+    ) -> IndexerResult<Vec<StoredTransactionCheckpoint>>;
     async fn get_estimated_count(&self, table: &str) -> IndexerResult<i64>;
 
     // for network metrics including TPS and counts of objects etc.


### PR DESCRIPTION
## Description 

various perf and fixes
- turns out fetching txns of 1k checkpoints was very slow and caused timeouts, thus we want to read only necessary columns
- a couple of fixes: retrial on each processor; no conflict do nothing when binary resumes.

## Test Plan 

local run analytical worker

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
