### PR TITLE
[graphql/docs] add docs for coin type in coin_connection

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -8,6 +8,12 @@ type Address implements ObjectOwner {
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	"""
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
+	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given address.
@@ -704,7 +710,10 @@ type Object implements ObjectOwner {
 	"""
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
-	The `0x2::sui::Coin` objects owned by the given object.
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
@@ -793,6 +802,12 @@ type Owner implements ObjectOwner {
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	"""
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
+	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
 	The stake objects for the given address

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -10,7 +10,6 @@ type Address implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""
@@ -711,7 +710,6 @@ type Object implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""
@@ -804,7 +802,6 @@ type Owner implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -106,6 +106,10 @@ impl Address {
             .extend()
     }
 
+    /// The coin objects for the given address.
+    ///
+    /// The type field is a string of the inner type of the coin
+    /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -107,7 +107,6 @@ impl Address {
     }
 
     /// The coin objects for the given address.
-    ///
     /// The type field is a string of the inner type of the coin
     /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -197,7 +197,10 @@ impl Object {
             .extend()
     }
 
-    /// The `0x2::sui::Coin` objects owned by the given object.
+    /// The coin objects for the given address.
+    ///
+    /// The type field is a string of the inner type of the coin
+    /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -198,7 +198,6 @@ impl Object {
     }
 
     /// The coin objects for the given address.
-    ///
     /// The type field is a string of the inner type of the coin
     /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -149,7 +149,6 @@ impl Owner {
     }
 
     /// The coin objects for the given address.
-    ///
     /// The type field is a string of the inner type of the coin
     /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -148,6 +148,10 @@ impl Owner {
             .extend()
     }
 
+    /// The coin objects for the given address.
+    ///
+    /// The type field is a string of the inner type of the coin
+    /// by which to filter (e.g., 0x2::sui::SUI).
     pub async fn coin_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -14,7 +14,6 @@ type Address implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""
@@ -715,7 +714,6 @@ type Object implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""
@@ -808,7 +806,6 @@ type Owner implements ObjectOwner {
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The coin objects for the given address.
-	
 	The type field is a string of the inner type of the coin
 	by which to filter (e.g., 0x2::sui::SUI).
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -12,6 +12,12 @@ type Address implements ObjectOwner {
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	"""
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
+	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given address.
@@ -708,7 +714,10 @@ type Object implements ObjectOwner {
 	"""
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
-	The `0x2::sui::Coin` objects owned by the given object.
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
@@ -797,6 +806,12 @@ type Owner implements ObjectOwner {
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	"""
+	The coin objects for the given address.
+	
+	The type field is a string of the inner type of the coin
+	by which to filter (e.g., 0x2::sui::SUI).
+	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	"""
 	The stake objects for the given address


### PR DESCRIPTION
## Description 

Improves the docs by explaining that the `type` field of the `coin_connection` expects the coin's inner type as a string. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
