### PR TITLE
[graphql/logging] change logging level for schema to debug

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -11,7 +11,7 @@ use async_graphql::{
 };
 use std::{fmt::Write, net::SocketAddr, sync::Arc};
 use tokio::sync::Mutex;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use uuid::Uuid;
 
 // TODO: mode in-depth logging to debug
@@ -153,10 +153,18 @@ impl Extension for LoggerExtension {
                 }
             }
         } else if self.config.log_response {
-            info!(
-                target: "async-graphql",
-                "[Response] {}: {}", self.session_id().await, resp.data
-            );
+            match operation_name {
+                Some("IntrospectionQuery") => {
+                    debug!(
+                        target: "async-graphql",
+                        "[Schema] {}: {}", self.session_id().await, resp.data
+                    );
+                }
+                _ => info!(
+                    target: "async-graphql",
+                    "[Response] {}: {}", self.session_id().await, resp.data
+                ),
+            }
         }
         resp
     }


### PR DESCRIPTION
## Description 
Force the `__schema` response that is generated everytime the server is reloaded to be logged using `debug` as it is too noisy.

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
