### PR TITLE
Consensus folk detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11419,6 +11419,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "shared-crypto",
  "signature 1.6.4",
+ "static_assertions",
  "sui-archival",
  "sui-config",
  "sui-execution",

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -22,6 +22,7 @@ use sui_swarm_config::network_config::NetworkConfig;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::base_types::{AuthorityName, ObjectID, VersionNumber};
 use sui_types::crypto::AuthoritySignature;
+use sui_types::digests::ConsensusCommitDigest;
 use sui_types::error::SuiError;
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
@@ -206,7 +207,12 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let round = self.epoch_state.next_consensus_round();
         let timestamp_ms = self.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
         let consensus_commit_prologue_transaction =
-            VerifiedTransaction::new_consensus_commit_prologue(epoch, round, timestamp_ms);
+            VerifiedTransaction::new_consensus_commit_prologue(
+                epoch,
+                round,
+                timestamp_ms,
+                Some(ConsensusCommitDigest::default()),
+            );
 
         self.execute_transaction(consensus_commit_prologue_transaction.into())
             .expect("advancing the clock cannot fail")

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -207,11 +207,11 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let round = self.epoch_state.next_consensus_round();
         let timestamp_ms = self.store.get_clock().timestamp_ms() + duration.as_millis() as u64;
         let consensus_commit_prologue_transaction =
-            VerifiedTransaction::new_consensus_commit_prologue(
+            VerifiedTransaction::new_consensus_commit_prologue_v2(
                 epoch,
                 round,
                 timestamp_ms,
-                Some(ConsensusCommitDigest::default()),
+                ConsensusCommitDigest::default(),
             );
 
         self.execute_transaction(consensus_commit_prologue_transaction.into())

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -34,6 +34,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 signature.workspace = true
+static_assertions.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -922,6 +922,7 @@ impl CheckpointBuilder {
                 if !matches!(
                     transaction.inner().transaction_data().kind(),
                     TransactionKind::ConsensusCommitPrologue(_)
+                        | TransactionKind::ConsensusCommitPrologueV2(_)
                         | TransactionKind::AuthenticatorStateUpdate(_)
                         | TransactionKind::RandomnessStateUpdate(_)
                 ) {

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -5,8 +5,8 @@ use crate::consensus_types::AuthorityIndex;
 use fastcrypto::hash::Hash;
 use narwhal_types::{BatchAPI, CertificateAPI, ConsensusOutputDigest, HeaderAPI, SystemMessage};
 use std::fmt::Display;
+use sui_types::digests::ConsensusCommitDigest;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
-use sui_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
 
 /// A list of tuples of:
 /// (certificate origin authority index, all transactions corresponding to the certificate).
@@ -27,6 +27,7 @@ pub(crate) trait ConsensusOutputAPI: Display {
     /// Returns all transactions in the commit.
     fn transactions(&self) -> ConsensusOutputTransactions<'_>;
 
+    /// Returns the digest of consensus output.
     fn consensus_digest(&self) -> ConsensusCommitDigest;
 }
 
@@ -103,6 +104,8 @@ impl ConsensusOutputAPI for narwhal_types::ConsensusOutput {
     }
 
     fn consensus_digest(&self) -> ConsensusCommitDigest {
+        // We port ConsensusOutputDigest, a narwhal space object, into ConsensusCommitDigest, a sui-core space object.
+        // We assume they always have the same format.
         static_assertions::assert_eq_size!(ConsensusCommitDigest, ConsensusOutputDigest);
         ConsensusCommitDigest::new(self.digest().into_inner())
     }
@@ -159,6 +162,7 @@ impl ConsensusOutputAPI for mysticeti_core::consensus::linearizer::CommittedSubD
     }
 
     fn consensus_digest(&self) -> ConsensusCommitDigest {
+        // TODO(mysticeti): implement consensus output digest.
         ConsensusCommitDigest::default()
     }
 }

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -222,11 +222,21 @@ CompressedSignature:
       ZkLogin:
         NEWTYPE:
           TYPENAME: ZkLoginAuthenticatorAsBytes
+ConsensusCommitDigest:
+  NEWTYPESTRUCT:
+    TYPENAME: Digest
 ConsensusCommitPrologue:
   STRUCT:
     - epoch: U64
     - round: U64
     - commit_timestamp_ms: U64
+ConsensusCommitPrologueV2:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+    - commit_timestamp_ms: U64
+    - consensus_commit_digest:
+        TYPENAME: ConsensusCommitDigest
 Data:
   ENUM:
     0:
@@ -955,6 +965,10 @@ TransactionKind:
       RandomnessStateUpdate:
         NEWTYPE:
           TYPENAME: RandomnessStateUpdate
+    7:
+      ConsensusCommitPrologueV2:
+        NEWTYPE:
+          TYPENAME: ConsensusCommitPrologueV2
 TypeArgumentError:
   ENUM:
     0:

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -41,8 +41,6 @@ async fn test_upgraded_multisig_feature_deny() {
 
     let err = do_upgraded_multisig_test().await.unwrap_err();
 
-    eprintln!("ZZZZZ error {:?}", err);
-
     assert!(matches!(err, SuiError::UnsupportedFeatureError { .. }));
 }
 

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -41,6 +41,8 @@ async fn test_upgraded_multisig_feature_deny() {
 
     let err = do_upgraded_multisig_test().await.unwrap_err();
 
+    eprintln!("ZZZZZ error {:?}", err);
+
     assert!(matches!(err, SuiError::UnsupportedFeatureError { .. }));
 }
 

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -59,7 +59,6 @@ async fn test_zklogin_feature_legacy_address_deny() {
     let err = do_zklogin_test(get_legacy_zklogin_user_address(), true)
         .await
         .unwrap_err();
-    eprintln!("ZZZZZ error {:?}", err);
     assert!(matches!(err, SuiError::SignerSignatureAbsent { .. }));
 }
 

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -59,6 +59,7 @@ async fn test_zklogin_feature_legacy_address_deny() {
     let err = do_zklogin_test(get_legacy_zklogin_user_address(), true)
         .await
         .unwrap_err();
+    eprintln!("ZZZZZ error {:?}", err);
     assert!(matches!(err, SuiError::SignerSignatureAbsent { .. }));
 }
 

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -253,7 +253,7 @@ Response: {
     "transactionBlockConnection": {
       "nodes": [
         {
-          "digest": "J2gfeoDEySDWfUEdboMehk45L9ndHHFv3nLF16UWXxej",
+          "digest": "CHyKA8xirNCGtcDMLJcxBZsxGyAA7DNrzDEVodxZzNn",
           "sender": {
             "location": "0x0000000000000000000000000000000000000000000000000000000000000000"
           },
@@ -297,7 +297,7 @@ Response: {
                 "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                  "digest": "G7kvXbP2RrfuNizWxggZ3FBc8XAUPCKpSkxEb5hdCExK"
+                  "digest": "28w3Mp2x4vt94bq4TejrbLcfMsMaevDyPz6h98sgcnw4"
                 }
               }
             ],
@@ -318,7 +318,7 @@ Response: {
               "sequenceNumber": 1
             },
             "transactionBlock": {
-              "digest": "J2gfeoDEySDWfUEdboMehk45L9ndHHFv3nLF16UWXxej"
+              "digest": "CHyKA8xirNCGtcDMLJcxBZsxGyAA7DNrzDEVodxZzNn"
             }
           },
           "expiration": null

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1738,6 +1738,14 @@ impl From<&TransactionKind> for TransactionBlockKind {
                 };
                 TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
             }
+            TransactionKind::ConsensusCommitPrologueV2(x) => {
+                let consensus = ConsensusCommitPrologueTransaction {
+                    epoch_id: x.epoch,
+                    round: Some(x.round),
+                    timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
+                };
+                TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
+            }
             TransactionKind::Genesis(x) => {
                 let genesis = GenesisTransaction {
                     objects: Some(

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -45,6 +45,7 @@ pub(crate) struct TxBlockKindNotImplementedYet {
     pub(crate) text: String,
 }
 
+// TODO: add ConsensusCommitPrologueTransactionV2 for TransactionKind::ConsensusCommitPrologueV2.
 #[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
 #[graphql(complex)]
 pub(crate) struct ConsensusCommitPrologueTransaction {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -25,7 +25,7 @@ use sui_types::base_types::{
     EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
 use sui_types::crypto::SuiSignature;
-use sui_types::digests::{ObjectDigest, TransactionEventsDigest};
+use sui_types::digests::{ConsensusCommitDigest, ObjectDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::{ExecutionError, SuiError, SuiResult};
 use sui_types::execution_status::ExecutionStatus;
@@ -382,6 +382,7 @@ pub enum SuiTransactionBlockKind {
     RandomnessStateUpdate(SuiRandomnessStateUpdate),
     /// The transaction which occurs only at the end of the epoch
     EndOfEpochTransaction(SuiEndOfEpochTransaction),
+    ConsensusCommitPrologueV2(SuiConsensusCommitPrologueV2),
     // .. more transaction types go here
 }
 
@@ -406,6 +407,14 @@ impl Display for SuiTransactionBlockKind {
                     writer,
                     "Epoch: {}, Round: {}, Timestamp : {}",
                     p.epoch, p.round, p.commit_timestamp_ms
+                )?;
+            }
+            Self::ConsensusCommitPrologueV2(p) => {
+                writeln!(writer, "Transaction Kind : Consensus Commit Prologue V2")?;
+                writeln!(
+                    writer,
+                    "Epoch: {}, Round: {}, Timestamp : {}, ConsensusCommitDigest : {}",
+                    p.epoch, p.round, p.commit_timestamp_ms, p.consensus_commit_digest
                 )?;
             }
             Self::ProgrammableTransaction(p) => {
@@ -438,6 +447,14 @@ impl SuiTransactionBlockKind {
                     epoch: p.epoch,
                     round: p.round,
                     commit_timestamp_ms: p.commit_timestamp_ms,
+                })
+            }
+            TransactionKind::ConsensusCommitPrologueV2(p) => {
+                Self::ConsensusCommitPrologueV2(SuiConsensusCommitPrologueV2 {
+                    epoch: p.epoch,
+                    round: p.round,
+                    commit_timestamp_ms: p.commit_timestamp_ms,
+                    consensus_commit_digest: p.consensus_commit_digest,
                 })
             }
             TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
@@ -502,6 +519,7 @@ impl SuiTransactionBlockKind {
             Self::ChangeEpoch(_) => "ChangeEpoch",
             Self::Genesis(_) => "Genesis",
             Self::ConsensusCommitPrologue(_) => "ConsensusCommitPrologue",
+            Self::ConsensusCommitPrologueV2(_) => "ConsensusCommitPrologueV2",
             Self::ProgrammableTransaction(_) => "ProgrammableTransaction",
             Self::AuthenticatorStateUpdate(_) => "AuthenticatorStateUpdate",
             Self::RandomnessStateUpdate(_) => "RandomnessStateUpdate",
@@ -1287,6 +1305,22 @@ pub struct SuiConsensusCommitPrologue {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "BigInt<u64>")]
     pub commit_timestamp_ms: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct SuiConsensusCommitPrologueV2 {
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub round: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub commit_timestamp_ms: u64,
+
+    pub consensus_commit_digest: ConsensusCommitDigest,
 }
 
 #[serde_as]

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1319,7 +1319,6 @@ pub struct SuiConsensusCommitPrologueV2 {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "BigInt<u64>")]
     pub commit_timestamp_ms: u64,
-
     pub consensus_commit_digest: ConsensusCommitDigest,
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1362,6 +1362,7 @@
                 "enable_effects_v2": false,
                 "enable_jwk_consensus_updates": false,
                 "end_of_epoch_transaction_supported": false,
+                "include_consensus_digest_in_prologue": false,
                 "loaded_child_object_format": false,
                 "loaded_child_object_format_type": false,
                 "loaded_child_objects_fixed": true,
@@ -5517,6 +5518,9 @@
             "additionalProperties": false
           }
         ]
+      },
+      "ConsensusCommitDigest": {
+        "$ref": "#/components/schemas/Digest"
       },
       "Data": {
         "oneOf": [
@@ -10234,6 +10238,36 @@
                 "items": {
                   "$ref": "#/components/schemas/SuiEndOfEpochTransactionKind"
                 }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "commit_timestamp_ms",
+              "consensus_commit_digest",
+              "epoch",
+              "kind",
+              "round"
+            ],
+            "properties": {
+              "commit_timestamp_ms": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              "consensus_commit_digest": {
+                "$ref": "#/components/schemas/ConsensusCommitDigest"
+              },
+              "epoch": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "ConsensusCommitPrologueV2"
+                ]
+              },
+              "round": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
               }
             }
           }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -349,6 +349,8 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     accept_zklogin_in_multisig: bool,
 
+    // If true, consensus prologue transaction also includes the consensus output digest.
+    // It can be used to detect consensus output folk.
     #[serde(skip_serializing_if = "is_false")]
     include_consensus_digest_in_prologue: bool,
 }
@@ -1676,6 +1678,7 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.narwhal_header_v2 = true;
                         cfg.feature_flags.random_beacon = true;
+                    }
                     // Only enable consensus digest in consensus commit prologue in devnet.
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         cfg.feature_flags.include_consensus_digest_in_prologue = true;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -348,6 +348,9 @@ struct FeatureFlags {
     // If true, multisig containing zkLogin sig is accepted.
     #[serde(skip_serializing_if = "is_false")]
     accept_zklogin_in_multisig: bool,
+
+    #[serde(skip_serializing_if = "is_false")]
+    include_consensus_digest_in_prologue: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1049,6 +1052,10 @@ impl ProtocolConfig {
     pub fn throughput_aware_consensus_submission(&self) -> bool {
         self.feature_flags.throughput_aware_consensus_submission
     }
+
+    pub fn include_consensus_digest_in_prologue(&self) -> bool {
+        self.feature_flags.include_consensus_digest_in_prologue
+    }
 }
 
 #[cfg(not(msim))]
@@ -1665,11 +1672,13 @@ impl ProtocolConfig {
                         cfg.transfer_receive_object_cost_base = Some(52);
                         cfg.feature_flags.receive_objects = true;
                     }
-
                     // Only enable random beacon on devnet
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.narwhal_header_v2 = true;
                         cfg.feature_flags.random_beacon = true;
+                    // Only enable consensus digest in consensus commit prologue in devnet.
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        cfg.feature_flags.include_consensus_digest_in_prologue = true;
                     }
 
                     // enable nw cert v2 on mainnet

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_32.snap
@@ -39,6 +39,7 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
+  include_consensus_digest_in_prologue: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -422,7 +422,8 @@ impl From<&SuiTransactionBlockKind> for OperationType {
         match tx {
             SuiTransactionBlockKind::ChangeEpoch(_) => OperationType::EpochChange,
             SuiTransactionBlockKind::Genesis(_) => OperationType::Genesis,
-            SuiTransactionBlockKind::ConsensusCommitPrologue(_) => {
+            SuiTransactionBlockKind::ConsensusCommitPrologue(_)
+            | SuiTransactionBlockKind::ConsensusCommitPrologueV2(_) => {
                 OperationType::ConsensusCommitPrologue
             }
             SuiTransactionBlockKind::ProgrammableTransaction(_) => {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -619,11 +619,11 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             SuiSubcommand::ConsensusCommitPrologue(ConsensusCommitPrologueCommand {
                 timestamp_ms,
             }) => {
-                let transaction = VerifiedTransaction::new_consensus_commit_prologue(
+                let transaction = VerifiedTransaction::new_consensus_commit_prologue_v2(
                     0,
                     0,
                     timestamp_ms,
-                    Some(ConsensusCommitDigest::default()),
+                    ConsensusCommitDigest::default(),
                 );
                 let summary = self.execute_txn(transaction.into()).await?;
                 let output = self.object_summary_output(&summary, /* summarize */ false);

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -59,6 +59,7 @@ use sui_storage::{
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::base_types::SequenceNumber;
 use sui_types::crypto::get_authority_key_pair;
+use sui_types::digests::ConsensusCommitDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::transaction::Command;
 use sui_types::transaction::ProgrammableTransaction;
@@ -618,8 +619,12 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             SuiSubcommand::ConsensusCommitPrologue(ConsensusCommitPrologueCommand {
                 timestamp_ms,
             }) => {
-                let transaction =
-                    VerifiedTransaction::new_consensus_commit_prologue(0, 0, timestamp_ms);
+                let transaction = VerifiedTransaction::new_consensus_commit_prologue(
+                    0,
+                    0,
+                    timestamp_ms,
+                    Some(ConsensusCommitDigest::default()),
+                );
                 let summary = self.execute_txn(transaction.into()).await?;
                 let output = self.object_summary_output(&summary, /* summarize */ false);
                 Ok(output)

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -940,6 +940,10 @@ impl ConsensusCommitDigest {
     pub const fn into_inner(self) -> [u8; 32] {
         self.0.into_inner()
     }
+
+    pub fn random() -> Self {
+        Self(Digest::random())
+    }
 }
 
 impl Default for ConsensusCommitDigest {

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -922,3 +922,54 @@ impl ZKLoginInputsDigest {
         Self(Digest::new(digest))
     }
 }
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct ConsensusCommitDigest(Digest);
+
+impl ConsensusCommitDigest {
+    pub const ZERO: Self = Self(Digest::ZERO);
+
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+
+    pub const fn inner(&self) -> &[u8; 32] {
+        self.0.inner()
+    }
+
+    pub const fn into_inner(self) -> [u8; 32] {
+        self.0.into_inner()
+    }
+}
+
+impl Default for ConsensusCommitDigest {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl From<ConsensusCommitDigest> for [u8; 32] {
+    fn from(digest: ConsensusCommitDigest) -> Self {
+        digest.into_inner()
+    }
+}
+
+impl From<[u8; 32]> for ConsensusCommitDigest {
+    fn from(digest: [u8; 32]) -> Self {
+        Self::new(digest)
+    }
+}
+
+impl fmt::Display for ConsensusCommitDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for ConsensusCommitDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ConsensusCommitDigest")
+            .field(&self.0)
+            .finish()
+    }
+}

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -644,6 +644,8 @@ impl VerifiedCheckpointContents {
 #[cfg(test)]
 #[cfg(feature = "test-utils")]
 mod tests {
+    use crate::digests::{ConsensusCommitDigest, TransactionDigest, TransactionEffectsDigest};
+    use crate::transaction::VerifiedTransaction;
     use fastcrypto::traits::KeyPair;
     use rand::prelude::StdRng;
     use rand::SeedableRng;
@@ -774,5 +776,68 @@ mod tests {
                 .verify_authority_signatures(&committee)
                 .is_err()
         )
+    }
+
+    // Generate a CheckpointSummary from the input transaction digest. All the other fields in the generated
+    // CheckpointSummary will be the same. The generated CheckpointSummary can be used to test how input
+    // transaction digest affects CheckpointSummary.
+    fn generate_test_checkpoint_summary_from_digest(
+        digest: TransactionDigest,
+    ) -> CheckpointSummary {
+        CheckpointSummary::new(
+            1,
+            2,
+            10,
+            &CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::new(
+                digest,
+                TransactionEffectsDigest::ZERO,
+            )]),
+            None,
+            GasCostSummary::default(),
+            None,
+            100,
+        )
+    }
+
+    // Tests that ConsensusCommitPrologue with different consensus commit digest will result in different checkpoint content.
+    #[test]
+    fn test_checkpoing_summary_with_different_consensus_digest() {
+        // First, tests that same consensus commit digest will procude the same checkpoint content.
+        {
+            let t1 = VerifiedTransaction::new_consensus_commit_prologue(
+                1,
+                2,
+                100,
+                Some(ConsensusCommitDigest::default()),
+            );
+            let t2 = VerifiedTransaction::new_consensus_commit_prologue(
+                1,
+                2,
+                100,
+                Some(ConsensusCommitDigest::default()),
+            );
+            let c1 = generate_test_checkpoint_summary_from_digest(*t1.digest());
+            let c2 = generate_test_checkpoint_summary_from_digest(*t2.digest());
+            assert_eq!(c1.digest(), c2.digest());
+        }
+
+        // Next, tests that different consensus commit digests will procude the different checkpoint contents.
+        {
+            let t1 = VerifiedTransaction::new_consensus_commit_prologue(
+                1,
+                2,
+                100,
+                Some(ConsensusCommitDigest::default()),
+            );
+            let t2 = VerifiedTransaction::new_consensus_commit_prologue(
+                1,
+                2,
+                100,
+                Some(ConsensusCommitDigest::random()),
+            );
+            let c1 = generate_test_checkpoint_summary_from_digest(*t1.digest());
+            let c2 = generate_test_checkpoint_summary_from_digest(*t2.digest());
+            assert_ne!(c1.digest(), c2.digest());
+        }
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -804,17 +804,17 @@ mod tests {
     fn test_checkpoing_summary_with_different_consensus_digest() {
         // First, tests that same consensus commit digest will procude the same checkpoint content.
         {
-            let t1 = VerifiedTransaction::new_consensus_commit_prologue(
+            let t1 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,
                 2,
                 100,
-                Some(ConsensusCommitDigest::default()),
+                ConsensusCommitDigest::default(),
             );
-            let t2 = VerifiedTransaction::new_consensus_commit_prologue(
+            let t2 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,
                 2,
                 100,
-                Some(ConsensusCommitDigest::default()),
+                ConsensusCommitDigest::default(),
             );
             let c1 = generate_test_checkpoint_summary_from_digest(*t1.digest());
             let c2 = generate_test_checkpoint_summary_from_digest(*t2.digest());
@@ -823,17 +823,17 @@ mod tests {
 
         // Next, tests that different consensus commit digests will procude the different checkpoint contents.
         {
-            let t1 = VerifiedTransaction::new_consensus_commit_prologue(
+            let t1 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,
                 2,
                 100,
-                Some(ConsensusCommitDigest::default()),
+                ConsensusCommitDigest::default(),
             );
-            let t2 = VerifiedTransaction::new_consensus_commit_prologue(
+            let t2 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,
                 2,
                 100,
-                Some(ConsensusCommitDigest::random()),
+                ConsensusCommitDigest::random(),
             );
             let c1 = generate_test_checkpoint_summary_from_digest(*t1.digest());
             let c2 = generate_test_checkpoint_summary_from_digest(*t2.digest());

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
+use crate::digests::ConsensusCommitDigest;
 use crate::messages_checkpoint::{
     CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointTimestamp,
 };
@@ -25,6 +26,18 @@ pub struct ConsensusCommitPrologue {
     pub round: u64,
     /// Unix timestamp from consensus
     pub commit_timestamp_ms: CheckpointTimestamp,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct ConsensusCommitPrologueV2 {
+    /// Epoch of the commit prologue transaction
+    pub epoch: u64,
+    /// Consensus round of the commit
+    pub round: u64,
+    /// Unix timestamp from consensus
+    pub commit_timestamp_ms: CheckpointTimestamp,
+    /// Digest of consensus output
+    pub consensus_commit_digest: ConsensusCommitDigest,
 }
 
 // In practice, JWKs are about 500 bytes of json each, plus a bit more for the ID.

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -273,6 +273,7 @@ pub enum TransactionKind {
     EndOfEpochTransaction(Vec<EndOfEpochTransactionKind>),
 
     RandomnessStateUpdate(RandomnessStateUpdate),
+    // V2 ConsensusCommitPrologue also includes the digest of the current consensus output.
     ConsensusCommitPrologueV2(ConsensusCommitPrologueV2),
     // .. more transaction types go here
 }
@@ -1348,6 +1349,7 @@ impl Display for TransactionKind {
             Self::ConsensusCommitPrologueV2(p) => {
                 writeln!(writer, "Transaction Kind : Consensus Commit Prologue V2")?;
                 writeln!(writer, "Timestamp : {}", p.commit_timestamp_ms)?;
+                writeln!(writer, "Consensus Digest: {}", p.consensus_commit_digest)?;
             }
             Self::ProgrammableTransaction(p) => {
                 writeln!(writer, "Transaction Kind : Programmable")?;

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2416,25 +2416,30 @@ impl VerifiedTransaction {
         epoch: u64,
         round: u64,
         commit_timestamp_ms: CheckpointTimestamp,
-        consensus_digest: Option<ConsensusCommitDigest>,
     ) -> Self {
-        match consensus_digest {
-            Some(digest) => ConsensusCommitPrologueV2 {
-                epoch,
-                round,
-                commit_timestamp_ms,
-                consensus_commit_digest: digest,
-            }
-            .pipe(TransactionKind::ConsensusCommitPrologueV2)
-            .pipe(Self::new_system_transaction),
-            None => ConsensusCommitPrologue {
-                epoch,
-                round,
-                commit_timestamp_ms,
-            }
-            .pipe(TransactionKind::ConsensusCommitPrologue)
-            .pipe(Self::new_system_transaction),
+        ConsensusCommitPrologue {
+            epoch,
+            round,
+            commit_timestamp_ms,
         }
+        .pipe(TransactionKind::ConsensusCommitPrologue)
+        .pipe(Self::new_system_transaction)
+    }
+
+    pub fn new_consensus_commit_prologue_v2(
+        epoch: u64,
+        round: u64,
+        commit_timestamp_ms: CheckpointTimestamp,
+        consensus_commit_digest: ConsensusCommitDigest,
+    ) -> Self {
+        ConsensusCommitPrologueV2 {
+            epoch,
+            round,
+            commit_timestamp_ms,
+            consensus_commit_digest,
+        }
+        .pipe(TransactionKind::ConsensusCommitPrologueV2)
+        .pipe(Self::new_system_transaction)
     }
 
     pub fn new_authenticator_state_update(

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1062,7 +1062,36 @@ fn test_change_epoch_transaction() {
 
 #[test]
 fn test_consensus_commit_prologue_transaction() {
-    let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42);
+    let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42, None);
+    assert!(tx.contains_shared_object());
+    assert_eq!(
+        tx.shared_input_objects().next().unwrap(),
+        SharedInputObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutable: true,
+        },
+    );
+    assert!(tx.is_system_tx());
+    assert_eq!(
+        tx.data()
+            .intent_message()
+            .value
+            .input_objects()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn test_consensus_commit_prologue_v2_transaction() {
+    let tx = VerifiedTransaction::new_consensus_commit_prologue(
+        0,
+        0,
+        42,
+        Some(ConsensusCommitDigest::default()),
+    );
     assert!(tx.contains_shared_object());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1062,7 +1062,7 @@ fn test_change_epoch_transaction() {
 
 #[test]
 fn test_consensus_commit_prologue_transaction() {
-    let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42, None);
+    let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42);
     assert!(tx.contains_shared_object());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),
@@ -1086,11 +1086,11 @@ fn test_consensus_commit_prologue_transaction() {
 
 #[test]
 fn test_consensus_commit_prologue_v2_transaction() {
-    let tx = VerifiedTransaction::new_consensus_commit_prologue(
+    let tx = VerifiedTransaction::new_consensus_commit_prologue_v2(
         0,
         0,
         42,
-        Some(ConsensusCommitDigest::default()),
+        ConsensusCommitDigest::default(),
     );
     assert!(tx.contains_shared_object());
     assert_eq!(

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -418,8 +418,14 @@ impl CommittedSubDagShell {
 pub type ShutdownToken = mpsc::Sender<()>;
 
 // Digest of ConsususOutput and CommittedSubDag
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ConsensusOutputDigest([u8; crypto::DIGEST_LENGTH]);
+
+impl ConsensusOutputDigest {
+    pub const fn into_inner(self) -> [u8; crypto::DIGEST_LENGTH] {
+        self.0
+    }
+}
 
 impl AsRef<[u8]> for ConsensusOutputDigest {
     fn as_ref(&self) -> &[u8] {

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -417,7 +417,9 @@ impl CommittedSubDagShell {
 /// Shutdown token dropped when a task is properly shut down.
 pub type ShutdownToken = mpsc::Sender<()>;
 
-// Digest of ConsususOutput and CommittedSubDag
+// Digest of ConsususOutput and CommittedSubDag.
+// In non-byzantine environment, ConsensusOutputDigest of each consensus output in different
+// validator must be the same.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ConsensusOutputDigest([u8; crypto::DIGEST_LENGTH]);
 

--- a/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
@@ -43,7 +43,7 @@ mod checked {
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
-    use sui_types::messages_consensus::ConsensusCommitPrologue;
+    use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::storage::BackingStore;
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;

--- a/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
@@ -536,7 +536,20 @@ mod checked {
             }
             TransactionKind::ConsensusCommitPrologue(prologue) => {
                 setup_consensus_commit(
-                    prologue,
+                    prologue.commit_timestamp_ms,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ConsensusCommitPrologueV2(prologue) => {
+                setup_consensus_commit(
+                    prologue.commit_timestamp_ms,
                     temporary_store,
                     tx_ctx,
                     move_vm,
@@ -892,7 +905,7 @@ mod checked {
     /// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
     ///   consensus.
     fn setup_consensus_commit(
-        prologue: ConsensusCommitPrologue,
+        consensus_commit_timestamp_ms: CheckpointTimestamp,
         temporary_store: &mut TemporaryStore<'_>,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
@@ -909,7 +922,7 @@ mod checked {
                 vec![],
                 vec![
                     CallArg::CLOCK_MUT,
-                    CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&consensus_commit_timestamp_ms).unwrap()),
                 ],
             );
             assert_invariant!(

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -29,7 +29,7 @@ mod checked {
     use sui_types::gas::SuiGasStatus;
     use sui_types::gas_coin::GAS;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
-    use sui_types::messages_consensus::ConsensusCommitPrologue;
+    use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::object::OBJECT_START_VERSION;
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -424,7 +424,20 @@ mod checked {
             }
             TransactionKind::ConsensusCommitPrologue(prologue) => {
                 setup_consensus_commit(
-                    prologue,
+                    prologue.commit_timestamp_ms,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ConsensusCommitPrologueV2(prologue) => {
+                setup_consensus_commit(
+                    prologue.commit_timestamp_ms,
                     temporary_store,
                     tx_ctx,
                     move_vm,
@@ -724,7 +737,7 @@ mod checked {
     /// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
     ///   consensus.
     fn setup_consensus_commit(
-        prologue: ConsensusCommitPrologue,
+        consensus_commit_timestamp_ms: CheckpointTimestamp,
         temporary_store: &mut TemporaryStore<'_>,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
@@ -741,7 +754,7 @@ mod checked {
                 vec![],
                 vec![
                     CallArg::CLOCK_MUT,
-                    CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&consensus_commit_timestamp_ms).unwrap()),
                 ],
             );
             assert_invariant!(

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -15,6 +15,7 @@ mod checked {
     };
     use sui_types::execution_mode::{self, ExecutionMode};
     use sui_types::gas_coin::GAS;
+    use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::object::OBJECT_START_VERSION;
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -38,7 +39,6 @@ mod checked {
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
-    use sui_types::messages_consensus::ConsensusCommitPrologue;
     use sui_types::storage::BackingStore;
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -531,7 +531,20 @@ mod checked {
             }
             TransactionKind::ConsensusCommitPrologue(prologue) => {
                 setup_consensus_commit(
-                    prologue,
+                    prologue.commit_timestamp_ms,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok(Mode::empty_results())
+            }
+            TransactionKind::ConsensusCommitPrologueV2(prologue) => {
+                setup_consensus_commit(
+                    prologue.commit_timestamp_ms,
                     temporary_store,
                     tx_ctx,
                     move_vm,
@@ -877,7 +890,7 @@ mod checked {
     /// - Set the timestamp for the `Clock` shared object from the timestamp in the header from
     ///   consensus.
     fn setup_consensus_commit(
-        prologue: ConsensusCommitPrologue,
+        consensus_commit_timestamp_ms: CheckpointTimestamp,
         temporary_store: &mut TemporaryStore<'_>,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,
@@ -894,7 +907,7 @@ mod checked {
                 vec![],
                 vec![
                     CallArg::CLOCK_MUT,
-                    CallArg::Pure(bcs::to_bytes(&prologue.commit_timestamp_ms).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&consensus_commit_timestamp_ms).unwrap()),
                 ],
             );
             assert_invariant!(


### PR DESCRIPTION
## Description 

This PR implements consensus folk detection by adding consensus output digest into consensus commit prologue transaction. The digest implementation uses the existing ConsensusOutputCommit.

## Test Plan 

Unit test to test to test basic ConsensusCommitPrologueV2
Unit test to test CheckpointSummary creates different digest if the included ConsensusCommitPrologueV2 transactions have different consensus output digest.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
