### PR TITLE
[graphql/rpc] add IDE title setting

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -18,6 +18,8 @@ const MAX_QUERY_FRAGMENTS: u32 = 50;
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
 
+const DEFAULT_IDE_TITLE: &str = "Sui GraphQL IDE";
+
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 pub struct ConnectionConfig {
@@ -57,6 +59,21 @@ pub struct Limits {
     pub(crate) max_query_fragments: u32,
     #[serde(default)]
     pub(crate) request_timeout_ms: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Ide {
+    #[serde(default)]
+    pub(crate) ide_title: String,
+}
+
+impl Default for Ide {
+    fn default() -> Self {
+        Self {
+            ide_title: DEFAULT_IDE_TITLE.to_string(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -218,6 +235,8 @@ pub struct ServerConfig {
     pub internal_features: InternalFeatureConfig,
     #[serde(default)]
     pub name_service: NameServiceConfig,
+    #[serde(default)]
+    pub ide: Ide,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Description 

Allows setting the the title of the IDE, which makes it easier to distinguish different envs esp for demo servers.


<img width="167" alt="Screenshot 2023-11-06 at 12 20 31" src="https://github.com/MystenLabs/sui/assets/93547199/a937530d-b809-4b3f-8022-db398817df93">

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
