### PR TITLE
[move-compiler] Suppress printing diagnostics (twice) when running tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11097,6 +11097,7 @@ dependencies = [
  "jsonrpsee",
  "move-binary-format",
  "move-cli",
+ "move-compiler",
  "move-disassembler",
  "move-ir-types",
  "move-package",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -20,6 +20,7 @@ const-str.workspace = true
 
 move-binary-format.workspace = true
 move-cli.workspace = true
+move-compiler.workspace = true
 move-disassembler.workspace = true
 move-ir-types.workspace = true
 move-package.workspace = true

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -45,9 +45,10 @@ pub struct Calib {
 
 pub fn execute_move_command(
     package_path: Option<PathBuf>,
-    build_config: BuildConfig,
+    mut build_config: BuildConfig,
     command: Command,
 ) -> anyhow::Result<()> {
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Sui);
     match command {
         #[cfg(feature = "build")]
         Command::Build(c) => c.execute(package_path, build_config),

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -122,6 +122,7 @@ pub fn run_move_unit_tests(
         compute_coverage,
         &mut std::io::sink(),
         &mut std::io::stdout(),
+        false, // report_diags
     )
 }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1501,7 +1501,7 @@ pub(crate) static PRE_COMPILED: Lazy<FullyCompiledProgram> = Lazy::new(|| {
     match fully_compiled_res {
         Err((files, diags)) => {
             eprintln!("!!!Sui framework failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, diags)
+            move_compiler::diagnostics::report_diagnostics(&files, diags, true /* report */)
         }
         Ok(res) => res,
     }

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -276,7 +276,7 @@ pub(crate) fn explain_publish_error(
                     }
                 }
             }
-            report_diagnostics(&files, diags)
+            report_diagnostics(&files, diags, true /* report */)
         }
         VMStatus::Error(status_code) => {
             println!("Publishing failed with unexpected error {:?}", status_code)

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -324,7 +324,7 @@ impl<'a> Compiler<'a> {
 
     pub fn check_and_report(self) -> anyhow::Result<FilesSourceText> {
         let (files, res) = self.check()?;
-        unwrap_or_report_diagnostics(&files, res);
+        unwrap_or_report_diagnostics(&files, res, true /* report */);
         Ok(files)
     }
 
@@ -343,7 +343,8 @@ impl<'a> Compiler<'a> {
 
     pub fn build_and_report(self) -> anyhow::Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)> {
         let (files, units_res) = self.build()?;
-        let (units, warnings) = unwrap_or_report_diagnostics(&files, units_res);
+        let (units, warnings) =
+            unwrap_or_report_diagnostics(&files, units_res, true /* report */);
         report_warnings(&files, warnings);
         Ok((files, units))
     }
@@ -459,7 +460,7 @@ macro_rules! ast_stepped_compilers {
 
                 pub fn check_and_report(self, files: &FilesSourceText)  {
                     let errors_result = self.check();
-                    unwrap_or_report_diagnostics(&files, errors_result);
+                    unwrap_or_report_diagnostics(&files, errors_result, true /*report */);
                 }
 
                 pub fn build_and_report(
@@ -467,7 +468,7 @@ macro_rules! ast_stepped_compilers {
                     files: &FilesSourceText,
                 ) -> Vec<AnnotatedCompiledUnit> {
                     let units_result = self.build();
-                    let (units, warnings) = unwrap_or_report_diagnostics(&files, units_result);
+                    let (units, warnings) = unwrap_or_report_diagnostics(&files, units_result, true /* report */);
                     report_warnings(&files, warnings);
                     units
                 }
@@ -614,7 +615,7 @@ pub fn sanity_check_compiled_units(
 ) {
     let ice_errors = compiled_unit::verify_units(compiled_units);
     if !ice_errors.is_empty() {
-        report_diagnostics(&files, ice_errors)
+        report_diagnostics(&files, ice_errors, true /* report */)
     }
 }
 
@@ -678,7 +679,7 @@ pub fn output_compiled_units(
     }
 
     if !ice_errors.is_empty() {
-        report_diagnostics(&files, ice_errors)
+        report_diagnostics(&files, ice_errors, true /* report */)
     }
     Ok(())
 }

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -91,9 +91,11 @@ enum UnprefixedWarningFilters {
 // Reporting
 //**************************************************************************************************
 
-pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
+pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics, report: bool) -> ! {
     let should_exit = true;
-    report_diagnostics_impl(files, diags, should_exit);
+    if report {
+        report_diagnostics_impl(files, diags, should_exit);
+    }
     std::process::exit(1)
 }
 
@@ -119,12 +121,16 @@ fn report_diagnostics_impl(files: &FilesSourceText, diags: Diagnostics, should_e
     }
 }
 
-pub fn unwrap_or_report_diagnostics<T>(files: &FilesSourceText, res: Result<T, Diagnostics>) -> T {
+pub fn unwrap_or_report_diagnostics<T>(
+    files: &FilesSourceText,
+    res: Result<T, Diagnostics>,
+    report: bool,
+) -> T {
     match res {
         Ok(t) => t,
         Err(diags) => {
             assert!(!diags.is_empty());
-            report_diagnostics(files, diags)
+            report_diagnostics(files, diags, report)
         }
     }
 }

--- a/external-crates/move/crates/move-stdlib/tests/move_unit_test.rs
+++ b/external-crates/move/crates/move-stdlib/tests/move_unit_test.rs
@@ -39,6 +39,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
         /* compute_coverage */ false,
         &mut std::io::stdout(),
         &mut std::io::stdout(),
+        true, // report_diags
     )
     .unwrap();
     if result != UnitTestResult::Success {

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -354,7 +354,7 @@ static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
         Ok(stdlib) => stdlib,
         Err((files, errors)) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, errors)
+            move_compiler::diagnostics::report_diagnostics(&files, errors, true /* report */)
         }
     }
 });
@@ -370,11 +370,11 @@ static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
     match units_res {
         Err(diags) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, diags)
+            move_compiler::diagnostics::report_diagnostics(&files, diags, true /* report */)
         }
         Ok((_, warnings)) if !warnings.is_empty() => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, warnings)
+            move_compiler::diagnostics::report_diagnostics(&files, warnings, true /* report */)
         }
         Ok((units, _warnings)) => units
             .into_iter()

--- a/external-crates/move/crates/move-unit-test/src/lib.rs
+++ b/external-crates/move/crates/move-unit-test/src/lib.rs
@@ -150,16 +150,22 @@ impl UnitTestingConfig {
                 .set_flags(flags)
                 .run::<PASS_CFGIR>()
                 .unwrap();
-        let (_, compiler) =
-            diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
+        let (_, compiler) = diagnostics::unwrap_or_report_diagnostics(
+            &files,
+            comments_and_compiler_res,
+            true, /* report */
+        );
 
         let (mut compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let test_plan = unit_test::plan_builder::construct_test_plan(compilation_env, None, &cfgir);
 
         let compilation_result = compiler.at_cfgir(cfgir).build();
-        let (units, warnings) =
-            diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
+        let (units, warnings) = diagnostics::unwrap_or_report_diagnostics(
+            &files,
+            compilation_result,
+            true, /* report */
+        );
         diagnostics::report_warnings(&files, warnings);
         test_plan.map(|tests| TestPlan::new(tests, files, units))
     }


### PR DESCRIPTION
## Description 

We suppress part of the second compiler run when executing tests vis CLI but we do not suppress printing diagnostics from this run. This PR fixes that.

## Test Plan 

Tested that diagnostics are suppressed during the second compiler run when testing in CLI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Developers will no longer see duplicate or spurious warnings when running tests.