### PR TITLE
Create an integration test to test object pruning

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -616,7 +616,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: false,
+            enable_pruning_tombstones: true,
         }
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3139,6 +3139,13 @@ impl AuthorityState {
             })
     }
 
+    #[cfg(msim)]
+    pub fn get_highest_pruned_checkpoint(&self) -> SuiResult<CheckpointSequenceNumber> {
+        self.database
+            .perpetual_tables
+            .get_highest_pruned_checkpoint()
+    }
+
     #[instrument(level = "trace", skip_all)]
     pub fn get_checkpoint_summary_by_sequence_number(
         &self,
@@ -4290,6 +4297,7 @@ impl AuthorityState {
     pub async fn prune_objects_and_compact_for_testing(&self) {
         let pruning_config = AuthorityStorePruningConfig {
             num_epochs_to_retain: 0,
+            enable_pruning_tombstones: true,
             ..Default::default()
         };
         let _ = AuthorityStorePruner::prune_objects_for_eligible_epochs(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1993,6 +1993,19 @@ impl AuthorityStore {
         info!("Removing all versions of object: {:?}", entries);
         self.perpetual_tables.objects.multi_remove(entries).unwrap();
     }
+
+    // Counts the number of versions exist in object store for `object_id`. This includes tombstone.
+    #[cfg(msim)]
+    pub fn count_object_versions(&self, object_id: ObjectID) -> usize {
+        self.perpetual_tables
+            .objects
+            .iter_with_bounds(
+                Some(ObjectKey(object_id, VersionNumber::MIN)),
+                Some(ObjectKey(object_id, VersionNumber::MAX)),
+            )
+            .collect::<Vec<_>>()
+            .len()
+    }
 }
 
 impl BackingPackageStore for AuthorityStore {

--- a/crates/sui-e2e-tests/tests/object_deletion_tests.rs
+++ b/crates/sui-e2e-tests/tests/object_deletion_tests.rs
@@ -4,14 +4,17 @@
 #[cfg(msim)]
 mod sim_only_tests {
     use std::path::PathBuf;
+    use std::time::Duration;
     use sui_core::authority::authority_store_tables::LiveObject;
     use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
     use sui_macros::sim_test;
     use sui_node::SuiNode;
     use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
     use sui_test_transaction_builder::publish_package;
-    use sui_types::base_types::ObjectID;
+    use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+    use sui_types::{base_types::ObjectID, digests::TransactionDigest};
     use test_cluster::{TestCluster, TestClusterBuilder};
+    use tokio::time::timeout;
 
     /// This test checks that after we enable simplified_unwrap_then_delete, we no longer depend
     /// on wrapped tombstones when generating effects and using effects.
@@ -64,6 +67,94 @@ mod sim_only_tests {
         assert_eq!(effects.unwrapped_then_deleted().len(), 1);
 
         test_cluster.trigger_reconfiguration().await;
+    }
+
+    // Tests that object pruning can prune objects correctly.
+    // Specifically, we first wrap a child object into a root object (tests wrap tombstone),
+    // then unwrap and delete the child object (tests unwrap and delete),
+    // and last delete the root object (tests object deletion).
+    #[sim_test]
+    async fn object_pruning_test() {
+        let test_cluster = TestClusterBuilder::new().build().await;
+        let fullnode = &test_cluster.fullnode_handle.sui_node;
+
+        // Create a root object and a child object. Wrap the child object inside the root object.
+        let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
+        let child_id = create_owned_child(&test_cluster, package_id).await;
+        let wrap_child_txn_digest = wrap_child(&test_cluster, package_id, object_id, child_id)
+            .await
+            .transaction_digest()
+            .clone();
+
+        fullnode
+            .with_async(|node| async {
+                // Wait until the wraping transaction is included in checkpoint.
+                let checkpoint = timeout(
+                    Duration::from_secs(60),
+                    wait_until_txn_in_checkpoint(node, &wrap_child_txn_digest),
+                )
+                .await
+                .unwrap();
+
+                // Wait until the above checkpoint is pruned.
+                let _ = timeout(
+                    Duration::from_secs(60),
+                    wait_until_checkpoint_pruned(node, checkpoint),
+                )
+                .await
+                .unwrap();
+
+                // Manually initiating a pruning and compaction job to make sure that deleted objects are gong from object store.
+                node.state().prune_objects_and_compact_for_testing().await;
+
+                // Check that no object with `child_id` exists in object store.
+                assert_eq!(node.state().db().count_object_versions(child_id), 0);
+                assert!(node.state().db().count_object_versions(object_id) > 0);
+            })
+            .await;
+
+        // Next, we unwrap and delete the child object, as well as delete the root object.
+        let unwrap_delete_txn_digest =
+            unwrap_and_delete_child(&test_cluster, package_id, object_id)
+                .await
+                .transaction_digest()
+                .clone();
+        let delete_root_obj_txn_digest = delete_object(&test_cluster, package_id, object_id)
+            .await
+            .transaction_digest()
+            .clone();
+
+        fullnode
+            .with_async(|node| async {
+                // Wait for both transactions to be included in checkpoint.
+                let checkpoint1 = timeout(
+                    Duration::from_secs(60),
+                    wait_until_txn_in_checkpoint(node, &unwrap_delete_txn_digest),
+                )
+                .await
+                .unwrap();
+                let checkpoint2 = timeout(
+                    Duration::from_secs(60),
+                    wait_until_txn_in_checkpoint(node, &delete_root_obj_txn_digest),
+                )
+                .await
+                .unwrap();
+
+                let _ = timeout(
+                    Duration::from_secs(60),
+                    wait_until_checkpoint_pruned(node, std::cmp::max(checkpoint1, checkpoint2)),
+                )
+                .await
+                .unwrap();
+
+                // Manually initiating a pruning and compaction job to make sure that deleted objects are gong from object store.
+                node.state().prune_objects_and_compact_for_testing().await;
+
+                // Check that both root and child objects are gone from object store.
+                assert_eq!(node.state().db().count_object_versions(child_id), 0);
+                assert_eq!(node.state().db().count_object_versions(object_id), 0);
+            })
+            .await;
     }
 
     async fn publish_package_and_create_parent_object(
@@ -172,6 +263,27 @@ mod sim_only_tests {
         effects
     }
 
+    async fn delete_object(
+        test_cluster: &TestCluster,
+        package_id: ObjectID,
+        object_id: ObjectID,
+    ) -> SuiTransactionBlockEffects {
+        let object = test_cluster.wallet.get_object_ref(object_id).await.unwrap();
+        let effects = test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(package_id, "objects", "delete", vec![object.into()])
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap();
+        assert_eq!(effects.deleted().len(), 1);
+        effects
+    }
+
     fn count_fullnode_wrapped_tombstones(test_cluster: &TestCluster) -> usize {
         test_cluster
             .fullnode_handle
@@ -184,5 +296,31 @@ mod sim_only_tests {
         db.iter_live_object_set(true)
             .filter(|o| matches!(o, LiveObject::Wrapped(_)))
             .count()
+    }
+
+    async fn wait_until_txn_in_checkpoint(
+        node: &SuiNode,
+        digest: &TransactionDigest,
+    ) -> CheckpointSequenceNumber {
+        loop {
+            if let Some(seq) = node
+                .state()
+                .epoch_store_for_testing()
+                .get_transaction_checkpoint(&digest)
+                .unwrap()
+            {
+                return seq;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    async fn wait_until_checkpoint_pruned(node: &SuiNode, checkpoint: CheckpointSequenceNumber) {
+        loop {
+            if node.state().get_highest_pruned_checkpoint().unwrap() >= checkpoint {
+                return;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 }

--- a/crates/sui-surfer/tests/move_building_blocks/sources/objects.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/objects.move
@@ -115,6 +115,17 @@ module move_building_blocks::objects {
             delete_child(child);
         }
     }
+    
+    public fun delete(object: Object) {
+        let Object { id, wrapped, table } = object;
+        object::delete(id);
+        if (option::is_some(&wrapped)) {
+            let child = option::extract(&mut wrapped);
+            delete_child(child);
+        };
+        option::destroy_none(wrapped);
+        table::destroy_empty(table);
+    }
 
     fun new_object(ctx: &mut TxContext): Object {
         Object {

--- a/sui-execution/v0/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/v0/sui-verifier/src/id_leak_verifier.rs
@@ -84,7 +84,7 @@ const SUI_CLOCK_CREATE: FunctionIdent = (
 );
 
 // Note: the authenticator/randomness objects should never exist when v0 execution is being used.
-// However, unwrapped_then_deleted_tests.rs forcibly sets the execution version to 0, so we need
+// However, object_deletion_tests.rs forcibly sets the execution version to 0, so we need
 // to handle this case. Since that test only runs in the simulator we can special case it with
 // cfg(msim) so that we don't risk breaking release builds.
 #[cfg(msim)]


### PR DESCRIPTION
## Description 

Modified unwrapped_then_deleted_tests.rs to add the pruning test there, since both are testing object deletion.

Will turn on tombstone pruning by default the next PR.

## Test Plan 

How did you test the new or updated feature?

This PR

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
