### PR TITLE
Some simple refactorings to clean up the commit cert path

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3419,27 +3419,6 @@ impl AuthorityState {
         .await;
     }
 
-    #[instrument(level = "trace", skip_all)]
-    pub fn get_certified_transaction(
-        &self,
-        tx_digest: &TransactionDigest,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<Option<VerifiedCertificate>> {
-        let Some(cert_sig) = epoch_store.get_transaction_cert_sig(tx_digest)? else {
-            return Ok(None);
-        };
-        let Some(transaction) = self.database.get_transaction_block(tx_digest)? else {
-            return Ok(None);
-        };
-
-        Ok(Some(VerifiedCertificate::new_unchecked(
-            CertifiedTransaction::new_from_data_and_sig(
-                transaction.into_inner().into_data(),
-                cert_sig,
-            ),
-        )))
-    }
-
     /// Make a status response for a transaction
     #[instrument(level = "trace", skip_all)]
     pub fn get_transaction_status(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::Ordering;
-use std::hash::Hash;
 use std::ops::Not;
 use std::sync::Arc;
 use std::{iter, mem, thread};
@@ -20,8 +19,8 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
-    get_module, BackingPackageStore, ChildObjectResolver, MarkerValue, ObjectKey, ObjectStore,
-    PackageObjectArc,
+    get_module, BackingPackageStore, ChildObjectResolver, InputKey, MarkerValue, ObjectKey,
+    ObjectStore, PackageObjectArc,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
@@ -2155,47 +2154,6 @@ impl From<LockDetails> for LockDetailsWrapper {
     fn from(details: LockDetails) -> Self {
         // always use latest version.
         LockDetailsWrapper::V1(details)
-    }
-}
-
-/// A potential input to a transaction.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum InputKey {
-    VersionedObject {
-        id: ObjectID,
-        version: SequenceNumber,
-    },
-    Package {
-        id: ObjectID,
-    },
-}
-
-impl InputKey {
-    pub fn id(&self) -> ObjectID {
-        match self {
-            InputKey::VersionedObject { id, .. } => *id,
-            InputKey::Package { id } => *id,
-        }
-    }
-
-    pub fn version(&self) -> Option<SequenceNumber> {
-        match self {
-            InputKey::VersionedObject { version, .. } => Some(*version),
-            InputKey::Package { .. } => None,
-        }
-    }
-}
-
-impl From<&Object> for InputKey {
-    fn from(obj: &Object) -> Self {
-        if obj.is_package() {
-            InputKey::Package { id: obj.id() }
-        } else {
-            InputKey::VersionedObject {
-                id: obj.id(),
-                version: obj.version(),
-            }
-        }
     }
 }
 

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -19,14 +19,14 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionEffectsDigest,
     error::SuiError,
+    storage::InputKey,
     transaction::{TransactionDataAPI, VerifiedCertificate},
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, instrument, trace, warn};
 
 use crate::authority::{
-    authority_per_epoch_store::AuthorityPerEpochStore,
-    authority_store::{InputKey, LockMode},
+    authority_per_epoch_store::AuthorityPerEpochStore, authority_store::LockMode,
 };
 use crate::authority::{AuthorityMetrics, AuthorityStore};
 use sui_types::transaction::SenderSignedData;

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -11,6 +11,7 @@ use sui_types::{
     crypto::deterministic_random_account_key,
     digests::TransactionEffectsDigest,
     object::Object,
+    storage::InputKey,
     transaction::{CallArg, ObjectArg},
     SUI_FRAMEWORK_PACKAGE_ID,
 };
@@ -20,9 +21,7 @@ use tokio::{
 };
 
 use crate::{
-    authority::{
-        authority_store::InputKey, authority_tests::init_state_with_objects, AuthorityState,
-    },
+    authority::{authority_tests::init_state_with_objects, AuthorityState},
     transaction_manager::TransactionManager,
 };
 

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{SequenceNumber, VersionDigest};
-use crate::effects::TransactionEvents;
+use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use crate::execution::DynamicallyLoadedObjectMetadata;
+use crate::storage::InputKey;
 use crate::{
     base_types::ObjectID,
     object::{Object, Owner},
@@ -12,6 +13,7 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::ModuleId;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub type WrittenObjects = BTreeMap<ObjectID, Object>;
@@ -30,6 +32,59 @@ pub struct InnerTemporaryStore {
     pub no_extraneous_module_bytes: bool,
     pub runtime_packages_loaded_from_db: BTreeMap<ObjectID, Object>,
     pub lamport_version: SequenceNumber,
+}
+
+impl InnerTemporaryStore {
+    pub fn get_output_keys(&self, effects: &TransactionEffects) -> Vec<InputKey> {
+        let mut output_keys: Vec<_> = self
+            .written
+            .iter()
+            .map(|(id, obj)| {
+                if obj.is_package() {
+                    InputKey::Package { id: *id }
+                } else {
+                    InputKey::VersionedObject {
+                        id: *id,
+                        version: obj.version(),
+                    }
+                }
+            })
+            .collect();
+
+        let deleted: HashMap<_, _> = effects
+            .deleted()
+            .iter()
+            .map(|oref| (oref.0, oref.1))
+            .collect();
+
+        // add deleted shared objects to the outputkeys that then get sent to notify_commit
+        let deleted_output_keys = deleted
+            .iter()
+            .filter(|(id, _)| {
+                self.input_objects
+                    .get(id)
+                    .is_some_and(|obj| obj.is_shared())
+            })
+            .map(|(id, seq)| InputKey::VersionedObject {
+                id: *id,
+                version: *seq,
+            });
+        output_keys.extend(deleted_output_keys);
+
+        // For any previously deleted shared objects that appeared mutably in the transaction,
+        // synthesize a notification for the next version of the object.
+        let smeared_version = self.lamport_version;
+        let deleted_accessed_objects = effects.deleted_mutably_accessed_shared_objects();
+        for object_id in deleted_accessed_objects.into_iter() {
+            let key = InputKey::VersionedObject {
+                id: object_id,
+                version: smeared_version,
+            };
+            output_keys.push(key);
+        }
+
+        output_keys
+    }
 }
 
 pub struct TemporaryModuleResolver<'a, R> {

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -31,6 +31,47 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 pub use write_store::WriteStore;
 
+/// A potential input to a transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum InputKey {
+    VersionedObject {
+        id: ObjectID,
+        version: SequenceNumber,
+    },
+    Package {
+        id: ObjectID,
+    },
+}
+
+impl InputKey {
+    pub fn id(&self) -> ObjectID {
+        match self {
+            InputKey::VersionedObject { id, .. } => *id,
+            InputKey::Package { id } => *id,
+        }
+    }
+
+    pub fn version(&self) -> Option<SequenceNumber> {
+        match self {
+            InputKey::VersionedObject { version, .. } => Some(*version),
+            InputKey::Package { .. } => None,
+        }
+    }
+}
+
+impl From<&Object> for InputKey {
+    fn from(obj: &Object) -> Self {
+        if obj.is_package() {
+            InputKey::Package { id: obj.id() }
+        } else {
+            InputKey::VersionedObject {
+                id: obj.id(),
+                version: obj.version(),
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum WriteKind {
     /// The object was in storage already but has been modified


### PR DESCRIPTION
- remove dead code
- Move output key computation into InnerTemporaryStore method
- Combine commit_cert_and_notify with commit_certificate
