### PR TITLE
[move-binary-format-wasm] Fix-up move dependencies

### DIFF
--- a/sdk/move-binary-format-wasm/Cargo.toml
+++ b/sdk/move-binary-format-wasm/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 
 [dependencies]
 hex = "0.4.3"
-move-binary-format = { path = "../../external-crates/move/move-binary-format", features = ["wasm"] }
-move-core-types = { path = "../../external-crates/move/move-core/types", default-features = false}
+move-binary-format = { path = "../../external-crates/move/crates/move-binary-format", features = ["wasm"] }
+move-core-types = { path = "../../external-crates/move/crates/move-core-types", default-features = false}
 serde = { version = "1.0.124", default-features = false }
 serde-wasm-bindgen = "0.5.0"
 serde_json = "1.0.64"


### PR DESCRIPTION
## Description

Broke with the recent flattening of the move repo, spotted in the CI runs for #14816 (not sure why it only started showing up now as the flattening happened 2 weeks ago: #14637).

## Test Plan

```
sui$ pnpm install
sui$ pnpm turbo build
```

Failed on `main` before this change, now succeeds.