### PR TITLE
[graphql][1/n] conditional db for testing and local dev

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -428,9 +428,9 @@ jobs:
           POSTGRES_PASSWORD: postgrespw
      - name: tests-requiring-postgres
        run: |
-         cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
-         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration
-         cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration pg_backend
+         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration pg_backend
+         cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration pg_backend
 
        env:
          POSTGRES_HOST: localhost

--- a/crates/sui-graphql-e2e-tests/Cargo.toml
+++ b/crates/sui-graphql-e2e-tests/Cargo.toml
@@ -21,7 +21,9 @@ harness = false
 workspace-hack.workspace = true
 
 [features]
+default = ["pg_backend"]
 pg_integration = []
+pg_backend = []
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -70,3 +70,4 @@ tower.workspace = true
 
 [features]
 pg_integration = []
+pg_backend = []

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -69,5 +69,6 @@ sui-move-build.workspace = true
 tower.workspace = true
 
 [features]
+default = ["pg_backend"]
 pg_integration = []
 pg_backend = []

--- a/crates/sui-graphql-rpc/README.md
+++ b/crates/sui-graphql-rpc/README.md
@@ -1,5 +1,12 @@
 # sui-graphql-rpc
 
+## Dev setup
+Note that we use compilation flags to determine the backend for Diesel. If you're using VS Code, make sure to update settings.json with the appropriate features - there should at least be a "pg_backend" (or other backend.)
+```
+"rust-analyzer.cargo.features": ["pg_backend"]
+```
+
+
 ## Spinning up locally
 
 ### Setting up local db

--- a/crates/sui-graphql-rpc/README.md
+++ b/crates/sui-graphql-rpc/README.md
@@ -5,7 +5,13 @@ Note that we use compilation flags to determine the backend for Diesel. If you'r
 ```
 "rust-analyzer.cargo.features": ["pg_backend"]
 ```
+Consequently, you'll also need to specify the backend when running cargo commands:
+```cargo run --features "pg_backend" --bin sui-graphql-rpc start-server --db-url <DB_URL>```
 
+The order is important:
+1. --features "pg_backend": This part tells Cargo to enable the pg_backend feature.
+2. --bin sui-graphql-rpc: This specifies which binary to run.
+3. start-server --db-url: These are arguments to the binary.
 
 ## Spinning up locally
 

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -96,5 +96,3 @@ impl<T: QueryId> QueryId for Explained<T> {
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
 }
-
-// - The following is db-specific, and can be conditionally compiled

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::backend::Backend;
+use sui_indexer::{
+    schema_v2::{checkpoints, epochs, objects, transactions},
+    types_v2::OwnerType,
+};
+
+use crate::{
+    error::Error,
+    types::{object::ObjectFilter, transaction_block::TransactionBlockFilter},
+};
+use diesel::{
+    pg::Pg,
+    query_builder::{AstPass, BoxedSelectStatement, FromClause, QueryFragment, QueryId},
+    sql_types::Text,
+    PgConnection, QueryResult, RunQueryDsl,
+};
+
+pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
+    'a,
+    (
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    ),
+    FromClause<objects::table>,
+    DB,
+    objects::dsl::coin_type,
+>;
+
+pub(crate) trait GenericQueryBuilder<DB: Backend> {
+    fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, DB>;
+    fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, DB>;
+    fn get_epoch(epoch_id: i64) -> epochs::BoxedQuery<'static, DB>;
+    fn get_latest_epoch() -> epochs::BoxedQuery<'static, DB>;
+    fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, DB>;
+    fn get_checkpoint_by_sequence_number(
+        sequence_number: i64,
+    ) -> checkpoints::BoxedQuery<'static, DB>;
+    fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
+    fn multi_get_txs(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<TransactionBlockFilter>,
+        after_tx_seq_num: Option<i64>,
+        before_tx_seq_num: Option<i64>,
+    ) -> Result<transactions::BoxedQuery<'static, DB>, Error>;
+    fn multi_get_coins(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        address: Vec<u8>,
+        coin_type: String,
+    ) -> objects::BoxedQuery<'static, DB>;
+    fn multi_get_objs(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<ObjectFilter>,
+        owner_type: Option<OwnerType>,
+    ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
+    fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
+    fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
+    fn multi_get_checkpoints(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        epoch: Option<i64>,
+    ) -> checkpoints::BoxedQuery<'static, DB>;
+}
+
+/// Struct for custom diesel function
+#[derive(Debug, Clone, Copy)]
+pub struct Explained<T> {
+    query: T,
+}
+
+/// Allows .explain() method on any Diesel query
+pub trait Explain: Sized {
+    fn explain(self) -> Explained<Self>;
+}
+impl<T> Explain for T {
+    fn explain(self) -> Explained<Self> {
+        Explained { query: self }
+    }
+}
+
+/// All queries need to implement QueryId
+impl<T: QueryId> QueryId for Explained<T> {
+    type QueryId = (T::QueryId, std::marker::PhantomData<&'static str>);
+    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
+}
+
+/// Explained<T> is a fully structured query with return of type Text
+impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
+    type SqlType = Text;
+}
+
+// - The following is db-specific, and can be conditionally compiled
+
+/// Allows methods like load(), get_result(), etc. on an Explained query
+impl<T> RunQueryDsl<PgConnection> for Explained<T> {}
+
+/// Implement logic for prefixing queries with "EXPLAIN"
+impl<T> QueryFragment<Pg> for Explained<T>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.push_sql("EXPLAIN (FORMAT JSON) ");
+        self.query.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     config::Limits,
     error::Error,
@@ -44,13 +45,7 @@ use crate::{
     },
 };
 use async_graphql::connection::{Connection, Edge};
-use diesel::{
-    pg::Pg,
-    query_builder::{AstPass, BoxedSelectStatement, FromClause, QueryFragment, QueryId},
-    sql_types::Text,
-    BoolExpressionMethods, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    QueryResult, RunQueryDsl,
-};
+use diesel::{pg::Pg, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl};
 use move_core_types::language_storage::StructTag;
 use std::str::FromStr;
 use sui_indexer::{
@@ -60,10 +55,7 @@ use sui_indexer::{
         checkpoints::StoredCheckpoint, epoch::StoredEpochInfo, objects::StoredObject,
         transactions::StoredTransaction,
     },
-    schema_v2::{
-        checkpoints, epochs, objects, transactions, tx_calls, tx_changed_objects, tx_input_objects,
-        tx_recipients, tx_senders,
-    },
+    schema_v2::transactions,
     types_v2::OwnerType,
     PgConnectionPoolConfig,
 };
@@ -98,7 +90,13 @@ use sui_types::{
     Identifier,
 };
 
-use super::DEFAULT_PAGE_SIZE;
+use super::{
+    db_backend::{Explain, GenericQueryBuilder},
+    DEFAULT_PAGE_SIZE,
+};
+
+#[cfg(feature = "pg_backend")]
+use super::pg_backend::QueryBuilder;
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum DbValidationError {
@@ -126,60 +124,6 @@ pub enum DbValidationError {
     QueryCostExceeded(u64, u64),
 }
 
-type BalanceQuery<'a> = BoxedSelectStatement<
-    'a,
-    (
-        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
-        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
-        diesel::sql_types::Nullable<diesel::sql_types::Text>,
-    ),
-    FromClause<objects::table>,
-    Pg,
-    objects::dsl::coin_type,
->;
-
-/// Allows .explain() method on any Diesel query
-pub trait Explain: Sized {
-    fn explain(self) -> Explained<Self>;
-}
-impl<T> Explain for T {
-    fn explain(self) -> Explained<Self> {
-        Explained { query: self }
-    }
-}
-
-/// Struct for custom diesel function
-#[derive(Debug, Clone, Copy)]
-pub struct Explained<T> {
-    query: T,
-}
-
-/// All queries need to implement QueryId
-impl<T: QueryId> QueryId for Explained<T> {
-    type QueryId = (T::QueryId, std::marker::PhantomData<&'static str>);
-    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
-}
-
-/// Explained<T> is a fully structured query with return of type Text
-impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
-    type SqlType = Text;
-}
-
-/// Allows methods like load(), get_result(), etc. on an Explained query
-impl<T> RunQueryDsl<PgConnection> for Explained<T> {}
-
-/// Implement logic for prefixing queries with "EXPLAIN"
-impl<T> QueryFragment<Pg> for Explained<T>
-where
-    T: QueryFragment<Pg>,
-{
-    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
-        out.push_sql("EXPLAIN (FORMAT JSON) ");
-        self.query.walk_ast(out.reborrow())?;
-        Ok(())
-    }
-}
-
 pub fn extract_cost(explain_result: &str) -> Result<f64, Error> {
     let parsed: serde_json::Value =
         serde_json::from_str(explain_result).map_err(|e| Error::Internal(e.to_string()))?;
@@ -194,347 +138,6 @@ pub fn extract_cost(explain_result: &str) -> Result<f64, Error> {
         Err(Error::Internal(
             "Failed to get cost from query plan".to_string(),
         ))
-    }
-}
-
-pub struct QueryBuilder;
-impl QueryBuilder {
-    fn get_tx_by_digest<'a>(digest: Vec<u8>) -> transactions::BoxedQuery<'a, Pg> {
-        transactions::dsl::transactions
-            .filter(transactions::dsl::transaction_digest.eq(digest))
-            .into_boxed()
-    }
-
-    fn get_obj<'a>(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'a, Pg> {
-        let mut query = objects::dsl::objects.into_boxed();
-        query = query.filter(objects::dsl::object_id.eq(address));
-
-        if let Some(version) = version {
-            query = query.filter(objects::dsl::object_version.eq(version));
-        }
-        query
-    }
-
-    fn get_epoch<'a>(epoch_id: i64) -> epochs::BoxedQuery<'a, Pg> {
-        epochs::dsl::epochs
-            .filter(epochs::dsl::epoch.eq(epoch_id))
-            .into_boxed()
-    }
-
-    fn get_latest_epoch<'a>() -> epochs::BoxedQuery<'a, Pg> {
-        epochs::dsl::epochs
-            .order_by(epochs::dsl::epoch.desc())
-            .limit(1)
-            .into_boxed()
-    }
-
-    fn get_checkpoint_by_digest<'a>(digest: Vec<u8>) -> checkpoints::BoxedQuery<'a, Pg> {
-        checkpoints::dsl::checkpoints
-            .filter(checkpoints::dsl::checkpoint_digest.eq(digest))
-            .into_boxed()
-    }
-
-    fn get_checkpoint_by_sequence_number<'a>(
-        sequence_number: i64,
-    ) -> checkpoints::BoxedQuery<'a, Pg> {
-        checkpoints::dsl::checkpoints
-            .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
-            .into_boxed()
-    }
-
-    fn get_latest_checkpoint<'a>() -> checkpoints::BoxedQuery<'a, Pg> {
-        checkpoints::dsl::checkpoints
-            .order_by(checkpoints::dsl::sequence_number.desc())
-            .limit(1)
-            .into_boxed()
-    }
-
-    fn multi_get_txs<'a>(
-        cursor: Option<i64>,
-        descending_order: bool,
-        limit: i64,
-        filter: Option<TransactionBlockFilter>,
-        after_tx_seq_num: Option<i64>,
-        before_tx_seq_num: Option<i64>,
-    ) -> Result<transactions::BoxedQuery<'a, Pg>, Error> {
-        let mut query = transactions::dsl::transactions.into_boxed();
-
-        if let Some(cursor_val) = cursor {
-            if descending_order {
-                let filter_value =
-                    before_tx_seq_num.map_or(cursor_val, |b| std::cmp::min(b, cursor_val));
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(filter_value));
-            } else {
-                let filter_value =
-                    after_tx_seq_num.map_or(cursor_val, |a| std::cmp::max(a, cursor_val));
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(filter_value));
-            }
-        } else {
-            if let Some(av) = after_tx_seq_num {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(av));
-            }
-            if let Some(bv) = before_tx_seq_num {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(bv));
-            }
-        }
-
-        if descending_order {
-            query = query.order(transactions::dsl::tx_sequence_number.desc());
-        } else {
-            query = query.order(transactions::dsl::tx_sequence_number.asc());
-        }
-
-        query = query.limit(limit + 1);
-
-        if let Some(filter) = filter {
-            // Filters for transaction table
-            // at_checkpoint mutually exclusive with before_ and after_checkpoint
-            if let Some(checkpoint) = filter.at_checkpoint {
-                query = query
-                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
-            }
-            if let Some(transaction_ids) = filter.transaction_ids {
-                let digests = transaction_ids
-                    .into_iter()
-                    .map(|id| Ok::<Vec<u8>, Error>(Digest::from_str(&id)?.into_vec()))
-                    .collect::<Result<Vec<_>, _>>()?;
-                query = query.filter(transactions::dsl::transaction_digest.eq_any(digests));
-            }
-
-            // Queries on foreign tables
-            match (filter.package, filter.module, filter.function) {
-                (Some(p), None, None) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                (Some(p), Some(m), None) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .filter(tx_calls::dsl::module.eq(m))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                (Some(p), Some(m), Some(f)) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .filter(tx_calls::dsl::module.eq(m))
-                        .filter(tx_calls::dsl::func.eq(f))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                _ => {}
-            }
-
-            if let Some(signer) = filter.sign_address {
-                if let Some(sender) = filter.sent_address {
-                    let subquery = tx_senders::dsl::tx_senders
-                        .filter(
-                            tx_senders::dsl::sender
-                                .eq(signer.into_vec())
-                                .or(tx_senders::dsl::sender.eq(sender.into_vec())),
-                        )
-                        .select(tx_senders::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                } else {
-                    let subquery = tx_senders::dsl::tx_senders
-                        .filter(tx_senders::dsl::sender.eq(signer.into_vec()))
-                        .select(tx_senders::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-            } else if let Some(sender) = filter.sent_address {
-                let subquery = tx_senders::dsl::tx_senders
-                    .filter(tx_senders::dsl::sender.eq(sender.into_vec()))
-                    .select(tx_senders::dsl::tx_sequence_number);
-
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-            if let Some(recipient) = filter.recv_address {
-                let subquery = tx_recipients::dsl::tx_recipients
-                    .filter(tx_recipients::dsl::recipient.eq(recipient.into_vec()))
-                    .select(tx_recipients::dsl::tx_sequence_number);
-
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-            if filter.paid_address.is_some() {
-                return Err(Error::Internal(
-                    "Paid address filter not supported".to_string(),
-                ));
-            }
-
-            if let Some(input_object) = filter.input_object {
-                let subquery = tx_input_objects::dsl::tx_input_objects
-                    .filter(tx_input_objects::dsl::object_id.eq(input_object.into_vec()))
-                    .select(tx_input_objects::dsl::tx_sequence_number);
-
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-            if let Some(changed_object) = filter.changed_object {
-                let subquery = tx_changed_objects::dsl::tx_changed_objects
-                    .filter(tx_changed_objects::dsl::object_id.eq(changed_object.into_vec()))
-                    .select(tx_changed_objects::dsl::tx_sequence_number);
-
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-        };
-
-        Ok(query)
-    }
-
-    fn multi_get_coins<'a>(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
-        limit: i64,
-        address: Vec<u8>,
-        coin_type: String,
-    ) -> objects::BoxedQuery<'a, Pg> {
-        let mut query = objects::dsl::objects.into_boxed();
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(objects::dsl::object_id.lt(cursor));
-            } else {
-                query = query.filter(objects::dsl::object_id.gt(cursor));
-            }
-        }
-        if descending_order {
-            query = query.order(objects::dsl::object_id.desc());
-        } else {
-            query = query.order(objects::dsl::object_id.asc());
-        }
-        query = query.limit(limit + 1);
-
-        query = query
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16)) // Leverage index on objects table
-            .filter(objects::dsl::coin_type.eq(coin_type));
-
-        query
-    }
-
-    fn multi_get_objs<'a>(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
-        limit: i64,
-        filter: Option<ObjectFilter>,
-        owner_type: Option<OwnerType>,
-    ) -> Result<objects::BoxedQuery<'a, Pg>, Error> {
-        let mut query = objects::dsl::objects.into_boxed();
-
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(objects::dsl::object_id.lt(cursor));
-            } else {
-                query = query.filter(objects::dsl::object_id.gt(cursor));
-            }
-        }
-
-        if descending_order {
-            query = query.order(objects::dsl::object_id.desc());
-        } else {
-            query = query.order(objects::dsl::object_id.asc());
-        }
-
-        query = query.limit(limit + 1);
-
-        if let Some(filter) = filter {
-            if let Some(object_ids) = filter.object_ids {
-                query = query.filter(
-                    objects::dsl::object_id.eq_any(
-                        object_ids
-                            .into_iter()
-                            .map(|id| id.into_vec())
-                            .collect::<Vec<_>>(),
-                    ),
-                );
-            }
-
-            if let Some(owner) = filter.owner {
-                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
-
-                match owner_type {
-                    Some(OwnerType::Address) => {
-                        query =
-                            query.filter(objects::dsl::owner_type.eq(OwnerType::Address as i16));
-                    }
-                    Some(OwnerType::Object) => {
-                        query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
-                    }
-                    None => {
-                        query = query.filter(
-                            objects::dsl::owner_type
-                                .eq(OwnerType::Address as i16)
-                                .or(objects::dsl::owner_type.eq(OwnerType::Object as i16)),
-                        );
-                    }
-                    _ => Err(DbValidationError::InvalidOwnerType)?,
-                }
-            }
-
-            if let Some(object_type) = filter.ty {
-                query = query.filter(objects::dsl::object_type.eq(object_type));
-            }
-        }
-
-        Ok(query)
-    }
-
-    fn multi_get_balances<'a>(address: Vec<u8>) -> BalanceQuery<'a> {
-        let query = objects::dsl::objects
-            .group_by(objects::dsl::coin_type)
-            .select((
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "CAST(SUM(coin_balance) AS BIGINT)",
-                ),
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "COUNT(*)",
-                ),
-                objects::dsl::coin_type,
-            ))
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
-            .filter(objects::dsl::coin_type.is_not_null())
-            .into_boxed();
-
-        query
-    }
-
-    fn get_balance<'a>(address: Vec<u8>, coin_type: String) -> BalanceQuery<'a> {
-        let query = QueryBuilder::multi_get_balances(address);
-        query.filter(objects::dsl::coin_type.eq(coin_type))
-    }
-
-    fn multi_get_checkpoints<'a>(
-        cursor: Option<i64>,
-        descending_order: bool,
-        limit: i64,
-        epoch: Option<i64>,
-    ) -> checkpoints::BoxedQuery<'a, Pg> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
-
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(checkpoints::dsl::sequence_number.lt(cursor));
-            } else {
-                query = query.filter(checkpoints::dsl::sequence_number.gt(cursor));
-            }
-        }
-        if descending_order {
-            query = query.order(checkpoints::dsl::sequence_number.desc());
-        } else {
-            query = query.order(checkpoints::dsl::sequence_number.asc());
-        }
-        if let Some(epoch) = epoch {
-            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
-        }
-        query = query.limit(limit + 1);
-
-        query
     }
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -45,7 +45,7 @@ use crate::{
     },
 };
 use async_graphql::connection::{Connection, Edge};
-use diesel::{pg::Pg, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl};
+use diesel::{ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl};
 use move_core_types::language_storage::StructTag;
 use std::str::FromStr;
 use sui_indexer::{
@@ -90,13 +90,10 @@ use sui_types::{
     Identifier,
 };
 
-use super::{
-    db_backend::{Explain, GenericQueryBuilder},
-    DEFAULT_PAGE_SIZE,
-};
+use super::{db_backend::GenericQueryBuilder, DEFAULT_PAGE_SIZE};
 
 #[cfg(feature = "pg_backend")]
-use super::pg_backend::QueryBuilder;
+use super::pg_backend::{PgQueryExecutor, QueryBuilder};
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum DbValidationError {
@@ -122,23 +119,6 @@ pub enum DbValidationError {
     InvalidOwnerType,
     #[error("Query cost exceeded - cost: {0}, limit: {1}")]
     QueryCostExceeded(u64, u64),
-}
-
-pub fn extract_cost(explain_result: &str) -> Result<f64, Error> {
-    let parsed: serde_json::Value =
-        serde_json::from_str(explain_result).map_err(|e| Error::Internal(e.to_string()))?;
-    if let Some(cost) = parsed
-        .get(0)
-        .and_then(|entry| entry.get("Plan"))
-        .and_then(|plan| plan.get("Total Cost"))
-        .and_then(|cost| cost.as_f64())
-    {
-        Ok(cost)
-    } else {
-        Err(Error::Internal(
-            "Failed to get cost from query plan".to_string(),
-        ))
-    }
 }
 
 pub(crate) struct PgManager {
@@ -171,51 +151,49 @@ impl PgManager {
             .map_err(|e| Error::Internal(e.to_string()))
     }
 
-    /// Takes a query_builder_fn that returns Result<QueryFragment> and a lambda to execute the query
-    /// Spawns a blocking task that determines the cost of the query fragment
-    /// And if within limits, then executes the query
-    async fn run_query_async_with_cost<T, Q, QResult, EF, E, F>(
-        &self,
-        mut query_builder_fn: Q,
-        execute_fn: EF,
-    ) -> Result<T, Error>
-    where
-        Q: FnMut() -> Result<QResult, Error> + Send + 'static,
-        QResult: QueryDsl
-            + RunQueryDsl<Pg>
-            + diesel::query_builder::QueryFragment<diesel::pg::Pg>
-            + diesel::query_builder::Query
-            + diesel::query_builder::QueryId
-            + Send
-            + 'static,
-        EF: FnOnce(QResult) -> F + Send + 'static,
-        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
-        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
-        T: Send + 'static,
-    {
-        let max_db_query_cost = self.limits.max_db_query_cost;
-        self.inner
-            .spawn_blocking(move |this| {
-                let query = query_builder_fn()?;
-                let explain_result: String = this
-                    .run_query(|conn| query.explain().get_result(conn))
-                    .map_err(|e| Error::Internal(e.to_string()))?;
-                let cost = extract_cost(&explain_result)?;
-                if cost > max_db_query_cost as f64 {
-                    return Err(DbValidationError::QueryCostExceeded(
-                        cost as u64,
-                        max_db_query_cost,
-                    )
-                    .into());
-                }
+    // / Takes a query_builder_fn that returns Result<QueryFragment> and a lambda to execute the query
+    // / Spawns a blocking task that determines the cost of the query fragment
+    // / And if within limits, then executes the query
+    // async fn run_query_async_with_cost<T, Q, QResult, EF, E, F>(
+    //     &self,
+    //     mut query_builder_fn: Q,
+    //     execute_fn: EF,
+    // ) -> Result<T, Error>
+    // where
+    //     Q: FnMut() -> Result<QResult, Error> + Send + 'static,
+    //     QResult: diesel::query_builder::QueryFragment<diesel::pg::Pg>
+    //         + diesel::query_builder::Query
+    //         + diesel::query_builder::QueryId
+    //         + Send
+    //         + 'static,
+    //     EF: FnOnce(QResult) -> F + Send + 'static,
+    //     F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
+    //     E: From<diesel::result::Error> + std::error::Error + Send + 'static,
+    //     T: Send + 'static,
+    // {
+    //     let max_db_query_cost = self.limits.max_db_query_cost;
+    //     self.inner
+    //         .spawn_blocking(move |this| {
+    //             let query = query_builder_fn()?;
+    //             let explain_result: String = this
+    //                 .run_query(|conn| query.explain().get_result(conn))
+    //                 .map_err(|e| Error::Internal(e.to_string()))?;
+    //             let cost = extract_cost(&explain_result)?;
+    //             if cost > max_db_query_cost as f64 {
+    //                 return Err(DbValidationError::QueryCostExceeded(
+    //                     cost as u64,
+    //                     max_db_query_cost,
+    //                 )
+    //                 .into());
+    //             }
 
-                let query = query_builder_fn()?;
-                let execute_closure = execute_fn(query);
-                this.run_query(execute_closure)
-                    .map_err(|e| Error::Internal(e.to_string()))
-            })
-            .await
-    }
+    //             let query = query_builder_fn()?;
+    //             let execute_closure = execute_fn(query);
+    //             this.run_query(execute_closure)
+    //                 .map_err(|e| Error::Internal(e.to_string()))
+    //         })
+    //         .await
+    // }
 }
 
 /// Implement methods to query db and return StoredData
@@ -1826,52 +1804,5 @@ impl From<SuiAddress> for NativeSuiAddress {
 impl From<&SuiAddress> for NativeSuiAddress {
     fn from(a: &SuiAddress) -> Self {
         NativeSuiAddress::try_from(a.as_slice()).unwrap()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_invalid_json() {
-        let explain_result = "invalid json";
-        let result = extract_cost(explain_result);
-        assert!(matches!(result, Err(Error::Internal(_))));
-    }
-
-    #[test]
-    fn test_missing_entry_at_0() {
-        let explain_result = "[]";
-        let result = extract_cost(explain_result);
-        assert!(matches!(result, Err(Error::Internal(_))));
-    }
-
-    #[test]
-    fn test_missing_plan() {
-        let explain_result = r#"[{}]"#;
-        let result = extract_cost(explain_result);
-        assert!(matches!(result, Err(Error::Internal(_))));
-    }
-
-    #[test]
-    fn test_missing_total_cost() {
-        let explain_result = r#"[{"Plan": {}}]"#;
-        let result = extract_cost(explain_result);
-        assert!(matches!(result, Err(Error::Internal(_))));
-    }
-
-    #[test]
-    fn test_failure_on_conversion_to_f64() {
-        let explain_result = r#"[{"Plan": {"Total Cost": "string_instead_of_float"}}]"#;
-        let result = extract_cost(explain_result);
-        assert!(matches!(result, Err(Error::Internal(_))));
-    }
-
-    #[test]
-    fn test_happy_scenario() {
-        let explain_result = r#"[{"Plan": {"Total Cost": 1.0}}]"#;
-        let result = extract_cost(explain_result).unwrap();
-        assert_eq!(result, 1.0);
     }
 }

--- a/crates/sui-graphql-rpc/src/context_data/mod.rs
+++ b/crates/sui-graphql-rpc/src/context_data/mod.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod db_backend;
 pub(crate) mod db_data_provider;
 pub mod db_query_cost;
 pub(crate) mod package_cache;
+#[cfg(feature = "pg_backend")]
+pub(crate) mod pg_backend;
 
 pub const DEFAULT_PAGE_SIZE: u64 = 10;

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -1,0 +1,454 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    db_backend::{BalanceQuery, GenericQueryBuilder},
+    db_data_provider::DbValidationError,
+};
+use crate::{
+    error::Error,
+    types::{digest::Digest, object::ObjectFilter, transaction_block::TransactionBlockFilter},
+};
+use diesel::{
+    pg::Pg,
+    query_builder::{BoxedSelectStatement, FromClause},
+    BoolExpressionMethods, ExpressionMethods, QueryDsl,
+};
+use std::str::FromStr;
+use sui_indexer::{
+    schema_v2::{
+        checkpoints, epochs, objects, transactions, tx_calls, tx_changed_objects, tx_input_objects,
+        tx_recipients, tx_senders,
+    },
+    types_v2::OwnerType,
+};
+
+type PgBalanceQuery<'a> = BoxedSelectStatement<
+    'a,
+    (
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+        diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    ),
+    FromClause<objects::table>,
+    Pg,
+    objects::dsl::coin_type,
+>;
+
+pub(crate) struct PgQueryBuilder;
+impl PgQueryBuilder {
+    fn get_tx_by_digest<'a>(digest: Vec<u8>) -> transactions::BoxedQuery<'a, Pg> {
+        transactions::dsl::transactions
+            .filter(transactions::dsl::transaction_digest.eq(digest))
+            .into_boxed()
+    }
+
+    fn get_obj<'a>(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'a, Pg> {
+        let mut query = objects::dsl::objects.into_boxed();
+        query = query.filter(objects::dsl::object_id.eq(address));
+
+        if let Some(version) = version {
+            query = query.filter(objects::dsl::object_version.eq(version));
+        }
+        query
+    }
+
+    fn get_epoch<'a>(epoch_id: i64) -> epochs::BoxedQuery<'a, Pg> {
+        epochs::dsl::epochs
+            .filter(epochs::dsl::epoch.eq(epoch_id))
+            .into_boxed()
+    }
+
+    fn get_latest_epoch<'a>() -> epochs::BoxedQuery<'a, Pg> {
+        epochs::dsl::epochs
+            .order_by(epochs::dsl::epoch.desc())
+            .limit(1)
+            .into_boxed()
+    }
+
+    fn get_checkpoint_by_digest<'a>(digest: Vec<u8>) -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .filter(checkpoints::dsl::checkpoint_digest.eq(digest))
+            .into_boxed()
+    }
+
+    fn get_checkpoint_by_sequence_number<'a>(
+        sequence_number: i64,
+    ) -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
+            .into_boxed()
+    }
+
+    fn get_latest_checkpoint<'a>() -> checkpoints::BoxedQuery<'a, Pg> {
+        checkpoints::dsl::checkpoints
+            .order_by(checkpoints::dsl::sequence_number.desc())
+            .limit(1)
+            .into_boxed()
+    }
+
+    fn multi_get_txs<'a>(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<TransactionBlockFilter>,
+        after_tx_seq_num: Option<i64>,
+        before_tx_seq_num: Option<i64>,
+    ) -> Result<transactions::BoxedQuery<'a, Pg>, Error> {
+        let mut query = transactions::dsl::transactions.into_boxed();
+
+        if let Some(cursor_val) = cursor {
+            if descending_order {
+                let filter_value =
+                    before_tx_seq_num.map_or(cursor_val, |b| std::cmp::min(b, cursor_val));
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(filter_value));
+            } else {
+                let filter_value =
+                    after_tx_seq_num.map_or(cursor_val, |a| std::cmp::max(a, cursor_val));
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(filter_value));
+            }
+        } else {
+            if let Some(av) = after_tx_seq_num {
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(av));
+            }
+            if let Some(bv) = before_tx_seq_num {
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(bv));
+            }
+        }
+
+        if descending_order {
+            query = query.order(transactions::dsl::tx_sequence_number.desc());
+        } else {
+            query = query.order(transactions::dsl::tx_sequence_number.asc());
+        }
+
+        query = query.limit(limit + 1);
+
+        if let Some(filter) = filter {
+            // Filters for transaction table
+            // at_checkpoint mutually exclusive with before_ and after_checkpoint
+            if let Some(checkpoint) = filter.at_checkpoint {
+                query = query
+                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
+            }
+            if let Some(transaction_ids) = filter.transaction_ids {
+                let digests = transaction_ids
+                    .into_iter()
+                    .map(|id| Ok::<Vec<u8>, Error>(Digest::from_str(&id)?.into_vec()))
+                    .collect::<Result<Vec<_>, _>>()?;
+                query = query.filter(transactions::dsl::transaction_digest.eq_any(digests));
+            }
+
+            // Queries on foreign tables
+            match (filter.package, filter.module, filter.function) {
+                (Some(p), None, None) => {
+                    let subquery = tx_calls::dsl::tx_calls
+                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                        .select(tx_calls::dsl::tx_sequence_number);
+
+                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+                }
+                (Some(p), Some(m), None) => {
+                    let subquery = tx_calls::dsl::tx_calls
+                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                        .filter(tx_calls::dsl::module.eq(m))
+                        .select(tx_calls::dsl::tx_sequence_number);
+
+                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+                }
+                (Some(p), Some(m), Some(f)) => {
+                    let subquery = tx_calls::dsl::tx_calls
+                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                        .filter(tx_calls::dsl::module.eq(m))
+                        .filter(tx_calls::dsl::func.eq(f))
+                        .select(tx_calls::dsl::tx_sequence_number);
+
+                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+                }
+                _ => {}
+            }
+
+            if let Some(signer) = filter.sign_address {
+                if let Some(sender) = filter.sent_address {
+                    let subquery = tx_senders::dsl::tx_senders
+                        .filter(
+                            tx_senders::dsl::sender
+                                .eq(signer.into_vec())
+                                .or(tx_senders::dsl::sender.eq(sender.into_vec())),
+                        )
+                        .select(tx_senders::dsl::tx_sequence_number);
+
+                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+                } else {
+                    let subquery = tx_senders::dsl::tx_senders
+                        .filter(tx_senders::dsl::sender.eq(signer.into_vec()))
+                        .select(tx_senders::dsl::tx_sequence_number);
+
+                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+                }
+            } else if let Some(sender) = filter.sent_address {
+                let subquery = tx_senders::dsl::tx_senders
+                    .filter(tx_senders::dsl::sender.eq(sender.into_vec()))
+                    .select(tx_senders::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+            }
+            if let Some(recipient) = filter.recv_address {
+                let subquery = tx_recipients::dsl::tx_recipients
+                    .filter(tx_recipients::dsl::recipient.eq(recipient.into_vec()))
+                    .select(tx_recipients::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+            }
+            if filter.paid_address.is_some() {
+                return Err(Error::Internal(
+                    "Paid address filter not supported".to_string(),
+                ));
+            }
+
+            if let Some(input_object) = filter.input_object {
+                let subquery = tx_input_objects::dsl::tx_input_objects
+                    .filter(tx_input_objects::dsl::object_id.eq(input_object.into_vec()))
+                    .select(tx_input_objects::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+            }
+            if let Some(changed_object) = filter.changed_object {
+                let subquery = tx_changed_objects::dsl::tx_changed_objects
+                    .filter(tx_changed_objects::dsl::object_id.eq(changed_object.into_vec()))
+                    .select(tx_changed_objects::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+            }
+        };
+
+        Ok(query)
+    }
+
+    fn multi_get_coins<'a>(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        address: Vec<u8>,
+        coin_type: String,
+    ) -> objects::BoxedQuery<'a, Pg> {
+        let mut query = objects::dsl::objects.into_boxed();
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(objects::dsl::object_id.lt(cursor));
+            } else {
+                query = query.filter(objects::dsl::object_id.gt(cursor));
+            }
+        }
+        if descending_order {
+            query = query.order(objects::dsl::object_id.desc());
+        } else {
+            query = query.order(objects::dsl::object_id.asc());
+        }
+        query = query.limit(limit + 1);
+
+        query = query
+            .filter(objects::dsl::owner_id.eq(address))
+            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16)) // Leverage index on objects table
+            .filter(objects::dsl::coin_type.eq(coin_type));
+
+        query
+    }
+
+    fn multi_get_objs<'a>(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<ObjectFilter>,
+        owner_type: Option<OwnerType>,
+    ) -> Result<objects::BoxedQuery<'a, Pg>, Error> {
+        let mut query = objects::dsl::objects.into_boxed();
+
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(objects::dsl::object_id.lt(cursor));
+            } else {
+                query = query.filter(objects::dsl::object_id.gt(cursor));
+            }
+        }
+
+        if descending_order {
+            query = query.order(objects::dsl::object_id.desc());
+        } else {
+            query = query.order(objects::dsl::object_id.asc());
+        }
+
+        query = query.limit(limit + 1);
+
+        if let Some(filter) = filter {
+            if let Some(object_ids) = filter.object_ids {
+                query = query.filter(
+                    objects::dsl::object_id.eq_any(
+                        object_ids
+                            .into_iter()
+                            .map(|id| id.into_vec())
+                            .collect::<Vec<_>>(),
+                    ),
+                );
+            }
+
+            if let Some(owner) = filter.owner {
+                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
+
+                match owner_type {
+                    Some(OwnerType::Address) => {
+                        query =
+                            query.filter(objects::dsl::owner_type.eq(OwnerType::Address as i16));
+                    }
+                    Some(OwnerType::Object) => {
+                        query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
+                    }
+                    None => {
+                        query = query.filter(
+                            objects::dsl::owner_type
+                                .eq(OwnerType::Address as i16)
+                                .or(objects::dsl::owner_type.eq(OwnerType::Object as i16)),
+                        );
+                    }
+                    _ => Err(DbValidationError::InvalidOwnerType)?,
+                }
+            }
+
+            if let Some(object_type) = filter.ty {
+                query = query.filter(objects::dsl::object_type.eq(object_type));
+            }
+        }
+
+        Ok(query)
+    }
+
+    fn multi_get_balances<'a>(address: Vec<u8>) -> PgBalanceQuery<'a> {
+        let query = objects::dsl::objects
+            .group_by(objects::dsl::coin_type)
+            .select((
+                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
+                    "CAST(SUM(coin_balance) AS BIGINT)",
+                ),
+                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
+                    "COUNT(*)",
+                ),
+                objects::dsl::coin_type,
+            ))
+            .filter(objects::dsl::owner_id.eq(address))
+            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
+            .filter(objects::dsl::coin_type.is_not_null())
+            .into_boxed();
+
+        query
+    }
+
+    fn get_balance<'a>(address: Vec<u8>, coin_type: String) -> PgBalanceQuery<'a> {
+        let query = PgQueryBuilder::multi_get_balances(address);
+        query.filter(objects::dsl::coin_type.eq(coin_type))
+    }
+
+    fn multi_get_checkpoints<'a>(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        epoch: Option<i64>,
+    ) -> checkpoints::BoxedQuery<'a, Pg> {
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+
+        if let Some(cursor) = cursor {
+            if descending_order {
+                query = query.filter(checkpoints::dsl::sequence_number.lt(cursor));
+            } else {
+                query = query.filter(checkpoints::dsl::sequence_number.gt(cursor));
+            }
+        }
+        if descending_order {
+            query = query.order(checkpoints::dsl::sequence_number.desc());
+        } else {
+            query = query.order(checkpoints::dsl::sequence_number.asc());
+        }
+        if let Some(epoch) = epoch {
+            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
+        }
+        query = query.limit(limit + 1);
+
+        query
+    }
+}
+
+impl GenericQueryBuilder<Pg> for PgQueryBuilder {
+    fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_tx_by_digest(digest)
+    }
+    fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_obj(address, version)
+    }
+    fn get_epoch(epoch_id: i64) -> epochs::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_epoch(epoch_id)
+    }
+    fn get_latest_epoch() -> epochs::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_latest_epoch()
+    }
+    fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_checkpoint_by_digest(digest)
+    }
+    fn get_checkpoint_by_sequence_number(
+        sequence_number: i64,
+    ) -> checkpoints::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_checkpoint_by_sequence_number(sequence_number)
+    }
+    fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::get_latest_checkpoint()
+    }
+    fn multi_get_txs(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<TransactionBlockFilter>,
+        after_tx_seq_num: Option<i64>,
+        before_tx_seq_num: Option<i64>,
+    ) -> Result<transactions::BoxedQuery<'static, Pg>, Error> {
+        PgQueryBuilder::multi_get_txs(
+            cursor,
+            descending_order,
+            limit,
+            filter,
+            after_tx_seq_num,
+            before_tx_seq_num,
+        )
+    }
+    fn multi_get_coins(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        address: Vec<u8>,
+        coin_type: String,
+    ) -> objects::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::multi_get_coins(cursor, descending_order, limit, address, coin_type)
+    }
+    fn multi_get_objs(
+        cursor: Option<Vec<u8>>,
+        descending_order: bool,
+        limit: i64,
+        filter: Option<ObjectFilter>,
+        owner_type: Option<OwnerType>,
+    ) -> Result<objects::BoxedQuery<'static, Pg>, Error> {
+        PgQueryBuilder::multi_get_objs(cursor, descending_order, limit, filter, owner_type)
+    }
+    fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, Pg> {
+        PgQueryBuilder::multi_get_balances(address)
+    }
+    fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, Pg> {
+        PgQueryBuilder::get_balance(address, coin_type)
+    }
+    fn multi_get_checkpoints(
+        cursor: Option<i64>,
+        descending_order: bool,
+        limit: i64,
+        epoch: Option<i64>,
+    ) -> checkpoints::BoxedQuery<'static, Pg> {
+        PgQueryBuilder::multi_get_checkpoints(cursor, descending_order, limit, epoch)
+    }
+}
+
+pub(crate) type QueryBuilder = PgQueryBuilder;

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, Explained, GenericQueryBuilder},
+    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder},
     db_data_provider::DbValidationError,
 };
+use crate::context_data::db_data_provider::PgManager;
 use crate::{
     error::Error,
     types::{digest::Digest, object::ObjectFilter, transaction_block::TransactionBlockFilter},
 };
+use async_trait::async_trait;
 use diesel::{
     pg::Pg,
     query_builder::{AstPass, BoxedSelectStatement, FromClause, QueryFragment},
@@ -22,7 +24,6 @@ use sui_indexer::{
     },
     types_v2::OwnerType,
 };
-
 type PgBalanceQuery<'a> = BoxedSelectStatement<
     'a,
     (
@@ -466,4 +467,135 @@ where
     }
 }
 
+#[async_trait]
+pub trait PgQueryExecutor {
+    async fn run_query_async_with_cost<T, Q, QResult, EF, E, F>(
+        &self,
+        mut query_builder_fn: Q,
+        execute_fn: EF,
+    ) -> Result<T, Error>
+    where
+        Q: FnMut() -> Result<QResult, Error> + Send + 'static,
+        QResult: diesel::query_builder::QueryFragment<diesel::pg::Pg>
+            + diesel::query_builder::Query
+            + diesel::query_builder::QueryId
+            + Send
+            + 'static,
+        EF: FnOnce(QResult) -> F + Send + 'static,
+        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
+        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
+        T: Send + 'static;
+}
+
+#[async_trait]
+impl PgQueryExecutor for PgManager {
+    /// Takes a query_builder_fn that returns Result<QueryFragment> and a lambda to execute the query
+    /// Spawns a blocking task that determines the cost of the query fragment
+    /// And if within limits, then executes the query
+    async fn run_query_async_with_cost<T, Q, QResult, EF, E, F>(
+        &self,
+        mut query_builder_fn: Q,
+        execute_fn: EF,
+    ) -> Result<T, Error>
+    where
+        Q: FnMut() -> Result<QResult, Error> + Send + 'static,
+        QResult: diesel::query_builder::QueryFragment<diesel::pg::Pg>
+            + diesel::query_builder::Query
+            + diesel::query_builder::QueryId
+            + Send
+            + 'static,
+        EF: FnOnce(QResult) -> F + Send + 'static,
+        F: FnOnce(&mut PgConnection) -> Result<T, E> + Send + 'static,
+        E: From<diesel::result::Error> + std::error::Error + Send + 'static,
+        T: Send + 'static,
+    {
+        let max_db_query_cost = self.limits.max_db_query_cost;
+        self.inner
+            .spawn_blocking(move |this| {
+                let query = query_builder_fn()?;
+                let explain_result: String = this
+                    .run_query(|conn| query.explain().get_result(conn))
+                    .map_err(|e| Error::Internal(e.to_string()))?;
+                let cost = extract_cost(&explain_result)?;
+                if cost > max_db_query_cost as f64 {
+                    return Err(DbValidationError::QueryCostExceeded(
+                        cost as u64,
+                        max_db_query_cost,
+                    )
+                    .into());
+                }
+
+                let query = query_builder_fn()?;
+                let execute_closure = execute_fn(query);
+                this.run_query(execute_closure)
+                    .map_err(|e| Error::Internal(e.to_string()))
+            })
+            .await
+    }
+}
+
+pub fn extract_cost(explain_result: &str) -> Result<f64, Error> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(explain_result).map_err(|e| Error::Internal(e.to_string()))?;
+    if let Some(cost) = parsed
+        .get(0)
+        .and_then(|entry| entry.get("Plan"))
+        .and_then(|plan| plan.get("Total Cost"))
+        .and_then(|cost| cost.as_f64())
+    {
+        Ok(cost)
+    } else {
+        Err(Error::Internal(
+            "Failed to get cost from query plan".to_string(),
+        ))
+    }
+}
+
 pub(crate) type QueryBuilder = PgQueryBuilder;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_json() {
+        let explain_result = "invalid json";
+        let result = extract_cost(explain_result);
+        assert!(matches!(result, Err(Error::Internal(_))));
+    }
+
+    #[test]
+    fn test_missing_entry_at_0() {
+        let explain_result = "[]";
+        let result = extract_cost(explain_result);
+        assert!(matches!(result, Err(Error::Internal(_))));
+    }
+
+    #[test]
+    fn test_missing_plan() {
+        let explain_result = r#"[{}]"#;
+        let result = extract_cost(explain_result);
+        assert!(matches!(result, Err(Error::Internal(_))));
+    }
+
+    #[test]
+    fn test_missing_total_cost() {
+        let explain_result = r#"[{"Plan": {}}]"#;
+        let result = extract_cost(explain_result);
+        assert!(matches!(result, Err(Error::Internal(_))));
+    }
+
+    #[test]
+    fn test_failure_on_conversion_to_f64() {
+        let explain_result = r#"[{"Plan": {"Total Cost": "string_instead_of_float"}}]"#;
+        let result = extract_cost(explain_result);
+        assert!(matches!(result, Err(Error::Internal(_))));
+    }
+
+    #[test]
+    fn test_happy_scenario() {
+        let explain_result = r#"[{"Plan": {"Total Cost": 1.0}}]"#;
+        let result = extract_cost(explain_result).unwrap();
+        assert_eq!(result, 1.0);
+    }
+}


### PR DESCRIPTION
## Description 

This PR is localized to just the graphql side.
Each backend implements GenericQueryBuilder, and then exports a type alias QueryBuilder to be used in db_data_provider (pending rename?)
Because the function for executing a query has its type defs tied to the db backend, we also move this out into the corresponding backend.rs file. So for pg_backend.rs, we define a new trait PgQueryExecutor and implement it for PgManager (also pending rename.)

Custom sql functions like 'explain' play nicely enough with this approach - each backend just needs to implement the QueryFragment and RunQueryDsl portion.


In subsequent PRs:
1. Rename PgManager, instantiate a reader based on config (which will just fail if not postgres, until the next one is supported)
2. Modify IndexerReader on indexer crate to support different db backends

## Test Plan 

Refactor, so existing tests should pass. To pass ci, I've set the default to pg_backend - this should be fine as we don't have any other backends right now anyways.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
