### PR TITLE
Make ConsensusHandler abstract

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -230,7 +230,6 @@ pub struct AuthorityMetrics {
     pending_notify_read: IntGauge,
 
     /// Consensus handler metrics
-    pub consensus_handler_processed_batches: IntCounter,
     pub consensus_handler_processed_bytes: IntCounter,
     pub consensus_handler_processed: IntCounterVec,
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
@@ -524,11 +523,6 @@ impl AuthorityMetrics {
                 registry,
             )
                 .unwrap(),
-            consensus_handler_processed_batches: register_int_counter_with_registry!(
-                "consensus_handler_processed_batches",
-                "Number of batches processed by consensus_handler",
-                registry
-            ).unwrap(),
             consensus_handler_processed_bytes: register_int_counter_with_registry!(
                 "consensus_handler_processed_bytes",
                 "Number of bytes processed by consensus_handler",

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1732,7 +1732,7 @@ impl AuthorityPerEpochStore {
                 ..
             }) => {
                 if transaction.sender_authority() != data.summary.auth_sig().authority {
-                    warn!("CheckpointSignature authority {} does not match narwhal certificate source {}", data.summary.auth_sig().authority, transaction.certificate.origin() );
+                    warn!("CheckpointSignature authority {} does not match narwhal certificate source {}", data.summary.auth_sig().authority, transaction.certificate_author_index );
                     return None;
                 }
             }
@@ -1743,8 +1743,7 @@ impl AuthorityPerEpochStore {
                 if &transaction.sender_authority() != authority {
                     warn!(
                         "EndOfPublish authority {} does not match narwhal certificate source {}",
-                        authority,
-                        transaction.certificate.origin()
+                        authority, transaction.certificate_author_index
                     );
                     return None;
                 }
@@ -1757,7 +1756,7 @@ impl AuthorityPerEpochStore {
                     warn!(
                         "CapabilityNotification authority {} does not match narwhal certificate source {}",
                         capabilities.authority,
-                        transaction.certificate.origin()
+                        transaction.certificate_author_index
                     );
                     return None;
                 }
@@ -1769,8 +1768,7 @@ impl AuthorityPerEpochStore {
                 if transaction.sender_authority() != *authority {
                     warn!(
                         "NewJWKFetched authority {} does not match narwhal certificate source {}",
-                        authority,
-                        transaction.certificate.origin()
+                        authority, transaction.certificate_author_index,
                     );
                     return None;
                 }
@@ -2104,7 +2102,7 @@ impl AuthorityPerEpochStore {
     ) -> SuiResult<ConsensusCertificateResult> {
         let _scope = monitored_scope("HandleConsensusTransaction");
         let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
-            certificate: _consensus_output,
+            certificate_author_index: _,
             certificate_author,
             consensus_index,
             transaction,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -8,19 +8,19 @@ use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::AuthorityMetrics;
 use crate::checkpoints::CheckpointServiceNotify;
 use crate::consensus_throughput_calculator::ConsensusThroughputCalculator;
+use crate::consensus_types::committee_api::CommitteeAPI;
 use crate::consensus_types::consensus_output_api::ConsensusOutputAPI;
+use crate::consensus_types::AuthorityIndex;
 use crate::scoring_decision::update_low_scoring_authorities;
 use crate::transaction_manager::TransactionManager;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use fastcrypto::hash::Hash as _Hash;
-use fastcrypto::traits::ToFromBytes;
+use fastcrypto::hash::{Digest, Hash as _Hash};
 use lru::LruCache;
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use narwhal_config::Committee;
 use narwhal_executor::{ExecutionIndices, ExecutionState};
-use narwhal_test_utils::latest_protocol_version;
-use narwhal_types::{BatchAPI, Certificate, CertificateAPI, ConsensusOutput, HeaderAPI};
+use narwhal_types::ConsensusOutput;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -142,7 +142,25 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
         let _scope = monitored_scope("HandleConsensusOutput");
+        let digest = consensus_output.digest();
+        self.handle_consensus_output_internal(consensus_output, digest.into())
+            .await;
+    }
 
+    async fn last_executed_sub_dag_index(&self) -> u64 {
+        self.last_consensus_stats.index.sub_dag_index
+    }
+}
+
+impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync>
+    ConsensusHandler<T, C>
+{
+    #[instrument(level = "debug", skip_all)]
+    async fn handle_consensus_output_internal(
+        &mut self,
+        consensus_output: impl ConsensusOutputAPI,
+        digest: Digest<32>,
+    ) {
         // This code no longer supports old protocol versions.
         assert!(self
             .epoch_store
@@ -151,7 +169,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
 
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
-        let round = consensus_output.sub_dag.leader_round();
+        let round = consensus_output.leader_round();
 
         assert!(round >= last_committed_round);
         if last_committed_round == round {
@@ -167,8 +185,9 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
 
         /* (serialized, transaction, output_cert) */
         let mut transactions = vec![];
-        let timestamp = consensus_output.sub_dag.commit_timestamp();
-        let leader_author = consensus_output.sub_dag.leader.header().author();
+        let timestamp = consensus_output.commit_timestamp();
+        let leader_author = consensus_output.leader_author_index();
+        let commit_sub_dag_index = consensus_output.commit_sub_dag_index();
 
         let epoch_start = self
             .epoch_store
@@ -185,9 +204,9 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
 
         info!(
             "Received consensus output {:?} at leader round {}, subdag index {}, timestamp {} epoch {}",
-            consensus_output.digest(),
+            digest,
             round,
-            consensus_output.sub_dag.sub_dag_index,
+            commit_sub_dag_index,
             timestamp,
             self.epoch_store.epoch(),
         );
@@ -196,7 +215,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
         transactions.push((
             vec![],
             SequencedConsensusTransactionKind::System(prologue_transaction),
-            Arc::new(consensus_output.sub_dag.leader.clone()),
+            consensus_output.leader_author_index(),
         ));
 
         // Load all jwks that became active in the previous round, and commit them in this round.
@@ -219,7 +238,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
             transactions.push((
                 vec![],
                 SequencedConsensusTransactionKind::System(authenticator_state_update_transaction),
-                Arc::new(consensus_output.sub_dag.leader.clone()),
+                consensus_output.leader_author_index(),
             ));
         }
 
@@ -239,47 +258,20 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
             .inc();
 
         let mut bytes = 0usize;
-        for (cert, batches) in consensus_output
-            .sub_dag
-            .certificates
-            .iter()
-            .zip(consensus_output.batches.iter())
         {
-            let span = trace_span!("process_consensus_cert");
+            let span = trace_span!("process_consensus_certs");
             let _guard = span.enter();
-
-            assert_eq!(cert.header().payload().len(), batches.len());
-            let author = cert.header().author();
-            let num_certs = self
-                .last_consensus_stats
-                .stats
-                .inc_narwhal_certificates(author.0 as usize);
-            self.metrics
-                .consensus_committed_certificates
-                .with_label_values(&[&author.to_string()])
-                .set(num_certs as i64);
-            let output_cert = Arc::new(cert.clone());
-            for batch in batches {
-                let span = trace_span!("process_consensus_batch");
-                let _guard = span.enter();
-
-                assert!(output_cert.header().payload().contains_key(&batch.digest()));
-                self.metrics.consensus_handler_processed_batches.inc();
-                for serialized_transaction in batch.transactions() {
+            for (authority_index, authority_transactions) in consensus_output.into_transactions() {
+                let num_certs = self
+                    .last_consensus_stats
+                    .stats
+                    .inc_narwhal_certificates(authority_index as usize);
+                self.metrics
+                    .consensus_committed_certificates
+                    .with_label_values(&[&authority_index.to_string()])
+                    .set(num_certs as i64);
+                for (serialized_transaction, transaction) in authority_transactions {
                     bytes += serialized_transaction.len();
-
-                    let transaction = match bcs::from_bytes::<ConsensusTransaction>(
-                        serialized_transaction,
-                    ) {
-                        Ok(transaction) => transaction,
-                        Err(err) => {
-                            // This should have been prevented by Narwhal batch verification.
-                            panic!(
-                                "Unexpected malformed transaction (failed to deserialize): {}\nCertificate={:?} BatchDigest={:?} Transaction={:?}",
-                                err, output_cert, batch.digest(), serialized_transaction
-                            );
-                        }
-                    };
                     self.metrics
                         .consensus_handler_processed
                         .with_label_values(&[classify(&transaction)])
@@ -291,17 +283,17 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
                         let num_txns = self
                             .last_consensus_stats
                             .stats
-                            .inc_user_transactions(author.0 as usize);
+                            .inc_user_transactions(authority_index as usize);
                         self.metrics
                             .consensus_committed_user_transactions
-                            .with_label_values(&[&author.to_string()])
+                            .with_label_values(&[&authority_index.to_string()])
                             .set(num_txns as i64);
                     }
                     let transaction = SequencedConsensusTransactionKind::External(transaction);
                     transactions.push((
                         serialized_transaction.clone(),
                         transaction,
-                        output_cert.clone(),
+                        authority_index,
                     ));
                 }
             }
@@ -316,12 +308,12 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
             // entries while we're iterating over the sequenced transactions.
             let mut processed_set = HashSet::new();
 
-            for (seq, (serialized, transaction, output_cert)) in
+            for (seq, (serialized, transaction, cert_origin)) in
                 transactions.into_iter().enumerate()
             {
                 let index = ExecutionIndices {
                     last_committed_round: round,
-                    sub_dag_index: consensus_output.sub_dag.sub_dag_index,
+                    sub_dag_index: commit_sub_dag_index,
                     transaction_index: seq as u64,
                 };
 
@@ -335,17 +327,13 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
                     continue;
                 };
 
-                let certificate_author = AuthorityName::from_bytes(
-                    self.committee
-                        .authority_safe(&output_cert.header().author())
-                        .protocol_key_bytes()
-                        .0
-                        .as_ref(),
-                )
-                .unwrap();
+                let certificate_author = self
+                    .committee
+                    .authority_pubkey_by_index(cert_origin)
+                    .unwrap();
 
                 let sequenced_transaction = SequencedConsensusTransaction {
-                    certificate: output_cert.clone(),
+                    certificate_author_index: cert_origin,
                     certificate_author,
                     consensus_index: index_with_stats.index,
                     transaction,
@@ -388,10 +376,6 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
         self.transaction_scheduler
             .schedule(transactions_to_schedule)
             .await;
-    }
-
-    async fn last_executed_sub_dag_index(&self) -> u64 {
-        self.last_consensus_stats.index.sub_dag_index
     }
 }
 
@@ -484,7 +468,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
 }
 
 pub struct SequencedConsensusTransaction {
-    pub certificate: Arc<narwhal_types::Certificate>,
+    pub certificate_author_index: AuthorityIndex,
     pub certificate_author: AuthorityName,
     pub consensus_index: ExecutionIndices,
     pub transaction: SequencedConsensusTransactionKind,
@@ -593,10 +577,10 @@ impl VerifiedSequencedConsensusTransaction {
 impl SequencedConsensusTransaction {
     pub fn new_test(transaction: ConsensusTransaction) -> Self {
         Self {
-            transaction: SequencedConsensusTransactionKind::External(transaction),
-            certificate: Arc::new(Certificate::default(&latest_protocol_version())),
+            certificate_author_index: 0,
             certificate_author: AuthorityName::ZERO,
             consensus_index: Default::default(),
+            transaction: SequencedConsensusTransactionKind::External(transaction),
         }
     }
 }

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -11,13 +11,15 @@ use sui_types::messages_consensus::ConsensusTransaction;
 /// For each transaction, returns the serialized transaction and the deserialized transaction.
 type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(Vec<u8>, ConsensusTransaction)>)>;
 
-pub(crate) trait ConsensusOutputAPI {
+const DIGEST_SIZE: usize = 32;
+
+pub(crate) trait ConsensusOutputAPI: Hash<DIGEST_SIZE> {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
     fn leader_round(&self) -> u64;
     fn leader_author_index(&self) -> AuthorityIndex;
 
     /// Returns epoch UNIX timestamp in milliseconds
-    fn commit_timestamp(&self) -> u64;
+    fn commit_timestamp_ms(&self) -> u64;
 
     /// Returns a unique global index for each committed sub-dag.
     fn commit_sub_dag_index(&self) -> u64;
@@ -49,7 +51,7 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
         self.sub_dag.leader.origin().0
     }
 
-    fn commit_timestamp(&self) -> u64 {
+    fn commit_timestamp_ms(&self) -> u64 {
         self.sub_dag.commit_timestamp()
     }
 

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -2,9 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::consensus_types::AuthorityIndex;
+use fastcrypto::hash::Hash;
+use narwhal_types::{BatchAPI, CertificateAPI, HeaderAPI};
+use sui_types::messages_consensus::ConsensusTransaction;
+
+/// A list of tuples of:
+/// (certificate origin authority index, all transactions corresponding to the certificate).
+/// For each transaction, returns the serialized transaction and the deserialized transaction.
+type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(Vec<u8>, ConsensusTransaction)>)>;
 
 pub(crate) trait ConsensusOutputAPI {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
+    fn leader_round(&self) -> u64;
+    fn leader_author_index(&self) -> AuthorityIndex;
+
+    /// Returns epoch UNIX timestamp in milliseconds
+    fn commit_timestamp(&self) -> u64;
+
+    /// Returns a unique global index for each committed sub-dag.
+    fn commit_sub_dag_index(&self) -> u64;
+
+    /// Returns all transactions in the commit.
+    fn into_transactions(self) -> ConsensusOutputTransactions;
 }
 
 impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
@@ -20,5 +39,51 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
                 .map(|(id, score)| (id.0, score))
                 .collect(),
         )
+    }
+
+    fn leader_round(&self) -> u64 {
+        self.sub_dag.leader_round()
+    }
+
+    fn leader_author_index(&self) -> AuthorityIndex {
+        self.sub_dag.leader.origin().0
+    }
+
+    fn commit_timestamp(&self) -> u64 {
+        self.sub_dag.commit_timestamp()
+    }
+
+    fn commit_sub_dag_index(&self) -> u64 {
+        self.sub_dag.sub_dag_index
+    }
+
+    fn into_transactions(self) -> ConsensusOutputTransactions {
+        self.sub_dag
+            .certificates
+            .iter()
+            .zip(self.batches)
+            .map(|(cert, batches)| {
+                assert_eq!(cert.header().payload().len(), batches.len());
+                let transactions: Vec<_> = batches.into_iter().flat_map(move |batch| {
+                    let digest = batch.digest();
+                    assert!(cert.header().payload().contains_key(&digest));
+                    batch.into_transactions().into_iter().map(move |serialized_transaction| {
+                        let transaction = match bcs::from_bytes::<ConsensusTransaction>(
+                            &serialized_transaction,
+                        ) {
+                            Ok(transaction) => transaction,
+                            Err(err) => {
+                                // This should have been prevented by Narwhal batch verification.
+                                panic!(
+                                    "Unexpected malformed transaction (failed to deserialize): {}\nCertificate={:?} BatchDigest={:?} Transaction={:?}",
+                                    err, cert, digest, serialized_transaction
+                                );
+                            }
+                        };
+                        (serialized_transaction, transaction)
+                    })
+                }).collect();
+                (cert.origin().0, transactions)
+            }).collect()
     }
 }

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -173,6 +173,7 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for Batch {
 pub trait BatchAPI {
     fn transactions(&self) -> &Vec<Transaction>;
     fn transactions_mut(&mut self) -> &mut Vec<Transaction>;
+    fn into_transactions(self) -> Vec<Transaction>;
     fn metadata(&self) -> &Metadata;
     fn metadata_mut(&mut self) -> &mut Metadata;
 
@@ -195,6 +196,10 @@ impl BatchAPI for BatchV1 {
 
     fn transactions_mut(&mut self) -> &mut Vec<Transaction> {
         &mut self.transactions
+    }
+
+    fn into_transactions(self) -> Vec<Transaction> {
+        self.transactions
     }
 
     fn metadata(&self) -> &Metadata {
@@ -241,6 +246,10 @@ impl BatchAPI for BatchV2 {
 
     fn transactions_mut(&mut self) -> &mut Vec<Transaction> {
         &mut self.transactions
+    }
+
+    fn into_transactions(self) -> Vec<Transaction> {
+        self.transactions
     }
 
     fn metadata(&self) -> &Metadata {
@@ -1435,7 +1444,7 @@ pub enum SignatureVerificationState {
     // and has not been verified yet.
     Unverified(AggregateSignatureBytes),
     // This state occurs when a certificate was either created locally, received
-    // via brodacast, or fetched but was not the parent of another certifiate.
+    // via brodacast, or fetched but was not the parent of another certificate.
     // Therefore this certificate had to be verified directly.
     VerifiedDirectly(AggregateSignatureBytes),
     // This state occurs when the cert was a parent of another fetched certificate


### PR DESCRIPTION
## Description 

This PR completes the `ConsensusOutputAPI` trait, and makes ConsensusHandler consensus-type agnostic.
There are a few changes that made this possible:
1. The biggest change is the `into_transactions()` function, which hides the details of the ConsensusOutput data structure and returns all transactions from it.
2. Introduced the `intro_transactions()` function to `Batch` so that we can get rid of unnecessary clones. In fact, all previous clones were removed.
3. Removed the `certificate` field from `SequencedConsensusTransaction` type, because we don't need it. Instead we only need the authority index of the origin of the certificate.
4. Added `handle_consensus_output_internal` which operates on common types only, and hence can be called from both Narwhal and Mysticeti.
5. The only semantic difference is that we no longer report the number of batches processed metric, which is too specific to Narwhal implementation. We could add it inside Narwhal if we want to.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
