### PR TITLE
[indexer][graphql] use to_canonical_string consistently for ObjectID and StructTag

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1301,8 +1301,13 @@ impl PgManager {
         coin_type: Option<String>,
     ) -> Result<Option<Balance>, Error> {
         let address = address.into_vec();
-        let coin_type = parse_to_type_tag(coin_type)
-            .map_err(|_| Error::Internal("Coin type is not valid".to_string()))?
+        let coin_type_tag = parse_to_type_tag(coin_type);
+        if coin_type_tag.is_err() {
+            // The provided `coin_type` cannot be parsed to a type tag so return None here.
+            return Ok(None);
+        }
+        let coin_type = coin_type_tag
+            .unwrap()
             .to_canonical_string(/* with_prefix */ true);
         let result = self.get_balance(address, coin_type).await?;
 

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -477,7 +477,7 @@ mod tests {
 
     fn json<T: Serialize>(layout: value::MoveTypeLayout, data: T) -> Result<Json> {
         let tag: TypeTag = (&layout).try_into().expect("Error fetching type tag");
-        let type_ = MoveType::new(tag.to_string());
+        let type_ = MoveType::new(tag.to_canonical_string(/* with_prefix */ true));
         let bcs = Base64(bcs::to_bytes(&data).unwrap());
         MoveValue { type_, bcs }.json_impl(layout)
     }

--- a/crates/sui-indexer/src/apis/coin_api_v2.rs
+++ b/crates/sui-indexer/src/apis/coin_api_v2.rs
@@ -39,7 +39,8 @@ impl CoinReadApiServer for CoinReadApiV2 {
         }
 
         // Normalize coin type tag and default to Gas
-        let coin_type = parse_to_type_tag(coin_type)?.to_string();
+        let coin_type =
+            parse_to_type_tag(coin_type)?.to_canonical_string(/* with_prefix */ true);
 
         let cursor = match cursor {
             Some(c) => c,
@@ -98,7 +99,8 @@ impl CoinReadApiServer for CoinReadApiV2 {
         coin_type: Option<String>,
     ) -> RpcResult<Balance> {
         // Normalize coin type tag and default to Gas
-        let coin_type = parse_to_type_tag(coin_type)?.to_string();
+        let coin_type =
+            parse_to_type_tag(coin_type)?.to_canonical_string(/* with_prefix */ true);
 
         let mut results = self
             .inner

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1569,7 +1569,8 @@ impl IndexerReader {
         coin_struct: StructTag,
     ) -> Result<Option<SuiCoinMetadata>, IndexerError> {
         let package_id = coin_struct.address.into();
-        let coin_metadata_type = CoinMetadata::type_(coin_struct).to_string();
+        let coin_metadata_type =
+            CoinMetadata::type_(coin_struct).to_canonical_string(/* with_prefix */ true);
         let coin_metadata_obj_id =
             get_single_obj_id_from_package_publish(self, package_id, coin_metadata_type)?;
         if let Some(id) = coin_metadata_obj_id {
@@ -1590,7 +1591,8 @@ impl IndexerReader {
 
     fn get_total_supply(&self, coin_struct: StructTag) -> Result<Supply, IndexerError> {
         let package_id = coin_struct.address.into();
-        let treasury_cap_type = TreasuryCap::type_(coin_struct).to_string();
+        let treasury_cap_type =
+            TreasuryCap::type_(coin_struct).to_canonical_string(/* with_prefix */ true);
         let treasury_cap_obj_id =
             get_single_obj_id_from_package_publish(self, package_id, treasury_cap_type.clone())?
                 .ok_or(IndexerError::GenericError(format!(

--- a/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
@@ -425,7 +425,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             .filter_map(|queried_move_metrics| {
                 let package = ObjectID::from_bytes(queried_move_metrics.move_package.clone()).ok();
                 let package_str = match package {
-                    Some(p) => p.to_string(),
+                    Some(p) => p.to_canonical_string(/* with_prefix */ true),
                     None => {
                         tracing::error!(
                             "Failed to parse move package ID: {:?}",


### PR DESCRIPTION

## Description 

Went through the code and there seems to be a few more places where we should switch to using `to_canonical_string`.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
