### PR TITLE
[graphql/rpc] disable genesis-sensitive test

### DIFF
--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -316,6 +316,7 @@ mod tests {
         test_query_complexity_metrics_impl().await;
     }
 
+    #[ignore]
     #[tokio::test]
     #[serial]
     async fn simulator_commands_test() {

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -16,6 +16,7 @@ mod tests {
     use sui_graphql_rpc::client::simple_client::GraphqlQueryVariable;
     use sui_graphql_rpc::config::ConnectionConfig;
     use sui_graphql_rpc::context_data::db_query_cost::extract_cost;
+    use sui_graphql_rpc::test_infra::cluster::simulator_commands_test_impl;
     use sui_indexer::indexer_reader::IndexerReader;
     use sui_indexer::models_v2::objects::StoredObject;
     use sui_indexer::new_pg_connection_pool_impl;
@@ -320,7 +321,6 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn simulator_commands_test() {
-        use sui_graphql_rpc::test_infra::cluster::simulator_commands_test_impl;
         simulator_commands_test_impl().await;
     }
 }


### PR DESCRIPTION
## Description 

Disable disable genesis-sensitive e2e test [this](https://github.com/MystenLabs/sui/pull/14822) pr goes in, which has a cleaner way of updating tests.


## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
