### PR TITLE
Update client-tssdk.mdx for Fixing bug in OwnedObjects component

### DIFF
--- a/docs/content/guides/developer/first-app/client-tssdk.mdx
+++ b/docs/content/guides/developer/first-app/client-tssdk.mdx
@@ -183,9 +183,8 @@ function ConnectedAccount() {
 
 function OwnedObjects({ address }: { address: string }) {
     const { data } = useSuiClientQuery('getOwnedObjects', {
-        owner: account?.address as string,
+        owner: address, 
     });
-
     if (!data) {
         return null;
     }


### PR DESCRIPTION
## Description 
The useSuiClientQuery 'owner' parameter was incorrectly set to 'account?.address', causing a bug. This has been fixed by correctly setting it to the 'address' prop passed to the OwnedObjects component.

