### PR TITLE
[graphql][fix][easy] add coinType to BalanceChange

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1415,10 +1415,10 @@
 >            }
 >          }
 >          amount
->        	coinType {
->            repr,
->            signature,
->            layout 
+>          coinType {
+>            repr
+>            signature
+>            layout
 >          }
 >        }
 >        dependencies {

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1415,6 +1415,11 @@
 >            }
 >          }
 >          amount
+>        	coinType {
+>            repr,
+>            signature,
+>            layout 
+>          }
 >        }
 >        dependencies {
 >          sender {

--- a/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
@@ -27,10 +27,10 @@
             }
           }
           amount
-        	coinType {
-            repr,
-            signature,
-            layout 
+          coinType {
+            repr
+            signature
+            layout
           }
         }
         dependencies {

--- a/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
@@ -27,6 +27,11 @@
             }
           }
           amount
+        	coinType {
+            repr,
+            signature,
+            layout 
+          }
         }
         dependencies {
           sender {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -46,6 +46,7 @@ type Balance {
 type BalanceChange {
 	owner: Owner
 	amount: BigInt
+	coinType: MoveType
 }
 
 type BalanceConnection {

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -19,5 +19,5 @@ pub(crate) struct Balance {
 pub(crate) struct BalanceChange {
     pub(crate) owner: Option<Owner>,
     pub(crate) amount: Option<BigInt>,
-    // pub(crate) coin_type: MoveType,
+    pub(crate) coin_type: Option<MoveType>,
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -12,6 +12,7 @@ use super::{
     digest::Digest,
     epoch::Epoch,
     gas::{GasEffects, GasInput},
+    move_type::MoveType,
     object_change::ObjectChange,
     owner::Owner,
     sui_address::SuiAddress,
@@ -263,6 +264,9 @@ impl BalanceChange {
             output.push(Some(BalanceChange {
                 owner: Some(owner),
                 amount: Some(amount),
+                coin_type: Some(MoveType::new(
+                    balance_change.coin_type.to_canonical_string(true),
+                )),
             }))
         }
         Ok(output)

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -50,6 +50,7 @@ type Balance {
 type BalanceChange {
 	owner: Owner
 	amount: BigInt
+	coinType: MoveType
 }
 
 type BalanceConnection {


### PR DESCRIPTION
## Description 

Add coinType to BalanceChange, so we know the coin type of the balance that was changed (rhymes)
<img width="1509" alt="Screenshot 2023-11-08 at 10 08 12 AM" src="https://github.com/MystenLabs/sui/assets/127570466/980c6d6e-2113-4d05-bb2d-d838f918450a">



## Test Plan 

manual verification, updated examples
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
