### PR TITLE
[Examples] Adds obo - object bound object

### DIFF
--- a/examples/move/object_bound/Move.toml
+++ b/examples/move/object_bound/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ObjectBound"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+[addresses]
+obo = "0x0"

--- a/examples/move/object_bound/sources/object_bound.move
+++ b/examples/move/object_bound/sources/object_bound.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module obo::object_bound {
+    use std::option::{Self, Option};
+    use sui::tx_context::TxContext;
+    use sui::object::{Self, ID, UID};
+    use sui::transfer::{Self, Receiving};
+
+    /// Trying to return a different object than the one that was borrowed.
+    const EDontMessWithMe: u64 = 0;
+
+    /// An object bound to a specific object. Created with the intention of
+    /// being returned to the original owner.
+    struct ObjectBound<T: key + store> has key {
+        id: UID,
+        for: address,
+        inner: Option<T>,
+    }
+
+    /// A HotPotato ensuring that the object is returned and sent back to the
+    /// original owner.
+    struct Borrow<T: key + store> { object: ObjectBound<T>, inner_id: ID }
+
+    /// Create and send an ObjectBound.
+    public fun new<T: key + store>(inner: T, for: address, ctx: &mut TxContext) {
+        transfer::transfer(ObjectBound {
+            for,
+            id: object::new(ctx),
+            inner: option::some(inner),
+        }, for);
+    }
+
+    /// Receive and use an ObjectBound.
+    public fun borrow<T: key + store>(
+        parent: &mut UID, to_receive: Receiving<ObjectBound<T>>
+    ): (T, Borrow<T>) {
+        let object = transfer::receive(parent, to_receive);
+        let inner = option::extract(&mut object.inner);
+        let inner_id = object::id(&inner);
+
+        (inner, Borrow { object, inner_id })
+    }
+
+    /// Store an ObjectBound.
+    public fun store<T: key + store>(inner: T, borrow: Borrow<T>) {
+        assert!(object::id(&inner) == borrow.inner_id, EDontMessWithMe);
+        let Borrow { object, inner_id: _ } = borrow;
+        let for = object.for;
+        option::fill(&mut object.inner, inner);
+        transfer::transfer(object, for);
+    }
+}

--- a/examples/move/object_bound/sources/object_bound.move
+++ b/examples/move/object_bound/sources/object_bound.move
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Implements a soul-bound primitive for objects. Unlike a typical Soulbound
+/// concept used with accounts, the object bound can not be directly referenced
+/// or mutated by its object owner.
+///
+/// To bypass the limitation with object, the "Transfer To Object" feature is
+/// used to receive and then send the object back to its object-owner.
 module obo::object_bound {
     use std::option::{Self, Option};
     use sui::tx_context::TxContext;


### PR DESCRIPTION
## Description 

Implements an OBO - object-bound object for "transfer to object", similar to soulbound for accounts.

One funny detail (and the main reason for this PR) is what we called a Matryoshka-pattern where T is taken from ObjectBound, and then ObjectBound is wrapped into a Borrow. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
