### PR TITLE
[cli] implement display for SuiTransactionBlock

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -3,6 +3,7 @@
 
 use crate::balance_changes::BalanceChange;
 use crate::object_changes::ObjectChange;
+use crate::sui_transaction::GenericSignature::Signature;
 use crate::{Filter, Page, SuiEvent, SuiObjectRef};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
@@ -23,6 +24,7 @@ use sui_types::authenticator_state::ActiveJwk;
 use sui_types::base_types::{
     EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
+use sui_types::crypto::SuiSignature;
 use sui_types::digests::{ObjectDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::{ExecutionError, SuiError, SuiResult};
@@ -1119,8 +1121,10 @@ impl Display for SuiTransactionBlock {
         for tx_sig in &self.tx_signatures {
             builder.push_record(vec![format!(
                 "   {}\n",
-                // this does not return the same sig string as the explorer?!?!
-                Base64::from_bytes(tx_sig.as_ref()).encoded()
+                match tx_sig {
+                    Signature(sig) => Base64::from_bytes(sig.signature_bytes()).encoded(),
+                    _ => Base64::from_bytes(tx_sig.as_ref()).encoded(), // the signatures for multisig and zklogin are not suited to be parsed out. they should be interpreted as a whole
+                }
             )]);
         }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1112,10 +1112,25 @@ impl SuiTransactionBlock {
 
 impl Display for SuiTransactionBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut writer = String::new();
-        writeln!(writer, "Transaction Signature: {:?}", self.tx_signatures)?;
-        write!(writer, "{}", &self.data)?;
-        write!(f, "{}", writer)
+        let mut builder = TableBuilder::default();
+
+        builder.push_record(vec![format!("{}", self.data)]);
+        builder.push_record(vec![format!("Signatures:")]);
+        for tx_sig in &self.tx_signatures {
+            builder.push_record(vec![format!(
+                "   {}\n",
+                // this does not return the same sig string as the explorer?!?!
+                Base64::from_bytes(tx_sig.as_ref()).encoded()
+            )]);
+        }
+
+        let mut table = builder.build();
+        table.with(TablePanel::header("Transaction Data"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        write!(f, "{}", table)
     }
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1777,12 +1777,10 @@ pub fn write_transaction_response(
     let mut writer = String::new();
     writeln!(writer, "{}", "----- Transaction Digest ----".bold())?;
     writeln!(writer, "{}", response.digest)?;
-    writeln!(writer, "{}", "----- Transaction Data ----".bold())?;
     if let Some(t) = &response.transaction {
         writeln!(writer, "{}", t)?;
     }
 
-    writeln!(writer, "{}", "----- Transaction Effects ----".bold())?;
     if let Some(e) = &response.effects {
         writeln!(writer, "{}", e)?;
     }


### PR DESCRIPTION
## Description 

Implements the `Display` trait for `SuiTransactionBlock` type - this is only at the top level. A follow-up PR will address the `SuiTransactionBlockData` stuff. 

## Test Plan 

<img width="1654" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/a3cc2d6b-b1cf-4cf1-af9a-dbe1cec7831d">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves the formatting output in the CLI for the `Transaction Data` part when a transaction's response is displayed.