### PR TITLE
[docs/graphql] add information about using curl with GraphQL

### DIFF
--- a/docs/content/references/sui-api/beta-graph-ql.mdx
+++ b/docs/content/references/sui-api/beta-graph-ql.mdx
@@ -24,8 +24,8 @@ The endpoint can also be queried using `curl` by passing the query to the call:
 ```shell
 curl -X POST https://graphql-beta.mainnet.sui.io \
      --header "Content-Type: application/json" \
-     --data '{ 
-       "query": "query { chainIdentifier }"
+     --data '{
+          "query": "query ($epochID: Int!) { epoch(id: $epochID) {referenceGasPrice} }", "variables": { "epochID": 123 } }
      }'
 ```
 

--- a/docs/content/references/sui-api/beta-graph-ql.mdx
+++ b/docs/content/references/sui-api/beta-graph-ql.mdx
@@ -20,6 +20,15 @@ Currently, there is one available playground for Sui GraphQL Service:
 
 This instance runs the GraphQL IDE, an interactive IDE with autocomplete support and in-built documentation.
 
+The endpoint can also be queried using `curl` by passing the query to the call:
+```shell
+curl -X POST https://graphql-beta.mainnet.sui.io \
+     --header "Content-Type: application/json" \
+     --data '{ 
+       "query": "query { chainIdentifier }"
+     }'
+```
+
 ## Query examples
 
 An extensive list of query examples is available in the Sui repository: https://github.com/MystenLabs/sui/tree/main/crates/sui-graphql-rpc/examples. 

--- a/docs/content/references/sui-api/beta-graph-ql.mdx
+++ b/docs/content/references/sui-api/beta-graph-ql.mdx
@@ -22,12 +22,20 @@ This instance runs the GraphQL IDE, an interactive IDE with autocomplete support
 
 The endpoint can also be queried using `curl` by passing the query to the call:
 ```shell
+# basic query
 curl -X POST https://graphql-beta.mainnet.sui.io \
      --header "Content-Type: application/json" \
      --data '{
-          "query": "query ($epochID: Int!) { epoch(id: $epochID) {referenceGasPrice} }", "variables": { "epochID": 123 } }
+          "query": "query { epoch {referenceGasPrice} }"
+     }'
+# query with variables
+curl -X POST https://graphql-beta.mainnet.sui.io \
+     --header "Content-Type: application/json" \
+     --data '{
+          "query": "query ($epochID: Int!) { epoch(id: $epochID) {referenceGasPrice} }", "variables": { "epochID": 123 } 
      }'
 ```
+
 
 ## Query examples
 

--- a/docs/content/references/sui-api/beta-graph-ql.mdx
+++ b/docs/content/references/sui-api/beta-graph-ql.mdx
@@ -32,7 +32,7 @@ curl -X POST https://graphql-beta.mainnet.sui.io \
 curl -X POST https://graphql-beta.mainnet.sui.io \
      --header "Content-Type: application/json" \
      --data '{
-          "query": "query ($epochID: Int!) { epoch(id: $epochID) {referenceGasPrice} }", "variables": { "epochID": 123 } 
+          "query": "query ($epochID: Int!) { epoch(id: $epochID) { referenceGasPrice } }", "variables": { "epochID": 123 } 
      }'
 ```
 

--- a/docs/content/references/sui-api/beta-graph-ql.mdx
+++ b/docs/content/references/sui-api/beta-graph-ql.mdx
@@ -26,7 +26,7 @@ The endpoint can also be queried using `curl` by passing the query to the call:
 curl -X POST https://graphql-beta.mainnet.sui.io \
      --header "Content-Type: application/json" \
      --data '{
-          "query": "query { epoch {referenceGasPrice} }"
+          "query": "query { epoch { referenceGasPrice } }"
      }'
 # query with variables
 curl -X POST https://graphql-beta.mainnet.sui.io \


### PR DESCRIPTION
## Description 

Adds a brief paragraph in the GraphQL page in our docs website showing how to query the GraphQL instance through `curl`.  

## Test Plan 

Made sure the `curl` command works. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improved the GraphQL docs by adding a short paragraph on how to use `curl` to query the GraphQL service.