### PR TITLE
[graphql/rpc] serialize data tests and use nextest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -419,6 +419,7 @@ jobs:
          - 5432:5432
    steps:
      - uses: actions/checkout@v3
+     - uses: taiki-e/install-action@nextest
      - name: Setup db
        run: |
          PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U $POSTGRES_USER -c 'CREATE DATABASE sui_indexer_v2;' -c 'ALTER SYSTEM SET max_connections = 500;'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -428,8 +428,8 @@ jobs:
           POSTGRES_PASSWORD: postgrespw
      - name: tests-requiring-postgres
        run: |
-         cargo nextest run --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
-         cargo nextest run --package sui-graphql-e2e-tests --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration
          cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration
 
        env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -427,9 +427,9 @@ jobs:
           POSTGRES_PASSWORD: postgrespw
      - name: tests-requiring-postgres
        run: |
-         cargo test --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
-         cargo test --package sui-graphql-e2e-tests --features pg_integration
-         cargo test --package sui-cluster-test --test local_cluster_test --features pg_integration
+         cargo nextest run --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
+         cargo nextest run --package sui-graphql-e2e-tests --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration
 
        env:
          POSTGRES_HOST: localhost


### PR DESCRIPTION
## Description 

Use nextest over cargo test
Serialize e2e tests due to PG instance limitations

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
