### PR TITLE
Explicitly add that the gas values are in MIST

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1110,8 +1110,8 @@ pub struct SuiGasData {
 impl Display for SuiGasData {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "Gas Owner: {}", self.owner)?;
-        writeln!(f, "Gas Budget: {}", self.budget)?;
-        writeln!(f, "Gas Price: {}", self.price)?;
+        writeln!(f, "Gas Budget: {} MIST", self.budget)?;
+        writeln!(f, "Gas Price: {} MIST", self.price)?;
         writeln!(f, "Gas Payment:")?;
         for payment in &self.payment {
             write!(f, "{} ", objref_string(payment))?;


### PR DESCRIPTION
## Description 

Explicitly add that the gas values are in MIST

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The gas price and budget are shown in MIST, but this is not explicitly stated when a transaction is retrieved or performed through the CLI. This change adds the word MIST after the gas's price and budget's respective value.