### PR TITLE
[cli] improve and fix the way transaction data is formatted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11013,6 +11013,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-types",
  "tabled",
+ "terminal_size",
  "tracing",
  "workspace-hack",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,6 +451,7 @@ sysinfo = "0.27.5"
 tabled = { version = "0.12" }
 tap = "1.0.1"
 tempfile = "3.3.0"
+terminal_size = "0.2.6"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 tiny-bip39 = "1.0.0"

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -23,6 +23,7 @@ sui-enum-compat-util.workspace = true
 enum_dispatch.workspace = true
 json_to_table.workspace = true
 tabled.workspace = true
+terminal_size.workspace = true
 
 move-binary-format.workspace = true
 move-core-types.workspace = true

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -33,6 +33,7 @@ mod sui_move;
 mod sui_object;
 mod sui_protocol;
 mod sui_transaction;
+mod utils;
 
 pub type DynamicFieldPage = Page<DynamicFieldInfo, ObjectID>;
 /// `next_cursor` points to the last item in the page;

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -151,7 +151,7 @@ impl Display for SuiEvent {
 }
 
 /// Convert a json array of bytes to Base64
-fn bytes_array_to_base64(v: &mut Value) {
+pub(crate) fn bytes_array_to_base64(v: &mut Value) {
     match v {
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => (),
         Value::Array(vals) => {
@@ -172,7 +172,7 @@ fn bytes_array_to_base64(v: &mut Value) {
 }
 
 /// Try to convert a json Value object into an u8.
-fn try_into_byte(v: &Value) -> Option<u8> {
+pub(crate) fn try_into_byte(v: &Value) -> Option<u8> {
     let num = v.as_u64()?;
     (num <= 255).then_some(num as u8)
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1401,12 +1401,9 @@ impl Display for SuiProgrammableTransactionBlock {
 
         if !inputs.is_empty() {
             writeln!(f, "Inputs:")?;
-
             for input in inputs {
                 write!(f, "{input}")?;
             }
-        } else {
-            writeln!(f, "No inputs")?;
         }
         if !commands.is_empty() {
             writeln!(f, "Transactions:\n ┌──")?;
@@ -1414,8 +1411,6 @@ impl Display for SuiProgrammableTransactionBlock {
                 writeln!(f, " │ {c}")?;
             }
             write!(f, " └──")?;
-        } else {
-            writeln!(f, "No transactions")?;
         }
         Ok(())
     }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -4,7 +4,8 @@
 use crate::balance_changes::BalanceChange;
 use crate::object_changes::ObjectChange;
 use crate::sui_transaction::GenericSignature::Signature;
-use crate::{bytes_array_to_base64, Filter, Page, SuiEvent, SuiObjectRef};
+use crate::utils::bytes_array_to_base64;
+use crate::{Filter, Page, SuiEvent, SuiObjectRef};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
 use move_binary_format::access::ModuleAccess;

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1240,9 +1240,7 @@ impl Display for SuiTransactionBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut builder = TableBuilder::default();
         let width = get_terminal_width();
-        let term_size_settings = TableSettings::default()
-            .with(TableWidth::wrap(width))
-            .with(TableWidth::increase(width));
+        let term_size_settings = TableSettings::default().with(TableWidth::wrap(width));
 
         builder.push_record(vec![format!("{}", self.data)]);
         builder.push_record(vec![format!("Signatures:")]);
@@ -2014,7 +2012,7 @@ impl Display for SuiObjectArg {
                 digest,
             } => write!(
                 f,
-                " ┌── ImmOrOwnedObject\n │ ObjectID: {} \n │ Version: {} \n │ Digest: {}\n └──",
+                " ┌── ImmOrOwnedObject\n │ ID: {} \n │ Version: {} \n │ Digest: {}\n └──",
                 object_id,
                 version.value(),
                 digest
@@ -2026,7 +2024,7 @@ impl Display for SuiObjectArg {
             } => {
                 write!(
                     f,
-                    " ┌── SharedObject\n │ ObjectID: {} \n │ Initial Shared Version: {} \n │ Mutable: {}\n └──",
+                    " ┌── SharedObject\n │ ID: {} \n │ Initial Shared Version: {} \n │ Mutable: {}\n └──",
                     object_id,
                     initial_shared_version.value(),
                     mutable
@@ -2038,7 +2036,7 @@ impl Display for SuiObjectArg {
                 digest,
             } => write!(
                 f,
-                " ┌── ReceivingObject\n │ ObjectID: {} \n │ Version: {} \n │ Digest: {}\n └──",
+                " ┌── ReceivingObject\n │ ID: {} \n │ Version: {} \n │ Digest: {}\n └──",
                 object_id,
                 version.value(),
                 digest

--- a/crates/sui-json-rpc-types/src/utils.rs
+++ b/crates/sui-json-rpc-types/src/utils.rs
@@ -1,0 +1,29 @@
+use fastcrypto::encoding::Base64;
+use serde_json::{json, Value};
+
+/// Convert a json array of bytes to Base64
+pub(crate) fn bytes_array_to_base64(v: &mut Value) {
+    match v {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => (),
+        Value::Array(vals) => {
+            if let Some(vals) = vals.iter().map(try_into_byte).collect::<Option<Vec<_>>>() {
+                *v = json!(Base64::from_bytes(&vals).encoded())
+            } else {
+                for val in vals {
+                    bytes_array_to_base64(val)
+                }
+            }
+        }
+        Value::Object(map) => {
+            for val in map.values_mut() {
+                bytes_array_to_base64(val)
+            }
+        }
+    }
+}
+
+/// Try to convert a json Value object into an u8.
+pub(crate) fn try_into_byte(v: &Value) -> Option<u8> {
+    let num = v.as_u64()?;
+    (num <= 255).then_some(num as u8)
+}


### PR DESCRIPTION
## Description 

This PR improves the way TransactionData is formatted in the CLI. There was an issue where an input of type PureValue of bcs data was too big, and it was completely messing the table. I fixed that and also have improved the formatting output for `SuiCallArg`, `SuiPureValue`. Importantly, if there is BCS data, it gets transformed into Base64. 

Finally, the `Transaction Data` table is wrapped around the terminal's size; it works well with terminals above 130-140 characters. Still need to fiddle a bit with it, but for now, this should work nicely. 

Here's the complete output. 
https://gist.github.com/stefan-mysten/19c23796c701f52320c8fb56ad50b275

## Test Plan 

<img width="2472" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/5ac23b19-7ded-441c-a2af-4e5fe725b273">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improves the way transaction data is formatted in the CLI.