### PR TITLE
[graphql] add timestamp for TransactionBlock

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1041,7 +1041,9 @@
 >    expiration {
 >      epochId
 >    }
->  	timestamp
+>    effects {
+>      timestamp
+>    }
 >  }
 >}</pre>
 

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -50,7 +50,8 @@
 ### [Sui System State Summary](#15)
 #### &emsp;&emsp;[Sui System State Summary](#983025)
 ### [Transaction Block](#16)
-#### &emsp;&emsp;[Transaction Block Kind](#1048560)
+#### &emsp;&emsp;[Transaction Block](#1048560)
+#### &emsp;&emsp;[Transaction Block Kind](#1048561)
 ### [Transaction Block Connection](#17)
 #### &emsp;&emsp;[Before After Checkpoint](#1114095)
 #### &emsp;&emsp;[Changed Object Filter](#1114096)
@@ -1010,6 +1011,41 @@
 ## <a id=16></a>
 ## Transaction Block
 ### <a id=1048560></a>
+### Transaction Block
+####  Get the data for a TransactionBlock by its digest
+
+><pre>{
+>  transactionBlock(digest: "HvTjk3ELg8gRofmB1GgrpLHBFeA53QKmUKGEuhuypezg") {
+>    sender {
+>      location
+>    }
+>    gasInput {
+>      gasSponsor {
+>        location
+>      }
+>      gasPayment {
+>        nodes {
+>          location
+>        }
+>      }
+>      gasPrice
+>      gasBudget
+>    }
+>    kind {
+>      __typename
+>    }
+>    signatures {
+>      base64Sig
+>    }
+>    digest
+>    expiration {
+>      epochId
+>    }
+>  	timestamp
+>  }
+>}</pre>
+
+### <a id=1048561></a>
 ### Transaction Block Kind
 
 ><pre>{

--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block.graphql
@@ -1,0 +1,31 @@
+# Get the data for a TransactionBlock by its digest
+{
+  transactionBlock(digest: "HvTjk3ELg8gRofmB1GgrpLHBFeA53QKmUKGEuhuypezg") {
+    sender {
+      location
+    }
+    gasInput {
+      gasSponsor {
+        location
+      }
+      gasPayment {
+        nodes {
+          location
+        }
+      }
+      gasPrice
+      gasBudget
+    }
+    kind {
+      __typename
+    }
+    signatures {
+      base64Sig
+    }
+    digest
+    expiration {
+      epochId
+    }
+  	timestamp
+  }
+}

--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block.graphql
@@ -26,6 +26,8 @@
     expiration {
       epochId
     }
-  	timestamp
+    effects {
+      timestamp
+    }
   }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1158,6 +1158,10 @@ type TransactionBlock {
 	"""
 	signatures: [TransactionSignature]
 	"""
+	UTC timestamp in milliseconds since epoch (1/1/1970)
+	"""
+	timestamp: DateTime
+	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1158,10 +1158,6 @@ type TransactionBlock {
 	"""
 	signatures: [TransactionSignature]
 	"""
-	UTC timestamp in milliseconds since epoch (1/1/1970)
-	"""
-	timestamp: DateTime
-	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain
 	"""
@@ -1208,6 +1204,12 @@ type TransactionBlockEffects {
 	errors: String
 	lamportVersion: Int
 	balanceChanges: [BalanceChange]
+	"""
+	UTC timestamp in milliseconds since epoch (1/1/1970)
+	representing the time when the checkpoint that contains
+	this transaction was created
+	"""
+	timestamp: DateTime
 	checkpoint: Checkpoint
 	dependencies: [TransactionBlock]
 	epoch: Epoch

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -721,7 +721,7 @@ type TransactionBlock {
   kind: TransactionBlockKind
   signatures: [TransactionSignature]
   effects: TransactionBlockEffects
-
+  timestamp: DateTime
   expiration: Epoch
 
   bcs: Base64

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -721,7 +721,7 @@ type TransactionBlock {
   kind: TransactionBlockKind
   signatures: [TransactionSignature]
   effects: TransactionBlockEffects
-  timestamp: DateTime
+
   expiration: Epoch
 
   bcs: Base64
@@ -840,7 +840,7 @@ type TransactionBlockEffects {
   objectReads: [Object]
   objectChanges: [ObjectChange]
   balanceChanges: [BalanceChange]
-
+  timestamp: DateTime
   epoch: Epoch
   checkpoint: Checkpoint
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1800,6 +1800,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
             epoch_id,
             kind: Some(kind),
             signatures: Some(signatures),
+            timestamp: DateTime::from_ms(tx.timestamp_ms),
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1758,6 +1758,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
 
         let balance_changes = tx.balance_changes;
         let object_changes = tx.object_changes;
+        let timestamp = DateTime::from_ms(tx.timestamp_ms);
         let effects = match SuiTransactionBlockEffects::try_from(effects) {
             Ok(effects) => {
                 let transaction_effects = TransactionBlockEffects::from_stored_transaction(
@@ -1766,6 +1767,7 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
                     object_changes,
                     &effects,
                     digest,
+                    timestamp,
                 );
                 transaction_effects.map_err(|e| Error::Internal(e.message))
             }
@@ -1800,7 +1802,6 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
             epoch_id,
             kind: Some(kind),
             signatures: Some(signatures),
-            timestamp: DateTime::from_ms(tx.timestamp_ms),
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -51,8 +51,6 @@ pub(crate) struct TransactionBlock {
     pub kind: Option<TransactionBlockKind>,
     /// A list of signatures of all signers, senders, and potentially the gas owner if this is a sponsored transaction.
     pub signatures: Option<Vec<Option<TransactionSignature>>>,
-    /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    pub timestamp: Option<DateTime>,
 }
 
 #[ComplexObject]
@@ -107,6 +105,10 @@ pub(crate) struct TransactionBlockEffects {
     // pub checkpoint: Option<Checkpoint>,
     #[graphql(skip)]
     checkpoint_seq_number: u64,
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    /// representing the time when the checkpoint that contains
+    /// this transaction was created
+    pub timestamp: Option<DateTime>,
 }
 
 impl TransactionBlockEffects {
@@ -116,6 +118,7 @@ impl TransactionBlockEffects {
         object_changes: Vec<Option<Vec<u8>>>,
         tx_effects: &SuiTransactionBlockEffects,
         tx_block_digest: Digest,
+        timestamp: Option<DateTime>,
     ) -> Result<Option<Self>> {
         let (status, errors) = match tx_effects.status() {
             SuiExecutionStatus::Success => (ExecutionStatus::Success, None),
@@ -140,6 +143,7 @@ impl TransactionBlockEffects {
             tx_block_digest,
             object_changes_as_bcs: object_changes,
             checkpoint_seq_number,
+            timestamp,
         }))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -9,6 +9,7 @@ use super::{
     base64::Base64,
     big_int::BigInt,
     checkpoint::Checkpoint,
+    date_time::DateTime,
     digest::Digest,
     epoch::Epoch,
     gas::{GasEffects, GasInput},
@@ -50,6 +51,8 @@ pub(crate) struct TransactionBlock {
     pub kind: Option<TransactionBlockKind>,
     /// A list of signatures of all signers, senders, and potentially the gas owner if this is a sponsored transaction.
     pub signatures: Option<Vec<Option<TransactionSignature>>>,
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    pub timestamp: Option<DateTime>,
 }
 
 #[ComplexObject]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1162,6 +1162,10 @@ type TransactionBlock {
 	"""
 	signatures: [TransactionSignature]
 	"""
+	UTC timestamp in milliseconds since epoch (1/1/1970)
+	"""
+	timestamp: DateTime
+	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1162,10 +1162,6 @@ type TransactionBlock {
 	"""
 	signatures: [TransactionSignature]
 	"""
-	UTC timestamp in milliseconds since epoch (1/1/1970)
-	"""
-	timestamp: DateTime
-	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain
 	"""
@@ -1212,6 +1208,12 @@ type TransactionBlockEffects {
 	errors: String
 	lamportVersion: Int
 	balanceChanges: [BalanceChange]
+	"""
+	UTC timestamp in milliseconds since epoch (1/1/1970)
+	representing the time when the checkpoint that contains
+	this transaction was created
+	"""
+	timestamp: DateTime
 	checkpoint: Checkpoint
 	dependencies: [TransactionBlock]
 	epoch: Epoch


### PR DESCRIPTION
## Description 

This PR adds the `timestamp` field for the `TransactionBlock` type. It also adds a corresponding example for querying a transaction block by its digest.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
