### PR TITLE
Fix local network command doc

### DIFF
--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -11,10 +11,11 @@ If you haven't already, you need to [install Sui](./sui-install.mdx) on your sys
 To start the local network, run the following command from your `sui` root folder.
 
 ```bash
-RUST_LOG="consensus=off" cargo run --bin sui-test-validator
+RUST_LOG="off,sui_node=info" cargo run --bin sui-test-validator
 ```
 
-The command starts the `sui-test-validator`. The `RUST_LOG`=`consensus=off` turns off consensus for the local network.
+The command starts the `sui-test-validator`. The `RUST_LOG`=`off,sui_node=info` turns off logging for all components except
+sui-node. If you want to see more detailed logs, you can remove `RUST_LOG` from the command.
 
 **Important:** Each time you start the `sui-test-validator`, the network starts as a new network with no previous data. The local network is not persistent.
 


### PR DESCRIPTION
## Description 

consensus-off doesn't turn off consensus. It just turns off logging for consensus.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
