### PR TITLE
[sui-test-validator] chore: cleanup unwraps

### DIFF
--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
         Some(epoch_duration_ms)
     };
 
-    let cluster = LocalNewCluster::start(&ClusterTestOpt {
+    let cluster_config = ClusterTestOpt {
         env: Env::NewLocal,
         fullnode_address: Some(format!("127.0.0.1:{}", fullnode_rpc_port)),
         indexer_address: with_indexer.then_some(format!("127.0.0.1:{}", indexer_rpc_port)),
@@ -127,8 +127,10 @@ async fn main() -> Result<()> {
         config_dir,
         graphql_address: Some(format!("{}:{}", graphql_host, graphql_port)),
         use_indexer_v2,
-    })
-    .await?;
+    };
+
+    println!("Starting Sui validator with config: {:#?}", cluster_config);
+    let cluster = LocalNewCluster::start(&cluster_config).await?;
 
     println!("Fullnode RPC URL: {}", cluster.fullnode_url());
 


### PR DESCRIPTION
## Description 

Cleans-up some unwraps and logic from sui-test-validator
Adds printing of config before cluster start. Makes it easy to see what GraphQL server exactly one should connect to.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
