### PR TITLE
indexer v2 analytical: faster move call and address processors

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161107_move_call_metrics/up.sql
@@ -1,19 +1,17 @@
 CREATE TABLE move_calls (
-    -- Diesel only supports table with a primary key.
-    id                          BIGSERIAL PRIMARY KEY,
     transaction_sequence_number BIGINT  NOT NULL,
     checkpoint_sequence_number  BIGINT  NOT NULL,
     epoch                       BIGINT  NOT NULL,
     move_package                BYTEA   NOT NULL,
     move_module                 TEXT    NOT NULL,
-    move_function               TEXT    NOT NULL
+    move_function               TEXT    NOT NULL,
+    PRIMARY KEY(transaction_sequence_number, move_package, move_module, move_function)
 );
 CREATE INDEX idx_move_calls_epoch_etc ON move_calls (epoch, move_package, move_module, move_function);
 
 CREATE TABLE move_call_metrics (
     -- Diesel only supports table with a primary key.
     id                          BIGSERIAL   PRIMARY KEY,
-    checkpoint_sequence_number  BIGINT      NOT NULL,
     epoch                       BIGINT      NOT NULL,
     day                         BIGINT      NOT NULL,
     move_package                TEXT        NOT NULL,
@@ -21,5 +19,4 @@ CREATE TABLE move_call_metrics (
     move_function               TEXT        NOT NULL,
     count                       BIGINT      NOT NULL
 );
-CREATE INDEX move_call_metrics_checkpoint ON move_call_metrics (checkpoint_sequence_number);
-CREATE INDEX move_call_metrics_day ON move_call_metrics (day);
+CREATE INDEX move_call_metrics_epoch_day ON move_call_metrics (epoch, day);

--- a/crates/sui-indexer/migrations_v2/2023-10-04-161115_address_metrics/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161115_address_metrics/up.sql
@@ -27,3 +27,4 @@ CREATE TABLE address_metrics
     cumulative_active_addresses BIGINT  NOT NULL,
     daily_active_addresses      BIGINT  NOT NULL
 );
+CREATE INDEX address_metrics_epoch_idx ON address_metrics (epoch);

--- a/crates/sui-indexer/migrations_v2/2023-10-04-161244_network_metrics/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-04-161244_network_metrics/down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS network_metrics;
+DROP TABLE IF EXISTS epoch_peak_tps;

--- a/crates/sui-indexer/src/indexer_v2.rs
+++ b/crates/sui-indexer/src/indexer_v2.rs
@@ -97,12 +97,13 @@ impl IndexerV2 {
 
     pub async fn start_analytical_worker(
         store: PgIndexerAnalyticalStore,
+        metrics: IndexerMetrics,
     ) -> Result<(), IndexerError> {
         info!(
             "Sui indexerV2 Analytical Worker (version {:?}) started...",
             env!("CARGO_PKG_VERSION")
         );
-        let mut processor_orchestrator_v2 = ProcessorOrchestratorV2::new(store);
+        let mut processor_orchestrator_v2 = ProcessorOrchestratorV2::new(store, metrics);
         processor_orchestrator_v2.run_forever().await;
         Ok(())
     }

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), IndexerError> {
             return IndexerV2::start_reader(&indexer_config, &registry, db_url).await;
         } else if indexer_config.analytical_worker {
             let store = PgIndexerAnalyticalStore::new(blocking_cp);
-            return IndexerV2::start_analytical_worker(store).await;
+            return IndexerV2::start_analytical_worker(store, indexer_metrics.clone()).await;
         } else {
             panic!("No worker is specified");
         }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -31,6 +31,10 @@ pub struct IndexerMetrics {
     pub latest_fullnode_checkpoint_sequence_number: IntGauge,
     pub latest_tx_checkpoint_sequence_number: IntGauge,
     pub latest_indexer_object_checkpoint_sequence_number: IntGauge,
+    // analytical
+    pub latest_move_call_metrics_tx_seq: IntGauge,
+    pub latest_address_metrics_tx_seq: IntGauge,
+    pub latest_network_metrics_cp_seq: IntGauge,
     // checkpoint E2E latency is:
     // fullnode_download_latency + checkpoint_index_latency + db_commit_latency
     pub fullnode_checkpoint_data_download_latency: Histogram,
@@ -169,6 +173,21 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            latest_move_call_metrics_tx_seq: register_int_gauge_with_registry!(
+                "latest_move_call_metrics_tx_seq",
+                "Latest move call metrics tx seq",
+                registry,
+            ).unwrap(),
+            latest_address_metrics_tx_seq: register_int_gauge_with_registry!(
+                "latest_address_metrics_tx_seq",
+                "Latest address metrics tx seq",
+                registry,
+            ).unwrap(),
+            latest_network_metrics_cp_seq: register_int_gauge_with_registry!(
+                "latest_network_metrics_cp_seq",
+                "Latest network metrics cp seq",
+                registry,
+            ).unwrap(),
             fullnode_checkpoint_data_download_latency: register_histogram_with_registry!(
                 "fullnode_checkpoint_data_download_latency",
                 "Time spent in downloading checkpoint and transation for a new checkpoint from the Full Node",

--- a/crates/sui-indexer/src/models_v2/move_call_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/move_call_metrics.rs
@@ -17,7 +17,6 @@ use crate::schema_v2::{move_call_metrics, move_calls};
 #[derive(Clone, Debug, Queryable, Insertable)]
 #[diesel(table_name = move_calls)]
 pub struct StoredMoveCall {
-    pub id: Option<i64>,
     pub transaction_sequence_number: i64,
     pub checkpoint_sequence_number: i64,
     pub epoch: i64,
@@ -26,11 +25,10 @@ pub struct StoredMoveCall {
     pub move_function: String,
 }
 
-#[derive(Clone, Debug, Default, Insertable)]
+#[derive(Clone, Debug, Insertable)]
 #[diesel(table_name = move_call_metrics)]
 pub struct StoredMoveCallMetrics {
     pub id: Option<i64>,
-    pub checkpoint_sequence_number: i64,
     pub epoch: i64,
     pub day: i64,
     pub move_package: String,
@@ -39,13 +37,26 @@ pub struct StoredMoveCallMetrics {
     pub count: i64,
 }
 
+impl Default for StoredMoveCallMetrics {
+    fn default() -> Self {
+        Self {
+            id: None,
+            epoch: -1,
+            day: -1,
+            move_package: "".to_string(),
+            move_module: "".to_string(),
+            move_function: "".to_string(),
+            count: -1,
+        }
+    }
+}
+
 // for auto-incremented id, the committed id is None, so Option<i64>,
 // but when querying, the returned type is i64, thus a separate type is needed.
 #[derive(Clone, Debug, Queryable)]
 #[diesel(table_name = move_call_metrics)]
 pub struct QueriedMoveCallMetrics {
     pub id: i64,
-    pub checkpoint_sequence_number: i64,
     pub epoch: i64,
     pub day: i64,
     pub move_package: String,
@@ -76,7 +87,6 @@ impl From<QueriedMoveCallMetrics> for StoredMoveCallMetrics {
     fn from(q: QueriedMoveCallMetrics) -> Self {
         StoredMoveCallMetrics {
             id: Some(q.id),
-            checkpoint_sequence_number: q.checkpoint_sequence_number,
             epoch: q.epoch,
             day: q.day,
             move_package: q.move_package,

--- a/crates/sui-indexer/src/models_v2/network_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/network_metrics.rs
@@ -8,12 +8,22 @@ use sui_json_rpc_types::NetworkMetrics;
 
 use crate::schema_v2::epoch_peak_tps;
 
-#[derive(Clone, Debug, Default, Queryable, Insertable)]
+#[derive(Clone, Debug, Queryable, Insertable)]
 #[diesel(table_name = epoch_peak_tps)]
 pub struct StoredEpochPeakTps {
     pub epoch: i64,
     pub peak_tps: f64,
     pub peak_tps_30d: f64,
+}
+
+impl Default for StoredEpochPeakTps {
+    fn default() -> Self {
+        Self {
+            epoch: -1,
+            peak_tps: 0.0,
+            peak_tps_30d: 0.0,
+        }
+    }
 }
 
 #[derive(QueryableByName, Debug, Clone, Default)]

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -39,6 +39,17 @@ pub struct StoredTransaction {
     pub success_command_count: i16,
 }
 
+#[derive(Debug, Queryable)]
+pub struct TxSeq {
+    pub seq: i64,
+}
+
+impl Default for TxSeq {
+    fn default() -> Self {
+        Self { seq: -1 }
+    }
+}
+
 #[derive(Clone, Debug, Queryable)]
 pub struct StoredTransactionTimestamp {
     pub tx_sequence_number: i64,

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -12,7 +12,6 @@ use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffects;
-use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::TransactionEvents;
 use sui_types::event::Event;
 use sui_types::transaction::SenderSignedData;
@@ -72,14 +71,6 @@ pub struct StoredTransactionSuccessCommandCount {
 
 impl From<&IndexedTransaction> for StoredTransaction {
     fn from(tx: &IndexedTransaction) -> Self {
-        let cmd_count = tx
-            .sender_signed_data
-            .intent_message()
-            .value
-            .execution_parts()
-            .0
-            .num_commands();
-
         StoredTransaction {
             tx_sequence_number: tx.tx_sequence_number as i64,
             transaction_digest: tx.tx_digest.into_inner().to_vec(),
@@ -103,7 +94,7 @@ impl From<&IndexedTransaction> for StoredTransaction {
                 .collect(),
             timestamp_ms: tx.timestamp_ms as i64,
             transaction_kind: tx.transaction_kind.clone() as i16,
-            success_command_count: tx.effects.status().is_ok() as i16 * cmd_count as i16,
+            success_command_count: tx.successful_tx_num as i16,
         }
     }
 }

--- a/crates/sui-indexer/src/models_v2/tx_count_metrics.rs
+++ b/crates/sui-indexer/src/models_v2/tx_count_metrics.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 
 use crate::schema_v2::tx_count_metrics;
 
-#[derive(Clone, Debug, Default, Queryable, Insertable)]
+#[derive(Clone, Debug, Queryable, Insertable)]
 #[diesel(table_name = tx_count_metrics)]
 pub struct StoredTxCountMetrics {
     pub checkpoint_sequence_number: i64,
@@ -14,4 +14,17 @@ pub struct StoredTxCountMetrics {
     pub total_transaction_blocks: i64,
     pub total_successful_transaction_blocks: i64,
     pub total_successful_transactions: i64,
+}
+
+impl Default for StoredTxCountMetrics {
+    fn default() -> Self {
+        Self {
+            checkpoint_sequence_number: -1,
+            epoch: -1,
+            timestamp_ms: -1,
+            total_transaction_blocks: -1,
+            total_successful_transaction_blocks: -1,
+            total_successful_transactions: -1,
+        }
+    }
 }

--- a/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/address_metrics_processor.rs
@@ -1,235 +1,89 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use itertools::Itertools;
-use rayon::prelude::*;
-use std::collections::HashMap;
 use tap::tap::TapFallible;
 use tracing::{error, info};
 
-use crate::errors::IndexerError;
-use crate::models_v2::address_metrics::{
-    dedup_addresses, AddressInfoToCommit, StoredActiveAddress, StoredAddress,
-};
+use crate::metrics::IndexerMetrics;
 use crate::store::IndexerAnalyticalStore;
 use crate::types_v2::IndexerResult;
 
-const ADDRESS_PROCESSOR_BATCH_SIZE: i64 = 1000;
-const PARALLEL_DOWNLOAD_CHUNK_SIZE: i64 = 100;
-const PARALLEL_COMMIT_CHUNK_SIZE: usize = 10000;
+const ADDRESS_PROCESSOR_BATCH_SIZE: usize = 80000;
+const PARALLELISM: usize = 10;
 
 pub struct AddressMetricsProcessor<S> {
     pub store: S,
-    pub parallel_commit_chunk_size: usize,
+    metrics: IndexerMetrics,
+    pub address_processor_batch_size: usize,
+    pub address_processor_parallelism: usize,
 }
 
 impl<S> AddressMetricsProcessor<S>
 where
     S: IndexerAnalyticalStore + Clone + Sync + Send + 'static,
 {
-    pub fn new(store: S) -> AddressMetricsProcessor<S> {
-        let parallel_commit_chunk_size = std::env::var("ADDRESS_CHUNK_SIZE")
-            .map(|s| s.parse::<usize>().unwrap_or(PARALLEL_COMMIT_CHUNK_SIZE))
-            .unwrap_or(PARALLEL_COMMIT_CHUNK_SIZE);
+    pub fn new(store: S, metrics: IndexerMetrics) -> AddressMetricsProcessor<S> {
+        let address_processor_batch_size = std::env::var("ADDRESS_PROCESSOR_BATCH_SIZE")
+            .map(|s| s.parse::<usize>().unwrap_or(ADDRESS_PROCESSOR_BATCH_SIZE))
+            .unwrap_or(ADDRESS_PROCESSOR_BATCH_SIZE);
+        let address_processor_parallelism = std::env::var("ADDRESS_PROCESSOR_PARALLELISM")
+            .map(|s| s.parse::<usize>().unwrap_or(PARALLELISM))
+            .unwrap_or(PARALLELISM);
         Self {
             store,
-            parallel_commit_chunk_size,
+            metrics,
+            address_processor_batch_size,
+            address_processor_parallelism,
         }
     }
 
     pub async fn start(&self) -> IndexerResult<()> {
         info!("Indexer address metrics async processor started...");
-        let latest_address_metrics = self
+        let latest_tx_seq = self
             .store
-            .get_latest_address_metrics()
-            .await
-            .unwrap_or_default();
-        let mut last_end_cp_seq = latest_address_metrics.checkpoint;
+            .get_address_metrics_last_processed_tx_seq()
+            .await?;
+        let mut last_processed_tx_seq = latest_tx_seq.unwrap_or_default().seq;
         loop {
-            let mut latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
-            while latest_stored_checkpoint.sequence_number
-                < last_end_cp_seq + ADDRESS_PROCESSOR_BATCH_SIZE
-            {
+            let mut latest_tx = self.store.get_latest_stored_transaction().await?;
+            while if let Some(tx) = latest_tx {
+                tx.tx_sequence_number
+                    < last_processed_tx_seq + self.address_processor_batch_size as i64
+            } else {
+                true
+            } {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
+                latest_tx = self.store.get_latest_stored_transaction().await?;
             }
 
-            let end_cp = self
-                .store
-                .get_checkpoints_in_range(
-                    last_end_cp_seq + ADDRESS_PROCESSOR_BATCH_SIZE,
-                    last_end_cp_seq + ADDRESS_PROCESSOR_BATCH_SIZE + 1,
-                )
-                .await?
-                .first()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read checkpoint from PG for address metrics".to_string(),
-                ))?
-                .clone();
-
-            let mut parallel_download_tasks = vec![];
-            for chunk_start_cp_seq in ((last_end_cp_seq + 1)
-                ..last_end_cp_seq + ADDRESS_PROCESSOR_BATCH_SIZE + 1)
-                .step_by(PARALLEL_DOWNLOAD_CHUNK_SIZE as usize)
+            let mut persist_tasks = vec![];
+            let batch_size = self.address_processor_batch_size;
+            let step_size = batch_size / self.address_processor_parallelism;
+            for chunk_start_tx_seq in (last_processed_tx_seq + 1
+                ..last_processed_tx_seq + batch_size as i64 + 1)
+                .step_by(step_size)
             {
-                let chunk_end_cp_seq = chunk_start_cp_seq + PARALLEL_DOWNLOAD_CHUNK_SIZE;
-                let store = self.store.clone();
-                parallel_download_tasks.push(tokio::task::spawn(async move {
-                    store
-                        .get_tx_timestamps_in_checkpoint_range(chunk_start_cp_seq, chunk_end_cp_seq)
-                        .await
+                let active_address_store = self.store.clone();
+                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                    active_address_store.persist_active_addresses_in_tx_range(
+                        chunk_start_tx_seq,
+                        chunk_start_tx_seq + step_size as i64,
+                    )
                 }));
             }
-
-            let tx_timestamps = futures::future::join_all(parallel_download_tasks)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error joining tx timestamps download tasks: {:?}", e);
-                })?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error downloading tx timestamps: {:?}", e);
-                })?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
-
-            let start_tx_seq = tx_timestamps
-                .first()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read first tx from PG for address metrics".to_string(),
-                ))?
-                .tx_sequence_number;
-            let end_tx_seq = tx_timestamps
-                .last()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read last tx from PG for address metrics".to_string(),
-                ))?
-                .tx_sequence_number;
-            let tx_timestamp_map = tx_timestamps
-                .iter()
-                .map(|tx| (tx.tx_sequence_number, tx.timestamp_ms))
-                .collect::<HashMap<_, _>>();
-
-            let get_senders_handle = self
-                .store
-                .get_senders_in_tx_range(start_tx_seq, end_tx_seq + 1);
-            let get_recipients_handle = self
-                .store
-                .get_recipients_in_tx_range(start_tx_seq, end_tx_seq + 1);
-            let (stored_senders_res, stored_recipients_res) =
-                tokio::join!(get_senders_handle, get_recipients_handle);
-            let stored_senders = stored_senders_res?;
-            let stored_senders_count = stored_senders.len();
-            let senders_to_commit: Vec<AddressInfoToCommit> = stored_senders
-                .into_par_iter()
-                .filter_map(|sender| {
-                    if let Some(timestamp_ms) = tx_timestamp_map.get(&sender.tx_sequence_number) {
-                        Some(AddressInfoToCommit {
-                            address: sender.sender,
-                            tx_seq: sender.tx_sequence_number,
-                            timestamp_ms: *timestamp_ms,
-                        })
-                    } else {
-                        error!(
-                            "Failed to find timestamp for tx {}",
-                            sender.tx_sequence_number
-                        );
-                        None
-                    }
-                })
-                .collect();
-            if stored_senders_count != senders_to_commit.len() {
-                error!(
-                    "Failed to find timestamp for {} senders in checkpoint {}",
-                    stored_senders_count - senders_to_commit.len(),
-                    end_cp.sequence_number
-                );
-                continue;
+            for chunk_start_tx_seq in (last_processed_tx_seq + 1
+                ..last_processed_tx_seq + batch_size as i64 + 1)
+                .step_by(step_size)
+            {
+                let address_store = self.store.clone();
+                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                    address_store.persist_addresses_in_tx_range(
+                        chunk_start_tx_seq,
+                        chunk_start_tx_seq + step_size as i64,
+                    )
+                }));
             }
-            let stored_recipients = stored_recipients_res?;
-            let stored_recipients_count = stored_recipients.len();
-            let recipients_to_commit: Vec<AddressInfoToCommit> = stored_recipients
-                .into_par_iter()
-                .filter_map(|recipient| {
-                    if let Some(timestamp_ms) = tx_timestamp_map.get(&recipient.tx_sequence_number)
-                    {
-                        Some(AddressInfoToCommit {
-                            address: recipient.recipient,
-                            tx_seq: recipient.tx_sequence_number,
-                            timestamp_ms: *timestamp_ms,
-                        })
-                    } else {
-                        error!(
-                            "Failed to find timestamp for tx {}",
-                            recipient.tx_sequence_number
-                        );
-                        None
-                    }
-                })
-                .collect();
-            if stored_recipients_count != recipients_to_commit.len() {
-                error!(
-                    "Failed to find timestamp for {} recipients in checkpoint {}",
-                    stored_recipients_count - recipients_to_commit.len(),
-                    end_cp.sequence_number
-                );
-                continue;
-            }
-
-            let sneders_recipients_to_commit: Vec<AddressInfoToCommit> = senders_to_commit
-                .clone()
-                .into_iter()
-                .chain(recipients_to_commit.into_iter())
-                .collect::<Vec<AddressInfoToCommit>>();
-            // de-dup senders with earliest and latest timestamps
-            let active_addresses_to_commit: Vec<StoredActiveAddress> =
-                dedup_addresses(senders_to_commit)
-                    .into_iter()
-                    .map(StoredActiveAddress::from)
-                    .collect();
-            let addresses_to_commit: Vec<StoredAddress> =
-                dedup_addresses(sneders_recipients_to_commit);
-            let end_cp_seq = end_cp.sequence_number;
-            let addr_count = addresses_to_commit.len();
-            let active_addr_count = active_addresses_to_commit.len();
-            info!(
-                "Indexed {} addresses and {} active addresses for checkpoint: {}",
-                addr_count, active_addr_count, end_cp_seq,
-            );
-
-            let address_chunk_to_commit = addresses_to_commit
-                .into_iter()
-                .chunks(self.parallel_commit_chunk_size)
-                .into_iter()
-                .map(|chunk| chunk.collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let parallel_address_commit_tasks = address_chunk_to_commit
-                .into_iter()
-                .map(|chunk| {
-                    let store = self.store.clone();
-                    tokio::task::spawn_blocking(move || store.persist_addresses(chunk))
-                })
-                .collect::<Vec<_>>();
-
-            let active_address_chunk_to_commit = active_addresses_to_commit
-                .into_iter()
-                .chunks(self.parallel_commit_chunk_size)
-                .into_iter()
-                .map(|chunk| chunk.collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let parallel_active_address_commit_tasks = active_address_chunk_to_commit
-                .into_iter()
-                .map(|chunk| {
-                    let store = self.store.clone();
-                    tokio::task::spawn_blocking(move || store.persist_active_addresses(chunk))
-                })
-                .collect::<Vec<_>>();
-
-            futures::future::join_all(parallel_address_commit_tasks)
+            futures::future::join_all(persist_tasks)
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
@@ -239,31 +93,31 @@ where
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
                 .tap_err(|e| {
-                    error!("Error persisting addresses: {:?}", e);
+                    error!("Error persisting addresses or active addresses: {:?}", e);
                 })?;
-            futures::future::join_all(parallel_active_address_commit_tasks)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error joining active address persist tasks: {:?}", e);
-                })?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error persisting active addresses: {:?}", e);
-                })?;
+            last_processed_tx_seq += self.address_processor_batch_size as i64;
             info!(
-                "Persisted {} addresses and {} active addresses for checkpoint: {}",
-                addr_count, active_addr_count, end_cp_seq,
+                "Persisted addresses and active addresses for tx seq: {}",
+                last_processed_tx_seq,
             );
+            self.metrics
+                .latest_address_metrics_tx_seq
+                .set(last_processed_tx_seq);
 
-            let address_metrics_to_commit = self.store.calculate_address_metrics(end_cp).await?;
+            let mut last_processed_tx = self.store.get_tx(last_processed_tx_seq).await?;
+            while last_processed_tx.is_none() {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                last_processed_tx = self.store.get_tx(last_processed_tx_seq).await?;
+            }
+            // unwrap is safe here b/c we just checked that it's not None
+            let last_processed_cp = last_processed_tx.unwrap().checkpoint_sequence_number;
             self.store
-                .persist_address_metrics(address_metrics_to_commit)
+                .calculate_and_persist_address_metrics(last_processed_cp)
                 .await?;
-            last_end_cp_seq = end_cp_seq;
-            info!("Persisted address metrics for checkpoint: {}", end_cp_seq);
+            info!(
+                "Persisted address metrics for checkpoint: {}",
+                last_processed_cp
+            );
         }
     }
 }

--- a/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/move_call_metrics_processor.rs
@@ -1,190 +1,76 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use itertools::Itertools;
-use rayon::prelude::*;
-use std::collections::HashMap;
 use tap::tap::TapFallible;
 use tracing::{error, info};
 
-use crate::errors::IndexerError;
-use crate::models_v2::move_call_metrics::StoredMoveCall;
+use crate::metrics::IndexerMetrics;
 use crate::store::IndexerAnalyticalStore;
 use crate::types_v2::IndexerResult;
 
-const MOVE_CALL_PROCESSOR_BATCH_SIZE: i64 = 1000;
-const PARALLEL_DOWNLOAD_CHUNK_SIZE: i64 = 100;
-const PARALLEL_COMMIT_CHUNK_SIZE: usize = 8000;
+const MOVE_CALL_PROCESSOR_BATCH_SIZE: usize = 80000;
+const PARALLELISM: usize = 10;
 
 pub struct MoveCallMetricsProcessor<S> {
     pub store: S,
-    pub parallel_commit_chunk_size: usize,
+    metrics: IndexerMetrics,
+    pub move_call_processor_batch_size: usize,
+    pub move_call_processor_parallelism: usize,
 }
 
 impl<S> MoveCallMetricsProcessor<S>
 where
     S: IndexerAnalyticalStore + Clone + Sync + Send + 'static,
 {
-    pub fn new(store: S) -> MoveCallMetricsProcessor<S> {
-        let parallel_commit_chunk_size = std::env::var("MOVE_CALL_CHUNK_SIZE")
-            .map(|s| s.parse::<usize>().unwrap_or(PARALLEL_COMMIT_CHUNK_SIZE))
-            .unwrap_or(PARALLEL_COMMIT_CHUNK_SIZE);
+    pub fn new(store: S, metrics: IndexerMetrics) -> MoveCallMetricsProcessor<S> {
+        let move_call_processor_batch_size = std::env::var("MOVE_CALL_PROCESSOR_BATCH_SIZE")
+            .map(|s| s.parse::<usize>().unwrap_or(MOVE_CALL_PROCESSOR_BATCH_SIZE))
+            .unwrap_or(MOVE_CALL_PROCESSOR_BATCH_SIZE);
+        let move_call_processor_parallelism = std::env::var("MOVE_CALL_PROCESSOR_PARALLELISM")
+            .map(|s| s.parse::<usize>().unwrap_or(PARALLELISM))
+            .unwrap_or(PARALLELISM);
         Self {
             store,
-            parallel_commit_chunk_size,
+            metrics,
+            move_call_processor_batch_size,
+            move_call_processor_parallelism,
         }
     }
 
     pub async fn start(&self) -> IndexerResult<()> {
         info!("Indexer move call metrics async processor started...");
-        let latest_move_call_metrics = self
-            .store
-            .get_latest_move_call_metrics()
-            .await
-            .unwrap_or_default();
-        let mut last_end_cp_seq = latest_move_call_metrics.checkpoint_sequence_number;
-        let mut last_move_call_epoch = latest_move_call_metrics.epoch;
+        let latest_move_call_tx_seq = self.store.get_latest_move_call_tx_seq().await?;
+        let mut last_processed_tx_seq = latest_move_call_tx_seq.unwrap_or_default().seq;
+        let latest_move_call_epoch = self.store.get_latest_move_call_metrics().await?;
+        let mut last_processed_epoch = latest_move_call_epoch.unwrap_or_default().epoch;
         loop {
-            let mut latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
-            while latest_stored_checkpoint.sequence_number
-                < last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE
-            {
+            let mut latest_tx = self.store.get_latest_stored_transaction().await?;
+            while if let Some(tx) = latest_tx {
+                tx.tx_sequence_number
+                    < last_processed_tx_seq + self.move_call_processor_batch_size as i64
+            } else {
+                true
+            } {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
+                latest_tx = self.store.get_latest_stored_transaction().await?;
             }
 
-            let mut parallel_download_tasks = vec![];
-            for chunk_start_cp_seq in ((last_end_cp_seq + 1)
-                ..last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE + 1)
-                .step_by(PARALLEL_DOWNLOAD_CHUNK_SIZE as usize)
+            let batch_size = self.move_call_processor_batch_size;
+            let step_size = batch_size / self.move_call_processor_parallelism;
+            let mut persist_tasks = vec![];
+            for chunk_start_tx_seq in (last_processed_tx_seq + 1
+                ..last_processed_tx_seq + batch_size as i64 + 1)
+                .step_by(step_size)
             {
-                let chunk_end_cp_seq = chunk_start_cp_seq + PARALLEL_DOWNLOAD_CHUNK_SIZE;
-                let store = self.store.clone();
-                parallel_download_tasks.push(tokio::task::spawn(async move {
-                    store
-                        .get_tx_checkpoints_in_checkpoint_range(
-                            chunk_start_cp_seq,
-                            chunk_end_cp_seq,
-                        )
-                        .await
+                let move_call_store = self.store.clone();
+                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                    move_call_store.persist_move_calls_in_tx_range(
+                        chunk_start_tx_seq,
+                        chunk_start_tx_seq + step_size as i64,
+                    )
                 }));
             }
-
-            let tx_checkpoints = futures::future::join_all(parallel_download_tasks)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error joining tx checkpoints download tasks: {:?}", e);
-                })?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| {
-                    error!("Error downloading tx checkpoints: {:?}", e);
-                })?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
-            let end_cp_seq = last_end_cp_seq + MOVE_CALL_PROCESSOR_BATCH_SIZE;
-            let cps = self
-                .store
-                .get_checkpoints_in_range(last_end_cp_seq + 1, end_cp_seq + 1)
-                .await?;
-            info!(
-                "Downloaded checkpoints and transactions from checkpoint {} to checkpoint {}",
-                last_end_cp_seq + 1,
-                end_cp_seq
-            );
-
-            let end_cp = cps
-                .last()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read checkpoint from PG for move call metrics".to_string(),
-                ))?
-                .clone();
-            let cp_epoch_map = cps
-                .par_iter()
-                .map(|cp| (cp.sequence_number, cp.epoch))
-                .collect::<HashMap<_, _>>();
-            let tx_cp_map = tx_checkpoints
-                .par_iter()
-                .map(|tx| (tx.tx_sequence_number, tx.checkpoint_sequence_number))
-                .collect::<HashMap<_, _>>();
-            let start_tx_seq = tx_checkpoints
-                .first()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read first tx from PG for move call metrics".to_string(),
-                ))?
-                .tx_sequence_number;
-            let end_tx_seq = tx_checkpoints
-                .last()
-                .ok_or(IndexerError::PostgresReadError(
-                    "Cannot read last tx from PG for move call metrics".to_string(),
-                ))?
-                .tx_sequence_number;
-            let stored_move_calls = self
-                .store
-                .get_move_calls_in_tx_range(start_tx_seq, end_tx_seq + 1)
-                .await?;
-            let stored_move_calls_count = stored_move_calls.len();
-            let move_calls_to_commit = stored_move_calls
-                .into_par_iter()
-                .filter_map(|call| {
-                    if let Some(cp) = tx_cp_map.get(&call.tx_sequence_number) {
-                        if let Some(epoch) = cp_epoch_map.get(cp) {
-                            Some(StoredMoveCall {
-                                id: None,
-                                transaction_sequence_number: call.tx_sequence_number,
-                                checkpoint_sequence_number: *cp,
-                                epoch: *epoch,
-                                move_package: call.package,
-                                move_module: call.module,
-                                move_function: call.func,
-                            })
-                        } else {
-                            error!("Failed to find epoch for checkpoint: {}", cp);
-                            None
-                        }
-                    } else {
-                        error!(
-                            "Failed to find checkpoint for tx: {}",
-                            call.tx_sequence_number
-                        );
-                        None
-                    }
-                })
-                .collect::<Vec<StoredMoveCall>>();
-            if stored_move_calls_count != move_calls_to_commit.len() {
-                error!(
-                    "Error enriching data of move calls to commit: {} != {}",
-                    stored_move_calls_count,
-                    move_calls_to_commit.len()
-                );
-                continue;
-            }
-
-            let end_cp_seq = end_cp.sequence_number;
-            let end_cp_epoch = end_cp.epoch;
-            let move_call_count = move_calls_to_commit.len();
-            info!(
-                "Indexed {} move_calls at checkpoint: {}",
-                move_call_count, end_cp_seq
-            );
-
-            let move_call_chunk_to_commit = move_calls_to_commit
-                .into_iter()
-                .chunks(self.parallel_commit_chunk_size)
-                .into_iter()
-                .map(|chunk| chunk.collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let mut parallel_commit_tasks = vec![];
-            for move_call_chunk in move_call_chunk_to_commit {
-                let store = self.store.clone();
-                parallel_commit_tasks.push(tokio::task::spawn_blocking(move || {
-                    store.persist_move_calls(move_call_chunk)
-                }));
-            }
-            futures::future::join_all(parallel_commit_tasks)
+            futures::future::join_all(persist_tasks)
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()
@@ -196,19 +82,31 @@ where
                 .tap_err(|e| {
                     error!("Error persisting move calls: {:?}", e);
                 })?;
-            info!(
-                "Persisted {} move_calls at checkpoint: {}",
-                move_call_count, end_cp_seq
-            );
-            if end_cp_epoch > last_move_call_epoch {
-                let move_call_metrics = self.store.calculate_move_call_metrics(end_cp).await?;
-                self.store
-                    .persist_move_call_metrics(move_call_metrics)
-                    .await?;
-                info!("Persisted move_call_metrics at epoch: {}", end_cp_epoch);
-                last_move_call_epoch = end_cp_epoch;
+            last_processed_tx_seq += batch_size as i64;
+            info!("Persisted move_calls at tx seq: {}", last_processed_tx_seq);
+            self.metrics
+                .latest_move_call_metrics_tx_seq
+                .set(last_processed_tx_seq);
+
+            let mut tx = self.store.get_tx(last_processed_tx_seq).await?;
+            while tx.is_none() {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                tx = self.store.get_tx(last_processed_tx_seq).await?;
             }
-            last_end_cp_seq = end_cp_seq;
+            let cp_seq = tx.unwrap().checkpoint_sequence_number;
+            let mut cp = self.store.get_cp(cp_seq).await?;
+            while cp.is_none() {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                cp = self.store.get_cp(cp_seq).await?;
+            }
+            let end_epoch = cp.unwrap().epoch;
+            for epoch in last_processed_epoch + 1..end_epoch {
+                self.store
+                    .calculate_and_persist_move_call_metrics(epoch)
+                    .await?;
+                info!("Persisted move_call_metrics for epoch: {}", epoch);
+            }
+            last_processed_epoch = end_epoch - 1;
         }
     }
 }

--- a/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/network_metrics_processor.rs
@@ -1,33 +1,45 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use tracing::info;
+
+use tap::tap::TapFallible;
+use tracing::{error, info};
 
 use crate::errors::IndexerError;
+use crate::metrics::IndexerMetrics;
 use crate::store::IndexerAnalyticalStore;
 use crate::types_v2::IndexerResult;
 
-const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: i64 = 10;
+const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: usize = 10;
+const PARALLELISM: usize = 1;
 
 pub struct NetworkMetricsProcessor<S> {
     pub store: S,
-    pub network_processor_metrics_batch_size: i64,
+    metrics: IndexerMetrics,
+    pub network_processor_metrics_batch_size: usize,
+    pub network_processor_metrics_parallelism: usize,
 }
 
 impl<S> NetworkMetricsProcessor<S>
 where
-    S: IndexerAnalyticalStore + Sync + Send + 'static,
+    S: IndexerAnalyticalStore + Clone + Sync + Send + 'static,
 {
-    pub fn new(store: S) -> NetworkMetricsProcessor<S> {
+    pub fn new(store: S, metrics: IndexerMetrics) -> NetworkMetricsProcessor<S> {
         let network_processor_metrics_batch_size =
             std::env::var("NETWORK_PROCESSOR_METRICS_BATCH_SIZE")
                 .map(|s| {
-                    s.parse::<i64>()
+                    s.parse::<usize>()
                         .unwrap_or(NETWORK_METRICS_PROCESSOR_BATCH_SIZE)
                 })
                 .unwrap_or(NETWORK_METRICS_PROCESSOR_BATCH_SIZE);
+        let network_processor_metrics_parallelism =
+            std::env::var("NETWORK_PROCESSOR_METRICS_PARALLELISM")
+                .map(|s| s.parse::<usize>().unwrap_or(PARALLELISM))
+                .unwrap_or(PARALLELISM);
         Self {
             store,
+            metrics,
             network_processor_metrics_batch_size,
+            network_processor_metrics_parallelism,
         }
     }
 
@@ -43,27 +55,59 @@ where
             .get_latest_epoch_peak_tps()
             .await
             .unwrap_or_default();
-        let mut last_processed_cp_seq = latest_tx_count_metrics.checkpoint_sequence_number;
-        let mut last_processed_peak_tps_epoch = latest_epoch_peak_tps.epoch;
+        let mut last_processed_cp_seq = latest_tx_count_metrics
+            .unwrap_or_default()
+            .checkpoint_sequence_number;
+        let mut last_processed_peak_tps_epoch = latest_epoch_peak_tps.unwrap_or_default().epoch;
         loop {
             let mut latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
-            while latest_stored_checkpoint.sequence_number
-                < last_processed_cp_seq + self.network_processor_metrics_batch_size
-            {
+            while if let Some(cp) = latest_stored_checkpoint {
+                cp.sequence_number
+                    < last_processed_cp_seq + self.network_processor_metrics_batch_size as i64
+            } else {
+                true
+            } {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 latest_stored_checkpoint = self.store.get_latest_stored_checkpoint().await?;
             }
-            self.store
-                .persist_tx_count_metrics(
-                    last_processed_cp_seq + 1,
-                    last_processed_cp_seq + self.network_processor_metrics_batch_size,
-                )
-                .await?;
-            last_processed_cp_seq += self.network_processor_metrics_batch_size;
+
+            info!(
+                "Persisting tx count metrics for checkpoint sequence number {}",
+                last_processed_cp_seq
+            );
+            let batch_size = self.network_processor_metrics_batch_size;
+            let step_size = batch_size / self.network_processor_metrics_parallelism;
+            let mut persist_tasks = vec![];
+            for chunk_start_cp in (last_processed_cp_seq + 1
+                ..last_processed_cp_seq + batch_size as i64 + 1)
+                .step_by(step_size)
+            {
+                let store = self.store.clone();
+                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                    store
+                        .persist_tx_count_metrics(chunk_start_cp, chunk_start_cp + step_size as i64)
+                }));
+            }
+            futures::future::join_all(persist_tasks)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| {
+                    error!("Error joining network persist tasks: {:?}", e);
+                })?
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .tap_err(|e| {
+                    error!("Error persisting tx count metrics: {:?}", e);
+                })?;
+            last_processed_cp_seq += batch_size as i64;
             info!(
                 "Persisted tx count metrics for checkpoint sequence number {}",
                 last_processed_cp_seq
             );
+            self.metrics
+                .latest_network_metrics_cp_seq
+                .set(last_processed_cp_seq);
 
             let end_cp = self
                 .store
@@ -74,7 +118,7 @@ where
                     "Cannot read checkpoint from PG for epoch peak TPS".to_string(),
                 ))?
                 .clone();
-            for epoch in last_processed_peak_tps_epoch + 1..=end_cp.epoch {
+            for epoch in last_processed_peak_tps_epoch + 1..end_cp.epoch {
                 self.store.persist_epoch_peak_tps(epoch).await?;
                 last_processed_peak_tps_epoch = epoch;
                 info!("Persisted epoch peak TPS for epoch {}", epoch);

--- a/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
+++ b/crates/sui-indexer/src/processors_v2/processor_orchestrator_v2.rs
@@ -4,6 +4,7 @@
 use futures::future::try_join_all;
 use tracing::{error, info};
 
+use crate::metrics::IndexerMetrics;
 use crate::store::IndexerAnalyticalStore;
 
 use super::address_metrics_processor::AddressMetricsProcessor;
@@ -12,20 +13,21 @@ use super::network_metrics_processor::NetworkMetricsProcessor;
 
 pub struct ProcessorOrchestratorV2<S> {
     store: S,
+    metrics: IndexerMetrics,
 }
 
 impl<S> ProcessorOrchestratorV2<S>
 where
     S: IndexerAnalyticalStore + Clone + Send + Sync + 'static,
 {
-    pub fn new(store: S) -> Self {
-        Self { store }
+    pub fn new(store: S, metrics: IndexerMetrics) -> Self {
+        Self { store, metrics }
     }
 
     pub async fn run_forever(&mut self) {
         info!("Processor orchestrator started...");
-        // TODO(gegaowp): add metrics for each processor to monitor health and progress
-        let network_metrics_processor = NetworkMetricsProcessor::new(self.store.clone());
+        let network_metrics_processor =
+            NetworkMetricsProcessor::new(self.store.clone(), self.metrics.clone());
         let network_metrics_handle = tokio::task::spawn(async move {
             loop {
                 let network_metrics_res = network_metrics_processor.start().await;
@@ -39,7 +41,8 @@ where
             }
         });
 
-        let addr_metrics_processor = AddressMetricsProcessor::new(self.store.clone());
+        let addr_metrics_processor =
+            AddressMetricsProcessor::new(self.store.clone(), self.metrics.clone());
         let addr_metrics_handle = tokio::task::spawn(async move {
             loop {
                 let addr_metrics_res = addr_metrics_processor.start().await;
@@ -53,7 +56,8 @@ where
             }
         });
 
-        let move_call_metrics_processor = MoveCallMetricsProcessor::new(self.store.clone());
+        let move_call_metrics_processor =
+            MoveCallMetricsProcessor::new(self.store.clone(), self.metrics.clone());
         let move_call_metrics_handle = tokio::task::spawn(async move {
             loop {
                 let move_call_metrics_res = move_call_metrics_processor.start().await;

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -115,7 +115,6 @@ diesel::table! {
 diesel::table! {
     move_call_metrics (id) {
         id -> Int8,
-        checkpoint_sequence_number -> Int8,
         epoch -> Int8,
         day -> Int8,
         move_package -> Text,
@@ -126,8 +125,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    move_calls (id) {
-        id -> Int8,
+    move_calls (transaction_sequence_number, move_package, move_module, move_function) {
         transaction_sequence_number -> Int8,
         checkpoint_sequence_number -> Int8,
         epoch -> Int8,

--- a/crates/sui-indexer/src/store/indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/indexer_analytical_store.rs
@@ -3,20 +3,20 @@
 
 use async_trait::async_trait;
 
-use crate::models_v2::address_metrics::{StoredActiveAddress, StoredAddress, StoredAddressMetrics};
 use crate::models_v2::checkpoints::StoredCheckpoint;
-use crate::models_v2::move_call_metrics::{StoredMoveCall, StoredMoveCallMetrics};
+use crate::models_v2::move_call_metrics::StoredMoveCallMetrics;
 use crate::models_v2::network_metrics::StoredEpochPeakTps;
 use crate::models_v2::transactions::{
-    StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount, StoredTransactionTimestamp,
+    StoredTransaction, StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount,
+    StoredTransactionTimestamp, TxSeq,
 };
 use crate::models_v2::tx_count_metrics::StoredTxCountMetrics;
-use crate::models_v2::tx_indices::{StoredTxCalls, StoredTxRecipients, StoredTxSenders};
 use crate::types_v2::IndexerResult;
 
 #[async_trait]
 pub trait IndexerAnalyticalStore {
-    async fn get_latest_stored_checkpoint(&self) -> IndexerResult<StoredCheckpoint>;
+    async fn get_latest_stored_transaction(&self) -> IndexerResult<Option<StoredTransaction>>;
+    async fn get_latest_stored_checkpoint(&self) -> IndexerResult<Option<StoredCheckpoint>>;
     async fn get_checkpoints_in_range(
         &self,
         start_checkpoint: i64,
@@ -37,11 +37,13 @@ pub trait IndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionSuccessCommandCount>>;
+    async fn get_tx(&self, tx_sequence_number: i64) -> IndexerResult<Option<StoredTransaction>>;
+    async fn get_cp(&self, sequence_number: i64) -> IndexerResult<Option<StoredCheckpoint>>;
 
     // for network metrics including TPS and counts of objects etc.
-    async fn get_latest_tx_count_metrics(&self) -> IndexerResult<StoredTxCountMetrics>;
-    async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<StoredEpochPeakTps>;
-    async fn persist_tx_count_metrics(
+    async fn get_latest_tx_count_metrics(&self) -> IndexerResult<Option<StoredTxCountMetrics>>;
+    async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<Option<StoredEpochPeakTps>>;
+    fn persist_tx_count_metrics(
         &self,
         start_checkpoint: i64,
         end_checkpoint: i64,
@@ -49,45 +51,26 @@ pub trait IndexerAnalyticalStore {
     async fn persist_epoch_peak_tps(&self, epoch: i64) -> IndexerResult<()>;
 
     // for address metrics
-    async fn get_latest_address_metrics(&self) -> IndexerResult<StoredAddressMetrics>;
-    fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()>;
-    async fn get_senders_in_tx_range(
+    async fn get_address_metrics_last_processed_tx_seq(&self) -> IndexerResult<Option<TxSeq>>;
+    fn persist_addresses_in_tx_range(
         &self,
         start_tx_seq: i64,
         end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxSenders>>;
-    async fn get_recipients_in_tx_range(
+    ) -> IndexerResult<()>;
+    fn persist_active_addresses_in_tx_range(
         &self,
         start_tx_seq: i64,
         end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxRecipients>>;
-    fn persist_active_addresses(
-        &self,
-        active_addresses: Vec<StoredActiveAddress>,
     ) -> IndexerResult<()>;
-    async fn calculate_address_metrics(
-        &self,
-        checkpoint: StoredCheckpoint,
-    ) -> IndexerResult<StoredAddressMetrics>;
-    async fn persist_address_metrics(
-        &self,
-        address_metrics: StoredAddressMetrics,
-    ) -> IndexerResult<()>;
+    async fn calculate_and_persist_address_metrics(&self, checkpoint: i64) -> IndexerResult<()>;
 
     // for move call metrics
-    async fn get_latest_move_call_metrics(&self) -> IndexerResult<StoredMoveCallMetrics>;
-    async fn get_move_calls_in_tx_range(
+    async fn get_latest_move_call_metrics(&self) -> IndexerResult<Option<StoredMoveCallMetrics>>;
+    async fn get_latest_move_call_tx_seq(&self) -> IndexerResult<Option<TxSeq>>;
+    fn persist_move_calls_in_tx_range(
         &self,
         start_tx_seq: i64,
         end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxCalls>>;
-    fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()>;
-    async fn calculate_move_call_metrics(
-        &self,
-        checkpoint: StoredCheckpoint,
-    ) -> IndexerResult<Vec<StoredMoveCallMetrics>>;
-    async fn persist_move_call_metrics(
-        &self,
-        move_call_metrics: Vec<StoredMoveCallMetrics>,
     ) -> IndexerResult<()>;
+    async fn calculate_and_persist_move_call_metrics(&self, epoch: i64) -> IndexerResult<()>;
 }

--- a/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_analytical_store.rs
@@ -3,32 +3,30 @@
 
 use std::time::Duration;
 use tap::tap::TapFallible;
-use tracing::error;
+use tracing::{error, info};
 
 use async_trait::async_trait;
 use core::result::Result::Ok;
 use diesel::dsl::count;
-use diesel::upsert::excluded;
-use diesel::ExpressionMethods;
+use diesel::{ExpressionMethods, OptionalExtension};
 use diesel::{QueryDsl, RunQueryDsl};
 use sui_types::base_types::ObjectID;
 
 use crate::errors::{Context, IndexerError};
-use crate::models_v2::address_metrics::{StoredActiveAddress, StoredAddress, StoredAddressMetrics};
+use crate::models_v2::address_metrics::StoredAddressMetrics;
 use crate::models_v2::checkpoints::StoredCheckpoint;
 use crate::models_v2::move_call_metrics::{
-    build_move_call_metric_query, QueriedMoveCallMetrics, QueriedMoveMetrics, StoredMoveCall,
-    StoredMoveCallMetrics,
+    build_move_call_metric_query, QueriedMoveCallMetrics, QueriedMoveMetrics, StoredMoveCallMetrics,
 };
 use crate::models_v2::network_metrics::{StoredEpochPeakTps, Tps};
 use crate::models_v2::transactions::{
-    StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount, StoredTransactionTimestamp,
+    StoredTransaction, StoredTransactionCheckpoint, StoredTransactionSuccessCommandCount,
+    StoredTransactionTimestamp, TxSeq,
 };
 use crate::models_v2::tx_count_metrics::StoredTxCountMetrics;
-use crate::models_v2::tx_indices::{StoredTxCalls, StoredTxRecipients, StoredTxSenders};
 use crate::schema_v2::{
     active_addresses, address_metrics, addresses, checkpoints, epoch_peak_tps, move_call_metrics,
-    move_calls, transactions, tx_calls, tx_count_metrics, tx_recipients, tx_senders,
+    move_calls, transactions, tx_count_metrics,
 };
 use crate::store::diesel_macro::{read_only_blocking, transactional_blocking_with_retry};
 use crate::types_v2::IndexerResult;
@@ -49,14 +47,26 @@ impl PgIndexerAnalyticalStore {
 
 #[async_trait]
 impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
-    async fn get_latest_stored_checkpoint(&self) -> IndexerResult<StoredCheckpoint> {
+    async fn get_latest_stored_checkpoint(&self) -> IndexerResult<Option<StoredCheckpoint>> {
         let latest_cp = read_only_blocking!(&self.blocking_cp, |conn| {
             checkpoints::dsl::checkpoints
                 .order(checkpoints::sequence_number.desc())
                 .first::<StoredCheckpoint>(conn)
+                .optional()
         })
         .context("Failed reading latest checkpoint from PostgresDB")?;
         Ok(latest_cp)
+    }
+
+    async fn get_latest_stored_transaction(&self) -> IndexerResult<Option<StoredTransaction>> {
+        let latest_tx = read_only_blocking!(&self.blocking_cp, |conn| {
+            transactions::dsl::transactions
+                .order(transactions::tx_sequence_number.desc())
+                .first::<StoredTransaction>(conn)
+                .optional()
+        })
+        .context("Failed reading latest transaction from PostgresDB")?;
+        Ok(latest_tx)
     }
 
     async fn get_checkpoints_in_range(
@@ -136,62 +146,85 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         .context("Failed reading transaction success command counts from PostgresDB")?;
         Ok(tx_success_cmd_counts)
     }
+    async fn get_tx(&self, tx_sequence_number: i64) -> IndexerResult<Option<StoredTransaction>> {
+        let tx = read_only_blocking!(&self.blocking_cp, |conn| {
+            transactions::dsl::transactions
+                .filter(transactions::dsl::tx_sequence_number.eq(tx_sequence_number))
+                .first::<StoredTransaction>(conn)
+                .optional()
+        })
+        .context("Failed reading transaction from PostgresDB")?;
+        Ok(tx)
+    }
 
-    async fn get_latest_tx_count_metrics(&self) -> IndexerResult<StoredTxCountMetrics> {
+    async fn get_cp(&self, sequence_number: i64) -> IndexerResult<Option<StoredCheckpoint>> {
+        let cp = read_only_blocking!(&self.blocking_cp, |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
+                .first::<StoredCheckpoint>(conn)
+                .optional()
+        })
+        .context("Failed reading checkpoint from PostgresDB")?;
+        Ok(cp)
+    }
+
+    async fn get_latest_tx_count_metrics(&self) -> IndexerResult<Option<StoredTxCountMetrics>> {
         let latest_tx_count = read_only_blocking!(&self.blocking_cp, |conn| {
             tx_count_metrics::dsl::tx_count_metrics
                 .order(tx_count_metrics::dsl::checkpoint_sequence_number.desc())
                 .first::<StoredTxCountMetrics>(conn)
+                .optional()
         })
         .context("Failed reading latest tx count metrics from PostgresDB")?;
         Ok(latest_tx_count)
     }
 
-    async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<StoredEpochPeakTps> {
+    async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<Option<StoredEpochPeakTps>> {
         let latest_network_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
             epoch_peak_tps::dsl::epoch_peak_tps
                 .order(epoch_peak_tps::dsl::epoch.desc())
                 .first::<StoredEpochPeakTps>(conn)
+                .optional()
         })
         .context("Failed reading latest epoch peak TPS from PostgresDB")?;
         Ok(latest_network_metrics)
     }
 
-    async fn persist_tx_count_metrics(
+    fn persist_tx_count_metrics(
         &self,
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<()> {
         let tx_count_query = construct_checkpoint_tx_count_query(start_checkpoint, end_checkpoint);
+        info!("Persisting tx count metrics for cp {}", start_checkpoint);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
                 diesel::sql_query(tx_count_query.clone()).execute(conn)?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            Duration::from_secs(10)
         )
         .context("Failed persisting tx count metrics to PostgresDB")?;
+        info!("Persisted tx count metrics for cp {}", start_checkpoint);
         Ok(())
     }
 
     async fn persist_epoch_peak_tps(&self, epoch: i64) -> IndexerResult<()> {
         let epoch_peak_tps_query = construct_peak_tps_query(epoch, 1);
         let peak_tps_30d_query = construct_peak_tps_query(epoch, 30);
-        let epoch_tps: Tps = read_only_blocking!(&self.blocking_cp, |conn|
-            // diesel::sql_query(epoch_peak_tps_query).first::<Option<f64>>(conn).map(|x| x.unwrap_or(0.0))
-            diesel::RunQueryDsl::get_result(
+        let epoch_tps: Tps =
+            read_only_blocking!(&self.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
                 diesel::sql_query(epoch_peak_tps_query),
                 conn
             ))
-        .context("Failed reading epoch peak TPS from PostgresDB")?;
-        let tps_30d: Tps = read_only_blocking!(&self.blocking_cp, |conn|
-            // diesel::sql_query(peak_tps_30d_query).first::<Option<f64>>(conn).map(|x| x.unwrap_or(0.0))
-            diesel::RunQueryDsl::get_result(
+            .context("Failed reading epoch peak TPS from PostgresDB")?;
+        let tps_30d: Tps =
+            read_only_blocking!(&self.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
                 diesel::sql_query(peak_tps_30d_query),
                 conn
             ))
-        .context("Failed reading 30d peak TPS from PostgresDB")?;
+            .context("Failed reading 30d peak TPS from PostgresDB")?;
 
         let epoch_peak_tps = StoredEpochPeakTps {
             epoch,
@@ -206,106 +239,74 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                     .on_conflict_do_nothing()
                     .execute(conn)
             },
-            Duration::from_secs(60)
+            Duration::from_secs(10)
         )
         .context("Failed persisting epoch peak TPS to PostgresDB.")?;
         Ok(())
     }
 
-    async fn get_latest_address_metrics(&self) -> IndexerResult<StoredAddressMetrics> {
-        let latest_address_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
-            address_metrics::dsl::address_metrics
-                .order(address_metrics::dsl::checkpoint.desc())
-                .first::<StoredAddressMetrics>(conn)
+    async fn get_address_metrics_last_processed_tx_seq(&self) -> IndexerResult<Option<TxSeq>> {
+        let last_processed_tx_seq = read_only_blocking!(&self.blocking_cp, |conn| {
+            active_addresses::dsl::active_addresses
+                .order(active_addresses::dsl::last_appearance_tx.desc())
+                .select((active_addresses::dsl::last_appearance_tx,))
+                .first::<TxSeq>(conn)
+                .optional()
         })
-        .context("Failed reading latest address metrics from PostgresDB")?;
-        Ok(latest_address_metrics)
+        .context("Failed to read address metrics last processed tx sequence.")?;
+        Ok(last_processed_tx_seq)
     }
 
-    async fn get_senders_in_tx_range(
+    fn persist_addresses_in_tx_range(
         &self,
         start_tx_seq: i64,
         end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxSenders>> {
-        let senders = read_only_blocking!(&self.blocking_cp, |conn| {
-            tx_senders::dsl::tx_senders
-                .filter(tx_senders::dsl::tx_sequence_number.ge(start_tx_seq))
-                .filter(tx_senders::dsl::tx_sequence_number.lt(end_tx_seq))
-                .order(tx_senders::dsl::tx_sequence_number.asc())
-                .load::<StoredTxSenders>(conn)
-        })
-        .context("Failed reading tx senders from PostgresDB")?;
-        Ok(senders)
-    }
-
-    async fn get_recipients_in_tx_range(
-        &self,
-        start_tx_seq: i64,
-        end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxRecipients>> {
-        let recipients = read_only_blocking!(&self.blocking_cp, |conn| {
-            tx_recipients::dsl::tx_recipients
-                .filter(tx_recipients::dsl::tx_sequence_number.ge(start_tx_seq))
-                .filter(tx_recipients::dsl::tx_sequence_number.lt(end_tx_seq))
-                .order(tx_recipients::dsl::tx_sequence_number.asc())
-                .load::<StoredTxRecipients>(conn)
-        })
-        .context("Failed reading tx recipients from PostgresDB")?;
-        Ok(recipients)
-    }
-
-    fn persist_addresses(&self, addresses: Vec<StoredAddress>) -> IndexerResult<()> {
+    ) -> IndexerResult<()> {
+        let address_persist_query = construct_address_persisting_query(start_tx_seq, end_tx_seq);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                diesel::insert_into(addresses::table)
-                    .values(addresses.clone())
-                    .on_conflict(addresses::address)
-                    .do_update()
-                    .set((
-                        addresses::last_appearance_time
-                            .eq(excluded(addresses::last_appearance_time)),
-                        addresses::last_appearance_tx.eq(excluded(addresses::last_appearance_tx)),
-                    ))
-                    .execute(conn)?;
+                diesel::sql_query(address_persist_query.clone()).execute(conn)?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            Duration::from_secs(10)
         )
         .context("Failed persisting addresses to PostgresDB")?;
         Ok(())
     }
 
-    fn persist_active_addresses(
+    fn persist_active_addresses_in_tx_range(
         &self,
-        active_addresses: Vec<StoredActiveAddress>,
+        start_tx_seq: i64,
+        end_tx_seq: i64,
     ) -> IndexerResult<()> {
+        let active_address_persist_query =
+            construct_active_address_persisting_query(start_tx_seq, end_tx_seq);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                diesel::insert_into(active_addresses::table)
-                    .values(active_addresses.clone())
-                    .on_conflict(active_addresses::address)
-                    .do_update()
-                    .set((
-                        active_addresses::last_appearance_time
-                            .eq(excluded(active_addresses::last_appearance_time)),
-                        active_addresses::last_appearance_tx
-                            .eq(excluded(active_addresses::last_appearance_tx)),
-                    ))
-                    .execute(conn)?;
+                diesel::sql_query(active_address_persist_query.clone()).execute(conn)?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            Duration::from_secs(10)
         )
         .context("Failed persisting active addresses to PostgresDB")?;
         Ok(())
     }
 
-    async fn calculate_address_metrics(
-        &self,
-        checkpoint: StoredCheckpoint,
-    ) -> IndexerResult<StoredAddressMetrics> {
+    async fn calculate_and_persist_address_metrics(&self, checkpoint: i64) -> IndexerResult<()> {
+        let mut checkpoint_opt = self
+            .get_checkpoints_in_range(checkpoint, checkpoint + 1)
+            .await?
+            .pop();
+        while checkpoint_opt.is_none() {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            checkpoint_opt = self
+                .get_checkpoints_in_range(checkpoint, checkpoint + 1)
+                .await?
+                .pop();
+        }
+        let checkpoint = checkpoint_opt.unwrap();
         let cp_timestamp_ms = checkpoint.timestamp_ms;
         let addr_count = read_only_blocking!(&self.blocking_cp, |conn| {
             addresses::dsl::addresses
@@ -327,25 +328,19 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .select(count(active_addresses::address))
                 .first(conn)
         })?;
-        Ok(StoredAddressMetrics {
+        let address_metrics_to_commit = StoredAddressMetrics {
             checkpoint: checkpoint.sequence_number,
             epoch: checkpoint.epoch,
             timestamp_ms: checkpoint.timestamp_ms,
             cumulative_addresses: addr_count,
             cumulative_active_addresses: active_addr_count,
             daily_active_addresses,
-        })
-    }
-
-    async fn persist_address_metrics(
-        &self,
-        address_metrics: StoredAddressMetrics,
-    ) -> IndexerResult<()> {
+        };
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
                 diesel::insert_into(address_metrics::table)
-                    .values(address_metrics.clone())
+                    .values(address_metrics_to_commit.clone())
                     .on_conflict_do_nothing()
                     .execute(conn)
             },
@@ -355,53 +350,48 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         Ok(())
     }
 
-    async fn get_latest_move_call_metrics(&self) -> IndexerResult<StoredMoveCallMetrics> {
-        let latest_move_call_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
-            move_call_metrics::dsl::move_call_metrics
-                .order(move_call_metrics::checkpoint_sequence_number.desc())
-                .first::<QueriedMoveCallMetrics>(conn)
+    async fn get_latest_move_call_tx_seq(&self) -> IndexerResult<Option<TxSeq>> {
+        let last_processed_tx_seq = read_only_blocking!(&self.blocking_cp, |conn| {
+            move_calls::dsl::move_calls
+                .order(move_calls::dsl::transaction_sequence_number.desc())
+                .select((move_calls::dsl::transaction_sequence_number,))
+                .first::<TxSeq>(conn)
+                .optional()
         })
-        .context("Failed reading latest move call metrics from PostgresDB")?;
-        Ok(latest_move_call_metrics.into())
+        .unwrap_or_default();
+        Ok(last_processed_tx_seq)
     }
 
-    async fn get_move_calls_in_tx_range(
+    async fn get_latest_move_call_metrics(&self) -> IndexerResult<Option<StoredMoveCallMetrics>> {
+        let latest_move_call_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
+            move_call_metrics::dsl::move_call_metrics
+                .order(move_call_metrics::epoch.desc())
+                .first::<QueriedMoveCallMetrics>(conn)
+                .optional()
+        })
+        .unwrap_or_default();
+        Ok(latest_move_call_metrics.map(|m| m.into()))
+    }
+
+    fn persist_move_calls_in_tx_range(
         &self,
         start_tx_seq: i64,
         end_tx_seq: i64,
-    ) -> IndexerResult<Vec<StoredTxCalls>> {
-        let move_calls = read_only_blocking!(&self.blocking_cp, |conn| {
-            tx_calls::dsl::tx_calls
-                .filter(tx_calls::dsl::tx_sequence_number.ge(start_tx_seq))
-                .filter(tx_calls::dsl::tx_sequence_number.lt(end_tx_seq))
-                .order(tx_calls::dsl::tx_sequence_number.asc())
-                .load::<StoredTxCalls>(conn)
-        })
-        .context("Failed reading tx move calls from PostgresDB")?;
-        Ok(move_calls)
-    }
-
-    fn persist_move_calls(&self, move_calls: Vec<StoredMoveCall>) -> IndexerResult<()> {
+    ) -> IndexerResult<()> {
+        let move_call_persist_query = construct_move_call_persist_query(start_tx_seq, end_tx_seq);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                diesel::insert_into(move_calls::table)
-                    .values(move_calls.clone())
-                    .on_conflict_do_nothing()
-                    .execute(conn)?;
+                diesel::sql_query(move_call_persist_query.clone()).execute(conn)?;
                 Ok::<(), IndexerError>(())
             },
-            Duration::from_secs(60)
+            Duration::from_secs(10)
         )
         .context("Failed persisting move calls to PostgresDB")?;
         Ok(())
     }
 
-    async fn calculate_move_call_metrics(
-        &self,
-        checkpoint: StoredCheckpoint,
-    ) -> IndexerResult<Vec<StoredMoveCallMetrics>> {
-        let epoch = checkpoint.epoch;
+    async fn calculate_and_persist_move_call_metrics(&self, epoch: i64) -> IndexerResult<()> {
         let move_call_query_3d = build_move_call_metric_query(epoch, 3);
         let move_call_query_7d = build_move_call_metric_query(epoch, 7);
         let move_call_query_30d = build_move_call_metric_query(epoch, 30);
@@ -457,8 +447,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 };
                 Some(StoredMoveCallMetrics {
                     id: None,
-                    checkpoint_sequence_number: checkpoint.sequence_number,
-                    epoch: checkpoint.epoch,
+                    epoch,
                     day: queried_move_metrics.day,
                     move_package: package_str,
                     move_module: queried_move_metrics.move_module,
@@ -467,13 +456,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 })
             })
             .collect();
-        Ok(move_call_metrics)
-    }
 
-    async fn persist_move_call_metrics(
-        &self,
-        move_call_metrics: Vec<StoredMoveCallMetrics>,
-    ) -> IndexerResult<()> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -500,8 +483,9 @@ fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i6
             FROM transactions t
             LEFT JOIN checkpoints c
             ON t.checkpoint_sequence_number = c.sequence_number
-            WHERE t.checkpoint_sequence_number >= {} AND t.checkpoint_sequence_number <= {}
+            WHERE t.checkpoint_sequence_number >= {} AND t.checkpoint_sequence_number < {}
           )
+          INSERT INTO tx_count_metrics
           SELECT 
             checkpoint_sequence_number,
             epoch,
@@ -510,7 +494,8 @@ fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i6
             SUM(CASE WHEN success_command_count > 0 THEN 1 ELSE 0 END) AS total_successful_transaction_blocks,
             SUM(success_command_count) AS total_successful_transactions
           FROM filtered_txns
-          GROUP BY checkpoint_sequence_number, epoch ORDER BY checkpoint_sequence_number;
+          GROUP BY checkpoint_sequence_number, epoch ORDER BY checkpoint_sequence_number
+          ON CONFLICT (checkpoint_sequence_number) DO NOTHING;
         ", start_checkpoint, end_checkpoint
     )
 }
@@ -524,7 +509,7 @@ fn construct_peak_tps_query(epoch: i64, offset: i64) -> String {
               timestamp_ms
             FROM
               tx_count_metrics
-              WHERE epoch > ({} - {})
+              WHERE epoch > ({} - {}) AND epoch <= {}
             GROUP BY
               timestamp_ms
           ),
@@ -543,6 +528,115 @@ fn construct_peak_tps_query(epoch: i64, offset: i64) -> String {
           WHERE 
             time_diff IS NOT NULL;
         ",
-        epoch, offset
+        epoch, offset, epoch
+    )
+}
+
+fn construct_address_persisting_query(start_tx_seq: i64, end_tx_seq: i64) -> String {
+    format!(
+        "WITH senders AS (
+        SELECT
+            s.sender AS address,
+            s.tx_sequence_number,
+            t.timestamp_ms
+        FROM tx_senders s
+        JOIN transactions t
+        ON s.tx_sequence_number = t.tx_sequence_number
+        WHERE s.tx_sequence_number >= {} AND s.tx_sequence_number < {}
+      ),
+      recipients AS (
+        SELECT
+            r.recipient AS address,
+            r.tx_sequence_number,
+            t.timestamp_ms
+        FROM tx_recipients r
+        JOIN transactions t
+        ON r.tx_sequence_number = t.tx_sequence_number
+        WHERE r.tx_sequence_number >= {} AND r.tx_sequence_number < {}
+      ),
+      union_address AS (
+        SELECT 
+            address, 
+            MIN(tx_sequence_number) as first_seq, 
+            MIN(timestamp_ms) AS first_timestamp,
+            MAX(tx_sequence_number) as last_seq,
+            MAX(timestamp_ms) AS last_timestamp
+        FROM recipients GROUP BY address
+        UNION ALL
+        SELECT 
+            address, 
+            MIN(tx_sequence_number) as first_seq, 
+            MIN(timestamp_ms) AS first_timestamp,
+            MAX(tx_sequence_number) as last_seq,
+            MAX(timestamp_ms) AS last_timestamp
+        FROM senders GROUP BY address
+      )
+      INSERT INTO addresses
+      SELECT 
+        address,
+        MIN(first_seq) AS first_appearance_tx,
+        MIN(first_timestamp) AS first_appearance_time,
+        MAX(last_seq) AS last_appearance_tx,
+        MAX(last_timestamp) AS last_appearance_time
+      FROM union_address
+      GROUP BY address
+      ON CONFLICT (address) DO UPDATE
+      SET
+        last_appearance_tx = GREATEST(EXCLUDED.last_appearance_tx, addresses.last_appearance_tx),
+        last_appearance_time = GREATEST(EXCLUDED.last_appearance_time, addresses.last_appearance_time);
+    ",
+        start_tx_seq, end_tx_seq, start_tx_seq, end_tx_seq
+    )
+}
+
+fn construct_active_address_persisting_query(start_tx_seq: i64, end_tx_seq: i64) -> String {
+    format!(
+        "WITH senders AS (
+        SELECT
+            s.sender AS address,
+            s.tx_sequence_number,
+            t.timestamp_ms
+        FROM tx_senders s
+        JOIN transactions t
+        ON s.tx_sequence_number = t.tx_sequence_number
+        WHERE s.tx_sequence_number >= {} AND s.tx_sequence_number < {}
+      )
+      INSERT INTO active_addresses
+      SELECT 
+            address,
+            MIN(tx_sequence_number) AS first_appearance_tx,
+            MIN(timestamp_ms) AS first_appearance_time,
+            MAX(tx_sequence_number) AS last_appearance_tx,
+            MAX(timestamp_ms) AS last_appearance_time
+      FROM senders
+      GROUP BY address
+      ON CONFLICT (address) DO UPDATE
+      SET 
+        last_appearance_tx = GREATEST(EXCLUDED.last_appearance_tx, active_addresses.last_appearance_tx),
+        last_appearance_time = GREATEST(EXCLUDED.last_appearance_time, active_addresses.last_appearance_time);
+    ",
+        start_tx_seq, end_tx_seq
+    )
+}
+
+fn construct_move_call_persist_query(start_tx_seq: i64, end_tx_seq: i64) -> String {
+    format!(
+        "INSERT INTO move_calls
+    SELECT
+        m.tx_sequence_number AS transaction_sequence_number,
+        c.sequence_number AS checkpoint_sequence_number,
+        c.epoch AS epoch,
+        m.package AS move_package,
+        m.module AS move_module,
+        m.func AS move_function
+    FROM tx_calls m
+    INNER JOIN transactions t
+        ON m.tx_sequence_number = t.tx_sequence_number
+    INNER JOIN checkpoints c
+        ON t.checkpoint_sequence_number = c.sequence_number
+    WHERE m.tx_sequence_number >= {} AND m.tx_sequence_number < {}
+    ON CONFLICT (transaction_sequence_number, move_package, move_module, move_function) DO NOTHING;
+    ",
+        start_tx_seq, end_tx_seq
     )
 }


### PR DESCRIPTION
## Description 

The overall idea is that, much of time in the past were spent on passing data from DB and then write them back, even with parallelism on many steps, instead this PR does that directly in DB, on testing this will reduce backfill time of move call metrics and DAU related metrics from days to hours.

## Test Plan 

local run and test speed on a separate testing DB

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
