### PR TITLE
[graphql/rpc] add rich graphql casting from response

### DIFF
--- a/crates/sui-graphql-rpc/src/client/mod.rs
+++ b/crates/sui-graphql-rpc/src/client/mod.rs
@@ -1,5 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_graphql::Value;
+use hyper::header::ToStrError;
+use serde_json::Number;
+
 pub mod response;
 pub mod simple_client;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    #[error("Service version header not found")]
+    ServiceVersionHeaderNotFound,
+    #[error("Service version header value invalid string: {error}")]
+    ServiceVersionHeaderValueInvalidString { error: ToStrError },
+    #[error("Invalid usage number for {usage_name}: {usage_number}")]
+    InvalidUsageNumber {
+        usage_name: String,
+        usage_number: Number,
+    },
+    #[error("Invalid usage field for {usage_name}: {usage_value}")]
+    InvalidUsageValue {
+        usage_name: String,
+        usage_value: Value,
+    },
+    #[error(transparent)]
+    InnerClientError(#[from] reqwest::Error),
+}

--- a/crates/sui-graphql-rpc/src/client/mod.rs
+++ b/crates/sui-graphql-rpc/src/client/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod response;
 pub mod simple_client;

--- a/crates/sui-graphql-rpc/src/client/response.rs
+++ b/crates/sui-graphql-rpc/src/client/response.rs
@@ -39,7 +39,7 @@ impl GraphqlResponse {
             .get(&VERSION_HEADER)
             .expect("Missing version header")
             .to_str()
-            .expect("Failed to parse version header")
+            .expect("Failed to parse version header to string")
             .to_string()
     }
 

--- a/crates/sui-graphql-rpc/src/client/response.rs
+++ b/crates/sui-graphql-rpc/src/client/response.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Response, ServerError, Value};
+use hyper::HeaderMap;
+use reqwest::Response as ReqwestResponse;
+use std::{collections::BTreeMap, net::SocketAddr};
+
+use crate::server::version::VERSION_HEADER;
+
+#[derive(Debug)]
+pub struct GraphqlResponse {
+    headers: HeaderMap,
+    remote_address: Option<SocketAddr>,
+    http_version: hyper::Version,
+    status: hyper::StatusCode,
+    full_response: Response,
+}
+
+impl GraphqlResponse {
+    pub async fn from_resp(resp: ReqwestResponse) -> Self {
+        let headers = resp.headers().clone();
+        let remote_address = resp.remote_addr();
+        let http_version = resp.version();
+        let status = resp.status();
+        let full_response: Response = resp.json().await.expect("Failed to parse response");
+
+        Self {
+            headers,
+            remote_address,
+            http_version,
+            status,
+            full_response,
+        }
+    }
+
+    pub fn graphql_version(&self) -> String {
+        self.headers
+            .get(&VERSION_HEADER)
+            .expect("Missing version header")
+            .to_str()
+            .expect("Failed to parse version header")
+            .to_string()
+    }
+
+    pub fn response_body(&self) -> &Response {
+        &self.full_response
+    }
+
+    pub fn http_status(&self) -> hyper::StatusCode {
+        self.status
+    }
+
+    pub fn http_version(&self) -> hyper::Version {
+        self.http_version
+    }
+
+    pub fn http_headers(&self) -> HeaderMap {
+        self.headers.clone()
+    }
+
+    pub fn remote_address(&self) -> Option<SocketAddr> {
+        self.remote_address
+    }
+
+    pub fn errors(&self) -> Vec<ServerError> {
+        self.full_response.errors.clone()
+    }
+
+    pub fn usage(&self) -> Option<BTreeMap<String, u64>> {
+        match self.full_response.extensions.get("usage").cloned() {
+            Some(Value::Object(obj)) => Some(
+                obj.into_iter()
+                    .map(|(k, v)| {
+                        (
+                            k.to_string(),
+                            match v {
+                                Value::Number(n) => {
+                                    n.as_u64().expect("Usage value should be a number")
+                                }
+                                _ => panic!("Usage value should be a number"),
+                            },
+                        )
+                    })
+                    .collect(),
+            ),
+            _ => None,
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/src/extensions/mod.rs
+++ b/crates/sui-graphql-rpc/src/extensions/mod.rs
@@ -3,5 +3,5 @@
 
 pub(crate) mod feature_gate;
 pub(crate) mod logger;
-pub(crate) mod query_limits_checker;
+pub mod query_limits_checker;
 pub(crate) mod timeout;

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -31,7 +31,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-static LIMITS_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-show-usage");
+pub static LIMITS_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-show-usage");
 
 /// Only display usage information if this header was in the request.
 pub(crate) struct ShowUsage;

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -12,7 +12,7 @@ pub mod cluster;
 pub mod context_data;
 mod error;
 pub mod examples;
-mod extensions;
+pub mod extensions;
 mod metrics;
 mod types;
 pub mod utils;

--- a/crates/sui-graphql-rpc/src/server/mod.rs
+++ b/crates/sui-graphql-rpc/src/server/mod.rs
@@ -4,4 +4,4 @@
 pub mod simple_server;
 
 pub mod builder;
-mod version;
+pub mod version;

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -15,7 +15,7 @@ const RPC_VERSION_FULL: &str = env!("CARGO_PKG_VERSION");
 const RPC_VERSION_YEAR: &str = env!("CARGO_PKG_VERSION_MAJOR");
 const RPC_VERSION_MONTH: &str = env!("CARGO_PKG_VERSION_MINOR");
 
-static VERSION_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-version");
+pub(crate) static VERSION_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-version");
 
 pub(crate) struct SuiRpcVersion(Vec<u8>, Vec<Vec<u8>>);
 

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -131,6 +131,43 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn test_graphql_client_response() {
+        sleep(Duration::from_secs(5)).await;
+        let rng = StdRng::from_seed([12; 32]);
+        let mut sim = Simulacrum::new_with_rng(rng);
+
+        sim.create_checkpoint();
+        sim.create_checkpoint();
+
+        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+        let cluster =
+            sui_graphql_rpc::cluster::serve_simulator(connection_config, 3000, Arc::new(sim)).await;
+
+        let query = r#"
+            query {
+                chainIdentifier
+            }
+        "#;
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(res.http_status().as_u16(), 200);
+        assert_eq!(res.http_version(), hyper::Version::HTTP_11);
+        assert!(res.graphql_version().len() >= 5);
+        assert!(res.errors().is_empty());
+
+        let usage = res.usage().unwrap();
+        assert_eq!(*usage.get("nodes").unwrap(), 1);
+        assert_eq!(*usage.get("depth").unwrap(), 1);
+        assert_eq!(*usage.get("variables").unwrap(), 0);
+        assert_eq!(*usage.get("fragments").unwrap(), 0);
+    }
+
     use sui_graphql_rpc::server::builder::tests::*;
 
     #[tokio::test]

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -158,10 +158,10 @@ mod tests {
 
         assert_eq!(res.http_status().as_u16(), 200);
         assert_eq!(res.http_version(), hyper::Version::HTTP_11);
-        assert!(res.graphql_version().len() >= 5);
+        assert!(res.graphql_version().unwrap().len() >= 5);
         assert!(res.errors().is_empty());
 
-        let usage = res.usage().unwrap();
+        let usage = res.usage().unwrap().unwrap();
         assert_eq!(*usage.get("nodes").unwrap(), 1);
         assert_eq!(*usage.get("depth").unwrap(), 1);
         assert_eq!(*usage.get("variables").unwrap(), 0);


### PR DESCRIPTION
## Description 

Creates a custom `GraphqlResponse` type which is created from http response and supports fetching commonly used data.
This will be useful for tests.

## Test Plan 

e2e test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
