### PR TITLE
[cli] implement Display for ObjectChange and update CLI's output

### DIFF
--- a/crates/sui-json-rpc-types/src/object_changes.rs
+++ b/crates/sui-json-rpc-types/src/object_changes.rs
@@ -5,6 +5,7 @@ use move_core_types::language_storage::StructTag;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::fmt::{Display, Formatter, Result};
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::object::Owner;
 use sui_types::sui_serde::SequenceNumber as AsSequenceNumber;
@@ -162,6 +163,92 @@ impl ObjectChange {
             }
             ObjectChange::Deleted { version, .. } | ObjectChange::Wrapped { version, .. } => {
                 *version = new_version
+            }
+        }
+    }
+}
+
+impl Display for ObjectChange {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            ObjectChange::Published {
+                package_id,
+                version,
+                digest,
+                modules,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ PackageID: {} \n │ Version: {} \n │ Digest: {}\n | Modules: {}\n └──",
+                    package_id, version, digest, modules.join(",").to_string()
+                )
+            }
+            ObjectChange::Transferred {
+                sender,
+                recipient,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Recipient: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
+                    object_id, sender, recipient, object_type, version, digest
+                )
+            }
+            ObjectChange::Mutated {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                previous_version: _,
+                digest,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
+                    object_id, sender, owner, object_type, version, digest
+                )
+            }
+            ObjectChange::Deleted {
+                sender,
+                object_type,
+                object_id,
+                version,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
+                    object_id, sender, object_type, version, 
+                )
+            }
+            ObjectChange::Wrapped {
+                sender,
+                object_type,
+                object_id,
+                version,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
+                    object_id, sender, object_type, version, 
+                )
+            }
+            ObjectChange::Created {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => {
+                writeln!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
+                    object_id, sender, owner, object_type, version, digest
+                )
             }
         }
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -35,7 +35,7 @@ use sui_json_rpc_types::{
     SuiParsedData, SuiRawData, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
-use sui_json_rpc_types::{SuiExecutionStatus, SuiObjectDataOptions};
+use sui_json_rpc_types::{ObjectChange, SuiExecutionStatus, SuiObjectDataOptions};
 use sui_keys::keystore::AccountKeystore;
 use sui_move_build::{
     build_from_resolution_graph, check_invalid_dependencies, check_unpublished_dependencies,
@@ -46,6 +46,7 @@ use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
 use sui_sdk::SuiClient;
 use sui_types::{
+    // balance::BALANCE_CREATE_REWARDS_FUNCTION_NAME,
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     crypto::SignatureScheme,
     digests::TransactionDigest,
@@ -1794,9 +1795,28 @@ pub fn write_transaction_response(
 
     writeln!(writer, "{}", "----- Object changes ----".bold())?;
     if let Some(e) = &response.object_changes {
-        for obj_change in e {
-            writeln!(writer, "{}", obj_change)?;
+        // Note that this will be refactored under Display for SuiTransactionBlockResponse
+        // as soon I implement all of the Display traits for all the types
+        let (mut created, mut deleted, mut mutated, mut published, mut transferred, mut wrapped) =
+            (vec![], vec![], vec![], vec![], vec![], vec![]);
+
+        for obj in e {
+            match obj {
+                ObjectChange::Created { .. } => created.push(obj),
+                ObjectChange::Deleted { .. } => deleted.push(obj),
+                ObjectChange::Mutated { .. } => mutated.push(obj),
+                ObjectChange::Published { .. } => published.push(obj),
+                ObjectChange::Transferred { .. } => transferred.push(obj),
+                ObjectChange::Wrapped { .. } => wrapped.push(obj),
+            };
         }
+
+        write_obj_changes(created, "Created", &mut writer)?;
+        write_obj_changes(deleted, "Deleted", &mut writer)?;
+        write_obj_changes(mutated, "Mutated", &mut writer)?;
+        write_obj_changes(published, "Published", &mut writer)?;
+        write_obj_changes(transferred, "Transferred", &mut writer)?;
+        write_obj_changes(wrapped, "Wrapped", &mut writer)?;
     }
 
     writeln!(writer, "{}", "----- Balance changes ----".bold())?;
@@ -1804,6 +1824,20 @@ pub fn write_transaction_response(
         writeln!(writer, "{:#?}", json!(e))?;
     }
     Ok(writer)
+}
+
+fn write_obj_changes<T: Display>(
+    values: Vec<T>,
+    output_string: &str,
+    writer: &mut String,
+) -> std::fmt::Result {
+    if !values.is_empty() {
+        writeln!(writer, "\n{} Objects: ", output_string)?;
+        for obj in values {
+            writeln!(writer, "{}", obj)?;
+        }
+    }
+    Ok(())
 }
 
 impl Debug for SuiClientCommandResult {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1794,7 +1794,9 @@ pub fn write_transaction_response(
 
     writeln!(writer, "{}", "----- Object changes ----".bold())?;
     if let Some(e) = &response.object_changes {
-        writeln!(writer, "{:#?}", json!(e))?;
+        for obj_change in e {
+            writeln!(writer, "{}", obj_change)?;
+        }
     }
 
     writeln!(writer, "{}", "----- Balance changes ----".bold())?;


### PR DESCRIPTION
## Description 

Implements the `Display` trait for `ObjectChange` type as part of a larger effort to have a good-looking output format for the `SuiTransactionBlockResponse` in the CLI. 

Note that the changes in the `write_transaction_response` are temporary until I get each the `Display` trait implemented for each type of `SuiTransactionBlockResponse`, after which this function will change. 

## Test Plan 

<img width="1055" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/8f40b60a-3642-4055-a259-7ce0bb32ba74">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Implements the `Display` trait for `ObjectChange` type as part of a larger effort to have a good-looking output format for the `SuiTransactionBlockResponse` in the CLI. 