### PR TITLE
[draft for feedback] spitballing compiler toochain versioning

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -41,6 +41,15 @@ impl Build {
     ) -> anyhow::Result<()> {
         let rerooted_path = base::reroot_path(path.clone())?;
         let build_config = resolve_lock_file_path(build_config, path)?;
+        if let Some(lock_file) = build_config.clone().lock_file {
+            let lock_string = std::fs::read_to_string(lock_file)?;
+            let _compiler_toolchain = move_package::lock_file::schema::CompilerToolchain::read(
+                &mut lock_string.as_bytes(),
+            )?;
+            // TODO: Check for Move.lock compiler toolchain. If it exists and we are not on the current
+            // version, run logic to download and execute the build for a previous version.
+        }
+
         Self::execute_internal(
             rerooted_path,
             build_config,
@@ -49,6 +58,10 @@ impl Build {
             self.generate_struct_layouts,
             !self.no_lint,
         )
+
+        // TODO: Write Move.lock with compiler toolchain / version info on success here.
+        // Grab compiler version from env!("CARGO_PKG_VERSION")
+        // Grab flags from build_config.compiler_flags.
     }
 
     pub fn execute_internal(

--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -61,6 +61,16 @@ pub struct Dependency {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct CompilerToolchain {
+    /// The Move compiler version used to compile this package.
+    #[serde(rename = "compiler-version")]
+    pub compiler_version: String,
+    /// The Move compiler flags used to compile this package.
+    #[serde(rename = "compiler-flags")]
+    pub compiler_flags: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct Header {
     pub version: u64,
     /// A hash of the manifest file content this lock file was generated from computed using SHA-256
@@ -92,6 +102,40 @@ impl Packages {
             toml::de::from_str::<Schema<Packages>>(&contents).context("Deserializing packages")?;
 
         Ok((packages, read_header(&contents)?))
+    }
+}
+
+impl CompilerToolchain {
+    /// Read compiler toolchain options from the lock file.
+    pub fn read(lock: &mut impl Read) -> Result<CompilerToolchain> {
+        let contents = {
+            let mut buf = String::new();
+            lock.read_to_string(&mut buf).context("Reading lock file")?;
+            buf
+        };
+
+        let Schema {
+            move_: compiler_toolchain,
+        } = toml::de::from_str::<Schema<CompilerToolchain>>(&contents)
+            .context("Deserializing compiler toolchain options")?;
+        Ok(compiler_toolchain)
+    }
+
+    pub fn write<W: Write>(
+        writer: &mut W,
+        _compiler_version: String,
+        _compiler_flags: Vec<String>,
+    ) -> Result<()> {
+        let compiler_version = env!("CARGO_PKG_VERSION").into(); // TODO
+        let compiler_flags = vec![]; // TODO
+        let compiler_toolchain = toml::ser::to_string(&Schema {
+            move_: CompilerToolchain {
+                compiler_version,
+                compiler_flags,
+            },
+        })?;
+        write!(writer, "{}", compiler_toolchain)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR is for discussing / uncovering implementation details to support compiler toolchain versioning ([Jira](https://mysten.atlassian.net/browse/DEVX-26)).

After digging into things, I've added some skeleton details in the code to kick off discussion and answer some open questions. See inline for comments for that. High-level things I want to answer, and my intuition so far:

- Q: Where is it suitable to add logic for reading the lock / casing out on compiler version / writing the lock? 
  - A: It seems reasonable to do this early in the build call stack, I've added code where this seems suitable.

- Q: What does the lock file schema need to support to reproduce a build? 
  - A: **For compiler versions**: I think supporting [versioned binary releases](https://github.com/MystenLabs/sui/releases) for mainnet is the way to go here, especially since the plan is to pull here initially (until we can have builds and releases for only the compiler, not all of the `sui` binary). It could be a good idea to include the commit too, but the benefit here is less obvious for the average user (maybe it's useful if we want to allow the option to build from source?). 
  - **For compiler flags**: I think we capture everything re: compiler flags in `BuildConfig` already, and preserving this in the lockfile ought to be enough?

- Other Q's inline

Below, more general thoughts / open questions around implementation details for corner cases. Top of mind is how to handle cases where dependencies specify different compiler versions in their `Move.lock`. In general I think it's reasonable to aim for having a single compiler version for a `move build` command. I.e., a package and all dependents must use the same compiler, and we offer error messages for the user to resolve things otherwise if version diverge. Example breakdown:

- Handle the case where the root package is compiled with `v1` but one or more dependents have shifted to one or more other versions `v2`.
  - Resolution (??): User needs to upgrade (build) using `v2` on the root package or change `Move.toml` to point to a specific revision / branch of a dependent package that was compiled with `v1`. Based on the user's choice, package and dependents now compile with `v1` or `v2`.

- Handle the case where root package wants to move ahead to `v2` but depends on packages that specify `v1`.
  - Resolution (??): Attempt to compile all packages with `v2` and persist version / compiler flags if it succeeds. Does the user need to perform further actions in this case? If compilation fails, it's basically a hard conflict and the user has to stick to `v1` or wait / find a way for dependent packages to support `v2` (and, e.g., possibly edit deps in `Move.toml`). 

