### PR TITLE
Fix check for comparing committee length with epoch

### DIFF
--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -399,7 +399,7 @@ impl InMemoryStore {
 
         self.epoch_to_committee.push(committee);
 
-        if self.epoch_to_committee.len() != epoch {
+        if self.epoch_to_committee.len() != epoch + 1 {
             error!("committee was inserted into EpochCommitteeMap out of order");
         }
     }


### PR DESCRIPTION
## Description 

I recently introduced this bug while moving `self.epoch_to_committee.push(committee);` outside the if condition. This PR fixes the check