### PR TITLE
[graphql/docs/easy] update doc comments to reflect the Event's bcs is Base64 encoded

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -288,7 +288,7 @@ type Event {
 	"""
 	json: String
 	"""
-	Base58 encoded bcs bytes of the Move event
+	Base64 encoded bcs bytes of the Move event
 	"""
 	bcs: Base64
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -19,7 +19,7 @@ pub(crate) struct Event {
     pub timestamp: Option<DateTime>,
     /// JSON string representation of the event
     pub json: Option<String>,
-    /// Base58 encoded bcs bytes of the Move event
+    /// Base64 encoded bcs bytes of the Move event
     pub bcs: Option<Base64>,
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -292,7 +292,7 @@ type Event {
 	"""
 	json: String
 	"""
-	Base58 encoded bcs bytes of the Move event
+	Base64 encoded bcs bytes of the Move event
 	"""
 	bcs: Base64
 }


### PR DESCRIPTION
## Description 

This PR corrects the event's bcs field doc comment, as the field is encoded to Base64 and not Base58. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
