### PR TITLE
[indexer] add ability to use struct type filter for get_owned_objects

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
@@ -33,3 +33,4 @@ CREATE TABLE objects (
 CREATE INDEX objects_owner ON objects (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
 CREATE INDEX objects_coin ON objects (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
 CREATE INDEX objects_checkpoint_sequence_number ON objects (checkpoint_sequence_number);
+CREATE INDEX objects_type ON objects (object_type);

--- a/crates/sui-indexer/src/apis/governance_api_v2.rs
+++ b/crates/sui-indexer/src/apis/governance_api_v2.rs
@@ -11,7 +11,9 @@ use cached::{proc_macro::cached, SizedCache};
 use sui_json_rpc::{
     api::GovernanceReadApiServer, governance_api::ValidatorExchangeRates, SuiRpcModule,
 };
-use sui_json_rpc_types::{DelegatedStake, EpochInfo, StakeStatus, SuiCommittee, ValidatorApys};
+use sui_json_rpc_types::{
+    DelegatedStake, EpochInfo, StakeStatus, SuiCommittee, SuiObjectDataFilter, ValidatorApys,
+};
 use sui_open_rpc::Module;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SuiAddress},
@@ -74,7 +76,9 @@ impl GovernanceReadApiV2 {
             .inner
             .get_owned_objects_in_blocking_task(
                 owner,
-                Some(MoveObjectType::staked_sui().to_string()),
+                Some(SuiObjectDataFilter::StructType(
+                    MoveObjectType::staked_sui().into(),
+                )),
                 None,
                 // Allow querying for up to 1000 staked objects
                 1000,

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -45,17 +45,10 @@ impl IndexerApiV2 {
         limit: usize,
     ) -> RpcResult<ObjectsPage> {
         let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
-        if filter.is_some() {
-            // TODO: do we want to support this?
-            return Err(IndexerError::NotSupportedError(
-                "Indexer does not support querying owned objects with filters".into(),
-            )
-            .into());
-        }
         let options = options.unwrap_or_default();
         let objects = self
             .inner
-            .get_owned_objects_in_blocking_task(address, None, cursor, limit + 1)
+            .get_owned_objects_in_blocking_task(address, filter, cursor, limit + 1)
             .await?;
         let mut objects = self
             .inner

--- a/crates/sui-indexer/src/apis/transaction_builder_api_v2.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api_v2.rs
@@ -6,7 +6,7 @@ use crate::indexer_reader::IndexerReader;
 use async_trait::async_trait;
 use move_core_types::language_storage::StructTag;
 use sui_json_rpc::transaction_builder_api::TransactionBuilderApi;
-use sui_json_rpc_types::{SuiObjectDataOptions, SuiObjectResponse};
+use sui_json_rpc_types::{SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse};
 use sui_transaction_builder::DataReader;
 use sui_types::base_types::{ObjectID, ObjectInfo, SuiAddress};
 use sui_types::object::Object;
@@ -33,7 +33,7 @@ impl DataReader for TransactionBuilderApiV2 {
             .inner
             .get_owned_objects_in_blocking_task(
                 address,
-                Some(object_type.to_canonical_string()),
+                Some(SuiObjectDataFilter::StructType(object_type)),
                 None,
                 50, // Limit the number of objects returned to 50
             )


### PR DESCRIPTION
## Description 

This PR enables struct type and `MatchAny` struct type filters for get_owned_objects method.

## Test Plan 

Tested locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
