### PR TITLE
[mysticeti] wire mysticeti consensus handler & boot consensus protocol based on property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=835bd1f150e92ed4dd124701a6a25f040f7dd2c6#835bd1f150e92ed4dd124701a6a25f040f7dd2c6"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=331d89344f59fc9e0015c128887047d78cb666e6#331d89344f59fc9e0015c128887047d78cb666e6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=835bd1f150e92ed4dd124701a6a25f040f7dd2c6#835bd1f150e92ed4dd124701a6a25f040f7dd2c6"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=835bd1f150e92ed4dd124701a6a25f040f7dd2c6#835bd1f150e92ed4dd124701a6a25f040f7dd2c6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=b0b567aacf2f0e9a95ba636c9ece80da510dcaf9#b0b567aacf2f0e9a95ba636c9ece80da510dcaf9"
 dependencies = [
  "memmap2 0.7.1",
  "serde",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "mysticeti-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysticeti?rev=835bd1f150e92ed4dd124701a6a25f040f7dd2c6#835bd1f150e92ed4dd124701a6a25f040f7dd2c6"
+source = "git+https://github.com/MystenLabs/mysticeti?rev=b0b567aacf2f0e9a95ba636c9ece80da510dcaf9#b0b567aacf2f0e9a95ba636c9ece80da510dcaf9"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -367,6 +367,7 @@ pub struct ConsensusConfig {
     pub narwhal_config: ConsensusParameters,
 
     /// The choice of consensus protocol to run. We default to Narwhal.
+    #[serde(skip)]
     #[serde(default = "default_consensus_protocol")]
     pub protocol: ConsensusProtocol,
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -332,6 +332,14 @@ impl NodeConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum ConsensusProtocol {
+    #[serde(rename = "narwhal")]
+    Narwhal,
+    #[serde(rename = "mysticeti")]
+    Mysticeti,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsensusConfig {
     pub address: Multiaddr,
@@ -357,6 +365,10 @@ pub struct ConsensusConfig {
     pub submit_delay_step_override_millis: Option<u64>,
 
     pub narwhal_config: ConsensusParameters,
+
+    /// The choice of consensus protocol to run. We default to Narwhal.
+    #[serde(default = "default_consensus_protocol")]
+    pub protocol: ConsensusProtocol,
 }
 
 impl ConsensusConfig {
@@ -380,6 +392,10 @@ impl ConsensusConfig {
     pub fn narwhal_config(&self) -> &ConsensusParameters {
         &self.narwhal_config
     }
+}
+
+pub fn default_consensus_protocol() -> ConsensusProtocol {
+    ConsensusProtocol::Narwhal
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -82,7 +82,7 @@ sui-storage.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
 zeroize.workspace = true
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6" }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6" }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -5,6 +5,7 @@ use crate::consensus_handler::ConsensusHandlerInitializer;
 use crate::consensus_manager::mysticeti_manager::MysticetiManager;
 use crate::consensus_manager::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use crate::consensus_validator::SuiTxValidator;
+use crate::mysticeti_adapter::LazyMysticetiClient;
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::traits::KeyPair;
@@ -71,6 +72,24 @@ impl ConsensusManager {
         let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
 
         Self::Narwhal(NarwhalManager::new(narwhal_config, metrics))
+    }
+
+    pub fn new_mysticeti(
+        config: &NodeConfig,
+        consensus_config: &ConsensusConfig,
+        registry_service: &RegistryService,
+        client: Arc<LazyMysticetiClient>,
+    ) -> Self {
+        let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
+
+        Self::Mysticeti(MysticetiManager::new(
+            config.protocol_key_pair().copy(),
+            config.network_key_pair().copy(),
+            consensus_config.db_path().to_path_buf(),
+            metrics,
+            registry_service.clone(),
+            client,
+        ))
     }
 }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -23,7 +23,7 @@ use fastcrypto_zkp::bn254::zk_login::OIDCProvider;
 use futures::TryFutureExt;
 use prometheus::Registry;
 use sui_core::authority::CHAIN_IDENTIFIER;
-use sui_core::consensus_adapter::LazyNarwhalClient;
+use sui_core::consensus_adapter::{LazyNarwhalClient, SubmitToConsensus};
 use sui_json_rpc::api::JsonRpcMetrics;
 use sui_types::authenticator_state::get_authenticator_state_obj_initial_shared_version;
 use sui_types::digests::ChainIdentifier;
@@ -48,7 +48,7 @@ use narwhal_network::metrics::MetricsMakeCallbackHandler;
 use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_archival::writer::ArchiveWriter;
-use sui_config::node::DBCheckpointConfig;
+use sui_config::node::{ConsensusProtocol, DBCheckpointConfig};
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::{ConsensusConfig, NodeConfig};
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -197,6 +197,7 @@ use simulator::*;
 #[cfg(msim)]
 pub use simulator::set_jwk_injector;
 use sui_core::consensus_handler::ConsensusHandlerInitializer;
+use sui_core::mysticeti_adapter::LazyMysticetiClient;
 
 pub struct SuiNode {
     config: NodeConfig,
@@ -992,16 +993,44 @@ impl SuiNode {
             .consensus_config()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
 
-        let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
-            &committee,
-            consensus_config,
-            state.name,
-            connection_monitor_status.clone(),
-            &registry_service.default_registry(),
-            epoch_store.protocol_config().clone(),
-        ));
-        let consensus_manager =
-            ConsensusManager::new_narwhal(config, consensus_config, registry_service);
+        let (consensus_adapter, consensus_manager) = match consensus_config.protocol {
+            ConsensusProtocol::Narwhal => {
+                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+                    &committee,
+                    consensus_config,
+                    state.name,
+                    connection_monitor_status.clone(),
+                    &registry_service.default_registry(),
+                    epoch_store.protocol_config().clone(),
+                    Arc::new(LazyNarwhalClient::new(
+                        consensus_config.address().to_owned(),
+                    )),
+                ));
+                let consensus_manager =
+                    ConsensusManager::new_narwhal(config, consensus_config, registry_service);
+                (consensus_adapter, consensus_manager)
+            }
+            ConsensusProtocol::Mysticeti => {
+                let client = Arc::new(LazyMysticetiClient::new());
+
+                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+                    &committee,
+                    consensus_config,
+                    state.name,
+                    connection_monitor_status.clone(),
+                    &registry_service.default_registry(),
+                    epoch_store.protocol_config().clone(),
+                    client.clone(),
+                ));
+                let consensus_manager = ConsensusManager::new_mysticeti(
+                    config,
+                    consensus_config,
+                    registry_service,
+                    client,
+                );
+                (consensus_adapter, consensus_manager)
+            }
+        };
 
         let mut consensus_epoch_data_remover =
             EpochDataRemover::new(consensus_manager.get_storage_base_path());
@@ -1185,14 +1214,13 @@ impl SuiNode {
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         prometheus_registry: &Registry,
         protocol_config: ProtocolConfig,
+        consensus_client: Arc<dyn SubmitToConsensus>,
     ) -> ConsensusAdapter {
         let ca_metrics = ConsensusAdapterMetrics::new(prometheus_registry);
         // The consensus adapter allows the authority to send user certificates through consensus.
 
         ConsensusAdapter::new(
-            Arc::new(LazyNarwhalClient::new(
-                consensus_config.address().to_owned(),
-            )),
+            consensus_client,
             authority,
             connection_monitor_status,
             consensus_config.max_pending_transactions(),

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -9,13 +9,13 @@ use narwhal_config::{NetworkAdminServerParameters, PrometheusMetricsParameters};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
-use sui_config::node::default_zklogin_oauth_providers;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
     AuthorityKeyPairWithPath, AuthorityStorePruningConfig, DBCheckpointConfig,
     ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath, StateArchiveConfig, StateSnapshotConfig,
     DEFAULT_GRPC_CONCURRENCY_LIMIT,
 };
+use sui_config::node::{default_zklogin_oauth_providers, ConsensusProtocol};
 use sui_config::p2p::{P2pConfig, SeedPeer};
 use sui_config::{
     local_ip_utils, ConsensusConfig, NodeConfig, AUTHORITIES_DB_NAME, CONSENSUS_DB_NAME,
@@ -90,6 +90,7 @@ impl ValidatorConfigBuilder {
             max_pending_transactions: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            protocol: ConsensusProtocol::Narwhal,
             narwhal_config: narwhal_config::Parameters {
                 network_admin_server: NetworkAdminServerParameters {
                     primary_network_admin_server_port: local_ip_utils::get_available_port(

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "331d89344f59fc9e0015c128887047d78cb666e6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -403,7 +403,7 @@ merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -452,7 +452,7 @@ multer = { version = "2" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }
@@ -1221,7 +1221,7 @@ migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false, features = ["frommmap"] }
+minibytes = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false, features = ["frommmap"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
@@ -1274,7 +1274,7 @@ multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "835bd1f150e92ed4dd124701a6a25f040f7dd2c6", default-features = false }
+mysticeti-core = { git = "https://github.com/MystenLabs/mysticeti", rev = "b0b567aacf2f0e9a95ba636c9ece80da510dcaf9", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 newline-converter = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Description 

Follow up of https://github.com/MystenLabs/sui/pull/14698

This PR:
* introduces a config property to switch between consensus protocols . We default to `Narwhal`
* initialises the consensus protocol when bootstrapping the node according to the property
* starts the mysticeti consensus handler on every mysticeti validator start

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
