### PR TITLE
Revert "Pruning object tombstones (#14373)"

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -18,7 +18,6 @@ authority-store-pruning-config:
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   pruning-run-delay-seconds: 60
-  enable-pruning-tombstones: false
 
 protocol-key-pair:
   path: "protocol.key"

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -18,4 +18,3 @@ authority-store-pruning-config:
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   pruning-run-delay-seconds: 60
-  enable-pruning-tombstones: false

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -543,7 +543,6 @@ pub struct AuthorityStorePruningConfig {
     /// number of epochs to keep the latest version of transactions and effects for
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_epochs_to_retain_for_checkpoints: Option<u64>,
-    pub enable_pruning_tombstones: bool,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -560,7 +559,6 @@ impl Default for AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: None,
-            enable_pruning_tombstones: false,
         }
     }
 }
@@ -580,7 +578,6 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: false,
         }
     }
     pub fn fullnode_config() -> Self {
@@ -597,7 +594,6 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: false,
         }
     }
 
@@ -616,10 +612,6 @@ impl AuthorityStorePruningConfig {
                     n
                 }
             })
-    }
-
-    pub fn set_enable_pruning_tombstones(&mut self, enable_pruning_tombstones: bool) {
-        self.enable_pruning_tombstones = enable_pruning_tombstones;
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -104,41 +104,25 @@ impl AuthorityStorePruner {
         checkpoint_number: CheckpointSequenceNumber,
         metrics: Arc<AuthorityStorePruningMetrics>,
         indirect_objects_threshold: usize,
-        enable_pruning_tombstones: bool,
     ) -> anyhow::Result<()> {
         let _scope = monitored_scope("ObjectsLivePruner");
         let mut wb = perpetual_db.objects.batch();
 
-        // Collect objects keys that need to be deleted from `transaction_effects`.
-        let mut live_object_keys_to_prune = vec![];
-        let mut object_tombstones_to_prune = vec![];
+        let mut object_keys_to_prune = vec![];
         for effects in &transaction_effects {
             for (object_id, seq_number) in effects.modified_at_versions() {
-                live_object_keys_to_prune.push(ObjectKey(object_id, seq_number));
-            }
-
-            if enable_pruning_tombstones {
-                for deleted_object_ref in effects
-                    .deleted()
-                    .into_iter()
-                    .chain(effects.unwrapped_then_deleted().into_iter())
-                    .chain(effects.wrapped().into_iter())
-                {
-                    object_tombstones_to_prune
-                        .push(ObjectKey(deleted_object_ref.0, deleted_object_ref.1));
-                }
+                object_keys_to_prune.push(ObjectKey(object_id, seq_number));
             }
         }
-
         metrics
             .num_pruned_objects
-            .inc_by((live_object_keys_to_prune.len() + object_tombstones_to_prune.len()) as u64);
-
+            .inc_by(object_keys_to_prune.len() as u64);
         let mut indirect_objects: HashMap<_, i64> = HashMap::new();
+
         if indirect_objects_threshold > 0 && indirect_objects_threshold < usize::MAX {
             for object in perpetual_db
                 .objects
-                .multi_get(live_object_keys_to_prune.iter())?
+                .multi_get(object_keys_to_prune.iter())?
                 .into_iter()
                 .flatten()
             {
@@ -151,13 +135,16 @@ impl AuthorityStorePruner {
         }
 
         let mut updates: HashMap<ObjectID, (VersionNumber, VersionNumber)> = HashMap::new();
-        for ObjectKey(object_id, seq_number) in live_object_keys_to_prune {
-            updates
-                .entry(object_id)
-                .and_modify(|range| *range = (min(range.0, seq_number), max(range.1, seq_number)))
-                .or_insert((seq_number, seq_number));
+        for effects in transaction_effects {
+            for (object_id, seq_number) in effects.modified_at_versions() {
+                updates
+                    .entry(object_id)
+                    .and_modify(|range| {
+                        *range = (min(range.0, seq_number), max(range.1, seq_number))
+                    })
+                    .or_insert((seq_number, seq_number));
+            }
         }
-
         for (object_id, (min_version, max_version)) in updates {
             debug!(
                 "Pruning object {:?} versions {:?} - {:?}",
@@ -166,26 +153,6 @@ impl AuthorityStorePruner {
             let start_range = ObjectKey(object_id, min_version);
             let end_range = ObjectKey(object_id, (max_version.value() + 1).into());
             wb.schedule_delete_range(&perpetual_db.objects, &start_range, &end_range)?;
-        }
-
-        // When enable_pruning_tombstones is enabled, instead of using range deletes, we need to do a scan of all the keys
-        // for the deleted objects and then do point deletes to delete all the existing keys. This is because to improve read
-        // performance, we set `ignore_range_deletions` on all read options, and using range delete to delete tombstones
-        // may leak object (imagine a tombstone is compacted away, but earlier version is still not). Using point deletes
-        // guarantees that all earlier versions are deleted in the database.
-        if !object_tombstones_to_prune.is_empty() {
-            let mut object_keys_to_delete = vec![];
-            for ObjectKey(object_id, seq_number) in object_tombstones_to_prune {
-                for (object_key, _object_value) in perpetual_db.objects.iter_with_bounds(
-                    Some(ObjectKey(object_id, VersionNumber::MIN)),
-                    Some(ObjectKey(object_id, seq_number.next())),
-                ) {
-                    assert_eq!(object_key.0, object_id);
-                    object_keys_to_delete.push(object_key);
-                }
-            }
-
-            wb.delete_batch(&perpetual_db.objects, object_keys_to_delete)?;
         }
 
         if !indirect_objects.is_empty() {
@@ -418,7 +385,6 @@ impl AuthorityStorePruner {
                             checkpoint_number,
                             metrics.clone(),
                             indirect_objects_threshold,
-                            config.enable_pruning_tombstones,
                         )
                         .await?
                     }
@@ -437,7 +403,6 @@ impl AuthorityStorePruner {
                 effects_to_prune = vec![];
             }
         }
-
         if !checkpoints_to_prune.is_empty() {
             match mode {
                 PruningMode::Objects => {
@@ -448,7 +413,6 @@ impl AuthorityStorePruner {
                         checkpoint_number,
                         metrics.clone(),
                         indirect_objects_threshold,
-                        config.enable_pruning_tombstones,
                     )
                     .await?
                 }
@@ -676,37 +640,30 @@ mod tests {
         Ok(after_pruning)
     }
 
-    type GenerateTestDataResult = (Vec<ObjectKey>, Vec<ObjectKey>, Vec<ObjectKey>);
-
     fn generate_test_data(
         db: Arc<AuthorityPerpetualTables>,
         num_versions_per_object: u64,
         num_object_versions_to_retain: u64,
         total_unique_object_ids: u32,
-        indirect_object_threshold: usize,
-    ) -> Result<GenerateTestDataResult, anyhow::Error> {
-        assert!(num_versions_per_object >= num_object_versions_to_retain);
-
-        let (mut to_keep, mut to_delete, mut tombstones) = (vec![], vec![], vec![]);
+    ) -> Result<(Vec<ObjectKey>, Vec<ObjectKey>), anyhow::Error> {
+        let (mut to_keep, mut to_delete) = (vec![], vec![]);
         let mut batch = db.objects.batch();
 
         let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids.into())?;
         for id in ids {
-            for (counter, seq) in (0..num_versions_per_object).rev().enumerate() {
-                let object_key = ObjectKey(id, SequenceNumber::from_u64(seq));
+            for (counter, i) in (0..num_versions_per_object).rev().enumerate() {
+                let object_key = ObjectKey(id, SequenceNumber::from_u64(i));
                 if counter < num_object_versions_to_retain.try_into().unwrap() {
                     // latest `num_object_versions_to_retain` should not have been pruned
                     to_keep.push(object_key);
                 } else {
                     to_delete.push(object_key);
                 }
-                let StoreObjectPair(obj, indirect_obj) = get_store_object_pair(
-                    Object::immutable_with_id_for_testing(id),
-                    indirect_object_threshold,
-                );
+                let StoreObjectPair(obj, indirect_obj) =
+                    get_store_object_pair(Object::immutable_with_id_for_testing(id), 1);
                 batch.insert_batch(
                     &db.objects,
-                    [(ObjectKey(id, SequenceNumber::from(seq)), obj.clone())],
+                    [(ObjectKey(id, SequenceNumber::from(i)), obj.clone())],
                 )?;
                 if let StoreObject::Value(o) = obj.into_inner() {
                     if let StoreData::IndirectObject(metadata) = o.data {
@@ -717,17 +674,6 @@ mod tests {
                     }
                 }
             }
-
-            // Adding a tombstone for deleted object.
-            if num_object_versions_to_retain == 0 {
-                let tombstone_key = ObjectKey(id, SequenceNumber::from(num_versions_per_object));
-                println!("Adding tombstone object {:?}", tombstone_key);
-                batch.insert_batch(
-                    &db.objects,
-                    [(tombstone_key, StoreObjectWrapper::V1(StoreObject::Deleted))],
-                )?;
-                tombstones.push(tombstone_key);
-            }
         }
         batch.write().unwrap();
         assert_eq!(
@@ -735,15 +681,7 @@ mod tests {
             std::cmp::min(num_object_versions_to_retain, num_versions_per_object)
                 * total_unique_object_ids as u64
         );
-        assert_eq!(
-            tombstones.len() as u64,
-            if num_object_versions_to_retain == 0 {
-                total_unique_object_ids as u64
-            } else {
-                0
-            }
-        );
-        Ok((to_keep, to_delete, tombstones))
+        Ok((to_keep, to_delete))
     }
 
     pub(crate) fn lock_table() -> Arc<RwLockTable<ObjectContentDigest>> {
@@ -755,82 +693,50 @@ mod tests {
         num_versions_per_object: u64,
         num_object_versions_to_retain: u64,
         total_unique_object_ids: u32,
-        indirect_object_threshold: usize,
     ) -> Vec<ObjectKey> {
         let registry = Registry::default();
         let metrics = AuthorityStorePruningMetrics::new(&registry);
         let to_keep = {
             let db = Arc::new(AuthorityPerpetualTables::open(path, None));
-            let (to_keep, to_delete, tombstones) = generate_test_data(
+            let (to_keep, to_delete) = generate_test_data(
                 db.clone(),
                 num_versions_per_object,
                 num_object_versions_to_retain,
                 total_unique_object_ids,
-                indirect_object_threshold,
             )
             .unwrap();
             let mut effects = TransactionEffects::default();
             for object in to_delete {
-                effects.unsafe_add_deleted_live_object_for_testing((
+                effects.unsafe_add_deleted_object_for_testing((
                     object.0,
                     object.1,
                     ObjectDigest::MIN,
                 ));
             }
-            for object in tombstones {
-                effects.unsafe_add_object_tombstone_for_testing((
-                    object.0,
-                    object.1,
-                    ObjectDigest::MIN,
-                ));
-            }
-            AuthorityStorePruner::prune_objects(
-                vec![effects],
-                &db,
-                &lock_table(),
-                0,
-                metrics,
-                indirect_object_threshold,
-                true,
-            )
-            .await
-            .unwrap();
+            AuthorityStorePruner::prune_objects(vec![effects], &db, &lock_table(), 0, metrics, 1)
+                .await
+                .unwrap();
             to_keep
         };
         tokio::time::sleep(Duration::from_secs(3)).await;
         to_keep
     }
 
-    // Tests pruning old version of live objects.
     #[tokio::test]
-    async fn test_pruning_objects() {
+    async fn test_pruning() {
         let path = tempfile::tempdir().unwrap().into_path();
-        let to_keep = run_pruner(&path, 3, 2, 1000, 0).await;
+        let to_keep = run_pruner(&path, 3, 2, 1000).await;
         assert_eq!(
             HashSet::from_iter(to_keep),
             get_keys_after_pruning(&path).unwrap()
         );
-        run_pruner(&tempfile::tempdir().unwrap().into_path(), 3, 2, 1000, 0).await;
-    }
-
-    // Tests pruning deleted objects (object tombstones).
-    #[tokio::test]
-    async fn test_pruning_tombstones() {
-        let path = tempfile::tempdir().unwrap().into_path();
-        let to_keep = run_pruner(&path, 0, 0, 1000, 0).await;
-        assert_eq!(to_keep.len(), 0);
-        assert_eq!(get_keys_after_pruning(&path).unwrap().len(), 0);
-
-        let path = tempfile::tempdir().unwrap().into_path();
-        let to_keep = run_pruner(&path, 3, 0, 1000, 0).await;
-        assert_eq!(to_keep.len(), 0);
-        assert_eq!(get_keys_after_pruning(&path).unwrap().len(), 0);
+        run_pruner(&tempfile::tempdir().unwrap().into_path(), 3, 2, 1000).await;
     }
 
     #[tokio::test]
     async fn test_ref_count_pruning() {
         let path = tempfile::tempdir().unwrap().into_path();
-        run_pruner(&path, 3, 2, 1000, 1).await;
+        run_pruner(&path, 3, 2, 1000).await;
         {
             let perpetual_db = AuthorityPerpetualTables::open(&path, None);
             let count = perpetual_db.indirect_move_objects.keys().count();
@@ -839,7 +745,7 @@ mod tests {
         }
 
         let path = tempfile::tempdir().unwrap().into_path();
-        run_pruner(&path, 3, 0, 1000, 1).await;
+        run_pruner(&path, 3, 0, 1000).await;
         {
             let perpetual_db = AuthorityPerpetualTables::open(&path, None);
             perpetual_db.indirect_move_objects.flush().unwrap();
@@ -902,11 +808,7 @@ mod tests {
 
         let mut effects = TransactionEffects::default();
         for object in to_delete {
-            effects.unsafe_add_deleted_live_object_for_testing((
-                object.0,
-                object.1,
-                ObjectDigest::MIN,
-            ));
+            effects.unsafe_add_deleted_object_for_testing((object.0, object.1, ObjectDigest::MIN));
         }
         let registry = Registry::default();
         let metrics = AuthorityStorePruningMetrics::new(&registry);
@@ -917,7 +819,6 @@ mod tests {
             0,
             metrics,
             0,
-            true,
         )
         .await;
         info!("Total pruned keys = {:?}", total_pruned);
@@ -985,11 +886,7 @@ mod pprof_tests {
 
         let mut effects = TransactionEffects::default();
         for object in to_delete {
-            effects.unsafe_add_deleted_live_object_for_testing((
-                object.0,
-                object.1,
-                ObjectDigest::MIN,
-            ));
+            effects.unsafe_add_deleted_object_for_testing((object.0, object.1, ObjectDigest::MIN));
         }
         Ok(effects)
     }
@@ -1037,7 +934,6 @@ mod pprof_tests {
             0,
             metrics,
             1,
-            true,
         )
         .await?;
         let guard = pprof::ProfilerGuardBuilder::default()
@@ -1073,7 +969,6 @@ mod pprof_tests {
             0,
             metrics,
             1,
-            true,
         )
         .await?;
         if let Ok(()) = perpetual_db.objects.flush() {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -247,13 +247,6 @@ impl<'a> TestAuthorityBuilder<'a> {
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
         let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
         let overload_threshold_config = self.overload_threshold_config.unwrap_or_default();
-        let mut pruning_config = AuthorityStorePruningConfig::default();
-        if !epoch_store
-            .protocol_config()
-            .simplified_unwrap_then_delete()
-        {
-            pruning_config.set_enable_pruning_tombstones(false);
-        }
         let state = AuthorityState::new(
             name,
             secret,
@@ -264,7 +257,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             index_store,
             checkpoint_store,
             &registry,
-            pruning_config,
+            AuthorityStorePruningConfig::default(),
             genesis.objects(),
             &DBCheckpointConfig::default(),
             ExpensiveSafetyCheckConfig::new_enable_all(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -562,14 +562,6 @@ impl SuiNode {
             state_snapshot_handle.is_some(),
         )?;
 
-        let mut pruning_config = config.authority_store_pruning_config;
-        if !epoch_store
-            .protocol_config()
-            .simplified_unwrap_then_delete()
-        {
-            pruning_config.set_enable_pruning_tombstones(false);
-        }
-
         let state = AuthorityState::new(
             config.protocol_public_key(),
             secret,
@@ -580,7 +572,7 @@ impl SuiNode {
             index_store.clone(),
             checkpoint_store.clone(),
             &prometheus_registry,
-            pruning_config,
+            config.authority_store_pruning_config,
             genesis.objects(),
             &db_checkpoint_config,
             config.expensive_safety_check_config.clone(),

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -58,7 +58,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -169,7 +168,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -280,7 +278,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -391,7 +388,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -502,7 +498,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -613,7 +608,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200
@@ -724,7 +718,6 @@ validator_configs:
       num-epochs-to-retain: 2
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
-      enable-pruning-tombstones: false
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 200

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -191,11 +191,8 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         }
     }
 
-    fn unsafe_add_deleted_live_object_for_testing(&mut self, object: ObjectRef) {
+    fn unsafe_add_deleted_object_for_testing(&mut self, object: ObjectRef) {
         self.modified_at_versions.push((object.0, object.1));
-    }
-
-    fn unsafe_add_object_tombstone_for_testing(&mut self, object: ObjectRef) {
         self.deleted.push(object);
     }
 }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -323,24 +323,7 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
         }
     }
 
-    fn unsafe_add_deleted_live_object_for_testing(&mut self, obj_ref: ObjectRef) {
-        self.changed_objects.push((
-            obj_ref.0,
-            EffectsObjectChange {
-                input_state: ObjectIn::Exist((
-                    (obj_ref.1, obj_ref.2),
-                    Owner::AddressOwner(SuiAddress::default()),
-                )),
-                output_state: ObjectOut::ObjectWrite((
-                    obj_ref.2,
-                    Owner::AddressOwner(SuiAddress::default()),
-                )),
-                id_operation: IDOperation::None,
-            },
-        ))
-    }
-
-    fn unsafe_add_object_tombstone_for_testing(&mut self, obj_ref: ObjectRef) {
+    fn unsafe_add_deleted_object_for_testing(&mut self, obj_ref: ObjectRef) {
         self.changed_objects.push((
             obj_ref.0,
             EffectsObjectChange {

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -397,12 +397,7 @@ pub trait TransactionEffectsAPI {
     fn transaction_digest_mut_for_testing(&mut self) -> &mut TransactionDigest;
     fn dependencies_mut_for_testing(&mut self) -> &mut Vec<TransactionDigest>;
     fn unsafe_add_input_shared_object_for_testing(&mut self, kind: InputSharedObject);
-
-    // Adding an old version of a live object.
-    fn unsafe_add_deleted_live_object_for_testing(&mut self, obj_ref: ObjectRef);
-
-    // Adding a tombstone for a deleted object.
-    fn unsafe_add_object_tombstone_for_testing(&mut self, obj_ref: ObjectRef);
+    fn unsafe_add_deleted_object_for_testing(&mut self, obj_ref: ObjectRef);
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Description 
This reverts commit e9735471f528ce27562bc7e85c687284a21da7ae because of validator crash
```
ubuntu@lax-suival-2f0e8:~$ sudo bash -c "RUST_BACKTRACE=1 /opt/sui/bin/sui-node --config-path /opt/sui/config/sui-node.yaml"
thread 'main' panicked at crates/sui-node/src/main.rs:53:58:
called `Result::unwrap()` on an `Err` value: authority-store-pruning-config: missing field `enable-pruning-tombstones` at line 52 column 33

Stack backtrace:
   0: sui_config::Config::load
   1: sui_node::main
   2: std::sys_common::backtrace::__rust_begin_short_backtrace
   3: std::rt::lang_start::{{closure}}
   4: std::rt::lang_start_internal
   5: main
   6: <unknown>
   7: __libc_start_main
   8: _start
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: sui_node::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Aborted
```

## Test Plan 
👀 