### PR TITLE
[move/next-vm] Fix main

### DIFF
--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
@@ -861,12 +861,12 @@ impl Interpreter {
             .iter()
             .rev()
             .take(count)
-            .map(|frame| {
-                (
-                    frame.function.module_id().cloned(),
+            .filter_map(|frame| {
+                Some((
+                    frame.function.module_id()?.clone(),
                     frame.function.index(),
                     frame.pc,
-                )
+                ))
             })
             .collect();
         ExecutionState::new(stack_trace)


### PR DESCRIPTION
## Description:

`next-vm` execution layer cut (#14874) raced with removal of scripts (#14870), introduced a build issue.

Fixed by replicating the fix applied to v0 from the scrip removal PR.

## Test Plan:

```
external-crates/move/move-execution/next-vm$ cargo nextest run
```