### PR TITLE
implement BlockHandler and SubmitToConsensus for mysticeti

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf#0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=1b34f9ac7ec5e0881b4231398fc4af1c56331ac5#1b34f9ac7ec5e0881b4231398fc4af1c56331ac5"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6432,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf#0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=1b34f9ac7ec5e0881b4231398fc4af1c56331ac5#1b34f9ac7ec5e0881b4231398fc4af1c56331ac5"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod epoch;
 mod execution_driver;
 pub mod metrics;
 pub mod module_cache_metrics;
+pub mod mysticeti_adapter;
 pub(crate) mod post_consensus_tx_reorder;
 pub mod quorum_driver;
 pub mod safe_client;

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use mysticeti_core::block_handler::BlockHandler;
+use mysticeti_core::minibytes;
+use mysticeti_core::types::{BaseStatement, StatementBlock};
+
+use sui_types::error::{SuiError, SuiResult};
+use tap::prelude::*;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::consensus_adapter::SubmitToConsensus;
+use mysticeti_core::data::Data;
+use sui_types::messages_consensus::ConsensusTransaction;
+use tracing::warn;
+
+#[derive(Clone)]
+pub struct SubmitToMysticeti {
+    sender: mpsc::Sender<(ConsensusTransaction, oneshot::Sender<()>)>,
+}
+
+impl SubmitToMysticeti {
+    pub fn new(
+        sender: mpsc::Sender<(ConsensusTransaction, oneshot::Sender<()>)>,
+    ) -> SubmitToMysticeti {
+        SubmitToMysticeti { sender }
+    }
+}
+
+#[async_trait::async_trait]
+impl SubmitToConsensus for SubmitToMysticeti {
+    async fn submit_to_consensus(
+        &self,
+        transaction: &ConsensusTransaction,
+        _epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send((transaction.clone(), sender))
+            .await
+            .tap_err(|e| warn!("Submit transaction failed with {:?}", e))
+            .map_err(|e| SuiError::FailedToSubmitToConsensus(format!("{:?}", e)))?;
+        // Give a little bit backpressure if BlockHandler is not able to keep up.
+        receiver
+            .await
+            .tap_err(|e| warn!("Block Handler failed to ack: {:?}", e))
+            .map_err(|e| SuiError::ConsensusConnectionBroken(format!("{:?}", e)))
+    }
+}
+
+/// A simple BlockHandler that adds received transactions to consensus.
+pub struct SimpleBlockHandler {
+    receiver:
+        mysten_metrics::metered_channel::Receiver<(ConsensusTransaction, oneshot::Sender<()>)>,
+}
+
+const MAX_PROPOSED_PER_BLOCK: usize = 10000;
+const CHANNEL_SIZE: usize = 10240;
+
+impl SimpleBlockHandler {
+    pub fn new() -> (
+        Self,
+        mysten_metrics::metered_channel::Sender<(ConsensusTransaction, oneshot::Sender<()>)>,
+    ) {
+        let (sender, receiver) = mysten_metrics::metered_channel::channel(
+            CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["simple_block_handler"]),
+        );
+
+        let this = Self { receiver };
+        (this, sender)
+    }
+}
+
+impl BlockHandler for SimpleBlockHandler {
+    fn handle_blocks(
+        &mut self,
+        _blocks: &[Data<StatementBlock>],
+        require_response: bool,
+    ) -> Vec<BaseStatement> {
+        if require_response {
+            return vec![];
+        }
+
+        // Returns transactions to be sequenced so that they will be
+        // proposed to DAG shortly.
+        let mut response = vec![];
+
+        while let Ok((tx, notify_when_done)) = self.receiver.try_recv() {
+            response.push(BaseStatement::Share(
+                mysticeti_core::types::Transaction::new(
+                    bcs::to_bytes(&tx.kind).expect("Serialization should not fail."),
+                ),
+            ));
+            // We don't mind if the receiver is dropped.
+            let _ = notify_when_done.send(());
+
+            if response.len() >= MAX_PROPOSED_PER_BLOCK {
+                break;
+            }
+        }
+        response
+    }
+
+    fn handle_proposal(&mut self, _block: &Data<StatementBlock>) {}
+
+    // No crash recovery at the moment.
+    fn state(&self) -> minibytes::Bytes {
+        minibytes::Bytes::new()
+    }
+
+    // No crash recovery at the moment.
+    fn recover_state(&mut self, _state: &minibytes::Bytes) {}
+
+    fn cleanup(&self) {}
+}

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -519,8 +519,6 @@ pub enum SuiError {
     FailedToSubmitToConsensus(String),
     #[error("Failed to connect with consensus node: {0}")]
     ConsensusConnectionBroken(String),
-    #[error("Failed to hear back from consensus: {0}")]
-    FailedToHearBackFromConsensus(String),
     #[error("Failed to execute handle_consensus_transaction on Sui: {0}")]
     HandleConsensusTransactionFailure(String),
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -536,10 +536,6 @@ impl TestCluster {
             let replies: Vec<_> = futures::future::join_all(futures)
                 .await
                 .into_iter()
-                // Remove all `FailedToHearBackFromConsensus` replies. Note that the original Sui error type
-                // `SuiError::FailedToHearBackFromConsensus(..)` is lost when the message is sent through the
-                // network (it is replaced by `RpcError`). As a result, the following filter doesn't work:
-                // `.filter(|result| !matches!(result, Err(SuiError::FailedToHearBackFromConsensus(..))))`.
                 .filter(|result| match result {
                     Err(e) => !e.to_string().contains("deadline has elapsed"),
                     _ => true,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -453,7 +453,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1222,7 +1222,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1276,7 +1276,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Description 

Add a simple BlockHandler and `SubmitToConsensus` impl


## Test Plan 

not trivial to test without being wired up by Consensus Manager 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
