### PR TITLE
Fix pruner tick_duration getting value from config

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -517,13 +517,16 @@ impl AuthorityStorePruner {
             "Starting object pruning service with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
-        let tick_duration = Duration::from_millis(config.pruning_run_delay_seconds.unwrap_or(
-            if config.num_epochs_to_retain > 0 {
-                min(epoch_duration_ms / 2, 60 * 60 * 1000)
-            } else {
-                min(epoch_duration_ms / 2, 60 * 1000)
-            },
-        ));
+        let tick_duration = Duration::from_millis(match config.pruning_run_delay_seconds {
+            None => {
+                if config.num_epochs_to_retain > 0 {
+                    min(epoch_duration_ms / 2, 60 * 60 * 1000)
+                } else {
+                    min(epoch_duration_ms / 2, 60 * 1000)
+                }
+            }
+            Some(duration_seconds) => duration_seconds * 1000,
+        });
         let pruning_initial_delay = if cfg!(msim) {
             Duration::from_millis(1)
         } else {


### PR DESCRIPTION
## Description 

When pruning_run_delay_seconds is set in config, it is used as milliseconds in tick_duration.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
