### PR TITLE
[dapp-kit] fix bug introduced in the last version where the ConnectButton doesn't open the modal

### DIFF
--- a/.changeset/silent-trains-whisper.md
+++ b/.changeset/silent-trains-whisper.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Fix the connect button component not opening the modal

--- a/sdk/dapp-kit/src/components/styling/StyleMarker.tsx
+++ b/sdk/dapp-kit/src/components/styling/StyleMarker.tsx
@@ -16,8 +16,8 @@ type StyleMarker = {
 export const StyleMarker = forwardRef<
 	ElementRef<typeof Slot>,
 	ComponentPropsWithoutRef<typeof Slot>
->(({ children }, forwardedRef) => (
-	<Slot ref={forwardedRef} {...styleDataAttribute}>
+>(({ children, ...props }, forwardedRef) => (
+	<Slot ref={forwardedRef} {...props} {...styleDataAttribute}>
 		{children}
 	</Slot>
 ));

--- a/sdk/dapp-kit/test/components/ConnectButton.test.tsx
+++ b/sdk/dapp-kit/test/components/ConnectButton.test.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConnectButton } from '../../src/components/ConnectButton';
+import { createWalletProviderContextWrapper } from '../test-utils';
+
+describe('ConnectButton', () => {
+	test('clicking the button opens the connect modal', async () => {
+		const wrapper = createWalletProviderContextWrapper();
+
+		render(<ConnectButton />, { wrapper });
+
+		const connectButtonEl = screen.getByRole('button', { name: 'Connect Wallet' });
+		expect(connectButtonEl).toBeInTheDocument();
+
+		const user = userEvent.setup();
+		await user.click(connectButtonEl);
+
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Description 

It looks like I introduced a pretty bad bug in the last version of dapp-kit where clicking the connect button does nothing since I'm not passing props through the `Slot` component in `StyleMarker`. I don't know how I didn't catch this in https://github.com/MystenLabs/sui/pull/14566... but automated tests are our friend 😅 

## Test Plan 
- https://sui-typescript-docs-git-wrobertson-bleh-mysten-labs.vercel.app/dapp-kit/wallet-components/ConnectButton
- Automated tests (the test fails on `main` and passes with this fix) 🌈 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
