### PR TITLE
Fix API ref bug that caused screen to jump when clicked

### DIFF
--- a/docs/site/src/components/API/api-ref/method.js
+++ b/docs/site/src/components/API/api-ref/method.js
@@ -19,6 +19,7 @@ const Method = (props) => {
 
   const handleClick = (e) => {
     let href = "#";
+    if (!e.target.nodeName.match(/^H/)) return;
     if (e.target.id) {
       href += e.target.id;
     } else {


### PR DESCRIPTION
## Description 

There was a bug Stefan found where immediately after using the reference navigation, anywhere you clicked on screen caused the page to jump to the top. The click event is only meant for headings, so return from handler if the activated node name does not begin with H. 

## Test Plan 

Vercel

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
