### PR TITLE
Cherrypick consensus metric fixes #14811 and #14875 to 1.13

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -236,7 +236,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
     pub consensus_handler_scores: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
-    pub consensus_committed_certificates: IntGaugeVec,
+    pub consensus_committed_messages: IntGaugeVec,
     pub consensus_committed_user_transactions: IntGaugeVec,
     pub consensus_calculated_throughput: IntGauge,
     pub consensus_calculated_throughput_profile: IntGauge,
@@ -553,9 +553,9 @@ impl AuthorityMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            consensus_committed_certificates: register_int_gauge_vec_with_registry!(
-                "consensus_committed_certificates",
-                "Number of committed certificates, sliced by author",
+            consensus_committed_messages: register_int_gauge_vec_with_registry!(
+                "consensus_committed_messages",
+                "Total number of committed consensus messages, sliced by author",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -131,11 +131,11 @@ pub struct ExecutionIndicesWithHash {
 pub trait ConsensusStatsAPI {
     fn is_initialized(&self) -> bool;
 
-    fn get_narwhal_certificates(&self, authority: usize) -> u64;
-    fn inc_narwhal_certificates(&mut self, authority: usize) -> u64;
+    fn get_num_messages(&self, authority: usize) -> u64;
+    fn inc_num_messages(&mut self, authority: usize) -> u64;
 
-    fn get_user_transactions(&self, authority: usize) -> u64;
-    fn inc_user_transactions(&mut self, authority: usize) -> u64;
+    fn get_num_user_transactions(&self, authority: usize) -> u64;
+    fn inc_num_user_transactions(&mut self, authority: usize) -> u64;
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -147,8 +147,8 @@ pub enum ConsensusStats {
 impl ConsensusStats {
     pub fn new(size: usize) -> Self {
         Self::V1(ConsensusStatsV1 {
-            narwhal_certificates: vec![0; size],
-            user_transactions: vec![0; size],
+            num_messages: vec![0; size],
+            num_user_transactions: vec![0; size],
         })
     }
 }
@@ -161,31 +161,31 @@ impl Default for ConsensusStats {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ConsensusStatsV1 {
-    pub narwhal_certificates: Vec<u64>,
-    pub user_transactions: Vec<u64>,
+    pub num_messages: Vec<u64>,
+    pub num_user_transactions: Vec<u64>,
 }
 
 impl ConsensusStatsAPI for ConsensusStatsV1 {
     fn is_initialized(&self) -> bool {
-        !self.narwhal_certificates.is_empty()
+        !self.num_messages.is_empty()
     }
 
-    fn get_narwhal_certificates(&self, authority: usize) -> u64 {
-        self.narwhal_certificates[authority]
+    fn get_num_messages(&self, authority: usize) -> u64 {
+        self.num_messages[authority]
     }
 
-    fn inc_narwhal_certificates(&mut self, authority: usize) -> u64 {
-        self.narwhal_certificates[authority] += 1;
-        self.narwhal_certificates[authority]
+    fn inc_num_messages(&mut self, authority: usize) -> u64 {
+        self.num_messages[authority] += 1;
+        self.num_messages[authority]
     }
 
-    fn get_user_transactions(&self, authority: usize) -> u64 {
-        self.user_transactions[authority]
+    fn get_num_user_transactions(&self, authority: usize) -> u64 {
+        self.num_user_transactions[authority]
     }
 
-    fn inc_user_transactions(&mut self, authority: usize) -> u64 {
-        self.user_transactions[authority] += 1;
-        self.user_transactions[authority]
+    fn inc_num_user_transactions(&mut self, authority: usize) -> u64 {
+        self.num_user_transactions[authority] += 1;
+        self.num_user_transactions[authority]
     }
 }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -249,14 +249,14 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
 
             assert_eq!(cert.header().payload().len(), batches.len());
             let author = cert.header().author();
-            let num_certs = self
+            let num_messages = self
                 .last_consensus_stats
                 .stats
-                .inc_narwhal_certificates(author.0 as usize);
+                .inc_num_messages(author.0 as usize);
             self.metrics
-                .consensus_committed_certificates
+                .consensus_committed_messages
                 .with_label_values(&[&author.to_string()])
-                .set(num_certs as i64);
+                .set(num_messages as i64);
             let output_cert = Arc::new(cert.clone());
             for batch in batches {
                 let span = trace_span!("process_consensus_batch");
@@ -290,7 +290,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
                         let num_txns = self
                             .last_consensus_stats
                             .stats
-                            .inc_user_transactions(author.0 as usize);
+                            .inc_num_user_transactions(author.0 as usize);
                         self.metrics
                             .consensus_committed_user_transactions
                             .with_label_values(&[&author.to_string()])
@@ -731,11 +731,11 @@ mod tests {
         assert_eq!(last_consensus_stats_1.index.last_committed_round, 5_u64);
         assert_ne!(last_consensus_stats_1.hash, 0);
         assert_eq!(
-            last_consensus_stats_1.stats.get_narwhal_certificates(0),
+            last_consensus_stats_1.stats.get_num_messages(0),
             num_certificates as u64
         );
         assert_eq!(
-            last_consensus_stats_1.stats.get_user_transactions(0),
+            last_consensus_stats_1.stats.get_num_user_transactions(0),
             num_transactions as u64
         );
 


### PR DESCRIPTION
## Description 

So we can release them earlier.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
