### PR TITLE
add ability to customize overload threshold in TestCluster

### DIFF
--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -6,6 +6,7 @@ use futures::join;
 use rand::distributions::Distribution;
 use std::ops::Deref;
 use std::time::{Duration, SystemTime};
+use sui_config::node::OverloadThresholdConfig;
 use sui_core::authority::EffectsNotifyRead;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
@@ -528,7 +529,13 @@ async fn access_clock_object_test() {
 
 #[sim_test]
 async fn shared_object_sync() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        // Set the threshold high enough so it won't be triggered.
+        .with_overload_threshold_config(OverloadThresholdConfig {
+            max_txn_age_in_queue: Duration::from_secs(60),
+        })
+        .build()
+        .await;
     let package_id = publish_basics_package(&test_cluster.wallet).await.0;
 
     // Since we use submit_transaction_to_validators in this test, which does not go through fullnode,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use std::{num::NonZeroUsize, path::Path, sync::Arc};
 use sui_config::genesis::{TokenAllocation, TokenDistributionScheduleBuilder};
+use sui_config::node::OverloadThresholdConfig;
 use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::base_types::{AuthorityName, SuiAddress};
 use sui_types::committee::{Committee, ProtocolVersion};
@@ -56,6 +57,7 @@ pub struct ConfigBuilder<R = OsRng> {
     additional_objects: Vec<Object>,
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
+    overload_threshold_config: Option<OverloadThresholdConfig>,
 }
 
 impl ConfigBuilder {
@@ -70,6 +72,7 @@ impl ConfigBuilder {
             additional_objects: vec![],
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
+            overload_threshold_config: None,
         }
     }
 
@@ -174,6 +177,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_overload_threshold_config(mut self, c: OverloadThresholdConfig) -> Self {
+        self.overload_threshold_config = Some(c);
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> ConfigBuilder<N> {
         ConfigBuilder {
             rng: Some(rng),
@@ -185,6 +193,7 @@ impl<R> ConfigBuilder<R> {
             additional_objects: self.additional_objects,
             num_unpruned_validators: self.num_unpruned_validators,
             jwk_fetch_interval: self.jwk_fetch_interval,
+            overload_threshold_config: self.overload_threshold_config,
         }
     }
 
@@ -318,6 +327,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
 
                 if let Some(jwk_fetch_interval) = self.jwk_fetch_interval {
                     builder = builder.with_jwk_fetch_interval(jwk_fetch_interval);
+                }
+
+                if let Some(overload_threshold_config) = &self.overload_threshold_config {
+                    builder =
+                        builder.with_overload_threshold_config(overload_threshold_config.clone());
                 }
 
                 if let Some(spvc) = &self.supported_protocol_versions_config {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
     AuthorityKeyPairWithPath, AuthorityStorePruningConfig, DBCheckpointConfig,
-    ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath, StateArchiveConfig, StateSnapshotConfig,
-    DEFAULT_GRPC_CONCURRENCY_LIMIT,
+    ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath, OverloadThresholdConfig,
+    StateArchiveConfig, StateSnapshotConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT,
 };
 use sui_config::node::{default_zklogin_oauth_providers, ConsensusProtocol};
 use sui_config::p2p::{P2pConfig, SeedPeer};
@@ -33,6 +33,7 @@ pub struct ValidatorConfigBuilder {
     supported_protocol_versions: Option<SupportedProtocolVersions>,
     force_unpruned_checkpoints: bool,
     jwk_fetch_interval: Option<Duration>,
+    overload_threshold_config: Option<OverloadThresholdConfig>,
 }
 
 impl ValidatorConfigBuilder {
@@ -62,6 +63,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_jwk_fetch_interval(mut self, i: Duration) -> Self {
         self.jwk_fetch_interval = Some(i);
+        self
+    }
+
+    pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
+        self.overload_threshold_config = Some(config);
         self
     }
 
@@ -171,7 +177,7 @@ impl ValidatorConfigBuilder {
                 .map(|i| i.as_secs())
                 .unwrap_or(3600),
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
-            overload_threshold_config: Default::default(),
+            overload_threshold_config: self.overload_threshold_config.unwrap_or_default(),
         }
     }
 

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -13,7 +13,7 @@ use std::{
     mem, ops,
     path::{Path, PathBuf},
 };
-use sui_config::node::DBCheckpointConfig;
+use sui_config::node::{DBCheckpointConfig, OverloadThresholdConfig};
 use sui_config::NodeConfig;
 use sui_node::SuiNodeHandle;
 use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
@@ -44,6 +44,7 @@ pub struct SwarmBuilder<R = OsRng> {
     db_checkpoint_config: DBCheckpointConfig,
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
+    overload_threshold_config: Option<OverloadThresholdConfig>,
 }
 
 impl SwarmBuilder {
@@ -64,6 +65,7 @@ impl SwarmBuilder {
             db_checkpoint_config: DBCheckpointConfig::default(),
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
+            overload_threshold_config: None,
         }
     }
 }
@@ -86,6 +88,7 @@ impl<R> SwarmBuilder<R> {
             db_checkpoint_config: self.db_checkpoint_config,
             jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
+            overload_threshold_config: self.overload_threshold_config,
         }
     }
 
@@ -207,6 +210,15 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_overload_threshold_config(
+        mut self,
+        overload_threshold_config: OverloadThresholdConfig,
+    ) -> Self {
+        assert!(self.network_config.is_none());
+        self.overload_threshold_config = Some(overload_threshold_config);
+        self
+    }
+
     fn get_or_init_genesis_config(&mut self) -> &mut GenesisConfig {
         if self.genesis_config.is_none() {
             assert!(self.network_config.is_none());
@@ -239,6 +251,11 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
             if let Some(jwk_fetch_interval) = self.jwk_fetch_interval {
                 config_builder = config_builder.with_jwk_fetch_interval(jwk_fetch_interval);
+            }
+
+            if let Some(overload_threshold_config) = self.overload_threshold_config {
+                config_builder =
+                    config_builder.with_overload_threshold_config(overload_threshold_config);
             }
 
             config_builder

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use sui_config::node::DBCheckpointConfig;
+use sui_config::node::{DBCheckpointConfig, OverloadThresholdConfig};
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{NodeConfig, PersistedConfig, SUI_KEYSTORE_FILENAME};
 use sui_core::authority_aggregator::AuthorityAggregator;
@@ -654,6 +654,7 @@ pub struct TestClusterBuilder {
     jwk_fetch_interval: Option<Duration>,
     config_dir: Option<PathBuf>,
     default_jwks: bool,
+    overload_threshold_config: Option<OverloadThresholdConfig>,
 }
 
 impl TestClusterBuilder {
@@ -673,6 +674,7 @@ impl TestClusterBuilder {
             jwk_fetch_interval: None,
             config_dir: None,
             default_jwks: false,
+            overload_threshold_config: None,
         }
     }
 
@@ -811,6 +813,12 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
+        assert!(self.network_config.is_none());
+        self.overload_threshold_config = Some(config);
+        self
+    }
+
     pub async fn build(mut self) -> TestCluster {
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to supply
@@ -899,6 +907,10 @@ impl TestClusterBuilder {
 
         if let Some(network_config) = self.network_config.take() {
             builder = builder.with_network_config(network_config);
+        }
+
+        if let Some(overload_threshold_config) = self.overload_threshold_config.take() {
+            builder = builder.with_overload_threshold_config(overload_threshold_config);
         }
 
         if let Some(fullnode_rpc_port) = self.fullnode_rpc_port {


### PR DESCRIPTION
## Description 

Originally I was going to just make the overload threshold high for tests by default to fix the `shared_object_sync` simtest failure, but I thought it would be useful to be able to customize it as we add more parameters to the config and may want to test these out in tests.

## Test Plan 

Test itself.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
