### PR TITLE
[data ingestion pipeline] optionally dump full checkpoint content to local directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10579,6 +10579,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util.workspace = true
 sui-core.workspace = true
 sui-config.workspace = true
 sui-network.workspace = true
+sui-storage.workspace = true
 sui-types.workspace = true
 sui-sdk.workspace = true
 sui-keys.workspace = true

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -415,6 +415,11 @@ pub struct CheckpointExecutorConfig {
     /// If unspecified, this will default to `10`.
     #[serde(default = "default_local_execution_timeout_sec")]
     pub local_execution_timeout_sec: u64,
+
+    /// Optional directory used for data ingestion pipeline
+    /// When specified, each executed checkpoint will be saved in a local directory for post processing
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_ingestion_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -529,6 +534,7 @@ impl Default for CheckpointExecutorConfig {
         Self {
             checkpoint_execution_max_concurrency: default_checkpoint_execution_max_concurrency(),
             local_execution_timeout_sec: default_local_execution_timeout_sec(),
+            data_ingestion_dir: None,
         }
     }
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::AuthorityStore;
+use crate::checkpoints::CheckpointStore;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use sui_storage::blob::{Blob, BlobEncoding};
+use sui_types::digests::TransactionDigest;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
+use sui_types::messages_checkpoint::VerifiedCheckpoint;
+use sui_types::storage::ObjectKey;
+
+pub(crate) fn store_checkpoint_locally(
+    path: PathBuf,
+    checkpoint: VerifiedCheckpoint,
+    authority_store: Arc<AuthorityStore>,
+    checkpoint_store: Arc<CheckpointStore>,
+    transaction_digests: Vec<TransactionDigest>,
+) -> SuiResult {
+    let checkpoint_contents = checkpoint_store
+        .get_checkpoint_contents(&checkpoint.content_digest)?
+        .expect("checkpoint content has to be stored");
+
+    let transactions = authority_store
+        .multi_get_transaction_blocks(&transaction_digests)?
+        .into_iter()
+        .zip(&transaction_digests)
+        .map(|(tx, digest)| tx.ok_or(SuiError::TransactionNotFound { digest: *digest }))
+        .collect::<SuiResult<Vec<_>>>()?;
+
+    let effects = authority_store
+        .multi_get_executed_effects(&transaction_digests)?
+        .into_iter()
+        .zip(transaction_digests)
+        .map(|(effects, digest)| effects.ok_or(SuiError::TransactionNotFound { digest }))
+        .collect::<SuiResult<Vec<_>>>()?;
+
+    let event_digests = effects
+        .iter()
+        .flat_map(|fx| fx.events_digest().copied())
+        .collect::<Vec<_>>();
+
+    let events = authority_store
+        .multi_get_events(&event_digests)?
+        .into_iter()
+        .zip(&event_digests)
+        .map(|(event, digest)| event.ok_or(SuiError::TransactionEventsNotFound { digest: *digest }))
+        .collect::<SuiResult<Vec<_>>>()?;
+
+    let events: HashMap<_, _> = event_digests.into_iter().zip(events).collect();
+    let mut full_transactions = Vec::with_capacity(transactions.len());
+    for (tx, fx) in transactions.into_iter().zip(effects) {
+        let events = fx.events_digest().map(|event_digest| {
+            events
+                .get(event_digest)
+                .cloned()
+                .expect("event was already checked to be present")
+        });
+        // Note unwrapped_then_deleted contains **updated** versions.
+        let unwrapped_then_deleted_obj_ids = fx
+            .unwrapped_then_deleted()
+            .into_iter()
+            .map(|k| k.0)
+            .collect::<HashSet<_>>();
+
+        let input_object_keys = fx
+            .input_shared_objects()
+            .into_iter()
+            .map(|kind| {
+                let (id, version) = kind.id_and_version();
+                ObjectKey(id, version)
+            })
+            .chain(
+                fx.modified_at_versions()
+                    .into_iter()
+                    .map(|(object_id, version)| ObjectKey(object_id, version)),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            // Unwrapped-then-deleted objects are not stored in state before the tx, so we have nothing to fetch.
+            .filter(|key| !unwrapped_then_deleted_obj_ids.contains(&key.0))
+            .collect::<Vec<_>>();
+
+        let input_objects = authority_store
+            .multi_get_object_by_key(&input_object_keys)?
+            .into_iter()
+            .zip(&input_object_keys)
+            .map(|(object, object_key)| {
+                object.ok_or(SuiError::UserInputError {
+                    error: UserInputError::ObjectNotFound {
+                        object_id: object_key.0,
+                        version: Some(object_key.1),
+                    },
+                })
+            })
+            .collect::<SuiResult<Vec<_>>>()?;
+
+        let output_object_keys = fx
+            .all_changed_objects()
+            .into_iter()
+            .map(|(object_ref, _owner, _kind)| ObjectKey::from(object_ref))
+            .collect::<Vec<_>>();
+
+        let output_objects = authority_store
+            .multi_get_object_by_key(&output_object_keys)?
+            .into_iter()
+            .zip(&output_object_keys)
+            .map(|(object, object_key)| {
+                object.ok_or(SuiError::UserInputError {
+                    error: UserInputError::ObjectNotFound {
+                        object_id: object_key.0,
+                        version: Some(object_key.1),
+                    },
+                })
+            })
+            .collect::<SuiResult<Vec<_>>>()?;
+
+        let full_transaction = CheckpointTransaction {
+            transaction: tx.into(),
+            effects: fx,
+            events,
+            input_objects,
+            output_objects,
+        };
+        full_transactions.push(full_transaction);
+    }
+    let file_name = format!("{}.chk", checkpoint.sequence_number);
+    let checkpoint_data = CheckpointData {
+        checkpoint_summary: checkpoint.into(),
+        checkpoint_contents,
+        transactions: full_transactions,
+    };
+
+    std::fs::create_dir_all(&path).map_err(|err| {
+        SuiError::FileIOError(format!(
+            "failed to save full checkpoint content locally {:?}",
+            err
+        ))
+    })?;
+
+    Blob::encode(&checkpoint_data, BlobEncoding::Bcs)
+        .map_err(|_| SuiError::TransactionSerializationError {
+            error: "failed to serialize full checkpoint content".to_string(),
+        }) // Map the first error
+        .and_then(|blob| {
+            std::fs::write(path.join(file_name), blob.to_bytes()).map_err(|_| {
+                SuiError::FileIOError("failed to save full checkpoint content locally".to_string())
+            })
+        })?;
+
+    Ok(())
+}

--- a/crates/sui-rest-api/src/checkpoints.rs
+++ b/crates/sui-rest-api/src/checkpoints.rs
@@ -11,15 +11,11 @@ use axum::{
     extract::{Path, State},
     Json, TypedHeader,
 };
-use serde::{Deserialize, Serialize};
+use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
 use sui_types::{
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
-    messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
-    },
-    object::Object,
+    effects::TransactionEffectsAPI,
+    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber},
     storage::ObjectKey,
-    transaction::Transaction,
 };
 
 use crate::{headers::Accept, node_state_getter::NodeStateGetter, AppError, Bcs};
@@ -161,51 +157,6 @@ pub async fn get_full_checkpoint(
         checkpoint_contents,
         transactions: full_transactions,
     }))
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointData {
-    pub checkpoint_summary: CertifiedCheckpointSummary,
-    pub checkpoint_contents: CheckpointContents,
-    pub transactions: Vec<CheckpointTransaction>,
-}
-
-impl CheckpointData {
-    pub fn output_objects(&self) -> Vec<&Object> {
-        self.transactions
-            .iter()
-            .flat_map(|tx| &tx.output_objects)
-            .collect()
-    }
-
-    pub fn input_objects(&self) -> Vec<&Object> {
-        self.transactions
-            .iter()
-            .flat_map(|tx| &tx.input_objects)
-            .collect()
-    }
-
-    pub fn all_objects(&self) -> Vec<&Object> {
-        self.transactions
-            .iter()
-            .flat_map(|tx| &tx.input_objects)
-            .chain(self.transactions.iter().flat_map(|tx| &tx.output_objects))
-            .collect()
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointTransaction {
-    /// The input Transaction
-    pub transaction: Transaction,
-    /// The effects produced by executing this transaction
-    pub effects: TransactionEffects,
-    /// The events, if any, emitted by this transaciton during execution
-    pub events: Option<TransactionEvents>,
-    /// The state of all inputs to this transaction as they were prior to execution.
-    pub input_objects: Vec<Object>,
-    /// The state of all output objects created or mutated by this transaction.
-    pub output_objects: Vec<Object>,
 }
 
 pub async fn get_latest_checkpoint(

--- a/crates/sui-rest-api/src/client.rs
+++ b/crates/sui-rest-api/src/client.rs
@@ -3,10 +3,9 @@
 
 use anyhow::Result;
 use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber};
 use sui_types::object::Object;
-
-use crate::checkpoints::CheckpointData;
 
 #[derive(Clone)]
 pub struct Client {

--- a/crates/sui-rest-api/src/lib.rs
+++ b/crates/sui-rest-api/src/lib.rs
@@ -9,9 +9,9 @@ pub mod headers;
 pub mod node_state_getter;
 mod objects;
 
-pub use checkpoints::{CheckpointData, CheckpointTransaction};
 pub use client::Client;
 use node_state_getter::NodeStateGetter;
+pub use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
 
 async fn health_check() -> StatusCode {
     StatusCode::OK

--- a/crates/sui-storage/src/blob.rs
+++ b/crates/sui-storage/src/blob.rs
@@ -72,6 +72,17 @@ impl Blob {
         blob_size += self.data.len();
         blob_size
     }
+    pub fn to_bytes(&self) -> Vec<u8> {
+        [vec![self.encoding.into()], self.data.clone()].concat()
+    }
+    pub fn from_bytes<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+        let (encoding, data) = bytes.split_first().ok_or(anyhow!("empty bytes"))?;
+        Blob {
+            data: data.to_vec(),
+            encoding: BlobEncoding::try_from(*encoding)?,
+        }
+        .decode()
+    }
 }
 
 /// An iterator over blobs in a blob file.

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -58,6 +58,7 @@ pub struct ConfigBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     overload_threshold_config: Option<OverloadThresholdConfig>,
+    data_ingestion_dir: Option<PathBuf>,
 }
 
 impl ConfigBuilder {
@@ -73,6 +74,7 @@ impl ConfigBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             overload_threshold_config: None,
+            data_ingestion_dir: None,
         }
     }
 
@@ -120,6 +122,11 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_jwk_fetch_interval(mut self, i: Duration) -> Self {
         self.jwk_fetch_interval = Some(i);
+        self
+    }
+
+    pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
+        self.data_ingestion_dir = Some(path);
         self
     }
 
@@ -194,6 +201,7 @@ impl<R> ConfigBuilder<R> {
             num_unpruned_validators: self.num_unpruned_validators,
             jwk_fetch_interval: self.jwk_fetch_interval,
             overload_threshold_config: self.overload_threshold_config,
+            data_ingestion_dir: self.data_ingestion_dir,
         }
     }
 
@@ -332,6 +340,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 if let Some(overload_threshold_config) = &self.overload_threshold_config {
                     builder =
                         builder.with_overload_threshold_config(overload_threshold_config.clone());
+                }
+
+                if let Some(path) = &self.data_ingestion_dir {
+                    builder = builder.with_data_ingestion_dir(path.clone());
                 }
 
                 if let Some(spvc) = &self.supported_protocol_versions_config {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -11,9 +11,10 @@ use std::path::PathBuf;
 use std::time::Duration;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
-    AuthorityKeyPairWithPath, AuthorityStorePruningConfig, DBCheckpointConfig,
-    ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath, OverloadThresholdConfig,
-    StateArchiveConfig, StateSnapshotConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT,
+    AuthorityKeyPairWithPath, AuthorityStorePruningConfig, CheckpointExecutorConfig,
+    DBCheckpointConfig, ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath,
+    OverloadThresholdConfig, StateArchiveConfig, StateSnapshotConfig,
+    DEFAULT_GRPC_CONCURRENCY_LIMIT,
 };
 use sui_config::node::{default_zklogin_oauth_providers, ConsensusProtocol};
 use sui_config::p2p::{P2pConfig, SeedPeer};
@@ -34,6 +35,7 @@ pub struct ValidatorConfigBuilder {
     force_unpruned_checkpoints: bool,
     jwk_fetch_interval: Option<Duration>,
     overload_threshold_config: Option<OverloadThresholdConfig>,
+    data_ingestion_dir: Option<PathBuf>,
 }
 
 impl ValidatorConfigBuilder {
@@ -68,6 +70,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
         self.overload_threshold_config = Some(config);
+        self
+    }
+
+    pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
+        self.data_ingestion_dir = Some(path);
         self
     }
 
@@ -129,6 +136,10 @@ impl ValidatorConfigBuilder {
             pruning_config.set_num_epochs_to_retain_for_checkpoints(None);
         }
         let pruning_config = pruning_config;
+        let checkpoint_executor_config = CheckpointExecutorConfig {
+            data_ingestion_dir: self.data_ingestion_dir,
+            ..Default::default()
+        };
 
         NodeConfig {
             protocol_key_pair: AuthorityKeyPairWithPath::new(validator.key_pair),
@@ -152,7 +163,7 @@ impl ValidatorConfigBuilder {
             authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:
                 default_end_of_epoch_broadcast_channel_capacity(),
-            checkpoint_executor_config: Default::default(),
+            checkpoint_executor_config,
             metrics: None,
             supported_protocol_versions: self.supported_protocol_versions,
             db_checkpoint_config: Default::default(),

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -45,6 +45,7 @@ pub struct SwarmBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     overload_threshold_config: Option<OverloadThresholdConfig>,
+    data_ingestion_dir: Option<PathBuf>,
 }
 
 impl SwarmBuilder {
@@ -66,6 +67,7 @@ impl SwarmBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             overload_threshold_config: None,
+            data_ingestion_dir: None,
         }
     }
 }
@@ -89,6 +91,7 @@ impl<R> SwarmBuilder<R> {
             jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
             overload_threshold_config: self.overload_threshold_config,
+            data_ingestion_dir: self.data_ingestion_dir,
         }
     }
 
@@ -219,6 +222,11 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
+        self.data_ingestion_dir = Some(path);
+        self
+    }
+
     fn get_or_init_genesis_config(&mut self) -> &mut GenesisConfig {
         if self.genesis_config.is_none() {
             assert!(self.network_config.is_none());
@@ -256,6 +264,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             if let Some(overload_threshold_config) = self.overload_threshold_config {
                 config_builder =
                     config_builder.with_overload_threshold_config(overload_threshold_config);
+            }
+
+            if let Some(path) = self.data_ingestion_dir {
+                config_builder = config_builder.with_data_ingestion_dir(path);
             }
 
             config_builder

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::effects::{TransactionEffects, TransactionEvents};
+use crate::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
+use crate::object::Object;
+use crate::transaction::Transaction;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointData {
+    pub checkpoint_summary: CertifiedCheckpointSummary,
+    pub checkpoint_contents: CheckpointContents,
+    pub transactions: Vec<CheckpointTransaction>,
+}
+
+impl CheckpointData {
+    pub fn output_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.output_objects)
+            .collect()
+    }
+
+    pub fn input_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.input_objects)
+            .collect()
+    }
+
+    pub fn all_objects(&self) -> Vec<&Object> {
+        self.transactions
+            .iter()
+            .flat_map(|tx| &tx.input_objects)
+            .chain(self.transactions.iter().flat_map(|tx| &tx.output_objects))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointTransaction {
+    /// The input Transaction
+    pub transaction: Transaction,
+    /// The effects produced by executing this transaction
+    pub effects: TransactionEffects,
+    /// The events, if any, emitted by this transaciton during execution
+    pub events: Option<TransactionEvents>,
+    /// The state of all inputs to this transaction as they were prior to execution.
+    pub input_objects: Vec<Object>,
+    /// The state of all output objects created or mutated by this transaction.
+    pub output_objects: Vec<Object>,
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -44,6 +44,7 @@ pub mod executable_transaction;
 pub mod execution;
 pub mod execution_mode;
 pub mod execution_status;
+pub mod full_checkpoint_content;
 pub mod gas;
 pub mod gas_coin;
 pub mod gas_model;

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -655,6 +655,7 @@ pub struct TestClusterBuilder {
     config_dir: Option<PathBuf>,
     default_jwks: bool,
     overload_threshold_config: Option<OverloadThresholdConfig>,
+    data_ingestion_dir: Option<PathBuf>,
 }
 
 impl TestClusterBuilder {
@@ -675,6 +676,7 @@ impl TestClusterBuilder {
             config_dir: None,
             default_jwks: false,
             overload_threshold_config: None,
+            data_ingestion_dir: None,
         }
     }
 
@@ -819,6 +821,11 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
+        self.data_ingestion_dir = Some(path);
+        self
+    }
+
     pub async fn build(mut self) -> TestCluster {
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to supply
@@ -926,6 +933,10 @@ impl TestClusterBuilder {
 
         if let Some(config_dir) = self.config_dir.take() {
             builder = builder.dir(config_dir);
+        }
+
+        if let Some(data_ingestion_dir) = self.data_ingestion_dir.take() {
+            builder = builder.with_data_ingestion_dir(data_ingestion_dir);
         }
 
         let mut swarm = builder.build();


### PR DESCRIPTION
## Description  
first step in implementing a new data ingestion pipeline.
Adds a new optional setting to FN. When enabled, FN will dump the full checkpoint content into the specified local directory. This directory will be used by an external daemon for post-processing

## Test Plan 

added simtest
