### PR TITLE
indexer v2: light-weight epoch endpoints

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -10,8 +10,9 @@ use sui_json_rpc::api::{
 };
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics,
-    Page, QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
+    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochMetricsPage, EpochPage, MoveCallMetrics,
+    NetworkMetrics, Page, QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse,
+    SuiObjectResponseQuery,
 };
 use sui_open_rpc::Module;
 use sui_types::sui_serde::BigInt;
@@ -107,6 +108,15 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
             next_cursor: next_cursor.map(|id| id.into()),
             has_next_page,
         })
+    }
+
+    async fn get_epoch_metrics(
+        &self,
+        _cursor: Option<BigInt<u64>>,
+        _limit: Option<usize>,
+        _descending_order: Option<bool>,
+    ) -> RpcResult<EpochMetricsPage> {
+        unimplemented!();
     }
 
     async fn get_current_epoch(&self) -> RpcResult<EpochInfo> {

--- a/crates/sui-indexer/src/apis/extended_api_v2.rs
+++ b/crates/sui-indexer/src/apis/extended_api_v2.rs
@@ -8,8 +8,8 @@ use sui_json_rpc::{
     SuiRpcModule,
 };
 use sui_json_rpc_types::{
-    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics,
-    Page, QueryObjectsPage, SuiObjectResponseQuery,
+    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochMetrics, EpochMetricsPage, EpochPage,
+    MoveCallMetrics, NetworkMetrics, Page, QueryObjectsPage, SuiObjectResponseQuery,
 };
 use sui_open_rpc::Module;
 use sui_types::sui_serde::BigInt;
@@ -49,6 +49,44 @@ impl ExtendedApiServer for ExtendedApiV2 {
         let next_cursor = epochs.last().map(|e| e.epoch);
         Ok(Page {
             data: epochs,
+            next_cursor: next_cursor.map(|id| id.into()),
+            has_next_page,
+        })
+    }
+
+    async fn get_epoch_metrics(
+        &self,
+        cursor: Option<BigInt<u64>>,
+        limit: Option<usize>,
+        descending_order: Option<bool>,
+    ) -> RpcResult<EpochMetricsPage> {
+        let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
+        let epochs = self
+            .inner
+            .spawn_blocking(move |this| {
+                this.get_epochs(
+                    cursor.map(|x| *x),
+                    limit + 1,
+                    descending_order.unwrap_or(false),
+                )
+            })
+            .await?;
+
+        let epoch_metrics = epochs
+            .into_iter()
+            .map(|e| EpochMetrics {
+                epoch: e.epoch,
+                epoch_total_transactions: e.epoch_total_transactions,
+                first_checkpoint_id: e.first_checkpoint_id,
+                epoch_start_timestamp: e.epoch_start_timestamp,
+                end_of_epoch_info: e.end_of_epoch_info,
+            })
+            .collect::<Vec<_>>();
+
+        let has_next_page = epoch_metrics.len() > limit;
+        let next_cursor = epoch_metrics.last().map(|e| e.epoch);
+        Ok(Page {
+            data: epoch_metrics,
             next_cursor: next_cursor.map(|id| id.into()),
             has_next_page,
         })

--- a/crates/sui-indexer/src/apis/extended_api_v2.rs
+++ b/crates/sui-indexer/src/apis/extended_api_v2.rs
@@ -72,7 +72,7 @@ impl ExtendedApiServer for ExtendedApiV2 {
             })
             .await?;
 
-        let epoch_metrics = epochs
+        let mut epoch_metrics = epochs
             .into_iter()
             .map(|e| EpochMetrics {
                 epoch: e.epoch,
@@ -84,6 +84,7 @@ impl ExtendedApiServer for ExtendedApiV2 {
             .collect::<Vec<_>>();
 
         let has_next_page = epoch_metrics.len() > limit;
+        epoch_metrics.truncate(limit);
         let next_cursor = epoch_metrics.last().map(|e| e.epoch);
         Ok(Page {
             data: epoch_metrics,

--- a/crates/sui-json-rpc-types/src/sui_extended.rs
+++ b/crates/sui-json-rpc-types/src/sui_extended.rs
@@ -21,6 +21,7 @@ use sui_types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
 use crate::Page;
 
 pub type EpochPage = Page<EpochInfo, BigInt<u64>>;
+pub type EpochMetricsPage = Page<EpochMetrics, BigInt<u64>>;
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -56,6 +57,26 @@ impl EpochInfo {
         }
         Ok(Committee::new(self.epoch, voting_rights))
     }
+}
+
+/// a light-weight version of `EpochInfo` for faster loading
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EpochMetrics {
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch: EpochId,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch_total_transactions: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub first_checkpoint_id: CheckpointSequenceNumber,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch_start_timestamp: u64,
+    pub end_of_epoch_info: Option<EndOfEpochInfo>,
 }
 
 #[serde_as]

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -5,8 +5,8 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics,
-    QueryObjectsPage, SuiObjectResponseQuery,
+    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochMetricsPage, EpochPage, MoveCallMetrics,
+    NetworkMetrics, QueryObjectsPage, SuiObjectResponseQuery,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::sui_serde::BigInt;
@@ -25,6 +25,18 @@ pub trait ExtendedApi {
         /// flag to return results in descending order
         descending_order: Option<bool>,
     ) -> RpcResult<EpochPage>;
+
+    /// Return a list of epoch metrics, which is a subset of epoch info
+    #[method(name = "getEpochMetrics")]
+    async fn get_epoch_metrics(
+        &self,
+        /// optional paging cursor
+        cursor: Option<BigInt<u64>>,
+        /// maximum number of items per page
+        limit: Option<usize>,
+        /// flag to return results in descending order
+        descending_order: Option<bool>,
+    ) -> RpcResult<EpochMetricsPage>;
 
     /// Return current epoch info
     #[method(name = "getCurrentEpoch")]


### PR DESCRIPTION
## Description 

A lightweight RPC endpoint for faster epoch metrics loading on Explorer.
The related thread is https://mysten-labs.slack.com/archives/C032676BWGN/p1699941535995239

## Test Plan 

local run RPC server and test via curl, the latest epoch is not complete, so still missing some end of epoch info

```
curl --location http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": "5",
  "method": "suix_getEpochMetrics",
  "params": [
    null,
    2,
    true
  ]
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   920  100   804  100   116   2288    330 --:--:-- --:--:-- --:--:--  2643
{
  "jsonrpc": "2.0",
  "result": {
    "data": [
      {
        "epoch": "216",
        "epochTotalTransactions": "0",
        "firstCheckpointId": "18262206",
        "epochStartTimestamp": "1699982134665",
        "endOfEpochInfo": null
      },
      {
        "epoch": "215",
        "epochTotalTransactions": "1677520",
        "firstCheckpointId": "18175281",
        "epochStartTimestamp": "1699895730447",
        "endOfEpochInfo": {
          "lastCheckpointId": "18262205",
          "epochEndTimestamp": "1699982134665",
          "protocolVersion": "30",
          "referenceGasPrice": "750",
          "totalStake": "8218097924380608713",
          "storageFundReinvestment": "10516014",
          "storageCharge": "25850857686800",
          "storageRebate": "25495122687804",
          "storageFundBalance": "183546558278278",
          "stakeSubsidyAmount": "900000000000000",
          "totalGasFees": "9424721682000",
          "totalStakeRewardsDistributed": "909424711165837",
          "leftoverStorageFundInflow": "149"
        }
      }
    ],
    "nextCursor": "215",
    "hasNextPage": true
  },
  "id": "5"
}
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
