### PR TITLE
Update zk_login.md to include instructions for downloading devnet proving key 

### DIFF
--- a/doc/src/build/zk_login.md
+++ b/doc/src/build/zk_login.md
@@ -372,9 +372,10 @@ wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-cont
 
    - To verify the correct zkey file is downloaded, you can check the Blake2b hash by running by running `b2sum ${file_name}.zkey`.
 
-| Network | zkey file name | Hash 
-| Mainnet, Testnet |  zkLogin-main.zkey | 060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce |
-| Devnet | zkLogin-test.zkey | 686e2f5fd969897b1c034d7654799ee2c3952489814e4eaaf3d7e1bb539841047ae8ee5fdcdaca5f4ddd76abb5a8e8eb77b44b693a2ba9d4be57e94292b26ce2 |
+| Network | zkey file name | Hash |
+| ------------ | ----------   | -------- |
+| Mainnet, Testnet |  `zkLogin-main.zkey` | 060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce |
+| Devnet | `zkLogin-test.zkey` | 686e2f5fd969897b1c034d7654799ee2c3952489814e4eaaf3d7e1bb539841047ae8ee5fdcdaca5f4ddd76abb5a8e8eb77b44b693a2ba9d4be57e94292b26ce2 |
 
 1. Run `prover` at `PORT1` with the downloaded zkey. This needs to be run on Linux-based machines (amd64). Further, we recommended using at least 16 vcpu, preferably an AMD cpu and at least 16gb ram for production use. Whereas 8 vcpu, 8gb ram works for testing (but its not fast).
 

--- a/doc/src/build/zk_login.md
+++ b/doc/src/build/zk_login.md
@@ -360,13 +360,21 @@ const partialZkLoginSignature = proofResponse as PartialZkLoginSignature;
 
 1. Download two images from from Docker Hub [repository](https://hub.docker.com/repository/docker/mysten/zklogin/general) that are tagged as `prover` and `prover-fe`. 
 
-1. Download the [Groth16 proving key zkey file](https://docs.circom.io/getting-started/proving-circuits/) that will be later used as an argument to run the prover. See [the Ceremony section](#ceremony) for more details on how the proving key was generated. Please install [git lfs](https://git-lfs.com/) which is needed before downloading the zkey.
+1. Download the [Groth16 proving key zkey file](https://docs.circom.io/getting-started/proving-circuits/) that will be later used as an argument to run the prover. We provide two zkey's, one for mainnet and testnet whereas a test one for devnet. See [the Ceremony section](#ceremony) for more details on how the main proving key was generated. Please install [git lfs](https://git-lfs.com/) which is needed before downloading the zkey.
 
 ```bash
-wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-zkey.sh | bash
+# For mainnet / testnet zkey
+wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-main-zkey.sh | bash
+
+# For devnet zkey
+wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-test-zkey.sh | bash
 ```
 
-   - To verify the correct zkey file is downloaded, you can check the Blake2b hash equals to `060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce` by running `b2sum zkLogin.zkey`.
+   - To verify the correct zkey file is downloaded, you can check the Blake2b hash by running by running `b2sum ${file_name}.zkey`.
+
+| Network | zkey file name | Hash 
+| Mainnet, Testnet |  zkLogin-main.zkey | 060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce |
+| Devnet | zkLogin-test.zkey | 686e2f5fd969897b1c034d7654799ee2c3952489814e4eaaf3d7e1bb539841047ae8ee5fdcdaca5f4ddd76abb5a8e8eb77b44b693a2ba9d4be57e94292b26ce2 |
 
 1. Run `prover` at `PORT1` with the downloaded zkey. This needs to be run on Linux-based machines (amd64). Further, we recommended using at least 16 vcpu, preferably an AMD cpu and at least 16gb ram for production use. Whereas 8 vcpu, 8gb ram works for testing (but its not fast).
 

--- a/docs/content/concepts/cryptography/zklogin.mdx
+++ b/docs/content/concepts/cryptography/zklogin.mdx
@@ -357,13 +357,23 @@ const partialZkLoginSignature = proofResponse as PartialZkLoginSignature;
 
 1. Download two images from from Docker Hub [repository](https://hub.docker.com/repository/docker/mysten/zklogin/general) that are tagged as `prover` and `prover-fe`. 
 
-1. Download the [Groth16 proving key zkey file](https://docs.circom.io/getting-started/proving-circuits/) that will be later used as an argument to run the prover. See [the Ceremony section](#ceremony) for more details on how the proving key was generated. Please install [git lfs](https://git-lfs.com/) which is needed before downloading the zkey.
+1. Download the [Groth16 proving key zkey file](https://docs.circom.io/getting-started/proving-circuits/) that will be later used as an argument to run the prover. There are zkeys available for Mainnet and Testnet, as well as a test zkey for Devnet. See [the Ceremony section](#ceremony) for more details on how the main proving key is generated. Please install [git lfs](https://git-lfs.com/) which is needed before downloading the zkey.
 
-	```bash
-	wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-zkey.sh | bash
-	```
+	- Main zkey (for Mainnet and Testnet)
+		```bash
+		wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-main-zkey.sh | bash
+		```
+	- Test zkey (for Devnet)
+		```bash
+		wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-test-zkey.sh | bash
+		```
 
-	To verify the correct zkey file is downloaded, you can check the Blake2b hash equals to `060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce` by running `b2sum zkLogin.zkey`.
+	- To verify the download contains the correct zkey file, you can check the Blake2b hash by running by running `b2sum ${file_name}.zkey`.
+	
+		| Network | zkey file name | Hash |
+		| ------------ | ----------   | -------- |
+		| Mainnet, Testnet |  `zkLogin-main.zkey` | `060b...bce` |
+		| Devnet | `zkLogin-test.zkey` | `686e...ce2` |
 
 1. Run `prover` at `PORT1` with the downloaded zkey. This needs to be run on Linux-based machines (amd64). Further, we recommended using at least 16 vcpu, preferably an AMD cpu and at least 16gb ram for production use. Whereas 8 vcpu, 8gb ram works for testing (but its not fast).
 

--- a/docs/content/concepts/cryptography/zklogin.mdx
+++ b/docs/content/concepts/cryptography/zklogin.mdx
@@ -368,8 +368,8 @@ const partialZkLoginSignature = proofResponse as PartialZkLoginSignature;
 		wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-test-zkey.sh | bash
 		```
 
-	- To verify the download contains the correct zkey file, you can check the Blake2b hash by running by running `b2sum ${file_name}.zkey`.
-	
+	- To verify the download contains the correct zkey file, you can run the following command to check the Blake2b hash: `b2sum ${file_name}.zkey`.
+
 		| Network | zkey file name | Hash |
 		| ------------ | ----------   | -------- |
 		| Mainnet, Testnet |  `zkLogin-main.zkey` | `060b...bce` |

--- a/docs/content/concepts/cryptography/zklogin.mdx
+++ b/docs/content/concepts/cryptography/zklogin.mdx
@@ -372,8 +372,8 @@ const partialZkLoginSignature = proofResponse as PartialZkLoginSignature;
 
 		| Network | zkey file name | Hash |
 		| ------------ | ----------   | -------- |
-		| Mainnet, Testnet |  `zkLogin-main.zkey` | `060b...bce` |
-		| Devnet | `zkLogin-test.zkey` | `686e...ce2` |
+		| Mainnet, Testnet |  `zkLogin-main.zkey` | `060beb961802568ac9ac7f14de0fbcd55e373e8f5ec7cc32189e26fb65700aa4e36f5604f868022c765e634d14ea1cd58bd4d79cef8f3cf9693510696bcbcbce` |
+		| Devnet | `zkLogin-test.zkey` | `686e2f5fd969897b1c034d7654799ee2c3952489814e4eaaf3d7e1bb539841047ae8ee5fdcdaca5f4ddd76abb5a8e8eb77b44b693a2ba9d4be57e94292b26ce2` |
 
 1. Run `prover` at `PORT1` with the downloaded zkey. This needs to be run on Linux-based machines (amd64). Further, we recommended using at least 16 vcpu, preferably an AMD cpu and at least 16gb ram for production use. Whereas 8 vcpu, 8gb ram works for testing (but its not fast).
 


### PR DESCRIPTION
## Description 

See above.

## Test Plan 

```
> wget -O - https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-test-zkey.sh | bash 
--2023-11-06 12:32:39--  https://raw.githubusercontent.com/sui-foundation/zklogin-ceremony-contributions/main/download-test-zkey.sh
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 2606:50c0:8001::154, 2606:50c0:8003::154, 2606:50c0:8000::154, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2606:50c0:8001::154|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 180 [text/plain]
Saving to: ‘STDOUT’

-                                               100%[=====================================================================================================>]     180  --.-KB/s    in 0s      

2023-11-06 12:32:39 (11.4 MB/s) - written to stdout [180/180]

Cloning into 'zklogin-ceremony-contributions'...
remote: Enumerating objects: 195, done.
remote: Counting objects: 100% (195/195), done.
remote: Compressing objects: 100% (181/181), done.
remote: Total 195 (delta 33), reused 155 (delta 12), pack-reused 0
Receiving objects: 100% (195/195), 59.85 KiB | 2.30 MiB/s, done.
Resolving deltas: 100% (33/33), done.
> cd zklogin-ceremony-contributions 
> ls
README.md             download-main-zkey.sh phase1                zkLogin-main.vkey     zkLogin-test.vkey
contributor_list.tsv  download-test-zkey.sh phase2                zkLogin-main.zkey     zkLogin-test.zkey
git❨ main ❩ 
> b2sum zkLogin-test.zkey 
686e2f5fd969897b1c034d7654799ee2c3952489814e4eaaf3d7e1bb539841047ae8ee5fdcdaca5f4ddd76abb5a8e8eb77b44b693a2ba9d4be57e94292b26ce2  zkLogin-test.zkey
git❨ main ❩ 

```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
