### PR TITLE
[GraphQL/Tests] README for running transactional-tests locally

### DIFF
--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -1,0 +1,37 @@
+End-to-end tests for GraphQL service, built on top of the transactional test
+runner.
+
+# Local Set-up
+
+These tests require a running instance of the `postgres` service, with a
+database set-up.  The instructions below assume that `postgres` has been
+installed using `brew`:
+
+1. See the instructions in the Sui Indexer [README](../sui-indexer/README.md)
+   for pre-requisites and starting the Postgres service.
+
+2. When postgres is initially installed, it creates a role for your current
+   user.  We need to use that role to create the role that will access the
+   database:
+
+```sh
+$ ME=$(whoami)
+$ psql "postgres://$ME:$ME@localhost:5432/postgres" \
+    -c "CREATE ROLE postgres WITH SUPERUSER LOGIN PASSWORD 'postgrespw';"
+```
+
+3. Then, create the database that the tests expect, using the `postgres` user:
+
+```sh
+$ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
+    -c "CREATE DATABASE sui_indexer_v2;"
+```
+
+# Running Locally
+
+When running the tests locally, they need to be run serially (one at a time),
+and with the `pg_integration` feature enabled:
+
+```sh
+$ cargo nextest run -j 1 --features pg_integration
+```

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
@@ -30,7 +30,7 @@ task 5 'create-checkpoint'. lines 58-58:
 Checkpoint created: 1
 
 task 6 'view-checkpoint'. lines 60-60:
-CheckpointSummary { epoch: 0, seq: 1, content_digest: 967T2ejWu25x5LEPDdbRte2bSD2i2jfsDE3XNUtfuqBy,
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 3roqGGtXUFwWgryXd47b8excsteDJyFXKoKUmFEcUbpD,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
 
 task 7 'run-graphql'. lines 62-75:
@@ -41,8 +41,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x37a05461f42db2e6382b941624dc41c0e508e1cffebea1f6601b1b36a05199a3",
-              "digest": "4mYGsy7zZGzyaYS1kBPWEpsLbAPKB5VvLuSNZo9u6Aox",
+              "location": "0x3934a5985b62d7536d183a67a650e36c6c2cc18cf5949e3d430fadbd4c40e9f7",
+              "digest": "Gm1nFyPuQ1w938sScdfzuyJ5HgtmCxV8URwu4jTtatt8",
               "kind": "OWNED"
             }
           }
@@ -60,8 +60,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x37a05461f42db2e6382b941624dc41c0e508e1cffebea1f6601b1b36a05199a3",
-              "digest": "4mYGsy7zZGzyaYS1kBPWEpsLbAPKB5VvLuSNZo9u6Aox",
+              "location": "0x3934a5985b62d7536d183a67a650e36c6c2cc18cf5949e3d430fadbd4c40e9f7",
+              "digest": "Gm1nFyPuQ1w938sScdfzuyJ5HgtmCxV8URwu4jTtatt8",
               "kind": "OWNED"
             }
           }
@@ -79,8 +79,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x37a05461f42db2e6382b941624dc41c0e508e1cffebea1f6601b1b36a05199a3",
-              "digest": "4mYGsy7zZGzyaYS1kBPWEpsLbAPKB5VvLuSNZo9u6Aox",
+              "location": "0x3934a5985b62d7536d183a67a650e36c6c2cc18cf5949e3d430fadbd4c40e9f7",
+              "digest": "Gm1nFyPuQ1w938sScdfzuyJ5HgtmCxV8URwu4jTtatt8",
               "kind": "OWNED"
             }
           }
@@ -98,8 +98,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "location": "0x37a05461f42db2e6382b941624dc41c0e508e1cffebea1f6601b1b36a05199a3",
-              "digest": "4mYGsy7zZGzyaYS1kBPWEpsLbAPKB5VvLuSNZo9u6Aox",
+              "location": "0x3934a5985b62d7536d183a67a650e36c6c2cc18cf5949e3d430fadbd4c40e9f7",
+              "digest": "Gm1nFyPuQ1w938sScdfzuyJ5HgtmCxV8URwu4jTtatt8",
               "kind": "OWNED"
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -19,14 +19,14 @@ task 4 'create-checkpoint'. lines 34-34:
 Checkpoint created: 1
 
 task 5 'view-checkpoint'. lines 36-36:
-CheckpointSummary { epoch: 0, seq: 1, content_digest: 967T2ejWu25x5LEPDdbRte2bSD2i2jfsDE3XNUtfuqBy,
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 3roqGGtXUFwWgryXd47b8excsteDJyFXKoKUmFEcUbpD,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
 
 task 6 'advance-epoch'. lines 39-39:
 Epoch advanced: 0
 
 task 7 'view-checkpoint'. lines 41-41:
-CheckpointSummary { epoch: 0, seq: 2, content_digest: 7ez6SVqHPjVu8c4yEFoMVPEc8j1qbFFKhkwY2VaT72oV,
+CheckpointSummary { epoch: 0, seq: 2, content_digest: HWHYKr1zLvWnGLeeiHFrHe9p7E23t8U6J4GWgwZxPWcE,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, storage_cost: 7873600, storage_rebate: 978120, non_refundable_storage_fee: 9880 }}
 
 task 8 'run-graphql'. lines 43-49:

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -6,7 +6,7 @@ Sui indexer is an off-fullnode service to serve data from Sui protocol, includin
 
 ## Steps to run locally
 ### Prerequisites
-- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgres@version` and then add the following to your `~/.zshrc` or `~/.zprofile`, etc: 
+- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgresql@version` and then add the following to your `~/.zshrc` or `~/.zprofile`, etc:
 ```sh
 export LDFLAGS="-L/opt/homebrew/opt/postgresql@15/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/postgresql@15/include"
@@ -17,6 +17,13 @@ export PATH="/opt/homebrew/opt/postgresql@15/bin:$PATH"
 - install Diesel CLI with `cargo install diesel_cli --no-default-features --features postgres`, refer to [Diesel Getting Started guide](https://diesel.rs/guides/getting-started) for more details
 - [optional but handy] Postgres client like [Postico](https://eggerapps.at/postico2/), for local check, query execution etc.
 
+### Start the Postgres Service
+
+Postgres must run as a service in the background for other tools to communicate with.  If it was installed using homebrew, it can be started as a service with:
+
+``` sh
+brew service start postgresql@version
+```
 
 ### Local Development(Recommended)
 


### PR DESCRIPTION
## Description

Instructions for how to set-up `postgresql` for the GraphQL E2E tests. Also updating the instructions for `sui-indexer` (Postgres is called `postgresql` on homebrew).

## Test Plan

Follow instructions.  Note that when I did this, the digests and IDs changed (not sure whether that's supposed to happen or not, but CI will tell us!).