### PR TITLE
[graphql] implement dynamicFieldsConnection

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -37,7 +37,8 @@
 #### &emsp;&emsp;[Filter Owner](#655351)
 #### &emsp;&emsp;[Object Connection](#655352)
 ### [Owner](#11)
-#### &emsp;&emsp;[Owner](#720885)
+#### &emsp;&emsp;[Dynamic Field Connection](#720885)
+#### &emsp;&emsp;[Owner](#720886)
 ### [Protocol Configs](#12)
 #### &emsp;&emsp;[Key Value](#786420)
 #### &emsp;&emsp;[Key Value Feature Flag](#786421)
@@ -838,6 +839,58 @@
 ## <a id=11></a>
 ## Owner
 ### <a id=720885></a>
+### Dynamic Field Connection
+####  defines a fragment for selecting fields from value matching either MoveValue or MoveObject
+####  a query that selects the name and value of the first dynamic field of the owner address
+
+><pre># defines a fragment for selecting fields from value matching either MoveValue or MoveObject
+>fragment DynamicFieldValueSelection on DynamicFieldValue {
+>  ... on MoveValue {
+>    type {
+>      repr
+>    }
+>    data
+>  }
+>  ... on MoveObject {
+>    hasPublicTransfer
+>    contents {
+>      type {
+>        repr
+>      }
+>      data
+>    }
+>  }
+>}
+>
+># a query that selects the name and value of the first dynamic field of the owner address
+>query DynamicFieldValue {
+>  owner(
+>    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
+>  ) {
+>    dynamicFieldConnection(first:1){
+>      pageInfo {
+>        hasNextPage
+>        endCursor
+>      }
+>      edges {
+>        cursor
+>        node {
+>          name {
+>            type {
+>              repr
+>            }
+>            data
+>          }
+>          value {
+>            ...DynamicFieldValueSelection
+>          }
+>        }
+>      }
+>    }
+>  }
+>}</pre>
+
+### <a id=720886></a>
 ### Owner
 
 ><pre>{

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
@@ -1,0 +1,46 @@
+# defines a fragment for selecting fields from value matching either MoveValue or MoveObject
+fragment DynamicFieldValueSelection on DynamicFieldValue {
+  ... on MoveValue {
+    type {
+      repr
+    }
+    data
+  }
+  ... on MoveObject {
+    hasPublicTransfer
+    contents {
+      type {
+        repr
+      }
+      data
+    }
+  }
+}
+
+# a query that selects the name and value of the first dynamic field of the owner address
+query DynamicFieldValue {
+  owner(
+    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
+  ) {
+    dynamicFieldConnection(first:1){
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          name {
+            type {
+              repr
+            }
+            data
+          }
+          value {
+            ...DynamicFieldValueSelection
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -587,6 +587,10 @@ type MoveTypeSignature =
         typeParameters: [MoveTypeSignature],
       }
     }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 70eac4c07c ([GraphQL] MoveType and MoveTypeSignature)
 """
 scalar MoveTypeSignature
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -14,6 +14,7 @@ type Address implements ObjectOwner {
 	"""
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 enum AddressTransactionBlockRelationship {
@@ -224,6 +225,42 @@ type ConsensusCommitPrologueTransaction {
 }
 
 scalar DateTime
+
+type DynamicField {
+	name: MoveValue
+	value: DynamicFieldValue
+}
+
+type DynamicFieldConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [DynamicFieldEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [DynamicField!]!
+}
+
+"""
+An edge in a connection.
+"""
+type DynamicFieldEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DynamicField!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+union DynamicFieldValue = MoveObject | MoveValue
 
 type EndOfEpochData {
 	newCommittee: [CommitteeMember!]
@@ -587,10 +624,6 @@ type MoveTypeSignature =
         typeParameters: [MoveTypeSignature],
       }
     }
-<<<<<<< HEAD
-=======
-
->>>>>>> 70eac4c07c ([GraphQL] MoveType and MoveTypeSignature)
 """
 scalar MoveTypeSignature
 
@@ -682,6 +715,7 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 type ObjectChange {
@@ -749,6 +783,7 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 type Owner implements ObjectOwner {
@@ -764,6 +799,7 @@ type Owner implements ObjectOwner {
 	"""
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 """

--- a/crates/sui-graphql-rpc/src/context_data/package_cache.rs
+++ b/crates/sui-graphql-rpc/src/context_data/package_cache.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use lru::LruCache;
 use move_binary_format::{
     access::ModuleAccess,

--- a/crates/sui-graphql-rpc/src/context_data/package_cache.rs
+++ b/crates/sui-graphql-rpc/src/context_data/package_cache.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use lru::LruCache;
 use move_binary_format::{
     access::ModuleAccess,

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -63,6 +63,8 @@ pub(crate) fn graphql_error_at_pos(
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("This query is unavailable through address. Please try again with the object or owner type.")]
+    DynamicFieldOnAddress,
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),
     #[error("Invalid filter option or value provided")]
@@ -96,7 +98,8 @@ pub enum Error {
 impl ErrorExtensions for Error {
     fn extend(&self) -> async_graphql::Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            Error::InvalidFilter
+            Error::DynamicFieldOnAddress
+            | Error::InvalidFilter
             | Error::ProtocolVersionUnsupported { .. }
             | Error::DomainParse(_)
             | Error::DbValidation(_)

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -145,7 +145,6 @@ mod tests {
             ("Checkpoint", "addressMetrics"),
             ("Epoch", "protocolConfig"),
             ("Object", "dynamicField"),
-            ("Object", "dynamicFieldConnection"),
             ("Query", "coinMetadata"),
             ("Query", "moveCallMetrics"),
             ("Query", "networkMetrics"),

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -4,11 +4,12 @@
 use async_graphql::{connection::Connection, *};
 use sui_json_rpc::name_service::NameServiceConfig;
 
-use crate::context_data::db_data_provider::PgManager;
+use crate::{context_data::db_data_provider::PgManager, error::Error};
 
 use super::{
     balance::Balance,
     coin::Coin,
+    dynamic_field::DynamicField,
     object::{Object, ObjectFilter},
     stake::Stake,
     sui_address::SuiAddress,
@@ -145,7 +146,6 @@ impl Address {
     // TODO disabled-for-rpc-1.5
     // pub async fn name_service_connection(
     //     &self,
-    //     ctx: &Context<'_>,
     //     first: Option<u64>,
     //     after: Option<String>,
     //     last: Option<u64>,
@@ -153,4 +153,14 @@ impl Address {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field_connection(
+        &self,
+        _first: Option<u64>,
+        _after: Option<String>,
+        _last: Option<u64>,
+        _before: Option<String>,
+    ) -> Result<Option<Connection<String, DynamicField>>, Error> {
+        Err(crate::error::Error::DynamicFieldOnAddress)
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_core_types::language_storage::StructTag;
+use move_core_types::value::{self, MoveStruct, MoveTypeLayout};
+use sui_indexer::models_v2::objects::StoredObject;
+use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::{dynamic_field::DynamicFieldType, TypeTag};
+
+use super::{
+    base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
+};
+use crate::context_data::package_cache::PackageCache;
+use crate::error::{code, Error};
+use crate::{context_data::db_data_provider::PgManager, error::graphql_error};
+use sui_types::object::Object as NativeSuiObject;
+
+pub(crate) struct DynamicField {
+    pub stored_object: StoredObject,
+    pub df_object_id: SuiAddress,
+    pub df_kind: DynamicFieldType,
+}
+
+#[derive(Union)]
+pub(crate) enum DynamicFieldValue {
+    MoveObject(MoveObject), // DynamicObject
+    MoveValue(MoveValue),   // DynamicField
+}
+
+#[derive(InputObject)] // used as input object
+pub(crate) struct DynamicFieldName {
+    pub type_: String,
+    pub bcs: Base64,
+}
+
+#[Object]
+impl DynamicField {
+    async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
+        let cache: &PackageCache = ctx.data().map_err(|_| {
+            graphql_error(
+                code::INTERNAL_SERVER_ERROR,
+                "Unable to fetch Package Cache.",
+            )
+        })?;
+        let (struct_tag, move_struct) =
+            deserialize_move_struct(&self.stored_object.serialized_object, cache)
+                .await
+                .extend()?;
+
+        // Get TypeTag of the DynamicField name from StructTag of the MoveStruct
+        let type_tag = DynamicFieldInfo::try_extract_field_name(&struct_tag, &self.df_kind)
+            .map_err(|e| Error::Internal(e.to_string()).extend())?;
+        let undecorated: Option<value::MoveValue>;
+
+        let name_move_value = extract_field_from_move_struct(move_struct, "name")?;
+
+        if self.df_kind == DynamicFieldType::DynamicObject {
+            let inner_name_move_value = match name_move_value {
+                value::MoveValue::Struct(inner_struct) => {
+                    extract_field_from_move_struct(inner_struct, "name")
+                }
+                _ => Err(Error::Internal("Expected a wrapper struct".to_string()).extend()),
+            }?;
+            undecorated = Some(inner_name_move_value.undecorate());
+        } else {
+            undecorated = Some(name_move_value.undecorate());
+        }
+
+        let bcs = if let Some(ref undec) = undecorated {
+            bcs::to_bytes(undec)
+                .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")).extend())
+        } else {
+            Err(Error::Internal("No value to serialize".to_string()).extend())
+        }?;
+
+        Ok(Some(MoveValue::new(
+            type_tag.to_canonical_string(true),
+            Base64::from(bcs),
+        )))
+    }
+
+    async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
+        if self.df_kind == DynamicFieldType::DynamicObject {
+            let obj = ctx
+                .data_unchecked::<PgManager>()
+                .fetch_move_obj(self.df_object_id, None)
+                .await
+                .extend()?;
+            Ok(obj.map(DynamicFieldValue::MoveObject))
+        } else {
+            let cache: &PackageCache = ctx.data().map_err(|_| {
+                graphql_error(
+                    code::INTERNAL_SERVER_ERROR,
+                    "Unable to fetch Package Cache.",
+                )
+            })?;
+            let (struct_tag, move_struct) =
+                deserialize_move_struct(&self.stored_object.serialized_object, cache)
+                    .await
+                    .extend()?;
+
+            // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
+            let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
+                .map_err(|e| Error::Internal(e.to_string()).extend())?;
+            let value_move_value = extract_field_from_move_struct(move_struct, "value")?;
+            let undecorated = value_move_value.undecorate();
+            let bcs = bcs::to_bytes(&undecorated).map_err(|e| {
+                Error::Internal(format!("Failed to serialize object: {e}")).extend()
+            })?;
+            Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
+                type_tag.to_canonical_string(true),
+                Base64::from(bcs),
+            ))))
+        }
+    }
+}
+
+pub(crate) async fn deserialize_move_struct(
+    serialized_object: &[u8],
+    cache: &PackageCache,
+) -> Result<(StructTag, MoveStruct)> {
+    let native_object: NativeSuiObject = bcs::from_bytes(serialized_object)
+        .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")).extend())?;
+    let move_object = native_object.data.try_as_move().ok_or_else(|| {
+        Error::Internal("Failed to convert object into MoveObject".to_string()).extend()
+    })?;
+    let struct_tag = native_object
+        .data
+        .struct_tag()
+        .ok_or_else(|| Error::Internal("StructTag missing on object".to_string()).extend())?;
+    let contents = move_object.contents();
+    let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
+    let move_type_layout = cache.type_layout(type_tag.clone()).await?;
+    let move_struct = match move_type_layout {
+        MoveTypeLayout::Struct(move_struct_layout) => {
+            MoveStruct::simple_deserialize(contents, &move_struct_layout)
+        }
+        _ => Err(Error::Internal("Object is not a move struct".to_string()).extend())?,
+    }?;
+    Ok((struct_tag, move_struct))
+}
+
+pub fn extract_field_from_move_struct(
+    move_struct: MoveStruct,
+    field_name: &str,
+) -> Result<value::MoveValue> {
+    match move_struct {
+        MoveStruct::WithTypes { fields, .. } => {
+            fields.into_iter().find_map(|(id, value)| {
+                if id.to_string() == field_name {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
+        }
+        .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)).extend()),
+        _ => Err(Error::Internal("Unexpected Move struct type".to_string()).extend()),
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod committee_member;
 pub(crate) mod date_time;
 pub(crate) mod digest;
 pub(crate) mod display;
+pub(crate) mod dynamic_field;
 pub(crate) mod end_of_epoch_data;
 pub(crate) mod epoch;
 pub(crate) mod event;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -6,6 +6,7 @@ use sui_json_rpc::name_service::NameServiceConfig;
 
 use super::big_int::BigInt;
 use super::digest::Digest;
+use super::dynamic_field::DynamicField;
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::{
@@ -246,6 +247,20 @@ impl Object {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field_connection(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Option<Connection<String, DynamicField>>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_dynamic_fields(first, after, last, before, self.address)
+            .await
+            .extend()
+    }
 }
 
 impl From<&NativeSuiObject> for Object {

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::address::Address;
+use super::dynamic_field::DynamicField;
 use super::stake::Stake;
 use crate::context_data::db_data_provider::PgManager;
 use crate::types::balance::*;
@@ -65,6 +66,14 @@ use sui_json_rpc::name_service::NameServiceConfig;
     //     arg(name = "last", ty = "Option<u64>"),
     //     arg(name = "before", ty = "Option<String>")
     // )
+    field(
+        name = "dynamic_field_connection",
+        ty = "Option<Connection<String, DynamicField>>",
+        arg(name = "first", ty = "Option<u64>"),
+        arg(name = "after", ty = "Option<String>"),
+        arg(name = "last", ty = "Option<u64>"),
+        arg(name = "before", ty = "Option<String>"),
+    )
 )]
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) enum ObjectOwner {
@@ -187,4 +196,18 @@ impl Owner {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field_connection(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Option<Connection<String, DynamicField>>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_dynamic_fields(first, after, last, before, self.address)
+            .await
+            .extend()
+    }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -18,6 +18,7 @@ type Address implements ObjectOwner {
 	"""
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 enum AddressTransactionBlockRelationship {
@@ -228,6 +229,42 @@ type ConsensusCommitPrologueTransaction {
 }
 
 scalar DateTime
+
+type DynamicField {
+	name: MoveValue
+	value: DynamicFieldValue
+}
+
+type DynamicFieldConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [DynamicFieldEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [DynamicField!]!
+}
+
+"""
+An edge in a connection.
+"""
+type DynamicFieldEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DynamicField!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+union DynamicFieldValue = MoveObject | MoveValue
 
 type EndOfEpochData {
 	newCommittee: [CommitteeMember!]
@@ -682,6 +719,7 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 type ObjectChange {
@@ -749,6 +787,7 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 type Owner implements ObjectOwner {
@@ -764,6 +803,7 @@ type Owner implements ObjectOwner {
 	"""
 	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
 	defaultNameServiceName: String
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1328,3 +1328,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1328,4 +1328,3 @@ type ValidatorSet {
 schema {
 	query: Query
 }
-

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -309,6 +309,17 @@ impl MoveObjectType {
         }
     }
 
+    pub fn try_extract_field_value(&self) -> SuiResult<TypeTag> {
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
+                Err(SuiError::ObjectDeserializationError {
+                    error: "Error extracting dynamic object value from Coin object".to_string(),
+                })
+            }
+            MoveObjectType_::Other(s) => DynamicFieldInfo::try_extract_field_value(s),
+        }
+    }
+
     pub fn is(&self, s: &StructTag) -> bool {
         match &self.0 {
             MoveObjectType_::GasCoin => GasCoin::is_gas_coin(s),

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -139,6 +139,15 @@ impl DynamicFieldInfo {
         }
     }
 
+    pub fn try_extract_field_value(tag: &StructTag) -> SuiResult<TypeTag> {
+        match tag.type_params.last() {
+            Some(value_type) => Ok(value_type.clone()),
+            None => Err(SuiError::ObjectDeserializationError {
+                error: format!("Error extracting dynamic object value from object: {tag}"),
+            }),
+        }
+    }
+
     pub fn parse_move_object(
         move_struct: &MoveStruct,
     ) -> SuiResult<(MoveValue, DynamicFieldType, ObjectID)> {
@@ -189,7 +198,7 @@ impl DynamicFieldInfo {
     }
 }
 
-fn extract_field_from_move_struct<'a>(
+pub fn extract_field_from_move_struct<'a>(
     move_struct: &'a MoveStruct,
     field_name: &str,
 ) -> Option<&'a MoveValue> {


### PR DESCRIPTION
## Description 
Implements Dynamic Field, rendering just the K of DynamicField<K, V> when DynamicField.name is queried, or the V of DynamicField for dynamic fields, or the actual object if the dynamic field is an object

Dynamic field object:
<img width="1574" alt="Screenshot 2023-11-06 at 4 56 23 PM" src="https://github.com/MystenLabs/sui/assets/127570466/a039dcfe-fe91-438d-a5e9-d862311eabf5">
dynamic field
<img width="1566" alt="Screenshot 2023-11-06 at 4 56 05 PM" src="https://github.com/MystenLabs/sui/assets/127570466/2588c972-ab05-4e35-a75c-8cd984befd9b">

## Test Plan
---
Manual tests and existing tests ...

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
