### PR TITLE
[move-compiler] Making the use of Sui linters opt-out

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -28,9 +28,9 @@ pub struct Build {
     /// and events.
     #[clap(long, global = true)]
     pub generate_struct_layouts: bool,
-    /// If `true`, enable linters
+    /// If `true`, disable linters
     #[clap(long, global = true)]
-    pub lint: bool,
+    pub no_lint: bool,
 }
 
 impl Build {
@@ -47,7 +47,7 @@ impl Build {
             self.with_unpublished_dependencies,
             self.dump_bytecode_as_base64,
             self.generate_struct_layouts,
-            self.lint,
+            !self.no_lint,
         )
     }
 

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -31,9 +31,9 @@ const MAX_UNIT_TEST_INSTRUCTIONS: u64 = 1_000_000;
 pub struct Test {
     #[clap(flatten)]
     pub test: test::Test,
-    /// If `true`, enable linters
+    /// If `true`, disable linters
     #[clap(long, global = true)]
-    pub lint: bool,
+    pub no_lint: bool,
 }
 
 impl Test {
@@ -58,7 +58,7 @@ impl Test {
             with_unpublished_deps,
             dump_bytecode_as_base64,
             generate_struct_layouts,
-            self.lint,
+            !self.no_lint,
         )?;
         run_move_unit_tests(
             rerooted_path,

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -179,7 +179,7 @@ async fn run_publish(
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -210,7 +210,7 @@ async fn run_upgrade(
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -405,9 +405,9 @@ pub enum SuiClientCommands {
         #[clap(long, required = false)]
         serialize_signed_transaction: bool,
 
-        /// If `true`, enable linters
+        /// If `true`, disable linters
         #[clap(long, global = true)]
-        lint: bool,
+        no_lint: bool,
     },
 
     /// Split a coin object into multiple coins.
@@ -568,9 +568,9 @@ pub enum SuiClientCommands {
         #[clap(long, required = false)]
         serialize_signed_transaction: bool,
 
-        /// If `true`, enable linters
+        /// If `true`, disable linters
         #[clap(long, global = true)]
-        lint: bool,
+        no_lint: bool,
     },
 
     /// Run the bytecode verifier on the package
@@ -723,7 +723,7 @@ impl SuiClientCommands {
                 with_unpublished_dependencies,
                 serialize_unsigned_transaction,
                 serialize_signed_transaction,
-                lint,
+                no_lint,
             } => {
                 let sender = context.try_get_object_owner(&gas).await?;
                 let sender = sender.unwrap_or(context.active_address()?);
@@ -736,7 +736,7 @@ impl SuiClientCommands {
                         package_path,
                         with_unpublished_dependencies,
                         skip_dependency_verification,
-                        lint,
+                        !no_lint,
                     )
                     .await?;
 
@@ -812,7 +812,7 @@ impl SuiClientCommands {
                 with_unpublished_dependencies,
                 serialize_unsigned_transaction,
                 serialize_signed_transaction,
-                lint,
+                no_lint,
             } => {
                 if build_config.test_mode {
                     return Err(SuiError::ModulePublishFailure {
@@ -839,7 +839,7 @@ impl SuiClientCommands {
                     package_path,
                     with_unpublished_dependencies,
                     skip_dependency_verification,
-                    lint,
+                    !no_lint,
                 )
                 .await?;
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -384,7 +384,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -606,7 +606,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -674,7 +674,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -801,7 +801,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -928,7 +928,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -1057,7 +1057,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
         with_unpublished_dependencies,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -1126,7 +1126,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
         with_unpublished_dependencies,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await;
@@ -1173,7 +1173,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
         with_unpublished_dependencies,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await;
@@ -1229,7 +1229,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
         with_unpublished_dependencies,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await;
@@ -1272,7 +1272,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await;
@@ -1316,7 +1316,7 @@ async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await;
@@ -1372,7 +1372,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -1445,7 +1445,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         with_unpublished_dependencies: false,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
-        lint: false,
+        no_lint: true,
     }
     .execute(context)
     .await?;
@@ -2476,7 +2476,7 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
 #[tokio::test]
 async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
     let mut cmd = assert_cmd::Command::cargo_bin("sui").unwrap();
-    let args = vec!["move", "test", "--lint", "--path", "tests/data/linter"];
+    let args = vec!["move", "test", "--path", "tests/data/linter"];
     let output = cmd
         .args(&args)
         .output()


### PR DESCRIPTION
## Description 

Linter support was initially introduced as opt-in but it's time to make it opt-out - it's been over two weeks after this has been announced (blog post, Discord, Sui forum). Switching to opt-out has been vetted by @dariorussi, @sblackshear, and @tedks.

## Test Plan 

Verified that opt-out flag works in the CLI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Recently introduced Sui linters are now enabled by default. Developers may see additional warnings without changing any of their code or compiler build/test/publish/upgrade options.