### PR TITLE
[refactor] wire Mysticeti in MysticetiManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,15 +5454,6 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
-dependencies = [
- "memmap2 0.7.1",
- "serde",
-]
-
-[[package]]
-name = "minibytes"
-version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
 dependencies = [
  "memmap2 0.7.1",
@@ -6424,40 +6415,6 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
-dependencies = [
- "async-trait",
- "axum",
- "bincode",
- "blake2",
- "crc32fast",
- "digest 0.10.6",
- "ed25519-consensus",
- "eyre",
- "futures",
- "gettid",
- "hex",
- "hyper",
- "libc",
- "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
- "parking_lot 0.12.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_yaml 0.9.21",
- "tabled",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "zeroize",
-]
-
-[[package]]
-name = "mysticeti-core"
-version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
 dependencies = [
  "async-trait",
@@ -6474,7 +6431,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "minibytes",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10362,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "mysticeti-core",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14336,7 +14293,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
+ "minibytes",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14390,7 +14347,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
+ "mysticeti-core",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,11 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
+=======
+source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
+>>>>>>> 103c2e1b4d ([chore] update mysticeti ref)
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -5463,7 +5467,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947#f87e013750a643815e699c7ea83cb3f97e7a3947"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6424,7 +6428,11 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
+=======
+source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
+>>>>>>> 103c2e1b4d ([chore] update mysticeti ref)
 dependencies = [
  "async-trait",
  "axum",
@@ -6440,7 +6448,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -6458,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947#f87e013750a643815e699c7ea83cb3f97e7a3947"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
 dependencies = [
  "async-trait",
  "axum",
@@ -6474,7 +6482,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10413,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14336,7 +14344,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14390,7 +14398,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,11 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
-=======
-source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
->>>>>>> 103c2e1b4d ([chore] update mysticeti ref)
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -5467,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6428,11 +6424,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb#18b27ff27c160f7f3f9705bee1d7c501e46e6beb"
-=======
-source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
->>>>>>> 103c2e1b4d ([chore] update mysticeti ref)
 dependencies = [
  "async-trait",
  "axum",
@@ -6448,7 +6440,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -6466,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
 dependencies = [
  "async-trait",
  "axum",
@@ -6482,7 +6474,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -14344,7 +14336,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14398,7 +14390,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=18b27ff27c160f7f3f9705bee1d7c501e46e6beb)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880#2d773a98198a33768a173a6f420de48a7e0a1880"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947#f87e013750a643815e699c7ea83cb3f97e7a3947"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880#2d773a98198a33768a173a6f420de48a7e0a1880"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947#f87e013750a643815e699c7ea83cb3f97e7a3947"
 dependencies = [
  "async-trait",
  "axum",
@@ -6474,7 +6474,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10405,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=f87e013750a643815e699c7ea83cb3f97e7a3947)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa#95cbf4c215af6af09cf26e6631171e1cab4146aa"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880#2d773a98198a33768a173a6f420de48a7e0a1880"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa#95cbf4c215af6af09cf26e6631171e1cab4146aa"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880#2d773a98198a33768a173a6f420de48a7e0a1880"
 dependencies = [
  "async-trait",
  "axum",
@@ -6474,7 +6474,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10405,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=2d773a98198a33768a173a6f420de48a7e0a1880)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,6 +5461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minibytes"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa#95cbf4c215af6af09cf26e6631171e1cab4146aa"
+dependencies = [
+ "memmap2 0.7.1",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6431,7 +6440,41 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_yaml 0.9.21",
+ "tabled",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "zeroize",
+]
+
+[[package]]
+name = "mysticeti-core"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa#95cbf4c215af6af09cf26e6631171e1cab4146aa"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bincode",
+ "blake2",
+ "crc32fast",
+ "digest 0.10.6",
+ "ed25519-consensus",
+ "eyre",
+ "futures",
+ "gettid",
+ "hex",
+ "hyper",
+ "libc",
+ "memmap2 0.7.1",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10362,7 +10405,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=95cbf4c215af6af09cf26e6631171e1cab4146aa)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14293,7 +14336,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14347,7 +14390,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "18b27ff27c160f7f3f9705bee1d7c501e46e6beb" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -3,20 +3,29 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_handler::ConsensusHandlerInitializer;
 use crate::consensus_manager::mysticeti_manager::MysticetiManager;
-use crate::consensus_manager::narwhal_manager::{
-    NarwhalConfiguration, NarwhalManager, NarwhalManagerMetrics,
-};
+use crate::consensus_manager::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use crate::consensus_validator::SuiTxValidator;
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
+use narwhal_config::Epoch;
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use sui_config::{ConsensusConfig, NodeConfig};
+use sui_protocol_config::ProtocolVersion;
+use tokio::sync::{Mutex, MutexGuard};
 
 pub mod mysticeti_manager;
 pub mod narwhal_manager;
+
+#[derive(PartialEq)]
+pub(crate) enum Running {
+    True(Epoch, ProtocolVersion),
+    False,
+}
 
 /// An enum to easily differentiate between the chosen consensus engine
 #[enum_dispatch]
@@ -38,6 +47,8 @@ pub trait ConsensusManagerTrait {
 
     async fn shutdown(&self);
 
+    async fn is_running(&self) -> bool;
+
     fn get_storage_base_path(&self) -> PathBuf;
 }
 
@@ -57,8 +68,146 @@ impl ConsensusManager {
             registry_service: registry_service.clone(),
         };
 
-        let metrics = NarwhalManagerMetrics::new(&registry_service.default_registry());
+        let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
 
         Self::Narwhal(NarwhalManager::new(narwhal_config, metrics))
+    }
+}
+
+pub struct ConsensusManagerMetrics {
+    start_latency: IntGauge,
+    shutdown_latency: IntGauge,
+    start_primary_retries: IntGauge,
+    start_worker_retries: IntGauge,
+}
+
+impl ConsensusManagerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            start_latency: register_int_gauge_with_registry!(
+                "consensus_manager_start_latency",
+                "The latency of starting up consensus nodes",
+                registry,
+            )
+            .unwrap(),
+            shutdown_latency: register_int_gauge_with_registry!(
+                "consensus_manager_shutdown_latency",
+                "The latency of shutting down consensus nodes",
+                registry,
+            )
+            .unwrap(),
+            start_primary_retries: register_int_gauge_with_registry!(
+                "narwhal_manager_start_primary_retries",
+                "The number of retries took to start narwhal primary node",
+                registry
+            )
+            .unwrap(),
+            start_worker_retries: register_int_gauge_with_registry!(
+                "narwhal_manager_start_worker_retries",
+                "The number of retries took to start narwhal worker node",
+                registry
+            )
+            .unwrap(),
+        }
+    }
+}
+
+pub(crate) struct RunningLockGuard<'a> {
+    state_guard: MutexGuard<'a, Running>,
+    metrics: &'a ConsensusManagerMetrics,
+    completed: bool,
+    epoch: Option<Epoch>,
+    protocol_version: Option<ProtocolVersion>,
+    start: Instant,
+}
+
+impl<'a> RunningLockGuard<'a> {
+    pub(crate) async fn acquire_start(
+        metrics: &'a ConsensusManagerMetrics,
+        running_mutex: &'a Mutex<Running>,
+        epoch: Epoch,
+        version: ProtocolVersion,
+    ) -> Option<RunningLockGuard<'a>> {
+        let running = running_mutex.lock().await;
+        if let Running::True(epoch, version) = *running {
+            tracing::warn!(
+                "Consensus is already Running for epoch {epoch:?} & protocol version {version:?} - shutdown first before starting",
+            );
+            return None;
+        }
+
+        tracing::info!("Starting up consensus for epoch {epoch:?} & protocol version {version:?}");
+
+        Some(RunningLockGuard {
+            state_guard: running,
+            metrics,
+            completed: false,
+            start: Instant::now(),
+            epoch: Some(epoch),
+            protocol_version: Some(version),
+        })
+    }
+
+    pub(crate) async fn acquire_shutdown(
+        metrics: &'a ConsensusManagerMetrics,
+        running_mutex: &'a Mutex<Running>,
+    ) -> Option<RunningLockGuard<'a>> {
+        let running = running_mutex.lock().await;
+        if let Running::True(epoch, version) = *running {
+            tracing::info!(
+                "Shutting down consensus for epoch {epoch:?} & protocol version {version:?}"
+            );
+        } else {
+            tracing::warn!("Consensus shutdown was called but Narwhal node is not running");
+            return None;
+        }
+
+        Some(RunningLockGuard {
+            state_guard: running,
+            metrics,
+            completed: false,
+            start: Instant::now(),
+            epoch: None,
+            protocol_version: None,
+        })
+    }
+
+    // has to be called when the process of start/shutdown has been finished in order to mark correctly timings.
+    fn completed(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for RunningLockGuard<'_> {
+    fn drop(&mut self) {
+        if self.completed {
+            match *self.state_guard {
+                // consensus was running and now will have to be marked as shutdown
+                Running::True(epoch, version) => {
+                    tracing::info!("Consensus shutdown for epoch {epoch:?} & protocol version {version:?} is complete - took {} seconds", self.start.elapsed().as_secs_f64());
+
+                    self.metrics
+                        .shutdown_latency
+                        .set(self.start.elapsed().as_secs_f64() as i64);
+
+                    *self.state_guard = Running::False;
+                }
+                // consensus was not running and now will be marked as started
+                Running::False => {
+                    tracing::info!(
+                    "Starting up consensus for epoch {} & protocol version {:?} is complete - took {} seconds",
+                    self.epoch.unwrap(),
+                    self.protocol_version.unwrap(),
+                    self.start.elapsed().as_secs_f64());
+
+                    self.metrics
+                        .start_latency
+                        .set(self.start.elapsed().as_secs_f64() as i64);
+
+                    *self.state_guard =
+                        Running::True(self.epoch.unwrap(), self.protocol_version.unwrap());
+                }
+            }
+        }
     }
 }

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -3,17 +3,23 @@
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_handler::ConsensusHandlerInitializer;
-use crate::consensus_manager::ConsensusManagerTrait;
+use crate::consensus_manager::{
+    ConsensusManagerMetrics, ConsensusManagerTrait, Running, RunningLockGuard,
+};
 use crate::consensus_validator::SuiTxValidator;
 use async_trait::async_trait;
 use narwhal_config::Epoch;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_config::NodeConfig;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
+use tokio::sync::Mutex;
 
 #[allow(unused)]
 pub struct MysticetiManager {
     storage_base_path: PathBuf,
+    running: Mutex<Running>,
+    metrics: ConsensusManagerMetrics,
 }
 
 impl MysticetiManager {
@@ -35,10 +41,42 @@ impl ConsensusManagerTrait for MysticetiManager {
         consensus_handler_initializer: ConsensusHandlerInitializer,
         tx_validator: SuiTxValidator,
     ) {
-        todo!()
+        let system_state = epoch_store.epoch_start_state();
+        let committee = system_state.get_narwhal_committee();
+        let protocol_config = epoch_store.protocol_config();
+
+        let Some(mut guard) = RunningLockGuard::acquire_start(
+            &self.metrics,
+            &self.running,
+            committee.epoch(),
+            protocol_config.version,
+        )
+        .await
+        else {
+            return;
+        };
+
+        /*
+        TODO: put validator bootstrap logic here
+        */
+        guard.completed();
     }
 
     async fn shutdown(&self) {
+        let Some(mut guard) =
+            RunningLockGuard::acquire_shutdown(&self.metrics, &self.running).await
+        else {
+            return;
+        };
+
+        /*
+        TODO: put validator shutdown logic here
+        */
+
+        guard.completed();
+    }
+
+    async fn is_running(&self) -> bool {
         todo!()
     }
 

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -83,7 +83,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         let epoch = epoch_store.epoch();
         let protocol_config = epoch_store.protocol_config();
 
-        let Some(mut guard) = RunningLockGuard::acquire_start(
+        let Some(_guard) = RunningLockGuard::acquire_start(
             &self.metrics,
             &self.running,
             epoch,
@@ -129,8 +129,6 @@ impl ConsensusManagerTrait for MysticetiManager {
                     self.validator
                         .swap(Some(Arc::new((validator, registry_id))));
 
-                    guard.completed();
-
                     break;
                 }
                 Err(err) => {
@@ -153,8 +151,7 @@ impl ConsensusManagerTrait for MysticetiManager {
     }
 
     async fn shutdown(&self) {
-        let Some(mut guard) =
-            RunningLockGuard::acquire_shutdown(&self.metrics, &self.running).await
+        let Some(_guard) = RunningLockGuard::acquire_shutdown(&self.metrics, &self.running).await
         else {
             return;
         };
@@ -170,9 +167,6 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         // unregister the registry id
         self.registry_service.remove(registry_id);
-
-        // mark shutdown as completed
-        guard.completed();
     }
 
     async fn is_running(&self) -> bool {

--- a/crates/sui-core/src/consensus_manager/narwhal_manager.rs
+++ b/crates/sui-core/src/consensus_manager/narwhal_manager.rs
@@ -104,7 +104,7 @@ impl ConsensusManagerTrait for NarwhalManager {
         let committee = system_state.get_narwhal_committee();
         let protocol_config = epoch_store.protocol_config();
 
-        let Some(mut guard) = RunningLockGuard::acquire_start(
+        let Some(_guard) = RunningLockGuard::acquire_start(
             &self.metrics,
             &self.running,
             epoch,
@@ -203,8 +203,6 @@ impl ConsensusManagerTrait for NarwhalManager {
             }
         }
 
-        guard.completed();
-
         self.metrics
             .start_primary_retries
             .set(primary_retries as i64);
@@ -213,16 +211,13 @@ impl ConsensusManagerTrait for NarwhalManager {
 
     // Shuts down whole Narwhal (primary & worker(s)) and waits until nodes have shutdown.
     async fn shutdown(&self) {
-        let Some(mut guard) =
-            RunningLockGuard::acquire_shutdown(&self.metrics, &self.running).await
+        let Some(_guard) = RunningLockGuard::acquire_shutdown(&self.metrics, &self.running).await
         else {
             return;
         };
 
         self.primary_node.shutdown().await;
         self.worker_nodes.shutdown().await;
-
-        guard.completed();
     }
 
     async fn is_running(&self) -> bool {

--- a/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -24,58 +24,60 @@ async fn test_mysticeti_manager() {
         .committee_size(1.try_into().unwrap())
         .build();
 
-    let config = &configs.validator_configs()[0];
+    for _i in 0..3 {
+        let config = &configs.validator_configs()[0];
 
-    let consensus_config = config.consensus_config().unwrap();
-    let registry_service = RegistryService::new(Registry::new());
-    let secret = Arc::pin(config.protocol_key_pair().copy());
-    let genesis = config.genesis().unwrap();
+        let consensus_config = config.consensus_config().unwrap();
+        let registry_service = RegistryService::new(Registry::new());
+        let secret = Arc::pin(config.protocol_key_pair().copy());
+        let genesis = config.genesis().unwrap();
 
-    let state = TestAuthorityBuilder::new()
-        .with_genesis_and_keypair(genesis, &secret)
-        .build()
-        .await;
+        let state = TestAuthorityBuilder::new()
+            .with_genesis_and_keypair(genesis, &secret)
+            .build()
+            .await;
 
-    let metrics = ConsensusManagerMetrics::new(&Registry::new());
-    let epoch_store = state.epoch_store_for_testing();
+        let metrics = ConsensusManagerMetrics::new(&Registry::new());
+        let epoch_store = state.epoch_store_for_testing();
 
-    let manager = MysticetiManager::new(
-        config.protocol_key_pair().copy(),
-        config.network_key_pair().copy(),
-        consensus_config.db_path().to_path_buf(),
-        metrics,
-        registry_service,
-    );
+        let manager = MysticetiManager::new(
+            config.protocol_key_pair().copy(),
+            config.network_key_pair().copy(),
+            consensus_config.db_path().to_path_buf(),
+            metrics,
+            registry_service,
+        );
 
-    let consensus_handler_initializer = ConsensusHandlerInitializer::new_for_testing(
-        state.clone(),
-        checkpoint_service_for_testing(state.clone()),
-    );
+        let consensus_handler_initializer = ConsensusHandlerInitializer::new_for_testing(
+            state.clone(),
+            checkpoint_service_for_testing(state.clone()),
+        );
 
-    // WHEN start mysticeti
-    manager
-        .start(
-            config,
-            epoch_store.clone(),
-            consensus_handler_initializer,
-            SuiTxValidator::new(
+        // WHEN start mysticeti
+        manager
+            .start(
+                config,
                 epoch_store.clone(),
-                Arc::new(CheckpointServiceNoop {}),
-                state.transaction_manager().clone(),
-                SuiTxValidatorMetrics::new(&Registry::new()),
-            ),
-        )
-        .await;
+                consensus_handler_initializer,
+                SuiTxValidator::new(
+                    epoch_store.clone(),
+                    Arc::new(CheckpointServiceNoop {}),
+                    state.transaction_manager().clone(),
+                    SuiTxValidatorMetrics::new(&Registry::new()),
+                ),
+            )
+            .await;
 
-    // THEN
-    assert!(manager.is_running().await);
+        // THEN
+        assert!(manager.is_running().await);
 
-    // Now try to shut it down
-    sleep(Duration::from_secs(1)).await;
+        // Now try to shut it down
+        sleep(Duration::from_secs(1)).await;
 
-    // WHEN
-    manager.shutdown().await;
+        // WHEN
+        manager.shutdown().await;
 
-    // THEN
-    assert!(!manager.is_running().await);
+        // THEN
+        assert!(!manager.is_running().await);
+    }
 }

--- a/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::checkpoints::CheckpointServiceNoop;
+use crate::consensus_handler::ConsensusHandlerInitializer;
+use crate::consensus_manager::mysticeti_manager::MysticetiManager;
+use crate::consensus_manager::narwhal_manager::narwhal_manager_tests::checkpoint_service_for_testing;
+use crate::consensus_manager::ConsensusManagerMetrics;
+use crate::consensus_manager::ConsensusManagerTrait;
+use crate::consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics};
+use fastcrypto::traits::KeyPair;
+use mysten_metrics::RegistryService;
+use prometheus::Registry;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use tokio::time::sleep;
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_mysticeti_manager() {
+    // GIVEN
+    let configs = ConfigBuilder::new_with_temp_dir()
+        .committee_size(1.try_into().unwrap())
+        .build();
+
+    let config = &configs.validator_configs()[0];
+
+    let consensus_config = config.consensus_config().unwrap();
+    let registry_service = RegistryService::new(Registry::new());
+    let secret = Arc::pin(config.protocol_key_pair().copy());
+    let genesis = config.genesis().unwrap();
+
+    let state = TestAuthorityBuilder::new()
+        .with_genesis_and_keypair(genesis, &secret)
+        .build()
+        .await;
+
+    let metrics = ConsensusManagerMetrics::new(&Registry::new());
+    let epoch_store = state.epoch_store_for_testing();
+
+    let manager = MysticetiManager::new(
+        config.protocol_key_pair().copy(),
+        config.network_key_pair().copy(),
+        consensus_config.db_path().to_path_buf(),
+        metrics,
+        registry_service,
+    );
+
+    let consensus_handler_initializer = ConsensusHandlerInitializer::new_for_testing(
+        state.clone(),
+        checkpoint_service_for_testing(state.clone()),
+    );
+
+    // WHEN start mysticeti
+    manager
+        .start(
+            config,
+            epoch_store.clone(),
+            consensus_handler_initializer,
+            SuiTxValidator::new(
+                epoch_store.clone(),
+                Arc::new(CheckpointServiceNoop {}),
+                state.transaction_manager().clone(),
+                SuiTxValidatorMetrics::new(&Registry::new()),
+            ),
+        )
+        .await;
+
+    // THEN
+    assert!(manager.is_running().await);
+
+    // Now try to shut it down
+    sleep(Duration::from_secs(1)).await;
+
+    // WHEN
+    manager.shutdown().await;
+
+    // THEN
+    assert!(!manager.is_running().await);
+}

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -67,7 +67,7 @@ async fn send_transactions(
     assert!(succeeded_once);
 }
 
-fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<CheckpointService> {
+pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<CheckpointService> {
     let (output, _result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);
     let accumulator = StateAccumulator::new(state.database.clone());
     let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -14,8 +14,7 @@ use fastcrypto::bls12381;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
 use narwhal_config::{Epoch, WorkerCache};
-use narwhal_executor::ExecutionState;
-use narwhal_types::{BatchAPI, ConsensusOutput, TransactionProto, TransactionsClient};
+use narwhal_types::{TransactionProto, TransactionsClient};
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,31 +26,6 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemS
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::{interval, sleep};
-
-#[derive(Clone)]
-struct NoOpExecutionState {
-    epoch: Epoch,
-}
-
-#[async_trait::async_trait]
-impl ExecutionState for NoOpExecutionState {
-    async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
-        for batches in consensus_output.batches {
-            for batch in batches {
-                for transaction in batch.transactions().iter() {
-                    assert_eq!(
-                        transaction.clone(),
-                        Bytes::from(self.epoch.to_be_bytes().to_vec())
-                    );
-                }
-            }
-        }
-    }
-
-    async fn last_executed_sub_dag_index(&self) -> u64 {
-        0
-    }
-}
 
 async fn send_transactions(
     name: &bls12381::min_sig::BLS12381PublicKey,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "18b27ff27c160f7f3f9705bee1d7c501e46e6beb", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "18b27ff27c160f7f3f9705bee1d7c501e46e6beb", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "18b27ff27c160f7f3f9705bee1d7c501e46e6beb", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "18b27ff27c160f7f3f9705bee1d7c501e46e6beb", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Description 

This PR is:
* abstracting via a guard the acquisition of locking, metric reporting & logging when start/shutdown the consensus engines to be used by the managers
* implementing the start/shutdown methods for the MysticetiManager to start/shutdown the mysticeti validator. Necessary type conversations take place. Some assumptions have been made for now for the integration reasons (some TODOs have been left)
* a simple test has been added for the MysticetiManager - will add more cases on follow up PRs

**Note:** a few types on Mysticeti had to be opened up to allow initialising and pass them to the mysticeti validator. PR here https://github.com/MystenLabs/mysticeti/pull/36

Next steps
- [ ] Wire in to Mysticeti Validator the `ConsensusHandler`
- [ ] Wire in to Mysticeti Validator the TxValidator
- [ ] Introduce property to flip between Narwhal & Mysticeti  and allow initialising Mysticeti as consensus engine
- [ ] Adapt MysticetiManager to wire in or return the component to communicate with the Mysticeti validator and submit transactions

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
