### PR TITLE
Add aws builder params to config

### DIFF
--- a/crates/sui-storage/src/object_store/mod.rs
+++ b/crates/sui-storage/src/object_store/mod.rs
@@ -65,9 +65,13 @@ pub struct ObjectStoreConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[arg(long)]
     pub aws_profile: Option<String>,
+    /// Enable virtual hosted style requests
+    #[serde(default)]
+    #[arg(long, default_value_t = true)]
+    pub aws_virtual_hosted_style_request: bool,
     /// Allow unencrypted HTTP connection to AWS.
     #[serde(default)]
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = true)]
     pub aws_allow_http: bool,
     /// When using Google Cloud Storage as the object store, set this to the
     /// path to the JSON file that contains the Google credentials.
@@ -113,11 +117,14 @@ impl ObjectStoreConfig {
 
         info!(bucket=?self.bucket, object_store_type="S3", "Object Store");
 
-        let mut builder = AmazonS3Builder::new()
-            .with_allow_http(true)
-            .with_virtual_hosted_style_request(true)
-            .with_imdsv1_fallback();
+        let mut builder = AmazonS3Builder::new().with_imdsv1_fallback();
 
+        if self.aws_virtual_hosted_style_request {
+            builder = builder.with_virtual_hosted_style_request(true);
+        }
+        if self.aws_allow_http {
+            builder = builder.with_allow_http(true);
+        }
         if let Some(region) = &self.aws_region {
             builder = builder.with_region(region);
         }


### PR DESCRIPTION
## Description 

In testing R2 writes, I've discovered that connections to R2 fail when `builder.with_virtual_hosted_style_request(true)` is set.

This PR allows that to be configurable, along with respecting the `aws_allow_http` setting.
## Test Plan 

Tested locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
