### PR TITLE
[GraphQL/RFC] Changes to `asX` fields in Object type hierarchy

### DIFF
--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -378,7 +378,7 @@ enum Feature {
   SYSTEM_STATE
 }
 
-interface ObjectOwner {
+interface IOwner {
   location: SuiAddress!
 
   objectConnection(
@@ -388,7 +388,7 @@ interface ObjectOwner {
     before: String,
     # Enhancement (post-MVP) relies on compound filters.
     filter: ObjectFilter,
-  ): ObjectConnection
+  ): MoveObjectConnection
 
   balance(type: String!): Balance
   balanceConnection(
@@ -414,6 +414,16 @@ interface ObjectOwner {
     before: String,
   ): StakeConnection
 
+  dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+  dynamicFieldConnection(
+    first: Int,
+    after: String,
+    last: Int,
+    before: String,
+    # Enhancement (post-MVP) to filter dynamic fields by type.
+    filter: DynamicFieldFilter,
+  ): DynamicFieldConnection
+
   defaultNameServiceName: String
   nameServiceNameConnection(
     first: Int,
@@ -423,14 +433,43 @@ interface ObjectOwner {
   ): NameServiceNameConnection
 }
 
+interface IObject {
+  version: Int!
+  digest: String!
+  owner: Owner
+  kind: ObjectKind
+
+  previousTransactionBlock: TransactionBlock
+  storageRebate: BigInt
+
+  display: [DisplayEntry!]
+
+  # Transaction Blocks that sent objects to this object
+  receivedTransactionBlockConnection(
+    first: Int,
+    after: String,
+    last: Int,
+    before: String,
+    # Enhancement (post-MVP) relies on compound filters.
+    filter: TransactionBlockFilter,
+  ): TransactionBlockConnection
+
+  bcs: Base64
+}
+
+interface IMoveObject {
+  contents: MoveValue
+  hasPublicTransfer: Boolean
+}
+
 # Returned by Object.owner, where we can't disambiguate between
 # Address and Object.
-type Owner implements ObjectOwner {
+type Owner implements IOwner {
   asAddress: Address
   asObject: Object
 }
 
-type Address implements ObjectOwner {
+type Address implements IOwner {
   transactionBlockConnection(
     first: Int,
     after: String,
@@ -456,41 +495,9 @@ enum ObjectKind {
   IMMUTABLE
 }
 
-type Object implements ObjectOwner {
-  version: Int!
-  digest: String!
-  owner: Owner
-  kind: ObjectKind
-
-  previousTransactionBlock: TransactionBlock
-  storageRebate: BigInt
-
-  display: [DisplayEntry!]
-
+type Object implements IOwner & IObject {
   asMoveObject: MoveObject
   asMovePackage: MovePackage
-
-  # Transaction Blocks that sent objects to this object
-  receivedTransactionBlockConnection(
-    first: Int,
-    after: String,
-    last: Int,
-    before: String,
-    # Enhancement (post-MVP) relies on compound filters.
-    filter: TransactionBlockFilter,
-  ): TransactionBlockConnection
-
-  dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
-  dynamicFieldConnection(
-    first: Int,
-    after: String,
-    last: Int,
-    before: String,
-    # Enhancement (post-MVP) to filter dynamic fields by type.
-    filter: DynamicFieldFilter,
-  ): DynamicFieldConnection
-
-  bcs: Base64
 }
 
 type DisplayEntry {
@@ -908,12 +915,11 @@ type Balance {
   totalBalance: BigInt
 }
 
-type Coin {
+type Coin implements IOwner & IObject {
   balance: BigInt
-  asMoveObject: MoveObject!
 }
 
-type StakedSui {
+type StakedSui implements IOwner & IObject {
   status: StakeStatus
   requestEpoch: Epoch
   activeEpoch: Epoch
@@ -921,8 +927,6 @@ type StakedSui {
 
   # Only available if status is `ACTIVE`.
   estimatedReward: BigInt
-
-  asMoveObject: MoveObject!
 }
 
 enum StakeStatus {
@@ -931,15 +935,13 @@ enum StakeStatus {
   UNSTAKED
 }
 
-type CoinMetadata {
+type CoinMetadata implements IOwner & IObject {
   decimals: Int
   name: String
   symbol: String
   description: String
   iconURL: String
   supply: BigInt
-
-  asMoveObject: MoveObject!
 }
 
 input DynamicFieldName {
@@ -954,16 +956,13 @@ type DynamicField {
 
 union DynamicFieldValue = MoveObject | MoveValue
 
-type MoveObject {
-  contents: MoveValue
-  hasPublicTransfer: Boolean
-
+type MoveObject implements IOwner & IObject & IMoveObject {
   asCoin: Coin
   asStakedSui: StakedSui
-  asObject: Object!
+  asCoinMetadata: CoinMetadata
 }
 
-type MovePackage {
+type MovePackage implements IOwner & IObject {
   module(name: String!): MoveModule
   moduleConnection(
     first: Int,
@@ -973,15 +972,21 @@ type MovePackage {
   ): MoveModuleConnection
 
   linkage: [Linkage!]
-  bcs: Base64
+  origins: [TypeOrigin!]
 
-  asObject: Object!
+  moduleBcs: Base64
 }
 
 type Linkage {
   originalId: SuiAddress!
   upgradedId: SuiAddress!
   version: Int!
+}
+
+type TypeOrigin {
+  module: String!
+  name: String!
+  package: SuiAddress!
 }
 
 type MoveModuleId {
@@ -1195,6 +1200,17 @@ type ObjectConnection {
 type ObjectEdge {
   cursor: String
   node: Object!
+}
+
+# MoveObject
+type MoveObjectConnection {
+  edges: [MoveObjectEdge!]!
+  pageInfo: PageInfo!
+}
+
+type MoveObjectEdge {
+  cursor: String
+  node: MoveObject!
 }
 
 # Event


### PR DESCRIPTION
## Description

Based on feedback that having to explicitly upcast (e.g. from `Coin`, to `MoveObject`, to `Object`) was annoying, this PR changes the schema so that accessing parent type fields is done via interfaces (each parent type comes with an accompanying interface).

`asX` fields are still used for downcasting, however, e.g. `MoveObject` has `asCoin`, `asStake`, etc.

This change required adopting a naming scheme for these accompanying interfaces, e.g. `Foo` is accompanied by `IFoo` (and this was retroactively applied to `ObjectOwner` which became `IOwner`).

Also cleans up some inconsistencies in the draft schema relative to the current planned schema:

- Dynamic Field related APIs have moved to the `IOwner` interface, to make it possible to query dynamic fields on wrapped objects (which can't otherwise be queried for using the `object` queries currently).
- Added `origins` as a field to `MovePackage` to expose type origin information (similar to linkage information).
- Added `asCoinMetadata` to `MoveObject` because it's another type that implements `IMoveObject`.
- Renamed `MovePackage.bcs` to `MovePackage.moduleBcs` as otherwise this field would clash with `IObject.bcs` (which holds a different value.)
- Have `IOwner.objectConnection` return a `MoveObjectConnection` instead of an `ObjectConnection`.  It's not possible for a package to be owned by another address, so the `Object`s that come from this field will all be `MoveObject`s, so we might as well avoid the indirection.

## Test Plan

:eyes: