### PR TITLE
[Sui] do not record ignored consensus transaction as processed

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2199,7 +2199,7 @@ impl AuthorityPerEpochStore {
 
         for tx in transactions {
             let key = tx.0.transaction.key();
-            self.record_consensus_message_processed(batch, key.clone())?;
+            let mut ignored = false;
             match self
                 .process_consensus_transaction(
                     batch,
@@ -2210,19 +2210,24 @@ impl AuthorityPerEpochStore {
                 .await?
             {
                 ConsensusCertificateResult::SuiTransaction(cert) => {
-                    notifications.push(key);
+                    notifications.push(key.clone());
                     verified_certificates.push(cert);
                 }
                 ConsensusCertificateResult::Defered(deferral_key) => {
-                    // Note: record_consensus_message_processed() must have been called for this
+                    // Note: record_consensus_message_processed() must be called for this
                     // cert even though we are not processing it now!
                     deferred_txns
                         .entry(deferral_key)
                         .or_default()
                         .push(tx.clone());
                 }
-                ConsensusCertificateResult::ConsensusMessage => notifications.push(key),
-                ConsensusCertificateResult::Ignored => (),
+                ConsensusCertificateResult::ConsensusMessage => notifications.push(key.clone()),
+                // Note: ignored transactions must not be recorded as processed. Otherwise
+                // they may not get reverted after restart during epoch change.
+                ConsensusCertificateResult::Ignored => ignored = true,
+            }
+            if !ignored {
+                self.record_consensus_message_processed(batch, key.clone())?;
             }
         }
 


### PR DESCRIPTION
## Description 

In #14087, we thought it is ok to set the processed bit for every transaction in the consensus output. But it turns out setting ignored transaction to `processed` may prevent reverting transactions, if a validator restarts during epoch change.

This change only avoid setting the `processed` bit for ignored transactions. It does not completely restore the behavior before #14087.

## Test Plan 

Ran on `simtest-01` CI machine:
```
SIM_STRESS_TEST_DURATION_SECS=300  USE_MOCK_CRYPTO=1 MSIM_TEST_NUM=60 cargo simtest test_simulated_load_reconfig_with_crashes_and_delays
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
