### PR TITLE
[GraphQL/Errors] Standardise use of Error types

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1863,17 +1863,14 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
         let object_changes = tx.object_changes;
         let timestamp = DateTime::from_ms(tx.timestamp_ms);
         let effects = match SuiTransactionBlockEffects::try_from(effects) {
-            Ok(effects) => {
-                let transaction_effects = TransactionBlockEffects::from_stored_transaction(
-                    balance_changes,
-                    tx.checkpoint_sequence_number as u64,
-                    object_changes,
-                    &effects,
-                    digest,
-                    timestamp,
-                );
-                transaction_effects.map_err(|e| Error::Internal(e.message))
-            }
+            Ok(effects) => TransactionBlockEffects::from_stored_transaction(
+                balance_changes,
+                tx.checkpoint_sequence_number as u64,
+                object_changes,
+                &effects,
+                digest,
+                timestamp,
+            ),
             Err(e) => Err(Error::Internal(format!(
                 "Can't convert TransactionEffects into SuiTransactionBlockEffects. Error: {e}",
             ))),

--- a/crates/sui-graphql-rpc/src/context_data/db_query_cost.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_query_cost.rs
@@ -9,13 +9,11 @@ use diesel::{
 use regex::Regex;
 use sui_indexer::{indexer_reader::IndexerReader, schema_v2::query_cost};
 
-use crate::context_data::DEFAULT_PAGE_SIZE;
+use crate::{context_data::DEFAULT_PAGE_SIZE, error::Error};
 
 /// Extracts the raw sql query string from a diesel query
 /// and replaces all the parameters with '0'
-pub fn raw_sql_string_values_set(
-    query: &dyn QueryFragment<Pg>,
-) -> Result<String, crate::error::Error> {
+pub fn raw_sql_string_values_set(query: &dyn QueryFragment<Pg>) -> Result<String, Error> {
     // This lets us get the underlying sql query param types & values
     // Currently unused because we set all vals to '0' but want to keep for future reference
 
@@ -38,7 +36,7 @@ pub fn raw_sql_string_values_set(
 
     let mut query_builder = <diesel::pg::Pg as diesel::backend::Backend>::QueryBuilder::default();
     QueryFragment::<Pg>::to_sql(&query, &mut query_builder, &Pg).map_err(|e| {
-        crate::error::Error::Internal(format!(
+        Error::Internal(format!(
             "Failed to extract raw sql string from query: {}",
             e
         ))
@@ -47,7 +45,7 @@ pub fn raw_sql_string_values_set(
 
     // handle limits, as '0' is invalid - set to DEFAULT_PAGE_SIZE instead
     let re = Regex::new(r"(LIMIT\s+)\$(\d+)")
-        .map_err(|e| crate::error::Error::Internal(format!("Failed create valid regex: {}", e)))?;
+        .map_err(|e| Error::Internal(format!("Failed create valid regex: {}", e)))?;
     let replacement_string = format!("LIMIT {}", DEFAULT_PAGE_SIZE);
     let output = re
         .replace_all(&sql, replacement_string.as_str())
@@ -55,7 +53,7 @@ pub fn raw_sql_string_values_set(
 
     // handle matching column against ANY value in input array
     let re = Regex::new(r"ANY\(\$(\d+)\)")
-        .map_err(|e| crate::error::Error::Internal(format!("Failed create valid regex: {}", e)))?;
+        .map_err(|e| Error::Internal(format!("Failed create valid regex: {}", e)))?;
     let nums: Vec<String> = (1..=50).map(|n| n.to_string()).collect();
     let nums_str = nums.join(", ");
     let replacement_string = format!("ANY ('{{{}}}')", nums_str);
@@ -64,7 +62,7 @@ pub fn raw_sql_string_values_set(
         .to_string();
 
     let re = Regex::new(r"\$(\d+)")
-        .map_err(|e| crate::error::Error::Internal(format!("Failed create valid regex: {}", e)))?;
+        .map_err(|e| Error::Internal(format!("Failed create valid regex: {}", e)))?;
 
     Ok(re.replace_all(&output, "'0'").to_string())
 }
@@ -72,13 +70,13 @@ pub fn raw_sql_string_values_set(
 pub fn extract_cost(
     query: &dyn QueryFragment<Pg>,
     pg_reader: &IndexerReader,
-) -> Result<f64, crate::error::Error> {
+) -> Result<f64, Error> {
     let raw_sql_string = raw_sql_string_values_set(query)?;
     // Use IndexerReader.run_query so we get alerted when blocking calls are made in an async thread
     pg_reader
         .run_query(|conn| diesel::select(query_cost(&raw_sql_string)).get_result::<f64>(conn))
         .map_err(|e| {
-            crate::error::Error::Internal(format!(
+            Error::Internal(format!(
                 "Unable to run query_cost function to determine query cost for {}: {}",
                 raw_sql_string, e
             ))

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -43,7 +43,7 @@ impl Server {
             .map_err(|e| Error::Internal(format!("Server run failed: {}", e)))
     }
 
-    pub async fn from_yaml_config(path: &str) -> Result<Self, crate::error::Error> {
+    pub async fn from_yaml_config(path: &str) -> Result<Self, Error> {
         let config = ServerConfig::from_yaml(path)?;
         Self::from_config(&config).await
     }
@@ -184,7 +184,7 @@ async fn get_schema() -> impl axum::response::IntoResponse {
     let schema = format!(
         r#"
     <span style="white-space: pre;">{}
-    </span>  
+    </span>
     "#,
         schema
     );

--- a/crates/sui-graphql-rpc/src/server/simple_server.rs
+++ b/crates/sui-graphql-rpc/src/server/simple_server.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::ServerConfig;
+use crate::error::Error;
 use crate::server::builder::Server;
 
-pub async fn start_example_server(server_config: &ServerConfig) -> Result<(), crate::error::Error> {
+pub async fn start_example_server(server_config: &ServerConfig) -> Result<(), Error> {
     println!("Starting server with config: {:?}", server_config);
 
     let server = Server::from_config(server_config).await?;

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -163,7 +163,7 @@ impl Address {
         _after: Option<String>,
         _last: Option<u64>,
         _before: Option<String>,
-    ) -> Result<Option<Connection<String, DynamicField>>, Error> {
-        Err(crate::error::Error::DynamicFieldOnAddress)
+    ) -> Result<Option<Connection<String, DynamicField>>> {
+        Err(Error::DynamicFieldOnAddress.extend())
     }
 }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -12,9 +12,9 @@ use sui_types::{dynamic_field::DynamicFieldType, TypeTag};
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
+use crate::context_data::db_data_provider::PgManager;
 use crate::context_data::package_cache::PackageCache;
-use crate::error::{code, Error};
-use crate::{context_data::db_data_provider::PgManager, error::graphql_error};
+use crate::error::Error;
 use sui_types::object::Object as NativeSuiObject;
 
 pub(crate) struct DynamicField {
@@ -38,12 +38,11 @@ pub(crate) struct DynamicFieldName {
 #[Object]
 impl DynamicField {
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
-        let resolver: &Resolver<PackageCache> = ctx.data().map_err(|_| {
-            graphql_error(
-                code::INTERNAL_SERVER_ERROR,
-                "Unable to fetch Package Cache.",
-            )
-        })?;
+        let resolver: &Resolver<PackageCache> = ctx
+            .data()
+            .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
+            .extend()?;
+
         let (struct_tag, move_struct) =
             deserialize_move_struct(&self.stored_object.serialized_object, resolver)
                 .await
@@ -51,24 +50,27 @@ impl DynamicField {
 
         // Get TypeTag of the DynamicField name from StructTag of the MoveStruct
         let type_tag = DynamicFieldInfo::try_extract_field_name(&struct_tag, &self.df_kind)
-            .map_err(|e| Error::Internal(e.to_string()).extend())?;
+            .map_err(|e| Error::Internal(e.to_string()))
+            .extend()?;
 
-        let name_move_value = extract_field_from_move_struct(move_struct, "name")?;
+        let name_move_value = extract_field_from_move_struct(move_struct, "name").extend()?;
 
         let undecorated = if self.df_kind == DynamicFieldType::DynamicObject {
             let inner_name_move_value = match name_move_value {
                 A::MoveValue::Struct(inner_struct) => {
                     extract_field_from_move_struct(inner_struct, "name")
                 }
-                _ => Err(Error::Internal("Expected a wrapper struct".to_string()).extend()),
-            }?;
+                _ => Err(Error::Internal("Expected a wrapper struct".to_string())),
+            }
+            .extend()?;
             inner_name_move_value.undecorate()
         } else {
             name_move_value.undecorate()
         };
 
         let bcs = bcs::to_bytes(&undecorated)
-            .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")).extend())?;
+            .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
+            .extend()?;
 
         Ok(Some(MoveValue::new(
             type_tag.to_canonical_string(true),
@@ -85,12 +87,11 @@ impl DynamicField {
                 .extend()?;
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
-            let resolver: &Resolver<PackageCache> = ctx.data().map_err(|_| {
-                graphql_error(
-                    code::INTERNAL_SERVER_ERROR,
-                    "Unable to fetch Package Cache.",
-                )
-            })?;
+            let resolver: &Resolver<PackageCache> = ctx
+                .data()
+                .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
+                .extend()?;
+
             let (struct_tag, move_struct) =
                 deserialize_move_struct(&self.stored_object.serialized_object, resolver)
                     .await
@@ -98,12 +99,16 @@ impl DynamicField {
 
             // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
             let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
-                .map_err(|e| Error::Internal(e.to_string()).extend())?;
-            let value_move_value = extract_field_from_move_struct(move_struct, "value")?;
+                .map_err(|e| Error::Internal(e.to_string()))
+                .extend()?;
+
+            let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
+
             let undecorated = value_move_value.undecorate();
-            let bcs = bcs::to_bytes(&undecorated).map_err(|e| {
-                Error::Internal(format!("Failed to serialize object: {e}")).extend()
-            })?;
+            let bcs = bcs::to_bytes(&undecorated)
+                .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
+                .extend()?;
+
             Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
                 type_tag.to_canonical_string(true),
                 Base64::from(bcs),
@@ -115,32 +120,46 @@ impl DynamicField {
 pub(crate) async fn deserialize_move_struct(
     serialized_object: &[u8],
     resolver: &Resolver<PackageCache>,
-) -> Result<(StructTag, MoveStruct)> {
+) -> Result<(StructTag, MoveStruct), Error> {
     let native_object: NativeSuiObject = bcs::from_bytes(serialized_object)
-        .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")).extend())?;
-    let move_object = native_object.data.try_as_move().ok_or_else(|| {
-        Error::Internal("Failed to convert object into MoveObject".to_string()).extend()
-    })?;
-    let struct_tag = native_object
-        .data
-        .struct_tag()
-        .ok_or_else(|| Error::Internal("StructTag missing on object".to_string()).extend())?;
+        .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?;
+
+    let Some(move_object) = native_object.data.try_as_move() else {
+        return Err(Error::Internal(
+            "Failed to convert object into MoveObject".to_string(),
+        ));
+    };
+
+    let struct_tag = StructTag::from(move_object.type_().clone());
     let contents = move_object.contents();
-    let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
-    let move_type_layout = resolver.type_layout(type_tag.clone()).await?;
-    let move_struct = match move_type_layout {
-        MoveTypeLayout::Struct(move_struct_layout) => {
-            MoveStruct::simple_deserialize(contents, &move_struct_layout)
-        }
-        _ => Err(Error::Internal("Object is not a move struct".to_string()).extend())?,
-    }?;
+    let move_type_layout = resolver
+        .type_layout(TypeTag::from(struct_tag.clone()))
+        .await
+        .map_err(|e| {
+            Error::Internal(format!(
+                "Error fetching layout for type {}: {e}",
+                struct_tag.to_canonical_string(/* with_prefix */ true)
+            ))
+        })?;
+
+    let MoveTypeLayout::Struct(layout) = move_type_layout else {
+        return Err(Error::Internal("Object is not a move struct".to_string()));
+    };
+
+    let move_struct = MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
+        Error::Internal(format!(
+            "Error deserializing move struct for type {}: {e}",
+            struct_tag.to_canonical_string(/* with_prefix */ true)
+        ))
+    })?;
+
     Ok((struct_tag, move_struct))
 }
 
 pub fn extract_field_from_move_struct(
     move_struct: MoveStruct,
     field_name: &str,
-) -> Result<A::MoveValue> {
+) -> Result<A::MoveValue, Error> {
     move_struct
         .fields
         .into_iter()
@@ -151,5 +170,5 @@ pub fn extract_field_from_move_struct(
                 None
             }
         })
-        .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)).extend())
+        .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)))
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -38,7 +38,8 @@ impl Epoch {
         Ok(Some(
             ctx.data_unchecked::<PgManager>()
                 .fetch_protocol_configs(Some(self.protocol_version))
-                .await?,
+                .await
+                .extend()?,
         ))
     }
 
@@ -74,7 +75,8 @@ impl Epoch {
             .extend()?
             .ok_or(Error::Internal(
                 "Epoch should be able to find itself".to_string(),
-            ))?;
+            ))
+            .extend()?;
 
         let new_filter = TransactionBlockFilter {
             after_checkpoint: if stored_epoch.first_checkpoint_id > 0 {

--- a/crates/sui-graphql-rpc/src/types/sui_system_state_summary.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_system_state_summary.rs
@@ -72,7 +72,8 @@ impl SuiSystemStateSummary {
         Ok(Some(
             ctx.data_unchecked::<PgManager>()
                 .fetch_protocol_configs(Some(self.protocol_version))
-                .await?,
+                .await
+                .extend()?,
         ))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -3,7 +3,7 @@
 
 use super::{big_int::BigInt, date_time::DateTime, epoch::Epoch, sui_address::SuiAddress};
 use crate::context_data::db_data_provider::PgManager;
-use async_graphql::{ComplexObject, Context, Result, ResultExt, SimpleObject, Union};
+use async_graphql::*;
 
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {


### PR DESCRIPTION
##  Description

Follow these rules when emitting errors in GraphQL:

- All implementations of GraphQL fields (that can fail), use `async_graphql::Result<T>` (meaning their error type is always `async_graphql::Error`).
- All other internal APIs that produce errors should produce `crate::error::Error`, for better composability, and to encourage use of the `extend()` API to convert to `async_graphql::Error` (this process is what adds the custom error code).
- Import the `Error` type rather than mention it in a fully-qualified way.

## Test Plan

GraphiQL:

![Screenshot 2023-11-13 at 10 07 33 PM](https://github.com/MystenLabs/sui/assets/332275/b33df178-3a78-4e37-a1db-f719a4d550ba)