### PR TITLE
indexer v2 analytical: optimize addr and move call processors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10763,6 +10763,7 @@ dependencies = [
  "mysten-metrics",
  "ntest",
  "prometheus",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -25,6 +25,7 @@ jsonrpsee.workspace = true
 prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+rayon.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
@@ -8,7 +8,7 @@ CREATE TABLE move_calls (
     move_module                 TEXT    NOT NULL,
     move_function               TEXT    NOT NULL
 );
-CREATE INDEX move_calls_epoch ON move_calls (epoch);
+CREATE INDEX idx_move_calls_epoch_etc ON move_calls (epoch, move_package, move_module, move_function);
 
 CREATE TABLE move_call_metrics (
     -- Diesel only supports table with a primary key.

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204335_tx_recipients/down.sql
@@ -1,3 +1,2 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS tx_recipients;
-DROP INDEX IF EXISTS tx_recipients_tx_sequence_number_index;

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204340_tx_senders/down.sql
@@ -1,3 +1,2 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS tx_senders;
-DROP INDEX IF EXISTS tx_senders_tx_sequence_number_index;

--- a/crates/sui-indexer/migrations_v2/2023-10-06-204400_tx_calls/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-06-204400_tx_calls/up.sql
@@ -11,3 +11,4 @@ CREATE TABLE tx_calls (
 
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number);
 CREATE INDEX tx_calls_func ON tx_calls (package, module, func, tx_sequence_number);
+CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number);

--- a/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
@@ -197,7 +197,7 @@ where
                 .into_iter()
                 .map(|chunk| {
                     let store = self.store.clone();
-                    tokio::task::spawn(async move { store.persist_addresses(chunk).await })
+                    tokio::task::spawn_blocking(move || store.persist_addresses(chunk))
                 })
                 .collect::<Vec<_>>();
 
@@ -211,7 +211,7 @@ where
                 .into_iter()
                 .map(|chunk| {
                     let store = self.store.clone();
-                    tokio::task::spawn(async move { store.persist_active_addresses(chunk).await })
+                    tokio::task::spawn_blocking(move || store.persist_active_addresses(chunk))
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 use tracing::{error, info};
@@ -94,7 +95,7 @@ where
             let stored_recipients = stored_recipients_res?;
             // replace cp seq with its timestamp
             let senders_to_commit: Vec<AddressInfoToCommit> = stored_senders
-                .into_iter()
+                .into_par_iter()
                 .filter_map(|sender| {
                     if let Some(timestamp_ms) = tx_timestamp_map.get(&sender.tx_sequence_number) {
                         Some(AddressInfoToCommit {
@@ -112,7 +113,7 @@ where
                 })
                 .collect();
             let recipients_to_commit: Vec<AddressInfoToCommit> = stored_recipients
-                .into_iter()
+                .into_par_iter()
                 .filter_map(|recipient| {
                     if let Some(timestamp_ms) = tx_timestamp_map.get(&recipient.tx_sequence_number)
                     {
@@ -149,7 +150,7 @@ where
             let active_addr_count = active_addresses_to_commit.len();
             info!(
                 "Indexed {} addresses and {} active addresses for checkpoint: {}",
-                addr_count, active_addr_count, end_cp.sequence_number,
+                addr_count, active_addr_count, end_cp_seq,
             );
 
             let persist_addr = self.store.persist_addresses(addresses_to_commit);

--- a/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
@@ -136,7 +136,6 @@ where
                 .into_iter()
                 .chain(recipients_to_commit.into_iter())
                 .collect::<Vec<AddressInfoToCommit>>();
-
             // de-dup senders with earliest and latest timestamps
             let active_addresses_to_commit: Vec<StoredActiveAddress> =
                 dedup_addresses(senders_to_commit)

--- a/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// similar to AddressMetricsProcessor in address_metrics_processor.rs
-
+use rayon::prelude::*;
 use std::collections::HashMap;
 use tracing::info;
 
@@ -51,6 +50,10 @@ where
                     last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE + 1,
                 )
                 .await?;
+            info!(
+                "Downloaded checkpoints for move call metrics on checkpoint {}",
+                last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE
+            );
             let end_cp = cps
                 .last()
                 .ok_or(IndexerError::PostgresReadError(
@@ -58,9 +61,13 @@ where
                 ))?
                 .clone();
             let cp_epoch_map = cps
-                .iter()
+                .par_iter()
                 .map(|cp| (cp.sequence_number, cp.epoch))
                 .collect::<HashMap<_, _>>();
+            info!(
+                "Constructed cp to epoch maps for move call metrics on checkpoint {}",
+                last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE
+            );
             let tx_checkpoints = self
                 .store
                 .get_tx_checkpoints_in_checkpoint_range(
@@ -68,8 +75,12 @@ where
                     end_cp.sequence_number + 1,
                 )
                 .await?;
+            info!(
+                "Downloaded transactions for checkpoint: {}",
+                end_cp.sequence_number
+            );
             let tx_cp_map = tx_checkpoints
-                .iter()
+                .par_iter()
                 .map(|tx| (tx.tx_sequence_number, tx.checkpoint_sequence_number))
                 .collect::<HashMap<_, _>>();
             let start_tx_seq = tx_checkpoints
@@ -84,13 +95,17 @@ where
                     "Cannot read last tx from PG for move call metrics".to_string(),
                 ))?
                 .tx_sequence_number;
+            info!(
+                "Constructed tx to cp maps for move call metrics on checkpoint {}",
+                end_cp.sequence_number
+            );
 
             let stored_move_calls = self
                 .store
                 .get_move_calls_in_tx_range(start_tx_seq, end_tx_seq + 1)
                 .await?;
             let move_calls_to_commit = stored_move_calls
-                .into_iter()
+                .into_par_iter()
                 .filter_map(|call| {
                     let cp = tx_cp_map.get(&call.tx_sequence_number)?;
                     let epoch = cp_epoch_map.get(cp)?;
@@ -112,18 +127,20 @@ where
                 move_call_count, end_cp_seq
             );
 
-            self.store.persist_move_calls(move_calls_to_commit).await?;
-            info!(
-                "Persisted {} move_calls for checkpoint: {}",
-                move_call_count, end_cp_seq
-            );
-
-            let move_call_metrics = self.store.calculate_move_call_metrics(end_cp).await?;
+            let persist_move_call_handle = self.store.persist_move_calls(move_calls_to_commit);
+            let calculate_move_call_metrics_handle = self.store.calculate_move_call_metrics(end_cp);
+            let (persist_move_call_res, calculate_move_call_metrics_res) =
+                tokio::join!(persist_move_call_handle, calculate_move_call_metrics_handle);
+            persist_move_call_res?;
+            let move_call_metrics = calculate_move_call_metrics_res?;
             self.store
                 .persist_move_call_metrics(move_call_metrics)
                 .await?;
             last_end_cp_seq = end_cp_seq;
-            info!("Persisted move_call_metrics for checkpoint: {}", end_cp_seq);
+            info!(
+                "Persisted {} move_calls and move_call_metrics for checkpoint: {}",
+                move_call_count, end_cp_seq
+            );
         }
     }
 }

--- a/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
@@ -105,10 +105,18 @@ where
                     })
                 })
                 .collect::<Vec<StoredMoveCall>>();
-
             let end_cp_seq = end_cp.sequence_number;
+            let move_call_count = move_calls_to_commit.len();
+            info!(
+                "Indexed {} move_calls for checkpoint: {}",
+                move_call_count, end_cp_seq
+            );
+
             self.store.persist_move_calls(move_calls_to_commit).await?;
-            info!("Persisted move_calls for checkpoint: {}", end_cp_seq);
+            info!(
+                "Persisted {} move_calls for checkpoint: {}",
+                move_call_count, end_cp_seq
+            );
 
             let move_call_metrics = self.store.calculate_move_call_metrics(end_cp).await?;
             self.store

--- a/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
+++ b/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
@@ -16,7 +16,7 @@ pub struct ProcessorOrchestratorV2<S> {
 
 impl<S> ProcessorOrchestratorV2<S>
 where
-    S: IndexerAnalyticalStore + Send + Sync + 'static + Clone,
+    S: IndexerAnalyticalStore + Clone + Send + Sync + 'static,
 {
     pub fn new(store: S) -> Self {
         Self { store }

--- a/crates/sui-indexer/src/store/indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/indexer_analytical_store.rs
@@ -53,7 +53,7 @@ pub trait IndexerAnalyticalStore {
 
     // for address metrics
     async fn get_latest_address_metrics(&self) -> IndexerResult<StoredAddressMetrics>;
-    async fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()>;
+    fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()>;
     async fn get_senders_in_tx_range(
         &self,
         start_tx_seq: i64,
@@ -64,7 +64,7 @@ pub trait IndexerAnalyticalStore {
         start_tx_seq: i64,
         end_tx_seq: i64,
     ) -> IndexerResult<Vec<StoredTxRecipients>>;
-    async fn persist_active_addresses(
+    fn persist_active_addresses(
         &self,
         active_addresses: Vec<StoredActiveAddress>,
     ) -> IndexerResult<()>;
@@ -84,7 +84,7 @@ pub trait IndexerAnalyticalStore {
         start_tx_seq: i64,
         end_tx_seq: i64,
     ) -> IndexerResult<Vec<StoredTxCalls>>;
-    async fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()>;
+    fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()>;
     async fn calculate_move_call_metrics(
         &self,
         checkpoint: StoredCheckpoint,

--- a/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
@@ -244,7 +244,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         Ok(recipients)
     }
 
-    async fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()> {
+    fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -266,7 +266,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         Ok(())
     }
 
-    async fn persist_active_addresses(
+    fn persist_active_addresses(
         &self,
         active_addresses: Vec<StoredActiveAddress>,
     ) -> IndexerResult<()> {
@@ -371,7 +371,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         Ok(move_calls)
     }
 
-    async fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()> {
+    fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {

--- a/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;
+use tap::tap::TapFallible;
+use tracing::error;
 
 use async_trait::async_trait;
 use core::result::Result::Ok;
@@ -396,21 +398,41 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         let move_call_query_7d = build_move_call_metric_query(epoch, 7);
         let move_call_query_30d = build_move_call_metric_query(epoch, 30);
 
-        let move_call_metrics_3d = read_only_blocking!(&self.blocking_cp, |conn| {
-            diesel::sql_query(move_call_query_3d).get_results::<QueriedMoveMetrics>(conn)
-        })?;
-        let move_call_metrics_7d = read_only_blocking!(&self.blocking_cp, |conn| {
-            diesel::sql_query(move_call_query_7d).get_results::<QueriedMoveMetrics>(conn)
-        })?;
-        let move_call_metrics_30d = read_only_blocking!(&self.blocking_cp, |conn| {
-            diesel::sql_query(move_call_query_30d).get_results::<QueriedMoveMetrics>(conn)
-        })?;
-
-        let chained = move_call_metrics_3d
+        let mut calculate_tasks = vec![];
+        let blocking_cp_3d = self.blocking_cp.clone();
+        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+            read_only_blocking!(&blocking_cp_3d, |conn| {
+                diesel::sql_query(move_call_query_3d).get_results::<QueriedMoveMetrics>(conn)
+            })
+        }));
+        let blocking_cp_7d = self.blocking_cp.clone();
+        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+            read_only_blocking!(&blocking_cp_7d, |conn| {
+                diesel::sql_query(move_call_query_7d).get_results::<QueriedMoveMetrics>(conn)
+            })
+        }));
+        let blocking_cp_30d = self.blocking_cp.clone();
+        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+            read_only_blocking!(&blocking_cp_30d, |conn| {
+                diesel::sql_query(move_call_query_30d).get_results::<QueriedMoveMetrics>(conn)
+            })
+        }));
+        let chained = futures::future::join_all(calculate_tasks)
+            .await
             .into_iter()
-            .chain(move_call_metrics_7d)
-            .chain(move_call_metrics_30d)
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| {
+                error!("Error joining move call calculation tasks: {:?}", e);
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| {
+                error!("Error calculating move call metrics: {:?}", e);
+            })?
+            .into_iter()
+            .flatten()
             .collect::<Vec<_>>();
+
         let move_call_metrics: Vec<StoredMoveCallMetrics> = chained
             .into_iter()
             .filter_map(|queried_move_metrics| {


### PR DESCRIPTION
## Description 

various optimizations on the address metrics and move call metrics processor, after all the optimizations per estimation, the analytical processor should be able to backfill in ~3 days as well.

## Test Plan 

local run to verify the correctness, run on explorer testing DB to see the improvement of speed

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
