### PR TITLE
Add support for shared-object deletion in test scenario

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -158,8 +158,11 @@ pub fn end_transaction(
     // deletions already handled above, but we drop the delete kind for the effects
     let mut deleted = vec![];
     for (id, _) in deleted_object_ids {
-        incorrect_shared_or_imm_handling =
-            incorrect_shared_or_imm_handling || taken_shared_or_imm.contains_key(&id);
+        // Mark as "incorrect" if a imm object was deleted. Allow shared objects to be deleted though.
+        incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling
+            || taken_shared_or_imm
+                .get(&id)
+                .is_some_and(|owner| matches!(owner, Owner::Immutable));
         deleted.push(id);
     }
     // find all wrapped objects


### PR DESCRIPTION
## Description 

Adds support for shared object deletion in the test scenario -- mainly making sure that we don't raise an error if a shared object was deleted, whereas before it would complain.

## Test Plan 

PR this is stacked on tests this.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

