### PR TITLE
Implement ConsensusOutputAPI for mysticeti

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,6 +5461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minibytes"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
+dependencies = [
+ "memmap2 0.7.1",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6448,7 +6457,41 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_yaml 0.9.21",
+ "tabled",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "zeroize",
+]
+
+[[package]]
+name = "mysticeti-core"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bincode",
+ "blake2",
+ "crc32fast",
+ "digest 0.10.6",
+ "ed25519-consensus",
+ "eyre",
+ "futures",
+ "gettid",
+ "hex",
+ "hyper",
+ "libc",
+ "memmap2 0.7.1",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10379,7 +10422,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14310,7 +14353,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14365,7 +14408,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,15 +5454,6 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=1b34f9ac7ec5e0881b4231398fc4af1c56331ac5#1b34f9ac7ec5e0881b4231398fc4af1c56331ac5"
-dependencies = [
- "memmap2 0.7.1",
- "serde",
-]
-
-[[package]]
-name = "minibytes"
-version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
 dependencies = [
  "memmap2 0.7.1",
@@ -6441,40 +6432,6 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=1b34f9ac7ec5e0881b4231398fc4af1c56331ac5#1b34f9ac7ec5e0881b4231398fc4af1c56331ac5"
-dependencies = [
- "async-trait",
- "axum",
- "bincode",
- "blake2",
- "crc32fast",
- "digest 0.10.6",
- "ed25519-consensus",
- "eyre",
- "futures",
- "gettid",
- "hex",
- "hyper",
- "libc",
- "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
- "parking_lot 0.12.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_yaml 0.9.21",
- "tabled",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "zeroize",
-]
-
-[[package]]
-name = "mysticeti-core"
-version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
 dependencies = [
  "async-trait",
@@ -6491,7 +6448,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9)",
+ "minibytes",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10422,7 +10379,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9)",
+ "mysticeti-core",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14353,7 +14310,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "minibytes",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14408,7 +14365,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=0bc1ae8f6cc5b1eb22752fa37ba64bdaf358f7cf)",
+ "mysticeti-core",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6432,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9#52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=829665dccd53107d9445d4ad97c718e03e131780#829665dccd53107d9445d4ad97c718e03e131780"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "829665dccd53107d9445d4ad97c718e03e131780" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -3,17 +3,18 @@
 
 use crate::consensus_types::AuthorityIndex;
 use fastcrypto::hash::Hash;
+use mysticeti_core::types::BaseStatement;
 use narwhal_types::{BatchAPI, CertificateAPI, HeaderAPI};
+use std::fmt::Display;
 use sui_types::messages_consensus::ConsensusTransaction;
+use sui_types::transaction::CertifiedTransaction;
 
 /// A list of tuples of:
 /// (certificate origin authority index, all transactions corresponding to the certificate).
 /// For each transaction, returns the serialized transaction and the deserialized transaction.
-type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(Vec<u8>, ConsensusTransaction)>)>;
+type ConsensusOutputTransactions<'a> = Vec<(AuthorityIndex, Vec<(&'a [u8], ConsensusTransaction)>)>;
 
-const DIGEST_SIZE: usize = 32;
-
-pub(crate) trait ConsensusOutputAPI: Hash<DIGEST_SIZE> {
+pub(crate) trait ConsensusOutputAPI: Display {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
     fn leader_round(&self) -> u64;
     fn leader_author_index(&self) -> AuthorityIndex;
@@ -25,7 +26,7 @@ pub(crate) trait ConsensusOutputAPI: Hash<DIGEST_SIZE> {
     fn commit_sub_dag_index(&self) -> u64;
 
     /// Returns all transactions in the commit.
-    fn into_transactions(self) -> ConsensusOutputTransactions;
+    fn transactions(&self) -> ConsensusOutputTransactions<'_>;
 }
 
 impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
@@ -59,19 +60,19 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
         self.sub_dag.sub_dag_index
     }
 
-    fn into_transactions(self) -> ConsensusOutputTransactions {
+    fn transactions(&self) -> ConsensusOutputTransactions {
         self.sub_dag
             .certificates
             .iter()
-            .zip(self.batches)
+            .zip(&self.batches)
             .map(|(cert, batches)| {
                 assert_eq!(cert.header().payload().len(), batches.len());
-                let transactions: Vec<_> = batches.into_iter().flat_map(move |batch| {
+                let transactions: Vec<(&[u8], ConsensusTransaction)> = batches.iter().flat_map(|batch| {
                     let digest = batch.digest();
                     assert!(cert.header().payload().contains_key(&digest));
-                    batch.into_transactions().into_iter().map(move |serialized_transaction| {
+                    batch.transactions().iter().map(move |serialized_transaction| {
                         let transaction = match bcs::from_bytes::<ConsensusTransaction>(
-                            &serialized_transaction,
+                            serialized_transaction,
                         ) {
                             Ok(transaction) => transaction,
                             Err(err) => {
@@ -82,10 +83,66 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
                                 );
                             }
                         };
-                        (serialized_transaction, transaction)
+                        (serialized_transaction.as_ref(), transaction)
                     })
                 }).collect();
                 (cert.origin().0, transactions)
             }).collect()
+    }
+}
+
+impl ConsensusOutputAPI for mysticeti_core::consensus::linearizer::CommittedSubDag {
+    fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
+        // TODO: Implement this in Mysticeti.
+        None
+    }
+
+    fn leader_round(&self) -> u64 {
+        self.anchor.round
+    }
+
+    fn leader_author_index(&self) -> AuthorityIndex {
+        self.anchor.authority as AuthorityIndex
+    }
+
+    fn commit_timestamp_ms(&self) -> u64 {
+        // TODO: Enforce ordered timestamp in Mysticeti
+        0
+    }
+
+    fn commit_sub_dag_index(&self) -> u64 {
+        // TODO: Mysticeti doesn't have this concept right now
+        self.anchor.round
+    }
+
+    fn transactions(&self) -> ConsensusOutputTransactions {
+        self.blocks
+            .iter()
+            .map(|block| {
+                let round = block.round();
+                let author = block.author() as AuthorityIndex;
+                let transactions: Vec<_> = block
+                    .statements()
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(idx, stmt)| match stmt {
+                        BaseStatement::Share(tx) => {
+                            let cert = bcs::from_bytes::<CertifiedTransaction>(tx.data());
+                            match cert {
+                                Ok(cert) => Some((
+                                    tx.data(),
+                                    ConsensusTransaction::new_mysticeti_certificate(
+                                        round, idx, cert,
+                                    ),
+                                )),
+                                Err(_) => None,
+                            }
+                        }
+                        BaseStatement::Vote(..) | BaseStatement::VoteRange(_) => None,
+                    })
+                    .collect();
+                (author, transactions)
+            })
+            .collect()
     }
 }

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -3,7 +3,6 @@
 
 use crate::consensus_types::AuthorityIndex;
 use fastcrypto::hash::Hash;
-use mysticeti_core::types::BaseStatement;
 use narwhal_types::{BatchAPI, CertificateAPI, HeaderAPI};
 use std::fmt::Display;
 use sui_types::messages_consensus::ConsensusTransaction;
@@ -124,8 +123,7 @@ impl ConsensusOutputAPI for mysticeti_core::consensus::linearizer::CommittedSubD
                 let author = block.author() as AuthorityIndex;
                 let transactions: Vec<_> = block
                     .shared_transactions()
-                    .iter()
-                    .map(|(loc, tx)| {
+                    .flat_map(|(loc, tx)| {
                         let cert = bcs::from_bytes::<CertifiedTransaction>(tx.data());
                         match cert {
                             Ok(cert) => Some((

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -106,8 +106,7 @@ impl ConsensusOutputAPI for mysticeti_core::consensus::linearizer::CommittedSubD
 
     fn commit_timestamp_ms(&self) -> u64 {
         // TODO: Enforce ordered timestamp in Mysticeti.
-        // Also, could this ever overflow u64?
-        (self.blocks[0].meta_creation_time_ns() / 1000) as u64
+        self.timestamp_ms
     }
 
     fn commit_sub_dag_index(&self) -> u64 {

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -194,6 +194,23 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_mysticeti_certificate(
+        round: u64,
+        pos: usize,
+        certificate: CertifiedTransaction,
+    ) -> Self {
+        let mut hasher = DefaultHasher::new();
+        let tx_digest = certificate.digest();
+        tx_digest.hash(&mut hasher);
+        round.hash(&mut hasher);
+        pos.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::UserTransaction(Box::new(certificate)),
+        }
+    }
+
     pub fn new_jwk_fetched(authority: AuthorityName, id: JwkId, jwk: JWK) -> Self {
         let mut hasher = DefaultHasher::new();
         id.hash(&mut hasher);

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -196,14 +196,14 @@ impl ConsensusTransaction {
 
     pub fn new_mysticeti_certificate(
         round: u64,
-        pos: usize,
+        offset: u64,
         certificate: CertifiedTransaction,
     ) -> Self {
         let mut hasher = DefaultHasher::new();
         let tx_digest = certificate.digest();
         tx_digest.hash(&mut hasher);
         round.hash(&mut hasher);
-        pos.hash(&mut hasher);
+        offset.hash(&mut hasher);
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "829665dccd53107d9445d4ad97c718e03e131780", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -453,7 +453,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "829665dccd53107d9445d4ad97c718e03e131780", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1222,7 +1222,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "829665dccd53107d9445d4ad97c718e03e131780", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1276,7 +1276,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "829665dccd53107d9445d4ad97c718e03e131780", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -453,7 +453,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1222,7 +1222,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1276,7 +1276,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "1b34f9ac7ec5e0881b4231398fc4af1c56331ac5", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "52f8f3aedadb3fc49a1da2ad91bc40cdfef671e9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -36,6 +37,19 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for ConsensusOutput {
             hasher.update(b.digest());
         });
         ConsensusOutputDigest(hasher.finalize().into())
+    }
+}
+
+impl Display for ConsensusOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ConsensusOutput(round={:?}, sub_dag_index={:?}, timestamp={:?}, digest={:?})",
+            self.sub_dag.leader_round(),
+            self.sub_dag.sub_dag_index,
+            self.sub_dag.commit_timestamp(),
+            self.digest()
+        )
     }
 }
 


### PR DESCRIPTION
## Description 

Implement ConsensusOutputAPI for CommittedSubDag in Mysticeti.
Instead of displaying the digest of consensus output, we now rely on the Display impl of the consensus output.
Also changed into_transactions() to transactions(), instead, which returns reference to the serialized bytes to avoid clones.
Left a few TODOs in the impl

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
