### PR TITLE
indexer v2 analytical: store command per tx for TPS calculation

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044026_transactions/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044026_transactions/up.sql
@@ -14,7 +14,10 @@ CREATE TABLE transactions (
     -- array of bcs serialized StoredEvent bytes
     events                      bytea[]      NOT NULL,
     -- SystemTransaction/ProgrammableTransaction. See types_v2.rs
-    transaction_kind            smallint     NOT NULL
+    transaction_kind            smallint     NOT NULL,
+    -- number of successful commands in this transaction, bound by number of command
+    -- in a programmaable transaction.
+    success_command_count       smallint     NOT NULL
 );
 
 CREATE INDEX transactions_transaction_digest ON transactions (transaction_digest);

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS tx_recipients;
+DROP INDEX IF EXISTS tx_recipients_tx_sequence_number_index;

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/up.sql
@@ -5,3 +5,4 @@ CREATE TABLE tx_recipients (
     recipient                   BYTEA        NOT NULL,
     PRIMARY KEY(recipient, tx_sequence_number)
 );
+CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number ASC);

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS tx_senders;
+DROP INDEX IF EXISTS tx_senders_tx_sequence_number_index;

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/up.sql
@@ -5,3 +5,4 @@ CREATE TABLE tx_senders (
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(sender, tx_sequence_number)
 );
+CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number ASC);

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -7,12 +7,12 @@ use sui_json_rpc_types::BalanceChange;
 use sui_json_rpc_types::ObjectChange;
 use sui_json_rpc_types::SuiTransactionBlock;
 use sui_json_rpc_types::SuiTransactionBlockEffects;
-use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_json_rpc_types::SuiTransactionBlockEvents;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffects;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::TransactionEvents;
 use sui_types::event::Event;
 use sui_types::transaction::SenderSignedData;
@@ -36,6 +36,7 @@ pub struct StoredTransaction {
     pub balance_changes: Vec<Option<Vec<u8>>>,
     pub events: Vec<Option<Vec<u8>>>,
     pub transaction_kind: i16,
+    pub success_command_count: i16,
 }
 
 #[derive(Clone, Debug, Queryable)]
@@ -50,8 +51,22 @@ pub struct StoredTransactionCheckpoint {
     pub checkpoint_sequence_number: i64,
 }
 
+#[derive(Clone, Debug, Queryable)]
+pub struct StoredTransactionSuccessCommandCount {
+    pub tx_sequence_number: i64,
+    pub success_command_count: i16,
+}
+
 impl From<&IndexedTransaction> for StoredTransaction {
     fn from(tx: &IndexedTransaction) -> Self {
+        let cmd_count = tx
+            .sender_signed_data
+            .intent_message()
+            .value
+            .execution_parts()
+            .0
+            .num_commands();
+
         StoredTransaction {
             tx_sequence_number: tx.tx_sequence_number as i64,
             transaction_digest: tx.tx_digest.into_inner().to_vec(),
@@ -73,8 +88,9 @@ impl From<&IndexedTransaction> for StoredTransaction {
                 .iter()
                 .map(|e| Some(bcs::to_bytes(&e).unwrap()))
                 .collect(),
-            transaction_kind: tx.transaction_kind.clone() as i16,
             timestamp_ms: tx.timestamp_ms as i64,
+            transaction_kind: tx.transaction_kind.clone() as i16,
+            success_command_count: tx.effects.status().is_ok() as i16 * cmd_count as i16,
         }
     }
 }
@@ -216,21 +232,5 @@ impl StoredTransaction {
         })?;
         let effects = SuiTransactionBlockEffects::try_from(effects)?;
         Ok(effects)
-    }
-
-    pub fn get_successful_tx_num(&self) -> IndexerResult<u64> {
-        let tx_cmd_num = self
-            .try_into_sender_signed_data()?
-            .intent_message()
-            .value
-            .execution_parts()
-            .0
-            .num_commands() as u64;
-
-        if self.try_into_sui_transaction_effects()?.status().is_ok() {
-            Ok(tx_cmd_num)
-        } else {
-            Ok(0)
-        }
     }
 }

--- a/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
@@ -61,17 +61,17 @@ where
                 ))?
                 .clone();
 
-            // +1 here b/c get_transactions_in_checkpoint_range is left-inclusive, right-exclusive,
+            // +1 here b/c get_tx_success_cmd_counts_in_checkpoint_range is left-inclusive, right-exclusive,
             // but we want left-exclusive, right-inclusive, as latest_tx_count_metrics has been processed.
-            let tx_batch = self
+            let tx_cmd_count_batch = self
                 .store
-                .get_transactions_in_checkpoint_range(
+                .get_tx_success_cmd_counts_in_checkpoint_range(
                     last_end_cp_seq + 1,
                     end_cp.sequence_number + 1,
                 )
                 .await?;
             let tx_count_metrics_delta =
-                TxCountMetricsDelta::get_tx_count_metrics_delta(&tx_batch, &end_cp);
+                TxCountMetricsDelta::get_tx_count_metrics_delta(&tx_cmd_count_batch, &end_cp);
             let tx_count_metrics = StoredTxCountMetrics::combine_tx_count_metrics_delta(
                 &latest_tx_count_metrics,
                 &tx_count_metrics_delta,

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -180,6 +180,7 @@ diesel::table! {
         balance_changes -> Array<Nullable<Bytea>>,
         events -> Array<Nullable<Bytea>>,
         transaction_kind -> Int2,
+        success_command_count -> Int2,
     }
 }
 

--- a/crates/sui-indexer/src/store/indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/indexer_analytical_store.rs
@@ -8,7 +8,7 @@ use crate::models_v2::checkpoints::StoredCheckpoint;
 use crate::models_v2::move_call_metrics::{StoredMoveCall, StoredMoveCallMetrics};
 use crate::models_v2::network_metrics::StoredNetworkMetrics;
 use crate::models_v2::transactions::{
-    StoredTransaction, StoredTransactionCheckpoint, StoredTransactionTimestamp,
+    StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount, StoredTransactionTimestamp,
 };
 use crate::models_v2::tx_count_metrics::StoredTxCountMetrics;
 use crate::models_v2::tx_indices::{StoredTxCalls, StoredTxRecipients, StoredTxSenders};
@@ -22,11 +22,6 @@ pub trait IndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredCheckpoint>>;
-    async fn get_transactions_in_checkpoint_range(
-        &self,
-        start_checkpoint: i64,
-        end_checkpoint: i64,
-    ) -> IndexerResult<Vec<StoredTransaction>>;
     async fn get_tx_timestamps_in_checkpoint_range(
         &self,
         start_checkpoint: i64,
@@ -37,6 +32,11 @@ pub trait IndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionCheckpoint>>;
+    async fn get_tx_success_cmd_counts_in_checkpoint_range(
+        &self,
+        start_checkpoint: i64,
+        end_checkpoint: i64,
+    ) -> IndexerResult<Vec<StoredTransactionSuccessCommandCount>>;
     async fn get_estimated_count(&self, table: &str) -> IndexerResult<i64>;
 
     // for network metrics including TPS and counts of objects etc.


### PR DESCRIPTION
## Description 

without storing this, the analytical pipeline has to fetch the whole row of transactions, parse them back to `SenderSignedData` and `TransactionEffects` to count the success cmd, which oftentimes is very slow on DB reading 

for example this query takes 262272.070 ms, or > 4 min to finish, it will be worse on larger checkpoints:
```
select * from transactions where checkpoint_sequence_number > 6370000 and checkpoint_sequence_number <= 6380000;
```

while fetching 2 columns from same set of txns takes only 578.369 ms
```
select tx_sequence_number, checkpoint_sequence_number from transactions where checkpoint_sequence_number > 6370000 and checkpoint_sequence_number <= 6380000;
```

## Test Plan 

local run fullnode sync worker and analytical worker, verify that
- the transaction table is properly populated with the new column
- TPS can be calculated properly based on the new column

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
