### PR TITLE
Remove shared object locking in transaction manager before sending to execute

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::Ordering;
-<<<<<<< HEAD
-=======
 use std::collections::BTreeSet;
-use std::hash::Hash;
->>>>>>> 4b60c0e9dd (Remove input object locking in transaction manager)
 use std::ops::Not;
 use std::sync::Arc;
 use std::{iter, mem, thread};

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::Ordering;
+<<<<<<< HEAD
+=======
+use std::collections::BTreeSet;
+use std::hash::Hash;
+>>>>>>> 4b60c0e9dd (Remove input object locking in transaction manager)
 use std::ops::Not;
 use std::sync::Arc;
 use std::{iter, mem, thread};
@@ -651,18 +656,18 @@ impl AuthorityStore {
     /// versions and types of owned, shared and package objects.
     /// When making changes, please see if check_sequenced_input_objects() below needs
     /// similar changes as well.
-    pub fn get_input_object_locks(
+    pub fn get_input_object_keys(
         &self,
         digest: &TransactionDigest,
         objects: &[InputObjectKind],
         epoch_store: &AuthorityPerEpochStore,
-    ) -> BTreeMap<InputKey, LockMode> {
+    ) -> BTreeSet<InputKey> {
         let mut shared_locks = HashMap::<ObjectID, SequenceNumber>::new();
         objects
             .iter()
             .map(|kind| {
                 match kind {
-                    InputObjectKind::SharedMoveObject { id, initial_shared_version: _, mutable } => {
+                    InputObjectKind::SharedMoveObject { id, .. } => {
                         if shared_locks.is_empty() {
                             shared_locks = epoch_store
                                 .get_shared_locks(digest)
@@ -679,17 +684,10 @@ impl AuthorityStore {
                                 id: {id:?}",
                             )
                         };
-                        let lock_mode = if *mutable {
-                            LockMode::Default
-                        } else {
-                            LockMode::ReadOnly
-                        };
-                        (InputKey::VersionedObject{ id: *id, version: *version}, lock_mode)
+                        InputKey::VersionedObject{ id: *id, version: *version}
                     }
-                    // TODO: use ReadOnly lock?
-                    InputObjectKind::MovePackage(id) => (InputKey::Package { id: *id }, LockMode::Default),
-                    // Cannot use ReadOnly lock because we do not know if the object is immutable.
-                    InputObjectKind::ImmOrOwnedMoveObject(objref) => (InputKey::VersionedObject {id: objref.0, version: objref.1}, LockMode::Default),
+                    InputObjectKind::MovePackage(id) => InputKey::Package { id: *id },
+                    InputObjectKind::ImmOrOwnedMoveObject(objref) => InputKey::VersionedObject {id: objref.0, version: objref.1},
                 }
             })
             .collect()
@@ -2174,15 +2172,4 @@ impl From<LockDetails> for LockDetailsWrapper {
         // always use latest version.
         LockDetailsWrapper::V1(details)
     }
-}
-
-/// How a transaction should lock a given input object.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum LockMode {
-    /// In the default mode, the transaction can acquire the lock whenever the object is available
-    /// and there is no pending or executing transaction with ReadOnly locks.
-    Default,
-    /// In the ReadOnly mode, the transaction can acquire the lock whenever the object is available.
-    /// The invariant is that no transaction should have locks on the object in default mode.
-    ReadOnly,
 }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -652,8 +652,8 @@ impl AuthorityStore {
         }
     }
 
-    /// Gets the input object keys and lock modes from input object kinds, by determining the
-    /// versions and types of owned, shared and package objects.
+    /// Gets the input object keys from input object kinds, by determining the versions of owned,
+    /// shared and package objects.
     /// When making changes, please see if check_sequenced_input_objects() below needs
     /// similar changes as well.
     pub fn get_input_object_keys(

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -3,7 +3,7 @@
 
 use std::{
     cmp::max,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -25,9 +25,7 @@ use sui_types::{
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, instrument, trace, warn};
 
-use crate::authority::{
-    authority_per_epoch_store::AuthorityPerEpochStore, authority_store::LockMode,
-};
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::{AuthorityMetrics, AuthorityStore};
 use sui_types::transaction::SenderSignedData;
 use tap::TapOptional;
@@ -71,41 +69,8 @@ struct PendingCertificate {
     // When executing from checkpoint, the certified effects digest is provided, so that forks can
     // be detected prior to committing the transaction.
     expected_effects_digest: Option<TransactionEffectsDigest>,
-    // Input object locks that have not been acquired, because:
-    // 1. The object has not been created yet.
-    // 2. The object exists, but this transaction is trying to acquire a r/w lock while the object
-    // is held in ro locks by other transaction(s).
-    acquiring_locks: BTreeMap<InputKey, LockMode>,
-    // Input object locks that have been acquired.
-    acquired_locks: BTreeMap<InputKey, LockMode>,
-}
-
-/// LockQueue is a queue of transactions waiting or holding a lock on an object.
-#[derive(Debug, Default)]
-struct LockQueue {
-    // Transactions waiting for read-only lock.
-    readonly_waiters: BTreeSet<TransactionDigest>,
-    // Transactions holding read-only lock that have not finished executions.
-    readonly_holders: BTreeSet<TransactionDigest>,
-    // Transactions waiting for default lock.
-    // Only after there is no more transaction wait or holding read-only locks,
-    // can a transaction acquire the default lock.
-    // Note that except for immutable objects, a given key may only have one TransactionDigest in
-    // the set. Unfortunately we cannot easily verify that this invariant is upheld, because you
-    // cannot determine from TransactionData whether an input is mutable or immutable.
-    default_waiters: BTreeSet<TransactionDigest>,
-}
-
-impl LockQueue {
-    fn has_readonly(&self) -> bool {
-        !(self.readonly_waiters.is_empty() && self.readonly_holders.is_empty())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.readonly_waiters.is_empty()
-            && self.readonly_holders.is_empty()
-            && self.default_waiters.is_empty()
-    }
+    // This certificate is waiting for these objects to become available in order to be executed.
+    waiting_input_objects: BTreeSet<InputKey>,
 }
 
 struct CacheInner {
@@ -248,8 +213,11 @@ struct Inner {
     // Current epoch of TransactionManager.
     epoch: EpochId,
 
-    // Maps input objects to transactions waiting for locks on the object.
-    lock_waiters: HashMap<InputKey, LockQueue>,
+    // Maps missing input objects to transactions in pending_certificates.
+    // Note that except for immutable objects, a given key may only have one TransactionDigest in
+    // the set. Unfortunately we cannot easily verify that this invariant is upheld, because you
+    // cannot determine from TransactionData whether an input is mutable or immutable.
+    missing_inputs: HashMap<InputKey, BTreeSet<TransactionDigest>>,
 
     // Stores age info for all transactions depending on each object.
     // Used for throttling signing and submitting transactions depending on hot objects.
@@ -266,26 +234,26 @@ struct Inner {
 
     // Maps transaction digests to their content and missing input objects.
     pending_certificates: HashMap<TransactionDigest, PendingCertificate>,
-    // Maps executing transaction digests to their acquired input object locks.
-    executing_certificates: HashMap<TransactionDigest, BTreeMap<InputKey, LockMode>>,
+    // Transactions that have all input objects available, but have not finished execution.
+    executing_certificates: HashSet<TransactionDigest>,
 }
 
 impl Inner {
     fn new(epoch: EpochId, metrics: Arc<AuthorityMetrics>) -> Inner {
         Inner {
             epoch,
-            lock_waiters: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
+            missing_inputs: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
             input_objects: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
             available_objects_cache: AvailableObjectsCache::new(metrics),
             pending_certificates: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
-            executing_certificates: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
+            executing_certificates: HashSet::with_capacity(MIN_HASHMAP_CAPACITY),
         }
     }
 
     // Checks if there is any transaction waiting on the lock of input_key, and try to
     // update transactions that can acquire the lock.
     // Must ensure input_key is available in storage before calling this function.
-    fn try_acquire_lock(
+    fn check_pending_transaction_waiting_for_object(
         &mut self,
         input_key: InputKey,
         update_cache: bool,
@@ -297,26 +265,10 @@ impl Inner {
 
         let mut ready_certificates = Vec::new();
 
-        let Some(lock_queue) = self.lock_waiters.get_mut(&input_key) else {
+        let Some(digests) = self.missing_inputs.remove(&input_key) else {
             // No transaction is waiting on the object yet.
             return ready_certificates;
         };
-
-        // Waiters can acquire lock in either readonly or default mode.
-        let mut digests = BTreeSet::new();
-        if !lock_queue.readonly_waiters.is_empty() {
-            std::mem::swap(&mut digests, &mut lock_queue.readonly_waiters);
-            lock_queue.readonly_holders.extend(digests.iter().cloned());
-        } else if lock_queue.readonly_holders.is_empty() {
-            // Only try to acquire default lock if there is no readonly lock waiter / holder.
-            std::mem::swap(&mut digests, &mut lock_queue.default_waiters);
-        };
-        if lock_queue.is_empty() {
-            self.lock_waiters.remove(&input_key);
-        }
-        if digests.is_empty() {
-            return ready_certificates;
-        }
 
         let input_txns = self
             .input_objects
@@ -343,19 +295,15 @@ impl Inner {
         for digest in digests {
             // Pending certificate must exist.
             let pending_cert = self.pending_certificates.get_mut(&digest).unwrap();
-            let lock_mode = pending_cert.acquiring_locks.remove(&input_key).unwrap();
-            assert!(pending_cert
-                .acquired_locks
-                .insert(input_key, lock_mode)
-                .is_none());
+            assert!(pending_cert.waiting_input_objects.remove(&input_key));
             // When a certificate has all locks acquired, it is ready to execute.
-            if pending_cert.acquiring_locks.is_empty() {
+            if pending_cert.waiting_input_objects.is_empty() {
                 let pending_cert = self.pending_certificates.remove(&digest).unwrap();
                 ready_certificates.push(pending_cert);
             } else {
                 // TODO: we should start logging this at a higher level after some period of
                 // time has elapsed.
-                trace!(tx_digest = ?digest,acquiring = ?pending_cert.acquiring_locks, "Certificate acquiring locks");
+                trace!(tx_digest = ?digest,missing = ?pending_cert.waiting_input_objects, "Certificate waiting on missing inputs");
             }
         }
 
@@ -363,7 +311,7 @@ impl Inner {
     }
 
     fn maybe_reserve_capacity(&mut self) {
-        self.lock_waiters.maybe_reserve_capacity();
+        self.missing_inputs.maybe_reserve_capacity();
         self.input_objects.maybe_reserve_capacity();
         self.pending_certificates.maybe_reserve_capacity();
         self.executing_certificates.maybe_reserve_capacity();
@@ -371,7 +319,7 @@ impl Inner {
 
     /// After reaching 1/4 load in hashmaps, decrease capacity to increase load to 1/2.
     fn maybe_shrink_capacity(&mut self) {
-        self.lock_waiters.maybe_shrink_capacity();
+        self.missing_inputs.maybe_shrink_capacity();
         self.input_objects.maybe_shrink_capacity();
         self.pending_certificates.maybe_shrink_capacity();
         self.executing_certificates.maybe_shrink_capacity();
@@ -489,13 +437,13 @@ impl TransactionManager {
                     .value
                     .input_objects()
                     .expect("input_objects() cannot fail");
-                let mut input_object_locks = self.authority_store.get_input_object_locks(
+                let mut input_object_keys = self.authority_store.get_input_object_keys(
                     &digest,
                     &input_object_kinds,
                     epoch_store,
                 );
 
-                if input_object_kinds.len() != input_object_locks.len() {
+                if input_object_kinds.len() != input_object_keys.len() {
                     error!("Duplicated input objects: {:?}", input_object_kinds);
                 }
 
@@ -507,14 +455,14 @@ impl TransactionManager {
                         version: entry.1,
                     };
                     receiving_objects.insert(key);
-                    input_object_locks.insert(key, LockMode::Default);
+                    input_object_keys.insert(key);
                 }
 
-                for key in input_object_locks.keys() {
+                for key in input_object_keys.iter() {
                     object_availability.insert(*key, None);
                 }
 
-                (cert, fx_digest, input_object_locks)
+                (cert, fx_digest, input_object_keys)
             })
             .collect();
 
@@ -585,14 +533,15 @@ impl TransactionManager {
 
         let mut pending = Vec::new();
 
-        for (cert, expected_effects_digest, input_object_locks) in certs {
+        for (cert, expected_effects_digest, input_object_keys) in certs {
             pending.push(PendingCertificate {
                 certificate: cert,
                 expected_effects_digest,
-                acquiring_locks: input_object_locks,
-                acquired_locks: BTreeMap::new(),
+                waiting_input_objects: input_object_keys,
             });
         }
+
+        // let mut missing_input_objects = Vec::new();
 
         for mut pending_cert in pending {
             // Tx lock is not held here, which makes it possible to send duplicated transactions to
@@ -621,7 +570,7 @@ impl TransactionManager {
                 continue;
             }
             // skip already executing txes
-            if inner.executing_certificates.contains_key(&digest) {
+            if inner.executing_certificates.contains(&digest) {
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["already_executing"])
@@ -639,58 +588,20 @@ impl TransactionManager {
                 continue;
             }
 
-            let mut acquiring_locks = BTreeMap::new();
-            std::mem::swap(&mut acquiring_locks, &mut pending_cert.acquiring_locks);
-            for (key, lock_mode) in acquiring_locks {
-                // The transaction needs to wait to acquire locks in two cases:
-                let mut acquire = false;
+            let mut waiting_input_objects = BTreeSet::new();
+            std::mem::swap(
+                &mut waiting_input_objects,
+                &mut pending_cert.waiting_input_objects,
+            );
+            for key in waiting_input_objects {
                 if !object_availability[&key].unwrap() {
-                    // 1. The input object is not yet available.
-                    acquire = true;
-                    let lock_queue = inner.lock_waiters.entry(key).or_default();
-                    match lock_mode {
-                        LockMode::Default => {
-                            // If the transaction is acquiring the object in Default mode, it must
-                            // wait for all ReadOnly locks to be released.
-                            assert!(lock_queue.default_waiters.insert(digest));
-                        }
-                        LockMode::ReadOnly => {
-                            assert!(lock_queue.readonly_waiters.insert(digest));
-                        }
-                    }
-                } else {
-                    match lock_mode {
-                        LockMode::Default => {
-                            // 2. The input object is currently locked in ReadOnly mode, and this
-                            // transaction is acquiring it in Default mode.
-                            if let Some(lock_queue) = inner.lock_waiters.get_mut(&key) {
-                                // If there are any ReadOnly locks, the transaction must wait for
-                                // them to be released.
-                                if lock_queue.has_readonly() {
-                                    acquire = true;
-                                    assert!(lock_queue.default_waiters.insert(digest));
-                                }
-                            }
-                        }
-                        LockMode::ReadOnly => {
-                            // Acquired readonly locks need to be tracked until the transaction has
-                            // finished execution.
-                            let lock_queue = inner.lock_waiters.entry(key).or_default();
-                            assert!(lock_queue.readonly_holders.insert(digest));
-                        }
-                    }
-                }
-                if acquire {
-                    pending_cert.acquiring_locks.insert(key, lock_mode);
-                    let input_txns = inner.input_objects.entry(key.id()).or_default();
-                    input_txns.insert(digest, Instant::now());
-                } else {
-                    pending_cert.acquired_locks.insert(key, lock_mode);
+                    // The input object is not yet available.
+                    pending_cert.waiting_input_objects.insert(key);
                 }
             }
 
             // Ready transactions can start to execute.
-            if pending_cert.acquiring_locks.is_empty() {
+            if pending_cert.waiting_input_objects.is_empty() {
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["ready"])
@@ -698,6 +609,22 @@ impl TransactionManager {
                 // Send to execution driver for execution.
                 self.certificate_ready(&mut inner, pending_cert);
                 continue;
+            }
+
+            // missing_input_objects.extend(pending_cert.waiting_input_objects.iter().cloned());
+            for input in &pending_cert.waiting_input_objects {
+                assert!(
+                    inner
+                        .missing_inputs
+                        .entry(*input)
+                        .or_default()
+                        .insert(digest),
+                    "Duplicated certificate {:?} for missing object {:?}",
+                    digest,
+                    input
+                );
+                let input_txns = inner.input_objects.entry(input.id()).or_default();
+                input_txns.insert(digest, Instant::now());
             }
 
             assert!(
@@ -717,7 +644,7 @@ impl TransactionManager {
 
         self.metrics
             .transaction_manager_num_missing_objects
-            .set(inner.lock_waiters.len() as i64);
+            .set(inner.missing_inputs.len() as i64);
         self.metrics
             .transaction_manager_num_pending_certificates
             .set(inner.pending_certificates.len() as i64);
@@ -759,14 +686,18 @@ impl TransactionManager {
 
         for input_key in input_keys {
             trace!(?input_key, "object available");
-            for ready_cert in inner.try_acquire_lock(input_key, update_cache, &self.metrics) {
+            for ready_cert in inner.check_pending_transaction_waiting_for_object(
+                input_key,
+                update_cache,
+                &self.metrics,
+            ) {
                 self.certificate_ready(inner, ready_cert);
             }
         }
 
         self.metrics
             .transaction_manager_num_missing_objects
-            .set(inner.lock_waiters.len() as i64);
+            .set(inner.missing_inputs.len() as i64);
         self.metrics
             .transaction_manager_num_pending_certificates
             .set(inner.pending_certificates.len() as i64);
@@ -794,26 +725,11 @@ impl TransactionManager {
 
             self.objects_available_locked(&mut inner, epoch_store, output_object_keys, true);
 
-            let Some(acquired_locks) = inner.executing_certificates.remove(digest) else {
+            if !inner.executing_certificates.remove(digest) {
                 trace!("{:?} not found in executing certificates, likely because it is a system transaction", digest);
                 return;
-            };
-            for (key, lock_mode) in acquired_locks {
-                if lock_mode == LockMode::Default {
-                    // Holders of default locks are not tracked.
-                    continue;
-                }
-                assert_eq!(lock_mode, LockMode::ReadOnly);
-                let lock_queue = inner.lock_waiters.get_mut(&key).unwrap();
-                assert!(
-                    lock_queue.readonly_holders.remove(digest),
-                    "Certificate {:?} not found among readonly lock holders",
-                    digest
-                );
-                for ready_cert in inner.try_acquire_lock(key, true, &self.metrics) {
-                    self.certificate_ready(&mut inner, ready_cert);
-                }
             }
+
             self.metrics
                 .transaction_manager_num_executing_certificates
                 .set(inner.executing_certificates.len() as i64);
@@ -829,16 +745,9 @@ impl TransactionManager {
         let cert = pending_certificate.certificate;
         let expected_effects_digest = pending_certificate.expected_effects_digest;
         trace!(tx_digest = ?cert.digest(), "certificate ready");
-        let tx_data = &cert.data().intent_message().value;
         // Record as an executing certificate.
-        assert_eq!(
-            pending_certificate.acquired_locks.len(),
-            tx_data.input_objects().unwrap().len() + tx_data.receiving_objects().len(),
-        );
-        assert!(inner
-            .executing_certificates
-            .insert(*cert.digest(), pending_certificate.acquired_locks)
-            .is_none());
+        assert_eq!(pending_certificate.waiting_input_objects.len(), 0);
+        assert!(inner.executing_certificates.insert(*cert.digest()));
         let _ = self
             .tx_ready_certificates
             .send((cert, expected_effects_digest));
@@ -852,7 +761,7 @@ impl TransactionManager {
         inner
             .pending_certificates
             .get(digest)
-            .map(|cert| cert.acquiring_locks.keys().cloned().collect())
+            .map(|cert| cert.waiting_input_objects.clone().into_iter().collect())
     }
 
     // Returns the number of transactions waiting on each object ID, as well as the age of the oldest transaction in the queue.
@@ -939,9 +848,9 @@ impl TransactionManager {
     fn check_empty_for_testing(&self) {
         let inner = self.inner.read();
         assert!(
-            inner.lock_waiters.is_empty(),
-            "Lock waiters: {:?}",
-            inner.lock_waiters
+            inner.missing_inputs.is_empty(),
+            "Missing inputs: {:?}",
+            inner.missing_inputs
         );
         assert!(
             inner.input_objects.is_empty(),
@@ -978,6 +887,30 @@ where
     }
 
     /// After reaching 1/4 load in hashmaps, decrease capacity to increase load to 1/2.
+    fn maybe_shrink_capacity(&mut self) {
+        if self.len() > MIN_HASHMAP_CAPACITY && self.len() < self.capacity() / 4 {
+            self.shrink_to(max(self.capacity() / 2, MIN_HASHMAP_CAPACITY))
+        }
+    }
+}
+
+trait ResizableHashSet<K> {
+    fn maybe_reserve_capacity(&mut self);
+    fn maybe_shrink_capacity(&mut self);
+}
+
+impl<K> ResizableHashSet<K> for HashSet<K>
+where
+    K: std::cmp::Eq + std::hash::Hash,
+{
+    /// After reaching 3/4 load in hashset, increase capacity to decrease load to 1/2.
+    fn maybe_reserve_capacity(&mut self) {
+        if self.len() > self.capacity() * 3 / 4 {
+            self.reserve(self.capacity() / 2);
+        }
+    }
+
+    /// After reaching 1/4 load in hashset, decrease capacity to increase load to 1/2.
     fn maybe_shrink_capacity(&mut self) {
         if self.len() > MIN_HASHMAP_CAPACITY && self.len() < self.capacity() / 4 {
             self.shrink_to(max(self.capacity() / 2, MIN_HASHMAP_CAPACITY))

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -251,7 +251,7 @@ impl Inner {
     // Checks if there is any transaction waiting on `input_key`. Returns all the pending
     // transactions that are ready to be executed.
     // Must ensure input_key is available in storage before calling this function.
-    fn check_pending_transaction_waiting_for_object(
+    fn find_ready_transactions(
         &mut self,
         input_key: InputKey,
         update_cache: bool,
@@ -675,11 +675,8 @@ impl TransactionManager {
 
         for input_key in input_keys {
             trace!(?input_key, "object available");
-            for ready_cert in inner.check_pending_transaction_waiting_for_object(
-                input_key,
-                update_cache,
-                &self.metrics,
-            ) {
+            for ready_cert in inner.find_ready_transactions(input_key, update_cache, &self.metrics)
+            {
                 self.certificate_ready(inner, ready_cert);
             }
         }

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -263,9 +263,14 @@ async fn transaction_manager_read_lock() {
     // TM should output the 2 read-only transactions eventually.
     let tx_0 = rx_ready_certificates.recv().await.unwrap().0;
     let tx_1 = rx_ready_certificates.recv().await.unwrap().0;
-    let mut want_digests = vec![transaction_read_0.digest(), transaction_read_1.digest()];
+    let tx_2 = rx_ready_certificates.recv().await.unwrap().0;
+    let mut want_digests = vec![
+        transaction_read_0.digest(),
+        transaction_read_1.digest(),
+        transaction_default.digest(),
+    ];
     want_digests.sort();
-    let mut got_digests = vec![tx_0.digest(), tx_1.digest()];
+    let mut got_digests = vec![tx_0.digest(), tx_1.digest(), tx_2.digest()];
     got_digests.sort();
     assert_eq!(want_digests, got_digests);
 
@@ -280,10 +285,13 @@ async fn transaction_manager_read_lock() {
     transaction_manager.notify_commit(tx_1.digest(), vec![], &state.epoch_store_for_testing());
 
     // TM should output the default-lock transaction eventually.
+
+    /*
     let tx_2 = rx_ready_certificates.recv().await.unwrap().0;
     assert_eq!(tx_2.digest(), transaction_default.digest());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
+    */
 
     // Notify TM about default-lock transaction commit
     transaction_manager.notify_commit(tx_2.digest(), vec![], &state.epoch_store_for_testing());

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -249,7 +249,7 @@ async fn transaction_manager_object_dependency() {
         )
         .unwrap();
 
-    // Enqueue one transaction with two readable shared objects, one is above shared object.
+    // Enqueue one transaction with two readonly shared object inputs, `shared_object` and `shared_object_2`.
     let shared_version_2 = 2000.into();
     let shared_object_arg_read_2 = ObjectArg::SharedObject {
         id: shared_object_2.id(),
@@ -258,7 +258,10 @@ async fn transaction_manager_object_dependency() {
     };
     let transaction_read_2 = make_transaction(
         gas_objects[3].clone(),
-        vec![CallArg::Object(shared_object_arg_read_2)],
+        vec![
+            CallArg::Object(shared_object_arg_default),
+            CallArg::Object(shared_object_arg_read_2),
+        ],
     );
     state
         .epoch_store_for_testing()
@@ -323,6 +326,8 @@ async fn transaction_manager_object_dependency() {
     transaction_manager.notify_commit(tx_0.digest(), vec![], &state.epoch_store_for_testing());
     transaction_manager.notify_commit(tx_1.digest(), vec![], &state.epoch_store_for_testing());
     transaction_manager.notify_commit(tx_2.digest(), vec![], &state.epoch_store_for_testing());
+
+    assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // Make shared_object_2 available.
     transaction_manager.objects_available(

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -165,8 +165,16 @@ async fn transaction_manager_basics() {
     transaction_manager.check_empty_for_testing();
 }
 
+// Tests when objects become available, correct set of transactions can be sent to execute.
+// Specifically, we have following setup,
+//         shared_object     shared_object_2
+//       /    |    \     \    /
+//    tx_0  tx_1  tx_2    tx_3
+//     r      r     w      r
+// And when shared_object is available, tx_0, tx_1, and tx_2 can be executed. And when
+// shared_object_2 becomes available, tx_3 can be executed.
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn transaction_manager_read_lock() {
+async fn transaction_manager_object_dependency() {
     // Initialize an authority state, with gas objects and a shared object.
     let (owner, _keypair) = deterministic_random_account_key();
     let gas_objects: Vec<Object> = (0..10)
@@ -176,9 +184,16 @@ async fn transaction_manager_read_lock() {
         })
         .collect();
     let shared_object = Object::shared_for_testing();
+    let shared_object_2 = Object::shared_for_testing();
 
-    let state =
-        init_state_with_objects([gas_objects.clone(), vec![shared_object.clone()]].concat()).await;
+    let state = init_state_with_objects(
+        [
+            gas_objects.clone(),
+            vec![shared_object.clone(), shared_object_2.clone()],
+        ]
+        .concat(),
+    )
+    .await;
 
     // Create a new transaction manager instead of reusing the authority's, to examine
     // transaction_manager output from rx_ready_certificates.
@@ -216,7 +231,7 @@ async fn transaction_manager_read_lock() {
         )
         .unwrap();
 
-    // Enqueue one transaction with default lock on the same shared object and version.
+    // Enqueue one transaction with the same shared object in mutable mode.
     let shared_object_arg_default = ObjectArg::SharedObject {
         id: shared_object.id(),
         initial_shared_version: 0.into(),
@@ -234,12 +249,35 @@ async fn transaction_manager_read_lock() {
         )
         .unwrap();
 
+    // Enqueue one transaction with two readable shared objects, one is above shared object.
+    let shared_version_2 = 2000.into();
+    let shared_object_arg_read_2 = ObjectArg::SharedObject {
+        id: shared_object_2.id(),
+        initial_shared_version: 0.into(),
+        mutable: false,
+    };
+    let transaction_read_2 = make_transaction(
+        gas_objects[3].clone(),
+        vec![CallArg::Object(shared_object_arg_read_2)],
+    );
+    state
+        .epoch_store_for_testing()
+        .set_shared_object_versions_for_testing(
+            transaction_read_2.digest(),
+            &vec![
+                (shared_object.id(), shared_version),
+                (shared_object_2.id(), shared_version_2),
+            ],
+        )
+        .unwrap();
+
     transaction_manager
         .enqueue(
             vec![
                 transaction_read_0.clone(),
                 transaction_read_1.clone(),
                 transaction_default.clone(),
+                transaction_read_2.clone(),
             ],
             &state.epoch_store_for_testing(),
         )
@@ -249,9 +287,9 @@ async fn transaction_manager_read_lock() {
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
 
-    assert_eq!(transaction_manager.inflight_queue_len(), 3);
+    assert_eq!(transaction_manager.inflight_queue_len(), 4);
 
-    // Notify TM about availability of the shared object.
+    // Notify TM about availability of the first shared object.
     transaction_manager.objects_available(
         vec![InputKey::VersionedObject {
             id: shared_object.id(),
@@ -260,41 +298,53 @@ async fn transaction_manager_read_lock() {
         &state.epoch_store_for_testing(),
     );
 
-    // TM should output the 2 read-only transactions eventually.
+    // TM should output the 3 transactions that are only waiting for this object.
     let tx_0 = rx_ready_certificates.recv().await.unwrap().0;
     let tx_1 = rx_ready_certificates.recv().await.unwrap().0;
     let tx_2 = rx_ready_certificates.recv().await.unwrap().0;
-    let mut want_digests = vec![
-        transaction_read_0.digest(),
-        transaction_read_1.digest(),
-        transaction_default.digest(),
-    ];
-    want_digests.sort();
-    let mut got_digests = vec![tx_0.digest(), tx_1.digest(), tx_2.digest()];
-    got_digests.sort();
-    assert_eq!(want_digests, got_digests);
+    {
+        let mut want_digests = vec![
+            transaction_read_0.digest(),
+            transaction_read_1.digest(),
+            transaction_default.digest(),
+        ];
+        want_digests.sort();
+        let mut got_digests = vec![tx_0.digest(), tx_1.digest(), tx_2.digest()];
+        got_digests.sort();
+        assert_eq!(want_digests, got_digests);
+    }
 
-    // TM should not output default-lock transaction yet.
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
 
-    assert_eq!(transaction_manager.inflight_queue_len(), 3);
+    assert_eq!(transaction_manager.inflight_queue_len(), 4);
 
     // Notify TM about read-only transaction commit
     transaction_manager.notify_commit(tx_0.digest(), vec![], &state.epoch_store_for_testing());
     transaction_manager.notify_commit(tx_1.digest(), vec![], &state.epoch_store_for_testing());
+    transaction_manager.notify_commit(tx_2.digest(), vec![], &state.epoch_store_for_testing());
 
-    // TM should output the default-lock transaction eventually.
+    // Make shared_object_2 available.
+    transaction_manager.objects_available(
+        vec![InputKey::VersionedObject {
+            id: shared_object_2.id(),
+            version: shared_version_2,
+        }],
+        &state.epoch_store_for_testing(),
+    );
 
-    /*
-    let tx_2 = rx_ready_certificates.recv().await.unwrap().0;
-    assert_eq!(tx_2.digest(), transaction_default.digest());
+    // Now, the transaction waiting for both shared objects can be executed.
+    let tx_3 = rx_ready_certificates.recv().await.unwrap().0;
+    assert_eq!(transaction_read_2.digest(), tx_3.digest());
+
+    sleep(Duration::from_secs(1)).await;
+    assert!(rx_ready_certificates.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
-    */
 
-    // Notify TM about default-lock transaction commit
-    transaction_manager.notify_commit(tx_2.digest(), vec![], &state.epoch_store_for_testing());
+    // Notify TM about tx_3.
+    transaction_manager.notify_commit(tx_3.digest(), vec![], &state.epoch_store_for_testing());
+
     transaction_manager.check_empty_for_testing();
 }
 


### PR DESCRIPTION
## Description 

This PR reverts the logic introduced in #10557 where transaction manager first executes all the transactions that only read a shared object and then executes the transaction that mutate it (if there is any). This was due to that child object reading was not properly handled. Now, since we have MVCC in child objects, we can remove this restriction, and send all transactions to execute as soon as all input objects become available.

## Test Plan 

Unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
