### PR TITLE
SDK - Adds `pure.id(..)`

### DIFF
--- a/.changeset/weak-penguins-hunt.md
+++ b/.changeset/weak-penguins-hunt.md
@@ -1,0 +1,6 @@
+---
+'@mysten/sui.js': patch
+'@mysten/kiosk': patch
+---
+
+Adds `txb.pure.id()` to pass ID pure values more intuitively

--- a/docs/content/guides/developer/app-examples/coin-flip.mdx
+++ b/docs/content/guides/developer/app-examples/coin-flip.mdx
@@ -1019,7 +1019,7 @@ export function HouseFinishGame() {
           txb.moveCall({
             target: `${PACKAGE_ID}::single_player_satoshi::finish_game`,
             arguments: [
-              txb.pure.address(game_id),
+              txb.pure.id(game_id),
               txb.pure(bcs.vector(bcs.U8).serialize(houseSignedInput)),
               txb.object(houseDataId),
             ],

--- a/docs/content/standards/kiosk.mdx
+++ b/docs/content/standards/kiosk.mdx
@@ -193,7 +193,7 @@ To take an item from a kiosk you must be the kiosk owner. As the owner, call the
 ```rust
 let tx = new TransactionBlock();
 
-let itemId = tx.pure.address('<ITEM_ID>');
+let itemId = tx.pure.id('<ITEM_ID>');
 let kioskArg = tx.object('<ID>');
 let kioskOwnerCapArg = tx.object('<ID>');
 
@@ -270,7 +270,7 @@ let tx = new TransactionBlock();
 
 let kioskArg = tx.object('<ID>');
 let capArg = tx.object('<ID>');
-let itemId = tx.pure.address('<ID>');
+let itemId = tx.pure.id('<ID>');
 let itemType = 'ITEM_TYPE';
 let priceArg = tx.pure.u64('<price>'); // in MIST (1 SUI = 10^9 MIST)
 
@@ -307,7 +307,7 @@ When you delist an item, Sui emits a `kiosk::ItemDelisted` event that contains t
 let tx = new TransactionBlock();
 let kioskArg = tx.object('<ID>');
 let capArg = tx.object('<ID>');
-let itemId = tx.pure.address('<ID>');
+let itemId = tx.pure.id('<ID>');
 let itemType = 'ITEM_TYPE';
 
 tx.moveCall({
@@ -390,7 +390,7 @@ You can use the PTB-friendly kiosk::borrow_val function. It allows you to take a
 let tx = new TransactionBlock();
 
 let itemType = 'ITEM_TYPE';
-let itemId = tx.pure.address('<ITEM_ID>');
+let itemId = tx.pure.id('<ITEM_ID>');
 let kioskArg = tx.object('<ID>');
 let capArg = tx.object('<ID>');
 

--- a/sdk/kiosk/src/tx/kiosk.ts
+++ b/sdk/kiosk/src/tx/kiosk.ts
@@ -100,7 +100,7 @@ export function take(
 	const [item] = tx.moveCall({
 		target: `${KIOSK_MODULE}::take`,
 		typeArguments: [itemType],
-		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.address(itemId)],
+		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.id(itemId)],
 	});
 
 	return item;
@@ -121,12 +121,7 @@ export function list(
 	tx.moveCall({
 		target: `${KIOSK_MODULE}::list`,
 		typeArguments: [itemType],
-		arguments: [
-			objArg(tx, kiosk),
-			objArg(tx, kioskCap),
-			tx.pure.address(itemId),
-			tx.pure.u64(price),
-		],
+		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.id(itemId), tx.pure.u64(price)],
 	});
 }
 
@@ -144,7 +139,7 @@ export function delist(
 	tx.moveCall({
 		target: `${KIOSK_MODULE}::delist`,
 		typeArguments: [itemType],
-		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.address(itemId)],
+		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.id(itemId)],
 	});
 }
 
@@ -181,7 +176,7 @@ export function purchase(
 	const [item, transferRequest] = tx.moveCall({
 		target: `${KIOSK_MODULE}::purchase`,
 		typeArguments: [itemType],
-		arguments: [objArg(tx, kiosk), tx.pure.address(itemId), objArg(tx, payment)],
+		arguments: [objArg(tx, kiosk), tx.pure.id(itemId), objArg(tx, payment)],
 	});
 
 	return [item, transferRequest];
@@ -223,7 +218,7 @@ export function borrowValue(
 	const [item, promise] = tx.moveCall({
 		target: `${KIOSK_MODULE}::borrow_val`,
 		typeArguments: [itemType],
-		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.address(itemId)],
+		arguments: [objArg(tx, kiosk), objArg(tx, kioskCap), tx.pure.id(itemId)],
 	});
 
 	return [item, promise];

--- a/sdk/typescript/src/builder/pure.ts
+++ b/sdk/typescript/src/builder/pure.ts
@@ -48,6 +48,7 @@ export function createPure(
 	pure.bool = (value: boolean) => makePure(bcs.Bool.serialize(value));
 	pure.string = (value: string) => makePure(bcs.String.serialize(value));
 	pure.address = (value: string) => makePure(bcs.Address.serialize(value));
+	pure.id = pure.address;
 
 	return pure;
 }


### PR DESCRIPTION
## Description 

Introduces `txb.pure.id()` for more intuitive ID argument in PTB calls.

## Test Plan 

Applied it on Kiosk SDK & tests run successfully.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
