### PR TITLE
[mysticeti] wire in mysticeti client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=b0b567aacf2f0e9a95ba636c9ece80da510dcaf9#b0b567aacf2f0e9a95ba636c9ece80da510dcaf9"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=b0b567aacf2f0e9a95ba636c9ece80da510dcaf9#b0b567aacf2f0e9a95ba636c9ece80da510dcaf9"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,6 +5461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minibytes"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6#7741e308c148b296b9a56b1e9158dc6c752c1fa6"
+dependencies = [
+ "memmap2 0.7.1",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6431,7 +6440,41 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_yaml 0.9.21",
+ "tabled",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "zeroize",
+]
+
+[[package]]
+name = "mysticeti-core"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6#7741e308c148b296b9a56b1e9158dc6c752c1fa6"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bincode",
+ "blake2",
+ "crc32fast",
+ "digest 0.10.6",
+ "ed25519-consensus",
+ "eyre",
+ "futures",
+ "gettid",
+ "hex",
+ "hyper",
+ "libc",
+ "memmap2 0.7.1",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10362,7 +10405,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14293,7 +14336,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14347,7 +14390,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,15 +5461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minibytes"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6#7741e308c148b296b9a56b1e9158dc6c752c1fa6"
-dependencies = [
- "memmap2 0.7.1",
- "serde",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,41 +6431,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6)",
- "parking_lot 0.12.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_yaml 0.9.21",
- "tabled",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
- "zeroize",
-]
-
-[[package]]
-name = "mysticeti-core"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6#7741e308c148b296b9a56b1e9158dc6c752c1fa6"
-dependencies = [
- "async-trait",
- "axum",
- "bincode",
- "blake2",
- "crc32fast",
- "digest 0.10.6",
- "ed25519-consensus",
- "eyre",
- "futures",
- "gettid",
- "hex",
- "hyper",
- "libc",
- "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
+ "minibytes",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10362,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6)",
+ "mysticeti-core",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14336,7 +14293,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
+ "minibytes",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14390,7 +14347,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
+ "mysticeti-core",
  "named-lock",
  "nested",
  "newline-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e#315917edbc14186d5bc24328a93eaaccabea673e"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
 dependencies = [
  "async-trait",
  "axum",
@@ -6440,7 +6440,7 @@ dependencies = [
  "hyper",
  "libc",
  "memmap2 0.7.1",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6)",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
@@ -10405,7 +10405,7 @@ dependencies = [
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6)",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-executor",
@@ -14336,7 +14336,7 @@ dependencies = [
  "migrations_macros",
  "mime",
  "mime_guess",
- "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "minibytes 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
  "minimal-lexical",
  "miniz_oxide",
  "mio 0.7.14",
@@ -14390,7 +14390,7 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
- "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=315917edbc14186d5bc24328a93eaaccabea673e)",
+ "mysticeti-core 0.1.0 (git+https://github.com/MystenLabs/mysticeti?rev=7741e308c148b296b9a56b1e9158dc6c752c1fa6)",
  "named-lock",
  "nested",
  "newline-converter",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -332,6 +332,14 @@ impl NodeConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ConsensusProtocol {
+    #[serde(rename = "narwhal")]
+    Narwhal,
+    #[serde(rename = "mysticeti")]
+    Mysticeti,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsensusConfig {
     pub address: Multiaddr,
@@ -357,6 +365,11 @@ pub struct ConsensusConfig {
     pub submit_delay_step_override_millis: Option<u64>,
 
     pub narwhal_config: ConsensusParameters,
+
+    /// The choice of consensus protocol to run. We default to Narwhal.
+    #[serde(skip)]
+    #[serde(default = "default_consensus_protocol")]
+    pub protocol: ConsensusProtocol,
 }
 
 impl ConsensusConfig {
@@ -380,6 +393,10 @@ impl ConsensusConfig {
     pub fn narwhal_config(&self) -> &ConsensusParameters {
         &self.narwhal_config
     }
+}
+
+pub fn default_consensus_protocol() -> ConsensusProtocol {
+    ConsensusProtocol::Narwhal
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -88,9 +88,9 @@ impl AuthorityServer {
         consensus_address: Multiaddr,
     ) -> Self {
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Box::new(Arc::new(LazyNarwhalClient::new(consensus_address))),
+            Arc::new(LazyNarwhalClient::new(consensus_address)),
             state.name,
-            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,
             100_000,
             None,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -88,7 +88,7 @@ impl AuthorityServer {
         consensus_address: Multiaddr,
     ) -> Self {
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Box::new(LazyNarwhalClient::new(consensus_address)),
+            Box::new(Arc::new(LazyNarwhalClient::new(consensus_address))),
             state.name,
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
             100_000,

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -289,7 +289,7 @@ impl SubmitToConsensus for LazyNarwhalClient {
 /// Submit Sui certificates to the consensus.
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
-    consensus_client: Box<dyn SubmitToConsensus>,
+    consensus_client: Box<Arc<dyn SubmitToConsensus>>,
     /// Authority pubkey.
     authority: AuthorityName,
     /// The limit to number of inflight transactions at this node.
@@ -337,7 +337,7 @@ pub struct ConnectionMonitorStatusForTests {}
 impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
-        consensus_client: Box<dyn SubmitToConsensus>,
+        consensus_client: Box<Arc<dyn SubmitToConsensus>>,
         authority: AuthorityName,
         connection_monitor_status: Box<Arc<dyn CheckConnection>>,
         max_pending_transactions: usize,
@@ -1168,9 +1168,9 @@ mod adapter_tests {
 
         // When we define max submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
-            Box::new(LazyNarwhalClient::new(
+            Box::new(Arc::new(LazyNarwhalClient::new(
                 "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-            )),
+            ))),
             *committee.authority_by_index(0).unwrap(),
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
             100_000,
@@ -1200,9 +1200,9 @@ mod adapter_tests {
 
         // Without submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
-            Box::new(LazyNarwhalClient::new(
+            Box::new(Arc::new(LazyNarwhalClient::new(
                 "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-            )),
+            ))),
             *committee.authority_by_index(0).unwrap(),
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
             100_000,

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -289,7 +289,7 @@ impl SubmitToConsensus for LazyNarwhalClient {
 /// Submit Sui certificates to the consensus.
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
-    consensus_client: Box<Arc<dyn SubmitToConsensus>>,
+    consensus_client: Arc<dyn SubmitToConsensus>,
     /// Authority pubkey.
     authority: AuthorityName,
     /// The limit to number of inflight transactions at this node.
@@ -303,7 +303,7 @@ pub struct ConsensusAdapter {
     /// as delay step.
     submit_delay_step_override: Option<Duration>,
     /// A structure to check the connection statuses populated by the Connection Monitor Listener
-    connection_monitor_status: Box<Arc<dyn CheckConnection>>,
+    connection_monitor_status: Arc<dyn CheckConnection>,
     /// A structure to check the reputation scores populated by Consensus
     low_scoring_authorities: ArcSwap<Arc<ArcSwap<HashMap<AuthorityName, u64>>>>,
     /// The throughput profiler to be used when making decisions to submit to consensus
@@ -337,9 +337,9 @@ pub struct ConnectionMonitorStatusForTests {}
 impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
-        consensus_client: Box<Arc<dyn SubmitToConsensus>>,
+        consensus_client: Arc<dyn SubmitToConsensus>,
         authority: AuthorityName,
-        connection_monitor_status: Box<Arc<dyn CheckConnection>>,
+        connection_monitor_status: Arc<dyn CheckConnection>,
         max_pending_transactions: usize,
         max_pending_local_submissions: usize,
         max_submit_position: Option<usize>,
@@ -1168,11 +1168,11 @@ mod adapter_tests {
 
         // When we define max submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
-            Box::new(Arc::new(LazyNarwhalClient::new(
+            Arc::new(LazyNarwhalClient::new(
                 "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-            ))),
+            )),
             *committee.authority_by_index(0).unwrap(),
-            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,
             100_000,
             Some(1),
@@ -1200,11 +1200,11 @@ mod adapter_tests {
 
         // Without submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
-            Box::new(Arc::new(LazyNarwhalClient::new(
+            Arc::new(LazyNarwhalClient::new(
                 "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-            ))),
+            )),
             *committee.authority_by_index(0).unwrap(),
-            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,
             100_000,
             None,

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -5,6 +5,7 @@ use crate::consensus_handler::ConsensusHandlerInitializer;
 use crate::consensus_manager::mysticeti_manager::MysticetiManager;
 use crate::consensus_manager::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use crate::consensus_validator::SuiTxValidator;
+use crate::mysticeti_adapter::LazyMysticetiClient;
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::traits::KeyPair;
@@ -71,6 +72,24 @@ impl ConsensusManager {
         let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
 
         Self::Narwhal(NarwhalManager::new(narwhal_config, metrics))
+    }
+
+    pub fn new_mysticeti(
+        config: &NodeConfig,
+        consensus_config: &ConsensusConfig,
+        registry_service: &RegistryService,
+        client: Arc<LazyMysticetiClient>,
+    ) -> Self {
+        let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
+
+        Self::Mysticeti(MysticetiManager::new(
+            config.protocol_key_pair().copy(),
+            config.network_key_pair().copy(),
+            consensus_config.db_path().to_path_buf(),
+            metrics,
+            registry_service.clone(),
+            client,
+        ))
     }
 }
 

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -45,6 +45,9 @@ pub struct MysticetiManager {
         Validator<SimpleBlockHandler, SimpleCommitObserver>,
         RegistryID,
     )>,
+    // we use a shared lazy mysticeti client so we can update the internal mysticeti client that
+    // gets created for every new epoch.
+    client: Arc<LazyMysticetiClient>,
 }
 
 impl MysticetiManager {
@@ -54,6 +57,7 @@ impl MysticetiManager {
         storage_base_path: PathBuf,
         metrics: ConsensusManagerMetrics,
         registry_service: RegistryService,
+        client: Arc<LazyMysticetiClient>,
     ) -> MysticetiManager {
         Self {
             keypair,
@@ -63,6 +67,7 @@ impl MysticetiManager {
             metrics,
             registry_service,
             validator: ArcSwapOption::empty(),
+            client,
         }
     }
 
@@ -141,8 +146,8 @@ impl ConsensusManagerTrait for MysticetiManager {
                     self.validator
                         .swap(Some(Arc::new((validator, registry_id))));
 
-                    // create the client to send transactions to Mysticeti and update it
-                    LazyMysticetiClient::set(MysticetiClient::new(tx_sender));
+                    // create the client to send transactions to Mysticeti and update it.
+                    self.client.set(MysticetiClient::new(tx_sender));
 
                     break;
                 }

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -52,8 +52,10 @@ pub struct LazyMysticetiClient {
 }
 
 impl LazyMysticetiClient {
-    pub fn new(client: Arc<ArcSwapOption<MysticetiClient>>) -> Self {
-        Self { client }
+    pub fn new() -> Self {
+        Self {
+            client: Arc::new(ArcSwapOption::empty()),
+        }
     }
 
     async fn get(&self) -> Guard<Option<Arc<MysticetiClient>>> {

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -1,41 +1,34 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use arc_swap::{ArcSwapOption, Guard};
 use std::sync::Arc;
-
-use mysticeti_core::block_handler::BlockHandler;
-use mysticeti_core::minibytes;
-use mysticeti_core::types::{BaseStatement, StatementBlock};
+use std::time::Duration;
 
 use sui_types::error::{SuiError, SuiResult};
 use tap::prelude::*;
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::{sleep, timeout};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_adapter::SubmitToConsensus;
-use mysticeti_core::data::Data;
 use sui_types::messages_consensus::ConsensusTransaction;
 use tracing::warn;
 
+static LOCAL_MYSTICETI_CLIENT: ArcSwapOption<MysticetiClient> = ArcSwapOption::const_empty();
+
 #[derive(Clone)]
-pub struct SubmitToMysticeti {
+pub struct MysticetiClient {
     // channel to transport bcs-serialized bytes of ConsensusTransaction
     sender: mpsc::Sender<(Vec<u8>, oneshot::Sender<()>)>,
 }
 
-impl SubmitToMysticeti {
-    pub fn new(sender: mpsc::Sender<(Vec<u8>, oneshot::Sender<()>)>) -> SubmitToMysticeti {
-        SubmitToMysticeti { sender }
+impl MysticetiClient {
+    pub fn new(sender: mpsc::Sender<(Vec<u8>, oneshot::Sender<()>)>) -> MysticetiClient {
+        MysticetiClient { sender }
     }
-}
 
-#[async_trait::async_trait]
-impl SubmitToConsensus for SubmitToMysticeti {
-    async fn submit_to_consensus(
-        &self,
-        transaction: &ConsensusTransaction,
-        _epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult {
+    async fn submit_transaction(&self, transaction: &ConsensusTransaction) -> SuiResult {
         let (sender, receiver) = oneshot::channel();
         let tx_bytes = bcs::to_bytes(&transaction).expect("Serialization should not fail.");
         self.sender
@@ -51,71 +44,71 @@ impl SubmitToConsensus for SubmitToMysticeti {
     }
 }
 
-/// A simple BlockHandler that adds received transactions to consensus.
-pub struct SimpleBlockHandler {
-    receiver: mysten_metrics::metered_channel::Receiver<(Vec<u8>, oneshot::Sender<()>)>,
-}
+/// Basically a wrapper struct that reads from the LOCAL_MYSTICETI_CLIENT variable where the latest
+/// MysticetiClient is stored in order to communicate with Mysticeti. The LazyMysticetiClient is considered
+/// "lazy" only in the sense that we can't use it directly to submit to consensus unless the underlying
+/// local client is set first.
+#[derive(Default)]
+pub struct LazyMysticetiClient;
 
-const MAX_PROPOSED_PER_BLOCK: usize = 10000;
-const CHANNEL_SIZE: usize = 10240;
-
-impl SimpleBlockHandler {
-    #[allow(clippy::type_complexity)]
-    pub fn new() -> (
-        Self,
-        mysten_metrics::metered_channel::Sender<(Vec<u8>, oneshot::Sender<()>)>,
-    ) {
-        let (sender, receiver) = mysten_metrics::metered_channel::channel(
-            CHANNEL_SIZE,
-            &mysten_metrics::get_metrics()
-                .unwrap()
-                .channels
-                .with_label_values(&["simple_block_handler"]),
-        );
-
-        let this = Self { receiver };
-        (this, sender)
-    }
-}
-
-impl BlockHandler for SimpleBlockHandler {
-    fn handle_blocks(
-        &mut self,
-        _blocks: &[Data<StatementBlock>],
-        require_response: bool,
-    ) -> Vec<BaseStatement> {
-        if !require_response {
-            return vec![];
+impl LazyMysticetiClient {
+    async fn get(&self) -> Guard<Option<Arc<MysticetiClient>>> {
+        let client = LOCAL_MYSTICETI_CLIENT.load();
+        if client.is_some() {
+            return client;
         }
 
-        // Returns transactions to be sequenced so that they will be
-        // proposed to DAG shortly.
-        let mut response = vec![];
-
-        while let Ok((tx_bytes, notify_when_done)) = self.receiver.try_recv() {
-            response.push(BaseStatement::Share(
-                // tx_bytes is bcs-serialized bytes of ConsensusTransaction
-                mysticeti_core::types::Transaction::new(tx_bytes),
-            ));
-            // We don't mind if the receiver is dropped.
-            let _ = notify_when_done.send(());
-
-            if response.len() >= MAX_PROPOSED_PER_BLOCK {
-                break;
+        // We expect this to get called during the SUI process start. After that at least one
+        // object will have initialised and won't need to call again.
+        const MYSTICETI_START_TIMEOUT: Duration = Duration::from_secs(30);
+        const LOAD_RETRY_TIMEOUT: Duration = Duration::from_millis(100);
+        if let Ok(client) = timeout(MYSTICETI_START_TIMEOUT, async {
+            loop {
+                let client = LOCAL_MYSTICETI_CLIENT.load();
+                if client.is_some() {
+                    return client;
+                } else {
+                    sleep(LOAD_RETRY_TIMEOUT).await;
+                }
             }
+        })
+        .await
+        {
+            return client;
         }
-        response
+
+        panic!(
+            "Timed out after {:?} waiting for Mysticeti to start!",
+            MYSTICETI_START_TIMEOUT,
+        );
     }
 
-    fn handle_proposal(&mut self, _block: &Data<StatementBlock>) {}
-
-    // No crash recovery at the moment.
-    fn state(&self) -> minibytes::Bytes {
-        minibytes::Bytes::new()
+    // Helper method to replace the mysticeti client with a new one to support the new epoch.
+    pub fn set(submit: MysticetiClient) {
+        LOCAL_MYSTICETI_CLIENT.store(Some(Arc::new(submit)));
     }
+}
 
-    // No crash recovery at the moment.
-    fn recover_state(&mut self, _state: &minibytes::Bytes) {}
-
-    fn cleanup(&self) {}
+#[async_trait::async_trait]
+impl SubmitToConsensus for LazyMysticetiClient {
+    async fn submit_to_consensus(
+        &self,
+        transaction: &ConsensusTransaction,
+        _epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        // The retrieved MysticetiClient can be from the past epoch. Submit would fail after
+        // Mysticeti shuts down, so there should be no correctness issue.
+        let client = self.get().await;
+        client
+            .as_ref()
+            .expect("Client should always be returned")
+            .submit_transaction(transaction)
+            .await
+            .map_err(|e| SuiError::FailedToSubmitToConsensus(format!("{:?}", e)))
+            .tap_err(|r| {
+                // Will be logged by caller as well.
+                warn!("Submit transaction failed with: {:?}", r);
+            })?;
+        Ok(())
+    }
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -136,9 +136,9 @@ async fn submit_transaction_to_consensus_adapter() {
     }
     // Make a new consensus adapter instance.
     let adapter = Arc::new(ConsensusAdapter::new(
-        Box::new(Arc::new(SubmitDirectly(state.clone()))),
+        Arc::new(SubmitDirectly(state.clone())),
         state.name,
-        Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+        Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,
         100_000,
         None,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -136,7 +136,7 @@ async fn submit_transaction_to_consensus_adapter() {
     }
     // Make a new consensus adapter instance.
     let adapter = Arc::new(ConsensusAdapter::new(
-        Box::new(SubmitDirectly(state.clone())),
+        Box::new(Arc::new(SubmitDirectly(state.clone()))),
         state.name,
         Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
         100_000,

--- a/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -9,6 +9,8 @@ use crate::consensus_manager::narwhal_manager::narwhal_manager_tests::checkpoint
 use crate::consensus_manager::ConsensusManagerMetrics;
 use crate::consensus_manager::ConsensusManagerTrait;
 use crate::consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics};
+use crate::mysticeti_adapter::LazyMysticetiClient;
+use arc_swap::ArcSwapOption;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
@@ -39,6 +41,7 @@ async fn test_mysticeti_manager() {
 
         let metrics = ConsensusManagerMetrics::new(&Registry::new());
         let epoch_store = state.epoch_store_for_testing();
+        let client = Arc::new(LazyMysticetiClient::new(Arc::new(ArcSwapOption::empty())));
 
         let manager = MysticetiManager::new(
             config.protocol_key_pair().copy(),
@@ -46,6 +49,7 @@ async fn test_mysticeti_manager() {
             consensus_config.db_path().to_path_buf(),
             metrics,
             registry_service,
+            client,
         );
 
         let consensus_handler_initializer = ConsensusHandlerInitializer::new_for_testing(

--- a/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -10,7 +10,6 @@ use crate::consensus_manager::ConsensusManagerMetrics;
 use crate::consensus_manager::ConsensusManagerTrait;
 use crate::consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics};
 use crate::mysticeti_adapter::LazyMysticetiClient;
-use arc_swap::ArcSwapOption;
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
@@ -41,7 +40,7 @@ async fn test_mysticeti_manager() {
 
         let metrics = ConsensusManagerMetrics::new(&Registry::new());
         let epoch_store = state.epoch_store_for_testing();
-        let client = Arc::new(LazyMysticetiClient::new(Arc::new(ArcSwapOption::empty())));
+        let client = Arc::new(LazyMysticetiClient::default());
 
         let manager = MysticetiManager::new(
             config.protocol_key_pair().copy(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1190,11 +1190,11 @@ impl SuiNode {
         // The consensus adapter allows the authority to send user certificates through consensus.
 
         ConsensusAdapter::new(
-            Box::new(Arc::new(LazyNarwhalClient::new(
+            Arc::new(LazyNarwhalClient::new(
                 consensus_config.address().to_owned(),
-            ))),
+            )),
             authority,
-            Box::new(connection_monitor_status),
+            connection_monitor_status,
             consensus_config.max_pending_transactions(),
             consensus_config.max_pending_transactions() * 2 / committee.num_members(),
             consensus_config.max_submit_position,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1190,9 +1190,9 @@ impl SuiNode {
         // The consensus adapter allows the authority to send user certificates through consensus.
 
         ConsensusAdapter::new(
-            Box::new(LazyNarwhalClient::new(
+            Box::new(Arc::new(LazyNarwhalClient::new(
                 consensus_config.address().to_owned(),
-            )),
+            ))),
             authority,
             Box::new(connection_monitor_status),
             consensus_config.max_pending_transactions(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -23,7 +23,7 @@ use fastcrypto_zkp::bn254::zk_login::OIDCProvider;
 use futures::TryFutureExt;
 use prometheus::Registry;
 use sui_core::authority::CHAIN_IDENTIFIER;
-use sui_core::consensus_adapter::LazyNarwhalClient;
+use sui_core::consensus_adapter::{LazyNarwhalClient, SubmitToConsensus};
 use sui_json_rpc::api::JsonRpcMetrics;
 use sui_types::authenticator_state::get_authenticator_state_obj_initial_shared_version;
 use sui_types::digests::ChainIdentifier;
@@ -48,7 +48,7 @@ use narwhal_network::metrics::MetricsMakeCallbackHandler;
 use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_archival::writer::ArchiveWriter;
-use sui_config::node::DBCheckpointConfig;
+use sui_config::node::{ConsensusProtocol, DBCheckpointConfig};
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::{ConsensusConfig, NodeConfig};
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -197,6 +197,7 @@ use simulator::*;
 #[cfg(msim)]
 pub use simulator::set_jwk_injector;
 use sui_core::consensus_handler::ConsensusHandlerInitializer;
+use sui_core::mysticeti_adapter::LazyMysticetiClient;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -992,16 +993,44 @@ impl SuiNode {
             .consensus_config()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
 
-        let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
-            &committee,
-            consensus_config,
-            state.name,
-            connection_monitor_status.clone(),
-            &registry_service.default_registry(),
-            epoch_store.protocol_config().clone(),
-        ));
-        let consensus_manager =
-            ConsensusManager::new_narwhal(config, consensus_config, registry_service);
+        let (consensus_adapter, consensus_manager) = match consensus_config.protocol {
+            ConsensusProtocol::Narwhal => {
+                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+                    &committee,
+                    consensus_config,
+                    state.name,
+                    connection_monitor_status.clone(),
+                    &registry_service.default_registry(),
+                    epoch_store.protocol_config().clone(),
+                    Arc::new(LazyNarwhalClient::new(
+                        consensus_config.address().to_owned(),
+                    )),
+                ));
+                let consensus_manager =
+                    ConsensusManager::new_narwhal(config, consensus_config, registry_service);
+                (consensus_adapter, consensus_manager)
+            }
+            ConsensusProtocol::Mysticeti => {
+                let client = Arc::new(LazyMysticetiClient::new());
+
+                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+                    &committee,
+                    consensus_config,
+                    state.name,
+                    connection_monitor_status.clone(),
+                    &registry_service.default_registry(),
+                    epoch_store.protocol_config().clone(),
+                    client.clone(),
+                ));
+                let consensus_manager = ConsensusManager::new_mysticeti(
+                    config,
+                    consensus_config,
+                    registry_service,
+                    client,
+                );
+                (consensus_adapter, consensus_manager)
+            }
+        };
 
         let mut consensus_epoch_data_remover =
             EpochDataRemover::new(consensus_manager.get_storage_base_path());
@@ -1185,14 +1214,13 @@ impl SuiNode {
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         prometheus_registry: &Registry,
         protocol_config: ProtocolConfig,
+        consensus_client: Arc<dyn SubmitToConsensus>,
     ) -> ConsensusAdapter {
         let ca_metrics = ConsensusAdapterMetrics::new(prometheus_registry);
         // The consensus adapter allows the authority to send user certificates through consensus.
 
         ConsensusAdapter::new(
-            Arc::new(LazyNarwhalClient::new(
-                consensus_config.address().to_owned(),
-            )),
+            consensus_client,
             authority,
             connection_monitor_status,
             consensus_config.max_pending_transactions(),

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -62,7 +62,10 @@ impl SingleValidator {
             _ => ConsensusMode::Noop,
         };
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Box::new(MockConsensusClient::new(validator.clone(), consensus_mode)),
+            Box::new(Arc::new(MockConsensusClient::new(
+                validator.clone(),
+                consensus_mode,
+            ))),
             validator.name,
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
             100_000,

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -62,12 +62,9 @@ impl SingleValidator {
             _ => ConsensusMode::Noop,
         };
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Box::new(Arc::new(MockConsensusClient::new(
-                validator.clone(),
-                consensus_mode,
-            ))),
+            Arc::new(MockConsensusClient::new(validator.clone(), consensus_mode)),
             validator.name,
-            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,
             100_000,
             None,

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -9,13 +9,13 @@ use narwhal_config::{NetworkAdminServerParameters, PrometheusMetricsParameters};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
-use sui_config::node::default_zklogin_oauth_providers;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
     AuthorityKeyPairWithPath, AuthorityStorePruningConfig, DBCheckpointConfig,
     ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath, StateArchiveConfig, StateSnapshotConfig,
     DEFAULT_GRPC_CONCURRENCY_LIMIT,
 };
+use sui_config::node::{default_zklogin_oauth_providers, ConsensusProtocol};
 use sui_config::p2p::{P2pConfig, SeedPeer};
 use sui_config::{
     local_ip_utils, ConsensusConfig, NodeConfig, AUTHORITIES_DB_NAME, CONSENSUS_DB_NAME,
@@ -90,6 +90,7 @@ impl ValidatorConfigBuilder {
             max_pending_transactions: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            protocol: ConsensusProtocol::Narwhal,
             narwhal_config: narwhal_config::Parameters {
                 network_admin_server: NetworkAdminServerParameters {
                     primary_network_admin_server_port: local_ip_utils::get_available_port(

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "315917edbc14186d5bc24328a93eaaccabea673e", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "7741e308c148b296b9a56b1e9158dc6c752c1fa6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Description 

This PR:
* introducing the `LazyMysticetiClient` to be used on the `consensus_adapter`
* Sharing the `LazyMysticetiClient` between the consensus adapter and the mysticeti manager to directly update the underneath client `MysticetiClient` on every epoch change. That was preferred to the global variable approach as it's more straightforward when needing to spin up programmatically multiple sui nodes.
* `SimpleBlockHandler` moved to `Mysticeti` as it was finally proved to be more convenient that way
* is updating the mysticeti ref

Next:

- [ ] [wire mysticeti consensus handler & boot consensus protocol based on property](https://github.com/MystenLabs/sui/pull/14699)

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
