### PR TITLE
[cli] add a check and warning message when trying to run sui move test --coverage in non debug builds

### DIFF
--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -43,6 +43,11 @@ impl Test {
         build_config: BuildConfig,
         unit_test_config: UnitTestingConfig,
     ) -> anyhow::Result<UnitTestResult> {
+        if !cfg!(debug_assertions) && self.test.compute_coverage {
+            return Err(anyhow::anyhow!(
+                "The --coverage flag is currently supported only in debug builds. Please build the Sui CLI from source in debug mode."
+            ));
+        }
         // find manifest file directory from a given path or (if missing) from current dir
         let rerooted_path = base::reroot_path(path)?;
         // pre build for Sui-specific verifications
@@ -104,11 +109,6 @@ pub fn run_move_unit_tests(
     config: Option<UnitTestingConfig>,
     compute_coverage: bool,
 ) -> anyhow::Result<UnitTestResult> {
-    if !cfg!(debug_assertions) && compute_coverage {
-        return Err(anyhow::anyhow!(
-            "--coverage flag is currently supported only in debug builds"
-        ));
-    }
     // bind the extension hook if it has not yet been done
     Lazy::force(&SET_EXTENSION_HOOK);
 

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -104,6 +104,11 @@ pub fn run_move_unit_tests(
     config: Option<UnitTestingConfig>,
     compute_coverage: bool,
 ) -> anyhow::Result<UnitTestResult> {
+    if !cfg!(debug_assertions) && compute_coverage {
+        return Err(anyhow::anyhow!(
+            "--coverage flag is currently supported only in debug builds"
+        ));
+    }
     // bind the extension hook if it has not yet been done
     Lazy::force(&SET_EXTENSION_HOOK);
 

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -66,7 +66,7 @@ pub struct Test {
     /// Verbose mode
     #[clap(long = "verbose")]
     pub verbose_mode: bool,
-    /// Collect coverage information for later use with the various `move coverage` subcommands
+    /// Collect coverage information for later use with the various `move coverage` subcommands. Currently supported only in debug builds.
     #[clap(long = "coverage")]
     pub compute_coverage: bool,
 }
@@ -100,6 +100,7 @@ impl Test {
             verbose: verbose_mode,
             ..UnitTestingConfig::default_with_bound(None)
         };
+
         let result = run_move_unit_tests(
             &rerooted_path,
             config,

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -100,7 +100,6 @@ impl Test {
             verbose: verbose_mode,
             ..UnitTestingConfig::default_with_bound(None)
         };
-
         let result = run_move_unit_tests(
             &rerooted_path,
             config,


### PR DESCRIPTION
## Description 

This PR adds warning message and returns early if it the binary is not a debug build when running `sui move test` with the `--coverage` flag. 

## Test Plan 

### Debug build
<img width="1350" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/660cd0b0-ffe1-449d-8a87-961bf9c9c63a">

### Release build before the change
<img width="2146" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/e8ca574a-4274-45ef-b4b8-82e29e21b74f">


### After the change with a release build
<img width="1350" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/a59924ee-447c-43ce-8788-04ccb24770c2">

### After the change without the --coverage flag
<img width="1350" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/67b143c9-e728-4124-9647-aa0330ec32b9">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves the error message when running `sui move test --coverage` with a non debug build binary. 