### PR TITLE
[transfer-to-object] Turn on in testnet, minor updates

### DIFF
--- a/crates/sui-core/src/unit_tests/data/tto/sources/tto4.move
+++ b/crates/sui-core/src/unit_tests/data/tto/sources/tto4.move
@@ -46,4 +46,9 @@ module tto::M4 {
         let _b = transfer::receive(&mut parent.id, x);
         abort 0
     }
+
+    public entry fun receive_type_mismatch(parent: &mut A, x: Receiving<A>) { 
+        let _b = transfer::receive(&mut parent.id, x);
+        abort 0
+    }
 }

--- a/crates/sui-core/src/unit_tests/data/tto/sources/tto4.move
+++ b/crates/sui-core/src/unit_tests/data/tto/sources/tto4.move
@@ -48,7 +48,7 @@ module tto::M4 {
     }
 
     public entry fun receive_type_mismatch(parent: &mut A, x: Receiving<A>) { 
-        let _b = transfer::receive(&mut parent.id, x);
+        let _b: A = transfer::receive(&mut parent.id, x);
         abort 0
     }
 }

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -1598,6 +1598,13 @@ async fn test_tto_dependencies_receive_and_type_mismatch() {
             .await;
 
         assert!(effects.status().is_err());
+
+        // Type mismatch is an abort code of 2 from `receive_impl`
+        let is_type_mismatch_error = matches!(
+            effects.status().clone().unwrap_err().0,
+            ExecutionFailureStatus::MoveAbort(x, 2) if x.function_name == Some("receive_impl".to_string())
+        );
+        assert!(is_type_mismatch_error);
         assert!(effects.created().is_empty());
         assert!(effects.unwrapped().is_empty());
         assert!(effects.deleted().is_empty());

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -94,6 +94,7 @@ const MAX_PROTOCOL_VERSION: u64 = 32;
 //             Update semantics of `sui::transfer::receive` and add `sui::transfer::public_receive`.
 // Version 32: Add delete functions for VerifiedID and VerifiedIssuer.
 //             Add sui::token module to sui framework.
+//             Enable transfer to object in testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1656,7 +1657,14 @@ impl ProtocolConfig {
                         cfg.feature_flags.shared_object_deletion = true;
                     }
                 }
-                32 => cfg.feature_flags.accept_zklogin_in_multisig = true,
+                32 => {
+                    cfg.feature_flags.accept_zklogin_in_multisig = true;
+                    // enable receiving objects in devnet and testnet
+                    if chain != Chain::Mainnet {
+                        cfg.transfer_receive_object_cost_base = Some(52);
+                        cfg.feature_flags.receive_objects = true;
+                    }
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_32.snap
@@ -30,6 +30,7 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
+  receive_objects: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
@@ -136,6 +137,7 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -453,6 +453,13 @@ impl<'a> ObjectRuntime<'a> {
     }
 
     pub fn loaded_runtime_objects(&self) -> BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata> {
+        // The loaded child objects, and the received objects, should be disjoint. If they are not,
+        // this is an error since it could lead to incorrect transaction dependency computations.
+        debug_assert!(self
+            .child_object_store
+            .cached_objects()
+            .keys()
+            .all(|id| !self.state.received.contains_key(id)));
         self.child_object_store
             .cached_objects()
             .iter()

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
@@ -453,6 +453,13 @@ impl<'a> ObjectRuntime<'a> {
     }
 
     pub fn loaded_runtime_objects(&self) -> BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata> {
+        // The loaded child objects, and the received objects, should be disjoint. If they are not,
+        // this is an error since it could lead to incorrect transaction dependency computations.
+        debug_assert!(self
+            .child_object_store
+            .cached_objects()
+            .keys()
+            .all(|id| !self.state.received.contains_key(id)));
         self.child_object_store
             .cached_objects()
             .iter()


### PR DESCRIPTION
## Description 

Minor updates and cleanups to execution code related to transfer-to-object. Nothing about the semantics should be changed with this. 

This also turns transfer-to-object on for testnet and devnet (only).

## Test Plan 

Added an additional test, and made sure existing tests continue to all pass. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Transfer-to-object is now turned on and supported in testnet and devnet. 