### PR TITLE
Fix analytics processor and parquet writer integration for empty files

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -136,8 +136,9 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
     }
 
     async fn cut(&mut self) -> anyhow::Result<()> {
-        if !self.current_checkpoint_range.is_empty() {
-            self.writer.flush(self.current_checkpoint_range.end)?;
+        if !self.current_checkpoint_range.is_empty()
+            && self.writer.flush(self.current_checkpoint_range.end)?
+        {
             let file_metadata = FileMetadata::new(
                 self.config.file_type,
                 self.config.file_format,

--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -89,7 +89,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         Ok(())
     }
 
-    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<()> {
+    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool> {
         self.writer.flush()?;
         let old_file_path = self.file_path(self.epoch, self.checkpoint_range.clone())?;
         let new_file_path = self.file_path(
@@ -97,7 +97,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
             self.checkpoint_range.start..end_checkpoint_seq_num,
         )?;
         fs::rename(old_file_path, new_file_path)?;
-        Ok(())
+        Ok(true)
     }
 
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()> {

--- a/crates/sui-analytics-indexer/src/writers/mod.rs
+++ b/crates/sui-analytics-indexer/src/writers/mod.rs
@@ -15,7 +15,7 @@ pub trait AnalyticsWriter<S: Serialize + ParquetSchema>: Send + Sync + 'static {
     /// Persist given rows into a file
     fn write(&mut self, rows: &[S]) -> Result<()>;
     /// Flush the current file
-    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<()>;
+    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool>;
     /// Reset internal state with given epoch and checkpoint sequence number
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()>;
 }

--- a/crates/sui-analytics-indexer/src/writers/parquet_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/parquet_writer.rs
@@ -98,9 +98,9 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for ParquetWriter {
         Ok(())
     }
 
-    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<()> {
+    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool> {
         if self.data.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
         self.checkpoint_range.end = end_checkpoint_seq_num;
         let mut batch_data = vec![];
@@ -118,7 +118,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for ParquetWriter {
         let mut writer = ArrowWriter::try_new(self.file()?, batch.schema(), Some(properties))?;
         writer.write(&batch)?;
         writer.close()?;
-        Ok(())
+        Ok(true)
     }
 
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()> {


### PR DESCRIPTION
## Description 

Parquet writer does not write a file when called with `flush()` if there are no records to write:
```
    fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool> {
        if self.data.is_empty() {
            return Ok(false);
        }
```
This is not handled in analytics processor today (with its integration with csv writer) because it expects the file to be written but later an empty file is just discarded when uploading to remote store. This PR fixes analytics processor to handle this scenario properly i.e handle the scenario when file is not written to disk (as parquet writer does it).
We basically change the function `flush()` to return a boolean true if it did write a file or false otherwise so analytics processor can handle it properly.

## Test Plan 

Ran locally for move-call pipeline (which generates empty files) and after this fix things work again.

