### PR TITLE
[indexer] add MatchNone struct filter

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -27,17 +27,19 @@ use anyhow::{anyhow, Result};
 use cached::proc_macro::cached;
 use cached::SizedCache;
 use diesel::{
-    r2d2::ConnectionManager, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    RunQueryDsl, TextExpressionMethods, sql_types::Bool, dsl::sql,
+    dsl::sql, r2d2::ConnectionManager, sql_types::Bool, ExpressionMethods, OptionalExtension,
+    PgConnection, QueryDsl, RunQueryDsl, TextExpressionMethods,
 };
 use fastcrypto::encoding::Encoding;
 use fastcrypto::encoding::Hex;
 use itertools::{any, Itertools};
 use move_core_types::language_storage::StructTag;
+use move_core_types::value::MoveStructLayout;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::{Arc, RwLock},
 };
+use sui_json_rpc_types::DisplayFieldsResponse;
 use sui_json_rpc_types::{
     AddressMetrics, CheckpointId, EpochInfo, EventFilter, MoveCallMetrics, MoveFunctionName,
     NetworkMetrics, SuiEvent, SuiObjectDataFilter, SuiTransactionBlockResponse, TransactionFilter,
@@ -558,33 +560,8 @@ impl IndexerReader {
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        // let object_types = Self::extract_struct_filters(filter)?;
         self.spawn_blocking(move |this| this.get_owned_objects_impl(address, filter, cursor, limit))
             .await
-    }
-
-    fn extract_struct_filters(
-        filter: Option<SuiObjectDataFilter>,
-    ) -> Result<Option<Vec<String>>, IndexerError> {
-        if filter.is_none() {
-            return Ok(None);
-        }
-        match filter.unwrap() {
-            SuiObjectDataFilter::StructType (struct_tag ) => Ok(Some(vec![struct_tag.to_canonical_string(/* with_prefix */ true)])),
-            SuiObjectDataFilter::MatchAny(filters) => {
-                filters.iter().map(|filter| {
-                    match filter {
-                        SuiObjectDataFilter::StructType (struct_tag ) => Ok(struct_tag.to_canonical_string(/* with_prefix */ true)),
-                        _ => Err(IndexerError::InvalidArgumentError(
-                            "Invalid filter type. Only struct filters and MatchAny of struct filters are supported.".into(),
-                        )),
-                    }
-                }).collect::<Result<Vec<_>, _>>().map(Some)
-            }
-            _ => Err(IndexerError::InvalidArgumentError(
-                "Invalid filter type. Only struct filters and MatchAny of struct filters are supported.".into(),
-            )),
-        }
     }
 
     fn get_owned_objects_impl(
@@ -623,14 +600,13 @@ impl IndexerReader {
                             }
                         }
                         condition += ")";
-                        println!("condition: {}", condition);
                         query = query.filter(sql::<Bool>(&condition));
                     },
                     SuiObjectDataFilter::MatchNone(filters) => {
                         for filter in filters {
                             if let SuiObjectDataFilter::StructType (struct_tag) = filter {
                                 let object_type = struct_tag.to_string();
-                                query = query.filter(objects::dsl::object_type.not_like(format!("{}%",object_type)));
+                                query = query.filter(objects::dsl::object_type.ne(object_type));
                             } else {
                                 return Err(IndexerError::InvalidArgumentError(
                                     "Invalid filter type. Only struct, MatchAny and MatchNone of struct filters are supported.".into(),
@@ -649,9 +625,9 @@ impl IndexerReader {
             if let Some(object_cursor) = cursor {
                 query = query.filter(objects::dsl::object_id.gt(object_cursor.to_vec()));
             }
-            let debug_sql = diesel::debug_query::<diesel::pg::Pg, _>(&query);
+            let debug_query = diesel::debug_query::<diesel::pg::Pg, _>(&query);
 
-            println!("{:?}", debug_sql);
+            println!("{:?}", debug_query);
             query.load::<StoredObject>(conn).map_err(|e| IndexerError::PostgresReadError(e.to_string()))
         })
     }
@@ -1579,6 +1555,33 @@ impl IndexerReader {
             .into_iter()
             .map(|stored_address_metrics| stored_address_metrics.into())
             .collect())
+    }
+
+    pub(crate) async fn get_display_fields(
+        &self,
+        original_object: &sui_types::object::Object,
+        original_layout: &Option<MoveStructLayout>,
+    ) -> Result<DisplayFieldsResponse, IndexerError> {
+        let (object_type, layout) = if let Some((object_type, layout)) =
+            sui_json_rpc::read_api::get_object_type_and_struct(original_object, original_layout)
+                .map_err(|e| IndexerError::GenericError(e.to_string()))?
+        {
+            (object_type, layout)
+        } else {
+            return Ok(DisplayFieldsResponse {
+                data: None,
+                error: None,
+            });
+        };
+
+        if let Some(display_object) = self.get_display_object_by_type(&object_type).await? {
+            return sui_json_rpc::read_api::get_rendered_fields(display_object.fields, &layout)
+                .map_err(|e| IndexerError::GenericError(e.to_string()));
+        }
+        Ok(DisplayFieldsResponse {
+            data: None,
+            error: None,
+        })
     }
 
     pub async fn get_coin_metadata_in_blocking_task(

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -580,14 +580,14 @@ impl IndexerReader {
             if let Some(filter) = filter {
                 match filter {
                     SuiObjectDataFilter::StructType (struct_tag ) => {
-                        let object_type = struct_tag.to_string();
+                        let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
                         query = query.filter(objects::dsl::object_type.like(format!("{}%",object_type)));
                     },
                     SuiObjectDataFilter::MatchAny(filters) => {
                         let mut condition = "(".to_string();
                         for (i, filter) in filters.iter().enumerate() {
                             if let SuiObjectDataFilter::StructType (struct_tag) = filter {
-                                let object_type = struct_tag.to_string();
+                                let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
                                 if i == 0 {
                                     condition += format!("objects.object_type LIKE '{}%'",object_type).as_str();
                                 } else {
@@ -605,7 +605,7 @@ impl IndexerReader {
                     SuiObjectDataFilter::MatchNone(filters) => {
                         for filter in filters {
                             if let SuiObjectDataFilter::StructType (struct_tag) = filter {
-                                let object_type = struct_tag.to_string();
+                                let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
                                 query = query.filter(objects::dsl::object_type.ne(object_type));
                             } else {
                                 return Err(IndexerError::InvalidArgumentError(

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -28,7 +28,7 @@ use cached::proc_macro::cached;
 use cached::SizedCache;
 use diesel::{
     r2d2::ConnectionManager, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    RunQueryDsl,
+    RunQueryDsl, TextExpressionMethods, sql_types::Bool, dsl::sql,
 };
 use fastcrypto::encoding::Encoding;
 use fastcrypto::encoding::Hex;
@@ -558,11 +558,9 @@ impl IndexerReader {
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        let object_types = Self::extract_struct_filters(filter)?;
-        self.spawn_blocking(move |this| {
-            this.get_owned_objects_impl(address, object_types, cursor, limit)
-        })
-        .await
+        // let object_types = Self::extract_struct_filters(filter)?;
+        self.spawn_blocking(move |this| this.get_owned_objects_impl(address, filter, cursor, limit))
+            .await
     }
 
     fn extract_struct_filters(
@@ -592,7 +590,7 @@ impl IndexerReader {
     fn get_owned_objects_impl(
         &self,
         address: SuiAddress,
-        object_types: Option<Vec<String>>,
+        filter: Option<SuiObjectDataFilter>,
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
@@ -602,14 +600,59 @@ impl IndexerReader {
                 .filter(objects::dsl::owner_id.eq(address.to_vec()))
                 .limit(limit as i64)
                 .into_boxed();
-            if let Some(object_types) = object_types {
-                query = query.filter(objects::dsl::object_type.eq_any(object_types));
+            if let Some(filter) = filter {
+                match filter {
+                    SuiObjectDataFilter::StructType (struct_tag ) => {
+                        let object_type = struct_tag.to_string();
+                        query = query.filter(objects::dsl::object_type.like(format!("{}%",object_type)));
+                    },
+                    SuiObjectDataFilter::MatchAny(filters) => {
+                        let mut condition = "(".to_string();
+                        for (i, filter) in filters.iter().enumerate() {
+                            if let SuiObjectDataFilter::StructType (struct_tag) = filter {
+                                let object_type = struct_tag.to_string();
+                                if i == 0 {
+                                    condition += format!("objects.object_type LIKE '{}%'",object_type).as_str();
+                                } else {
+                                    condition += format!(" OR objects.object_type LIKE '{}%'",object_type).as_str();
+                                }
+                            } else {
+                                return Err(IndexerError::InvalidArgumentError(
+                                    "Invalid filter type. Only struct, MatchAny and MatchNone of struct filters are supported.".into(),
+                                ));
+                            }
+                        }
+                        condition += ")";
+                        println!("condition: {}", condition);
+                        query = query.filter(sql::<Bool>(&condition));
+                    },
+                    SuiObjectDataFilter::MatchNone(filters) => {
+                        for filter in filters {
+                            if let SuiObjectDataFilter::StructType (struct_tag) = filter {
+                                let object_type = struct_tag.to_string();
+                                query = query.filter(objects::dsl::object_type.not_like(format!("{}%",object_type)));
+                            } else {
+                                return Err(IndexerError::InvalidArgumentError(
+                                    "Invalid filter type. Only struct, MatchAny and MatchNone of struct filters are supported.".into(),
+                                ));
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(IndexerError::InvalidArgumentError(
+                            "Invalid filter type. Only struct, MatchAny and MatchNone of struct filters are supported.".into(),
+                        ));
+                    }
+                }
             }
 
             if let Some(object_cursor) = cursor {
                 query = query.filter(objects::dsl::object_id.gt(object_cursor.to_vec()));
             }
-            query.load::<StoredObject>(conn)
+            let debug_sql = diesel::debug_query::<diesel::pg::Pg, _>(&query);
+
+            println!("{:?}", debug_sql);
+            query.load::<StoredObject>(conn).map_err(|e| IndexerError::PostgresReadError(e.to_string()))
         })
     }
 


### PR DESCRIPTION
## Description 

Same as ##14750 except rebased on main and using `to_canonical_string`.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
