### PR TITLE
[analytics]Add optional path prefix while writing data in remote bucket

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -112,6 +112,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
             remote_object_store,
             local_object_store.clone(),
             checkpoint_dir,
+            config.remote_store_path_prefix.clone(),
             receiver,
             kill_receiver,
             cloned_metrics,
@@ -192,6 +193,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
         remote_object_store: Arc<DynObjectStore>,
         local_object_store: Arc<DynObjectStore>,
         local_staging_root_dir: PathBuf,
+        remote_store_path_prefix: Option<Path>,
         mut file_recv: mpsc::Receiver<FileMetadata>,
         mut recv: oneshot::Receiver<()>,
         metrics: AnalyticsMetrics,
@@ -207,6 +209,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
                         Self::sync_file_to_remote(
                                 local_staging_root_dir.clone(),
                                 file_metadata.file_path(),
+                                remote_store_path_prefix.clone(),
                                 local_object_store.clone(),
                                 remote_object_store.clone()
                             )
@@ -226,11 +229,15 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
     async fn sync_file_to_remote(
         dir: PathBuf,
         path: Path,
+        prefix: Option<Path>,
         from: Arc<DynObjectStore>,
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
-        info!("Syncing file to remote: {:?}", path);
-        copy_file(&path, &path, &from, &to).await?;
+        let remote_dest = prefix
+            .map(|p| p.child(path.to_string()))
+            .unwrap_or(path.clone());
+        info!("Syncing file to remote: {:?}", &remote_dest);
+        copy_file(&path, &remote_dest, &from, &to).await?;
         fs::remove_file(path_to_filesystem(dir, &path)?)?;
         Ok(())
     }

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -88,6 +88,9 @@ pub struct AnalyticsIndexerConfig {
     // Remote object store where data gets written to
     #[command(flatten)]
     pub remote_store_config: ObjectStoreConfig,
+    // Remote object store path prefix to use while writing
+    #[clap(long, default_value = None, global = true)]
+    pub remote_store_path_prefix: Option<Path>,
     // File format to store data in i.e. csv, parquet, etc
     #[clap(long, value_enum, default_value = "csv", global = true)]
     pub file_format: FileFormat,


### PR DESCRIPTION
## Description 

Add an optional path prefix which could be used to write data to remote buckets (s3/gcs, etc). This is primarily needed for backfills where we would re-run the pipelines for older checkpoints and write data to a different prefix so regular workflow isn't interrupted.

## Test Plan 

Ran locally on local directory with prefix
