### PR TITLE
[graphql/rpc] support variables in client

### DIFF
--- a/crates/sui-graphql-rpc/src/client/mod.rs
+++ b/crates/sui-graphql-rpc/src/client/mod.rs
@@ -26,13 +26,15 @@ pub enum ClientError {
     },
     #[error("{item_type} at pos {idx} must not be empty")]
     InvalidEmptyItem { item_type: String, idx: usize },
-    #[error("Variable {var_name} previously defined {var_type_prev} vs {var_type_curr}")]
+    #[error(
+        "Conflicting type definitions for variable {var_name}: {var_type_prev} vs {var_type_curr}"
+    )]
     VariableDefinitionConflict {
         var_name: String,
         var_type_prev: String,
         var_type_curr: String,
     },
-    #[error("Variable {var_name} previously set to {var_val_prev} vs {var_val_curr}")]
+    #[error("Conflicting values for variable {var_name}: {var_val_prev} vs {var_val_curr}")]
     VariableValueConflict {
         var_name: String,
         var_val_prev: serde_json::Value,

--- a/crates/sui-graphql-rpc/src/client/mod.rs
+++ b/crates/sui-graphql-rpc/src/client/mod.rs
@@ -24,6 +24,20 @@ pub enum ClientError {
         usage_name: String,
         usage_value: Value,
     },
+    #[error("{item_type} at pos {idx} must not be empty")]
+    InvalidEmptyItem { item_type: String, idx: usize },
+    #[error("Variable {var_name} previously defined {var_type_prev} vs {var_type_curr}")]
+    VariableDefinitionConflict {
+        var_name: String,
+        var_type_prev: String,
+        var_type_curr: String,
+    },
+    #[error("Variable {var_name} previously set to {var_val_prev} vs {var_val_curr}")]
+    VariableValueConflict {
+        var_name: String,
+        var_val_prev: serde_json::Value,
+        var_val_curr: serde_json::Value,
+    },
     #[error(transparent)]
     InnerClientError(#[from] reqwest::Error),
 }

--- a/crates/sui-graphql-rpc/src/client/simple_client.rs
+++ b/crates/sui-graphql-rpc/src/client/simple_client.rs
@@ -5,9 +5,12 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use axum::http::HeaderValue;
 use hyper::header;
 use reqwest::{RequestBuilder, Response};
+use serde_json::Value;
 
 use crate::client::ClientError;
 use crate::{
@@ -18,6 +21,50 @@ use crate::{
 };
 
 use super::response::GraphqlResponse;
+
+pub struct GraphqlVariable {
+    pub name: String,
+    pub ty: String,
+    pub value: Value,
+}
+
+pub struct GraphqlVariables {
+    // A list of the variable name to its type
+    pub type_defintions: Vec<(String, String)>,
+    // Maps the variable names to the values
+    pub value_mappings: BTreeMap<String, Value>,
+}
+
+// impl GraphqlVariables {
+
+//     pub fn new() -> Self {
+//         Self {
+//             type_defintions: vec![],
+//             value_mappings: BTreeMap::new(),
+//         }
+//     }
+
+//     pu
+
+//     pub fn validate(&self) -> Result<(), ClientError> {
+//         if self.value_mappings.len() != self.type_defintions.len() {
+//             return Err(ClientError::VariableLengthMismatch {
+//                 def_len: self.type_defintions.len(),
+//                 val_len: self.value_mappings.len(),
+//             });
+//         }
+//         for (name, ty) in &self.type_defintions {
+//             if !self.value_mappings.contains_key(name) {
+//                 return Err(ClientError::VariableNotSet {
+//                     var_name: name.to_owned(),
+//                     var_type: ty.to_string(),
+//                 });
+//             }
+//         }
+//         Ok(())
+//     }
+// }
+
 #[derive(Clone)]
 pub struct SimpleClient {
     inner: reqwest::Client,
@@ -37,7 +84,7 @@ impl SimpleClient {
         query: String,
         headers: Vec<(header::HeaderName, header::HeaderValue)>,
     ) -> Result<serde_json::Value, ClientError> {
-        self.execute_impl(query, headers)
+        self.execute_impl(query, vec![], headers)
             .await?
             .json()
             .await
@@ -48,22 +95,39 @@ impl SimpleClient {
         &self,
         query: String,
         get_usage: bool,
+        variables: Vec<GraphqlVariable>,
         mut headers: Vec<(header::HeaderName, header::HeaderValue)>,
     ) -> Result<GraphqlResponse, ClientError> {
         if get_usage {
             headers.push((LIMITS_HEADER.clone(), HeaderValue::from_static("true")));
         }
-        GraphqlResponse::from_resp(self.execute_impl(query, headers).await?).await
+        GraphqlResponse::from_resp(self.execute_impl(query, variables, headers).await?).await
     }
 
     async fn execute_impl(
         &self,
         query: String,
+        variables: Vec<GraphqlVariable>,
         headers: Vec<(header::HeaderName, header::HeaderValue)>,
     ) -> Result<Response, ClientError> {
-        let body = serde_json::json!({
-            "query": query,
-        });
+        let (type_defs, var_vals) = resolve_variables(&variables)?;
+        let body = if type_defs.is_empty() {
+            serde_json::json!({
+                "query": query,
+            })
+        } else {
+            // Make type defs which is a csv is the form of $var_name: $var_type
+            let type_defs_csv = type_defs
+                .iter()
+                .map(|(name, ty)| format!("${}: {}", name, ty))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let query = format!("query ({}) {}", type_defs_csv, query);
+            serde_json::json!({
+                "query": query,
+                "variables": var_vals,
+            })
+        };
 
         let mut builder = self.inner.post(&self.url).json(&body);
         for (key, value) in headers {
@@ -71,4 +135,48 @@ impl SimpleClient {
         }
         builder.send().await.map_err(|e| e.into())
     }
+}
+
+#[allow(clippy::type_complexity)]
+pub fn resolve_variables(
+    vars: &[GraphqlVariable],
+) -> Result<(BTreeMap<String, String>, BTreeMap<String, Value>), ClientError> {
+    let mut type_defs: BTreeMap<String, String> = BTreeMap::new();
+    let mut var_vals: BTreeMap<String, Value> = BTreeMap::new();
+
+    for (idx, GraphqlVariable { name, ty, value }) in vars.iter().enumerate() {
+        // todo: check that name is valid identifier
+        if name.trim().is_empty() {
+            return Err(ClientError::InvalidEmptyItem {
+                item_type: "Variable name".to_owned(),
+                idx,
+            });
+        }
+        if ty.trim().is_empty() {
+            return Err(ClientError::InvalidEmptyItem {
+                item_type: "Variable type".to_owned(),
+                idx,
+            });
+        }
+        if let Some(var_type_prev) = type_defs.get(name) {
+            if var_type_prev != ty {
+                return Err(ClientError::VariableDefinitionConflict {
+                    var_name: name.to_owned(),
+                    var_type_prev: var_type_prev.to_owned(),
+                    var_type_curr: ty.to_owned(),
+                });
+            }
+            if var_vals[name] != *value {
+                return Err(ClientError::VariableValueConflict {
+                    var_name: name.to_owned(),
+                    var_val_prev: var_vals[name].clone(),
+                    var_val_curr: value.clone(),
+                });
+            }
+        }
+        type_defs.insert(name.to_owned(), ty.to_owned());
+        var_vals.insert(name.to_owned(), value.to_owned());
+    }
+
+    Ok((type_defs, var_vals))
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -288,16 +288,6 @@ mod tests {
             .await;
 
         assert!(res.is_err());
-        // assert_eq!(res.http_status().as_u16(), 200);
-        // assert_eq!(res.http_version(), hyper::Version::HTTP_11);
-        // assert!(res.graphql_version().unwrap().len() >= 5);
-        // assert!(res.errors().is_empty());
-
-        // let usage = res.usage().unwrap().unwrap();
-        // assert_eq!(*usage.get("nodes").unwrap(), 1);
-        // assert_eq!(*usage.get("depth").unwrap(), 1);
-        // assert_eq!(*usage.get("variables").unwrap(), 0);
-        // assert_eq!(*usage.get("fragments").unwrap(), 0);
     }
 
     use sui_graphql_rpc::server::builder::tests::*;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -8,10 +8,12 @@ mod tests {
     use diesel::{ExpressionMethods, QueryDsl};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use serde_json::json;
     use serial_test::serial;
     use simulacrum::Simulacrum;
     use std::sync::Arc;
     use std::time::Duration;
+    use sui_graphql_rpc::client::simple_client::GraphqlVariable;
     use sui_graphql_rpc::config::ConnectionConfig;
     use sui_graphql_rpc::context_data::db_query_cost::extract_cost;
     use sui_indexer::indexer_reader::IndexerReader;
@@ -21,6 +23,8 @@ mod tests {
     use sui_indexer::utils::reset_database;
     use sui_indexer::PgConnectionPoolConfig;
     use sui_types::digests::ChainIdentifier;
+    use sui_types::DEEPBOOK_ADDRESS;
+    use sui_types::SUI_FRAMEWORK_ADDRESS;
     use tokio::time::sleep;
 
     #[tokio::test]
@@ -39,7 +43,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         let query = r#"
-            query {
+            {
                 chainIdentifier
             }
         "#;
@@ -94,7 +98,7 @@ mod tests {
         .await;
 
         let query = r#"
-            query {
+            {
                 chainIdentifier
             }
         "#;
@@ -155,13 +159,13 @@ mod tests {
         .await;
 
         let query = r#"
-            query {
+            {
                 chainIdentifier
             }
         "#;
         let res = cluster
             .graphql_client
-            .execute_to_graphql(query.to_string(), true, vec![])
+            .execute_to_graphql(query.to_string(), true, vec![], vec![])
             .await
             .unwrap();
 
@@ -175,6 +179,125 @@ mod tests {
         assert_eq!(*usage.get("depth").unwrap(), 1);
         assert_eq!(*usage.get("variables").unwrap(), 0);
         assert_eq!(*usage.get("fragments").unwrap(), 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_graphql_client_variables() {
+        sleep(Duration::from_secs(5)).await;
+        let rng = StdRng::from_seed([12; 32]);
+        let mut sim = Simulacrum::new_with_rng(rng);
+
+        sim.create_checkpoint();
+        sim.create_checkpoint();
+
+        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+        let cluster = sui_graphql_rpc::test_infra::cluster::serve_executor(
+            connection_config,
+            3000,
+            Arc::new(sim),
+        )
+        .await;
+
+        let query = r#"{obj1: object(address: $framework_addr) {location}
+            obj2: object(address: $deepbook_addr) {location}}"#;
+        let variables = vec![
+            GraphqlVariable {
+                name: "framework_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0x2"),
+            },
+            GraphqlVariable {
+                name: "deepbook_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0xdee9"),
+            },
+        ];
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, variables, vec![])
+            .await
+            .unwrap();
+
+        assert!(res.errors().is_empty());
+        let data = res.response_body().data.clone().into_json().unwrap();
+        data.get("obj1").unwrap().get("location").unwrap();
+        assert_eq!(
+            data.get("obj1")
+                .unwrap()
+                .get("location")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            SUI_FRAMEWORK_ADDRESS.to_canonical_string(true)
+        );
+        assert_eq!(
+            data.get("obj2")
+                .unwrap()
+                .get("location")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            DEEPBOOK_ADDRESS.to_canonical_string(true)
+        );
+
+        let bad_variables = vec![
+            GraphqlVariable {
+                name: "framework_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0x2"),
+            },
+            GraphqlVariable {
+                name: "deepbook_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0xdee9"),
+            },
+            GraphqlVariable {
+                name: "deepbook_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0xdee96666666"),
+            },
+        ];
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, bad_variables, vec![])
+            .await;
+
+        assert!(res.is_err());
+
+        let bad_variables = vec![
+            GraphqlVariable {
+                name: "framework_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0x2"),
+            },
+            GraphqlVariable {
+                name: "deepbook_addr".to_string(),
+                ty: "SuiAddress!".to_string(),
+                value: json!("0xdee9"),
+            },
+            GraphqlVariable {
+                name: "deepbook_addr".to_string(),
+                ty: "SuiAddressP!".to_string(),
+                value: json!("0xdee9"),
+            },
+        ];
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, bad_variables, vec![])
+            .await;
+
+        assert!(res.is_err());
+        // assert_eq!(res.http_status().as_u16(), 200);
+        // assert_eq!(res.http_version(), hyper::Version::HTTP_11);
+        // assert!(res.graphql_version().unwrap().len() >= 5);
+        // assert!(res.errors().is_empty());
+
+        // let usage = res.usage().unwrap().unwrap();
+        // assert_eq!(*usage.get("nodes").unwrap(), 1);
+        // assert_eq!(*usage.get("depth").unwrap(), 1);
+        // assert_eq!(*usage.get("variables").unwrap(), 0);
+        // assert_eq!(*usage.get("fragments").unwrap(), 0);
     }
 
     use sui_graphql_rpc::server::builder::tests::*;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -13,7 +13,7 @@ mod tests {
     use simulacrum::Simulacrum;
     use std::sync::Arc;
     use std::time::Duration;
-    use sui_graphql_rpc::client::simple_client::GraphqlVariable;
+    use sui_graphql_rpc::client::simple_client::GraphqlQueryVariable;
     use sui_graphql_rpc::config::ConnectionConfig;
     use sui_graphql_rpc::context_data::db_query_cost::extract_cost;
     use sui_indexer::indexer_reader::IndexerReader;
@@ -202,12 +202,12 @@ mod tests {
         let query = r#"{obj1: object(address: $framework_addr) {location}
             obj2: object(address: $deepbook_addr) {location}}"#;
         let variables = vec![
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "framework_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0x2"),
             },
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "deepbook_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0xdee9"),
@@ -242,17 +242,17 @@ mod tests {
         );
 
         let bad_variables = vec![
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "framework_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0x2"),
             },
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "deepbook_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0xdee9"),
             },
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "deepbook_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0xdee96666666"),
@@ -266,17 +266,17 @@ mod tests {
         assert!(res.is_err());
 
         let bad_variables = vec![
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "framework_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0x2"),
             },
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "deepbook_addr".to_string(),
                 ty: "SuiAddress!".to_string(),
                 value: json!("0xdee9"),
             },
-            GraphqlVariable {
+            GraphqlQueryVariable {
                 name: "deepbook_addr".to_string(),
                 ty: "SuiAddressP!".to_string(),
                 value: json!("0xdee9"),


### PR DESCRIPTION
## Description 

Allow passing variables in the graphql client.
This will make testing suite much more flexible as we can swap out value easier. 

## Test Plan 

e2e test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
