### PR TITLE
[cli] nicer formatting of `SuiGasData` object

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -984,7 +984,7 @@ impl Display for SuiGasData {
         writeln!(f, "Gas Owner: {}", self.owner)?;
         writeln!(f, "Gas Budget: {}", self.budget)?;
         writeln!(f, "Gas Price: {}", self.price)?;
-        write!(f, "Gas Payment:\n")?;
+        writeln!(f, "Gas Payment:")?;
         for payment in &self.payment {
             write!(f, "{} ", objref_string(payment))?;
         }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -979,6 +979,19 @@ pub struct SuiGasData {
     pub budget: u64,
 }
 
+impl Display for SuiGasData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Gas Owner: {}", self.owner)?;
+        writeln!(f, "Gas Budget: {}", self.budget)?;
+        writeln!(f, "Gas Price: {}", self.price)?;
+        write!(f, "Gas Payment:\n")?;
+        for payment in &self.payment {
+            write!(f, "{} ", objref_string(payment))?;
+        }
+        writeln!(f)
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[enum_dispatch(SuiTransactionBlockDataAPI)]
 #[serde(
@@ -1040,14 +1053,7 @@ impl Display for SuiTransactionBlockData {
         match self {
             Self::V1(data) => {
                 writeln!(f, "Sender: {}", data.sender)?;
-                writeln!(f, "Gas Owner: {}", data.gas_data.owner)?;
-                writeln!(f, "Gas Budget: {}", data.gas_data.budget)?;
-                writeln!(f, "Gas Price: {}", data.gas_data.price)?;
-                write!(f, "Gas Payment:\n")?;
-                for payment in &self.gas_data().payment {
-                    write!(f, "{} ", objref_string(payment))?;
-                }
-                writeln!(f)?;
+                writeln!(f, "{}", self.gas_data())?;
                 writeln!(f, "{}", data.transaction)
             }
         }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1039,16 +1039,16 @@ impl Display for SuiTransactionBlockData {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::V1(data) => {
-                writeln!(f, "{}", data.transaction)?;
                 writeln!(f, "Sender: {}", data.sender)?;
-                write!(f, "Gas Payment: ")?;
+                writeln!(f, "Gas Owner: {}", data.gas_data.owner)?;
+                writeln!(f, "Gas Budget: {}", data.gas_data.budget)?;
+                writeln!(f, "Gas Price: {}", data.gas_data.price)?;
+                write!(f, "Gas Payment:\n")?;
                 for payment in &self.gas_data().payment {
-                    write!(f, "{} ", payment)?;
+                    write!(f, "{} ", objref_string(payment))?;
                 }
                 writeln!(f)?;
-                writeln!(f, "Gas Owner: {}", data.gas_data.owner)?;
-                writeln!(f, "Gas Price: {}", data.gas_data.price)?;
-                writeln!(f, "Gas Budget: {}", data.gas_data.budget)
+                writeln!(f, "{}", data.transaction)
             }
         }
     }


### PR DESCRIPTION
## Description 

Improves the formatting output of the `SuiGasData` type when a transaction response is displayed in the CLI.

## Test Plan 

<img width="803" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/e0369872-8059-419e-afe0-2a3e3826b201">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improved the formatting output of the gas data information shown in a transaction in the CLI.