### PR TITLE
[dapp-kit] update docs to include a snippet about importing the CSS stylesheet

### DIFF
--- a/sdk/dapp-kit/README.md
+++ b/sdk/dapp-kit/README.md
@@ -27,7 +27,7 @@ To use the Sui dApp Kit in your project, run the following command in your proje
 npm i --save @mysten/dapp-kit @mysten/sui.js @tanstack/react-query
 ```
 
-## Setting up Providers
+## Setting up providers
 
 To be able to use the hooks and components in the dApp Kit, you need to wrap your app with a couple
 providers. The props available on the providers are covered in more detail in their respective docs
@@ -58,7 +58,7 @@ function App() {
 }
 ```
 
-## Using UI components to connect and manage wallet accounts
+## Using UI components to connect to a wallet
 
 The dApp Kit provides a set of flexible UI components that can be used to connect and manage wallet
 accounts from your dApp. The components are built on top of [Radix UI](radix-ui.com/primitives) and
@@ -66,7 +66,7 @@ are customizable so you can quickly get your dApp up and running.
 
 To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
 dApp as shown below. For more information regarding customization options, check out the respective
-documentation pages the components and
+documentation pages for the components and
 [theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
 
 ```tsx

--- a/sdk/dapp-kit/README.md
+++ b/sdk/dapp-kit/README.md
@@ -67,7 +67,7 @@ are customizable so you can quickly get your dApp up and running.
 To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
 dApp as shown below. For more information regarding customization options, check out the respective
 documentation pages for the components and
-[theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
+[themes](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
 
 ```tsx
 import '@mysten/dapp-kit/dist/index.css';

--- a/sdk/dapp-kit/README.md
+++ b/sdk/dapp-kit/README.md
@@ -58,11 +58,26 @@ function App() {
 }
 ```
 
-## using hooks to make rpc calls
+## Using UI components to connect and manage wallet accounts
 
-The dApp Kit provides a set of hooks for making rpc calls to the Sui blockchain. The hooks are thin
+The dApp Kit provides a set of flexible UI components that can be used to connect and manage wallet
+accounts from your dApp. The components are built on top of [Radix UI](radix-ui.com/primitives) and
+are customizable so you can quickly get your dApp up and running.
+
+To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
+dApp as shown below. For more information regarding customization options, check out the respective
+documentation pages the components and
+[theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
+
+```tsx
+import '@mysten/dapp-kit/dist/index.css';
+```
+
+## Using hooks to make RPC calls
+
+The dApp Kit provides a set of hooks for making RPC calls to the Sui blockchain. The hooks are thin
 wrappers around `useQuery` from `@tanstack/react-query`. For more comprehensive documentation on how
-these query hooks checkout the
+these query hooks can be used, check out the
 [react-query docs](https://tanstack.com/query/latest/docs/react/overview).
 
 ```tsx

--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -25,7 +25,7 @@ To use the Sui dApp Kit in your project, run the following command in your proje
 npm i --save @mysten/dapp-kit @mysten/sui.js @tanstack/react-query
 ```
 
-## Setting up Providers
+## Setting up providers
 
 To be able to use the hooks and components in the dApp Kit, you need to wrap your app with a couple
 providers. The props available on the providers are covered in more detail in their respective docs
@@ -56,7 +56,7 @@ function App() {
 }
 ```
 
-## Using UI components to connect and manage wallet accounts
+## Using UI components to connect to a wallet
 
 The dApp Kit provides a set of flexible UI components that can be used to connect and manage wallet
 accounts from your dApp. The components are built on top of [Radix UI](radix-ui.com/primitives) and
@@ -64,7 +64,7 @@ are customizable so you can quickly get your dApp up and running.
 
 To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
 dApp as shown below. For more information regarding customization options, check out the respective
-documentation pages the components and
+documentation pages for the components and
 [theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
 
 ```tsx

--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -56,11 +56,26 @@ function App() {
 }
 ```
 
-## using hooks to make rpc calls
+## Using UI components to connect and manage wallet accounts
 
-The dApp Kit provides a set of hooks for making rpc calls to the Sui blockchain. The hooks are thin
+The dApp Kit provides a set of flexible UI components that can be used to connect and manage wallet
+accounts from your dApp. The components are built on top of [Radix UI](radix-ui.com/primitives) and
+are customizable so you can quickly get your dApp up and running.
+
+To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
+dApp as shown below. For more information regarding customization options, check out the respective
+documentation pages the components and
+[theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
+
+```tsx
+import '@mysten/dapp-kit/dist/index.css';
+```
+
+## Using hooks to make RPC calls
+
+The dApp Kit provides a set of hooks for making RPC calls to the Sui blockchain. The hooks are thin
 wrappers around `useQuery` from `@tanstack/react-query`. For more comprehensive documentation on how
-these query hooks checkout the
+these query hooks can be used, check out the
 [react-query docs](https://tanstack.com/query/latest/docs/react/overview).
 
 ```tsx

--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -65,7 +65,7 @@ are customizable so you can quickly get your dApp up and running.
 To use our provided UI components, you will need to import the dApp Kit's CSS stylesheet into your
 dApp as shown below. For more information regarding customization options, check out the respective
 documentation pages for the components and
-[theming](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
+[themes](https://sui-typescript-docs.vercel.app/dapp-kit/themes).
 
 ```tsx
 import '@mysten/dapp-kit/dist/index.css';


### PR DESCRIPTION
## Description 

A builder in Discord was confused about why the provided UI components weren't displaying correctly in their app, and it was because they didn't realize they needed to import the CSS file for dApp Kit into their application. I noticed we don't have anything in our documentation about this, so I'm adding a section in the docs with this PR 😄 

<img width="1379" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/cf346843-1fbf-4893-9cbd-c0c9c01ad140">

https://mysten-labs.slack.com/archives/C0393DWJD7X/p1700380725599999

## Test Plan 
- 👁️ 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
