### PR TITLE
[sui-tool] Include git commit hash in sui-tool version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bc011a04793b8ce7bca0efd59e3697c2061760df6efbb8c895e8a81548db67"
+checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
 
 [[package]]
 name = "constant_time_eq"
@@ -11967,9 +11967,11 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "const-str",
  "eyre",
  "fastcrypto",
  "futures",
+ "git-version",
  "hex",
  "indicatif",
  "itertools",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -49,3 +49,5 @@ sui-storage.workspace = true
 sui-types.workspace = true
 sui-archival.workspace = true
 workspace-hack.workspace = true
+git-version.workspace = true
+const-str = "0.5.6"

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -34,6 +34,22 @@ pub enum Verbosity {
     Concise,
     Verbose,
 }
+const GIT_REVISION: &str = {
+    if let Some(revision) = option_env!("GIT_REVISION") {
+        revision
+    } else {
+        let version = git_version::git_version!(
+            args = ["--always", "--abbrev=12", "--dirty", "--exclude", "*"],
+            fallback = ""
+        );
+
+        if version.is_empty() {
+            panic!("unable to query git revision");
+        }
+        version
+    }
+};
+const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
 
 #[derive(Parser)]
 #[command(
@@ -41,7 +57,7 @@ pub enum Verbosity {
     about = "Debugging utilities for sui",
     rename_all = "kebab-case",
     author,
-    version
+    version = VERSION,
 )]
 pub enum ToolCommand {
     /// Fetch the same object from all validators


### PR DESCRIPTION
## Description 

This PR adds the git commit hash to the `sui-tool --version` output, matching [sui-node](https://github.com/MystenLabs/sui/blob/main/crates/sui-node/src/main.rs#L18-L38) behavior. This is will help us easily identify the running commit in some internal workflows.

## Test Plan 

Local run output:
```
cargo run --bin sui-tool -- --version
    Finished dev [unoptimized + debuginfo] target(s) in 0.59s
     Running `/Users/chrisgorham/github.com/sui/target/debug/sui-tool --version`
sui-tool 1.15.0-59d4a595c5fa-dirty
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
