### PR TITLE
[cli] Implement Display for BalanceChange type

### DIFF
--- a/crates/sui-json-rpc-types/src/balance_changes.rs
+++ b/crates/sui-json-rpc-types/src/balance_changes.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+use std::fmt::{Display, Formatter, Result};
 use sui_types::object::Owner;
 use sui_types::sui_serde::SuiTypeTag;
 
@@ -22,4 +23,17 @@ pub struct BalanceChange {
     #[schemars(with = "String")]
     #[serde_as(as = "DisplayFromStr")]
     pub amount: i128,
+}
+
+impl Display for BalanceChange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(
+            f,
+            "{}",
+            format!(
+                " ┌──\n │ Owner: {} \n │ CoinType: {} \n │ Amount: {}\n └──",
+                self.owner, self.coin_type, self.amount
+            )
+        )
+    }
 }

--- a/crates/sui-json-rpc-types/src/balance_changes.rs
+++ b/crates/sui-json-rpc-types/src/balance_changes.rs
@@ -29,11 +29,8 @@ impl Display for BalanceChange {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(
             f,
-            "{}",
-            format!(
-                " ┌──\n │ Owner: {} \n │ CoinType: {} \n │ Amount: {}\n └──",
-                self.owner, self.coin_type, self.amount
-            )
+            " ┌──\n │ Owner: {} \n │ CoinType: {} \n │ Amount: {}\n └──",
+            self.owner, self.coin_type, self.amount
         )
     }
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1799,7 +1799,9 @@ pub fn write_transaction_response(
 
     writeln!(writer, "{}", "----- Balance changes ----".bold())?;
     if let Some(e) = &response.balance_changes {
-        writeln!(writer, "{:#?}", json!(e))?;
+        for balance in e {
+            writeln!(writer, "{}", balance)?;
+        }
     }
     Ok(writer)
 }


### PR DESCRIPTION
## Description 

Implements the Display trait for the `BalanceChange` type. This is part of a larger effort (and multiple PRs) in implementing a nice format output for `SuiTransactionBlockResponse` in the CLI, following @laura-makdah's excellent formatting in `SuiTransactionBlockEffects`.

## Test Plan 

<img width="1055" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/d4911f8d-569a-4cf6-a1fe-7d26f531327b">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Implements the `Display` trait for the `BalanceChange` type as part of a larger effort in implementing a good-looking format output for `SuiTransactionBlockResponse` in the CLI.