### PR TITLE
Replace panic with error when adding committee out of order in shared…

### DIFF
--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 use tap::Pipe;
+use tracing::error;
 
 #[derive(Clone, Debug, Default)]
 pub struct SharedInMemoryStore(Arc<std::sync::RwLock<InMemoryStore>>);
@@ -396,10 +397,10 @@ impl InMemoryStore {
             return;
         }
 
-        if self.epoch_to_committee.len() == epoch {
-            self.epoch_to_committee.push(committee);
-        } else {
-            panic!("committee was inserted into EpochCommitteeMap out of order");
+        self.epoch_to_committee.push(committee);
+
+        if self.epoch_to_committee.len() != epoch {
+            error!("committee was inserted into EpochCommitteeMap out of order");
         }
     }
 


### PR DESCRIPTION
… memory store

## Description 

For printing a checkpoint from archive, we don't add all committees since genesis, and hence this could be an error.
## Test Plan 

Existing tests
