### PR TITLE
indexer v2 analytical: simplify and fix network metrics

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-10-04-161058_tx_count_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161058_tx_count_metrics/up.sql
@@ -3,12 +3,11 @@ CREATE TABLE tx_count_metrics
     checkpoint_sequence_number          BIGINT  PRIMARY KEY,
     epoch                               BIGINT  NOT NULL,
     timestamp_ms                        BIGINT  NOT NULL,
-    -- totals of the current tx batch
     total_transaction_blocks            BIGINT  NOT NULL,
     total_successful_transaction_blocks BIGINT  NOT NULL,
-    total_successful_transactions       BIGINT  NOT NULL,
-    -- below are rolling totals from genesis used by get_total_transactions API
-    network_total_transaction_blocks            BIGINT  NOT NULL,
-    network_total_successful_transactions       BIGINT  NOT NULL,
-    network_total_successful_transaction_blocks BIGINT  NOT NULL
+    total_successful_transactions       BIGINT  NOT NULL
 );
+-- epoch for peak 30D TPS filter
+CREATE INDEX tx_count_metrics_epoch ON tx_count_metrics (epoch);
+-- timestamp for timestamp grouping, in case multiple checkpoints have the same timestamp
+CREATE INDEX tx_count_metrics_timestamp_ms ON tx_count_metrics (timestamp_ms);

--- a/crates/sui-indexer/migrations_v2/2023-10-04-161244_network_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161244_network_metrics/up.sql
@@ -1,11 +1,45 @@
-CREATE TABLE network_metrics 
+CREATE TABLE epoch_peak_tps
 (
-    checkpoint      BIGINT  PRIMARY KEY,
-    epoch           BIGINT  NOT NULL,   
-    timestamp_ms    BIGINT  NOT NULL,
-    real_time_tps   FLOAT8  NOT NULL,
-    peak_tps_30d    FLOAT8  NOT NULL, 
-    total_addresses BIGINT  NOT NULL,
-    total_objects   BIGINT  NOT NULL,
-    total_packages  BIGINT  NOT NULL
+    epoch           BIGINT  PRIMARY KEY,   
+    peak_tps        FLOAT8  NOT NULL,
+    peak_tps_30d    FLOAT8  NOT NULL
 );
+
+CREATE OR REPLACE VIEW real_time_tps AS 
+WITH recent_checkpoints AS (
+  SELECT
+    checkpoint_sequence_number as sequence_number,
+    total_successful_transactions,
+    timestamp_ms
+  FROM
+    tx_count_metrics
+  ORDER BY
+    timestamp_ms DESC
+  LIMIT 100
+),
+diff_checkpoints AS (
+  SELECT
+    MAX(sequence_number) as sequence_number,
+    SUM(total_successful_transactions) as total_successful_transactions,
+    timestamp_ms - LAG(timestamp_ms) OVER (ORDER BY timestamp_ms) AS time_diff
+  FROM
+    recent_checkpoints
+  GROUP BY
+    timestamp_ms
+)
+SELECT
+  (total_successful_transactions * 1000.0 / time_diff)::float8 as recent_tps
+FROM
+  diff_checkpoints
+WHERE 
+  time_diff IS NOT NULL
+ORDER BY sequence_number DESC LIMIT 1;
+
+CREATE OR REPLACE VIEW network_metrics AS 
+SELECT  (SELECT recent_tps from real_time_tps)                                                          AS current_tps,
+        (SELECT COALESCE(peak_tps_30d, 0) FROM epoch_peak_tps ORDER BY epoch DESC LIMIT 1)              AS tps_30_days,
+        (SELECT reltuples AS estimate FROM pg_class WHERE relname = 'addresses')::BIGINT                AS total_addresses,
+        (SELECT reltuples AS estimate FROM pg_class WHERE relname = 'objects')::BIGINT                  AS total_objects,
+        (SELECT reltuples AS estimate FROM pg_class WHERE relname = 'packages')::BIGINT                 AS total_packages,
+        (SELECT MAX(epoch) FROM epochs)                                                                 AS current_epoch,
+        (SELECT MAX(sequence_number) FROM checkpoints)                                                  AS current_checkpoint;

--- a/crates/sui-indexer/src/models_v2/network_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/network_metrics.rs
@@ -2,41 +2,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
-use diesel::sql_types::BigInt;
+use diesel::sql_types::{BigInt, Double, Float8};
 
 use sui_json_rpc_types::NetworkMetrics;
 
-use crate::schema_v2::network_metrics;
+use crate::schema_v2::epoch_peak_tps;
 
 #[derive(Clone, Debug, Default, Queryable, Insertable)]
-#[diesel(table_name = network_metrics)]
-pub struct StoredNetworkMetrics {
-    pub checkpoint: i64,
+#[diesel(table_name = epoch_peak_tps)]
+pub struct StoredEpochPeakTps {
     pub epoch: i64,
-    pub timestamp_ms: i64,
-    pub real_time_tps: f64,
+    pub peak_tps: f64,
     pub peak_tps_30d: f64,
-    pub total_addresses: i64,
-    pub total_objects: i64,
-    pub total_packages: i64,
 }
 
 #[derive(QueryableByName, Debug, Clone, Default)]
-pub struct RowCountEstimation {
+pub struct StoredNetworkMetrics {
+    #[diesel(sql_type = Double)]
+    pub current_tps: f64,
+    #[diesel(sql_type = Double)]
+    pub tps_30_days: f64,
     #[diesel(sql_type = BigInt)]
-    pub estimated_count: i64,
+    pub total_packages: i64,
+    #[diesel(sql_type = BigInt)]
+    pub total_addresses: i64,
+    #[diesel(sql_type = BigInt)]
+    pub total_objects: i64,
+    #[diesel(sql_type = BigInt)]
+    pub current_epoch: i64,
+    #[diesel(sql_type = BigInt)]
+    pub current_checkpoint: i64,
 }
 
 impl From<StoredNetworkMetrics> for NetworkMetrics {
-    fn from(metrics: StoredNetworkMetrics) -> Self {
+    fn from(db: StoredNetworkMetrics) -> Self {
         Self {
-            current_checkpoint: metrics.checkpoint as u64,
-            current_epoch: metrics.epoch as u64,
-            current_tps: metrics.real_time_tps,
-            tps_30_days: metrics.peak_tps_30d,
-            total_addresses: metrics.total_addresses as u64,
-            total_objects: metrics.total_objects as u64,
-            total_packages: metrics.total_packages as u64,
+            current_tps: db.current_tps,
+            tps_30_days: db.tps_30_days,
+            total_packages: db.total_packages as u64,
+            total_addresses: db.total_addresses as u64,
+            total_objects: db.total_objects as u64,
+            current_epoch: db.current_epoch as u64,
+            current_checkpoint: db.current_checkpoint as u64,
         }
     }
+}
+
+#[derive(Debug, QueryableByName)]
+pub struct Tps {
+    #[diesel(sql_type = Float8)]
+    pub peak_tps: f64,
 }

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -54,7 +54,9 @@ pub struct StoredTransactionCheckpoint {
 #[derive(Clone, Debug, Queryable)]
 pub struct StoredTransactionSuccessCommandCount {
     pub tx_sequence_number: i64,
+    pub checkpoint_sequence_number: i64,
     pub success_command_count: i16,
+    pub timestamp_ms: i64,
 }
 
 impl From<&IndexedTransaction> for StoredTransaction {

--- a/crates/sui-indexer/src/models_v2/tx_count_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/tx_count_metrics.rs
@@ -5,9 +5,6 @@ use diesel::prelude::*;
 
 use crate::schema_v2::tx_count_metrics;
 
-use super::checkpoints::StoredCheckpoint;
-use super::transactions::StoredTransactionSuccessCommandCount;
-
 #[derive(Clone, Debug, Default, Queryable, Insertable)]
 #[diesel(table_name = tx_count_metrics)]
 pub struct StoredTxCountMetrics {
@@ -17,71 +14,4 @@ pub struct StoredTxCountMetrics {
     pub total_transaction_blocks: i64,
     pub total_successful_transaction_blocks: i64,
     pub total_successful_transactions: i64,
-    pub network_total_transaction_blocks: i64,
-    pub network_total_successful_transactions: i64,
-    pub network_total_successful_transaction_blocks: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct TxCountMetricsDelta {
-    pub checkpoint_sequence_number: i64,
-    pub epoch: i64,
-    pub timestamp_ms: i64,
-    pub total_transaction_blocks: i64,
-    pub total_successful_transaction_blocks: i64,
-    pub total_successful_transactions: i64,
-}
-
-impl TxCountMetricsDelta {
-    pub fn get_tx_count_metrics_delta(
-        tx_cmd_count_batch: &[StoredTransactionSuccessCommandCount],
-        end_cp: &StoredCheckpoint,
-    ) -> Self {
-        let checkpoint_sequence_number = end_cp.sequence_number;
-        let epoch = end_cp.epoch;
-        let timestamp_ms = end_cp.timestamp_ms;
-
-        let total_transaction_blocks = tx_cmd_count_batch.len() as i64;
-        let total_successful_transaction_blocks = tx_cmd_count_batch
-            .iter()
-            .filter(|tx_cmd_count| tx_cmd_count.success_command_count > 0)
-            .count() as i64;
-        let total_successful_transactions =
-            tx_cmd_count_batch.iter().fold(0, |acc, tx_cmd_count| {
-                acc + tx_cmd_count.success_command_count as i64
-            });
-        Self {
-            checkpoint_sequence_number,
-            epoch,
-            timestamp_ms,
-            total_transaction_blocks,
-            total_successful_transaction_blocks,
-            total_successful_transactions,
-        }
-    }
-}
-
-impl StoredTxCountMetrics {
-    pub fn combine_tx_count_metrics_delta(
-        last_tx_count_metrics: &StoredTxCountMetrics,
-        delta: &TxCountMetricsDelta,
-    ) -> StoredTxCountMetrics {
-        StoredTxCountMetrics {
-            checkpoint_sequence_number: delta.checkpoint_sequence_number,
-            epoch: delta.epoch,
-            timestamp_ms: delta.timestamp_ms,
-            total_transaction_blocks: delta.total_transaction_blocks,
-            total_successful_transaction_blocks: delta.total_successful_transaction_blocks,
-            total_successful_transactions: delta.total_successful_transactions,
-            network_total_transaction_blocks: last_tx_count_metrics
-                .network_total_transaction_blocks
-                + delta.total_transaction_blocks,
-            network_total_successful_transactions: last_tx_count_metrics
-                .network_total_successful_transactions
-                + delta.total_successful_transactions,
-            network_total_successful_transaction_blocks: last_tx_count_metrics
-                .network_total_successful_transaction_blocks
-                + delta.total_successful_transaction_blocks,
-        }
-    }
 }

--- a/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
@@ -3,15 +3,14 @@
 use tracing::info;
 
 use crate::errors::IndexerError;
-use crate::models_v2::network_metrics::StoredNetworkMetrics;
-use crate::models_v2::tx_count_metrics::{StoredTxCountMetrics, TxCountMetricsDelta};
 use crate::store::IndexerAnalyticalStore;
 use crate::types_v2::IndexerResult;
 
-const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: i64 = 100;
+const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: i64 = 10;
 
 pub struct NetworkMetricsProcessor<S> {
     pub store: S,
+    pub network_processor_metrics_batch_size: i64,
 }
 
 impl<S> NetworkMetricsProcessor<S>
@@ -19,100 +18,67 @@ where
     S: IndexerAnalyticalStore + Sync + Send + 'static,
 {
     pub fn new(store: S) -> NetworkMetricsProcessor<S> {
-        Self { store }
+        let network_processor_metrics_batch_size =
+            std::env::var("NETWORK_PROCESSOR_METRICS_BATCH_SIZE")
+                .map(|s| {
+                    s.parse::<i64>()
+                        .unwrap_or(NETWORK_METRICS_PROCESSOR_BATCH_SIZE)
+                })
+                .unwrap_or(NETWORK_METRICS_PROCESSOR_BATCH_SIZE);
+        Self {
+            store,
+            network_processor_metrics_batch_size,
+        }
     }
 
     pub async fn start(&self) -> IndexerResult<()> {
         info!("Indexer network metrics async processor started...");
-        let mut latest_tx_count_metrics = self
+        let latest_tx_count_metrics = self
             .store
             .get_latest_tx_count_metrics()
             .await
             .unwrap_or_default();
-        let mut last_end_cp_seq = latest_tx_count_metrics.checkpoint_sequence_number;
+        let latest_epoch_peak_tps = self
+            .store
+            .get_latest_epoch_peak_tps()
+            .await
+            .unwrap_or_default();
+        let mut last_processed_cp_seq = latest_tx_count_metrics.checkpoint_sequence_number;
+        let mut last_processed_peak_tps_epoch = latest_epoch_peak_tps.epoch;
         loop {
-            // NOTE: network metrics include address count, which is handled by populated by address metrics processor.
-            let mut latest_address_metrics = self
-                .store
-                .get_latest_address_metrics()
-                .await
-                .unwrap_or_default();
-            while latest_address_metrics.checkpoint
-                < last_end_cp_seq + NETWORK_METRICS_PROCESSOR_BATCH_SIZE
+            let mut latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
+            while latest_stored_checkpoint.sequence_number
+                < last_processed_cp_seq + self.network_processor_metrics_batch_size
             {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                latest_address_metrics = self
-                    .store
-                    .get_latest_address_metrics()
-                    .await
-                    .unwrap_or_default();
+                latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
             }
+            self.store
+                .persist_tx_count_metrics(
+                    last_processed_cp_seq + 1,
+                    last_processed_cp_seq + self.network_processor_metrics_batch_size,
+                )
+                .await?;
+            last_processed_cp_seq += self.network_processor_metrics_batch_size;
+            info!(
+                "Persisted tx count metrics for checkpoint sequence number {}",
+                last_processed_cp_seq
+            );
 
             let end_cp = self
                 .store
-                .get_checkpoints_in_range(
-                    last_end_cp_seq + NETWORK_METRICS_PROCESSOR_BATCH_SIZE,
-                    last_end_cp_seq + NETWORK_METRICS_PROCESSOR_BATCH_SIZE + 1,
-                )
+                .get_checkpoints_in_range(last_processed_cp_seq, last_processed_cp_seq + 1)
                 .await?
                 .first()
                 .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read checkpoint from PG for address metrics".to_string(),
+                    "Cannot read checkpoint from PG for epoch peak TPS".to_string(),
                 ))?
                 .clone();
-
-            // +1 here b/c get_tx_success_cmd_counts_in_checkpoint_range is left-inclusive, right-exclusive,
-            // but we want left-exclusive, right-inclusive, as latest_tx_count_metrics has been processed.
-            let tx_cmd_count_batch = self
-                .store
-                .get_tx_success_cmd_counts_in_checkpoint_range(
-                    last_end_cp_seq + 1,
-                    end_cp.sequence_number + 1,
-                )
-                .await?;
-            let tx_count_metrics_delta =
-                TxCountMetricsDelta::get_tx_count_metrics_delta(&tx_cmd_count_batch, &end_cp);
-            let tx_count_metrics = StoredTxCountMetrics::combine_tx_count_metrics_delta(
-                &latest_tx_count_metrics,
-                &tx_count_metrics_delta,
-            );
-            self.store
-                .persist_tx_count_metrics(tx_count_metrics.clone())
-                .await?;
-
-            let real_time_tps = (tx_count_metrics_delta.total_successful_transactions
-                + tx_count_metrics_delta.total_transaction_blocks
-                - tx_count_metrics_delta.total_successful_transaction_blocks)
-                as f64
-                * 1000.0f64
-                / (tx_count_metrics_delta.timestamp_ms - latest_tx_count_metrics.timestamp_ms)
-                    as f64;
-            let prev_peak_30d_tps = self
-                .store
-                .get_peak_network_peak_tps(end_cp.epoch, 30)
-                .await?;
-            let peak_tps_30d = f64::max(real_time_tps, prev_peak_30d_tps);
-            let estimated_object_count = self.store.get_estimated_count("objects").await?;
-            let estimated_packages_count = self.store.get_estimated_count("packages").await?;
-            let estimated_addresses_count = self.store.get_estimated_count("addresses").await?;
-
-            let network_metrics = StoredNetworkMetrics {
-                checkpoint: end_cp.sequence_number,
-                epoch: end_cp.epoch,
-                timestamp_ms: end_cp.timestamp_ms,
-                real_time_tps,
-                peak_tps_30d,
-                total_objects: estimated_object_count,
-                total_addresses: estimated_addresses_count,
-                total_packages: estimated_packages_count,
-            };
-            self.store.persist_network_metrics(network_metrics).await?;
-            last_end_cp_seq = end_cp.sequence_number;
-            latest_tx_count_metrics = tx_count_metrics;
-            info!(
-                "Processed checkpoint for network_metrics: {}",
-                end_cp.sequence_number
-            );
+            for epoch in last_processed_peak_tps_epoch + 1..=end_cp.epoch {
+                self.store.persist_epoch_peak_tps(epoch).await?;
+                last_processed_peak_tps_epoch = epoch;
+                info!("Persisted epoch peak TPS for epoch {}", epoch);
+            }
         }
     }
 }

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -64,6 +64,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    epoch_peak_tps (epoch) {
+        epoch -> Int8,
+        peak_tps -> Float8,
+        peak_tps_30d -> Float8,
+    }
+}
+
+diesel::table! {
     epochs (epoch) {
         epoch -> Int8,
         validators -> Array<Nullable<Bytea>>,
@@ -126,19 +134,6 @@ diesel::table! {
         move_package -> Bytea,
         move_module -> Text,
         move_function -> Text,
-    }
-}
-
-diesel::table! {
-    network_metrics (checkpoint) {
-        checkpoint -> Int8,
-        epoch -> Int8,
-        timestamp_ms -> Int8,
-        real_time_tps -> Float8,
-        peak_tps_30d -> Float8,
-        total_addresses -> Int8,
-        total_objects -> Int8,
-        total_packages -> Int8,
     }
 }
 
@@ -208,9 +203,6 @@ diesel::table! {
         total_transaction_blocks -> Int8,
         total_successful_transaction_blocks -> Int8,
         total_successful_transactions -> Int8,
-        network_total_transaction_blocks -> Int8,
-        network_total_successful_transactions -> Int8,
-        network_total_successful_transaction_blocks -> Int8,
     }
 }
 
@@ -257,11 +249,11 @@ diesel::allow_tables_to_appear_in_same_query!(
     addresses,
     checkpoints,
     display,
+    epoch_peak_tps,
     epochs,
     events,
     move_call_metrics,
     move_calls,
-    network_metrics,
     objects,
     packages,
     transactions,

--- a/crates/sui-indexer/src/store/indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/indexer_analytical_store.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use crate::models_v2::address_metrics::{StoredActiveAddress, StoredAddress, StoredAddressMetrics};
 use crate::models_v2::checkpoints::StoredCheckpoint;
 use crate::models_v2::move_call_metrics::{StoredMoveCall, StoredMoveCallMetrics};
-use crate::models_v2::network_metrics::StoredNetworkMetrics;
+use crate::models_v2::network_metrics::StoredEpochPeakTps;
 use crate::models_v2::transactions::{
     StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount, StoredTransactionTimestamp,
 };
@@ -37,19 +37,16 @@ pub trait IndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionSuccessCommandCount>>;
-    async fn get_estimated_count(&self, table: &str) -> IndexerResult<i64>;
 
     // for network metrics including TPS and counts of objects etc.
     async fn get_latest_tx_count_metrics(&self) -> IndexerResult<StoredTxCountMetrics>;
-    async fn get_peak_network_peak_tps(&self, epoch: i64, day: i64) -> IndexerResult<f64>;
+    async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<StoredEpochPeakTps>;
     async fn persist_tx_count_metrics(
         &self,
-        tx_count_metrics: StoredTxCountMetrics,
+        start_checkpoint: i64,
+        end_checkpoint: i64,
     ) -> IndexerResult<()>;
-    async fn persist_network_metrics(
-        &self,
-        network_metrics: StoredNetworkMetrics,
-    ) -> IndexerResult<()>;
+    async fn persist_epoch_peak_tps(&self, epoch: i64) -> IndexerResult<()>;
 
     // for address metrics
     async fn get_latest_address_metrics(&self) -> IndexerResult<StoredAddressMetrics>;


### PR DESCRIPTION
## Description 

- simplify the network metrics such that only peak TPS is calculated per epoch
- other data like realtime TPS can be done on the reading side, as the view query takes < 100 ms to finish on a fully populated DB

this will
- shorten network metrics backfill from days to a couple of hours
- also on Explorer, metrics of current checkpoint and current TPS is more realtime.

## Test Plan 

local run and verify

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
