### PR TITLE
Add some tracing annotation for checkpoint execution

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1325,6 +1325,7 @@ impl AuthorityPerEpochStore {
     /// Lock a sequence number for the shared objects of the input transaction based on the effects
     /// of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who catch up by state sync.
+    #[instrument(level = "trace", skip_all)]
     pub async fn acquire_shared_locks_from_effects(
         &self,
         certificate: &VerifiedExecutableTransaction,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -233,6 +233,7 @@ impl CheckpointExecutor {
 
     /// Post processing and plumbing after we executed a checkpoint. This function is guaranteed
     /// to be called in the order of checkpoint sequence number.
+    #[instrument(level = "debug", skip_all)]
     fn process_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         // Ensure that we are not skipping checkpoints at any point
         let seq = *checkpoint.sequence_number();
@@ -281,6 +282,7 @@ impl CheckpointExecutor {
         checkpoint.report_checkpoint_age_ms(&self.metrics.last_executed_checkpoint_age_ms);
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn schedule_synced_checkpoints(
         &self,
         pending: &mut CheckpointExecutionBuffer,
@@ -357,6 +359,7 @@ impl CheckpointExecutor {
 
     // Logs within the function are annotated with the checkpoint sequence number and epoch,
     // from schedule_checkpoint().
+    #[instrument(level = "debug", skip_all)]
     async fn execute_checkpoint(
         &self,
         checkpoint: VerifiedCheckpoint,
@@ -400,6 +403,7 @@ impl CheckpointExecutor {
 
     // Logs within the function are annotated with the checkpoint sequence number and epoch,
     // from schedule_checkpoint().
+    #[instrument(level = "debug", skip_all)]
     async fn execute_transactions(
         &self,
         execution_digests: Vec<ExecutionDigests>,
@@ -981,6 +985,7 @@ fn get_unexecuted_transactions(
     (execution_digests, all_tx_digests, executable_txns)
 }
 
+#[instrument(level = "debug", skip_all)]
 fn finalize_checkpoint(
     authority_store: Arc<AuthorityStore>,
     tx_digests: &[TransactionDigest],


### PR DESCRIPTION
## Description 

Add some tracing to examine checkpoint execution.

I'm playing with tracing to see the effectiveness of #14667 . As a result, a typical transaction execution (`handle_execution_effects`) may take 100s of milliseconds, whereas the `finalize checkpoint` takes ~1.5ms before #14667 and ~700µs.

The DB is setup in a way that is moderately busy (compaction takes 20% of CPU).

Before #14667:
<img width="1261" alt="Screenshot 2023-11-09 at 10 11 12 AM" src="https://github.com/MystenLabs/sui/assets/9200652/0c3aa770-dd47-4711-8492-ca6ce12c9880">

After #14667:
<img width="1255" alt="Screenshot 2023-11-09 at 10 12 57 AM" src="https://github.com/MystenLabs/sui/assets/9200652/95f7ab66-3b82-4971-ba2f-081433fd009c">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
