### PR TITLE
[sdk/shared-object-deletion] Update SDKs

### DIFF
--- a/.changeset/calm-ligers-rush.md
+++ b/.changeset/calm-ligers-rush.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Properly determine shared object mutability when being passed by value.

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -405,7 +405,9 @@ impl TransactionBuilder {
                     self.get_object_arg(
                         id,
                         &mut objects,
-                        matches!(expected_type, SignatureToken::MutableReference(_)),
+                        // Is mutable if passed by mutable reference or by value
+                        matches!(expected_type, SignatureToken::MutableReference(_))
+                            || !expected_type.is_reference(),
                         &view,
                         &expected_type,
                     )

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -636,6 +636,114 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let object_refs = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
+
+    // Provide path to well formed package sources
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("sod");
+    let build_config = BuildConfig::new_for_testing().config;
+    let resp = SuiClientCommands::Publish {
+        package_path,
+        build_config,
+        gas: Some(gas_obj_id),
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+        no_lint: true,
+    }
+    .execute(context)
+    .await?;
+
+    let owned_obj_ids = if let SuiClientCommandResult::Publish(response) = resp {
+        let x = response.effects.unwrap();
+        x.created().to_vec()
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    // Check the objects
+    for OwnedObjectRef { reference, .. } in &owned_obj_ids {
+        get_parsed_object_assert_existence(reference.object_id, context).await;
+    }
+
+    let package_id = owned_obj_ids
+        .into_iter()
+        .find(|OwnedObjectRef { owner, .. }| owner == &Owner::Immutable)
+        .expect("Must find published package ID")
+        .reference;
+
+    // Start and then receive the object
+    let start_call_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "sod".to_string(),
+        function: "start".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    let shared_id = if let SuiClientCommandResult::Call(response) = start_call_result {
+        response.effects.unwrap().created().to_vec()[0]
+            .reference
+            .object_id
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    let delete_result = SuiClientCommands::Call {
+        package: (*package_id.object_id).into(),
+        module: "sod".to_string(),
+        function: "delete".to_string(),
+        type_args: vec![],
+        gas: None,
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        args: vec![SuiJsonValue::from_str(&shared_id.to_string()).unwrap()],
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await?;
+
+    if let SuiClientCommandResult::Call(response) = delete_result {
+        assert!(response.effects.unwrap().into_status().is_ok());
+    } else {
+        unreachable!("Invalid response");
+    };
+
+    Ok(())
+}
+
+#[sim_test]
 async fn test_receive_argument() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;

--- a/crates/sui/tests/data/sod/Move.toml
+++ b/crates/sui/tests/data/sod/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sod"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+sod =  "0x0"

--- a/crates/sui/tests/data/sod/sources/sod.move
+++ b/crates/sui/tests/data/sod/sources/sod.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sod::sod {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    public fun start(ctx: &mut TxContext) {
+        let a = A { id: object::new(ctx) };
+        transfer::public_share_object(a);
+    }
+
+    public entry fun delete(a: A) {
+        let A { id } = a;
+        object::delete(id);
+    }
+}

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -11,6 +11,7 @@ import type { Keypair, SignatureWithBytes } from '../cryptography/index.js';
 import type { SuiObjectResponse } from '../types/index.js';
 import {
 	extractMutableReference,
+	extractReference,
 	extractStructTag,
 	getObjectReference,
 	SuiObjectRef,
@@ -773,10 +774,15 @@ export class TransactionBlock {
 
 				if (initialSharedVersion) {
 					// There could be multiple transactions that reference the same shared object.
-					// If one of them is a mutable reference, then we should mark the input
+					// If one of them is a mutable reference or taken by value, then we should mark the input
 					// as mutable.
+					const isByValue =
+						normalizedType != null &&
+						extractMutableReference(normalizedType) == null &&
+						extractReference(normalizedType) == null;
 					const mutable =
 						isMutableSharedObjectInput(input.value) ||
+						isByValue ||
 						(normalizedType != null && extractMutableReference(normalizedType) != null);
 
 					input.value = Inputs.SharedObjectRef({

--- a/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
@@ -42,6 +42,11 @@ module serializer::serializer_tests {
         clock.value = 10;
     }
 
+    public entry fun delete_value(clock: MutableShared) {
+        let MutableShared { id, value: _ } = clock;
+        object::delete(id);
+    }
+
     public fun test_abort() {
         abort 0
     }

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
@@ -42,6 +42,11 @@ module serializer::serializer_tests {
         clock.value = 20;
     }
 
+    public entry fun delete_value(clock: MutableShared) {
+        let MutableShared { id, value: _ } = clock;
+        object::delete(id);
+    }
+
     public fun test_abort() {
         abort 1
     }

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -137,6 +137,19 @@ describe('Transaction Builders', () => {
 		await validateTransaction(toolbox.client, toolbox.keypair, tx);
 	});
 
+	it('Move Shared Object Call by Value', async () => {
+		const tx = new TransactionBlock();
+		tx.moveCall({
+			target: `${packageId}::serializer_tests::value`,
+			arguments: [tx.object(sharedObjectId)],
+		});
+		tx.moveCall({
+			target: `${packageId}::serializer_tests::delete_value`,
+			arguments: [tx.object(sharedObjectId)],
+		});
+		await validateTransaction(toolbox.client, toolbox.keypair, tx);
+	});
+
 	it('immutable clock', async () => {
 		const tx = new TransactionBlock();
 		tx.moveCall({


### PR DESCRIPTION
## Description 

Updates SDKs to properly determine mutability of shared objects when passed by value.

## Test Plan 

Added new tests in both the Typescript and Rust SDKs

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
