### PR TITLE
move new TransactionKind::RandomnessStateUpdate to end of list

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -947,14 +947,14 @@ TransactionKind:
         NEWTYPE:
           TYPENAME: AuthenticatorStateUpdate
     5:
-      RandomnessStateUpdate:
-        NEWTYPE:
-          TYPENAME: RandomnessStateUpdate
-    6:
       EndOfEpochTransaction:
         NEWTYPE:
           SEQ:
             TYPENAME: EndOfEpochTransactionKind
+    6:
+      RandomnessStateUpdate:
+        NEWTYPE:
+          TYPENAME: RandomnessStateUpdate
 TypeArgumentError:
   ENUM:
     0:

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -267,11 +267,12 @@ pub enum TransactionKind {
     Genesis(GenesisTransaction),
     ConsensusCommitPrologue(ConsensusCommitPrologue),
     AuthenticatorStateUpdate(AuthenticatorStateUpdate),
-    RandomnessStateUpdate(RandomnessStateUpdate),
 
     /// EndOfEpochTransaction replaces ChangeEpoch with a list of transactions that are allowed to
     /// run at the end of the epoch.
     EndOfEpochTransaction(Vec<EndOfEpochTransactionKind>),
+
+    RandomnessStateUpdate(RandomnessStateUpdate),
     // .. more transaction types go here
 }
 


### PR DESCRIPTION
## Description 

This may fix backwards compat issues with FullCheckpointContents serialization.

## Test Plan 

Add into failing replay workflows.