### PR TITLE
[typed-store/graphql] add util to sync all read only tables

### DIFF
--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -659,7 +659,8 @@ impl NodeStateGetter for PersistedStoreInnerReadOnlyWrapper {
 
 impl PersistedStoreInnerReadOnlyWrapper {
     pub fn sync(&self) {
-        self.inner.try_catch_up_with_primary_all()
+        self.inner
+            .try_catch_up_with_primary_all()
             .expect("Fatal: DB sync failed");
     }
 }

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -659,46 +659,7 @@ impl NodeStateGetter for PersistedStoreInnerReadOnlyWrapper {
 
 impl PersistedStoreInnerReadOnlyWrapper {
     pub fn sync(&self) {
-        // Todo: add macro utility for this in typed store derive
-        self.inner
-            .checkpoint_digest_to_sequence_number
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .checkpoints
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .effects
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .epoch_to_committee
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .events
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .events_tx_digest_index
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .live_objects
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .objects
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .transactions
-            .try_catch_up_with_primary()
-            .expect("Fatal: DB sync failed");
-        self.inner
-            .checkpoint_contents
-            .try_catch_up_with_primary()
+        self.inner.try_catch_up_with_primary_all()
             .expect("Fatal: DB sync failed");
     }
 }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -600,6 +600,15 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     (stringify!(#field_names).to_owned(), (stringify!(#key_names).to_owned(), stringify!(#value_names).to_owned())),
                 )*].into_iter().collect()
             }
+
+            /// Try catch up with primary for all tables. This can be a slow operation
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn try_catch_up_with_primary_all(&self) -> eyre::Result<()> {
+                #(
+                    typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
+                )*
+                Ok(())
+            }
         }
 
         impl <


### PR DESCRIPTION
## Description 

Expands DBMapUtil macros to allow read replicas to sync all tables at once. 
This is useful in transactional test logic (for graphql) which needs to catchup to primary periodically.


## Test Plan 

Existiing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
