### PR TITLE
[graphql/rpc] fix test and comment

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -266,16 +266,23 @@ pub async fn simulator_commands_test_impl() {
     .to_string();
 
     // Get the latest checkpoint via graphql
-    let resp = cluster
-        .graphql_client
-        .execute(query, vec![])
-        .await
-        .unwrap()
-        .to_string();
+    let resp = cluster.graphql_client.execute(query, vec![]).await.unwrap();
 
     // Result should be something like {"data":{"checkpointConnection":{"nodes":[{"sequenceNumber":XYZ}]}}}
     // Where XYZ is the seq number of the latest checkpoint
-    let seq_num = resp.split(':').last().unwrap().split('}').next().unwrap();
+    let fetched_chk = resp
+        .get("data")
+        .unwrap()
+        .get("checkpointConnection")
+        .unwrap()
+        .get("nodes")
+        .unwrap()
+        .as_array()
+        .unwrap()[0]
+        .get("sequenceNumber")
+        .unwrap()
+        .as_i64()
+        .unwrap();
 
-    assert_eq!(seq_num, format!("{}", checkpoint));
+    assert_eq!(fetched_chk as u64, checkpoint);
 }

--- a/crates/sui-graphql-rpc/src/test_infra/data/example.exp
+++ b/crates/sui-graphql-rpc/src/test_infra/data/example.exp
@@ -47,5 +47,5 @@ task 12 'advance-epoch'. lines 104-104:
 Epoch advanced: 2
 
 task 13 'view-checkpoint'. lines 106-106:
-CheckpointSummary { epoch: 2, seq: 6, content_digest: 5mS1rhtzVMdBmD6nhpcjsF9E9hGgQrYtycJf2Ky756Uu,
+CheckpointSummary { epoch: 2, seq: 6, content_digest: GyYwMWrjkzGwSBxo3LsRqXZ8nM6w5RJU28zKbjjcZEQ4,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}


### PR DESCRIPTION
## Description 

Fixes a test due to checkpoint digest change, and uses better logic for getting sequence number as flagged in [PR](https://github.com/MystenLabs/sui/pull/14710#discussion_r1385656414)

## Test Plan 

Existiing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
