### PR TITLE
[graphql/rpc] set DB pool size to 20 in indexer start test

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -23,6 +23,7 @@ use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 use tokio::task::JoinHandle;
+use tracing::info;
 
 const VALIDATOR_COUNT: usize = 7;
 const EPOCH_DURATION_MS: u64 = 15000;
@@ -163,6 +164,11 @@ pub async fn start_test_indexer_v2(
     reader_mode_rpc_url: Option<String>,
     use_indexer_experimental_methods: bool,
 ) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
+    // Reduce the connection pool size to 20 for testing
+    // to prevent maxing out
+    info!("Setting DB_POOL_SIZE to 20");
+    std::env::set_var("DB_POOL_SIZE", "20");
+
     let db_url = db_url.unwrap_or_else(|| {
         let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".into());
         let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "32770".into());


### PR DESCRIPTION
## Description 

Set to 20 to reduce hitting limits

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
