### PR TITLE
Turn on tombstone pruning by default

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -560,16 +560,9 @@ pub struct AuthorityStorePruningConfig {
     /// number of epochs to keep the latest version of transactions and effects for
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_epochs_to_retain_for_checkpoints: Option<u64>,
-    /// enables pruner to prune no longer needed object tombstones. We don't serialize it if it is the default value, true.
-    #[serde(
-        default = "default_enable_pruning_tombstones",
-        skip_serializing_if = "Clone::clone"
-    )]
-    pub enable_pruning_tombstones: bool,
-}
-
-fn default_enable_pruning_tombstones() -> bool {
-    true
+    /// disables object tombstone pruning. We don't serialize it if it is the default value, false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub killswitch_tombstone_pruning: bool,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -586,7 +579,7 @@ impl Default for AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: None,
-            enable_pruning_tombstones: true,
+            killswitch_tombstone_pruning: false,
         }
     }
 }
@@ -606,7 +599,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: true,
+            killswitch_tombstone_pruning: false,
         }
     }
     pub fn fullnode_config() -> Self {
@@ -623,7 +616,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: true,
+            killswitch_tombstone_pruning: false,
         }
     }
 
@@ -644,8 +637,8 @@ impl AuthorityStorePruningConfig {
             })
     }
 
-    pub fn set_enable_pruning_tombstones(&mut self, enable_pruning_tombstones: bool) {
-        self.enable_pruning_tombstones = enable_pruning_tombstones;
+    pub fn set_killswitch_tombstone_pruning(&mut self, killswitch_tombstone_pruning: bool) {
+        self.killswitch_tombstone_pruning = killswitch_tombstone_pruning;
     }
 }
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -560,9 +560,16 @@ pub struct AuthorityStorePruningConfig {
     /// number of epochs to keep the latest version of transactions and effects for
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_epochs_to_retain_for_checkpoints: Option<u64>,
-    /// enables pruner to prune no longer needed object tombstones. We don't serialize it if it is the default value, false.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    /// enables pruner to prune no longer needed object tombstones. We don't serialize it if it is the default value, true.
+    #[serde(
+        default = "default_enable_pruning_tombstones",
+        skip_serializing_if = "Clone::clone"
+    )]
     pub enable_pruning_tombstones: bool,
+}
+
+fn default_enable_pruning_tombstones() -> bool {
+    true
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -579,7 +586,7 @@ impl Default for AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: None,
-            enable_pruning_tombstones: false,
+            enable_pruning_tombstones: true,
         }
     }
 }
@@ -599,7 +606,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints,
-            enable_pruning_tombstones: false,
+            enable_pruning_tombstones: true,
         }
     }
     pub fn fullnode_config() -> Self {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4297,7 +4297,6 @@ impl AuthorityState {
     pub async fn prune_objects_and_compact_for_testing(&self) {
         let pruning_config = AuthorityStorePruningConfig {
             num_epochs_to_retain: 0,
-            enable_pruning_tombstones: true,
             ..Default::default()
         };
         let _ = AuthorityStorePruner::prune_objects_for_eligible_epochs(

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -423,7 +423,7 @@ impl AuthorityStorePruner {
                             checkpoint_number,
                             metrics.clone(),
                             indirect_objects_threshold,
-                            config.enable_pruning_tombstones,
+                            !config.killswitch_tombstone_pruning,
                         )
                         .await?
                     }
@@ -453,7 +453,7 @@ impl AuthorityStorePruner {
                         checkpoint_number,
                         metrics.clone(),
                         indirect_objects_threshold,
-                        config.enable_pruning_tombstones,
+                        !config.killswitch_tombstone_pruning,
                     )
                     .await?
                 }

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -253,7 +253,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             .protocol_config()
             .simplified_unwrap_then_delete()
         {
-            pruning_config.set_enable_pruning_tombstones(false);
+            // We cannot prune tombstones if simplified_unwrap_then_delete is not enabled.
+            pruning_config.set_killswitch_tombstone_pruning(true);
         }
         let state = AuthorityState::new(
             name,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -569,7 +569,8 @@ impl SuiNode {
             .protocol_config()
             .simplified_unwrap_then_delete()
         {
-            pruning_config.set_enable_pruning_tombstones(false);
+            // We cannot prune tombstones if simplified_unwrap_then_delete is not enabled.
+            pruning_config.set_killswitch_tombstone_pruning(true);
         }
 
         let state = AuthorityState::new(


### PR DESCRIPTION
## Description 

Leaving the config option there for now in case we need to turn it off for emergency.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
