### PR TITLE
indexer v2: fix transaction count

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -412,7 +412,7 @@ where
                 checkpoint_sequence_number: Some(*checkpoint_summary.sequence_number() as i64),
                 timestamp_ms: Some(checkpoint_summary.timestamp_ms as i64),
                 transaction_kind: tx.kind().name().to_owned(),
-                transaction_count: tx.kind().num_commands() as i64,
+                transaction_count: tx.kind().tx_count() as i64,
                 execution_success: fx.status().is_ok(),
                 gas_object_id: fx.gas_object().0 .0.to_string(),
                 gas_object_sequence: fx.gas_object().0 .1.value() as i64,

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -447,7 +447,7 @@ where
                 events,
                 transaction_kind,
                 successful_tx_num: if fx.status().is_ok() {
-                    tx.kind().num_commands() as u64
+                    tx.kind().tx_count() as u64
                 } else {
                     0
                 },

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1219,6 +1219,14 @@ impl TransactionKind {
         }
     }
 
+    /// number of transactions, or 1 if it is a system transaction
+    pub fn tx_count(&self) -> usize {
+        match self {
+            TransactionKind::ProgrammableTransaction(pt) => pt.commands.len(),
+            _ => 1,
+        }
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             Self::ChangeEpoch(_) => "ChangeEpoch",


### PR DESCRIPTION
## Description 

the tx count was designed to count system tx as well, after c667fdb975ea515cb3b59aeaf9530c0f30073bae it stopped counting the system tx, this PR is to fix that.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
