### PR TITLE
[graphql/rpc] limit query payload size

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -914,6 +914,10 @@ type ServiceConfig {
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: BigInt!
+	"""
+	Maximum length of a query payload string.
+	"""
+	maxQueryPayloadSize: Int!
 }
 
 type Stake {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -12,7 +12,7 @@ use crate::functional_group::FunctionalGroup;
 // TODO: calculate proper cost limits
 const MAX_QUERY_DEPTH: u32 = 20;
 const MAX_QUERY_NODES: u32 = 200;
-const MAX_QUERY_PAYLOAD_SIZE: u64 = 5_000;
+const MAX_QUERY_PAYLOAD_SIZE: u32 = 5_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
 const MAX_QUERY_VARIABLES: u32 = 50;
 const MAX_QUERY_FRAGMENTS: u32 = 50;
@@ -53,7 +53,7 @@ pub struct Limits {
     #[serde(default)]
     pub(crate) max_query_nodes: u32,
     #[serde(default)]
-    pub(crate) max_query_payload_size: u64,
+    pub(crate) max_query_payload_size: u32,
     #[serde(default)]
     pub(crate) max_db_query_cost: u64,
     #[serde(default)]
@@ -173,6 +173,11 @@ impl ServiceConfig {
     /// Maximum time in milliseconds that will be spent to serve one request.
     async fn request_timeout_ms(&self) -> BigInt {
         BigInt::from(self.limits.request_timeout_ms)
+    }
+
+    /// Maximum length of a query payload string.
+    async fn max_query_payload_size(&self) -> u32 {
+        self.limits.max_query_payload_size
     }
 }
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -12,6 +12,7 @@ use crate::functional_group::FunctionalGroup;
 // TODO: calculate proper cost limits
 const MAX_QUERY_DEPTH: u32 = 20;
 const MAX_QUERY_NODES: u32 = 200;
+const MAX_QUERY_PAYLOAD_SIZE: u64 = 5_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
 const MAX_QUERY_VARIABLES: u32 = 50;
 const MAX_QUERY_FRAGMENTS: u32 = 50;
@@ -51,6 +52,8 @@ pub struct Limits {
     pub(crate) max_query_depth: u32,
     #[serde(default)]
     pub(crate) max_query_nodes: u32,
+    #[serde(default)]
+    pub(crate) max_query_payload_size: u64,
     #[serde(default)]
     pub(crate) max_db_query_cost: u64,
     #[serde(default)]
@@ -190,6 +193,7 @@ impl Default for Limits {
         Self {
             max_query_depth: MAX_QUERY_DEPTH,
             max_query_nodes: MAX_QUERY_NODES,
+            max_query_payload_size: MAX_QUERY_PAYLOAD_SIZE,
             max_db_query_cost: MAX_DB_QUERY_COST,
             max_query_variables: MAX_QUERY_VARIABLES,
             max_query_fragments: MAX_QUERY_FRAGMENTS,
@@ -285,6 +289,7 @@ mod tests {
             r#" [limits]
                 max-query-depth = 100
                 max-query-nodes = 300
+                max-query-payload-size = 2000
                 max-db-query-cost = 50
                 max-query-variables = 45
                 max-query-fragments = 32
@@ -297,6 +302,7 @@ mod tests {
             limits: Limits {
                 max_query_depth: 100,
                 max_query_nodes: 300,
+                max_query_payload_size: 2000,
                 max_db_query_cost: 50,
                 max_query_variables: 45,
                 max_query_fragments: 32,
@@ -354,6 +360,7 @@ mod tests {
                 [limits]
                 max-query-depth = 42
                 max-query-nodes = 320
+                max-query-payload-size = 200
                 max-db-query-cost = 20
                 max-query-variables = 34
                 max-query-fragments = 31
@@ -369,6 +376,7 @@ mod tests {
             limits: Limits {
                 max_query_depth: 42,
                 max_query_nodes: 320,
+                max_query_payload_size: 200,
                 max_db_query_cost: 20,
                 max_query_variables: 34,
                 max_query_fragments: 31,

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -14,6 +14,7 @@ use crate::context_data::db_data_provider::DbValidationError;
 pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
+    pub const GRAPHQL_VALIDATION_FAILED: &str = "GRAPHQL_VALIDATION_FAILED";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
 }
 

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -3,7 +3,9 @@
 
 use crate::config::Limits;
 use crate::config::ServiceConfig;
+use crate::error::code;
 use crate::error::code::INTERNAL_SERVER_ERROR;
+use crate::error::graphql_error;
 use crate::error::graphql_error_at_pos;
 use crate::metrics::RequestMetrics;
 use async_graphql::extensions::NextParseQuery;
@@ -129,12 +131,12 @@ impl Extension for QueryLimitsChecker {
             .expect("No service config provided in schema data");
 
         if query.len() > cfg.limits.max_query_payload_size as usize {
-            return Err(ServerError::new(
+            return Err(graphql_error(
+                code::GRAPHQL_VALIDATION_FAILED,
                 format!(
                     "Query payload is too large. The maximum allowed is {} bytes",
                     cfg.limits.max_query_payload_size
                 ),
-                None,
             ));
         }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -918,6 +918,10 @@ type ServiceConfig {
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: BigInt!
+	"""
+	Maximum length of a query payload string.
+	"""
+	maxQueryPayloadSize: Int!
 }
 
 type Stake {


### PR DESCRIPTION
## Description 

Limits the size of graphql query payloads

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
