### PR TITLE
[graphql/rpc] remove fragment and variable count limits

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -956,14 +956,6 @@ type ServiceConfig {
 	"""
 	maxDbQueryCost: BigInt!
 	"""
-	Maximum number of variables a query can define
-	"""
-	maxQueryVariables: Int!
-	"""
-	Maximum number of fragments a query can define
-	"""
-	maxQueryFragments: Int!
-	"""
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: BigInt!

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -14,8 +14,6 @@ const MAX_QUERY_DEPTH: u32 = 20;
 const MAX_QUERY_NODES: u32 = 200;
 const MAX_QUERY_PAYLOAD_SIZE: u32 = 5_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
-const MAX_QUERY_VARIABLES: u32 = 50;
-const MAX_QUERY_FRAGMENTS: u32 = 50;
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
 
@@ -56,10 +54,6 @@ pub struct Limits {
     pub(crate) max_query_payload_size: u32,
     #[serde(default)]
     pub(crate) max_db_query_cost: u64,
-    #[serde(default)]
-    pub(crate) max_query_variables: u32,
-    #[serde(default)]
-    pub(crate) max_query_fragments: u32,
     #[serde(default)]
     pub(crate) request_timeout_ms: u64,
 }
@@ -160,16 +154,6 @@ impl ServiceConfig {
         BigInt::from(self.limits.max_db_query_cost)
     }
 
-    /// Maximum number of variables a query can define
-    async fn max_query_variables(&self) -> u32 {
-        self.limits.max_query_variables
-    }
-
-    /// Maximum number of fragments a query can define
-    async fn max_query_fragments(&self) -> u32 {
-        self.limits.max_query_fragments
-    }
-
     /// Maximum time in milliseconds that will be spent to serve one request.
     async fn request_timeout_ms(&self) -> BigInt {
         BigInt::from(self.limits.request_timeout_ms)
@@ -200,8 +184,6 @@ impl Default for Limits {
             max_query_nodes: MAX_QUERY_NODES,
             max_query_payload_size: MAX_QUERY_PAYLOAD_SIZE,
             max_db_query_cost: MAX_DB_QUERY_COST,
-            max_query_variables: MAX_QUERY_VARIABLES,
-            max_query_fragments: MAX_QUERY_FRAGMENTS,
             request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         }
     }
@@ -296,8 +278,6 @@ mod tests {
                 max-query-nodes = 300
                 max-query-payload-size = 2000
                 max-db-query-cost = 50
-                max-query-variables = 45
-                max-query-fragments = 32
                 request-timeout-ms = 27000
             "#,
         )
@@ -309,8 +289,6 @@ mod tests {
                 max_query_nodes: 300,
                 max_query_payload_size: 2000,
                 max_db_query_cost: 50,
-                max_query_variables: 45,
-                max_query_fragments: 32,
                 request_timeout_ms: 27_000,
             },
             ..Default::default()
@@ -367,8 +345,6 @@ mod tests {
                 max-query-nodes = 320
                 max-query-payload-size = 200
                 max-db-query-cost = 20
-                max-query-variables = 34
-                max-query-fragments = 31
                 request-timeout-ms = 30000
 
                 [experiments]
@@ -383,8 +359,6 @@ mod tests {
                 max_query_nodes: 320,
                 max_query_payload_size: 200,
                 max_db_query_cost: 20,
-                max_query_variables: 34,
-                max_query_fragments: 31,
                 request_timeout_ms: 30_000,
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -140,28 +140,8 @@ impl Extension for QueryLimitsChecker {
             ));
         }
 
-        if variables.len() > cfg.limits.max_query_variables as usize {
-            return Err(ServerError::new(
-                format!(
-                    "Query has too many variables. The maximum allowed is {}",
-                    cfg.limits.max_query_variables
-                ),
-                None,
-            ));
-        }
-
         // Document layout of the query
         let doc = next.run(ctx, query, variables).await?;
-
-        if doc.fragments.len() > cfg.limits.max_query_fragments as usize {
-            return Err(ServerError::new(
-                format!(
-                    "Query has too many fragments definitions. The maximum allowed is {}",
-                    cfg.limits.max_query_fragments
-                ),
-                None,
-            ));
-        }
 
         // TODO: Limit the complexity of fragments early on
 

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -123,7 +123,6 @@ impl Extension for QueryLimitsChecker {
         variables: &Variables,
         next: NextParseQuery<'_>,
     ) -> ServerResult<ExecutableDocument> {
-        // TODO: limit number of variables, fragments, etc
         // TODO: limit/ban directives for now
 
         let cfg = ctx

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -960,14 +960,6 @@ type ServiceConfig {
 	"""
 	maxDbQueryCost: BigInt!
 	"""
-	Maximum number of variables a query can define
-	"""
-	maxQueryVariables: Int!
-	"""
-	Maximum number of fragments a query can define
-	"""
-	maxQueryFragments: Int!
-	"""
 	Maximum time in milliseconds that will be spent to serve one request.
 	"""
 	requestTimeoutMs: BigInt!


### PR DESCRIPTION
## Description 

Query payload limit makes fragment and variable limits unnecessary.


## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
