### PR TITLE
Revert unwrapped and deleted tombstones during tx revert

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/mod.rs
+++ b/crates/sui-analytics-indexer/src/handlers/mod.rs
@@ -128,11 +128,9 @@ impl ObjectStatusTracker {
             .map(|(obj_ref, _)| obj_ref.0)
             .collect();
         let deleted: BTreeSet<ObjectID> = effects
-            .deleted()
-            .iter()
-            .chain(effects.unwrapped_then_deleted().iter())
-            .chain(effects.wrapped().iter())
-            .map(|obj_ref| obj_ref.0)
+            .all_tombstones()
+            .into_iter()
+            .map(|(id, _)| id)
             .collect();
         Self {
             created,

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -118,14 +118,9 @@ impl AuthorityStorePruner {
             }
 
             if enable_pruning_tombstones {
-                for deleted_object_ref in effects
-                    .deleted()
-                    .into_iter()
-                    .chain(effects.unwrapped_then_deleted().into_iter())
-                    .chain(effects.wrapped().into_iter())
-                {
+                for deleted_object_key in effects.all_tombstones() {
                     object_tombstones_to_prune
-                        .push(ObjectKey(deleted_object_ref.0, deleted_object_ref.1));
+                        .push(ObjectKey(deleted_object_key.0, deleted_object_key.1));
                 }
             }
         }

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -269,6 +269,17 @@ impl TransactionEffects {
             .collect()
     }
 
+    /// Returns all objects that will become a tombstone after this transaction.
+    /// This includes deleted, unwrapped_then_deleted and wrapped objects.
+    pub fn all_tombstones(&self) -> Vec<(ObjectID, SequenceNumber)> {
+        self.deleted()
+            .into_iter()
+            .chain(self.unwrapped_then_deleted())
+            .chain(self.wrapped())
+            .map(|obj_ref| (obj_ref.0, obj_ref.1))
+            .collect()
+    }
+
     /// Return an iterator of mutated objects, but excluding the gas object.
     pub fn mutated_excluding_gas(&self) -> Vec<(ObjectRef, Owner)> {
         self.mutated()


### PR DESCRIPTION
## Description 

Added a new API to effects to return all tombstones.
Revert all tombstones during transaction revert.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
