### PR TITLE
[GraphQL][EASY] Stake -> StakedSui

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -987,7 +987,7 @@
 >      }
 >      totalBalance
 >    }
->    stakeConnection {
+>    stakedSuiConnection {
 >      nodes {
 >        status
 >        principal

--- a/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -10,7 +10,7 @@
       }
       totalBalance
     }
-    stakeConnection {
+    stakedSuiConnection {
       nodes {
         status
         principal

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -17,7 +17,7 @@ type Address implements ObjectOwner {
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given address.
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -556,7 +556,7 @@ type MoveObject {
 	"""
 	Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
 	"""
-	asStake: Stake
+	asStakedSui: StakedSui
 }
 
 type MovePackage {
@@ -720,7 +720,7 @@ type Object implements ObjectOwner {
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given object.
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	"""
 	The domain that a user address has explicitly configured as their default domain
 	"""
@@ -791,7 +791,7 @@ interface ObjectOwner {
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -812,7 +812,7 @@ type Owner implements ObjectOwner {
 	"""
 	The stake objects for the given address
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -967,71 +967,6 @@ type ServiceConfig {
 	maxQueryPayloadSize: Int!
 }
 
-type Stake {
-	"""
-	A stake can be pending, active, or unstaked
-	"""
-	status: StakeStatus!
-	"""
-	The epoch at which this stake became active
-	"""
-	activeEpoch: Epoch
-	"""
-	The epoch at which this object was requested to join a stake pool
-	"""
-	requestEpoch: Epoch
-	"""
-	The SUI that was initially staked.
-	"""
-	principal: BigInt
-	"""
-	The estimated reward for this stake object, calculated as:
-	
-	principal * (initial_stake_rate / current_stake_rate - 1.0)
-	
-	Or 0, if this value is negative, where:
-	
-	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
-	- `current_stake_rate` is the stake rate in the current epoch.
-	
-	This value is only available if the stake is active.
-	"""
-	estimatedReward: BigInt
-	"""
-	The corresponding `0x3::staking_pool::StakedSui` Move object.
-	"""
-	asMoveObject: MoveObject!
-}
-
-type StakeConnection {
-	"""
-	Information to aid in pagination.
-	"""
-	pageInfo: PageInfo!
-	"""
-	A list of edges.
-	"""
-	edges: [StakeEdge!]!
-	"""
-	A list of nodes.
-	"""
-	nodes: [Stake!]!
-}
-
-"""
-An edge in a connection.
-"""
-type StakeEdge {
-	"""
-	The item at the end of the edge
-	"""
-	node: Stake!
-	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-}
-
 enum StakeStatus {
 	"""
 	The stake object is active in a staking pool and it is generating rewards
@@ -1075,6 +1010,71 @@ type StakeSubsidy {
 	period, expressed in basis points.
 	"""
 	decreaseRate: Int
+}
+
+type StakedSui {
+	"""
+	A stake can be pending, active, or unstaked
+	"""
+	status: StakeStatus!
+	"""
+	The epoch at which this stake became active
+	"""
+	activeEpoch: Epoch
+	"""
+	The epoch at which this object was requested to join a stake pool
+	"""
+	requestEpoch: Epoch
+	"""
+	The SUI that was initially staked.
+	"""
+	principal: BigInt
+	"""
+	The estimated reward for this stake object, calculated as:
+	
+	principal * (initial_stake_rate / current_stake_rate - 1.0)
+	
+	Or 0, if this value is negative, where:
+	
+	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
+	- `current_stake_rate` is the stake rate in the current epoch.
+	
+	This value is only available if the stake is active.
+	"""
+	estimatedReward: BigInt
+	"""
+	The corresponding `0x3::staking_pool::StakedSui` Move object.
+	"""
+	asMoveObject: MoveObject!
+}
+
+type StakedSuiConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [StakedSuiEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [StakedSui!]!
+}
+
+"""
+An edge in a connection.
+"""
+type StakedSuiEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: StakedSui!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -407,7 +407,7 @@ interface IOwner {
     type: String,
   ): CoinConnection
 
-  stakeConnection(
+  stakedSuiConnection(
     first: Int,
     after: String,
     last: Int,
@@ -1292,8 +1292,8 @@ type AddressMetricEdge {
 }
 
 # StakeConnection
-type StakeConnection {
-  edges: [StakeEdge!]!
+type StakedSuiConnection {
+  edges: [StakedSuiEdge!]!
   pageInfo: PageInfo!
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -25,7 +25,7 @@ use crate::{
         object::{Object, ObjectFilter},
         protocol_config::{ProtocolConfigAttr, ProtocolConfigFeatureFlag, ProtocolConfigs},
         safe_mode::SafeMode,
-        stake::Stake,
+        stake::StakedSui,
         stake_subsidy::StakeSubsidy,
         storage_fund::StorageFund,
         sui_address::SuiAddress,
@@ -85,7 +85,7 @@ use sui_types::{
     effects::TransactionEffects,
     event::EventID,
     gas_coin::GAS,
-    governance::StakedSui,
+    governance::StakedSui as NativeStakedSui,
     messages_checkpoint::{
         CheckpointCommitment, CheckpointDigest, EndOfEpochData as NativeEndOfEpochData,
     },
@@ -1523,7 +1523,7 @@ impl PgManager {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Result<Option<Connection<String, Stake>>, Error> {
+    ) -> Result<Option<Connection<String, StakedSui>>, Error> {
         let obj_filter = ObjectFilter {
             package: None,
             module: None,
@@ -1559,7 +1559,7 @@ impl PgManager {
                 ))
             })?;
 
-            let stake_object = Stake::try_from(&move_object).map_err(|_| {
+            let stake_object = StakedSui::try_from(&move_object).map_err(|_| {
                 Error::Internal(format!(
                     "Expected {} to be a staked sui, but it is not.",
                     object.address,
@@ -1581,7 +1581,7 @@ impl PgManager {
     /// object.  Used to implement fields that are implemented in JSON-RPC but not GraphQL (yet).
     pub(crate) async fn fetch_rpc_staked_sui(
         &self,
-        stake: StakedSui,
+        stake: NativeStakedSui,
     ) -> Result<RpcStakedSui, Error> {
         let governance_api = GovernanceReadApiV2::new(self.inner.clone());
 

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -11,7 +11,7 @@ use super::{
     coin::Coin,
     dynamic_field::DynamicField,
     object::{Object, ObjectFilter},
-    stake::Stake,
+    stake::StakedSui,
     sui_address::SuiAddress,
     transaction_block::{TransactionBlock, TransactionBlockFilter},
 };
@@ -125,14 +125,14 @@ impl Address {
     }
 
     /// The `0x3::staking_pool::StakedSui` objects owned by the given address.
-    pub async fn stake_connection(
+    pub async fn staked_sui_connection(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Result<Option<Connection<String, Stake>>> {
+    ) -> Result<Option<Connection<String, StakedSui>>> {
         ctx.data_unchecked::<PgManager>()
             .fetch_staked_sui(self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -6,7 +6,7 @@ use super::move_value::MoveValue;
 use super::stake::StakedSuiDowncastError;
 use super::{coin::Coin, object::Object};
 use crate::error::Error;
-use crate::types::stake::Stake;
+use crate::types::stake::StakedSui;
 use async_graphql::*;
 use move_core_types::language_storage::StructTag;
 use sui_types::object::{Data, MoveObject as NativeMoveObject};
@@ -59,8 +59,8 @@ impl MoveObject {
     }
 
     /// Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
-    async fn as_stake(&self) -> Result<Option<Stake>, Error> {
-        match Stake::try_from(self) {
+    async fn as_staked_sui(&self) -> Result<Option<StakedSui>, Error> {
+        match StakedSui::try_from(self) {
             Ok(coin) => Ok(Some(coin)),
             Err(StakedSuiDowncastError::NotAStakedSui) => Ok(None),
             Err(StakedSuiDowncastError::Bcs(e)) => Err(Error::Internal(format!(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -13,7 +13,7 @@ use super::dynamic_field::DynamicField;
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::{
-    balance::Balance, coin::Coin, owner::Owner, stake::Stake, sui_address::SuiAddress,
+    balance::Balance, coin::Coin, owner::Owner, stake::StakedSui, sui_address::SuiAddress,
     transaction_block::TransactionBlock,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -194,14 +194,14 @@ impl Object {
     }
 
     /// The `0x3::staking_pool::StakedSui` objects owned by the given object.
-    pub async fn stake_connection(
+    pub async fn staked_sui_connection(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Result<Option<Connection<String, Stake>>, Error> {
+    ) -> Result<Option<Connection<String, StakedSui>>, Error> {
         ctx.data_unchecked::<PgManager>()
             .fetch_staked_sui(self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -3,7 +3,7 @@
 
 use super::address::Address;
 use super::dynamic_field::DynamicField;
-use super::stake::Stake;
+use super::stake::StakedSui;
 use crate::context_data::db_data_provider::PgManager;
 use crate::types::balance::*;
 use crate::types::coin::*;
@@ -49,8 +49,8 @@ use sui_json_rpc::name_service::NameServiceConfig;
         arg(name = "type", ty = "Option<String>")
     ),
     field(
-        name = "stake_connection",
-        ty = "Option<Connection<String, Stake>>",
+        name = "staked_sui_connection",
+        ty = "Option<Connection<String, StakedSui>>",
         arg(name = "first", ty = "Option<u64>"),
         arg(name = "after", ty = "Option<String>"),
         arg(name = "last", ty = "Option<u64>"),
@@ -167,14 +167,14 @@ impl Owner {
     }
 
     /// The stake objects for the given address
-    pub async fn stake_connection(
+    pub async fn staked_sui_connection(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
-    ) -> Result<Option<Connection<String, Stake>>> {
+    ) -> Result<Option<Connection<String, StakedSui>>> {
         ctx.data_unchecked::<PgManager>()
             .fetch_staked_sui(self.address, first, after, last, before)
             .await

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -25,7 +25,7 @@ pub(crate) enum StakedSuiDowncastError {
 }
 
 #[derive(Clone)]
-pub(crate) struct Stake {
+pub(crate) struct StakedSui {
     /// Representation of this StakedSui as a generic Move Object.
     pub super_: MoveObject,
 
@@ -35,7 +35,7 @@ pub(crate) struct Stake {
 }
 
 #[Object]
-impl Stake {
+impl StakedSui {
     /// A stake can be pending, active, or unstaked
     async fn status(&self, ctx: &Context<'_>) -> Result<StakeStatus, Error> {
         Ok(match self.rpc_stake(ctx).await?.status {
@@ -92,7 +92,7 @@ impl Stake {
     }
 }
 
-impl Stake {
+impl StakedSui {
     /// The JSON-RPC representation of a StakedSui so that we can "cheat" to implement fields that
     /// are not yet implemented directly for GraphQL.
     ///
@@ -104,7 +104,7 @@ impl Stake {
     }
 }
 
-impl TryFrom<&MoveObject> for Stake {
+impl TryFrom<&MoveObject> for StakedSui {
     type Error = StakedSuiDowncastError;
 
     fn try_from(move_object: &MoveObject) -> Result<Self, Self::Error> {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -21,7 +21,7 @@ type Address implements ObjectOwner {
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given address.
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -560,7 +560,7 @@ type MoveObject {
 	"""
 	Attempts to convert the Move object into a `0x3::staking_pool::StakedSui`.
 	"""
-	asStake: Stake
+	asStakedSui: StakedSui
 }
 
 type MovePackage {
@@ -724,7 +724,7 @@ type Object implements ObjectOwner {
 	"""
 	The `0x3::staking_pool::StakedSui` objects owned by the given object.
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	"""
 	The domain that a user address has explicitly configured as their default domain
 	"""
@@ -795,7 +795,7 @@ interface ObjectOwner {
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -816,7 +816,7 @@ type Owner implements ObjectOwner {
 	"""
 	The stake objects for the given address
 	"""
-	stakeConnection(first: Int, after: String, last: Int, before: String): StakeConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultNameServiceName: String
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
@@ -971,71 +971,6 @@ type ServiceConfig {
 	maxQueryPayloadSize: Int!
 }
 
-type Stake {
-	"""
-	A stake can be pending, active, or unstaked
-	"""
-	status: StakeStatus!
-	"""
-	The epoch at which this stake became active
-	"""
-	activeEpoch: Epoch
-	"""
-	The epoch at which this object was requested to join a stake pool
-	"""
-	requestEpoch: Epoch
-	"""
-	The SUI that was initially staked.
-	"""
-	principal: BigInt
-	"""
-	The estimated reward for this stake object, calculated as:
-	
-	principal * (initial_stake_rate / current_stake_rate - 1.0)
-	
-	Or 0, if this value is negative, where:
-	
-	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
-	- `current_stake_rate` is the stake rate in the current epoch.
-	
-	This value is only available if the stake is active.
-	"""
-	estimatedReward: BigInt
-	"""
-	The corresponding `0x3::staking_pool::StakedSui` Move object.
-	"""
-	asMoveObject: MoveObject!
-}
-
-type StakeConnection {
-	"""
-	Information to aid in pagination.
-	"""
-	pageInfo: PageInfo!
-	"""
-	A list of edges.
-	"""
-	edges: [StakeEdge!]!
-	"""
-	A list of nodes.
-	"""
-	nodes: [Stake!]!
-}
-
-"""
-An edge in a connection.
-"""
-type StakeEdge {
-	"""
-	The item at the end of the edge
-	"""
-	node: Stake!
-	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-}
-
 enum StakeStatus {
 	"""
 	The stake object is active in a staking pool and it is generating rewards
@@ -1079,6 +1014,71 @@ type StakeSubsidy {
 	period, expressed in basis points.
 	"""
 	decreaseRate: Int
+}
+
+type StakedSui {
+	"""
+	A stake can be pending, active, or unstaked
+	"""
+	status: StakeStatus!
+	"""
+	The epoch at which this stake became active
+	"""
+	activeEpoch: Epoch
+	"""
+	The epoch at which this object was requested to join a stake pool
+	"""
+	requestEpoch: Epoch
+	"""
+	The SUI that was initially staked.
+	"""
+	principal: BigInt
+	"""
+	The estimated reward for this stake object, calculated as:
+	
+	principal * (initial_stake_rate / current_stake_rate - 1.0)
+	
+	Or 0, if this value is negative, where:
+	
+	- `initial_stake_rate` is the stake rate at the epoch this stake was activated at.
+	- `current_stake_rate` is the stake rate in the current epoch.
+	
+	This value is only available if the stake is active.
+	"""
+	estimatedReward: BigInt
+	"""
+	The corresponding `0x3::staking_pool::StakedSui` Move object.
+	"""
+	asMoveObject: MoveObject!
+}
+
+type StakedSuiConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [StakedSuiEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [StakedSui!]!
+}
+
+"""
+An edge in a connection.
+"""
+type StakedSuiEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: StakedSui!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """


### PR DESCRIPTION
## Description

Change type representing Staked SUI to `StakedSui` (from `Stake`). This matches the naming used in the draft schema, which was in turn chosen to match the names used in Move code (as opposed to the names in JSON-RPC where this concept is also called `Stake`).

Also tweaks the draft schema to make the connection types and names also use this naming scheme.

## Test Plan

GraphiQL:

![Screenshot 2023-11-13 at 3 51 15 PM](https://github.com/MystenLabs/sui/assets/332275/fe59ef54-9429-4536-96b1-446cd3ba709f)