### PR TITLE
[graphql] implement dynamicField

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
@@ -1,0 +1,230 @@
+processed 13 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 13-54:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8329600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 56-56:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 58-58:
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6536000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4 'run'. lines 60-60:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 5 'create-checkpoint'. lines 62-62:
+Checkpoint created: 1
+
+task 6 'run-graphql'. lines 64-87:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 7 'run'. lines 89-89:
+created: object(7,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2485200,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 8 'create-checkpoint'. lines 91-91:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 93-116:
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 10 'run-graphql'. lines 118-143:
+Response: {
+  "data": {
+    "owner": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "bcs": "AAAAAAAAAAA=",
+              "data": {
+                "Number": "0"
+              },
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "bcs": "AQAAAAAAAAA=",
+              "data": {
+                "Number": "1"
+              },
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "bcs": "AgAAAAAAAAA=",
+              "data": {
+                "Number": "2"
+              },
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 145-165:
+Response: {
+  "data": {
+    "owner": {
+      "dynamicField": {
+        "name": {
+          "type": {
+            "repr": "u64"
+          },
+          "data": {
+            "Number": "0"
+          },
+          "bcs": "AAAAAAAAAAA="
+        },
+        "value": {
+          "__typename": "MoveValue",
+          "bcs": "AAAAAAAAAAA=",
+          "data": {
+            "Number": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 167-178:
+Response: {
+  "data": {
+    "owner": {
+      "dynamicObjectField": {
+        "value": {
+          "__typename": "MoveObject"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -1,0 +1,178 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Create some dynamic fields on an object, and then try to query them.
+// There should be 1 dynamic object field (MoveObject) and 3 dynamic fields.
+// When the object is wrapped, we expect that making the query through Object will return null.
+// But it should still be visible through the Owner type.
+// This test also demonstrates why we need separate dynamicField and dynamicObjectField APIs.
+// It is possible for a dynamic field and a dynamic object field to share the same name lookup.
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::m {
+    use sui::dynamic_field as field;
+    use sui::dynamic_object_field as ofield;
+    use sui::object;
+    use sui::tx_context::{sender, TxContext};
+
+    struct Wrapper has key {
+        id: object::UID,
+        o: Parent
+    }
+
+    struct Parent has key, store {
+        id: object::UID,
+    }
+
+    struct Child has key, store {
+        id: object::UID,
+    }
+
+    public entry fun create_obj(ctx: &mut TxContext){
+        let id = object::new(ctx);
+        sui::transfer::public_transfer(Parent { id }, sender(ctx))
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<u64, u64>(id, 0, 0);
+        field::add<vector<u8>, u64>(id, b"", 1);
+        field::add<bool, u64>(id, false, 2);
+    }
+
+    public entry fun add_dof(parent: &mut Parent, ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx) };
+        ofield::add(&mut parent.id, 0, child);
+    }
+
+    public entry fun wrap(parent: Parent, ctx: &mut TxContext) {
+        let wrapper = Wrapper { id: object::new(ctx), o: parent };
+        sui::transfer::transfer(wrapper, sender(ctx))
+    }
+}
+
+//# run Test::m::create_obj --sender A
+
+//# run Test::m::add_df --sender A --args object(2,0)
+
+//# run Test::m::add_dof --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql --variables obj_2_0
+{
+  object(address: $obj_2_0) {
+    dynamicFieldConnection {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run Test::m::wrap --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql --variables obj_2_0
+{
+  object(address: $obj_2_0) {
+    dynamicFieldConnection {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --variables obj_2_0
+{
+  owner(address: $obj_2_0) {
+    dynamicFieldConnection {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            bcs
+            data
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --variables obj_2_0
+{
+  owner(address: $obj_2_0) {
+    dynamicField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
+      name {
+        type {
+          repr
+        }
+        data
+        bcs
+      }
+      value {
+        ... on MoveValue {
+          __typename
+          bcs
+          data
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --variables obj_2_0
+{
+  owner(address: $obj_2_0) {
+    dynamicObjectField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
+      value {
+        ... on MoveObject {
+          __typename
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
@@ -1,11 +1,11 @@
-processed 12 tasks
+processed 11 tasks
 
 task 1 'publish'. lines 15-37:
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run-graphql'. lines 39-52:
+task 2 'run-graphql'. lines 39-53:
 Response: {
   "data": {
     "address": {
@@ -16,24 +16,20 @@ Response: {
   }
 }
 
-task 3 'run'. lines 54-54:
+task 3 'run'. lines 55-55:
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4 'view-object'. lines 56-56:
+task 4 'view-object'. lines 57-57:
 Owner: Account Address ( A )
 Version: 3
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, value: 0u64}
 
-task 5 'create-checkpoint'. lines 58-58:
+task 5 'create-checkpoint'. lines 59-59:
 Checkpoint created: 1
 
-task 6 'view-checkpoint'. lines 60-60:
-CheckpointSummary { epoch: 0, seq: 1, content_digest: 94FSxnwDKDpJ8txUBNcnxU75aathRbysGuihNUchZokV,
-            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
-
-task 7 'run-graphql'. lines 62-75:
+task 6 'run-graphql'. lines 61-75:
 Response: {
   "data": {
     "address": {
@@ -41,9 +37,10 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x289d74be6572c74c6b9652175e2f77d8cffc181b9cf997c7782b000ceed6edf0",
-              "digest": "9KxfyrxUUSMJK1UD7PAMzVEbdRF3wQHghE1qHrMh47fV",
-              "kind": "OWNED"
+              "kind": "OWNED",
+              "owner": {
+                "location": "0x0000000000000000000000000000000000000000000000000000000000000042"
+              }
             }
           }
         ]
@@ -52,7 +49,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 77-90:
+task 7 'run-graphql'. lines 77-91:
 Response: {
   "data": {
     "address": {
@@ -60,9 +57,10 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x289d74be6572c74c6b9652175e2f77d8cffc181b9cf997c7782b000ceed6edf0",
-              "digest": "9KxfyrxUUSMJK1UD7PAMzVEbdRF3wQHghE1qHrMh47fV",
-              "kind": "OWNED"
+              "kind": "OWNED",
+              "owner": {
+                "location": "0x0000000000000000000000000000000000000000000000000000000000000042"
+              }
             }
           }
         ]
@@ -71,7 +69,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 92-105:
+task 8 'run-graphql'. lines 93-107:
 Response: {
   "data": {
     "address": {
@@ -79,9 +77,10 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x289d74be6572c74c6b9652175e2f77d8cffc181b9cf997c7782b000ceed6edf0",
-              "digest": "9KxfyrxUUSMJK1UD7PAMzVEbdRF3wQHghE1qHrMh47fV",
-              "kind": "OWNED"
+              "kind": "OWNED",
+              "owner": {
+                "location": "0x0000000000000000000000000000000000000000000000000000000000000042"
+              }
             }
           }
         ]
@@ -90,7 +89,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 107-120:
+task 9 'run-graphql'. lines 109-123:
 Response: {
   "data": {
     "owner": {
@@ -98,9 +97,10 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x289d74be6572c74c6b9652175e2f77d8cffc181b9cf997c7782b000ceed6edf0",
-              "digest": "9KxfyrxUUSMJK1UD7PAMzVEbdRF3wQHghE1qHrMh47fV",
-              "kind": "OWNED"
+              "kind": "OWNED",
+              "owner": {
+                "location": "0x0000000000000000000000000000000000000000000000000000000000000042"
+              }
             }
           }
         ]
@@ -109,7 +109,7 @@ Response: {
   }
 }
 
-task 11 'run-graphql'. lines 122-135:
+task 10 'run-graphql'. lines 125-139:
 Response: {
   "data": {
     "object": null

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -42,9 +42,10 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }
@@ -57,17 +58,16 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# view-checkpoint
-
 //# run-graphql
 {
   address(address: "0x42") {
     objectConnection{
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }
@@ -80,9 +80,10 @@ module Test::M1 {
     objectConnection(filter: {owner: "0x42"}) {
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }
@@ -95,9 +96,10 @@ module Test::M1 {
     objectConnection(filter: {owner: "0x888"}) {
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }
@@ -110,9 +112,10 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }
@@ -125,9 +128,10 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          location
-          digest
           kind
+          owner {
+            location
+          }
         }
       }
     }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -873,7 +873,6 @@
 >}
 >
 >fragment DynamicFieldSelect on DynamicField {
->  kind
 >  name {
 >    ...DynamicFieldNameSelection
 >  }
@@ -927,7 +926,6 @@
 >}
 >
 >fragment DynamicFieldSelect on DynamicField {
->  kind,
 >  name {
 >    ...DynamicFieldNameSelection
 >  }
@@ -987,7 +985,6 @@
 >}
 >
 >fragment DynamicFieldSelect on DynamicField {
->  kind
 >  name {
 >    ...DynamicFieldNameSelection
 >  }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -861,8 +861,7 @@
 >  }
 >}
 >
->fragment DynamicFieldNameSelection on TypedDynamicFieldName {
->  kind
+>fragment DynamicFieldNameSelection on MoveValue {
 >  type {
 >    repr
 >  }
@@ -871,6 +870,7 @@
 >}
 >
 >fragment DynamicFieldSelect on DynamicField {
+>  kind,
 >  name {
 >    ...DynamicFieldNameSelection
 >  }
@@ -897,11 +897,8 @@
 
 ### <a id=720886></a>
 ### Dynamic Field Connection
-####  defines a fragment for selecting fields from value matching either MoveValue or MoveObject
-####  a query that selects the name and value of the first dynamic field of the owner address
 
-><pre># defines a fragment for selecting fields from value matching either MoveValue or MoveObject
->fragment DynamicFieldValueSelection on DynamicFieldValue {
+><pre>fragment DynamicFieldValueSelection on DynamicFieldValue {
 >  ... on MoveValue {
 >    type {
 >      repr
@@ -919,12 +916,29 @@
 >  }
 >}
 >
-># a query that selects the name and value of the first dynamic field of the owner address
->query DynamicFieldValue {
->  owner(
+>fragment DynamicFieldNameSelection on MoveValue {
+>  type {
+>    repr
+>  }
+>  data
+>  bcs
+>}
+>
+>fragment DynamicFieldSelect on DynamicField {
+>  kind,
+>  name {
+>    ...DynamicFieldNameSelection
+>  }
+>  value {
+>    ...DynamicFieldValueSelection
+>  }
+>}
+>
+>query DynamicFieldConnection {
+>  object(
 >    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
 >  ) {
->    dynamicFieldConnection(first:1){
+>    dynamicFieldConnection {
 >      pageInfo {
 >        hasNextPage
 >        endCursor
@@ -932,15 +946,7 @@
 >      edges {
 >        cursor
 >        node {
->          name {
->            type {
->              repr
->            }
->            data
->          }
->          value {
->            ...DynamicFieldValueSelection
->          }
+>          ...DynamicFieldSelect
 >        }
 >      }
 >    }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -37,8 +37,9 @@
 #### &emsp;&emsp;[Filter Owner](#655351)
 #### &emsp;&emsp;[Object Connection](#655352)
 ### [Owner](#11)
-#### &emsp;&emsp;[Dynamic Field Connection](#720885)
-#### &emsp;&emsp;[Owner](#720886)
+#### &emsp;&emsp;[Dynamic Field](#720885)
+#### &emsp;&emsp;[Dynamic Field Connection](#720886)
+#### &emsp;&emsp;[Owner](#720887)
 ### [Protocol Configs](#12)
 #### &emsp;&emsp;[Key Value](#786420)
 #### &emsp;&emsp;[Key Value Feature Flag](#786421)
@@ -840,6 +841,59 @@
 ## <a id=11></a>
 ## Owner
 ### <a id=720885></a>
+### Dynamic Field
+####  Selects a dynamic field child of the parent object
+
+><pre>fragment DynamicFieldValueSelection on DynamicFieldValue {
+>  ... on MoveValue {
+>    type {
+>      repr
+>    }
+>    data
+>  }
+>  ... on MoveObject {
+>    hasPublicTransfer
+>    contents {
+>      type {
+>        repr
+>      }
+>      data
+>    }
+>  }
+>}
+>
+>fragment DynamicFieldNameSelection on MoveValue {
+>  type {
+>    repr
+>  }
+>  data
+>  bcs
+>}
+>
+>fragment DynamicFieldSelect on DynamicField {
+>  name {
+>    ...DynamicFieldNameSelection
+>  }
+>  value {
+>    ...DynamicFieldValueSelection
+>  }
+>}
+>
+># Selects a dynamic field child of the parent object
+>query DynamicField {
+>  object(
+>    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
+>  ) {
+>    dynamicField(dynamicFieldName: {
+>      type: "0x2::kiosk::Listing",
+>      bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA"
+>    }){
+>      ...DynamicFieldSelect
+>    }
+>  }
+>}</pre>
+
+### <a id=720886></a>
 ### Dynamic Field Connection
 ####  defines a fragment for selecting fields from value matching either MoveValue or MoveObject
 ####  a query that selects the name and value of the first dynamic field of the owner address
@@ -891,7 +945,11 @@
 >  }
 >}</pre>
 
+<<<<<<< HEAD
 ### <a id=720886></a>
+=======
+### <a id=720887></a>
+>>>>>>> 05930e71e1 (move dynamicFieldConnection implementation to ObjectOwner interface, implement for owner and object)
 ### Owner
 
 ><pre>{
@@ -1468,4 +1526,3 @@
 >    }
 >  }
 >}</pre>
-

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -39,7 +39,8 @@
 ### [Owner](#11)
 #### &emsp;&emsp;[Dynamic Field](#720885)
 #### &emsp;&emsp;[Dynamic Field Connection](#720886)
-#### &emsp;&emsp;[Owner](#720887)
+#### &emsp;&emsp;[Dynamic Object Field](#720887)
+#### &emsp;&emsp;[Owner](#720888)
 ### [Protocol Configs](#12)
 #### &emsp;&emsp;[Key Value](#786420)
 #### &emsp;&emsp;[Key Value Feature Flag](#786421)
@@ -849,6 +850,7 @@
 >      repr
 >    }
 >    data
+>    __typename
 >  }
 >  ... on MoveObject {
 >    hasPublicTransfer
@@ -858,6 +860,7 @@
 >      }
 >      data
 >    }
+>    __typename
 >  }
 >}
 >
@@ -870,7 +873,7 @@
 >}
 >
 >fragment DynamicFieldSelect on DynamicField {
->  kind,
+>  kind
 >  name {
 >    ...DynamicFieldNameSelection
 >  }
@@ -885,9 +888,8 @@
 >  ) {
 >    dynamicField(
 >      dynamicFieldName: {
->        type: "0x2::kiosk::Item",
->        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw=",
->        kind:"DynamicObject"
+>        type: "0x2::kiosk::Listing",
+>        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
 >      }
 >    ) {
 >      ...DynamicFieldSelect
@@ -954,6 +956,59 @@
 >}</pre>
 
 ### <a id=720887></a>
+### Dynamic Object Field
+
+><pre>fragment DynamicFieldValueSelection on DynamicFieldValue {
+>  ... on MoveValue {
+>    type {
+>      repr
+>    }
+>    data
+>    __typename
+>  }
+>  ... on MoveObject {
+>    hasPublicTransfer
+>    contents {
+>      type {
+>        repr
+>      }
+>      data
+>    }
+>    __typename
+>  }
+>}
+>
+>fragment DynamicFieldNameSelection on MoveValue {
+>  type {
+>    repr
+>  }
+>  data
+>  bcs
+>}
+>
+>fragment DynamicFieldSelect on DynamicField {
+>  kind
+>  name {
+>    ...DynamicFieldNameSelection
+>  }
+>  value {
+>    ...DynamicFieldValueSelection
+>  }
+>}
+>
+>query DynamicObjectField {
+>  object(
+>    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
+>  ) {
+>    dynamicObjectField(
+>      dynamicFieldName: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
+>    ) {
+>      ...DynamicFieldSelect
+>    }
+>  }
+>}</pre>
+
+### <a id=720888></a>
 ### Owner
 
 ><pre>{

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -945,11 +945,7 @@
 >  }
 >}</pre>
 
-<<<<<<< HEAD
-### <a id=720886></a>
-=======
 ### <a id=720887></a>
->>>>>>> 05930e71e1 (move dynamicFieldConnection implementation to ObjectOwner interface, implement for owner and object)
 ### Owner
 
 ><pre>{
@@ -1526,3 +1522,4 @@
 >    }
 >  }
 >}</pre>
+

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -842,7 +842,6 @@
 ## Owner
 ### <a id=720885></a>
 ### Dynamic Field
-####  Selects a dynamic field child of the parent object
 
 ><pre>fragment DynamicFieldValueSelection on DynamicFieldValue {
 >  ... on MoveValue {
@@ -862,7 +861,8 @@
 >  }
 >}
 >
->fragment DynamicFieldNameSelection on MoveValue {
+>fragment DynamicFieldNameSelection on TypedDynamicFieldName {
+>  kind
 >  type {
 >    repr
 >  }
@@ -879,15 +879,17 @@
 >  }
 >}
 >
-># Selects a dynamic field child of the parent object
 >query DynamicField {
 >  object(
 >    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
 >  ) {
->    dynamicField(dynamicFieldName: {
->      type: "0x2::kiosk::Listing",
->      bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA"
->    }){
+>    dynamicField(
+>      dynamicFieldName: {
+>        type: "0x2::kiosk::Item",
+>        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw=",
+>        kind:"DynamicObject"
+>      }
+>    ) {
 >      ...DynamicFieldSelect
 >    }
 >  }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -886,7 +886,7 @@
 >    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
 >  ) {
 >    dynamicField(
->      dynamicFieldName: {
+>      name: {
 >        type: "0x2::kiosk::Listing",
 >        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
 >      }
@@ -998,7 +998,7 @@
 >    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
 >  ) {
 >    dynamicObjectField(
->      dynamicFieldName: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
+>      name: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
 >    ) {
 >      ...DynamicFieldSelect
 >    }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -27,7 +27,6 @@ fragment DynamicFieldNameSelection on MoveValue {
 }
 
 fragment DynamicFieldSelect on DynamicField {
-  kind
   name {
     ...DynamicFieldNameSelection
   }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -16,7 +16,8 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
   }
 }
 
-fragment DynamicFieldNameSelection on MoveValue {
+fragment DynamicFieldNameSelection on TypedDynamicFieldName {
+  kind
   type {
     repr
   }
@@ -33,15 +34,17 @@ fragment DynamicFieldSelect on DynamicField {
   }
 }
 
-# Selects a dynamic field child of the parent object
 query DynamicField {
   object(
     address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
   ) {
-    dynamicField(dynamicFieldName: {
-      type: "0x2::kiosk::Listing",
-      bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA"
-    }){
+    dynamicField(
+      dynamicFieldName: {
+        type: "0x2::kiosk::Item",
+        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw=",
+        kind:"DynamicObject"
+      }
+    ) {
       ...DynamicFieldSelect
     }
   }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -1,0 +1,48 @@
+fragment DynamicFieldValueSelection on DynamicFieldValue {
+  ... on MoveValue {
+    type {
+      repr
+    }
+    data
+  }
+  ... on MoveObject {
+    hasPublicTransfer
+    contents {
+      type {
+        repr
+      }
+      data
+    }
+  }
+}
+
+fragment DynamicFieldNameSelection on MoveValue {
+  type {
+    repr
+  }
+  data
+  bcs
+}
+
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    ...DynamicFieldNameSelection
+  }
+  value {
+    ...DynamicFieldValueSelection
+  }
+}
+
+# Selects a dynamic field child of the parent object
+query DynamicField {
+  object(
+    address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
+  ) {
+    dynamicField(dynamicFieldName: {
+      type: "0x2::kiosk::Listing",
+      bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA"
+    }){
+      ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -16,8 +16,7 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
   }
 }
 
-fragment DynamicFieldNameSelection on TypedDynamicFieldName {
-  kind
+fragment DynamicFieldNameSelection on MoveValue {
   type {
     repr
   }
@@ -26,6 +25,7 @@ fragment DynamicFieldNameSelection on TypedDynamicFieldName {
 }
 
 fragment DynamicFieldSelect on DynamicField {
+  kind,
   name {
     ...DynamicFieldNameSelection
   }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -40,7 +40,7 @@ query DynamicField {
     address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
   ) {
     dynamicField(
-      dynamicFieldName: {
+      name: {
         type: "0x2::kiosk::Listing",
         bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
       }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
@@ -1,4 +1,3 @@
-# defines a fragment for selecting fields from value matching either MoveValue or MoveObject
 fragment DynamicFieldValueSelection on DynamicFieldValue {
   ... on MoveValue {
     type {
@@ -17,12 +16,29 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
   }
 }
 
-# a query that selects the name and value of the first dynamic field of the owner address
-query DynamicFieldValue {
-  owner(
+fragment DynamicFieldNameSelection on MoveValue {
+  type {
+    repr
+  }
+  data
+  bcs
+}
+
+fragment DynamicFieldSelect on DynamicField {
+  kind,
+  name {
+    ...DynamicFieldNameSelection
+  }
+  value {
+    ...DynamicFieldValueSelection
+  }
+}
+
+query DynamicFieldConnection {
+  object(
     address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
   ) {
-    dynamicFieldConnection(first:1){
+    dynamicFieldConnection {
       pageInfo {
         hasNextPage
         endCursor
@@ -30,15 +46,7 @@ query DynamicFieldValue {
       edges {
         cursor
         node {
-          name {
-            type {
-              repr
-            }
-            data
-          }
-          value {
-            ...DynamicFieldValueSelection
-          }
+          ...DynamicFieldSelect
         }
       }
     }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
@@ -25,7 +25,6 @@ fragment DynamicFieldNameSelection on MoveValue {
 }
 
 fragment DynamicFieldSelect on DynamicField {
-  kind,
   name {
     ...DynamicFieldNameSelection
   }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
@@ -27,7 +27,6 @@ fragment DynamicFieldNameSelection on MoveValue {
 }
 
 fragment DynamicFieldSelect on DynamicField {
-  kind
   name {
     ...DynamicFieldNameSelection
   }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
@@ -36,15 +36,12 @@ fragment DynamicFieldSelect on DynamicField {
   }
 }
 
-query DynamicField {
+query DynamicObjectField {
   object(
     address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
   ) {
-    dynamicField(
-      dynamicFieldName: {
-        type: "0x2::kiosk::Listing",
-        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
-      }
+    dynamicObjectField(
+      dynamicFieldName: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
     ) {
       ...DynamicFieldSelect
     }

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
@@ -40,7 +40,7 @@ query DynamicObjectField {
     address: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac"
   ) {
     dynamicObjectField(
-      dynamicFieldName: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
+      name: {type: "0x2::kiosk::Item", bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw="}
     ) {
       ...DynamicFieldSelect
     }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -20,6 +20,7 @@ type Address implements ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -242,7 +243,7 @@ type DynamicField {
 	kind: String!
 	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
-	This field is used in conjunction with the 'kind' field to uniquely identify a child of the parent object.
+	This field is used to uniquely identify a child of the parent object.
 	"""
 	name: MoveValue
 	"""
@@ -281,12 +282,6 @@ type DynamicFieldEdge {
 }
 
 input DynamicFieldName {
-	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
 	"""
 	The string type of the DynamicField's 'name' field.
 	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
@@ -757,7 +752,17 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	"""
+	A field on an object that can be added or removed on-the-fly,
+	only affects gas when accessed, and can store heterogenous values.
+	"""
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	An object stored as a dynamic field on the parent object.
+	This object is also accessible directly via its address.
+	A dynamic field is an object field if its returned type is MoveObject.
+	"""
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -827,6 +832,7 @@ interface ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -848,7 +854,16 @@ type Owner implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	"""
+	A field on an object that can be added or removed on-the-fly,
+	only affects gas when accessed, and can store heterogenous values.
+	"""
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	An object stored as a dynamic field on the parent object.
+	This object is also accessible directly via its address.
+	"""
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -631,6 +631,10 @@ type MoveTypeSignature =
         typeParameters: [MoveTypeSignature],
       }
     }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 70eac4c07c ([GraphQL] MoveType and MoveTypeSignature)
 """
 scalar MoveTypeSignature
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -631,10 +631,6 @@ type MoveTypeSignature =
         typeParameters: [MoveTypeSignature],
       }
     }
-<<<<<<< HEAD
-=======
-
->>>>>>> 70eac4c07c ([GraphQL] MoveType and MoveTypeSignature)
 """
 scalar MoveTypeSignature
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -236,12 +236,6 @@ scalar DateTime
 
 type DynamicField {
 	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
-	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
 	This field is used to uniquely identify a child of the parent object.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -19,8 +19,14 @@ type Address implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	This resolver is not supported on the Address type.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	This resolver is not supported on the Address type.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -242,6 +248,8 @@ type DynamicField {
 	name: MoveValue
 	"""
 	The actual data stored in the dynamic field.
+	The returned dynamic field is an object if its return type is MoveObject,
+	in which case it is also accessible off-chain via its address.
 	"""
 	value: DynamicFieldValue
 }
@@ -747,16 +755,24 @@ type Object implements ObjectOwner {
 	"""
 	defaultNameServiceName: String
 	"""
-	A field on an object that can be added or removed on-the-fly,
-	only affects gas when accessed, and can store heterogenous values.
+	Access a dynamic field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
-	An object stored as a dynamic field on the parent object.
-	This object is also accessible directly via its address.
-	A dynamic field is an object field if its returned type is MoveObject.
+	Access a dynamic object field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields on an object.
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
+	"""
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -825,8 +841,8 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -849,15 +865,24 @@ type Owner implements ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	"""
-	A field on an object that can be added or removed on-the-fly,
-	only affects gas when accessed, and can store heterogenous values.
+	Access a dynamic field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
-	An object stored as a dynamic field on the parent object.
-	This object is also accessible directly via its address.
+	Access a dynamic object field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields on an object.
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
+	"""
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -235,10 +235,16 @@ scalar DateTime
 
 type DynamicField {
 	"""
-	The string type, data, and serialized value of the DynamicField's 'name' field.
-	This field is used to uniquely identify a child of the parent object.
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
 	"""
-	name: TypedDynamicFieldName
+	kind: String!
+	"""
+	The string type, data, and serialized value of the DynamicField's 'name' field.
+	This field is used in conjunction with the 'kind' field to uniquely identify a child of the parent object.
+	"""
+	name: MoveValue
 	"""
 	The actual data stored in the dynamic field.
 	"""
@@ -1358,39 +1364,6 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
-}
-
-"""
-The string type, data, and serialized value of a DynamicField's 'name' field.
-"""
-type TypedDynamicFieldName {
-	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
-	type: MoveType!
-	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -277,8 +277,7 @@ type DynamicFieldEdge {
 input DynamicFieldName {
 	"""
 	The string type of the DynamicField's 'name' field.
-	This may be the string representation of a Move primitive like 'u64',
-	or a struct type like 0x2::kiosk::Listing.
+	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
 	"""
 	type: String!
 	"""
@@ -664,7 +663,7 @@ type MoveValue {
 	data: MoveData!
 	"""
 	Representation of a Move value in JSON, where:
-
+	
 	- Addresses and UIDs are represented in canonical form, as JSON strings.
 	- Bools are represented by JSON boolean literals.
 	- u8, u16, and u32 are represented as JSON numbers.
@@ -672,7 +671,7 @@ type MoveValue {
 	- Vectors are represented by JSON arrays.
 	- Structs are represented by JSON objects.
 	- Empty optional values are represented by `null`.
-
+	
 	This form is offered as a less verbose convenience in cases where the layout of the type is
 	known by the client.
 	"""
@@ -1119,7 +1118,7 @@ type StorageFund {
 	totalObjectStorageRebates: BigInt
 	"""
 	The portion of the storage fund that will never be refunded through storage rebates.
-
+	
 	The system maintains an invariant that the sum of all storage fees into the storage fund is
 	equal to the sum of of all storage rebates out, the total storage rebates remaining, and the
 	non-refundable balance.

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -19,6 +19,7 @@ type Address implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -233,7 +234,14 @@ type ConsensusCommitPrologueTransaction {
 scalar DateTime
 
 type DynamicField {
+	"""
+	The string type, data, and serialized value of the DynamicField's 'name' field.
+	This field is used to uniquely identify a child of the parent object.
+	"""
 	name: MoveValue
+	"""
+	The actual data stored in the dynamic field.
+	"""
 	value: DynamicFieldValue
 }
 
@@ -264,6 +272,19 @@ type DynamicFieldEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+input DynamicFieldName {
+	"""
+	The string type of the DynamicField's 'name' field.
+	This may be the string representation of a Move primitive like 'u64',
+	or a struct type like 0x2::kiosk::Listing.
+	"""
+	type: String!
+	"""
+	The base64 encoded bcs serialization of the DynamicField's 'name' field.
+	"""
+	bcs: Base64!
 }
 
 union DynamicFieldValue = MoveObject | MoveValue
@@ -643,7 +664,7 @@ type MoveValue {
 	data: MoveData!
 	"""
 	Representation of a Move value in JSON, where:
-	
+
 	- Addresses and UIDs are represented in canonical form, as JSON strings.
 	- Bools are represented by JSON boolean literals.
 	- u8, u16, and u32 are represented as JSON numbers.
@@ -651,7 +672,7 @@ type MoveValue {
 	- Vectors are represented by JSON arrays.
 	- Structs are represented by JSON objects.
 	- Empty optional values are represented by `null`.
-	
+
 	This form is offered as a less verbose convenience in cases where the layout of the type is
 	known by the client.
 	"""
@@ -725,6 +746,7 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -793,6 +815,7 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -814,6 +837,7 @@ type Owner implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -1095,7 +1119,7 @@ type StorageFund {
 	totalObjectStorageRebates: BigInt
 	"""
 	The portion of the storage fund that will never be refunded through storage rebates.
-	
+
 	The system maintains an invariant that the sum of all storage fees into the storage fund is
 	equal to the sum of of all storage rebates out, the total storage rebates remaining, and the
 	non-refundable balance.

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -238,7 +238,7 @@ type DynamicField {
 	The string type, data, and serialized value of the DynamicField's 'name' field.
 	This field is used to uniquely identify a child of the parent object.
 	"""
-	name: MoveValue
+	name: TypedDynamicFieldName
 	"""
 	The actual data stored in the dynamic field.
 	"""
@@ -276,12 +276,18 @@ type DynamicFieldEdge {
 
 input DynamicFieldName {
 	"""
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
+	"""
+	kind: String!
+	"""
 	The string type of the DynamicField's 'name' field.
 	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
 	"""
 	type: String!
 	"""
-	The base64 encoded bcs serialization of the DynamicField's 'name' field.
+	The Base64 encoded bcs serialization of the DynamicField's 'name' field.
 	"""
 	bcs: Base64!
 }
@@ -1352,6 +1358,39 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
+}
+
+"""
+The string type, data, and serialized value of a DynamicField's 'name' field.
+"""
+type TypedDynamicFieldName {
+	"""
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
+	"""
+	kind: String!
+	type: MoveType!
+	bcs: Base64!
+	"""
+	Structured contents of a Move value.
+	"""
+	data: MoveData!
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Empty optional values are represented by `null`.
+	
+	This form is offered as a less verbose convenience in cases where the layout of the type is
+	known by the client.
+	"""
+	json: JSON!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -14,7 +14,7 @@ use crate::{
         committee_member::CommitteeMember,
         date_time::DateTime,
         digest::Digest,
-        dynamic_field::DynamicField,
+        dynamic_field::{DynamicField, DynamicFieldName},
         end_of_epoch_data::EndOfEpochData,
         epoch::Epoch,
         event::{Event, EventFilter},
@@ -1305,8 +1305,72 @@ impl PgManager {
                 },
             ));
         }
-
         Ok(Some(connection))
+    }
+
+    pub(crate) async fn fetch_dynamic_field_object(
+        &self,
+        address: SuiAddress,
+        name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>, Error> {
+        let type_tag =
+            TypeTag::from_str(&name.type_).map_err(|e| Error::Internal(format!("{e}")))?;
+        // This is expected to be from DynamicField.name.bcs, and is the undecorated MoveValue K of DF<K, V>
+        // Or for dynamic objects, the inner type of DF<Wrapper<T>, V>
+        let name_bcs_value = &name.bcs.0;
+        let parent_object_id =
+            ObjectID::from_bytes(address.as_slice()).map_err(|e| Error::Internal(e.to_string()))?;
+        let id = sui_types::dynamic_field::derive_dynamic_field_id(
+            parent_object_id,
+            &type_tag,
+            name_bcs_value,
+        )
+        .expect("oops");
+
+        println!("id: {:?}", id);
+
+        let stored_obj = self.get_obj(id.to_vec(), None).await?;
+        if let Some(stored_object) = stored_obj {
+            let df_object_id = stored_object.df_object_id.as_ref().ok_or_else(|| {
+                Error::Internal("Dynamic field does not have df_object_id".to_string())
+            })?;
+            let df_object_id = SuiAddress::from_bytes(df_object_id)
+                .map_err(|e| Error::Internal(format!("{e}")))?;
+            println!("df_object_id: {:?}", df_object_id);
+            return Ok(Some(DynamicField {
+                stored_object,
+                df_object_id,
+                df_kind: DynamicFieldType::DynamicField,
+            }));
+        }
+
+        // Try reading as dynamic field object by wrapping the inner T back into Wrapper<T> of DF<Wrapper<T>, V>
+        let dynamic_object_field_struct =
+            sui_types::dynamic_field::DynamicFieldInfo::dynamic_object_field_wrapper(type_tag);
+        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
+        let dynamic_object_field_id = sui_types::dynamic_field::derive_dynamic_field_id(
+            parent_object_id,
+            &dynamic_object_field_type,
+            name_bcs_value,
+        )
+        .expect("deriving dynamic field id can't fail");
+        println!("dynamic_object_field_id: {:?}", dynamic_object_field_id);
+
+        let stored_obj = self.get_obj(dynamic_object_field_id.to_vec(), None).await?;
+        if let Some(stored_object) = stored_obj {
+            let df_object_id = stored_object.df_object_id.as_ref().ok_or_else(|| {
+                Error::Internal("Dynamic field does not have df_object_id".to_string())
+            })?;
+            let df_object_id = SuiAddress::from_bytes(df_object_id)
+                .map_err(|e| Error::Internal(format!("{e}")))?;
+            println!("df_object_id: {:?}", df_object_id);
+            return Ok(Some(DynamicField {
+                stored_object,
+                df_object_id,
+                df_kind: DynamicFieldType::DynamicObject,
+            }));
+        }
+        Ok(None)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -92,6 +92,9 @@ pub enum Error {
     _CursorConnectionFetchFailed(String),
     #[error("Error received in multi-get query: {0}")]
     MultiGet(String),
+    #[error("{0}")]
+    // Catch-all for client-fault errors
+    Client(String),
     #[error("Internal error occurred while processing request: {0}")]
     Internal(String),
 }
@@ -112,7 +115,8 @@ impl ErrorExtensions for Error {
             | Error::_CursorConnectionFetchFailed(_)
             | Error::MultiGet(_)
             | Error::InvalidBase58(_)
-            | Error::InvalidDigestLength { .. } => {
+            | Error::InvalidDigestLength { .. }
+            | Error::Client(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }
             Error::Internal(_) => {

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -144,7 +144,6 @@ mod tests {
         let unimplemented = BTreeSet::from_iter([
             ("Checkpoint", "addressMetrics"),
             ("Epoch", "protocolConfig"),
-            ("Object", "dynamicField"),
             ("Query", "coinMetadata"),
             ("Query", "moveCallMetrics"),
             ("Query", "networkMetrics"),

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -160,8 +160,15 @@ impl Address {
     pub async fn dynamic_field(
         &self,
         _dynamic_field_name: DynamicFieldName,
-    ) -> Result<Option<DynamicField>, Error> {
-        Err(crate::error::Error::DynamicFieldOnAddress)
+    ) -> Result<Option<DynamicField>> {
+        Err(Error::DynamicFieldOnAddress.extend())
+    }
+
+    pub async fn dynamic_object_field(
+        &self,
+        _dynamic_field_name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>> {
+        Err(Error::DynamicFieldOnAddress.extend())
     }
 
     pub async fn dynamic_field_connection(

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -9,7 +9,7 @@ use crate::{context_data::db_data_provider::PgManager, error::Error};
 use super::{
     balance::Balance,
     coin::Coin,
-    dynamic_field::DynamicField,
+    dynamic_field::{DynamicField, DynamicFieldName},
     object::{Object, ObjectFilter},
     stake::StakedSui,
     sui_address::SuiAddress,
@@ -156,6 +156,13 @@ impl Address {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field(
+        &self,
+        _dynamic_field_name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>, Error> {
+        Err(crate::error::Error::DynamicFieldOnAddress)
+    }
 
     pub async fn dynamic_field_connection(
         &self,

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -157,16 +157,15 @@ impl Address {
     //     unimplemented!()
     // }
 
-    pub async fn dynamic_field(
-        &self,
-        _dynamic_field_name: DynamicFieldName,
-    ) -> Result<Option<DynamicField>> {
+    /// This resolver is not supported on the Address type.
+    pub async fn dynamic_field(&self, _name: DynamicFieldName) -> Result<Option<DynamicField>> {
         Err(Error::DynamicFieldOnAddress.extend())
     }
 
+    /// This resolver is not supported on the Address type.
     pub async fn dynamic_object_field(
         &self,
-        _dynamic_field_name: DynamicFieldName,
+        _name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         Err(Error::DynamicFieldOnAddress.extend())
     }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -31,10 +31,6 @@ pub(crate) enum DynamicFieldValue {
 
 #[derive(InputObject)] // used as input object
 pub(crate) struct DynamicFieldName {
-    /// A string flag of 'DynamicField' or 'DynamicObject'.
-    /// This is needed to disambiguate the child object,
-    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
-    pub kind: String,
     /// The string type of the DynamicField's 'name' field.
     /// A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
     pub type_: String,

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -77,6 +77,25 @@ impl DynamicField {
             .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
             .extend()?;
 
+        let parent_object_id =
+            SuiAddress::from_bytes(self.stored_object.owner_id.clone().unwrap().as_slice())?;
+
+        let derived_id =
+            sui_types::dynamic_field::derive_dynamic_field_id(parent_object_id, &type_tag, &bcs)
+                .expect("oops");
+
+        let dynamic_object_field_struct =
+            sui_types::dynamic_field::DynamicFieldInfo::dynamic_object_field_wrapper(
+                type_tag.clone(),
+            );
+        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
+        let dynamic_object_field_id = sui_types::dynamic_field::derive_dynamic_field_id(
+            parent_object_id,
+            &dynamic_object_field_type,
+            &bcs,
+        )
+        .expect("deriving dynamic field id can't fail");
+
         Ok(Some(MoveValue::new(
             type_tag.to_canonical_string(true),
             Base64::from(bcs),

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -37,6 +37,8 @@ pub(crate) struct DynamicFieldName {
 
 #[Object]
 impl DynamicField {
+    /// The string type, data, and serialized value of the DynamicField's 'name' field.
+    /// This field is used to uniquely identify a child of the parent object.
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
         let resolver: &Resolver<PackageCache> = ctx
             .data()
@@ -78,6 +80,7 @@ impl DynamicField {
         )))
     }
 
+    /// The actual data stored in the dynamic field.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         if self.df_kind == DynamicFieldType::DynamicObject {
             let obj = ctx

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -23,6 +23,17 @@ pub(crate) struct DynamicField {
     pub df_kind: DynamicFieldType,
 }
 
+/// The string type, data, and serialized value of a DynamicField's 'name' field.
+#[derive(SimpleObject)]
+pub(crate) struct TypedDynamicFieldName {
+    /// A string flag of 'DynamicField' or 'DynamicObject'.
+    /// This is needed to disambiguate the child object,
+    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
+    pub kind: String,
+    #[graphql(flatten)]
+    name: MoveValue,
+}
+
 #[derive(Union)]
 pub(crate) enum DynamicFieldValue {
     MoveObject(MoveObject), // DynamicObject
@@ -31,10 +42,14 @@ pub(crate) enum DynamicFieldValue {
 
 #[derive(InputObject)] // used as input object
 pub(crate) struct DynamicFieldName {
+    /// A string flag of 'DynamicField' or 'DynamicObject'.
+    /// This is needed to disambiguate the child object,
+    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
+    pub kind: String,
     /// The string type of the DynamicField's 'name' field.
     /// A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
     pub type_: String,
-    /// The base64 encoded bcs serialization of the DynamicField's 'name' field.
+    /// The Base64 encoded bcs serialization of the DynamicField's 'name' field.
     pub bcs: Base64,
 }
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -40,16 +40,6 @@ pub(crate) struct DynamicFieldName {
 
 #[Object]
 impl DynamicField {
-    /// A string flag of 'DynamicField' or 'DynamicObject'.
-    /// This is needed to disambiguate the child object,
-    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
-    async fn kind(&self) -> &str {
-        match self.df_kind {
-            DynamicFieldType::DynamicField => "DynamicField",
-            DynamicFieldType::DynamicObject => "DynamicObject",
-        }
-    }
-
     /// The string type, data, and serialized value of the DynamicField's 'name' field.
     /// This field is used to uniquely identify a child of the parent object.
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -31,7 +31,10 @@ pub(crate) enum DynamicFieldValue {
 
 #[derive(InputObject)] // used as input object
 pub(crate) struct DynamicFieldName {
+    /// The string type of the DynamicField's 'name' field.
+    /// A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
     pub type_: String,
+    /// The base64 encoded bcs serialization of the DynamicField's 'name' field.
     pub bcs: Base64,
 }
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -23,17 +23,6 @@ pub(crate) struct DynamicField {
     pub df_kind: DynamicFieldType,
 }
 
-/// The string type, data, and serialized value of a DynamicField's 'name' field.
-#[derive(SimpleObject)]
-pub(crate) struct TypedDynamicFieldName {
-    /// A string flag of 'DynamicField' or 'DynamicObject'.
-    /// This is needed to disambiguate the child object,
-    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
-    pub kind: String,
-    #[graphql(flatten)]
-    name: MoveValue,
-}
-
 #[derive(Union)]
 pub(crate) enum DynamicFieldValue {
     MoveObject(MoveObject), // DynamicObject
@@ -55,6 +44,16 @@ pub(crate) struct DynamicFieldName {
 
 #[Object]
 impl DynamicField {
+    /// A string flag of 'DynamicField' or 'DynamicObject'.
+    /// This is needed to disambiguate the child object,
+    /// as it is possible for a dynamic field and a dynamic object field to share the same name.
+    async fn kind(&self) -> &str {
+        match self.df_kind {
+            DynamicFieldType::DynamicField => "DynamicField",
+            DynamicFieldType::DynamicObject => "DynamicObject",
+        }
+    }
+
     /// The string type, data, and serialized value of the DynamicField's 'name' field.
     /// This field is used to uniquely identify a child of the parent object.
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
@@ -91,25 +90,6 @@ impl DynamicField {
         let bcs = bcs::to_bytes(&undecorated)
             .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
             .extend()?;
-
-        let parent_object_id =
-            SuiAddress::from_bytes(self.stored_object.owner_id.clone().unwrap().as_slice())?;
-
-        let derived_id =
-            sui_types::dynamic_field::derive_dynamic_field_id(parent_object_id, &type_tag, &bcs)
-                .expect("oops");
-
-        let dynamic_object_field_struct =
-            sui_types::dynamic_field::DynamicFieldInfo::dynamic_object_field_wrapper(
-                type_tag.clone(),
-            );
-        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
-        let dynamic_object_field_id = sui_types::dynamic_field::derive_dynamic_field_id(
-            parent_object_id,
-            &dynamic_object_field_type,
-            &bcs,
-        )
-        .expect("deriving dynamic field id can't fail");
 
         Ok(Some(MoveValue::new(
             type_tag.to_canonical_string(true),

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -84,6 +84,8 @@ impl DynamicField {
     }
 
     /// The actual data stored in the dynamic field.
+    /// The returned dynamic field is an object if its return type is MoveObject,
+    /// in which case it is also accessible off-chain via its address.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         if self.df_kind == DynamicFieldType::DynamicObject {
             let obj = ctx

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -9,7 +9,6 @@ use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc::name_service::NameServiceConfig;
 
 use super::big_int::BigInt;
-use super::digest::Digest;
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -9,7 +9,8 @@ use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc::name_service::NameServiceConfig;
 
 use super::big_int::BigInt;
-use super::dynamic_field::DynamicField;
+use super::digest::Digest;
+use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::{
@@ -232,6 +233,17 @@ impl Object {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field(
+        &self,
+        ctx: &Context<'_>,
+        dynamic_field_name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_dynamic_field_object(self.address, dynamic_field_name)
+            .await
+            .extend()
+    }
 
     pub async fn dynamic_field_connection(
         &self,

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -234,41 +234,39 @@ impl Object {
     //     unimplemented!()
     // }
 
-    /// A field on an object that can be added or removed on-the-fly,
-    /// only affects gas when accessed, and can store heterogenous values.
+    /// Access a dynamic field on an object using its name.
+    /// Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+    /// using their type, and their BCS contents, Base64 encoded.
+    /// Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
     pub async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
-        dynamic_field_name: DynamicFieldName,
+        name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_field(
-                self.address,
-                dynamic_field_name,
-                DynamicFieldType::DynamicField,
-            )
+            .fetch_dynamic_field(self.address, name, DynamicFieldType::DynamicField)
             .await
             .extend()
     }
 
-    /// An object stored as a dynamic field on the parent object.
-    /// This object is also accessible directly via its address.
-    /// A dynamic field is an object field if its returned type is MoveObject.
+    /// Access a dynamic object field on an object using its name.
+    /// Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+    /// using their type, and their BCS contents, Base64 encoded.
+    /// The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+    /// Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
     pub async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,
-        dynamic_field_name: DynamicFieldName,
+        name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_field(
-                self.address,
-                dynamic_field_name,
-                DynamicFieldType::DynamicObject,
-            )
+            .fetch_dynamic_field(self.address, name, DynamicFieldType::DynamicObject)
             .await
             .extend()
     }
 
+    /// The dynamic fields on an object.
+    /// Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
     pub async fn dynamic_field_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -68,14 +68,11 @@ use sui_json_rpc::name_service::NameServiceConfig;
     //     arg(name = "before", ty = "Option<String>")
     // )
     field(
-<<<<<<< HEAD
-=======
         name = "dynamic_field",
         ty = "Option<DynamicField>",
         arg(name = "dynamic_field_name", ty = "DynamicFieldName")
     ),
     field(
->>>>>>> 05930e71e1 (move dynamicFieldConnection implementation to ObjectOwner interface, implement for owner and object)
         name = "dynamic_field_connection",
         ty = "Option<Connection<String, DynamicField>>",
         arg(name = "first", ty = "Option<u64>"),

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -3,6 +3,7 @@
 
 use super::address::Address;
 use super::dynamic_field::DynamicField;
+use super::dynamic_field::DynamicFieldName;
 use super::stake::StakedSui;
 use crate::context_data::db_data_provider::PgManager;
 use crate::types::balance::*;
@@ -67,6 +68,14 @@ use sui_json_rpc::name_service::NameServiceConfig;
     //     arg(name = "before", ty = "Option<String>")
     // )
     field(
+<<<<<<< HEAD
+=======
+        name = "dynamic_field",
+        ty = "Option<DynamicField>",
+        arg(name = "dynamic_field_name", ty = "DynamicFieldName")
+    ),
+    field(
+>>>>>>> 05930e71e1 (move dynamicFieldConnection implementation to ObjectOwner interface, implement for owner and object)
         name = "dynamic_field_connection",
         ty = "Option<Connection<String, DynamicField>>",
         arg(name = "first", ty = "Option<u64>"),
@@ -199,6 +208,17 @@ impl Owner {
     // ) -> Result<Option<Connection<String, NameService>>> {
     //     unimplemented!()
     // }
+
+    pub async fn dynamic_field(
+        &self,
+        ctx: &Context<'_>,
+        dynamic_field_name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_dynamic_field_object(self.address, dynamic_field_name)
+            .await
+            .extend()
+    }
 
     pub async fn dynamic_field_connection(
         &self,

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -71,12 +71,12 @@ use sui_types::dynamic_field::DynamicFieldType;
     field(
         name = "dynamic_field",
         ty = "Option<DynamicField>",
-        arg(name = "dynamic_field_name", ty = "DynamicFieldName")
+        arg(name = "name", ty = "DynamicFieldName")
     ),
     field(
         name = "dynamic_object_field",
         ty = "Option<DynamicField>",
-        arg(name = "dynamic_field_name", ty = "DynamicFieldName")
+        arg(name = "name", ty = "DynamicFieldName")
     ),
     field(
         name = "dynamic_field_connection",
@@ -212,40 +212,39 @@ impl Owner {
     //     unimplemented!()
     // }
 
-    /// A field on an object that can be added or removed on-the-fly,
-    /// only affects gas when accessed, and can store heterogenous values.
+    /// Access a dynamic field on an object using its name.
+    /// Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+    /// using their type, and their BCS contents, Base64 encoded.
+    /// This field exists as a convenience when accessing a dynamic field on a wrapped object.
     pub async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
-        dynamic_field_name: DynamicFieldName,
+        name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_field(
-                self.address,
-                dynamic_field_name,
-                DynamicFieldType::DynamicField,
-            )
+            .fetch_dynamic_field(self.address, name, DynamicFieldType::DynamicField)
             .await
             .extend()
     }
 
-    /// An object stored as a dynamic field on the parent object.
-    /// This object is also accessible directly via its address.
+    /// Access a dynamic object field on an object using its name.
+    /// Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+    /// using their type, and their BCS contents, Base64 encoded.
+    /// The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+    /// This field exists as a convenience when accessing a dynamic field on a wrapped object.
     pub async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,
-        dynamic_field_name: DynamicFieldName,
+        name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_field(
-                self.address,
-                dynamic_field_name,
-                DynamicFieldType::DynamicObject,
-            )
+            .fetch_dynamic_field(self.address, name, DynamicFieldType::DynamicObject)
             .await
             .extend()
     }
 
+    /// The dynamic fields on an object.
+    /// This field exists as a convenience when accessing a dynamic field on a wrapped object.
     pub async fn dynamic_field_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -24,6 +24,7 @@ type Address implements ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -246,7 +247,7 @@ type DynamicField {
 	kind: String!
 	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
-	This field is used in conjunction with the 'kind' field to uniquely identify a child of the parent object.
+	This field is used to uniquely identify a child of the parent object.
 	"""
 	name: MoveValue
 	"""
@@ -285,12 +286,6 @@ type DynamicFieldEdge {
 }
 
 input DynamicFieldName {
-	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
 	"""
 	The string type of the DynamicField's 'name' field.
 	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
@@ -761,7 +756,17 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	"""
+	A field on an object that can be added or removed on-the-fly,
+	only affects gas when accessed, and can store heterogenous values.
+	"""
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	An object stored as a dynamic field on the parent object.
+	This object is also accessible directly via its address.
+	A dynamic field is an object field if its returned type is MoveObject.
+	"""
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -831,6 +836,7 @@ interface ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -852,7 +858,16 @@ type Owner implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	"""
+	A field on an object that can be added or removed on-the-fly,
+	only affects gas when accessed, and can store heterogenous values.
+	"""
 	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	An object stored as a dynamic field on the parent object.
+	This object is also accessible directly via its address.
+	"""
+	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -240,12 +240,6 @@ scalar DateTime
 
 type DynamicField {
 	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
-	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
 	This field is used to uniquely identify a child of the parent object.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -281,8 +281,7 @@ type DynamicFieldEdge {
 input DynamicFieldName {
 	"""
 	The string type of the DynamicField's 'name' field.
-	This may be the string representation of a Move primitive like 'u64',
-	or a struct type like 0x2::kiosk::Listing.
+	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
 	"""
 	type: String!
 	"""
@@ -668,7 +667,7 @@ type MoveValue {
 	data: MoveData!
 	"""
 	Representation of a Move value in JSON, where:
-
+	
 	- Addresses and UIDs are represented in canonical form, as JSON strings.
 	- Bools are represented by JSON boolean literals.
 	- u8, u16, and u32 are represented as JSON numbers.
@@ -676,7 +675,7 @@ type MoveValue {
 	- Vectors are represented by JSON arrays.
 	- Structs are represented by JSON objects.
 	- Empty optional values are represented by `null`.
-
+	
 	This form is offered as a less verbose convenience in cases where the layout of the type is
 	known by the client.
 	"""
@@ -1123,7 +1122,7 @@ type StorageFund {
 	totalObjectStorageRebates: BigInt
 	"""
 	The portion of the storage fund that will never be refunded through storage rebates.
-
+	
 	The system maintains an invariant that the sum of all storage fees into the storage fund is
 	equal to the sum of of all storage rebates out, the total storage rebates remaining, and the
 	non-refundable balance.
@@ -1425,3 +1424,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -23,6 +23,7 @@ type Address implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -237,7 +238,14 @@ type ConsensusCommitPrologueTransaction {
 scalar DateTime
 
 type DynamicField {
+	"""
+	The string type, data, and serialized value of the DynamicField's 'name' field.
+	This field is used to uniquely identify a child of the parent object.
+	"""
 	name: MoveValue
+	"""
+	The actual data stored in the dynamic field.
+	"""
 	value: DynamicFieldValue
 }
 
@@ -268,6 +276,19 @@ type DynamicFieldEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+input DynamicFieldName {
+	"""
+	The string type of the DynamicField's 'name' field.
+	This may be the string representation of a Move primitive like 'u64',
+	or a struct type like 0x2::kiosk::Listing.
+	"""
+	type: String!
+	"""
+	The base64 encoded bcs serialization of the DynamicField's 'name' field.
+	"""
+	bcs: Base64!
 }
 
 union DynamicFieldValue = MoveObject | MoveValue
@@ -647,7 +668,7 @@ type MoveValue {
 	data: MoveData!
 	"""
 	Representation of a Move value in JSON, where:
-	
+
 	- Addresses and UIDs are represented in canonical form, as JSON strings.
 	- Bools are represented by JSON boolean literals.
 	- u8, u16, and u32 are represented as JSON numbers.
@@ -655,7 +676,7 @@ type MoveValue {
 	- Vectors are represented by JSON arrays.
 	- Structs are represented by JSON objects.
 	- Empty optional values are represented by `null`.
-	
+
 	This form is offered as a less verbose convenience in cases where the layout of the type is
 	known by the client.
 	"""
@@ -729,6 +750,7 @@ type Object implements ObjectOwner {
 	The domain that a user address has explicitly configured as their default domain
 	"""
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -797,6 +819,7 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -818,6 +841,7 @@ type Owner implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
+	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -1099,7 +1123,7 @@ type StorageFund {
 	totalObjectStorageRebates: BigInt
 	"""
 	The portion of the storage fund that will never be refunded through storage rebates.
-	
+
 	The system maintains an invariant that the sum of all storage fees into the storage fund is
 	equal to the sum of of all storage rebates out, the total storage rebates remaining, and the
 	non-refundable balance.
@@ -1401,4 +1425,3 @@ type ValidatorSet {
 schema {
 	query: Query
 }
-

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1401,3 +1401,4 @@ type ValidatorSet {
 schema {
 	query: Query
 }
+

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1401,4 +1401,3 @@ type ValidatorSet {
 schema {
 	query: Query
 }
-

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -23,8 +23,14 @@ type Address implements ObjectOwner {
 	"""
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	"""
+	This resolver is not supported on the Address type.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	This resolver is not supported on the Address type.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -246,6 +252,8 @@ type DynamicField {
 	name: MoveValue
 	"""
 	The actual data stored in the dynamic field.
+	The returned dynamic field is an object if its return type is MoveObject,
+	in which case it is also accessible off-chain via its address.
 	"""
 	value: DynamicFieldValue
 }
@@ -751,16 +759,24 @@ type Object implements ObjectOwner {
 	"""
 	defaultNameServiceName: String
 	"""
-	A field on an object that can be added or removed on-the-fly,
-	only affects gas when accessed, and can store heterogenous values.
+	Access a dynamic field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
-	An object stored as a dynamic field on the parent object.
-	This object is also accessible directly via its address.
-	A dynamic field is an object field if its returned type is MoveObject.
+	Access a dynamic object field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields on an object.
+	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
+	"""
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -829,8 +845,8 @@ interface ObjectOwner {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
@@ -853,15 +869,24 @@ type Owner implements ObjectOwner {
 	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	"""
-	A field on an object that can be added or removed on-the-fly,
-	only affects gas when accessed, and can store heterogenous values.
+	Access a dynamic field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
-	An object stored as a dynamic field on the parent object.
-	This object is also accessible directly via its address.
+	Access a dynamic object field on an object using its name.
+	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
+	using their type, and their BCS contents, Base64 encoded.
+	The value of a dynamic object field can also be accessed off-chain directly via its address (e.g. using `Query.object`).
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicObjectField(dynamicFieldName: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields on an object.
+	This field exists as a convenience when accessing a dynamic field on a wrapped object.
+	"""
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -242,7 +242,7 @@ type DynamicField {
 	The string type, data, and serialized value of the DynamicField's 'name' field.
 	This field is used to uniquely identify a child of the parent object.
 	"""
-	name: MoveValue
+	name: TypedDynamicFieldName
 	"""
 	The actual data stored in the dynamic field.
 	"""
@@ -280,12 +280,18 @@ type DynamicFieldEdge {
 
 input DynamicFieldName {
 	"""
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
+	"""
+	kind: String!
+	"""
 	The string type of the DynamicField's 'name' field.
 	A string representation of a Move primitive like 'u64', or a struct type like '0x2::kiosk::Listing'
 	"""
 	type: String!
 	"""
-	The base64 encoded bcs serialization of the DynamicField's 'name' field.
+	The Base64 encoded bcs serialization of the DynamicField's 'name' field.
 	"""
 	bcs: Base64!
 }
@@ -1356,6 +1362,39 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
+}
+
+"""
+The string type, data, and serialized value of a DynamicField's 'name' field.
+"""
+type TypedDynamicFieldName {
+	"""
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
+	"""
+	kind: String!
+	type: MoveType!
+	bcs: Base64!
+	"""
+	Structured contents of a Move value.
+	"""
+	data: MoveData!
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Empty optional values are represented by `null`.
+	
+	This form is offered as a less verbose convenience in cases where the layout of the type is
+	known by the client.
+	"""
+	json: JSON!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -239,10 +239,16 @@ scalar DateTime
 
 type DynamicField {
 	"""
-	The string type, data, and serialized value of the DynamicField's 'name' field.
-	This field is used to uniquely identify a child of the parent object.
+	A string flag of 'DynamicField' or 'DynamicObject'.
+	This is needed to disambiguate the child object,
+	as it is possible for a dynamic field and a dynamic object field to share the same name.
 	"""
-	name: TypedDynamicFieldName
+	kind: String!
+	"""
+	The string type, data, and serialized value of the DynamicField's 'name' field.
+	This field is used in conjunction with the 'kind' field to uniquely identify a child of the parent object.
+	"""
+	name: MoveValue
 	"""
 	The actual data stored in the dynamic field.
 	"""
@@ -1362,39 +1368,6 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
-}
-
-"""
-The string type, data, and serialized value of a DynamicField's 'name' field.
-"""
-type TypedDynamicFieldName {
-	"""
-	A string flag of 'DynamicField' or 'DynamicObject'.
-	This is needed to disambiguate the child object,
-	as it is possible for a dynamic field and a dynamic object field to share the same name.
-	"""
-	kind: String!
-	type: MoveType!
-	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type Validator {


### PR DESCRIPTION
## Description 

Implements fetching dynamicField by dynamicFieldName. Clients are expected to know whether they're looking up a dynamic field or dynamic object field.

## Test Plan 

Manual + existing + new test suite

Fetching dynamic field
<img width="1758" alt="Screenshot 2023-11-16 at 10 23 25 AM" src="https://github.com/MystenLabs/sui/assets/127570466/33691eca-c437-4dd0-a299-0e264605e6b3">

Fetching dynamic object
<img width="1757" alt="Screenshot 2023-11-16 at 10 23 12 AM" src="https://github.com/MystenLabs/sui/assets/127570466/e5149da0-c9fe-40ba-b420-947f7d27a1ca">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
