### PR TITLE
remove rocksdb deps for sui types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12146,7 +12146,7 @@ dependencies = [
  "thiserror",
  "tonic 0.10.0",
  "tracing",
- "typed-store",
+ "typed-store-error",
  "workspace-hack",
 ]
 
@@ -13284,6 +13284,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-store-derive",
+ "typed-store-error",
  "uint",
  "workspace-hack",
 ]
@@ -13300,6 +13301,15 @@ dependencies = [
  "tempfile",
  "tokio",
  "typed-store",
+ "workspace-hack",
+]
+
+[[package]]
+name = "typed-store-error"
+version = "0.4.0"
+dependencies = [
+ "serde",
+ "thiserror",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ members = [
     "crates/transaction-fuzzer",
     "crates/typed-store",
     "crates/typed-store-derive",
+    "crates/typed-store-error",
     "crates/workspace-hack",
     "crates/x",
     "narwhal/config",
@@ -610,6 +611,7 @@ test-cluster = { path = "crates/test-cluster" }
 transaction-fuzzer = { path = "crates/transaction-fuzzer" }
 typed-store = { path = "crates/typed-store" }
 typed-store-derive = { path = "crates/typed-store-derive" }
+typed-store-error = { path = "crates/typed-store-error" }
 workspace-hack = "0.1.0"
 x = { path = "crates/x" }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -32,10 +32,11 @@ use sui_types::transaction::{
     TransactionDataAPI, VerifiedCertificate, VerifiedSignedTransaction,
 };
 use tracing::{debug, error, info, instrument, trace, warn};
-use typed_store::rocks::{
-    default_db_options, DBBatch, DBMap, DBOptions, MetricConf, TypedStoreError,
-};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
+use typed_store::{
+    rocks::{default_db_options, DBBatch, DBMap, DBOptions, MetricConf},
+    TypedStoreError,
+};
 
 use super::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -50,9 +50,12 @@ use tokio::{
     time::timeout,
 };
 use tracing::{debug, error, info, instrument, warn};
-use typed_store::rocks::{DBMap, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;
+use typed_store::{
+    rocks::{DBMap, MetricConf},
+    TypedStoreError,
+};
 use typed_store_derive::DBMapUtils;
 
 pub type CheckpointCommitHeight = u64;

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -47,7 +47,7 @@ use sui_types::{
         Argument, CallArg, Command, EndOfEpochTransactionKind, ObjectArg, TransactionKind,
     },
 };
-use typed_store::rocks::TypedStoreError;
+use typed_store::TypedStoreError;
 
 fn get_registry() -> Result<Registry> {
     let config = TracerConfig::default()

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -23,7 +23,7 @@ use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::SuiResult;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, ECMHLiveObjectSetDigest};
-use typed_store::rocks::TypedStoreError;
+use typed_store::TypedStoreError;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store_tables::LiveObject;

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -62,7 +62,7 @@ impl RocksDbStore {
 }
 
 impl ReadStore for RocksDbStore {
-    type Error = typed_store::rocks::TypedStoreError;
+    type Error = typed_store::TypedStoreError;
 
     fn get_checkpoint_by_digest(
         &self,

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -6,9 +6,9 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::SuiAddress;
 use sui_types::{base_types::ObjectID, transaction::TransactionData};
-use typed_store::rocks::{DBMap, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;
+use typed_store::{rocks::DBMap, TypedStoreError};
 
 use tracing::info;
 use typed_store_derive::DBMapUtils;

--- a/crates/sui-rosetta/src/errors.rs
+++ b/crates/sui-rosetta/src/errors.rs
@@ -21,7 +21,7 @@ use strum::EnumProperty;
 use strum_macros::Display;
 use strum_macros::EnumDiscriminants;
 use thiserror::Error;
-use typed_store::rocks::TypedStoreError;
+use typed_store::TypedStoreError;
 
 /// Sui-Rosetta specific error types.
 /// This contains all the errors returns by the sui-rosetta server.

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -58,7 +58,7 @@ sui-enum-compat-util.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 fastcrypto-zkp.workspace = true
 
-typed-store.workspace = true
+typed-store-error.workspace = true
 derive_more.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 use strum_macros::{AsRefStr, IntoStaticStr};
 use thiserror::Error;
 use tonic::Status;
-use typed_store::rocks::TypedStoreError;
+use typed_store_error::TypedStoreError;
 
 pub const TRANSACTION_NOT_FOUND_MSG_PREFIX: &str = "Could not find the referenced transaction";
 pub const TRANSACTIONS_NOT_FOUND_MSG_PREFIX: &str = "Could not find the referenced transactions";

--- a/crates/typed-store-error/Cargo.toml
+++ b/crates/typed-store-error/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "typed-store-error"
+version = "0.4.0"
+license = "Apache-2.0"
+authors = ["Ade A. <ade@mystenlabs.com>"]
+description = "error types for typed-store crate"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+workspace-hack.workspace = true
+

--- a/crates/typed-store-error/src/errors.rs
+++ b/crates/typed-store-error/src/errors.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[non_exhaustive]
+#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+pub enum TypedStoreError {
+    #[error("rocksdb error: {0}")]
+    RocksDBError(String),
+    #[error("(de)serialization error: {0}")]
+    SerializationError(String),
+    #[error("the column family {0} was not registered with the database")]
+    UnregisteredColumn(String),
+    #[error("a batch operation can't operate across databases")]
+    CrossDBBatch,
+    #[error("Metric reporting thread failed with error")]
+    MetricsReporting,
+    #[error("Transaction should be retried")]
+    RetryableTransactionError,
+}

--- a/crates/typed-store-error/src/lib.rs
+++ b/crates/typed-store-error/src/lib.rs
@@ -8,13 +8,7 @@
     rust_2021_compatibility
 )]
 
-pub mod traits;
-pub use traits::Map;
-pub mod metrics;
-pub mod rocks;
-pub use typed_store_error::TypedStoreError;
-pub mod sally;
-pub mod test_db;
-pub use metrics::DBMetrics;
+pub mod errors;
 
-pub type StoreError = typed_store_error::TypedStoreError;
+pub use errors::TypedStoreError;
+pub type StoreError = errors::TypedStoreError;

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing.workspace = true
+typed-store-error.workspace = true
 sui-macros.workspace = true
 ouroboros.workspace = true
 rand.workspace = true

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -7,41 +7,11 @@ use rocksdb::Error as RocksError;
 use serde::{Deserialize, Serialize};
 use std::{fmt, fmt::Display};
 use thiserror::Error;
-
-#[non_exhaustive]
-#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
-pub enum TypedStoreError {
-    #[error("rocksdb error: {0}")]
-    RocksDBError(String),
-    #[error("(de)serialization error: {0}")]
-    SerializationError(String),
-    #[error("the column family {0} was not registered with the database")]
-    UnregisteredColumn(String),
-    #[error("a batch operation can't operate across databases")]
-    CrossDBBatch,
-    #[error("Metric reporting thread failed with error")]
-    MetricsReporting,
-    #[error("Transaction should be retried")]
-    RetryableTransactionError,
-}
+use typed_store_error::TypedStoreError;
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
 pub(crate) struct RocksErrorDef {
     message: String,
-}
-
-impl From<RocksError> for RocksErrorDef {
-    fn from(err: RocksError) -> Self {
-        RocksErrorDef {
-            message: err.as_ref().to_string(),
-        }
-    }
-}
-
-impl From<RocksError> for TypedStoreError {
-    fn from(err: RocksError) -> Self {
-        TypedStoreError::RocksDBError(format!("{err}"))
-    }
 }
 
 impl Display for RocksErrorDef {
@@ -110,14 +80,14 @@ impl From<bincode::Error> for BincodeErrorDef {
     }
 }
 
-impl From<bcs::Error> for TypedStoreError {
-    fn from(err: bcs::Error) -> Self {
-        TypedStoreError::SerializationError(format!("{err}"))
-    }
+pub fn typed_store_err_from_bincode_err(err: bincode::Error) -> TypedStoreError {
+    TypedStoreError::SerializationError(format!("{err}"))
 }
 
-impl From<bincode::Error> for TypedStoreError {
-    fn from(err: bincode::Error) -> Self {
-        TypedStoreError::SerializationError(format!("{err}"))
-    }
+pub fn typed_store_err_from_bcs_err(err: bcs::Error) -> TypedStoreError {
+    TypedStoreError::SerializationError(format!("{err}"))
+}
+
+pub fn typed_store_err_from_rocks_err(err: RocksError) -> TypedStoreError {
+    TypedStoreError::RocksDBError(format!("{err}"))
 }

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -7,7 +7,7 @@ use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
 
-use super::{be_fix_int_ser, errors::TypedStoreError, RocksDBRawIter};
+use super::{be_fix_int_ser, RocksDBRawIter, TypedStoreError};
 use crate::metrics::RocksDBPerfContext;
 use crate::DBMetrics;
 use serde::{de::DeserializeOwned, Serialize};

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -8,7 +8,7 @@ use rocksdb::Direction;
 
 use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
-use super::{be_fix_int_ser, errors::TypedStoreError, RocksDBRawIter};
+use super::{be_fix_int_ser, RocksDBRawIter, TypedStoreError};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// An iterator over all key-value pairs in a data map.

--- a/crates/typed-store/src/sally/mod.rs
+++ b/crates/typed-store/src/sally/mod.rs
@@ -51,10 +51,11 @@
 use crate::{
     rocks::{
         default_db_options, keys::Keys, values::Values, DBBatch, DBMap, DBOptions,
-        RocksDBAccessType, TypedStoreError,
+        RocksDBAccessType,
     },
     test_db::{TestDB, TestDBKeys, TestDBValues, TestDBWriteBatch},
     traits::{AsyncMap, Map},
+    TypedStoreError,
 };
 
 use crate::rocks::safe_iter::{SafeIter as RocksDBIter, SafeRevIter};

--- a/crates/typed-store/src/sally/mod.rs
+++ b/crates/typed-store/src/sally/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! ```
 //! use typed_store::rocks::*;
+//! use typed_store::*;
 //! use typed_store::test_db::*;
 //! use typed_store::sally::SallyDBOptions;
 //! use typed_store_derive::SallyDB;

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use crate::{
-    rocks::{be_fix_int_ser, TypedStoreError},
-    Map,
+    rocks::{be_fix_int_ser, errors::typed_store_err_from_bcs_err},
+    Map, TypedStoreError,
 };
 use bincode::Options;
 use collectable::TryExtend;
@@ -246,7 +246,7 @@ where
 
     fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error> {
         let raw_key = be_fix_int_ser(key)?;
-        let raw_value = bcs::to_bytes(value)?;
+        let raw_value = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         let mut locked = self.rows.write().unwrap();
         locked.insert(raw_key, raw_value);
         Ok(())

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -14,10 +14,7 @@ use tap::Tap;
 use crate::StoreResult;
 use config::AuthorityIdentifier;
 use mysten_common::sync::notify_read::NotifyRead;
-use store::{
-    rocks::{DBMap, TypedStoreError::RocksDBError},
-    Map,
-};
+use store::{rocks::DBMap, Map, TypedStoreError::RocksDBError};
 use types::{Certificate, CertificateDigest, Round};
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description 

This PR separates out TypedStore error into its own crate so crates which only depend on the error don't need to import and build RocksDB. hopefully this speeds up build times for specific crates.

`sui-types` is one of those crates which benefits from this. It's also used in many places so perf is important.

Ideally I don't want to use the explicit convert functions but Rust traits rules prevent implementing From trait outside.

Thanks to @stefan-mysten for pointing out this issue.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
