### PR TITLE
[move] Temporarily remove stdlib link

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -10,11 +10,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub const MOVE_STDLIB_PACKAGE_NAME: &str = "MoveStdlib";
-pub const MOVE_STDLIB_PACKAGE_PATH: &str = "{ \
-    git = \"https://github.com/move-language/move.git\", \
-    subdir = \"language/move-stdlib\", rev = \"main\" \
-}";
+// TODO get a stable path to this stdlib
+// pub const MOVE_STDLIB_PACKAGE_NAME: &str = "MoveStdlib";
+// pub const MOVE_STDLIB_PACKAGE_PATH: &str = "{ \
+//     git = \"https://github.com/move-language/move.git\", \
+//     subdir = \"language/move-stdlib\", rev = \"main\" \
+// }";
 pub const MOVE_STDLIB_ADDR_NAME: &str = "std";
 pub const MOVE_STDLIB_ADDR_VALUE: &str = "0x1";
 
@@ -32,8 +33,8 @@ impl New {
         self.execute(
             path,
             "0.0.0",
-            [(MOVE_STDLIB_PACKAGE_NAME, MOVE_STDLIB_PACKAGE_PATH)],
-            [(MOVE_STDLIB_ADDR_NAME, MOVE_STDLIB_ADDR_VALUE)],
+            std::iter::empty::<(&str, &str)>(),
+            std::iter::empty::<(&str, &str)>(),
             "",
         )
     }

--- a/external-crates/move/crates/move-cli/tests/build_tests/simple_build_with_docs/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/simple_build_with_docs/args.exp
@@ -1,7 +1,5 @@
 Command `new --path . Foo`:
 Command `build`:
-UPDATING GIT DEPENDENCY https://github.com/move-language/move.git
-INCLUDING DEPENDENCY MoveStdlib
 BUILDING Foo
 Command `docgen --template template.md --exclude-impl --exclude-private-fun --exclude-specs --include-call-diagrams --include-dep-diagrams --independent-specs --no-collapsed-sections --output-directory doc --references-file template.md --section-level-start 3 --toc-depth 3`:
 Generated "doc/template.md"

--- a/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
@@ -5,10 +5,8 @@ name = "P1"
 version = "0.0.0"
 
 [dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
 
 [addresses]
-std = "0x1"
 Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
@@ -16,7 +14,5 @@ name = "P2"
 version = "0.0.0"
 
 [dependencies]
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
 
 [addresses]
-std = "0x1"


### PR DESCRIPTION
## Description 

- We are making changes that make our compiler fail against move-language/move's version of stdlib 
- This does not affect the Sui CLI 
- At least temporarily, we will remove the stdlib link from the core Move CLI. We can add it back once we have our repo situation figured out

## Test Plan 

- ran CLI tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
