### PR TITLE
chore: remove more rocksdb deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10939,7 +10939,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "typed-store",
+ "typed-store-error",
  "workspace-hack",
 ]
 
@@ -11498,7 +11498,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "typed-store",
  "workspace-hack",
 ]
 

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -47,7 +47,7 @@ sui-json-rpc-types.workspace = true
 sui-transaction-builder.workspace = true
 mysten-metrics.workspace = true
 shared-crypto.workspace = true
-typed-store.workspace = true
+typed-store-error.workspace = true
 cached.workspace = true
 workspace-hack.workspace = true
 

--- a/crates/sui-json-rpc/src/api/mod.rs
+++ b/crates/sui-json-rpc/src/api/mod.rs
@@ -24,10 +24,11 @@ use prometheus::{register_int_counter_with_registry, IntCounter};
 pub use read::ReadApiClient;
 pub use read::ReadApiOpenRpc;
 pub use read::ReadApiServer;
+use tap::TapFallible;
+use tracing::warn;
 pub use transaction_builder::TransactionBuilderClient;
 pub use transaction_builder::TransactionBuilderOpenRpc;
 pub use transaction_builder::TransactionBuilderServer;
-use typed_store::rocks::read_size_from_env;
 pub use write::WriteApiClient;
 pub use write::WriteApiOpenRpc;
 pub use write::WriteApiServer;
@@ -275,4 +276,17 @@ impl JsonRpcMetrics {
         let registry = prometheus::Registry::new();
         Self::new(&registry)
     }
+}
+
+pub fn read_size_from_env(var_name: &str) -> Option<usize> {
+    std::env::var(var_name)
+        .ok()?
+        .parse::<usize>()
+        .tap_err(|e| {
+            warn!(
+                "Env var {} does not contain valid usize integer: {}",
+                var_name, e
+            )
+        })
+        .ok()
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -423,7 +423,7 @@ mod tests {
     use sui_types::object::Object;
     use sui_types::utils::create_fake_transaction;
     use sui_types::{parse_sui_struct_tag, TypeTag};
-    use typed_store::TypedStoreError;
+    use typed_store_error::TypedStoreError;
 
     mock! {
         pub KeyValueStore {}

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -33,7 +33,6 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 tokio.workspace = true
-typed-store.workspace = true
 
 sui-config.workspace = true
 sui-core.workspace = true


### PR DESCRIPTION
## Description 

In cleaning up build times, this removes more unneeded deps on RocksDB 

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
