### PR TITLE
[sui-cli] Propagate version

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -31,6 +31,7 @@ const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REV
     rename_all = "kebab-case",
     author,
     version = VERSION,
+    propagate_version = true,
 )]
 struct Args {
     #[clap(subcommand)]

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Default)]
-#[clap(author, version, about)]
+#[clap(about)]
 pub struct BuildConfig {
     /// Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if
     /// this flag is set. This flag is useful for development of packages that expose named


### PR DESCRIPTION
## Description 

- Propagate version for all commands in the CLI
- Removed standalone Move Package version

## Test Plan 

- `cargo run --bin sui --locked -- <COMMAND> -V`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

The Sui CLI tools will now display the correct version across all subcommands.
