### PR TITLE
[fix] Update link to developer grants program in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Use the following links to learn more about Sui and the Sui ecosystem:
  * Learn more about working with Sui in the [Sui Documentation](doc/src/learn/index.md).
  * Join the Sui community on [Sui Discord](https://discord.gg/sui).
  * Find out more about the Sui ecosystem on the [Sui Resources](https://sui.io/resources/) page.
- * Review information about Sui governance, [decentralization](https://suifoundation.org/decentralization), and [Developer Grants Program](https://suifoundation.org/#grants) on the [Sui Foundation](https://suifoundation.org/) site.
+ * Review information about Sui governance, [decentralization](https://suifoundation.org/decentralization), and [Developer Grants Program](https://sui.io/grants-hub) on the [Sui Foundation](https://suifoundation.org/) site.


### PR DESCRIPTION
## Description 

I noticed the link to the developer grants program was broken with the new Sui Foundation website. This PR corrects the link in the README so that it points to the correct page on the sui.io website.

## Test Plan 

N/A, README only.
