### PR TITLE
Add a simple MANIFEST file to db snapshots

### DIFF
--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -275,7 +275,7 @@ impl DBCheckpointHandler {
                 // This writes a single "MANIFEST" file which contains a list of all files that make up a db snapshot
                 write_snapshot_manifest(
                     db_path,
-                    self.input_object_store.clone(),
+                    &self.input_object_store,
                     format!("epoch_{}/", epoch),
                 )
                 .await?;

--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -273,7 +273,12 @@ impl DBCheckpointHandler {
         for (epoch, db_path) in dirs {
             if missing_epochs.contains(epoch) || *epoch >= last_missing_epoch {
                 // This writes a single "MANIFEST" file which contains a list of all files that make up a db snapshot
-                write_snapshot_manifest(db_path, self.input_object_store.clone()).await?;
+                write_snapshot_manifest(
+                    db_path,
+                    self.input_object_store.clone(),
+                    format!("epoch_{}/", epoch),
+                )
+                .await?;
 
                 if self.prune_and_compact_before_upload {
                     // Convert `db_path` to the local filesystem path to where db checkpoint is stored


### PR DESCRIPTION
## Description 

For http-based snapshot downloads we need to have an easily accessible list of the files available in a snapshot. This PR creates a MANIFEST file which is written to the epoch dir root, and contains the list of all files available.

## Test Plan 

Just a unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
