### PR TITLE
[Narwhal] set default rate limits on RPC handlers

### DIFF
--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -277,6 +277,28 @@ pub struct AnemoParameters {
 }
 
 impl AnemoParameters {
+    // By default, at most 10 certificates can be sent concurrently to a peer.
+    pub fn send_certificate_rate_limit(&self) -> u32 {
+        self.send_certificate_rate_limit
+            .unwrap_or(NonZeroU32::new(20).unwrap())
+            .get()
+    }
+
+    // By default, at most 100 batches can be broadcasted concurrently.
+    pub fn report_batch_rate_limit(&self) -> u32 {
+        self.report_batch_rate_limit
+            .unwrap_or(NonZeroU32::new(200).unwrap())
+            .get()
+    }
+
+    // As of 11/02/2023, when one worker is actively fetching, each peer receives
+    // 20~30 requests per second.
+    pub fn request_batches_rate_limit(&self) -> u32 {
+        self.request_batches_rate_limit
+            .unwrap_or(NonZeroU32::new(100).unwrap())
+            .get()
+    }
+
     pub fn excessive_message_size(&self) -> usize {
         const EXCESSIVE_MESSAGE_SIZE: usize = 8 << 20;
 


### PR DESCRIPTION
## Description 

Add default rate limits to RPC handlers, in case they are not set.

## Test Plan 

Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
