### PR TITLE
Don't retry non-recoverable errors in benchmark

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -72,7 +72,7 @@ pub mod util;
 pub mod workloads;
 use futures::FutureExt;
 use sui_types::messages_grpc::{HandleCertificateResponse, TransactionStatus};
-use sui_types::quorum_driver_types::QuorumDriverResponse;
+use sui_types::quorum_driver_types::{QuorumDriverError, QuorumDriverResponse};
 
 #[derive(Debug)]
 /// A wrapper on execution results to accommodate different types of
@@ -374,12 +374,8 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
                         events,
                     ));
                 }
-                Err(NonRecoverableTransactionError { .. }) => {
-                    bail!(
-                        "Transaction {:?} failed with non-recoverable err: {:?}.",
-                        tx_digest,
-                        err,
-                    );
+                Err(QuorumDriverError::NonRecoverableTransactionError { errors }) => {
+                    bail!(QuorumDriverError::NonRecoverableTransactionError { errors });
                 }
                 Err(err) => {
                     let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -374,6 +374,13 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
                         events,
                     ));
                 }
+                Err(NonRecoverableTransactionError { .. }) => {
+                    bail!(
+                        "Transaction {:?} failed with non-recoverable err: {:?}.",
+                        tx_digest,
+                        err,
+                    );
+                }
                 Err(err) => {
                     let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));
                     error!(


### PR DESCRIPTION
This was causing simtest failures due to the following sequence of events:

- Client submits a tx, fails to gather an effects cert, but the tx is included in the final checkpoint
- after reconfiguration, the client retries. validators re-sign the effects, but client fails to accept the new effects cert because it does not yet know about the new committee
- validators prune tx
- client retries again
- client now gets ObjectVersionUnavailableForConsumption

The transaction can never succeed (from the client's POV) after this point, so it retries forever, generating enough errors to cause the test to fail.