### PR TITLE
[transfer-to-object] Transfer to object examples and long-form doc

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -74,7 +74,7 @@ fn run_docs_examples_move_unit_tests() -> io::Result<()> {
 
     for entry in fs::read_dir(examples)? {
         let entry = entry?;
-        if entry.file_type()?.is_dir() {
+        if entry.file_type()?.is_dir() && entry.path().join("Move.toml").exists() {
             check_package_builds(entry.path());
             check_move_unit_tests(entry.path());
         }

--- a/examples/move/transfer-to-object/README.md
+++ b/examples/move/transfer-to-object/README.md
@@ -1,0 +1,214 @@
+# Transfer-to-object: Cash Register example
+
+This document explores some different ways of implementing a cash register that
+can accept and process payments on Sui, and we'll focus on highlighting the
+trade-offs of each approach. Through these examples, you'll gain insights into
+the new transfer-to-object functionality and understand some of its applications
+and the types of issues it can address.
+
+## Representing payments
+
+Before getting started, we first will define a common way of making payments.
+Each payment is an object that consists of a `payment_id` which is a unique
+identifier for the payment (i.e., a way of tracking what the payment was for)
+along with the actual `coin` for the payment.
+
+```move
+/// A unique payment for a good or service that can be uniquely identified by
+/// `payment_id`.
+struct IdentifiedPayment has key {
+    // Object ID
+    id: UID,
+    // The unique id for the good/service being paid for.
+    payment_id: u64,
+    // The payment
+    coin: Coin<SUI>,
+}
+
+```
+
+Using this customers can make a payment with a unique payment ID to an address using the `fun
+make_payment(payment_id: u64, coin: Coin<SUI>, to: address)`. This function creates
+an `IdentifiedPayment`, sends it to the `to` address, and emits an event with
+the payment's ID, who it's being payed to, the amount being payed, and who's
+paying it.
+
+Once the receiver of the payment has the `IdentifiedPayment` object, they can
+`unpack` the identified payment into the coin that was sent. This will then
+emit a separate event that marks the payment ID within the `IdentifiedPayment`
+as processed.
+
+You can see the Move code for this section (along with `EarmarkedPayment`s
+which we'll use later on) [here](./common/sources/identified_payment.move).
+
+With how we will represents payments out of the way, lets now take a look at a
+couple different ways that you could represent a cash register or perform
+customer-to-business type transactions on-chain.
+
+## Implementation 1: Using an account address
+
+Let's say you run a restaurant called Bill's Burgers. Your business will have
+an address `A` on-chain and when an order is taken the customer will make a
+payment with the payment ID provided by Bill's Burgers to `A`.
+
+Whenever a `IdentifiedPayment` is sent you'll be able to track it on your end
+and mark the bill as paid when you see the `SentPaymentEvent` with the given
+payment ID that you've provided them and match it against the amount owed.  
+
+Later on (either asynchronously or in a batch at the end of the day), you can
+then process the paymens you've received by iterating over the set of
+`IdentifiedPayment` objects under your account, `unpack`ing them, and then
+using the unpacked SUI coin.
+
+Overall, this is a very simple representation for on-chian payments and
+relatively easy to setup. However, it has some issues:
+
+1. If your private key(s) for `A` are compromised it would need to
+change it's address. This could cause issues for customers that are still
+using the older address for the business.
+2. If you want to permit multiple employees to access the cash
+register it can only do via a multi-sig policy. However this could present
+issues if an employee departs, or if there are a large number of employees
+that you want to allow to access payments.
+
+You can see the Move implemenation for this section [here](./owned-no-tto/sources/cash_register.move).
+
+## Implementation 2: Using a shared object
+
+To get around some of these issues you could have Bill's Burgers use a shared object and
+have customers pay into the shared object. In particular:
+
+1. If Bill's Burgers' private key(s) are compromised you can simply create a new
+address and change the "owner" field of the shared `Register` object to that
+new account address.
+2. Bill's Burgers can add additional employees to the `Register`s
+`authorized_employees` list. If an employee departs or is hired they can easily be
+removed from or added to this list without changing the object ID of the shared
+`Register` object.
+
+However, with the shared `Register` payments need to be made a different way
+than by simply transferring the coins to the Bill's Burgers shared object -- in particular
+without transfer-to-object a payment to the `Register` object would involve
+taking the shared `Register` object for Bill's Burgers and adding the payment as
+a dynamic object field under it:
+
+```move
+public fun make_shared_payment(register_uid: &mut UID, payment_id: u64, coin: Coin<SUI>, ctx: &mut TxContext) {
+    let identified_payment = IdentifiedPayment {
+        id: object::new(ctx),
+        payment_id,
+        coin,
+    };
+    dynamic_object_field::add(register_uid, payment_id, identified_payment)
+}
+
+```
+
+Because of this, if Bill's Burgers becomes incredibly popular across all their
+locations and they need to serve hundreds or thousands of customers at once
+those customers payments must all be processed serially since they would all be
+using the same shared object their transactions. This could lead to contention
+over the `Register` object and payments could take a while to process because
+of this whereas with Implementation 1 since it is using only owned objects, all
+payments across all of the Bill's Burgers locations could be processed in
+parallel.
+
+Luckily, transfer-to-object can help parallelize the payment process to the
+`Register` object, while also keeping the benefits of dynamic authorization and
+stable interaction IDs that we saw in this implementation. Lets take a look at exactly how
+it does this in the next example.
+
+You can see the Move implementation for this section [here](./shared-no-tto/sources/shared_cash_register.move).
+
+## Implementation 3: Using a shared object + transfer-to-object
+
+With transfer-to-object, we can get the benefits of both of the implementations that we've seen so far:
+
+- The object ID stability of the shared object.
+- The ability to transfer the ownership of the object in case of key compromise.
+- Easy way of dynamically adding, removing, and enforcing permissions on who can withdraw payments.
+- Payments can all still be made using the `identified_payment::make_payment` function that uses
+`sui::transfer::transfer` under the hood, so payments can happen in parallel
+across all Bill's Burgers locations without needing to be sequenced against
+the shared `Register` object for Bill's Burgers.
+
+You can see the entire implementation for the shared object register using
+transfer-to-object [here](./shared-with-tto/sources/shared_cash_register.move). 
+
+Let's go through this in a bit more detail, and compare it to the above two implementations.
+
+### Interaction stability: Object ID remains the same
+
+To make a payment, nothing changes from Implementation 1. In particular,
+customers will still use `identified_payment::make_payment` and simply set the address they want to
+send to to be the object ID of the Bill's Burgers `Register` object. If Bill's
+Burgers changes the ownership of the `Register` object this will be 
+opaque to the customers -- they will always send their payment to the same
+`Register` object.
+
+### Receiving payments
+
+At a high level, handling payments after they have been made using
+transfer-to-object resides somewhere between both Implementation 1, and
+Implementation 2. In particular:
+
+- Similar to Implementation 1, the object IDs of the payments you want to
+  handle in that transaction will show up in the transaction's inputs;
+- Similar to Implementation 2, there are dynamic checks that are enforced on being able to access the sent payments.
+
+To really see what's going on here though it's best to go through the implementation of `handle_payment`:
+
+```move
+/// We take the `Register` shared object mutably, along with a "ticket"
+// `handle_payment` that we can exchange for the actual `IdentifiedPayment` object
+// that it is associated with.
+public fun handle_payment(register: &mut Register, handle_payment: Receiving<IdentifiedPayment>, ctx: &TxContext): IdentifiedPayment {
+    // If the sender of the transaction that wants to handle this payment is in the list of authorized employees in the `Register` object
+    // then we will permit them to withdraw the `IdentifiedPayment` object.
+    assert!(vector::contains(&register.authorized_employees, tx_context::sender(ctx)), ENotAuthorized);
+    // Authorization check succcessful -- exchange the `handle_payment` ticket
+    // for the `IdentifiedPayment` object and return it.
+    transfer::public_receive(&mut register.id, handle_payment)
+}
+```
+
+### Adding tips using a custom `receive` rule
+
+One additional benefit of transfer-to-object is that in addition to being able
+to specify custom transfer rules for `key`-only objects, you can also
+specify custom receiving rules for `key`-only objects in a very similar manner:
+if an object is `key`-only, then the `sui::transfer::receive` function can be
+called in the module that defines the object, but not elsewhere -- elsewhere
+the `sui::transfer::public_receive` function must be called and can only be
+used on objects that also have the `store` ability.
+
+With this information, we can define a wrapper around `IdentifiedPayment`s
+where we can earmark that payment for a specific address, e.g., the address of
+our server at the restaurant. We can then use the the custom receive rule to
+ensure that only our server can access their tip and no one else can.
+
+```move
+struct EarmarkedPayment has key {
+    id: UID,
+    payment: IdentifiedPayment,
+    for: address,
+}
+```
+
+Since `EarmarkedPayment` is `key` only we can then define a custom receiving
+rule for it so that only the address that we specified for it can receive the
+payment:
+
+```move
+public fun receive(parent: &mut UID, ticket: Receiving<EarmarkedPayment>, ctx: &TxContext): IdentifiedPayment {
+    let EarmarkedPayment { id, payment, for } = transfer::receive(parent, ticket);
+    // If the sender isn't the address we specified the transaction will abort.
+    assert!(tx_context::sender(ctx) == for, ENotEarmarkedForSender);
+    object::delete(id);
+    payment
+}
+```
+
+You can see the implementations for `EarmarkedPayment`s and the custom
+receiving rules and function at the bottom of the file
+[here](./common/sources/identified_payment.move).

--- a/examples/move/transfer-to-object/README.md
+++ b/examples/move/transfer-to-object/README.md
@@ -1,16 +1,16 @@
-# Transfer-to-object: Cash Register example
+# Transfer-to-Object: Cash Register Example
 
-This document explores some different ways of implementing a cash register that
-can accept and process payments on Sui, and we'll focus on highlighting the
-trade-offs of each approach. Through these examples, you'll gain insights into
-the new transfer-to-object functionality and understand some of its applications
-and the types of issues it can address.
+This document explores various methods of implementing a cash register that can
+accept and process payments on Sui. We'll focus on highlighting the trade-offs
+of each approach. Through these examples, you'll gain insights into the new
+transfer-to-object functionality and understand some of its applications and
+the types of issues it can address.
 
-## Representing payments
+## Representing Payments
 
-Before getting started, we first will define a common way of making payments.
-Each payment is an object that consists of a `payment_id` which is a unique
-identifier for the payment (i.e., a way of tracking what the payment was for)
+Before getting started, we need to define a common method for making payments.
+Each payment is an object that consists of a `payment_id`, which is a unique
+identifier for the payment (i.e., a way of tracking what the payment was for),
 along with the actual `coin` for the payment.
 
 ```move
@@ -19,78 +19,78 @@ along with the actual `coin` for the payment.
 struct IdentifiedPayment has key {
     // Object ID
     id: UID,
-    // The unique id for the good/service being paid for.
+    // The unique id for the good/service being paid for
     payment_id: u64,
     // The payment
     coin: Coin<SUI>,
 }
-
 ```
 
-Using this customers can make a payment with a unique payment ID to an address using the `fun
-make_payment(payment_id: u64, coin: Coin<SUI>, to: address)`. This function creates
-an `IdentifiedPayment`, sends it to the `to` address, and emits an event with
-the payment's ID, who it's being payed to, the amount being payed, and who's
-paying it.
+Using this, customers can make a payment with a unique payment ID to an address
+using the function `fun make_payment(payment_id: u64, coin: Coin<SUI>, to:
+address)`. This function creates an `IdentifiedPayment`, sends it to the `to`
+address, and emits an event with the payment's ID, the recipient, the amount
+paid, and the payer.
 
 Once the receiver of the payment has the `IdentifiedPayment` object, they can
 `unpack` the identified payment into the coin that was sent. This will then
 emit a separate event that marks the payment ID within the `IdentifiedPayment`
 as processed.
 
-You can see the Move code for this section (along with `EarmarkedPayment`s
+You can see the Move code for this section (along with `EarmarkedPayment`s,
 which we'll use later on) [here](./common/sources/identified_payment.move).
 
-With how we will represents payments out of the way, lets now take a look at a
-couple different ways that you could represent a cash register or perform
+Now that we have established how we'll represent payments, let's examine a
+couple of different ways you could represent a cash register or perform
 customer-to-business type transactions on-chain.
 
-## Implementation 1: Using an account address
+## Implementation 1: Using an Account Address
 
-Let's say you run a restaurant called Bill's Burgers. Your business will have
-an address `A` on-chain and when an order is taken the customer will make a
-payment with the payment ID provided by Bill's Burgers to `A`.
+Imagine you run a restaurant called Bill's Burgers. Your business will have an
+address `A` on-chain. When an order is taken, the customer will make a payment
+with the payment ID provided by Bill's Burgers to `A`.
 
-Whenever a `IdentifiedPayment` is sent you'll be able to track it on your end
-and mark the bill as paid when you see the `SentPaymentEvent` with the given
-payment ID that you've provided them and match it against the amount owed.  
+Whenever an `IdentifiedPayment` is sent, you'll be able to track it and mark
+the bill as paid when you see the `SentPaymentEvent` with the given payment ID
+that you provided and match it against the amount owed.
 
 Later on (either asynchronously or in a batch at the end of the day), you can
-then process the paymens you've received by iterating over the set of
+process the payments you've received by iterating over the set of
 `IdentifiedPayment` objects under your account, `unpack`ing them, and then
 using the unpacked SUI coin.
 
-Overall, this is a very simple representation for on-chian payments and
-relatively easy to setup. However, it has some issues:
+Overall, this is a very simple representation for on-chain payments and
+relatively easy to set up. However, it has some issues:
 
-1. If your private key(s) for `A` are compromised it would need to
-change it's address. This could cause issues for customers that are still
-using the older address for the business.
-2. If you want to permit multiple employees to access the cash
-register it can only do via a multi-sig policy. However this could present
-issues if an employee departs, or if there are a large number of employees
-that you want to allow to access payments.
+1. If your private key(s) for `A` are compromised, you would need to change to
+   a different address. This could cause issues for customers still using the
+   older address for the business.
+2. If you want to allow multiple employees to access the cash register, it can
+   only be done via a multi-sig policy. However, this could present issues if
+   an employee departs or is compromised, or if there are a large number of
+   employees that you want to allow access to payments.
 
-You can see the Move implemenation for this section [here](./owned-no-tto/sources/cash_register.move).
+You can see the Move implementation for this section [here](./owned-no-tto/sources/cash_register.move).
 
-## Implementation 2: Using a shared object
+## Implementation 2: Using a Shared Object
 
-To get around some of these issues you could have Bill's Burgers use a shared object and
-have customers pay into the shared object. In particular:
+To address some of the issues mentioned above, you could have Bill's Burgers
+use a shared object and have customers pay into the shared object. In
+particular:
 
-1. If Bill's Burgers' private key(s) are compromised you can simply create a new
-address and change the "owner" field of the shared `Register` object to that
-new account address.
-2. Bill's Burgers can add additional employees to the `Register`s
-`authorized_employees` list. If an employee departs or is hired they can easily be
-removed from or added to this list without changing the object ID of the shared
-`Register` object.
+1. If the private key(s) of the register owner are compromised, a new address
+   can be created and the `owner` field of the shared `Register` object can be
+   set to the new address.
+2. Additional employees can be added to the `Register`'s `authorized_employees`
+   list. If an employee departs or is hired, they can easily be removed from or
+   added to this list without changing the object ID of the shared `Register`
+   object that customers interact with.
 
-However, with the shared `Register` payments need to be made a different way
-than by simply transferring the coins to the Bill's Burgers shared object -- in particular
-without transfer-to-object a payment to the `Register` object would involve
-taking the shared `Register` object for Bill's Burgers and adding the payment as
-a dynamic object field under it:
+However, with the shared `Register`, payments must be made differently than
+simply transferring the coins to the Bill's Burgers shared object. In
+particular, without transfer-to-object, a payment to the `Register` object
+would involve taking the shared `Register` object for Bill's Burgers and adding
+the payment as a dynamic object field under it:
 
 ```move
 public fun make_shared_payment(register_uid: &mut UID, payment_id: u64, coin: Coin<SUI>, ctx: &mut TxContext) {
@@ -99,64 +99,68 @@ public fun make_shared_payment(register_uid: &mut UID, payment_id: u64, coin: Co
         payment_id,
         coin,
     };
+    // Add the payment as a dynamic field under the register object
     dynamic_object_field::add(register_uid, payment_id, identified_payment)
 }
-
 ```
 
 Because of this, if Bill's Burgers becomes incredibly popular across all their
-locations and they need to serve hundreds or thousands of customers at once
-those customers payments must all be processed serially since they would all be
-using the same shared object their transactions. This could lead to contention
-over the `Register` object and payments could take a while to process because
-of this whereas with Implementation 1 since it is using only owned objects, all
-payments across all of the Bill's Burgers locations could be processed in
-parallel.
+locations and they need to serve hundreds or thousands of customers at once,
+those customers' payments must all be processed serially since they would all
+be using the same shared object. This could lead to contention over the
+`Register` object and delays in payment processing. In contrast, with
+Implementation 1, since it uses only owned objects, all payments across all of
+the Bill's Burgers locations could be processed in parallel and not effect each
+other.
 
 Luckily, transfer-to-object can help parallelize the payment process to the
-`Register` object, while also keeping the benefits of dynamic authorization and
-stable interaction IDs that we saw in this implementation. Lets take a look at exactly how
-it does this in the next example.
+`Register` object while also keeping the benefits of dynamic authorization and
+stable interaction IDs that we saw in this implementation. Let's examine
+exactly how it does this in the next example.
 
 You can see the Move implementation for this section [here](./shared-no-tto/sources/shared_cash_register.move).
 
-## Implementation 3: Using a shared object + transfer-to-object
+## Implementation 3: Using a Shared Object + Transfer-to-Object
 
-With transfer-to-object, we can get the benefits of both of the implementations that we've seen so far:
+With transfer-to-object, we can combine the benefits of the two previous implementations:
 
-- The object ID stability of the shared object.
+- The object ID stability of the shared object register.
 - The ability to transfer the ownership of the object in case of key compromise.
-- Easy way of dynamically adding, removing, and enforcing permissions on who can withdraw payments.
-- Payments can all still be made using the `identified_payment::make_payment` function that uses
-`sui::transfer::transfer` under the hood, so payments can happen in parallel
-across all Bill's Burgers locations without needing to be sequenced against
-the shared `Register` object for Bill's Burgers.
+- An easy way of dynamically adding, removing, and enforcing permissions on who
+  can withdraw payments.
+- Payments can still be made using the `identified_payment::make_payment`
+  function that uses `sui::transfer::transfer` under the hood, so payments can
+  happen in parallel across all Bill's Burgers locations without needing to be
+  sequenced against the shared `Register` object.
 
 You can see the entire implementation for the shared object register using
-transfer-to-object [here](./shared-with-tto/sources/shared_cash_register.move). 
+transfer-to-object [here](./shared-with-tto/sources/shared_cash_register.move).
 
-Let's go through this in a bit more detail, and compare it to the above two implementations.
+Let's go through this implementation in more detail and compare it to the above
+two implementations.
 
-### Interaction stability: Object ID remains the same
+### Interaction Stability: Object ID Remains the Same
 
 To make a payment, nothing changes from Implementation 1. In particular,
-customers will still use `identified_payment::make_payment` and simply set the address they want to
-send to to be the object ID of the Bill's Burgers `Register` object. If Bill's
-Burgers changes the ownership of the `Register` object this will be 
-opaque to the customers -- they will always send their payment to the same
-`Register` object.
+customers will still use `identified_payment::make_payment` and simply set the
+address they want to send to be the object ID of the Bill's Burgers `Register`
+object. If Bill's Burgers changes the ownership of the `Register` object, this
+will be opaque to the customers – they will always send their payment to the
+same `Register` object.
 
-### Receiving payments
+### Receiving Payments
 
 At a high level, handling payments after they have been made using
-transfer-to-object resides somewhere between both Implementation 1, and
+transfer-to-object resides somewhere between both Implementation 1 and
 Implementation 2. In particular:
 
 - Similar to Implementation 1, the object IDs of the payments you want to
-  handle in that transaction will show up in the transaction's inputs;
-- Similar to Implementation 2, there are dynamic checks that are enforced on being able to access the sent payments.
+  handle in that transaction will show up in the transaction's inputs.
+- Similar to Implementation 2, there are dynamic checks enforced on being able
+  to access the sent payments.
 
-To really see what's going on here though it's best to go through the implementation of `handle_payment`:
+To understand what's going on here, it's best to go through the implementation
+of `handle_payment`:
 
 ```move
 /// We take the `Register` shared object mutably, along with a "ticket"
@@ -166,26 +170,26 @@ public fun handle_payment(register: &mut Register, handle_payment: Receiving<Ide
     // If the sender of the transaction that wants to handle this payment is in the list of authorized employees in the `Register` object
     // then we will permit them to withdraw the `IdentifiedPayment` object.
     assert!(vector::contains(&register.authorized_employees, tx_context::sender(ctx)), ENotAuthorized);
-    // Authorization check succcessful -- exchange the `handle_payment` ticket
+    // Authorization check successful -- exchange the `handle_payment` ticket
     // for the `IdentifiedPayment` object and return it.
     transfer::public_receive(&mut register.id, handle_payment)
 }
 ```
 
-### Adding tips using a custom `receive` rule
+### Adding Tips Using a Custom `Receive` Rule
 
-One additional benefit of transfer-to-object is that in addition to being able
-to specify custom transfer rules for `key`-only objects, you can also
-specify custom receiving rules for `key`-only objects in a very similar manner:
-if an object is `key`-only, then the `sui::transfer::receive` function can be
-called in the module that defines the object, but not elsewhere -- elsewhere
-the `sui::transfer::public_receive` function must be called and can only be
-used on objects that also have the `store` ability.
+One additional benefit of transfer-to-object is that, in addition to being able
+to specify custom transfer rules for `key`-only objects, you can also specify
+custom receiving rules for `key`-only objects in a very similar manner: if an
+object is `key`-only, then the `sui::transfer::receive` function can be called
+in the module that defines the object, but not elsewhere. Elsewhere, the
+`sui::transfer::public_receive` function must be called and can only be used on
+objects that also have the `store` ability.
 
 With this information, we can define a wrapper around `IdentifiedPayment`s
 where we can earmark that payment for a specific address, e.g., the address of
-our server at the restaurant. We can then use the the custom receive rule to
-ensure that only our server can access their tip and no one else can.
+our server at the restaurant. We can then use the custom receive rule to ensure
+that only our server can access their tip and no one else can.
 
 ```move
 struct EarmarkedPayment has key {
@@ -195,20 +199,20 @@ struct EarmarkedPayment has key {
 }
 ```
 
-Since `EarmarkedPayment` is `key` only we can then define a custom receiving
+Since `EarmarkedPayment` is `key` only, we can then define a custom receiving
 rule for it so that only the address that we specified for it can receive the
 payment:
 
 ```move
 public fun receive(parent: &mut UID, ticket: Receiving<EarmarkedPayment>, ctx: &TxContext): IdentifiedPayment {
     let EarmarkedPayment { id, payment, for } = transfer::receive(parent, ticket);
-    // If the sender isn't the address we specified the transaction will abort.
+    // If the sender isn't the address we specified, the transaction will abort.
     assert!(tx_context::sender(ctx) == for, ENotEarmarkedForSender);
     object::delete(id);
     payment
 }
 ```
 
-You can see the implementations for `EarmarkedPayment`s and the custom
-receiving rules and function at the bottom of the file
+You can see the implementations for `EarmarkedPayment`s, the custom receiving
+rules, and functions at the bottom of the file
 [here](./common/sources/identified_payment.move).

--- a/examples/move/transfer-to-object/README.md
+++ b/examples/move/transfer-to-object/README.md
@@ -46,9 +46,10 @@ customer-to-business type transactions on-chain.
 
 ## Implementation 1: Using an Account Address
 
-Imagine you run a restaurant called Bill's Burgers. Your business will have an
-address `A` on-chain. When an order is taken, the customer will make a payment
-with the payment ID provided by Bill's Burgers to `A`.
+Imagine you run a restaurant. Your business will have an
+address `A` on-chain. When an order is taken, the customer will simply make a
+payment by transferring an `IdentifiedPayment` object with the payment ID you provided
+to them to your address `A`.
 
 Whenever an `IdentifiedPayment` is sent, you'll be able to track it and mark
 the bill as paid when you see the `SentPaymentEvent` with the given payment ID
@@ -74,9 +75,9 @@ You can see the Move implementation for this section [here](./owned-no-tto/sourc
 
 ## Implementation 2: Using a Shared Object
 
-To address some of the issues mentioned above, you could have Bill's Burgers
-use a shared object and have customers pay into the shared object. In
-particular:
+To address some of the issues mentioned above, you could instead have your restaurant
+use a shared "cash register" object for payments and have customers pay into
+this shared object. In particular:
 
 1. If the private key(s) of the register owner are compromised, a new address
    can be created and the `owner` field of the shared `Register` object can be
@@ -87,9 +88,9 @@ particular:
    object that customers interact with.
 
 However, with the shared `Register`, payments must be made differently than
-simply transferring the coins to the Bill's Burgers shared object. In
+simply transferring the coins to the shared object. In
 particular, without transfer-to-object, a payment to the `Register` object
-would involve taking the shared `Register` object for Bill's Burgers and adding
+would involve taking the shared `Register` object for the restaurant and adding
 the payment as a dynamic object field under it:
 
 ```move
@@ -104,13 +105,13 @@ public fun make_shared_payment(register_uid: &mut UID, payment_id: u64, coin: Co
 }
 ```
 
-Because of this, if Bill's Burgers becomes incredibly popular across all their
-locations and they need to serve hundreds or thousands of customers at once,
+Because of this, if your restaurant becomes incredibly popular across multiple
+locations and you need to serve hundreds or thousands of customers at once,
 those customers' payments must all be processed serially since they would all
 be using the same shared object. This could lead to contention over the
 `Register` object and delays in payment processing. In contrast, with
 Implementation 1, since it uses only owned objects, all payments across all of
-the Bill's Burgers locations could be processed in parallel and not effect each
+your restaurant locations could be processed in parallel and not effect each
 other.
 
 Luckily, transfer-to-object can help parallelize the payment process to the
@@ -130,7 +131,7 @@ With transfer-to-object, we can combine the benefits of the two previous impleme
   can withdraw payments.
 - Payments can still be made using the `identified_payment::make_payment`
   function that uses `sui::transfer::transfer` under the hood, so payments can
-  happen in parallel across all Bill's Burgers locations without needing to be
+  happen in parallel across all restaurant locations without needing to be
   sequenced against the shared `Register` object.
 
 You can see the entire implementation for the shared object register using
@@ -143,8 +144,8 @@ two implementations.
 
 To make a payment, nothing changes from Implementation 1. In particular,
 customers will still use `identified_payment::make_payment` and simply set the
-address they want to send to be the object ID of the Bill's Burgers `Register`
-object. If Bill's Burgers changes the ownership of the `Register` object, this
+address they want to send to be the object ID of the restaurant's `Register`
+object. If the restaurant changes the ownership of the `Register` object, this
 will be opaque to the customers – they will always send their payment to the
 same `Register` object.
 

--- a/examples/move/transfer-to-object/common/Move.toml
+++ b/examples/move/transfer-to-object/common/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "common"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+
+[addresses]
+common = "0x0"

--- a/examples/move/transfer-to-object/common/sources/identified_payment.move
+++ b/examples/move/transfer-to-object/common/sources/identified_payment.move
@@ -1,0 +1,125 @@
+#[lint_allow(coin_field)]
+module common::identified_payment {
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+    use sui::object::{Self, UID};
+    use sui::transfer::{Self, Receiving};
+    use sui::tx_context::{Self, TxContext};
+    use sui::event;
+    use sui::dynamic_object_field;
+
+    const ENotEarmarkedForSender: u64 = 0;
+
+    /// An `IdentifiedPayment` is an object that represents a payment that has
+    /// been made for a specific good or service that is identified by a
+    /// `payment_id` that is unique to the good or service provided for the customer.
+    /// NB: This has the `store` ability to allow the `make_shared_payment`
+    ///     function. Without this `IdentifiedPayment` could be `key` only and
+    ///     custom transfer and receiving rules can be written for it.
+    struct IdentifiedPayment has key, store {
+        id: UID, 
+        payment_id: u64,
+        coin: Coin<SUI>,
+    }
+
+    /// An `EarmarkedPayment` payment is an `IdentifiedPayment` that is
+    /// earmarked for a specific address. E.g., in the restuarant example, you
+    /// may tip your serverd with an `EarmarkedPayment` which will ensure that only
+    /// server that you specified in your tip can receive it.
+    /// Since this object is `key` only it can only be transferred and
+    /// received by functions defined in this module.
+    struct EarmarkedPayment has key {
+        id: UID, 
+        payment: IdentifiedPayment,
+        for: address,
+    }
+
+    /// Event emitted when a payment is made. This contains the `payment_id`
+    /// that the payment is being made for, the `payment_amount` that is being made,
+    /// and the `originator` of the payment.
+    struct SentPaymentEvent has copy, drop {
+        payment_id: u64,
+        payed_to: address,
+        payment_amount: u64,
+        originator: address,
+    }
+
+    /// Event emitted when a payment is processed. This contains the
+    /// `payment_id` of the payment, and the amount processed.
+    struct ProcessedPaymentEvent has copy, drop {
+        payment_id: u64,
+        payment_amount: u64,
+    }
+
+    /// Make a payment with the given payment ID to the provided `to` address.
+    /// Will create an `IdentifiedPayment` object that can be unpacked by the
+    /// recipient, and also emits an event.
+    public fun make_payment(payment_id: u64, coin: Coin<SUI>, to: address, ctx: &mut TxContext) {
+        let payment_amount = coin::value(&coin);
+        let identified_payment = IdentifiedPayment {
+            id: object::new(ctx),
+            payment_id,
+            coin,
+        };
+        event::emit(SentPaymentEvent {
+            payment_id,
+            payed_to: to,
+            payment_amount,
+            originator: tx_context::sender(ctx),
+        });
+        transfer::transfer(identified_payment, to);
+    }
+
+    /// Only needed for the non transfer-to-object-based cash register.
+    public fun make_shared_payment(register_uid: &mut UID, payment_id: u64, coin: Coin<SUI>, ctx: &mut TxContext) {
+        let payment_amount = coin::value(&coin);
+        let identified_payment = IdentifiedPayment {
+            id: object::new(ctx),
+            payment_id,
+            coin,
+        };
+        event::emit(SentPaymentEvent {
+            payment_id,
+            payed_to: object::uid_to_address(register_uid),
+            payment_amount,
+            originator: tx_context::sender(ctx),
+        });
+        dynamic_object_field::add(register_uid, payment_id, identified_payment)
+    }
+
+    /// Process an `IdentifiedPayment` payment returning back the payments ID,
+    /// along with the coin that was sent in the payment.
+    public fun unpack(identified_payment: IdentifiedPayment): (u64, Coin<SUI>) {
+        let IdentifiedPayment { id, payment_id, coin } = identified_payment;
+        object::delete(id);
+        event::emit(ProcessedPaymentEvent {
+            payment_id,
+            payment_amount: coin::value(&coin),
+        });
+        (payment_id, coin)
+    }
+
+    //--------------------------------------------------------------------------- 
+    // Functions for `EarmarkedPayment`s
+    //--------------------------------------------------------------------------- 
+
+    /// Custom transfer rule for `EarmarkedPayment` payments -- anyone can transfer them.
+    public fun transfer(earmarked: EarmarkedPayment, to: address) {
+        transfer::transfer(earmarked, to);
+    }
+
+    /// An example of a custom receiving rule -- this behaves in a similar manner
+    /// to custom transfer rules: if the object is `key` only , the
+    /// `sui::transfer::receive` function can only be called on the object from
+    /// within the same module that defined that object.
+    /// 
+    /// In this case `EarmarkedPayment` is defined with `key` only, so this is
+    /// defining a custom receive rule that specifies that only `for` can receive
+    /// the payment no matter what object it was sent to.
+    public fun receive(parent: &mut UID, ticket: Receiving<EarmarkedPayment>, ctx: &TxContext): IdentifiedPayment {
+        let EarmarkedPayment { id, payment, for } = transfer::receive(parent, ticket);
+        assert!(tx_context::sender(ctx) == for, ENotEarmarkedForSender);
+        object::delete(id);
+        payment
+    }
+}

--- a/examples/move/transfer-to-object/common/sources/identified_payment.move
+++ b/examples/move/transfer-to-object/common/sources/identified_payment.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[lint_allow(coin_field)]
 module common::identified_payment {
     use sui::sui::SUI;

--- a/examples/move/transfer-to-object/common/sources/identified_payment.move
+++ b/examples/move/transfer-to-object/common/sources/identified_payment.move
@@ -9,7 +9,7 @@ module common::identified_payment {
     use sui::transfer::{Self, Receiving};
     use sui::tx_context::{Self, TxContext};
     use sui::event;
-    use sui::dynamic_object_field;
+    use sui::dynamic_field;
 
     const ENotEarmarkedForSender: u64 = 0;
 
@@ -87,7 +87,7 @@ module common::identified_payment {
             payment_amount,
             originator: tx_context::sender(ctx),
         });
-        dynamic_object_field::add(register_uid, payment_id, identified_payment)
+        dynamic_field::add(register_uid, payment_id, identified_payment)
     }
 
     /// Process an `IdentifiedPayment` payment returning back the payments ID,

--- a/examples/move/transfer-to-object/owned-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/owned-no-tto/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "owned_no_tto"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+common = { local = "../common" }
+
+[addresses]
+owned_no_tto = "0x0"

--- a/examples/move/transfer-to-object/owned-no-tto/sources/cash_register.move
+++ b/examples/move/transfer-to-object/owned-no-tto/sources/cash_register.move
@@ -1,0 +1,30 @@
+/// Note that there isn't any cash register for this and while the code is
+/// small it hides the complexity elsewhere. In particular-- the authentication
+/// for the address is all held behind a 1-of-N multisig where each authorized user has a key.
+/// This would present issues either in the case where the register is
+/// compromised (either via a key being exposed or an authorized user leaving the
+/// company).
+///
+/// In either case a new address would need to be created, and customers would
+/// then need to understand that they should interact with the new address and
+/// not the old (now possibly compomised) one.
+/// 
+/// Overall, while it may seem simple it has pretty significant shortcomings
+/// that can be overcome with a transfer-to-object  based approach using a
+/// shared-object register for tracking authorization.
+module owned_no_tto::cash_register {
+    use common::identified_payment::{Self, IdentifiedPayment};
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+    use sui::event;
+
+    struct PaymentProcessed has copy, drop { payment_id: u64, amount: u64 }
+
+    public fun process_payment(payment: IdentifiedPayment): Coin<SUI> {
+        let (payment_id, coin) = identified_payment::unpack(payment);
+        event::emit(PaymentProcessed { payment_id, amount: coin::value(&coin)});
+        coin
+    }
+
+    // NB: Payments are performed with the `identified_payment::make_payment` function.
+}

--- a/examples/move/transfer-to-object/owned-no-tto/sources/cash_register.move
+++ b/examples/move/transfer-to-object/owned-no-tto/sources/cash_register.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Note that there isn't any cash register for this and while the code is
 /// small it hides the complexity elsewhere. In particular-- the authentication
 /// for the address is all held behind a 1-of-N multisig where each authorized user has a key.

--- a/examples/move/transfer-to-object/shared-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-no-tto/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shared_no_tto"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+common = { local = "../common" }
+
+[addresses]
+shared_no_tto = "0x0"

--- a/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
+++ b/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
@@ -1,0 +1,101 @@
+module shared_no_tto::shared_cash_register {
+    use common::identified_payment::{Self, IdentifiedPayment};
+    use sui::sui::SUI;
+    use sui::coin::Coin;
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::dynamic_object_field;
+    use sui::vec_set::{Self, VecSet};
+    use std::vector;
+    use std::string::String;
+
+    const EInvalidOwner: u64 = 0;
+    const EInvalidPaymentID: u64 = 1;
+    const ENotAuthorized: u64 = 2;
+
+    struct CashRegister has key {
+        id: UID,
+        authorized_individuals: VecSet<address>,
+        business_name: String,
+        register_owner: address,
+    }
+
+    /// Create a cash register for the business to use with an initial owner,
+    /// business name, and authorized set of individuals that can process
+    /// payments.
+    public fun create_cash_register(
+        authorized_individuals_vec: vector<address>,
+        business_name: String,
+        ctx: &mut TxContext,
+    ) {
+        let authorized_individuals = vec_set::empty();
+
+        while (!vector::is_empty(&authorized_individuals_vec)) {
+            let addr = vector::pop_back(&mut authorized_individuals_vec);
+            vec_set::insert(&mut authorized_individuals, addr);
+        };
+
+        let register = CashRegister {
+            id: object::new(ctx),
+            authorized_individuals,
+            business_name,
+            register_owner: tx_context::sender(ctx),
+        };
+        transfer::share_object(register);
+    }
+
+    /// Transfer the ownership of this cash register to a new owner.
+    public fun transfer_cash_register_ownership(
+        register: &mut CashRegister,
+        new_owner: address,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        register.register_owner = new_owner;
+    }
+
+    /// Update the business name associated with the cash register.
+    public fun update_business_name(
+        register: &mut CashRegister,
+        new_name: String,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        register.business_name = new_name;
+    }
+
+    /// Add or remove an auhorized individual to the cash register. If removing them they must be in the set of authorized individuals.
+    public fun update_authorized_individuals(
+        register: &mut CashRegister,
+        addr: address,
+        add_or_remove: bool,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        if (add_or_remove) {
+            assert!(vec_set::contains(&register.authorized_individuals, &addr), ENotAuthorized);
+            vec_set::remove(&mut register.authorized_individuals, &addr);
+        } else {
+            vec_set::insert(&mut register.authorized_individuals, addr);
+        } 
+    }
+
+    /// Process a payment that has been made, removing it from the register and
+    /// returning the coin that can then be combined or sent elsewhere by the authorized individual.
+    /// Payments can ony be processed by either an account in the / `authorized_individuals` set or by the owner of the cash register.
+    public fun process_payment(register: &mut CashRegister, payment_id: u64, ctx: &TxContext): Coin<SUI> {
+        let sender = tx_context::sender(ctx);
+        assert!(vec_set::contains(&register.authorized_individuals, &sender) || sender == register.register_owner, ENotAuthorized);
+        assert!(dynamic_object_field::exists_(&register.id, payment_id), EInvalidPaymentID);
+        let payment: IdentifiedPayment = dynamic_object_field::remove(&mut register.id, payment_id);
+        let (_, coin) = identified_payment::unpack(payment);
+        coin
+    }
+
+    /// Make a payment to the cash register -- this is the function that the
+    /// customer will use to make a payment to the cash register.
+    public fun pay(register: &mut CashRegister, payment_id: u64, coin: Coin<SUI>, ctx: &mut TxContext) {
+        identified_payment::make_shared_payment(&mut register.id, payment_id, coin, ctx);
+    }
+}

--- a/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
+++ b/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module shared_no_tto::shared_cash_register {
     use common::identified_payment::{Self, IdentifiedPayment};
     use sui::sui::SUI;

--- a/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
+++ b/examples/move/transfer-to-object/shared-no-tto/sources/shared_cash_register.move
@@ -8,7 +8,7 @@ module shared_no_tto::shared_cash_register {
     use sui::object::{Self, UID};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
-    use sui::dynamic_object_field;
+    use sui::dynamic_field;
     use sui::vec_set::{Self, VecSet};
     use std::vector;
     use std::string::String;
@@ -90,8 +90,8 @@ module shared_no_tto::shared_cash_register {
     public fun process_payment(register: &mut CashRegister, payment_id: u64, ctx: &TxContext): Coin<SUI> {
         let sender = tx_context::sender(ctx);
         assert!(vec_set::contains(&register.authorized_individuals, &sender) || sender == register.register_owner, ENotAuthorized);
-        assert!(dynamic_object_field::exists_(&register.id, payment_id), EInvalidPaymentID);
-        let payment: IdentifiedPayment = dynamic_object_field::remove(&mut register.id, payment_id);
+        assert!(dynamic_field::exists_(&register.id, payment_id), EInvalidPaymentID);
+        let payment: IdentifiedPayment = dynamic_field::remove(&mut register.id, payment_id);
         let (_, coin) = identified_payment::unpack(payment);
         coin
     }

--- a/examples/move/transfer-to-object/shared-with-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-with-tto/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shared-with-tto"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
+common = { local = "../common" }
+
+[addresses]
+shared_with_tto = "0x0"

--- a/examples/move/transfer-to-object/shared-with-tto/sources/shared_cash_register.move
+++ b/examples/move/transfer-to-object/shared-with-tto/sources/shared_cash_register.move
@@ -1,0 +1,107 @@
+module shared_with_tto::shared_cash_register {
+    use common::identified_payment::{Self, IdentifiedPayment, EarmarkedPayment};
+    use sui::sui::SUI;
+    use sui::coin::Coin;
+    use sui::object::{Self, UID};
+    use sui::transfer::{Self, Receiving};
+    use sui::tx_context::{Self, TxContext};
+    use sui::vec_set::{Self, VecSet};
+    use std::vector;
+    use std::string::String;
+
+    const EInvalidOwner: u64 = 0;
+    const ENotAuthorized: u64 = 2;
+
+    struct CashRegister has key {
+        id: UID,
+        authorized_individuals: VecSet<address>,
+        business_name: String,
+        register_owner: address,
+    }
+
+    /// Create a cash register for the business to use with an initial owner,
+    /// business name, and authorized set of individuals that can process
+    /// payments.
+    public fun create_cash_register(
+        authorized_individuals_vec: vector<address>,
+        business_name: String,
+        ctx: &mut TxContext,
+    ) {
+        let authorized_individuals = vec_set::empty();
+
+        while (!vector::is_empty(&authorized_individuals_vec)) {
+            let addr = vector::pop_back(&mut authorized_individuals_vec);
+            vec_set::insert(&mut authorized_individuals, addr);
+        };
+
+        let register = CashRegister {
+            id: object::new(ctx),
+            authorized_individuals,
+            business_name,
+            register_owner: tx_context::sender(ctx),
+        };
+        transfer::share_object(register);
+    }
+
+    /// Transfer the ownership of this cash register to a new owner.
+    public fun transfer_cash_register_ownership(
+        register: &mut CashRegister,
+        new_owner: address,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        register.register_owner = new_owner;
+    }
+
+    /// Update the business name associated with the cash register.
+    public fun update_business_name(
+        register: &mut CashRegister,
+        new_name: String,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        register.business_name = new_name;
+    }
+
+    /// Add or remove an auhorized individual to the cash register. If removing them they must be in the set of authorized individuals.
+    public fun update_authorized_individuals(
+        register: &mut CashRegister,
+        addr: address,
+        add_or_remove: bool,
+        ctx: &TxContext,
+    ) {
+        assert!(register.register_owner == tx_context::sender(ctx), EInvalidOwner);
+        if (add_or_remove) {
+            assert!(vec_set::contains(&register.authorized_individuals, &addr), ENotAuthorized);
+            vec_set::remove(&mut register.authorized_individuals, &addr);
+        } else {
+            vec_set::insert(&mut register.authorized_individuals, addr);
+        } 
+    }
+
+    //--------------------------------------------------------------------------------
+    // Changes from here down only -- the rest is the same as in the previous example.
+    //--------------------------------------------------------------------------------
+
+    /// Process a payment that has been made, removing it from the register and
+    /// returning the coin that can then be combined or sent elsewhere by the authorized individual.
+    /// Payments can ony be processed by either an account in the / `authorized_individuals` set or by the owner of the cash register.
+    public fun process_payment(register: &mut CashRegister, payment_ticket: Receiving<IdentifiedPayment>, ctx: &TxContext): Coin<SUI> {
+        let sender = tx_context::sender(ctx);
+        assert!(vec_set::contains(&register.authorized_individuals, &sender) || sender == register.register_owner, ENotAuthorized);
+        let payment: IdentifiedPayment = transfer::public_receive(&mut register.id, payment_ticket);
+        let (_, coin) = identified_payment::unpack(payment);
+        coin
+    }
+
+    /// Process a tip -- only the person who was tipped can process it despite it being sent to the shared object.
+    public fun process_tip(register: &mut CashRegister, earmarked_ticket: Receiving<EarmarkedPayment>, ctx: &TxContext): Coin<SUI> {
+        let payment: IdentifiedPayment = identified_payment::receive(&mut register.id, earmarked_ticket, ctx);
+        let (_, coin) = identified_payment::unpack(payment);
+        coin
+    }
+
+    // NB: The `pay` function from the previous example is now gone! They can
+    // now just use `identified_payment::make_payment` as the shared
+    // `CashRegister` object does not need to be a part of the transaction.
+}

--- a/examples/move/transfer-to-object/shared-with-tto/sources/shared_cash_register.move
+++ b/examples/move/transfer-to-object/shared-with-tto/sources/shared_cash_register.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module shared_with_tto::shared_cash_register {
     use common::identified_payment::{Self, IdentifiedPayment, EarmarkedPayment};
     use sui::sui::SUI;


### PR DESCRIPTION
## Description 

Adds a long-form example where transfer to object can be useful. It's a long running example on how to create a "cash register" on chain. It does this in a number of ways and compares them:
* Using an address and having all payments sent to that address;
* Using a shared object without transfer-to-object;
* Using a shared object along with transfer-to-object.
* Adds a bonus on how to use custom receiving rules to add tips.


