### PR TITLE
Add comments to `publish/upgrade` methods in `(Programmable)TransactionBuilder`

### DIFF
--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -434,6 +434,17 @@ impl TransactionBuilder {
         Ok(args)
     }
 
+    /// Publish a Sui Move package to the network.
+    ///
+    /// The `sender` address is used to author the transaction.
+    ///
+    /// In order to obtain the package's `compiled_modules: Vec<Vec<u8>>` and the `ObjectID`s
+    /// of its dependencies, `dep_ids: Vec<ObjectID>`, use the public API for
+    /// [`sui_move_build::CompiledPackage`].
+    ///
+    /// Specifically:
+    /// * the [`sui_move_build::CompiledPackage::get_package_bytes`] function, and
+    /// * the [`sui_move_build::CompiledPackage::dependency_ids`] field
     pub async fn publish(
         &self,
         sender: SuiAddress,
@@ -456,6 +467,24 @@ impl TransactionBuilder {
         ))
     }
 
+    /// Upgrade a Sui Move package which is published on the network.
+    ///
+    /// * The `sender` address is used to author the upgrade transaction,
+    /// * `package_id` is the [`sui_types::base_types::ObjectID`] of the published package, and
+    /// * `upgrade_capability` is the [`sui_types::base_types::ObjectID`] of the
+    ///   `UpgradeCapability` object associated with the published package.
+    ///
+    /// In order to obtain
+    /// * the package's `compiled_modules: Vec<Vec<u8>>`,
+    /// * the `ObjectID`s of its dependencies, `dep_ids: Vec<ObjectID>`, and
+    /// * and its `digest: Vec<u8>`
+    ///
+    /// use the public API for [`sui_move_build::CompiledPackage`].
+    ///
+    /// Specifically:
+    /// * the [`sui_move_build::CompiledPackage::get_package_bytes`] function, and
+    /// * the [`sui_move_build::CompiledPackage::dependency_ids`] field
+    /// * the [`sui_move_build::CompiledPackage::get_package_digest`] function
     pub async fn upgrade(
         &self,
         sender: SuiAddress,

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -179,6 +179,13 @@ impl ProgrammableTransactionBuilder {
         })))
     }
 
+    /// In order to obtain the package's `compiled_modules: Vec<Vec<u8>>` and the `ObjectID`s
+    /// of its dependencies, `dep_ids: Vec<ObjectID>`, use the public API for
+    /// [`sui_move_build::CompiledPackage`].
+    ///
+    /// Specifically:
+    /// * the [`sui_move_build::CompiledPackage::get_package_bytes`] function, and
+    /// * the [`sui_move_build::CompiledPackage::dependency_ids`] field
     pub fn publish_upgradeable(
         &mut self,
         modules: Vec<Vec<u8>>,
@@ -187,6 +194,8 @@ impl ProgrammableTransactionBuilder {
         self.command(Command::Publish(modules, dep_ids))
     }
 
+    /// To see how to provide this function's arguments correctly, see the comment above for
+    /// [`ProgrammableTransactionBuilder::publish_upgradeable`].
     pub fn publish_immutable(&mut self, modules: Vec<Vec<u8>>, dep_ids: Vec<ObjectID>) {
         let cap = self.publish_upgradeable(modules, dep_ids);
         self.commands
@@ -199,6 +208,8 @@ impl ProgrammableTransactionBuilder {
             })));
     }
 
+    /// To see how to provide this function's arguments correctly, see the comment above for
+    /// [`ProgrammableTransactionBuilder::publish_upgradeable`].
     pub fn upgrade(
         &mut self,
         current_package_object_id: ObjectID,


### PR DESCRIPTION
## Description 

As a downstream consumer of `sui-sdk`, I found it a little difficult to understand how to use `TransactionBuilder::{publish, upgrade}` without jumping some IDE hoops.
Hopefully, the documentation added in this PR will help others who are also unfamiliar with the codebase.

## Test Plan 

No tests required.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration