### PR TITLE
[move-compiler] disable rewrite optimizations

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-79:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12395600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 81-81:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-69:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9218800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 71-73:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 
 task 3 'view-object'. lines 75-75:
 Owner: Account Address ( A )
 Version: 2
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 0u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 4 'programmable'. lines 77-78:
 mutated: object(0,0), object(2,2), object(2,3), object(2,4)
@@ -25,28 +25,28 @@ gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 
 task 5 'view-object'. lines 80-80:
 Owner: Account Address ( A )
 Version: 3
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
 
 task 6 'programmable'. lines 82-83:
-mutated: object(0,0), object(2,4)
-deleted: object(2,0), object(2,2)
+mutated: object(0,0), object(2,2)
+deleted: object(2,0), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
 
 task 7 'view-object'. lines 85-88:
 Owner: Account Address ( A )
 Version: 4
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
 
 task 8 'programmable'. lines 90-91:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 9 'programmable'. lines 93-94:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 10 'programmable'. lines 96-100:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 11 'programmable'. lines 102-103:

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
@@ -72,38 +72,38 @@ module test::m {
 //> 0: test::m::new();
 //> TransferObjects([Result(0)], Input(0))
 
-//# view-object 2,4
+//# view-object 2,2
 
-//# programmable --sender A --inputs object(2,4) 1 2 3
+//# programmable --sender A --inputs object(2,2) 1 2 3
 //> test::m::set(Input(0), Input(1), Input(2), Input(3))
 
-//# view-object 2,4
+//# view-object 2,2
 
-//# programmable --sender A --inputs object(2,4)
+//# programmable --sender A --inputs object(2,2)
 //> test::m::remove(Input(0))
 
-//# view-object 2,4
+//# view-object 2,2
 
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,4)@2 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@3 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@4 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,4)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@2 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-121:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 123-125:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 160-161:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-134:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13353200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 136-138:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 173-174:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-144:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13862400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 146-148:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 183-184:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-61:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 10533600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10548800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 63-63:
 created: object(2,0), object(2,1), object(2,2), object(2,3)
@@ -14,99 +14,99 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 65-65:
-Owner: Object ID: ( fake(2,1) )
+Owner: Object ID: ( fake(2,2) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
 
 task 4 'view-object'. lines 67-67:
-Owner: Account Address ( fake(2,2) )
+Owner: Object ID: ( fake(2,0) )
 Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
 
 task 5 'view-object'. lines 69-69:
-Owner: Account Address ( A )
+Owner: Account Address ( fake(2,3) )
 Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
-task 6 'view-object'. lines 71-73:
-Owner: Object ID: ( fake(2,0) )
+task 6 'view-object'. lines 71-71:
+Owner: Account Address ( A )
 Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
 
-task 7 'run'. lines 75-75:
+task 7 'run'. lines 73-73:
 created: object(7,0)
-mutated: object(0,0), object(2,1), object(2,2)
+mutated: object(0,0), object(2,2), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 5996400,  storage_rebate: 3506184, non_refundable_storage_fee: 35416
 
-task 8 'view-object'. lines 77-79:
-Owner: Object ID: ( fake(2,1) )
+task 8 'view-object'. lines 75-77:
+Owner: Object ID: ( fake(2,2) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
 
-task 9 'view-object'. lines 80-80:
-Owner: Object ID: ( fake(7,0) )
-Version: 3
+task 9 'view-object'. lines 78-78:
+Owner: Object ID: ( fake(2,0) )
+Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
 
-task 10 'view-object'. lines 82-82:
-Owner: Account Address ( A )
+task 10 'view-object'. lines 80-80:
+Owner: Object ID: ( fake(7,0) )
 Version: 3
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
-task 11 'view-object'. lines 84-84:
-Owner: Object ID: ( fake(2,0) )
-Version: 2
+task 11 'view-object'. lines 82-82:
+Owner: Account Address ( A )
+Version: 3
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
 
-task 12 'programmable'. lines 86-87:
+task 12 'programmable'. lines 84-85:
 mutated: object(0,0), object(2,1), object(2,2), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 4818400,  storage_rebate: 4770216, non_refundable_storage_fee: 48184
 
-task 13 'view-object'. lines 89-91:
-Owner: Object ID: ( fake(2,1) )
+task 13 'view-object'. lines 87-89:
+Owner: Object ID: ( fake(2,2) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
 
-task 14 'view-object'. lines 92-92:
-Owner: Object ID: ( fake(7,0) )
-Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 2u64}
-
-task 15 'view-object'. lines 94-94:
-Owner: Account Address ( A )
-Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
-
-task 16 'view-object'. lines 96-96:
+task 14 'view-object'. lines 90-90:
 Owner: Object ID: ( fake(2,0) )
 Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 3u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 3u64}
 
-task 17 'programmable'. lines 98-101:
-mutated: object(0,0), object(2,2)
-deleted: object(2,0), object(2,3)
+task 15 'view-object'. lines 92-92:
+Owner: Object ID: ( fake(7,0) )
+Version: 4
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 2u64}
+
+task 16 'view-object'. lines 94-94:
+Owner: Account Address ( A )
+Version: 4
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 1u64}
+
+task 17 'programmable'. lines 96-99:
+mutated: object(0,0), object(2,3)
+deleted: object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 2264800,  storage_rebate: 5936436, non_refundable_storage_fee: 59964
 
-task 18 'programmable'. lines 103-104:
-mutated: object(_), object(2,2)
+task 18 'programmable'. lines 101-102:
+mutated: object(_), object(2,3)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
-task 19 'programmable'. lines 106-107:
-mutated: object(_), object(2,2)
+task 19 'programmable'. lines 104-105:
+mutated: object(_), object(2,3)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
-task 20 'programmable'. lines 109-112:
-mutated: object(_), object(2,2)
+task 20 'programmable'. lines 107-110:
+mutated: object(_), object(2,3)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
-task 21 'programmable'. lines 114-115:
+task 21 'programmable'. lines 112-113:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: tto, name: Identifier("M1") }, function: 4, instruction: 10, function_name: Some("check") }, 0) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: tto, name: Identifier("M1") }, function: 4, instruction: 10, function_name: Some("check") }, 0) in command 0
 
-task 22 'programmable'. lines 117-118:
+task 22 'programmable'. lines 115-116:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
-task 23 'programmable'. lines 120-121:
+task 23 'programmable'. lines 118-119:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: tto, name: Identifier("M1") }, function: 4, instruction: 10, function_name: Some("check") }, 0) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: tto, name: Identifier("M1") }, function: 4, instruction: 10, function_name: Some("check") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.move
@@ -70,9 +70,7 @@ module tto::M1 {
 
 //# view-object 2,3
 
-// Current ownership chain: 3 => 0 => 1 => 2 => A
-
-//# run tto::M1::receive --args object(2,2) receiving(2,1) --sender A
+//# run tto::M1::receive --args object(2,3) receiving(2,2) --sender A
 
 //# view-object 2,0
 
@@ -83,7 +81,7 @@ module tto::M1 {
 
 //# view-object 2,3
 
-//# programmable --sender A --inputs object(2,2) 1 2 3
+//# programmable --sender A --inputs object(2,3) 1 2 3
 //> tto::M1::set(Input(0), Input(1), Input(2), Input(3))
 
 //# view-object 2,0
@@ -95,27 +93,27 @@ module tto::M1 {
 
 //# view-object 2,3
 
-//# programmable --sender A --inputs object(2,2)
+//# programmable --sender A --inputs object(2,3)
 //> tto::M1::remove(Input(0))
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@3 0 0 vector[0] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@4 1 2 vector[3] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@5 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@5 1 2 vector[] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,2)@4 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@4 0 0 vector[0] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@5 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@5 1 2 vector[3] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@3 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,3)@3 1 2 vector[] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-69:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9218800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 71-73:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 
 task 3 'view-object'. lines 75-75:
 Owner: Account Address ( A )
 Version: 2
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 0u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 4 'programmable'. lines 77-78:
 mutated: object(0,0), object(2,2), object(2,3), object(2,4)
@@ -25,28 +25,28 @@ gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 
 task 5 'view-object'. lines 80-80:
 Owner: Account Address ( A )
 Version: 3
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
 
 task 6 'programmable'. lines 82-83:
-mutated: object(0,0), object(2,4)
-deleted: object(2,0), object(2,2)
+mutated: object(0,0), object(2,2)
+deleted: object(2,0), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
 
 task 7 'view-object'. lines 85-88:
 Owner: Account Address ( A )
 Version: 4
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
 
 task 8 'programmable'. lines 90-91:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 9 'programmable'. lines 93-94:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 10 'programmable'. lines 96-100:
-mutated: object(_), object(2,4)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 11 'programmable'. lines 102-103:

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
@@ -72,38 +72,38 @@ module test::m {
 //> 0: test::m::new();
 //> TransferObjects([Result(0)], Input(0))
 
-//# view-object 2,4
+//# view-object 2,2
 
-//# programmable --sender A --inputs object(2,4) 1 2 3
+//# programmable --sender A --inputs object(2,2) 1 2 3
 //> test::m::set(Input(0), Input(1), Input(2), Input(3))
 
-//# view-object 2,4
+//# view-object 2,2
 
-//# programmable --sender A --inputs object(2,4)
+//# programmable --sender A --inputs object(2,2)
 //> test::m::remove(Input(0))
 
-//# view-object 2,4
+//# view-object 2,2
 
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,4)@2 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@3 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@4 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,4)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,4)@2 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-121:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 123-125:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 160-161:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-134:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13353200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 136-138:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 173-174:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-144:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13862400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 146-148:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 183-184:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
@@ -3,7 +3,7 @@ processed 10 tasks
 task 1 'publish'. lines 8-57:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7311200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7326400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 58-60:
 events: 1
@@ -26,12 +26,12 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 6 'run'. lines 70-72:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1393000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1413000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 7 'run'. lines 73-75:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1814000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1840000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8 'run'. lines 76-78:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.exp
@@ -3,7 +3,7 @@ processed 6 tasks
 task 1 'publish'. lines 8-68:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7919200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7934400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 69-71:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
@@ -19,4 +19,4 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5 'run'. lines 78-78:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 33)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-82:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9933200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9963600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 83-85:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
@@ -15,9 +15,9 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 3 'run'. lines 86-88:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1863000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1888000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 89-89:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1863000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1888000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
@@ -3,7 +3,7 @@
 
 mod constant_fold;
 mod eliminate_locals;
-mod forwarding_jumps;
+// mod forwarding_jumps;
 mod inline_blocks;
 mod simplify_jumps;
 
@@ -22,7 +22,7 @@ pub type Optimization = fn(
 const OPTIMIZATIONS: &[Optimization] = &[
     eliminate_locals::optimize,
     constant_fold::optimize,
-    forwarding_jumps::optimize,
+    // forwarding_jumps::optimize,
     simplify_jumps::optimize,
     inline_blocks::optimize,
 ];

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -626,9 +626,6 @@ fn function_body(
             let (mut cfg, infinite_loop_starts, diags) =
                 MutForwardCFG::new(start, &mut blocks, binfo);
             context.env.add_diags(diags);
-            if DEBUG_PRINT {
-                println!("-- cfg built ------------------");
-            }
 
             let function_context = super::CFGContext {
                 module,
@@ -643,6 +640,13 @@ fn function_body(
             if !context.env.has_errors() {
                 cfgir::optimize(signature, &locals, &UniqueMap::new(), &mut cfg);
             }
+            if DEBUG_PRINT {
+                println!("-------------------------------");
+                blocks.print_verbose();
+            }
+            // if DEBUG_PRINT {
+            //     println!("-- cfg built ------------------");
+            // }
 
             let block_info = block_info
                 .into_iter()

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -33,6 +33,7 @@ pub enum FeatureGate {
     DotCall,
     PositionalFields,
     LetMut,
+    Move2024Optimizations,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -188,6 +189,7 @@ impl FeatureGate {
             FeatureGate::DotCall => "Method syntax is",
             FeatureGate::PositionalFields => "Positional fields are",
             FeatureGate::LetMut => "'mut' variable modifiers are",
+            FeatureGate::Move2024Optimizations => "Move 2024 optimizations are are",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -85,7 +85,7 @@ pub fn display_var(s: Symbol) -> DisplayVar {
 // Context
 //**************************************************************************************************
 
-const DEBUG_PRINT: bool = true;
+const DEBUG_PRINT: bool = false;
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,


### PR DESCRIPTION
## Description 

This is an experiment to disable the optimizations I introduced during the CFG and HLIR  rewrites (#13497, https://github.com/MystenLabs/sui/pull/14641) until we have a better solution for handling on-chain divergence, in hopes of landing those rewrites sooner.
## Test Plan 

Revised tests match main, and all work.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
