### PR TITLE
[examples/defi] Fix missing 0 in comment describing fee_percent values

### DIFF
--- a/sui_programmability/examples/defi/sources/pool.move
+++ b/sui_programmability/examples/defi/sources/pool.move
@@ -72,7 +72,7 @@ module defi::pool {
     /// The pool with exchange.
     ///
     /// - `fee_percent` should be in the range: [0-10000), meaning
-    /// that 1000 is 100% and 1 is 0.1%
+    /// that 10000 is 100% and 1 is 0.1%
     struct Pool<phantom P, phantom T> has key {
         id: UID,
         sui: Balance<SUI>,


### PR DESCRIPTION
## Description 

Fix missing 0 in comment describing fee_percent values

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fix missing 0 in comment describing `fee_percent` values in the defi example.