### PR TITLE
[cli] remove the extra empty line between two consecutive items and fix the object's version

### DIFF
--- a/crates/sui-json-rpc-types/src/object_changes.rs
+++ b/crates/sui-json-rpc-types/src/object_changes.rs
@@ -181,7 +181,7 @@ impl Display for ObjectChange {
                     f,
                     " ┌──\n │ PackageID: {} \n │ Version: {} \n │ Digest: {}\n | Modules: {}\n └──",
                     package_id,
-                    version,
+                    u64::from(*version),
                     digest,
                     modules.join(", ")
                 )
@@ -197,7 +197,7 @@ impl Display for ObjectChange {
                 writeln!(
                     f,
                     " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Recipient: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, recipient, object_type, version, digest
+                    object_id, sender, recipient, object_type, u64::from(*version), digest
                 )
             }
             ObjectChange::Mutated {
@@ -212,7 +212,7 @@ impl Display for ObjectChange {
                 writeln!(
                     f,
                     " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, owner, object_type, version, digest
+                    object_id, sender, owner, object_type, u64::from(*version), digest
                 )
             }
             ObjectChange::Deleted {
@@ -224,7 +224,7 @@ impl Display for ObjectChange {
                 writeln!(
                     f,
                     " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
-                    object_id, sender, object_type, version
+                    object_id, sender, object_type, u64::from(*version)
                 )
             }
             ObjectChange::Wrapped {
@@ -236,7 +236,7 @@ impl Display for ObjectChange {
                 writeln!(
                     f,
                     " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
-                    object_id, sender, object_type, version
+                    object_id, sender, object_type, u64::from(*version)
                 )
             }
             ObjectChange::Created {
@@ -250,7 +250,7 @@ impl Display for ObjectChange {
                 writeln!(
                     f,
                     " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, owner, object_type, version, digest
+                    object_id, sender, owner, object_type, u64::from(*version), digest
                 )
             }
         }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1833,7 +1833,7 @@ fn write_obj_changes<T: Display>(
     if !values.is_empty() {
         writeln!(writer, "\n{} Objects: ", output_string)?;
         for obj in values {
-            writeln!(writer, "{}", obj)?;
+            write!(writer, "{}", obj)?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Description 

Removes the extra empty line that exists between two items and fixes the version to be a u64. 

## Test Plan 

### Before
<img width="1311" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/cff73dc1-df29-42ca-85da-9e20570cd194">


### After
<img width="1311" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/999b0fb6-5870-4485-b61f-68afa0744285">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves the consistency across the way object changes are shown in transaction effects and outside of transaction effects, and fixes a bug that was not displaying an object's change version correctly as a u64. 