### PR TITLE
[graphqlrpc] remove tests which depend on framework

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -1,4 +1,4 @@
-processed 15 tasks
+processed 14 tasks
 
 task 1 'publish'. lines 6-28:
 created: object(1,0)
@@ -22,72 +22,62 @@ task 5 'view-checkpoint'. lines 36-36:
 CheckpointSummary { epoch: 0, seq: 1, content_digest: 967T2ejWu25x5LEPDdbRte2bSD2i2jfsDE3XNUtfuqBy,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
 
-task 6 'run-graphql'. lines 38-42:
-Response: {
-  "data": {
-    "chainIdentifier": "f5c0cb17"
-  }
-}
-
-task 7 'advance-epoch'. lines 44-44:
+task 6 'advance-epoch'. lines 39-39:
 Epoch advanced: 0
 
-task 8 'view-checkpoint'. lines 46-46:
+task 7 'view-checkpoint'. lines 41-41:
 CheckpointSummary { epoch: 0, seq: 2, content_digest: 7ez6SVqHPjVu8c4yEFoMVPEc8j1qbFFKhkwY2VaT72oV,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
 
-task 9 'run-graphql'. lines 48-55:
+task 8 'run-graphql'. lines 43-49:
 Response: {
   "data": {
     "checkpoint": {
-      "sequenceNumber": 2,
-      "digest": "9RA5HeWZ2umB2PtBq7AaYCug2JwjCszAtB7bVh5727u7"
+      "sequenceNumber": 2
     }
   }
 }
 
-task 10 'create-checkpoint'. lines 56-56:
+task 9 'create-checkpoint'. lines 50-50:
 Checkpoint created: 3
 
-task 11 'view-checkpoint'. lines 58-58:
+task 10 'view-checkpoint'. lines 52-52:
 CheckpointSummary { epoch: 1, seq: 3, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 12 'run-graphql'. lines 60-67:
+task 11 'run-graphql'. lines 54-60:
 Response: {
   "data": {
     "checkpoint": {
-      "sequenceNumber": 3,
-      "digest": "FVyevuXSECGiGbQSXNY168L4wPxpwgSz7xveecrdzr7N"
+      "sequenceNumber": 3
     }
   }
 }
 
-task 13 'run-graphql'. lines 69-76:
+task 12 'run-graphql'. lines 62-68:
 Headers: {
     "content-type": "application/json",
-    "content-length": "192",
+    "content-length": "136",
     "x-sui-rpc-version": "0.1.0",
 }
 Service version: 0.1.0
 Response: {
   "data": {
     "checkpoint": {
-      "sequenceNumber": 3,
-      "digest": "FVyevuXSECGiGbQSXNY168L4wPxpwgSz7xveecrdzr7N"
+      "sequenceNumber": 3
     }
   },
   "extensions": {
     "usage": {
-      "nodes": 3,
+      "nodes": 2,
       "depth": 2,
       "variables": 0,
       "fragments": 0,
-      "query_payload": 52
+      "query_payload": 41
     }
   }
 }
 
-task 14 'view-checkpoint'. lines 78-78:
+task 13 'view-checkpoint'. lines 70-70:
 CheckpointSummary { epoch: 1, seq: 3, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -35,11 +35,6 @@ module Test::M1 {
 
 //# view-checkpoint
 
-//# run-graphql
-
-{
-    chainIdentifier
-}
 
 //# advance-epoch
 
@@ -50,7 +45,6 @@ module Test::M1 {
 {
   checkpoint {
     sequenceNumber
-    digest
   }
 }
 //# create-checkpoint
@@ -62,7 +56,6 @@ module Test::M1 {
 {
   checkpoint {
     sequenceNumber
-    digest
   }
 }
 
@@ -71,7 +64,6 @@ module Test::M1 {
 {
   checkpoint {
     sequenceNumber
-    digest
   }
 }
 


### PR DESCRIPTION
## Description 

Remove tests which can change when framework changes.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
