### PR TITLE
Integrate http based downloader with archival, snapshot and sui tool

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -230,7 +230,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
         info!("Syncing file to remote: {:?}", path);
-        copy_file(path.clone(), path.clone(), from, to).await?;
+        copy_file(&path, &path, &from, &to).await?;
         fs::remove_file(path_to_filesystem(dir, &path)?)?;
         Ok(())
     }

--- a/crates/sui-archival/src/lib.rs
+++ b/crates/sui-archival/src/lib.rs
@@ -17,7 +17,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use num_enum::IntoPrimitive;
 use num_enum::TryFromPrimitive;
 use object_store::path::Path;
-use object_store::DynObjectStore;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
@@ -30,7 +29,7 @@ use sui_config::genesis::Genesis;
 use sui_config::node::ArchiveReaderConfig;
 use sui_storage::blob::{Blob, BlobEncoding};
 use sui_storage::object_store::util::{get, put};
-use sui_storage::object_store::ObjectStoreConfig;
+use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreGetExt, ObjectStorePutExt};
 use sui_storage::{compute_sha3_checksum, SHA3_BYTES};
 use sui_types::base_types::ExecutionData;
 use sui_types::messages_checkpoint::{FullCheckpointContents, VerifiedCheckpointContents};
@@ -262,9 +261,9 @@ pub fn create_file_metadata(
     Ok(file_metadata)
 }
 
-pub async fn read_manifest(remote_store: Arc<DynObjectStore>) -> Result<Manifest> {
+pub async fn read_manifest<S: ObjectStoreGetExt>(remote_store: S) -> Result<Manifest> {
     let manifest_file_path = Path::from(MANIFEST_FILENAME);
-    let vec = get(&manifest_file_path, remote_store).await?.to_vec();
+    let vec = get(&remote_store, &manifest_file_path).await?.to_vec();
     let manifest_file_size = vec.len();
     let mut manifest_reader = Cursor::new(vec);
     manifest_reader.rewind()?;
@@ -293,7 +292,10 @@ pub async fn read_manifest(remote_store: Arc<DynObjectStore>) -> Result<Manifest
     Blob::read(&mut manifest_reader)?.decode()
 }
 
-pub async fn write_manifest(manifest: Manifest, remote_store: Arc<DynObjectStore>) -> Result<()> {
+pub async fn write_manifest<S: ObjectStorePutExt>(
+    manifest: Manifest,
+    remote_store: S,
+) -> Result<()> {
     let path = Path::from(MANIFEST_FILENAME);
     let mut buf = BufWriter::new(vec![]);
     buf.write_u32::<BigEndian>(MANIFEST_FILE_MAGIC)?;
@@ -305,7 +307,7 @@ pub async fn write_manifest(manifest: Manifest, remote_store: Arc<DynObjectStore
     let computed_digest = hasher.finalize().digest;
     buf.write_all(&computed_digest)?;
     let bytes = Bytes::from(buf.into_inner()?);
-    put(&path, bytes, remote_store).await?;
+    put(&remote_store, &path, bytes).await?;
     Ok(())
 }
 

--- a/crates/sui-archival/src/reader.rs
+++ b/crates/sui-archival/src/reader.rs
@@ -8,7 +8,6 @@ use anyhow::{anyhow, Context, Result};
 use bytes::buf::Reader;
 use bytes::{Buf, Bytes};
 use futures::{StreamExt, TryStreamExt};
-use object_store::DynObjectStore;
 use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
 use rand::seq::SliceRandom;
 use std::borrow::Borrow;
@@ -18,7 +17,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::node::ArchiveReaderConfig;
+use sui_storage::object_store::http::HttpDownloaderBuilder;
 use sui_storage::object_store::util::get;
+use sui_storage::object_store::ObjectStoreGetExt;
 use sui_storage::{compute_sha3_checksum_for_bytes, make_iterator, verify_checkpoint};
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointSequenceNumber,
@@ -58,7 +59,7 @@ impl ArchiveReaderMetrics {
 }
 
 // ArchiveReaderBalancer selects archives for reading based on whether they can fulfill a checkpoint request
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub struct ArchiveReaderBalancer {
     readers: Vec<Arc<ArchiveReader>>,
 }
@@ -128,14 +129,14 @@ impl ArchiveReaderBalancer {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ArchiveReader {
     bucket: String,
     concurrency: usize,
     sender: Arc<Sender<()>>,
     manifest: Arc<Mutex<Manifest>>,
     use_for_pruning_watermark: bool,
-    remote_object_store: Arc<DynObjectStore>,
+    remote_object_store: Arc<dyn ObjectStoreGetExt>,
     archive_reader_metrics: Arc<ArchiveReaderMetrics>,
 }
 
@@ -146,7 +147,11 @@ impl ArchiveReader {
             .bucket
             .clone()
             .unwrap_or("unknown".to_string());
-        let remote_object_store = config.remote_store_config.make()?;
+        let remote_object_store = if config.remote_store_config.no_sign_request {
+            config.remote_store_config.make_http()?
+        } else {
+            config.remote_store_config.make().map(Arc::new)?
+        };
         let (sender, recv) = oneshot::channel();
         let manifest = Arc::new(Mutex::new(Manifest::new(0, 0)));
         // Start a background tokio task to keep local manifest in sync with remote
@@ -221,9 +226,9 @@ impl ArchiveReader {
                 let remote_object_store = remote_object_store.clone();
                 async move {
                     let summary_data =
-                        get(&summary_metadata.file_path(), remote_object_store.clone()).await?;
+                        get(&remote_object_store, &summary_metadata.file_path()).await?;
                     let content_data =
-                        get(&content_metadata.file_path(), remote_object_store.clone()).await?;
+                        get(&remote_object_store, &content_metadata.file_path()).await?;
                     Ok::<((Bytes, &FileMetadata), (Bytes, &FileMetadata)), anyhow::Error>((
                         (summary_data, summary_metadata),
                         (content_data, content_metadata),
@@ -281,7 +286,7 @@ impl ArchiveReader {
                 let remote_object_store = remote_object_store.clone();
                 async move {
                     let summary_data =
-                        get(&summary_metadata.file_path(), remote_object_store.clone()).await?;
+                        get(&remote_object_store, &summary_metadata.file_path()).await?;
                     Ok::<Bytes, anyhow::Error>(summary_data)
                 }
             })
@@ -405,9 +410,9 @@ impl ArchiveReader {
                 let remote_object_store = remote_object_store.clone();
                 async move {
                     let summary_data =
-                        get(&summary_metadata.file_path(), remote_object_store.clone()).await?;
+                        get(&remote_object_store, &summary_metadata.file_path()).await?;
                     let content_data =
-                        get(&content_metadata.file_path(), remote_object_store.clone()).await?;
+                        get(&remote_object_store, &content_metadata.file_path()).await?;
                     Ok::<(Bytes, Bytes), anyhow::Error>((summary_data, content_data))
                 }
             })
@@ -495,7 +500,7 @@ impl ArchiveReader {
     }
 
     async fn sync_manifest(
-        remote_store: Arc<DynObjectStore>,
+        remote_store: Arc<dyn ObjectStoreGetExt>,
         manifest: Arc<Mutex<Manifest>>,
     ) -> Result<()> {
         let new_manifest = read_manifest(remote_store.clone()).await?;
@@ -602,8 +607,8 @@ impl ArchiveReader {
         Ok((summary_files, start_index, end_index))
     }
 
-    fn spawn_manifest_sync_task(
-        remote_store: Arc<DynObjectStore>,
+    fn spawn_manifest_sync_task<S: ObjectStoreGetExt + Clone>(
+        remote_store: S,
         manifest: Arc<Mutex<Manifest>>,
         mut recv: oneshot::Receiver<()>,
     ) {

--- a/crates/sui-archival/src/writer.rs
+++ b/crates/sui-archival/src/writer.rs
@@ -493,7 +493,7 @@ impl ArchiveWriter {
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
         debug!("Syncing archive file to remote: {:?}", path);
-        copy_file(path.clone(), path.clone(), from, to).await?;
+        copy_file(&path, &path, &from, &to).await?;
         fs::remove_file(path_to_filesystem(dir, &path)?)?;
         Ok(())
     }

--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -194,10 +194,9 @@ impl DBCheckpointHandler {
                     }
                     let bytes = Bytes::from_static(b"success");
                     let upload_completed_marker = db_path.child(UPLOAD_COMPLETED_MARKER);
-                    put(
+                    put(&self.input_object_store,
                         &upload_completed_marker,
                         bytes.clone(),
-                        self.input_object_store.clone(),
                     )
                     .await?;
                 }
@@ -282,22 +281,22 @@ impl DBCheckpointHandler {
                 info!("Copying db checkpoint for epoch: {epoch} to remote storage");
                 copy_recursively(
                     db_path,
-                    self.input_object_store.clone(),
-                    object_store.clone(),
+                    &self.input_object_store,
+                    &object_store,
                     NonZeroUsize::new(20).unwrap(),
                 )
                 .await?;
                 // Drop marker in the output directory that upload completed successfully
                 let bytes = Bytes::from_static(b"success");
                 let success_marker = db_path.child(SUCCESS_MARKER);
-                put(&success_marker, bytes.clone(), object_store.clone()).await?;
+                put(&object_store, &success_marker, bytes.clone()).await?;
             }
             let bytes = Bytes::from_static(b"success");
             let upload_completed_marker = db_path.child(UPLOAD_COMPLETED_MARKER);
             put(
+                &self.input_object_store,
                 &upload_completed_marker,
                 bytes.clone(),
-                self.input_object_store.clone(),
             )
             .await?;
         }

--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -15,7 +15,6 @@ use futures::{StreamExt, TryStreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use integer_encoding::VarIntReader;
 use object_store::path::Path;
-use object_store::DynObjectStore;
 use std::collections::BTreeMap;
 use std::fs;
 use std::fs::File;
@@ -27,8 +26,9 @@ use std::sync::Arc;
 use sui_core::authority::authority_store_tables::{AuthorityPerpetualTables, LiveObject};
 use sui_core::authority::AuthorityStore;
 use sui_storage::blob::{Blob, BlobEncoding};
+use sui_storage::object_store::http::HttpDownloaderBuilder;
 use sui_storage::object_store::util::{copy_file, copy_files, path_to_filesystem};
-use sui_storage::object_store::ObjectStoreConfig;
+use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreGetExt, ObjectStorePutExt};
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber};
 use tokio::sync::Mutex;
@@ -42,8 +42,8 @@ pub type DigestByBucketAndPartition = BTreeMap<u32, BTreeMap<u32, [u8; 32]>>;
 pub struct StateSnapshotReaderV1 {
     epoch: u64,
     local_staging_dir_root: PathBuf,
-    remote_object_store: Arc<DynObjectStore>,
-    local_object_store: Arc<DynObjectStore>,
+    remote_object_store: Arc<dyn ObjectStoreGetExt>,
+    local_object_store: Arc<dyn ObjectStorePutExt>,
     ref_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
     object_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
     indirect_objects_threshold: usize,
@@ -61,9 +61,13 @@ impl StateSnapshotReaderV1 {
         m: MultiProgress,
     ) -> Result<Self> {
         let epoch_dir = format!("epoch_{}", epoch);
-        let remote_object_store = remote_store_config.make()?;
-
-        let local_object_store = local_store_config.make()?;
+        let remote_object_store = if remote_store_config.no_sign_request {
+            remote_store_config.make_http()?
+        } else {
+            remote_store_config.make().map(Arc::new)?
+        };
+        let local_object_store: Arc<dyn ObjectStorePutExt> =
+            local_store_config.make().map(Arc::new)?;
         let local_staging_dir_root = local_store_config
             .directory
             .as_ref()
@@ -77,10 +81,10 @@ impl StateSnapshotReaderV1 {
         // Download MANIFEST first
         let manifest_file_path = Path::from(epoch_dir.clone()).child("MANIFEST");
         copy_file(
-            manifest_file_path.clone(),
-            manifest_file_path.clone(),
-            remote_object_store.clone(),
-            local_object_store.clone(),
+            &manifest_file_path,
+            &manifest_file_path,
+            &remote_object_store,
+            &local_object_store,
         )
         .await?;
         let manifest = Self::read_manifest(path_to_filesystem(
@@ -141,8 +145,8 @@ impl StateSnapshotReaderV1 {
         copy_files(
             &files,
             &files,
-            remote_object_store.clone(),
-            local_object_store.clone(),
+            &remote_object_store,
+            &local_object_store,
             download_concurrency,
             Some(progress_bar.clone()),
         )
@@ -369,11 +373,9 @@ impl StateSnapshotReaderV1 {
                             timeout = std::cmp::min(max_timeout, timeout);
                             let mut attempts = 0usize;
                             let bytes = loop {
-                                let get_result = match remote_object_store.get(&file_path).await {
-                                    Ok(get_result) => {
-                                        timeout = Duration::from_secs(2);
-                                        attempts = 0usize;
-                                        get_result
+                                match remote_object_store.get_bytes(&file_path).await {
+                                    Ok(bytes) => {
+                                        break bytes;
                                     }
                                     Err(err) => {
                                         error!(
@@ -387,27 +389,6 @@ impl StateSnapshotReaderV1 {
                                                 "Failed to get obj file after {} attempts",
                                                 attempts
                                             );
-                                        } else {
-                                            attempts += 1;
-                                            tokio::time::sleep(timeout).await;
-                                            timeout += timeout / 2;
-                                            continue;
-                                        }
-                                    }
-                                };
-                                match get_result.bytes().await {
-                                    Ok(bytes) => {
-                                        break bytes;
-                                    }
-                                    Err(err) => {
-                                        error!(
-                                            "Obj {} bytes conversion (attempt {}) failed: {}",
-                                            file_metadata.file_path(&epoch_dir),
-                                            attempts,
-                                            err,
-                                        );
-                                        if timeout > max_timeout {
-                                            panic!("Failed bytes() after {} attempts", attempts);
                                         } else {
                                             attempts += 1;
                                             tokio::time::sleep(timeout).await;

--- a/crates/sui-snapshot/src/uploader.rs
+++ b/crates/sui-snapshot/src/uploader.rs
@@ -147,14 +147,14 @@ impl StateSnapshotUploader {
                 // Drop marker in the output directory that upload completed successfully
                 let bytes = Bytes::from_static(b"success");
                 let success_marker = db_path.child(SUCCESS_MARKER);
-                put(&success_marker, bytes.clone(), self.snapshot_store.clone()).await?;
+                put(&self.snapshot_store, &success_marker, bytes.clone()).await?;
                 let bytes = Bytes::from_static(b"success");
                 let state_snapshot_completed_marker =
                     db_path.child(STATE_SNAPSHOT_COMPLETED_MARKER);
                 put(
+                    &self.db_checkpoint_store.clone(),
                     &state_snapshot_completed_marker,
                     bytes.clone(),
-                    self.db_checkpoint_store.clone(),
                 )
                 .await?;
                 info!("State snapshot completed for epoch: {epoch}");

--- a/crates/sui-snapshot/src/writer.rs
+++ b/crates/sui-snapshot/src/writer.rs
@@ -450,7 +450,7 @@ impl StateSnapshotWriterV1 {
         // Delete remote epoch dir if it exists
         delete_recursively(
             &epoch_dir,
-            self.remote_object_store.clone(),
+            &self.remote_object_store,
             NonZeroUsize::new(self.concurrency).unwrap(),
         )
         .await?;
@@ -470,7 +470,7 @@ impl StateSnapshotWriterV1 {
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
         debug!("Syncing snapshot file to remote: {:?}", path);
-        copy_file(path.clone(), path.clone(), from, to).await?;
+        copy_file(&path, &path, &from, &to).await?;
         fs::remove_file(path_to_filesystem(local_path, &path)?)?;
         Ok(())
     }

--- a/crates/sui-storage/src/object_store/http/gcs.rs
+++ b/crates/sui-storage/src/object_store/http/gcs.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::object_store::downloader::{get, Downloader, DEFAULT_USER_AGENT};
+use crate::object_store::http::{get, DEFAULT_USER_AGENT};
+use crate::object_store::ObjectStoreGetExt;
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -10,6 +11,7 @@ use object_store::GetResult;
 use percent_encoding::{percent_encode, utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::Client;
 use reqwest::ClientBuilder;
+use std::fmt;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -60,9 +62,15 @@ impl GoogleCloudStorage {
     }
 }
 
+impl fmt::Display for GoogleCloudStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "gcs:{}", self.client.bucket_name_encoded)
+    }
+}
+
 #[async_trait]
-impl Downloader for GoogleCloudStorage {
-    async fn get(&self, location: &Path) -> Result<Bytes> {
+impl ObjectStoreGetExt for GoogleCloudStorage {
+    async fn get_bytes(&self, location: &Path) -> Result<Bytes> {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)

--- a/crates/sui-storage/src/object_store/http/local.rs
+++ b/crates/sui-storage/src/object_store/http/local.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::object_store::downloader::Downloader;
 use crate::object_store::util::path_to_filesystem;
+use crate::object_store::ObjectStoreGetExt;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use object_store::path::Path;
-use std::fs;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+use std::{fmt, fs};
 
 pub struct LocalStorage {
     root: PathBuf,
@@ -27,9 +27,15 @@ impl LocalStorage {
     }
 }
 
+impl fmt::Display for LocalStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "local:{}", self.root.display())
+    }
+}
+
 #[async_trait]
-impl Downloader for LocalStorage {
-    async fn get(&self, location: &Path) -> Result<Bytes> {
+impl ObjectStoreGetExt for LocalStorage {
+    async fn get_bytes(&self, location: &Path) -> Result<Bytes> {
         let path_to_filesystem = path_to_filesystem(self.root.clone(), location)?;
         let handle = tokio::task::spawn_blocking(move || {
             let mut f = File::open(path_to_filesystem)

--- a/crates/sui-storage/src/object_store/http/s3.rs
+++ b/crates/sui-storage/src/object_store/http/s3.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::object_store::downloader::{
-    get, Downloader, DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET,
-};
+use crate::object_store::http::{get, DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET};
+use crate::object_store::ObjectStoreGetExt;
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -12,6 +11,7 @@ use object_store::GetResult;
 use percent_encoding::{utf8_percent_encode, PercentEncode};
 use reqwest::Client;
 use reqwest::ClientBuilder;
+use std::fmt;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -21,23 +21,15 @@ pub(crate) struct S3Client {
 }
 
 impl S3Client {
-    pub fn new(bucket: &str, region: &str, transfer_accelerated: bool) -> Result<Self> {
-        let mut builder = ClientBuilder::new();
-        builder = builder.user_agent(DEFAULT_USER_AGENT);
-        let endpoint = if transfer_accelerated {
-            format!("https://{bucket}.s3-accelerate.amazonaws.com")
-        } else {
-            // only use virtual hosted style requests
-            format!("https://{bucket}.s3.{region}.amazonaws.com")
-        };
-        let client = builder.https_only(false).build()?;
-        Ok(Self { endpoint, client })
-    }
-    pub fn new_with_endpoint(endpoint: String) -> Result<Self> {
+    pub fn new(endpoint: &str) -> Result<Self> {
         let mut builder = ClientBuilder::new();
         builder = builder.user_agent(DEFAULT_USER_AGENT);
         let client = builder.https_only(false).build()?;
-        Ok(Self { endpoint, client })
+
+        Ok(Self {
+            endpoint: endpoint.to_string(),
+            client,
+        })
     }
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let url = self.path_url(location);
@@ -58,17 +50,23 @@ pub struct AmazonS3 {
 }
 
 impl AmazonS3 {
-    pub fn new(bucket: &str, region: &str, transfer_accelerated: bool) -> Result<Self> {
-        let s3_client = S3Client::new(bucket, region, transfer_accelerated)?;
+    pub fn new(endpoint: &str) -> Result<Self> {
+        let s3_client = S3Client::new(endpoint)?;
         Ok(AmazonS3 {
             client: Arc::new(s3_client),
         })
     }
 }
 
+impl fmt::Display for AmazonS3 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "s3:{}", self.client.endpoint)
+    }
+}
+
 #[async_trait]
-impl Downloader for AmazonS3 {
-    async fn get(&self, location: &Path) -> Result<Bytes> {
+impl ObjectStoreGetExt for AmazonS3 {
+    async fn get_bytes(&self, location: &Path) -> Result<Bytes> {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)

--- a/crates/sui-storage/src/object_store/mod.rs
+++ b/crates/sui-storage/src/object_store/mod.rs
@@ -1,17 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
 use clap::*;
+use futures::stream::BoxStream;
 use object_store::aws::AmazonS3Builder;
-use object_store::DynObjectStore;
+use object_store::path::Path;
+use object_store::{DynObjectStore, ObjectMeta};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 
-pub mod downloader;
+pub mod http;
 pub mod util;
 
 /// Object-store type.
@@ -91,6 +95,9 @@ pub struct ObjectStoreConfig {
     #[serde(default = "default_object_store_connection_limit")]
     #[arg(long, default_value_t = 20)]
     pub object_store_connection_limit: usize,
+    #[serde(default)]
+    #[arg(long, default_value_t = false)]
+    pub no_sign_request: bool,
 }
 
 fn default_object_store_connection_limit() -> usize {
@@ -200,5 +207,129 @@ impl ObjectStoreConfig {
             Some(ObjectStoreType::Azure) => self.new_azure(),
             _ => Err(anyhow!("At least one storage backend should be provided")),
         }
+    }
+}
+
+#[async_trait]
+pub trait ObjectStoreGetExt: std::fmt::Display + Send + Sync + 'static {
+    /// Return the bytes at given path in object store
+    async fn get_bytes(&self, src: &Path) -> Result<Bytes>;
+}
+
+macro_rules! as_ref_get_ext_impl {
+    ($type:ty) => {
+        #[async_trait]
+        impl ObjectStoreGetExt for $type {
+            async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
+                self.as_ref().get_bytes(src).await
+            }
+        }
+    };
+}
+
+as_ref_get_ext_impl!(Arc<dyn ObjectStoreGetExt>);
+as_ref_get_ext_impl!(Box<dyn ObjectStoreGetExt>);
+
+#[async_trait]
+impl ObjectStoreGetExt for Arc<DynObjectStore> {
+    async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
+        self.get(src)
+            .await?
+            .bytes()
+            .await
+            .map_err(|e| anyhow!("Failed to get file: {} with error: {}", src, e.to_string()))
+    }
+}
+
+#[async_trait]
+pub trait ObjectStoreListExt: Send + Sync + 'static {
+    /// List the objects at the given path in object store
+    async fn list_objects(
+        &self,
+        src: Option<&Path>,
+    ) -> object_store::Result<BoxStream<'_, object_store::Result<ObjectMeta>>>;
+}
+
+macro_rules! as_ref_list_ext_impl {
+    ($type:ty) => {
+        #[async_trait]
+        impl ObjectStoreListExt for $type {
+            async fn list_objects(
+                &self,
+                src: Option<&Path>,
+            ) -> object_store::Result<BoxStream<'_, object_store::Result<ObjectMeta>>> {
+                self.as_ref().list_objects(src).await
+            }
+        }
+    };
+}
+
+as_ref_list_ext_impl!(Arc<dyn ObjectStoreListExt>);
+as_ref_list_ext_impl!(Box<dyn ObjectStoreListExt>);
+
+#[async_trait]
+impl ObjectStoreListExt for Arc<DynObjectStore> {
+    async fn list_objects(
+        &self,
+        src: Option<&Path>,
+    ) -> object_store::Result<BoxStream<'_, object_store::Result<ObjectMeta>>> {
+        self.list(src).await
+    }
+}
+
+#[async_trait]
+pub trait ObjectStorePutExt: Send + Sync + 'static {
+    /// Write the bytes at the given location in object store
+    async fn put_bytes(&self, src: &Path, bytes: Bytes) -> Result<()>;
+}
+
+macro_rules! as_ref_put_ext_impl {
+    ($type:ty) => {
+        #[async_trait]
+        impl ObjectStorePutExt for $type {
+            async fn put_bytes(&self, src: &Path, bytes: Bytes) -> Result<()> {
+                self.as_ref().put_bytes(src, bytes).await
+            }
+        }
+    };
+}
+
+as_ref_put_ext_impl!(Arc<dyn ObjectStorePutExt>);
+as_ref_put_ext_impl!(Box<dyn ObjectStorePutExt>);
+
+#[async_trait]
+impl ObjectStorePutExt for Arc<DynObjectStore> {
+    async fn put_bytes(&self, src: &Path, bytes: Bytes) -> Result<()> {
+        self.put(src, bytes).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait ObjectStoreDeleteExt: Send + Sync + 'static {
+    /// Delete the object at the given location in object store
+    async fn delete_object(&self, src: &Path) -> Result<()>;
+}
+
+macro_rules! as_ref_delete_ext_impl {
+    ($type:ty) => {
+        #[async_trait]
+        impl ObjectStoreDeleteExt for $type {
+            async fn delete_object(&self, src: &Path) -> Result<()> {
+                self.as_ref().delete_object(src).await
+            }
+        }
+    };
+}
+
+as_ref_delete_ext_impl!(Arc<dyn ObjectStoreDeleteExt>);
+as_ref_delete_ext_impl!(Box<dyn ObjectStoreDeleteExt>);
+
+#[async_trait]
+
+impl ObjectStoreDeleteExt for Arc<DynObjectStore> {
+    async fn delete_object(&self, src: &Path) -> Result<()> {
+        self.delete(src).await?;
+        Ok(())
     }
 }

--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -1,14 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context};
+use crate::object_store::{
+    ObjectStoreDeleteExt, ObjectStoreGetExt, ObjectStoreListExt, ObjectStorePutExt,
+};
+use anyhow::{anyhow, Context, Result};
 use backoff::future::retry;
 use bytes::Bytes;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use object_store::path::Path;
-use object_store::{DynObjectStore, Error};
+use object_store::{DynObjectStore, Error, ObjectStore};
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::ops::Range;
@@ -18,34 +21,26 @@ use tokio::time::Instant;
 use tracing::{error, warn};
 use url::Url;
 
-pub async fn get(location: &Path, from: Arc<DynObjectStore>) -> Result<Bytes, object_store::Error> {
-    let backoff = backoff::ExponentialBackoff::default();
-    let bytes = retry(backoff, || async {
-        from.get(location).await.map_err(|e| {
+pub async fn get<S: ObjectStoreGetExt>(store: &S, src: &Path) -> Result<Bytes> {
+    let bytes = retry(backoff::ExponentialBackoff::default(), || async {
+        store.get_bytes(src).await.map_err(|e| {
             error!("Failed to read file from object store with error: {:?}", &e);
             backoff::Error::transient(e)
         })
     })
-    .await?
-    .bytes()
     .await?;
     Ok(bytes)
 }
 
-pub async fn put(
-    location: &Path,
-    bytes: Bytes,
-    to: Arc<DynObjectStore>,
-) -> Result<(), object_store::Error> {
-    let backoff = backoff::ExponentialBackoff::default();
-    retry(backoff, || async {
+pub async fn put<S: ObjectStorePutExt>(store: &S, src: &Path, bytes: Bytes) -> Result<()> {
+    retry(backoff::ExponentialBackoff::default(), || async {
         if !bytes.is_empty() {
-            to.put(location, bytes.clone()).await.map_err(|e| {
+            store.put_bytes(src, bytes.clone()).await.map_err(|e| {
                 error!("Failed to write file to object store with error: {:?}", &e);
                 backoff::Error::transient(e)
             })
         } else {
-            warn!("Not copying empty file: {:?}", location);
+            warn!("Not copying empty file: {:?}", src);
             Ok(())
         }
     })
@@ -53,39 +48,35 @@ pub async fn put(
     Ok(())
 }
 
-pub async fn copy_file(
-    path_in: Path,
-    path_out: Path,
-    from: Arc<DynObjectStore>,
-    to: Arc<DynObjectStore>,
-) -> Result<(), object_store::Error> {
-    let bytes = from.get(&path_in).await?.bytes().await?;
+pub async fn copy_file<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
+    src: &Path,
+    dest: &Path,
+    src_store: &S,
+    dest_store: &D,
+) -> Result<()> {
+    let bytes = get(src_store, src).await?;
     if !bytes.is_empty() {
-        put(&path_out, bytes, to).await
+        put(dest_store, dest, bytes).await
     } else {
-        warn!("Not copying empty file: {:?}", path_in);
+        warn!("Not copying empty file: {:?}", src);
         Ok(())
     }
 }
 
-pub async fn copy_files(
-    files_in: &[Path],
-    files_out: &[Path],
-    from: Arc<DynObjectStore>,
-    to: Arc<DynObjectStore>,
+pub async fn copy_files<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
+    src: &[Path],
+    dest: &[Path],
+    src_store: &S,
+    dest_store: &D,
     concurrency: NonZeroUsize,
     progress_bar: Option<ProgressBar>,
-) -> Result<Vec<()>, object_store::Error> {
+) -> Result<Vec<()>> {
     let mut instant = Instant::now();
     let progress_bar_clone = progress_bar.clone();
-    let results = futures::stream::iter(files_in.iter().zip(files_out.iter()))
-        .map(|(path_in, path_out)| {
-            let from_clone = from.clone();
-            let to_clone = to.clone();
-            async move {
-                let ret = copy_file(path_in.clone(), path_out.clone(), from_clone, to_clone).await;
-                Ok((path_out.clone(), ret))
-            }
+    let results = futures::stream::iter(src.iter().zip(dest.iter()))
+        .map(|(path_in, path_out)| async move {
+            let ret = copy_file(path_in, path_out, src_store, dest_store).await;
+            Ok((path_out.clone(), ret))
         })
         .boxed()
         .buffer_unordered(concurrency.get())
@@ -101,44 +92,43 @@ pub async fn copy_files(
     Ok(results.into_iter().collect())
 }
 
-pub async fn copy_recursively(
+pub async fn copy_recursively<S: ObjectStoreGetExt + ObjectStoreListExt, D: ObjectStorePutExt>(
     dir: &Path,
-    from: Arc<DynObjectStore>,
-    to: Arc<DynObjectStore>,
+    src_store: &S,
+    dest_store: &D,
     concurrency: NonZeroUsize,
-) -> Result<Vec<()>, object_store::Error> {
+) -> Result<Vec<()>> {
     let mut input_paths = vec![];
     let mut output_paths = vec![];
-    let mut paths = from.list(Some(dir)).await?;
+    let mut paths = src_store.list_objects(Some(dir)).await?;
     while let Some(res) = paths.next().await {
         if let Ok(object_metadata) = res {
             input_paths.push(object_metadata.location.clone());
             output_paths.push(object_metadata.location);
         } else {
-            return Err(res.err().unwrap());
+            return Err(res.err().unwrap().into());
         }
     }
     copy_files(
         &input_paths,
         &output_paths,
-        from.clone(),
-        to.clone(),
+        src_store,
+        dest_store,
         concurrency,
         None,
     )
     .await
 }
 
-pub async fn delete_files(
+pub async fn delete_files<S: ObjectStoreDeleteExt>(
     files: &[Path],
-    store: Arc<DynObjectStore>,
+    store: &S,
     concurrency: NonZeroUsize,
-) -> Result<Vec<()>, object_store::Error> {
-    let results: Vec<Result<(), object_store::Error>> = futures::stream::iter(files)
+) -> Result<Vec<()>> {
+    let results: Vec<Result<()>> = futures::stream::iter(files)
         .map(|f| {
-            let backoff = backoff::ExponentialBackoff::default();
-            retry(backoff, || async {
-                store.clone().delete(f).await.map_err(|e| {
+            retry(backoff::ExponentialBackoff::default(), || async {
+                store.delete_object(f).await.map_err(|e| {
                     error!("Failed to delete file on object store with error: {:?}", &e);
                     backoff::Error::transient(e)
                 })
@@ -151,21 +141,21 @@ pub async fn delete_files(
     results.into_iter().collect()
 }
 
-pub async fn delete_recursively(
+pub async fn delete_recursively<S: ObjectStoreDeleteExt + ObjectStoreListExt>(
     path: &Path,
-    store: Arc<DynObjectStore>,
+    store: &S,
     concurrency: NonZeroUsize,
-) -> Result<Vec<()>, object_store::Error> {
+) -> Result<Vec<()>> {
     let mut paths_to_delete = vec![];
-    let mut paths = store.list(Some(path)).await?;
+    let mut paths = store.list_objects(Some(path)).await?;
     while let Some(res) = paths.next().await {
         if let Ok(object_metadata) = res {
             paths_to_delete.push(object_metadata.location);
         } else {
-            return Err(res.err().unwrap());
+            return Err(res.err().unwrap().into());
         }
     }
-    delete_files(&paths_to_delete, store.clone(), concurrency).await
+    delete_files(&paths_to_delete, store, concurrency).await
 }
 
 pub fn path_to_filesystem(local_dir_path: PathBuf, location: &Path) -> anyhow::Result<PathBuf> {
@@ -321,8 +311,8 @@ mod tests {
 
         copy_recursively(
             &Path::from("child"),
-            input_store,
-            output_store,
+            &input_store,
+            &output_store,
             NonZeroUsize::new(1).unwrap(),
         )
         .await?;
@@ -365,7 +355,7 @@ mod tests {
 
         delete_recursively(
             &Path::from("child"),
-            input_store,
+            &input_store,
             NonZeroUsize::new(1).unwrap(),
         )
         .await?;

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -7,7 +7,7 @@ use crate::{
     make_clients, restore_from_db_checkpoint, state_sync_from_archive, verify_archive,
     verify_archive_by_checksum, ConciseObjectOutput, GroupedObjectOutput, VerboseObjectOutput,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::env;
 use std::path::PathBuf;
 use sui_config::genesis::Genesis;
@@ -254,9 +254,12 @@ pub enum ToolCommand {
         archive_bucket: Option<String>,
         #[clap(long = "archive-bucket-type", default_value = "s3")]
         archive_bucket_type: ObjectStoreType,
+        /// If true, no authentication is needed for snapshot restores
+        #[clap(long = "no-sign-request")]
+        no_sign_request: bool,
         /// If false (default), log level will be overridden to "off",
         /// and output will be reduced to necessary status information.
-        #[clap(long = "formal")]
+        #[clap(long = "verbose")]
         verbose: bool,
     },
 
@@ -461,6 +464,7 @@ impl ToolCommand {
                 snapshot_path,
                 archive_bucket,
                 archive_bucket_type,
+                no_sign_request,
                 verbose,
             } => {
                 if !verbose {
@@ -473,78 +477,91 @@ impl ToolCommand {
                         .checked_sub(1)
                         .expect("Failed to get number of CPUs")
                 });
-                let snapshot_bucket = snapshot_bucket.unwrap_or_else(|| match (formal, network) {
-                    (true, Chain::Mainnet) => "mysten-mainnet-formal".to_string(),
-                    (false, Chain::Mainnet) => "mysten-mainnet-snapshots".to_string(),
-                    (true, Chain::Testnet) => "mysten-testnet-formal".to_string(),
-                    (false, Chain::Testnet) => "mysten-testnet-snapshots".to_string(),
-                    (_, Chain::Unknown) => {
-                        panic!("Cannot generate default snapshot bucket for unknown network");
-                    }
-                });
-                let archive_bucket = archive_bucket.unwrap_or_else(|| match network {
-                    Chain::Mainnet => "mysten-mainnet-archives".to_string(),
-                    Chain::Testnet => "mysten-testnet-archives".to_string(),
-                    Chain::Unknown => {
-                        panic!("Cannot generate default archive bucket for unknown network");
-                    }
-                });
-                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or({
-                    if formal {
-                        ObjectStoreType::GCS
-                    } else {
-                        ObjectStoreType::S3
-                    }
-                });
+                let snapshot_bucket =
+                    snapshot_bucket.or_else(|| match (formal, network, no_sign_request) {
+                        (true, Chain::Mainnet, false) => Some(
+                            env::var("MAINNET_FORMAL_SIGNED_BUCKET")
+                                .unwrap_or("mysten-mainnet-formal".to_string()),
+                        ),
+                        (false, Chain::Mainnet, false) => Some(
+                            env::var("MAINNET_DB_SIGNED_BUCKET")
+                                .unwrap_or("mysten-mainnet-snapshots".to_string()),
+                        ),
+                        (true, Chain::Mainnet, true) => {
+                            env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok()
+                        }
+                        (false, Chain::Mainnet, true) => {
+                            env::var("MAINNET_DB_UNSIGNED_BUCKET").ok()
+                        }
+                        (true, Chain::Testnet, true) => {
+                            env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok()
+                        }
+                        (false, Chain::Testnet, true) => {
+                            env::var("TESTNET_DB_UNSIGNED_BUCKET").ok()
+                        }
+                        (true, Chain::Testnet, _) => Some(
+                            env::var("TESTNET_FORMAL_SIGNED_BUCKET")
+                                .unwrap_or("mysten-testnet-formal".to_string()),
+                        ),
+                        (false, Chain::Testnet, _) => Some(
+                            env::var("TESTNET_DB_SIGNED_BUCKET")
+                                .unwrap_or("mysten-testnet-snapshots".to_string()),
+                        ),
+                        (_, Chain::Unknown, _) => {
+                            panic!("Cannot generate default snapshot bucket for unknown network");
+                        }
+                    });
+
+                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or(ObjectStoreType::S3);
 
                 // index staging is not yet supported for formal snapshots
                 let skip_indexes = skip_indexes || formal;
                 // Checkpoint db does not exist in formal snapshots and
                 // is not reconstructed during formal snapshot restore
                 let skip_checkpoints = skip_checkpoints || formal;
-
+                let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
+                    if formal && no_sign_request {
+                        Some("https://formal-snapshot.testnet.sui.io".to_string())
+                    } else {
+                        None
+                    }
+                });
                 let snapshot_store_config = match snapshot_bucket_type {
-                    ObjectStoreType::S3 => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::S3),
-                            bucket: Some(snapshot_bucket),
-                            aws_access_key_id: Some(env::var(
-                                "AWS_SNAPSHOT_ACCESS_KEY_ID",
-                            ).map_err(|_| anyhow!("Please provide AWS_SNAPSHOT_ACCESS_KEY_ID as env variable"))?),
-                            aws_secret_access_key: Some(env::var(
-                                "AWS_SNAPSHOT_SECRET_ACCESS_KEY",
-                            ).map_err(|_| anyhow!("Please provide AWS_SNAPSHOT_SECRET_ACCESS_KEY as env variable"))?),
-                            aws_region: Some(env::var(
-                                "AWS_SNAPSHOT_REGION",
-                            ).map_err(|_| anyhow!("Please provide AWS_SNAPSHOT_REGION as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::S3 => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::S3),
+                        bucket: snapshot_bucket.filter(|s| !s.is_empty()),
+                        aws_access_key_id: env::var("AWS_SNAPSHOT_ACCESS_KEY_ID").ok(),
+                        aws_secret_access_key: env::var("AWS_SNAPSHOT_SECRET_ACCESS_KEY").ok(),
+                        aws_region: env::var("AWS_SNAPSHOT_REGION").ok(),
+                        aws_endpoint: aws_endpoint.filter(|s| !s.is_empty()),
+                        aws_virtual_hosted_style_request: env::var(
+                            "AWS_SNAPSHOT_VIRTUAL_HOSTED_REQUESTS",
+                        )
+                        .ok()
+                        .and_then(|b| b.parse().ok())
+                        .unwrap_or(formal && no_sign_request),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
-                    ObjectStoreType::GCS => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::GCS),
-                            bucket: Some(snapshot_bucket),
-                            google_service_account: Some(env::var(
-                                "GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH",
-                            ).map_err(|_| anyhow!("Please provide GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::GCS => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::GCS),
+                        bucket: snapshot_bucket,
+                        google_service_account: env::var("GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
-                    ObjectStoreType::Azure => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::Azure),
-                            bucket: Some(snapshot_bucket),
-                            azure_storage_account: Some(env::var(
-                                "AZURE_SNAPSHOT_STORAGE_ACCOUNT",
-                            ).map_err(|_| anyhow!("Please provide AZURE_SNAPSHOT_STORAGE_ACCOUNT as env variable"))?),
-                            azure_storage_access_key: Some(env::var(
-                                "AZURE_SNAPSHOT_STORAGE_ACCESS_KEY",
-                            ).map_err(|_| anyhow!("Please provide AZURE_SNAPSHOT_STORAGE_ACCESS_KEY as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::Azure => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::Azure),
+                        bucket: snapshot_bucket,
+                        azure_storage_account: env::var("AZURE_SNAPSHOT_STORAGE_ACCOUNT").ok(),
+                        azure_storage_access_key: env::var("AZURE_SNAPSHOT_STORAGE_ACCESS_KEY")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
                     ObjectStoreType::File => {
                         if snapshot_path.is_some() {
@@ -554,55 +571,67 @@ impl ToolCommand {
                                 ..Default::default()
                             }
                         } else {
-                            panic!("--snapshot-path must be specified for --snapshot-bucket-type=file");
+                            panic!(
+                                "--snapshot-path must be specified for --snapshot-bucket-type=file"
+                            );
                         }
                     }
                 };
 
+                let archive_bucket = archive_bucket.or_else(|| match network {
+                    Chain::Mainnet => Some(
+                        env::var("MAINNET_ARCHIVE_BUCKET")
+                            .unwrap_or("mysten-mainnet-archives".to_string()),
+                    ),
+                    Chain::Testnet => Some(
+                        env::var("TESTNET_ARCHIVE_BUCKET")
+                            .unwrap_or("mysten-testnet-archives".to_string()),
+                    ),
+                    Chain::Unknown => {
+                        panic!("Cannot generate default archive bucket for unknown network");
+                    }
+                });
+                let aws_region =
+                    Some(env::var("AWS_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
                 let archive_store_config = match archive_bucket_type {
-                    ObjectStoreType::S3 => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::S3),
-                            bucket: Some(archive_bucket),
-                            aws_access_key_id: Some(env::var(
-                                "AWS_ARCHIVE_ACCESS_KEY_ID",
-                            ).map_err(|_| anyhow!("Please provide AWS_ARCHIVE_ACCESS_KEY_ID as env variable"))?),
-                            aws_secret_access_key: Some(env::var(
-                                "AWS_ARCHIVE_SECRET_ACCESS_KEY",
-                            ).map_err(|_| anyhow!("Please provide AWS_ARCHIVE_SECRET_ACCESS_KEY as env variable"))?),
-                            aws_region: Some(env::var(
-                                "AWS_ARCHIVE_REGION",
-                            ).map_err(|_| anyhow!("Please provide AWS_ARCHIVE_REGION as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::S3 => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::S3),
+                        bucket: archive_bucket.filter(|s| !s.is_empty()),
+                        aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
+                        aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
+                        aws_region: aws_region.filter(|s| !s.is_empty()),
+                        aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
+                        aws_virtual_hosted_style_request: env::var(
+                            "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
+                        )
+                        .ok()
+                        .and_then(|b| b.parse().ok())
+                        .unwrap_or(false),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
-                    ObjectStoreType::GCS => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::GCS),
-                            bucket: Some(archive_bucket),
-                            google_service_account: Some(env::var(
-                                "GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH",
-                            ).map_err(|_| anyhow!("Please provide GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::GCS => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::GCS),
+                        bucket: archive_bucket,
+                        google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
-                    ObjectStoreType::Azure => {
-                        ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::Azure),
-                            bucket: Some(archive_bucket),
-                            azure_storage_account: Some(env::var(
-                                "AZURE_ARCHIVE_STORAGE_ACCOUNT",
-                            ).map_err(|_| anyhow!("Please provide AZURE_ARCHIVE_STORAGE_ACCOUNT as env variable"))?),
-                            azure_storage_access_key: Some(env::var(
-                                "AZURE_ARCHIVE_STORAGE_ACCESS_KEY",
-                            ).map_err(|_| anyhow!("Please provide AZURE_ARCHIVE_STORAGE_ACCESS_KEY as env variable"))?),
-                            object_store_connection_limit: 200,
-                            ..Default::default()
-                        }
+                    ObjectStoreType::Azure => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::Azure),
+                        bucket: archive_bucket,
+                        azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
+                        azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
                     },
-                    ObjectStoreType::File => panic!("Download from local filesystem is not supported")
+                    ObjectStoreType::File => {
+                        panic!("Download from local filesystem is not supported")
+                    }
                 };
 
                 if formal {

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -968,6 +968,7 @@ pub async fn download_db_snapshot(
     skip_indexes: bool,
     num_parallel_downloads: usize,
 ) -> Result<(), anyhow::Error> {
+    // TODO: Enable downloading db snapshots with no sign requests
     let remote_store = snapshot_store_config.make()?;
     let entries = remote_store.list_with_delimiter(None).await?;
     let epoch_path = format!("epoch_{}", epoch);
@@ -1133,13 +1134,7 @@ pub async fn download_db_snapshot(
                 let counter_cloned = file_counter.clone();
                 async move {
                     counter_cloned.fetch_add(1, Ordering::Relaxed);
-                    copy_file(
-                        file.location.clone(),
-                        file.location.clone(),
-                        remote_store.clone(),
-                        local_store.clone(),
-                    )
-                    .await?;
+                    copy_file(&file.location, &file.location, &remote_store, &local_store).await?;
                     Ok::<(::object_store::path::Path, usize), anyhow::Error>((
                         file.location.clone(),
                         file.size,


### PR DESCRIPTION
## Description 

Allow using no sign requests for sui tool, archival and snapshot use cases in sui. User just passes in so sign request as a parameter in their object store config and right downloader tool is used. 
Also cleaned up the abstractions and created new ones so in the future we can support unauthenticated list requests if need be.
