### PR TITLE
remove run_book_examples_move_unit_tests after cleaning old doc folder

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -81,19 +81,6 @@ fn run_docs_examples_move_unit_tests() -> io::Result<()> {
     Ok(())
 }
 
-#[test]
-#[cfg_attr(msim, ignore)]
-fn run_book_examples_move_unit_tests() {
-    let path = {
-        let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        buf.extend(["..", "..", "doc", "book", "examples"]);
-        buf
-    };
-
-    check_package_builds(path.clone());
-    check_move_unit_tests(path);
-}
-
 /// Ensure packages build outside of test mode.
 fn check_package_builds(path: PathBuf) {
     let mut config = BuildConfig::new_for_testing();


### PR DESCRIPTION
## Description 

https://github.com/MystenLabs/sui/pull/14808/ deletes the doc folder so this test is no longer valid.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
remove run_book_examples_move_unit_tests after cleaning old doc folder
