### PR TITLE
[cli] Impl Display for SuiEvent and SuiTransactionBlockEvents

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -130,7 +130,7 @@ impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let parsed_json = &mut self.parsed_json.clone();
         bytes_array_to_base64(parsed_json);
-        let mut table = json_to_table(&parsed_json);
+        let mut table = json_to_table(parsed_json);
         let style = TableStyle::modern();
         table.collapse().with(style);
         let bcs_base58 = Base58::encode(&self.bcs);
@@ -154,9 +154,9 @@ impl Display for SuiEvent {
 // Transform in-place a JSON array of bytes into a Base64 string
 fn bytes_array_to_base64(v: &mut Value) {
     match v {
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => return,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => (),
         Value::Array(ref mut vals) => {
-            if vals.iter().all(|val| check_is_number(val)) {
+            if vals.iter().all(check_is_number) {
                 let new_vals = vals
                     .iter()
                     .map(|num| num.as_u64().unwrap() as u8)
@@ -164,8 +164,8 @@ fn bytes_array_to_base64(v: &mut Value) {
                 let new_val = serde_json::json!(Base64::from_bytes(&new_vals).encoded());
                 *v = new_val;
             } else {
-                for mut val in vals {
-                    bytes_array_to_base64(&mut val)
+                for val in vals {
+                    bytes_array_to_base64(val)
                 }
             }
         }

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -140,7 +140,7 @@ impl Display for SuiEvent {
         }
         writeln!(f, " │ ParsedJSON:")?;
         let table_string = table.to_string();
-        let table_rows = table_string.split_inclusive("\n");
+        let table_rows = table_string.split_inclusive('\n');
         for r in table_rows {
             write!(f, " │   {r}")?;
         }

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::Base58;
+use json_to_table::json_to_table;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -126,16 +127,16 @@ impl SuiEvent {
 
 impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let output = format!(
+        let table_json = json_to_table::json_to_table(&self.parsed_json)
+            .into_table()
+            .to_string();
+        write!(f,
             " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n │ ParsedJSON: {}\n │ BCS: {:?}\n",
-            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, self.parsed_json, self.bcs);
-        match self.timestamp_ms {
-            Some(ts) => {
-                writeln!(f, "{output} │ Timestamp: {}\n └──", ts)
-            }
-            None => {
-                writeln!(f, "{output} └──")
-            }
+            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, table_json, self.bcs);
+        if let Some(ts) = self.timestamp_ms {
+            writeln!(f, " │ Timestamp: {}\n └──", ts)
+        } else {
+            writeln!(f, " └──")
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -127,7 +127,7 @@ impl SuiEvent {
 impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n",
+            " ┌──\n │ Event ID: {}:{}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {}\n │ EventType: {}\n",
             self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_)?;
         if let Some(ts) = self.timestamp_ms {
             writeln!(f, " │ Timestamp: {}\n └──", ts)?;

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -137,7 +137,8 @@ impl Display for SuiEvent {
             writeln!(f, " │ Timestamp: {}\n └──", ts)?;
         }
         writeln!(f, " │ ParsedJSON: {}\n", table.to_string())?;
-        for _ in rows {
+        // add the vertical line for rows - 1
+        for _ in 1..rows {
             writeln!(f, " │")?;
         }
         writeln!(f, " └──")

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::Base58;
-use json_to_table::json_to_table;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -127,15 +126,13 @@ impl SuiEvent {
 
 impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let json_as_table = json_to_table(&self.parsed_json).into_table().to_string();
         write!(f,
-            " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n │ ParsedJSON: {}\n │ BCS: {:?}\n",
-            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, json_as_table, self.bcs)?;
+            " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n",
+            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_)?;
         if let Some(ts) = self.timestamp_ms {
-            writeln!(f, " │ Timestamp: {}\n └──", ts)
-        } else {
-            writeln!(f, " └──")
+            writeln!(f, " │ Timestamp: {}\n └──", ts)?;
         }
+        writeln!(f, " └──")
     }
 }
 

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::Base58;
+use json_to_table::json_to_table;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -126,11 +127,18 @@ impl SuiEvent {
 
 impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let parsed_json_table = json_to_table(&self.parsed_json);
+        let table = parsed_json_table.into_table();
+        let rows = table.count_rows();
         write!(f,
             " ┌──\n │ Event ID: {}:{}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {}\n │ EventType: {}\n",
             self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_)?;
         if let Some(ts) = self.timestamp_ms {
             writeln!(f, " │ Timestamp: {}\n └──", ts)?;
+        }
+        writeln!(f, " │ ParsedJSON: {}\n", table.to_string())?;
+        for _ in rows {
+            writeln!(f, " │")?;
         }
         writeln!(f, " └──")
     }

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -127,12 +127,10 @@ impl SuiEvent {
 
 impl Display for SuiEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let table_json = json_to_table::json_to_table(&self.parsed_json)
-            .into_table()
-            .to_string();
+        let json_as_table = json_to_table(&self.parsed_json).into_table().to_string();
         write!(f,
             " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n │ ParsedJSON: {}\n │ BCS: {:?}\n",
-            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, table_json, self.bcs);
+            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, json_as_table, self.bcs)?;
         if let Some(ts) = self.timestamp_ms {
             writeln!(f, " │ Timestamp: {}\n └──", ts)
         } else {

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+use std::fmt;
+use std::fmt::Display;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::error::SuiResult;
 use sui_types::event::{Event, EventEnvelope, EventID};
@@ -119,6 +121,22 @@ impl SuiEvent {
             bcs,
             timestamp_ms,
         })
+    }
+}
+
+impl Display for SuiEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let output = format!(
+            " ┌──\n │ EventID: {}\n │ PackageID: {}\n │ Transaction Module: {}\n │ Sender: {} \n │ EventType: {}:{}\n │ ParsedJSON: {}\n │ BCS: {:?}\n",
+            self.id.tx_digest, self.id.event_seq, self.package_id, self.transaction_module, self.sender, self.type_, self.parsed_json, self.bcs);
+        match self.timestamp_ms {
+            Some(ts) => {
+                writeln!(f, "{output} │ Timestamp: {}\n └──", ts)
+            }
+            None => {
+                writeln!(f, "{output} └──")
+            }
+        }
     }
 }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -831,9 +831,9 @@ impl SuiTransactionBlockEvents {
 impl Display for SuiTransactionBlockEvents {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.data.is_empty() {
-            writeln!(f, "╭───────────────────────────────────────────────────────────────────────────────────────────────────╮")?;
-            writeln!(f, "│ No transaction block events                                                                       │")?;
-            writeln!(f, "╰───────────────────────────────────────────────────────────────────────────────────────────────────╯")
+            writeln!(f, "╭─────────────────────────────╮")?;
+            writeln!(f, "│ No transaction block events │")?;
+            writeln!(f, "╰─────────────────────────────╯")
         } else {
             let mut builder = TableBuilder::default();
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -830,19 +830,25 @@ impl SuiTransactionBlockEvents {
 
 impl Display for SuiTransactionBlockEvents {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut builder = TableBuilder::default();
+        if self.data.is_empty() {
+            writeln!(f, "╭───────────────────────────────────────────────────────────────────────────────────────────────────╮")?;
+            writeln!(f, "│ No transaction events                                                                             │")?;
+            writeln!(f, "╰───────────────────────────────────────────────────────────────────────────────────────────────────╯")
+        } else {
+            let mut builder = TableBuilder::default();
 
-        for event in &self.data {
-            builder.push_record(vec![format!("{}", event)]);
+            for event in &self.data {
+                builder.push_record(vec![format!("{:?}", event)]);
+            }
+
+            let mut table = builder.build();
+            table.with(TablePanel::header("Transaction Block Events"));
+            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                1,
+                TableStyle::modern().get_horizontal(),
+            )]));
+            write!(f, "{}", table)
         }
-
-        let mut table = builder.build();
-        table.with(TablePanel::header("Transaction Block Events"));
-        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
-            1,
-            TableStyle::modern().get_horizontal(),
-        )]));
-        write!(f, "{}", table)
     }
 }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -828,6 +828,24 @@ impl SuiTransactionBlockEvents {
     }
 }
 
+impl Display for SuiTransactionBlockEvents {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut builder = TableBuilder::default();
+
+        for event in &self.data {
+            builder.push_record(vec![format!("{}", event)]);
+        }
+
+        let mut table = builder.build();
+        table.with(TablePanel::header("Transaction Block Events"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        write!(f, "{}", table)
+    }
+}
+
 /// The response from processing a dev inspect transaction
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "DevInspectResults", rename_all = "camelCase")]

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -838,7 +838,7 @@ impl Display for SuiTransactionBlockEvents {
             let mut builder = TableBuilder::default();
 
             for event in &self.data {
-                builder.push_record(vec![format!("{:?}", event)]);
+                builder.push_record(vec![format!("{}", event)]);
             }
 
             let mut table = builder.build();

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -832,7 +832,7 @@ impl Display for SuiTransactionBlockEvents {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.data.is_empty() {
             writeln!(f, "╭───────────────────────────────────────────────────────────────────────────────────────────────────╮")?;
-            writeln!(f, "│ No transaction events                                                                             │")?;
+            writeln!(f, "│ No transaction block events                                                                       │")?;
             writeln!(f, "╰───────────────────────────────────────────────────────────────────────────────────────────────────╯")
         } else {
             let mut builder = TableBuilder::default();

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1785,9 +1785,8 @@ pub fn write_transaction_response(
         writeln!(writer, "{}", e)?;
     }
 
-    writeln!(writer, "{}", "----- Events ----".bold())?;
     if let Some(e) = &response.events {
-        writeln!(writer, "{:#?}", json!(e))?;
+        writeln!(writer, "{}", e)?;
     }
 
     writeln!(writer, "{}", "----- Object changes ----".bold())?;


### PR DESCRIPTION
## Description 

Implements the `Display` trait for `SuiEvent` and `SuiTransactionBlockEvents` to enable better output formatting of transaction responses in the CLI.

## Test Plan 
Run `sui client tx-block GQLaqTNk2XRxYkDRauj7MkLkkG6ZatdPp5dxR17FBt9Q` on `mainnet`

<img width="1189" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/00797ce6-a06b-40b9-b73c-5b1efed57bf4">


Run `sui client tx-block CGjPmjpxuYGYuDrGQMTrBvyujFjkzakRvBnwr3bERBen` on `mainnet`
<img width="1195" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/c432b96d-60f4-4c8c-a889-4410b844532a">



### Message when there are no transaction block events
Run `sui client tx-block DjwYzwnDENdZfeLec2b2grKthuLudgN1dCGr4Ltn9YAu` on `mainnet`
<img width="1058" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/361b8089-b2b7-4b3a-9a0b-b443cd42a241">



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves the formatting output of `SuiEvent` objects in the CLI. 