### PR TITLE
[GraphQL] Change Object hierarchy representation

### DIFF
--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -6,9 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use move_core_types::account_address::AccountAddress;
-use sui_package_resolver::{
-    error::Error as PackageResolverError, make_package, Package, PackageStore, Result,
-};
+use sui_package_resolver::{error::Error as PackageResolverError, Package, PackageStore, Result};
 use sui_rest_api::Client;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::object::Object;
@@ -118,11 +116,6 @@ impl PackageStore for LocalDBPackageStore {
 
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
         let object = self.get(id).await?;
-        let package = Arc::new(make_package(
-            AccountAddress::from(object.id()),
-            object.version(),
-            &object,
-        )?);
-        Ok(package)
+        Ok(Arc::new(Package::read(&object)?))
     }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -994,7 +994,7 @@ type Stake {
 	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
 	- `current_stake_rate` is the stake rate in the current epoch.
 	
-	This value is only avaiable if the stake is active.
+	This value is only available if the stake is active.
 	"""
 	estimatedReward: BigInt
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -187,7 +187,7 @@ type Coin {
 	"""
 	Convert the coin object into a Move object
 	"""
-	asMoveObject: MoveObject
+	asMoveObject: MoveObject!
 }
 
 type CoinConnection {
@@ -535,8 +535,9 @@ type MoveModuleId {
 
 type MoveObject {
 	"""
-	Displays the contents of the MoveObject in a json string and through graphql types
-	Also provides the flat representation of the type signature, and the bcs of the corresponding data
+	Displays the contents of the MoveObject in a JSON string and through graphql types.  Also
+	provides the flat representation of the type signature, and the bcs of the corresponding
+	data
 	"""
 	contents: MoveValue
 	"""
@@ -547,13 +548,13 @@ type MoveObject {
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
 	"""
-	asObject: Object
+	asObject: Object!
 	"""
-	Attempts to convert the Move object into a Coin
+	Attempts to convert the Move object into a `0x2::coin::Coin`.
 	"""
 	asCoin: Coin
 	"""
-	Attempts to convert the Move object into a Stake
+	Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
 	"""
 	asStake: Stake
 }
@@ -581,7 +582,7 @@ type MovePackage {
 	name, followed by module bytes), in alphabetic order by module name.
 	"""
 	bcs: Base64
-	asObject: Object
+	asObject: Object!
 }
 
 """
@@ -682,7 +683,8 @@ type Object implements ObjectOwner {
 	"""
 	kind: ObjectKind
 	"""
-	The Address or Object that owns this Object.  Immutable and Shared Objects do not have owners.
+	The Address or Object that owns this Object.  Immutable and Shared Objects do not have
+	owners.
 	"""
 	owner: Owner
 	"""
@@ -967,18 +969,9 @@ type ServiceConfig {
 
 type Stake {
 	"""
-	The estimated reward for this stake object, computed as the
-	value of multiplying the principal value with the ratio between the initial stake rate and the current rate
+	A stake can be pending, active, or unstaked
 	"""
-	estimatedReward: BigInt
-	"""
-	The amount of SUI that is used to stake
-	"""
-	principal: BigInt
-	"""
-	The status of this stake object: Active, Pending, Unstaked
-	"""
-	status: StakeStatus
+	status: StakeStatus!
 	"""
 	The epoch at which this stake became active
 	"""
@@ -988,9 +981,26 @@ type Stake {
 	"""
 	requestEpoch: Epoch
 	"""
-	The corresponding StakedSui Move object
+	The SUI that was initially staked.
 	"""
-	asMoveObject: MoveObject
+	principal: BigInt
+	"""
+	The estimated reward for this stake object, calculated as:
+	
+	principal * (initial_stake_rate / current_stake_rate - 1.0)
+	
+	Or 0, if this value is negative, where:
+	
+	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
+	- `current_stake_rate` is the stake rate in the current epoch.
+	
+	This value is only avaiable if the stake is active.
+	"""
+	estimatedReward: BigInt
+	"""
+	The corresponding `0x3::staking_pool::StakedSui` Move object.
+	"""
+	asMoveObject: MoveObject!
 }
 
 type StakeConnection {

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -5,7 +5,7 @@ use super::{big_int::BigInt, move_type::MoveType};
 use crate::types::owner::Owner;
 use async_graphql::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct Balance {
     /// Coin type for the balance, such as 0x2::sui::SUI
     pub(crate) coin_type: Option<MoveType>,
@@ -15,7 +15,7 @@ pub(crate) struct Balance {
     pub(crate) total_balance: Option<BigInt>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct BalanceChange {
     pub(crate) owner: Option<Owner>,
     pub(crate) amount: Option<BigInt>,

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -5,41 +5,47 @@ use super::big_int::BigInt;
 use super::move_object::MoveObject;
 use async_graphql::*;
 
-use sui_types::coin::Coin as NativeSuiCoin;
+use sui_types::coin::Coin as NativeCoin;
 
 #[derive(Clone)]
 pub(crate) struct Coin {
-    pub move_obj: MoveObject,
-    pub balance: Option<BigInt>,
+    /// Representation of this Coin as a generic Move Object.
+    pub super_: MoveObject,
+
+    /// The deserialized representation of the Move Object's contents, as a `0x2::coin::Coin`.
+    pub native: NativeCoin,
+}
+
+pub(crate) enum CoinDowncastError {
+    NotACoin,
+    Bcs(bcs::Error),
 }
 
 #[Object]
 impl Coin {
     /// Balance of the coin object
     async fn balance(&self) -> Option<BigInt> {
-        if let Some(existing_balance) = &self.balance {
-            return Some(existing_balance.clone());
-        }
-
-        self.move_obj
-            .native_object
-            .data
-            .try_as_move()
-            .and_then(|x| {
-                if x.is_coin() {
-                    Some(NativeSuiCoin::extract_balance_if_coin(
-                        &self.move_obj.native_object,
-                    ))
-                } else {
-                    None
-                }
-            })
-            .and_then(|x| x.expect("Coin should have balance."))
-            .map(BigInt::from)
+        Some(BigInt::from(self.native.balance.value()))
     }
 
     /// Convert the coin object into a Move object
-    async fn as_move_object(&self) -> Option<MoveObject> {
-        Some(self.move_obj.clone())
+    async fn as_move_object(&self) -> &MoveObject {
+        &self.super_
+    }
+}
+
+impl TryFrom<&MoveObject> for Coin {
+    type Error = CoinDowncastError;
+
+    fn try_from(move_object: &MoveObject) -> Result<Self, Self::Error> {
+        if !move_object.native.is_coin() {
+            return Err(CoinDowncastError::NotACoin);
+        }
+
+        Ok(Self {
+            super_: move_object.clone(),
+            native: bcs::from_bytes(move_object.native.contents())
+                .map_err(CoinDowncastError::Bcs)?,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use move_binary_format::CompiledModule;
 
-use crate::{context_data::db_data_provider::PgManager, error::Error};
+use crate::context_data::db_data_provider::PgManager;
+use crate::error::Error;
+use sui_package_resolver::Module as ParsedMoveModule;
 
 use super::{move_package::MovePackage, sui_address::SuiAddress};
 
 #[derive(Clone)]
 pub(crate) struct MoveModule {
-    pub native_module: CompiledModule,
+    pub parsed: ParsedMoveModule,
 }
 
 /// Represents a module in Move, a library that defines struct types
@@ -18,7 +19,7 @@ pub(crate) struct MoveModule {
 #[Object]
 impl MoveModule {
     async fn file_format_version(&self) -> u32 {
-        self.native_module.version
+        self.parsed.bytecode().version
     }
 
     // TODO: impl all fields

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -1,111 +1,86 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::big_int::BigInt;
+use super::coin::CoinDowncastError;
 use super::move_value::MoveValue;
-use super::stake::StakeStatus;
+use super::stake::StakedSuiDowncastError;
 use super::{coin::Coin, object::Object};
-use crate::context_data::db_data_provider::PgManager;
 use crate::error::Error;
 use crate::types::stake::Stake;
 use async_graphql::*;
-use move_core_types::language_storage::TypeTag;
-use sui_types::governance::StakedSui;
-use sui_types::object::Object as NativeSuiObject;
+use move_core_types::language_storage::StructTag;
+use sui_types::object::{Data, MoveObject as NativeMoveObject};
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub(crate) struct MoveObject {
-    pub native_object: NativeSuiObject,
+    /// Representation of this Move Object as a generic Object.
+    pub super_: Object,
+
+    /// Move-object-specific data, extracted from the native representation at
+    /// `graphql_object.native_object.data`.
+    pub native: NativeMoveObject,
 }
+
+pub(crate) struct MoveObjectDowncastError;
 
 #[Object]
 impl MoveObject {
-    /// Displays the contents of the MoveObject in a json string and through graphql types
-    /// Also provides the flat representation of the type signature, and the bcs of the corresponding data
-    async fn contents(&self) -> Result<Option<MoveValue>> {
-        if let Some(struct_tag) = self.native_object.data.struct_tag() {
-            let type_tag = TypeTag::Struct(Box::new(struct_tag));
-            return Ok(Some(MoveValue::new(
-                type_tag.to_string(),
-                self.native_object
-                    .data
-                    .try_as_move()
-                    .ok_or_else(|| {
-                        Error::Internal(format!(
-                            "Failed to convert native object to move object: {}",
-                            self.native_object.id()
-                        ))
-                    })?
-                    .contents()
-                    .into(),
-            )));
-        }
-
-        Ok(None)
+    /// Displays the contents of the MoveObject in a JSON string and through graphql types.  Also
+    /// provides the flat representation of the type signature, and the bcs of the corresponding
+    /// data
+    async fn contents(&self) -> Option<MoveValue> {
+        let type_ = StructTag::from(self.native.type_().clone());
+        Some(MoveValue::new(
+            type_.to_canonical_string(/* with_prefix */ true),
+            self.native.contents().into(),
+        ))
     }
 
     /// Determines whether a tx can transfer this object
     async fn has_public_transfer(&self) -> Option<bool> {
-        self.native_object
-            .data
-            .try_as_move()
-            .map(|x| x.has_public_transfer())
+        Some(self.native.has_public_transfer())
     }
 
     /// Attempts to convert the Move object into an Object
     /// This provides additional information such as version and digest on the top-level
-    async fn as_object(&self) -> Option<Object> {
-        Some(Object::from(&self.native_object))
+    async fn as_object(&self) -> &Object {
+        &self.super_
     }
 
-    /// Attempts to convert the Move object into a Coin
-    async fn as_coin(&self) -> Option<Coin> {
-        let move_object = self.native_object.data.try_as_move()?;
-
-        if !move_object.is_coin() {
-            return None;
+    /// Attempts to convert the Move object into a `0x2::coin::Coin`.
+    async fn as_coin(&self) -> Result<Option<Coin>, Error> {
+        match Coin::try_from(self) {
+            Ok(coin) => Ok(Some(coin)),
+            Err(CoinDowncastError::NotACoin) => Ok(None),
+            Err(CoinDowncastError::Bcs(e)) => {
+                Err(Error::Internal(format!("Failed to deserialize coin: {e}")))
+            }
         }
-
-        Some(Coin {
-            move_obj: self.clone(),
-            balance: None, // Defer to resolver
-        })
     }
 
-    /// Attempts to convert the Move object into a Stake
-    async fn as_stake(&self, ctx: &Context<'_>) -> Result<Option<Stake>> {
-        let Some(move_object) = self.native_object.data.try_as_move() else {
-            return Ok(None);
-        };
-
-        if !move_object.is_staked_sui() {
-            return Ok(None);
+    /// Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
+    async fn as_stake(&self) -> Result<Option<Stake>, Error> {
+        match Stake::try_from(self) {
+            Ok(coin) => Ok(Some(coin)),
+            Err(StakedSuiDowncastError::NotAStakedSui) => Ok(None),
+            Err(StakedSuiDowncastError::Bcs(e)) => Err(Error::Internal(format!(
+                "Failed to deserialize staked sui: {e}"
+            ))),
         }
+    }
+}
 
-        let stake: StakedSui = bcs::from_bytes(move_object.contents())
-            .map_err(|e| Error::Internal(format!("Failed to deserialized Staked Sui: {e}")))?;
+impl TryFrom<&Object> for MoveObject {
+    type Error = MoveObjectDowncastError;
 
-        let latest_system_state = ctx
-            .data_unchecked::<PgManager>()
-            .fetch_latest_sui_system_state()
-            .await
-            .map_err(|e| Error::Internal(e.to_string()))?;
-
-        let current_epoch_id = latest_system_state.epoch_id;
-
-        let status = if current_epoch_id >= stake.activation_epoch() {
-            StakeStatus::Active
+    fn try_from(object: &Object) -> Result<Self, Self::Error> {
+        if let Data::Move(move_object) = &object.native.data {
+            Ok(Self {
+                super_: object.clone(),
+                native: move_object.clone(),
+            })
         } else {
-            StakeStatus::Pending
-        };
-
-        Ok(Some(Stake {
-            active_epoch_id: Some(stake.activation_epoch()),
-            estimated_reward: None,
-            principal: Some(BigInt::from(stake.principal())),
-            request_epoch_id: Some(stake.activation_epoch().saturating_sub(1)),
-            status: Some(status),
-            staked_sui_id: stake.id(),
-        }))
+            Err(MoveObjectDowncastError)
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -6,20 +6,21 @@ use super::move_module::MoveModule;
 use super::object::Object;
 use super::sui_address::SuiAddress;
 use crate::context_data::db_data_provider::validate_cursor_pagination;
-use crate::error::code::INTERNAL_SERVER_ERROR;
-use crate::error::{graphql_error, Error};
+use crate::context_data::DEFAULT_PAGE_SIZE;
+use crate::error::Error;
 use async_graphql::connection::{Connection, Edge};
 use async_graphql::*;
-use move_binary_format::CompiledModule;
-use sui_types::{
-    move_package::MovePackage as NativeMovePackage, object::Object as NativeSuiObject, Identifier,
-};
-
-const DEFAULT_PAGE_SIZE: usize = 10;
+use sui_package_resolver::{error::Error as PackageCacheError, Package as ParsedMovePackage};
+use sui_types::{move_package::MovePackage as NativeMovePackage, object::Data};
 
 #[derive(Clone)]
 pub(crate) struct MovePackage {
-    pub native_object: NativeSuiObject,
+    /// Representation of this Move Object as a generic Object.
+    pub super_: Object,
+
+    /// Move-object-specific data, extracted from the native representation at
+    /// `graphql_object.native_object.data`.
+    pub native: NativeMovePackage,
 }
 
 /// Information used by a package to link to a specific version of its dependency.
@@ -49,25 +50,23 @@ struct TypeOrigin {
     defining_id: SuiAddress,
 }
 
+pub(crate) struct MovePackageDowncastError;
+
 #[Object]
 impl MovePackage {
     /// A representation of the module called `name` in this package, including the
     /// structs and functions it defines.
-    async fn module(&self, name: String) -> Result<Option<MoveModule>> {
-        let identifier = Identifier::new(name).map_err(|e| Error::Internal(e.to_string()))?;
-
-        let module = self.native_object.data.try_as_package().map(|x| {
-            x.deserialize_module(
-                &identifier,
-                move_binary_format::file_format_common::VERSION_MAX,
-                true,
-            )
-            .map(|x| MoveModule { native_module: x })
-        });
-        if let Some(modu) = module {
-            return Ok(Some(modu?));
+    async fn module(&self, name: String) -> Result<Option<MoveModule>, Error> {
+        use PackageCacheError as E;
+        match self.parsed_package()?.module(&name) {
+            Ok(module) => Ok(Some(MoveModule {
+                parsed: module.clone(),
+            })),
+            Err(E::ModuleNotFound(_, _)) => Ok(None),
+            Err(e) => Err(Error::Internal(format!(
+                "Unexpected error fetching module: {e}"
+            ))),
         }
-        Ok(None)
     }
 
     /// Paginate through the MoveModules defined in this package.
@@ -78,96 +77,63 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Option<Connection<String, MoveModule>>> {
+        use std::ops::Bound as B;
+
         // TODO: make cursor opaque.
         // for now it same as module name
         validate_cursor_pagination(&first, &after, &last, &before)?;
 
-        if let Some(mod_map) = self
-            .native_object
-            .data
-            .try_as_package()
-            .map(|x| x.serialized_module_map())
-        {
-            if mod_map.is_empty() {
-                return Err(graphql_error(
-                    INTERNAL_SERVER_ERROR,
-                    format!(
-                        "Published package cannot contain zero modules. Id: {}",
-                        self.native_object.id()
-                    ),
-                )
-                .into());
-            }
+        let parsed = self.parsed_package()?;
+        let module_range = parsed.modules().range((
+            after.map_or(B::Unbounded, B::Excluded),
+            before.map_or(B::Unbounded, B::Excluded),
+        ));
 
-            let mut forward = true;
-            let mut count = first.unwrap_or(DEFAULT_PAGE_SIZE as u64);
-            count = last.unwrap_or(count);
+        let total = module_range.clone().count() as u64;
+        let (skip, take) = match (first, last) {
+            (Some(first), Some(last)) if last < first => (first - last, last),
+            (Some(first), _) => (0, first),
+            (None, Some(last)) => (total - last, last),
+            (None, None) => (0, DEFAULT_PAGE_SIZE),
+        };
 
-            let mut mod_list = mod_map
-                .clone()
-                .into_iter()
-                .collect::<Vec<(String, Vec<u8>)>>();
-
-            // ok to unwrap because we know mod_map is not empty
-            let mut start = &if last.is_some() {
-                forward = false;
-                mod_list.last().map(|c| c.0.clone())
-            } else {
-                mod_list.first().map(|c| c.0.clone())
-            }
-            .unwrap();
-
-            if let Some(aft) = &after {
-                start = aft;
-            } else if let Some(bef) = &before {
-                start = bef;
-                forward = false;
-            };
-
-            if !forward {
-                mod_list = mod_list.into_iter().rev().collect();
-            }
-
-            let mut res: Vec<_> = mod_list
-                .iter()
-                .skip_while(|(name, _)| name.as_str() != start)
-                .skip((after.is_some() || before.is_some()) as usize)
-                .take(count as usize)
-                .map(|(name, module)| {
-                    CompiledModule::deserialize_with_config(
-                        module,
-                        move_binary_format::file_format_common::VERSION_MAX,
-                        true,
-                    )
-                    .map(|x| (name, MoveModule { native_module: x }))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let mut has_prev_page = &mod_list.first().unwrap().0 != start;
-            let mut has_next_page =
-                !res.is_empty() && &mod_list.last().unwrap().0 != res.last().unwrap().0;
-            if !forward {
-                res = res.into_iter().rev().collect();
-                has_prev_page = &mod_list.first().unwrap().0 != start;
-                has_next_page =
-                    !res.is_empty() && &mod_list.last().unwrap().0 != res.first().unwrap().0;
-            }
-
-            let mut connection = Connection::new(has_prev_page, has_next_page);
-
-            connection.edges.extend(
-                res.into_iter()
-                    .map(|(name, module)| Edge::new(name.clone(), module)),
-            );
-            return Ok(Some(connection));
+        let mut connection = Connection::new(false, false);
+        for (name, module) in module_range.skip(skip as usize).take(take as usize) {
+            connection.edges.push(Edge::new(
+                name.clone(),
+                MoveModule {
+                    parsed: module.clone(),
+                },
+            ))
         }
 
-        Ok(None)
+        connection.has_previous_page = connection.edges.first().is_some_and(|fst| {
+            parsed
+                .modules()
+                .range::<String, _>((B::Unbounded, B::Excluded(&fst.cursor)))
+                .count()
+                > 0
+        });
+
+        connection.has_next_page = connection.edges.last().is_some_and(|lst| {
+            parsed
+                .modules()
+                .range::<String, _>((B::Excluded(&lst.cursor), B::Unbounded))
+                .count()
+                > 0
+        });
+
+        if connection.edges.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(connection))
+        }
     }
 
     /// The transitive dependencies of this package.
-    async fn linkage(&self) -> Result<Option<Vec<Linkage>>> {
+    async fn linkage(&self) -> Option<Vec<Linkage>> {
         let linkage = self
-            .as_native_package()?
+            .native
             .linkage_table()
             .iter()
             .map(|(&runtime_id, upgrade_info)| Linkage {
@@ -177,13 +143,13 @@ impl MovePackage {
             })
             .collect();
 
-        Ok(Some(linkage))
+        Some(linkage)
     }
 
     /// The (previous) versions of this package that introduced its types.
-    async fn type_origins(&self) -> Result<Option<Vec<TypeOrigin>>> {
+    async fn type_origins(&self) -> Option<Vec<TypeOrigin>> {
         let type_origins = self
-            .as_native_package()?
+            .native
             .type_origin_table()
             .iter()
             .map(|origin| TypeOrigin {
@@ -193,36 +159,44 @@ impl MovePackage {
             })
             .collect();
 
-        Ok(Some(type_origins))
+        Some(type_origins)
     }
 
     /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
     /// name, followed by module bytes), in alphabetic order by module name.
     async fn bcs(&self) -> Result<Option<Base64>> {
-        let modules = self.as_native_package()?.serialized_module_map();
-
-        let bcs = bcs::to_bytes(modules).map_err(|_| {
-            Error::Internal(format!(
-                "Failed to serialize package {}",
-                self.native_object.id(),
-            ))
+        let bcs = bcs::to_bytes(self.native.serialized_module_map()).map_err(|_| {
+            Error::Internal(format!("Failed to serialize package {}", self.native.id()))
         })?;
 
         Ok(Some(bcs.into()))
     }
 
-    async fn as_object(&self) -> Option<Object> {
-        Some(Object::from(&self.native_object))
+    async fn as_object(&self) -> &Object {
+        &self.super_
     }
 }
 
 impl MovePackage {
-    fn as_native_package(&self) -> Result<&NativeMovePackage> {
-        Ok(self.native_object.data.try_as_package().ok_or_else(|| {
-            Error::Internal(format!(
-                "Failed to convert native object to move package: {}",
-                self.native_object.id(),
-            ))
-        })?)
+    fn parsed_package(&self) -> Result<ParsedMovePackage, Error> {
+        // TODO: Leverage the package cache (attempt to read from it, and if that doesn't succeed,
+        // write back the parsed Package to the cache as well.)
+        ParsedMovePackage::read(&self.super_.native)
+            .map_err(|e| Error::Internal(format!("Error reading package: {e}")))
+    }
+}
+
+impl TryFrom<&Object> for MovePackage {
+    type Error = MovePackageDowncastError;
+
+    fn try_from(object: &Object) -> Result<Self, Self::Error> {
+        if let Data::Package(move_package) = &object.native.data {
+            Ok(Self {
+                super_: object.clone(),
+                native: move_package.clone(),
+            })
+        } else {
+            Err(MovePackageDowncastError)
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -4,7 +4,7 @@
 use super::object::Object;
 use async_graphql::SimpleObject;
 
-#[derive(PartialEq, Eq, Clone, SimpleObject)]
+#[derive(Clone, SimpleObject)]
 pub(crate) struct ObjectChange {
     pub input_state: Option<Object>,
     pub output_state: Option<Object>,

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -75,14 +75,14 @@ use sui_json_rpc::name_service::NameServiceConfig;
         arg(name = "before", ty = "Option<String>"),
     )
 )]
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum ObjectOwner {
     Address(Address),
     Owner(Owner),
     Object(Object),
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Owner {
     pub address: SuiAddress,
 }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context_data::db_data_provider::PgManager;
+use crate::error::Error;
 
 use super::{big_int::BigInt, epoch::Epoch, move_object::MoveObject};
 use async_graphql::*;
-use sui_types::base_types::ObjectID;
+use sui_json_rpc_types::{Stake as RpcStakedSui, StakeStatus as RpcStakeStatus};
+use sui_types::governance::StakedSui as NativeStakedSui;
 
 #[derive(Copy, Clone, Enum, PartialEq, Eq)]
 pub(crate) enum StakeStatus {
@@ -17,62 +19,103 @@ pub(crate) enum StakeStatus {
     Unstaked,
 }
 
-#[derive(Clone, PartialEq, Eq, SimpleObject)]
-#[graphql(complex)]
-pub(crate) struct Stake {
-    /// The epoch at which the stake became active
-    #[graphql(skip)]
-    pub active_epoch_id: Option<u64>,
-    /// The estimated reward for this stake object, computed as the
-    /// value of multiplying the principal value with the ratio between the initial stake rate and the current rate
-    pub estimated_reward: Option<BigInt>,
-    /// The amount of SUI that is used to stake
-    pub principal: Option<BigInt>,
-    #[graphql(skip)]
-    pub request_epoch_id: Option<u64>,
-    /// The status of this stake object: Active, Pending, Unstaked
-    pub status: Option<StakeStatus>,
-    #[graphql(skip)]
-    pub staked_sui_id: ObjectID,
+pub(crate) enum StakedSuiDowncastError {
+    NotAStakedSui,
+    Bcs(bcs::Error),
 }
 
-#[ComplexObject]
+#[derive(Clone)]
+pub(crate) struct Stake {
+    /// Representation of this StakedSui as a generic Move Object.
+    pub super_: MoveObject,
+
+    /// Deserialized representation of the Move Object's contents as a
+    /// `0x3::staking_pool::StakedSui`.
+    pub native: NativeStakedSui,
+}
+
+#[Object]
 impl Stake {
+    /// A stake can be pending, active, or unstaked
+    async fn status(&self, ctx: &Context<'_>) -> Result<StakeStatus, Error> {
+        Ok(match self.rpc_stake(ctx).await?.status {
+            RpcStakeStatus::Pending => StakeStatus::Pending,
+            RpcStakeStatus::Active { .. } => StakeStatus::Active,
+            RpcStakeStatus::Unstaked => StakeStatus::Unstaked,
+        })
+    }
+
     /// The epoch at which this stake became active
-    async fn active_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        if let Some(epoch_id) = self.active_epoch_id {
-            let epoch = ctx
-                .data_unchecked::<PgManager>()
-                .fetch_epoch_strict(epoch_id)
-                .await
-                .extend()?;
-            Ok(Some(epoch))
-        } else {
-            Ok(None)
-        }
+    async fn active_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
+        Ok(Some(
+            ctx.data_unchecked::<PgManager>()
+                .fetch_epoch_strict(self.native.activation_epoch())
+                .await?,
+        ))
     }
 
     /// The epoch at which this object was requested to join a stake pool
-    async fn request_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        if let Some(epoch_id) = self.request_epoch_id {
-            let epoch = ctx
-                .data_unchecked::<PgManager>()
-                .fetch_epoch_strict(epoch_id)
-                .await
-                .extend()?;
-            Ok(Some(epoch))
-        } else {
-            Ok(None)
-        }
+    async fn request_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
+        Ok(Some(
+            ctx.data_unchecked::<PgManager>()
+                .fetch_epoch_strict(self.native.request_epoch())
+                .await?,
+        ))
     }
 
-    /// The corresponding StakedSui Move object
-    async fn as_move_object(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        let obj = ctx
-            .data_unchecked::<PgManager>()
-            .inner
-            .get_object_in_blocking_task(self.staked_sui_id)
-            .await?;
-        Ok(obj.map(|x| MoveObject { native_object: x }))
+    /// The SUI that was initially staked.
+    async fn principal(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.principal()))
+    }
+
+    /// The estimated reward for this stake object, calculated as:
+    ///
+    ///  principal * (initial_stake_rate / current_stake_rate - 1.0)
+    ///
+    /// Or 0, if this value is negative, where:
+    ///
+    /// - `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
+    /// - `current_stake_rate` is the stake rate in the current epoch.
+    ///
+    /// This value is only avaiable if the stake is active.
+    async fn estimated_reward(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, Error> {
+        let RpcStakeStatus::Active { estimated_reward } = self.rpc_stake(ctx).await?.status else {
+            return Ok(None);
+        };
+
+        Ok(Some(BigInt::from(estimated_reward)))
+    }
+
+    /// The corresponding `0x3::staking_pool::StakedSui` Move object.
+    async fn as_move_object(&self) -> &MoveObject {
+        &self.super_
+    }
+}
+
+impl Stake {
+    /// The JSON-RPC representation of a StakedSui so that we can "cheat" to implement fields that
+    /// are not yet implemented directly for GraphQL.
+    ///
+    /// TODO: Make this obsolete
+    async fn rpc_stake(&self, ctx: &Context<'_>) -> Result<RpcStakedSui, Error> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_rpc_staked_sui(self.native.clone())
+            .await
+    }
+}
+
+impl TryFrom<&MoveObject> for Stake {
+    type Error = StakedSuiDowncastError;
+
+    fn try_from(move_object: &MoveObject) -> Result<Self, Self::Error> {
+        if !move_object.native.is_staked_sui() {
+            return Err(StakedSuiDowncastError::NotAStakedSui);
+        }
+
+        Ok(Self {
+            super_: move_object.clone(),
+            native: bcs::from_bytes(move_object.native.contents())
+                .map_err(StakedSuiDowncastError::Bcs)?,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -77,7 +77,7 @@ impl Stake {
     /// - `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
     /// - `current_stake_rate` is the stake rate in the current epoch.
     ///
-    /// This value is only avaiable if the stake is active.
+    /// This value is only available if the stake is active.
     async fn estimated_reward(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, Error> {
         let RpcStakeStatus::Active { estimated_reward } = self.rpc_stake(ctx).await?.status else {
             return Ok(None);

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -30,7 +30,7 @@ use sui_json_rpc_types::{
 };
 use sui_types::digests::TransactionDigest;
 
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
+#[derive(SimpleObject, Clone)]
 #[graphql(complex)]
 pub(crate) struct TransactionBlock {
     #[graphql(skip)]
@@ -80,7 +80,7 @@ impl TransactionBlock {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, SimpleObject)]
+#[derive(Clone, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct TransactionBlockEffects {
     #[graphql(skip)]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -191,7 +191,7 @@ type Coin {
 	"""
 	Convert the coin object into a Move object
 	"""
-	asMoveObject: MoveObject
+	asMoveObject: MoveObject!
 }
 
 type CoinConnection {
@@ -539,8 +539,9 @@ type MoveModuleId {
 
 type MoveObject {
 	"""
-	Displays the contents of the MoveObject in a json string and through graphql types
-	Also provides the flat representation of the type signature, and the bcs of the corresponding data
+	Displays the contents of the MoveObject in a JSON string and through graphql types.  Also
+	provides the flat representation of the type signature, and the bcs of the corresponding
+	data
 	"""
 	contents: MoveValue
 	"""
@@ -551,13 +552,13 @@ type MoveObject {
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
 	"""
-	asObject: Object
+	asObject: Object!
 	"""
-	Attempts to convert the Move object into a Coin
+	Attempts to convert the Move object into a `0x2::coin::Coin`.
 	"""
 	asCoin: Coin
 	"""
-	Attempts to convert the Move object into a Stake
+	Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
 	"""
 	asStake: Stake
 }
@@ -585,7 +586,7 @@ type MovePackage {
 	name, followed by module bytes), in alphabetic order by module name.
 	"""
 	bcs: Base64
-	asObject: Object
+	asObject: Object!
 }
 
 """
@@ -686,7 +687,8 @@ type Object implements ObjectOwner {
 	"""
 	kind: ObjectKind
 	"""
-	The Address or Object that owns this Object.  Immutable and Shared Objects do not have owners.
+	The Address or Object that owns this Object.  Immutable and Shared Objects do not have
+	owners.
 	"""
 	owner: Owner
 	"""
@@ -971,18 +973,9 @@ type ServiceConfig {
 
 type Stake {
 	"""
-	The estimated reward for this stake object, computed as the
-	value of multiplying the principal value with the ratio between the initial stake rate and the current rate
+	A stake can be pending, active, or unstaked
 	"""
-	estimatedReward: BigInt
-	"""
-	The amount of SUI that is used to stake
-	"""
-	principal: BigInt
-	"""
-	The status of this stake object: Active, Pending, Unstaked
-	"""
-	status: StakeStatus
+	status: StakeStatus!
 	"""
 	The epoch at which this stake became active
 	"""
@@ -992,9 +985,26 @@ type Stake {
 	"""
 	requestEpoch: Epoch
 	"""
-	The corresponding StakedSui Move object
+	The SUI that was initially staked.
 	"""
-	asMoveObject: MoveObject
+	principal: BigInt
+	"""
+	The estimated reward for this stake object, calculated as:
+	
+	principal * (initial_stake_rate / current_stake_rate - 1.0)
+	
+	Or 0, if this value is negative, where:
+	
+	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
+	- `current_stake_rate` is the stake rate in the current epoch.
+	
+	This value is only avaiable if the stake is active.
+	"""
+	estimatedReward: BigInt
+	"""
+	The corresponding `0x3::staking_pool::StakedSui` Move object.
+	"""
+	asMoveObject: MoveObject!
 }
 
 type StakeConnection {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -998,7 +998,7 @@ type Stake {
 	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
 	- `current_stake_rate` is the stake rate in the current epoch.
 	
-	This value is only avaiable if the stake is active.
+	This value is only available if the stake is active.
 	"""
 	estimatedReward: BigInt
 	"""

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -209,6 +209,24 @@ pub enum OwnerType {
     Shared = 3,
 }
 
+impl TryFrom<i16> for OwnerType {
+    type Error = IndexerError;
+
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => OwnerType::Immutable,
+            1 => OwnerType::Address,
+            2 => OwnerType::Object,
+            3 => OwnerType::Shared,
+            value => {
+                return Err(IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "{value} as OwnerType"
+                )))
+            }
+        })
+    }
+}
+
 // Returns owner_type, owner_address
 pub fn owner_to_owner_info(owner: &Owner) -> (OwnerType, Option<SuiAddress>) {
     match owner {

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -86,6 +86,11 @@ impl StakedSui {
         self.stake_activation_epoch
     }
 
+    pub fn request_epoch(&self) -> EpochId {
+        // TODO: this might change when we implement warm up period.
+        self.stake_activation_epoch.saturating_sub(1)
+    }
+
     pub fn principal(&self) -> u64 {
         self.principal.value()
     }


### PR DESCRIPTION
## Description

A number of changes to bring all the type representations within the `Object` hierarchy inline with each other, and make it easier to adopt a `DataLoader` style interface for all of them (which will be the next step).

### Change `Object` representation

Every type in this hierarchy (`Object`, `MoveObject`, `MovePackage`, `Coin, `Stake`) stores the following:

- Their `super_` type, by value (e.g. `Coin` stores `MoveObject` which stores `Object`).
- The "native" representation (the `sui-type` type).

Additionally, `Object`, as the top of the hierarchy also contains its `stored` representation, and its `address` (to avoid having to convert it from a byte array every time).

All upcast operations have been made infallible, and work by returning a reference to `super_`.  This is temporary because after #14649, these will eventually become a true type hierarchy.

All downcasts are implemented by `try_from` implementations that have been moved into the module that defines the type being created (e.g. `MovePackage` implements `TryFrom<&Object>`).  These convert from a reference to prevent unnecessarily copying the value when the conversion might fail.

These `try_from` implementations have been re-used in both the downcast and `fetch` operations to avoid code duplication.

This type hierarchy now does not use the `SimpleObject` pattern, but implements each field in an `#[Object]` `impl` block.

### `Eq`, `PartialEq`

I'm not sure why we scattered these derive clauses around everywhere but I took them out -- because (a) we don't use them, and (b) now that objects keep the stored representation, we would need to also propagate the derive clauses into the indexer codebase to use these.

If this is for testing purposes, we should rely on snapshot/expect testing instead.

### `Result<...>`

If a command can never fail, I've removed the `Result` type, and in code I have touched, I have made sure we are returning a `crate::error::Error` and not an `async_graphql::Error` (because the latter does not apply our error code extension).

I will follow up with an audit across the codebase to make sure this is done consistently.

### `MovePackage`

`MovePackage` serves requests by first reading its package as a `ParsedMovePackage`, which is the representation used by `PackageCache`.  To do this required exposing a `Package::read` function as well as some accessors to the resulting `Package` and `Module` data structures.

This de-duplicates the work of understanding the structure of a package, and allows fast random access to module and struct information.

Today, this is not done efficiently, because each package will be re-parsed on each request, but we will follow-up to have this leverage the package cache (the query will first check whether the package exists in the cache and re-use it if so, and if not, it will push it into the cache so the read results can be re-used).

#### `moduleConnection`

There were some bugs in this implication that are now fixed:

`count` was calculated as `last.unwrap_or(first.unwrap_or(DEFAULT))`, which has the effect of making `last` take precedence.  According to the Relay Connection Spec, the number of edges should be equivalent to `min(first, last)` if both are present.

Similarly, if both `first` and `last` are present, the algorithm presented in the Relay Connection Spec states that you should take the first `firt` from the left, and then take the last `last` from the right (i.e. they layer on top of each other), which the previous implementation did not do.

Not really a bug, but a behaviour change: if the edges of the `Connection` are empty, then return `None` instead of the connection.

### `Stake`

This has been changed quite drastically:  Its representation now matches `Coin` in that it only contains its `super_` representation and the Rust (`sui-types`) representation of its Move value.

The features that are not currently supported directly in GraphQL (stake status and estimated rewards) have been implemented by making an RPC call for the JSON-RPC representation of stake, and then working on that.  I have not been able to test this out because it times out, but at least this means you can access other fields on the stake object without being subject to the timeout.

This type should be called `StakedSui` as per the draft schema -- I will make this change in a follow-up.

## Test Plan

This change is a refactor and therefore is behaviour preserving, so no extra tests were written, but the following tests were conducted:

```
sui-graphql-rpc$ cargo nextest run
```

Package queries:
![Screenshot 2023-11-09 at 11 55 29 AM](https://github.com/MystenLabs/sui/assets/332275/7ea1c061-1591-4198-a15d-8cfc800ab836)

Object queries:
![Screenshot 2023-11-09 at 11 55 31 AM](https://github.com/MystenLabs/sui/assets/332275/1efe59a4-37c0-45a6-9705-1d8cdceae53b)

Object downcasts:
![Screenshot 2023-11-09 at 11 55 50 AM](https://github.com/MystenLabs/sui/assets/332275/09412351-2fdc-4d3e-84bf-66c82df375fc)

Object upcasts:
![Screenshot 2023-11-09 at 12 34 26 PM](https://github.com/MystenLabs/sui/assets/332275/7cf3f079-f150-4279-a247-6cca7f679515)