### PR TITLE
Use default registry for mysticeti metrics

### DIFF
--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -11,7 +11,7 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair;
 use itertools::Itertools;
-use mysten_metrics::{RegistryID, RegistryService};
+use mysten_metrics::RegistryService;
 use mysticeti_core::commit_observer::SimpleCommitObserver;
 use mysticeti_core::committee::{Authority, Committee};
 use mysticeti_core::config::{Identifier, Parameters, PrivateConfig};
@@ -19,7 +19,6 @@ use mysticeti_core::types::AuthorityIndex;
 use mysticeti_core::validator::Validator;
 use mysticeti_core::{CommitConsumer, PublicKey, Signer, SimpleBlockHandler};
 use narwhal_executor::ExecutionState;
-use prometheus::Registry;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -42,10 +41,7 @@ pub struct MysticetiManager {
     running: Mutex<Running>,
     metrics: ConsensusManagerMetrics,
     registry_service: RegistryService,
-    validator: ArcSwapOption<(
-        Validator<SimpleBlockHandler, SimpleCommitObserver>,
-        RegistryID,
-    )>,
+    validator: ArcSwapOption<Validator<SimpleBlockHandler, SimpleCommitObserver>>,
     // we use a shared lazy mysticeti client so we can update the internal mysticeti client that
     // gets created for every new epoch.
     client: Arc<LazyMysticetiClient>,
@@ -118,8 +114,6 @@ impl ConsensusManagerTrait for MysticetiManager {
             .into();
         let config = PrivateConfig::new(self.get_store_path(epoch), authority_index);
 
-        let registry = Registry::new_custom(Some("mysticeti_".to_string()), None).unwrap();
-
         const MAX_RETRIES: u32 = 2;
         let mut retries = 0;
 
@@ -142,7 +136,7 @@ impl ConsensusManagerTrait for MysticetiManager {
                 committee.clone(),
                 &parameters,
                 config.clone(),
-                registry.clone(),
+                self.registry_service.default_registry(),
                 Signer(Box::new(private_key.0.clone())),
                 consumer,
                 tx_validator.clone(),
@@ -150,10 +144,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             .await
             {
                 Ok((validator, tx_sender)) => {
-                    let registry_id = self.registry_service.add(registry);
-
-                    self.validator
-                        .swap(Some(Arc::new((validator, registry_id))));
+                    self.validator.swap(Some(Arc::new(validator)));
 
                     // create the client to send transactions to Mysticeti and update it.
                     self.client.set(MysticetiClient::new(tx_sender));
@@ -192,7 +183,7 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         // swap with empty to ensure there is no other reference to validator and we can safely do Arc unwrap
         let r = self.validator.swap(None).unwrap();
-        let Ok((validator, registry_id)) = Arc::try_unwrap(r) else {
+        let Ok(validator) = Arc::try_unwrap(r) else {
             panic!("Failed to retrieve the mysticeti validator");
         };
 
@@ -201,9 +192,6 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         // drop the old consensus handler to force stop any underlying task running.
         self.consensus_handler.store(None);
-
-        // unregister the registry id
-        self.registry_service.remove(registry_id);
     }
 
     async fn is_running(&self) -> bool {


### PR DESCRIPTION
I am not sure why we needed to use custom registry, but for some reason mysticeti metrics are not populated in that case to private-testnet, even though we seem to be running mysticeti

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
