### PR TITLE
Enable CertV2 in mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -95,6 +95,7 @@ const MAX_PROTOCOL_VERSION: u64 = 32;
 // Version 32: Add delete functions for VerifiedID and VerifiedIssuer.
 //             Add sui::token module to sui framework.
 //             Enable transfer to object in testnet.
+//             Enable Narwhal CertificateV2 on mainnet
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1665,6 +1666,9 @@ impl ProtocolConfig {
                         cfg.feature_flags.narwhal_header_v2 = true;
                         cfg.feature_flags.random_beacon = true;
                     }
+
+                    // enable nw cert v2 on mainnet
+                    cfg.feature_flags.narwhal_certificate_v2 = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_32.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_32.snap
@@ -30,6 +30,7 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
+  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true


### PR DESCRIPTION
## Test Plan 

Protocol upgrade happened successfully in testnet and a [catchup test in testnet was also successfully](https://metrics.sui.io/goto/T9Wm8C4Ig?orgId=1) completed

![image](https://github.com/MystenLabs/sui/assets/97870774/48a74ea3-a524-4191-ac6a-1fd058766523)
