### PR TITLE
[graphql][fix] cursor connection logic follows spec for checkpoint connection

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,15 @@
-processed 8 tasks
+processed 10 tasks
 
-task 1 'create-checkpoint'. lines 16-16:
-Checkpoint created: 11
+task 1 'create-checkpoint'. lines 18-18:
+Checkpoint created: 4
 
-task 2 'run-graphql'. lines 18-25:
+task 2 'create-checkpoint'. lines 20-20:
+Checkpoint created: 8
+
+task 3 'create-checkpoint'. lines 22-22:
+Checkpoint created: 12
+
+task 4 'run-graphql'. lines 24-31:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -25,7 +31,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 27-34:
+task 5 'run-graphql'. lines 33-40:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -38,7 +44,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 36-43:
+task 6 'run-graphql'. lines 42-49:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -60,14 +66,11 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 45-52:
+task 7 'run-graphql'. lines 51-58:
 Response: {
   "data": {
     "checkpointConnection": {
       "nodes": [
-        {
-          "sequenceNumber": 8
-        },
         {
           "sequenceNumber": 9
         },
@@ -76,13 +79,16 @@ Response: {
         },
         {
           "sequenceNumber": 11
+        },
+        {
+          "sequenceNumber": 12
         }
       ]
     }
   }
 }
 
-task 6 'run-graphql'. lines 54-61:
+task 8 'run-graphql'. lines 60-67:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -104,7 +110,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 63-70:
+task 9 'run-graphql'. lines 69-76:
 Response: {
   "data": {
     "checkpointConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,0 +1,105 @@
+processed 7 tasks
+
+task 1 'create-checkpoint'. lines 15-15:
+Checkpoint created: 20
+
+task 2 'run-graphql'. lines 17-24:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        },
+        {
+          "sequenceNumber": 10
+        }
+      ]
+    }
+  }
+}
+
+task 3 'run-graphql'. lines 26-33:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        }
+      ]
+    }
+  }
+}
+
+task 4 'run-graphql'. lines 35-42:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 0
+        },
+        {
+          "sequenceNumber": 1
+        },
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        }
+      ]
+    }
+  }
+}
+
+task 5 'run-graphql'. lines 44-51:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 17
+        },
+        {
+          "sequenceNumber": 18
+        },
+        {
+          "sequenceNumber": 19
+        },
+        {
+          "sequenceNumber": 20
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 53-60:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        },
+        {
+          "sequenceNumber": 4
+        },
+        {
+          "sequenceNumber": 5
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 task 1 'create-checkpoint'. lines 16-16:
-Checkpoint created: 20
+Checkpoint created: 11
 
 task 2 'run-graphql'. lines 18-25:
 Response: {
@@ -66,16 +66,16 @@ Response: {
     "checkpointConnection": {
       "nodes": [
         {
-          "sequenceNumber": 17
+          "sequenceNumber": 8
         },
         {
-          "sequenceNumber": 18
+          "sequenceNumber": 9
         },
         {
-          "sequenceNumber": 19
+          "sequenceNumber": 10
         },
         {
-          "sequenceNumber": 20
+          "sequenceNumber": 11
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,9 @@
-processed 7 tasks
+processed 8 tasks
 
-task 1 'create-checkpoint'. lines 15-15:
+task 1 'create-checkpoint'. lines 16-16:
 Checkpoint created: 20
 
-task 2 'run-graphql'. lines 17-24:
+task 2 'run-graphql'. lines 18-25:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -25,7 +25,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 26-33:
+task 3 'run-graphql'. lines 27-34:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -38,7 +38,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 35-42:
+task 4 'run-graphql'. lines 36-43:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -60,7 +60,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 44-51:
+task 5 'run-graphql'. lines 45-52:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -82,7 +82,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 53-60:
+task 6 'run-graphql'. lines 54-61:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -93,6 +93,22 @@ Response: {
         {
           "sequenceNumber": 3
         },
+        {
+          "sequenceNumber": 4
+        },
+        {
+          "sequenceNumber": 5
+        }
+      ]
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 63-70:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
         {
           "sequenceNumber": 4
         },

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,15 +1,9 @@
-processed 10 tasks
+processed 8 tasks
 
 task 1 'create-checkpoint'. lines 18-18:
-Checkpoint created: 4
-
-task 2 'create-checkpoint'. lines 20-20:
-Checkpoint created: 8
-
-task 3 'create-checkpoint'. lines 22-22:
 Checkpoint created: 12
 
-task 4 'run-graphql'. lines 24-31:
+task 2 'run-graphql'. lines 20-27:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -31,7 +25,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 33-40:
+task 3 'run-graphql'. lines 29-36:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -44,7 +38,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 42-49:
+task 4 'run-graphql'. lines 38-45:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -66,7 +60,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 51-58:
+task 5 'run-graphql'. lines 47-54:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -88,7 +82,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 60-67:
+task 6 'run-graphql'. lines 56-63:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -110,7 +104,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 69-76:
+task 7 'run-graphql'. lines 65-72:
 Response: {
   "data": {
     "checkpointConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -4,16 +4,22 @@
 // Test cursor connection pagination logic
 // The implementation privileges `after`, `before`, `first`, and `last` in that order.
 // Currently implemented only for items ordered in ascending order by `sequenceNumber`.
+
+// Assuming checkpoints 0 through 12
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints 8, 9, 10, 11
+// last: 4, after: "6" -> checkpoints 9, 10, 11, 12
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 11
+//# create-checkpoint 4
+
+//# create-checkpoint 4
+
+//# create-checkpoint 4
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -15,11 +15,7 @@
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 4
-
-//# create-checkpoint 4
-
-//# create-checkpoint 4
+//# create-checkpoint 12
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -9,6 +9,7 @@
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
 // last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
+// last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
@@ -53,6 +54,15 @@
 //# run-graphql
 {
   checkpointConnection(last: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, before: "6", after: "3") {
     nodes {
       sequenceNumber
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -7,13 +7,13 @@
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
+// last: 4, after: "6" -> checkpoints 11, 10, 9, 8
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 20
+//# create-checkpoint 11
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test cursor connection pagination logic
+// The implementation privileges `after`, `before`, `first`, and `last` in that order.
+// Currently implemented only for items ordered in ascending order by `sequenceNumber`.
+// first: 4, after: "6" -> checkpoints 7, 8, 9, 10
+// first: 4, after: "6", before: "8" -> checkpoints 7
+// first: 4, before: "6" -> checkpoints 0, 1, 2, 3
+// last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
+// last: 4, before: "6" -> checkpoints 2, 3, 4, 5
+
+//# init --addresses Test=0x0 --simulator
+
+//# create-checkpoint 20
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, after: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, after: "6", before: "8") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, after: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -7,7 +7,7 @@
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints 11, 10, 9, 8
+// last: 4, after: "6" -> checkpoints 8, 9, 10, 11
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::backend::Backend;
+use diesel::{backend::Backend, query_builder::AsQuery, query_dsl::methods::BoxedDsl};
 use sui_indexer::{
     schema_v2::{checkpoints, epochs, objects, transactions},
     types_v2::OwnerType,
@@ -15,6 +15,34 @@ use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
     sql_types::Text,
 };
+
+#[derive(Clone, Copy)]
+pub(crate) enum Cursor {
+    After,
+    Before,
+}
+
+/// Controls how many records the query fetches before or after some cursor
+#[derive(Clone, Copy)]
+pub(crate) enum QueryDirection {
+    /// Fetch first n records after some cursor (exclusive) or from the beginning.
+    /// The edge closest to the cursor or beginning comes first in the result set.
+    First(i64),
+    /// Fetch last n records before some cursor (exclusive) or from the end.
+    /// The edge closest to the cursor or end comes last in the result set.
+    Last(i64),
+}
+
+/// Controls the final ordering of the result set
+#[derive(Clone, Copy)]
+pub(crate) enum SortOrder {
+    /// Preserves the original order of the result set.
+    /// This is typically a query ordered by some key in ascending order.
+    Asc,
+    /// Reverses the order of the result set.
+    /// This is typically a query ordered by some key in descending order.
+    Desc,
+}
 
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     'a,
@@ -65,13 +93,15 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
         cursor: Option<i64>,
-        descending_order: bool,
+        cursor_type: Option<Cursor>,
         limit: i64,
+        edge_order: SortOrder,
+        query_direction: QueryDirection,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;
 }
 
-/// Struct for custom diesel function
+/// The struct returned for query.explain()
 #[derive(Debug, Clone, Copy)]
 pub struct Explained<T> {
     pub query: T,
@@ -96,4 +126,31 @@ impl<T: QueryId> QueryId for Explained<T> {
 /// Explained<T> is a fully structured query with return of type Text
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
+}
+
+/// The struct returned for query.subquery()
+#[derive(Debug, Clone, Copy)]
+pub struct Subqueried<T> {
+    pub query: T,
+}
+
+/// Allows .subquery() method on any Diesel query
+pub trait Subquery: AsQuery + Sized {
+    fn subquery(self) -> Subqueried<Self>;
+}
+impl<T: AsQuery> Subquery for T {
+    fn subquery(self) -> Subqueried<Self> {
+        Subqueried { query: self }
+    }
+}
+
+/// All queries need to implement QueryId
+impl<T: QueryId> QueryId for Subqueried<T> {
+    type QueryId = (T::QueryId, std::marker::PhantomData<&'static str>);
+    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
+}
+
+/// Subqueried<T> wraps the query in a SELECT * FROM (query) AS SUB
+impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Subqueried<T> {
+    type SqlType = T::SqlType;
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -16,30 +16,18 @@ use diesel::{
     sql_types::Text,
 };
 
+/// An enum that determines whether to select rows that are greater than or less than the cursor.
 #[derive(Clone, Copy, PartialEq)]
-pub(crate) enum PaginationBound<T> {
+pub(crate) enum CursorBound<T> {
     Gt(T),
     Lt(T),
 }
 
-/// An enum representing whether first and/ or last was provided in the graphql request.
-#[derive(Clone, Copy, PartialEq)]
-pub(crate) enum QueryDirection {
-    /// If first is provided, the result set fetched from the db does not need to be reversed.
-    /// Queries default to this direction.
-    First,
-    /// The direction is last iff first is not provided and last is provided.
-    Last,
-}
-
-/// Controls the final ordering of the result set.
-/// Does not directly correspond to whether the query is ordered by ascending or descending.
+/// Controls whether the query is in ascending or descending order.
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum SortOrder {
-    /// Preserves the original ordering of the set before applying cursor and limit.
     Asc,
-    /// Reverses the ordering of the set before applying cursor and limit.
     Desc,
 }
 
@@ -101,8 +89,8 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
         sort_order: SortOrder,
-        before: Option<PaginationBound<i64>>,
-        after: Option<PaginationBound<i64>>,
+        before: Option<CursorBound<i64>>,
+        after: Option<CursorBound<i64>>,
         limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -26,16 +26,16 @@ pub(crate) enum CursorBound<T> {
 /// Controls whether the query is in ascending or descending order.
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq)]
-pub(crate) enum SortOrder {
+pub(crate) enum OrderBy {
     Asc,
     Desc,
 }
 
-impl SortOrder {
+impl OrderBy {
     pub fn invert(&self) -> Self {
         match self {
-            SortOrder::Asc => SortOrder::Desc,
-            SortOrder::Desc => SortOrder::Asc,
+            OrderBy::Asc => OrderBy::Desc,
+            OrderBy::Desc => OrderBy::Asc,
         }
     }
 }
@@ -88,7 +88,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
-        sort_order: SortOrder,
+        order_by: OrderBy,
         before: Option<CursorBound<i64>>,
         after: Option<CursorBound<i64>>,
         limit: i64,

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -27,6 +27,7 @@ pub(crate) enum QueryDirection {
 }
 
 /// Controls the final ordering of the result set
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum SortOrder {
     /// Preserves the original order of the result set.

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -26,15 +26,14 @@ pub(crate) enum QueryDirection {
     Last,
 }
 
-/// Controls the final ordering of the result set
+/// Controls the final ordering of the result set.
+/// Does not directly correspond to whether the query is ordered by ascending or descending.
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum SortOrder {
-    /// Preserves the original order of the result set.
-    /// This is typically a query ordered by some key in ascending order.
+    /// Preserves the original ordering of the set before applying cursor and limit.
     Asc,
-    /// Reverses the order of the result set.
-    /// This is typically a query ordered by some key in descending order.
+    /// Reverses the ordering of the set before applying cursor and limit.
     Desc,
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1884,6 +1884,10 @@ pub(crate) fn validate_cursor_pagination(
         return Err(Error::CursorNoBeforeAfter);
     }
 
+    if first.is_some() && last.is_some() {
+        return Err(Error::CursorNoFirstLast);
+    }
+
     Ok(())
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -152,6 +152,13 @@ impl PgManager {
 
 /// Implement methods to query db and return StoredData
 impl PgManager {
+    /// handle pagination logic
+    // fn handle_checkpoint_pagination(
+    // before: Option<String>,
+    // after: Option<String>,
+    // sort_order: SortOrder
+    // ) -> Result<(), Error> {}
+
     async fn get_tx(&self, digest: Vec<u8>) -> Result<Option<StoredTransaction>, Error> {
         self.run_query_async_with_cost(
             move || Ok(QueryBuilder::get_tx_by_digest(digest.clone())),

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{
-        BalanceQuery, Explain, Explained, GenericQueryBuilder, PaginationBound, SortOrder,
-    },
+    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, SortOrder},
     db_data_provider::DbValidationError,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -339,8 +337,8 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     }
     fn multi_get_checkpoints(
         sort_order: SortOrder,
-        before: Option<PaginationBound<i64>>,
-        after: Option<PaginationBound<i64>>,
+        before: Option<CursorBound<i64>>,
+        after: Option<CursorBound<i64>>,
         limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
@@ -357,10 +355,10 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
 
         if let Some(after) = after {
             match after {
-                PaginationBound::Gt(after) => {
+                CursorBound::Gt(after) => {
                     query = query.filter(checkpoints::dsl::sequence_number.gt(after));
                 }
-                PaginationBound::Lt(after) => {
+                CursorBound::Lt(after) => {
                     query = query.filter(checkpoints::dsl::sequence_number.lt(after));
                 }
             }
@@ -368,10 +366,10 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
 
         if let Some(before) = before {
             match before {
-                PaginationBound::Gt(before) => {
+                CursorBound::Gt(before) => {
                     query = query.filter(checkpoints::dsl::sequence_number.gt(before));
                 }
-                PaginationBound::Lt(before) => {
+                CursorBound::Lt(before) => {
                     query = query.filter(checkpoints::dsl::sequence_number.lt(before));
                 }
             }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, SortOrder},
+    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, OrderBy},
     db_data_provider::DbValidationError,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -336,7 +336,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         query.filter(objects::dsl::coin_type.eq(coin_type))
     }
     fn multi_get_checkpoints(
-        sort_order: SortOrder,
+        order_by: OrderBy,
         before: Option<CursorBound<i64>>,
         after: Option<CursorBound<i64>>,
         limit: i64,
@@ -345,11 +345,11 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
         // TODO (wlmyng): Reduce redundancy when other multi-gets are refactored
-        match sort_order {
-            SortOrder::Asc => {
+        match order_by {
+            OrderBy::Asc => {
                 query = query.order(checkpoints::dsl::sequence_number.asc());
             }
-            SortOrder::Desc => {
+            OrderBy::Desc => {
                 query = query.order(checkpoints::dsl::sequence_number.desc());
             }
         }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -30,6 +30,7 @@ use sui_indexer::{
 pub(crate) struct PgQueryBuilder;
 
 impl PgQueryBuilder {
+    /// Handles pagination logic when the query selects for the first n
     fn handle_checkpoint_pagination_first(
         before: Option<i64>,
         after: Option<i64>,
@@ -61,7 +62,8 @@ impl PgQueryBuilder {
         query
     }
 
-    // 'last' queries require a final reverse ordering
+    /// Handles pagination logic when the query selects for the last n
+    /// These queries require a reverse ordering of the result set
     fn handle_checkpoint_pagination_last(
         before: Option<i64>,
         after: Option<i64>,

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -344,6 +344,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     ) -> checkpoints::BoxedQuery<'static, Pg> {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
+        // TODO (wlmyng): Reduce redundancy when other multi-gets are refactored
         match sort_order {
             SortOrder::Asc => {
                 query = query.order(checkpoints::dsl::sequence_number.asc());


### PR DESCRIPTION
## Description 

Fix cursor pagination logic per:
https://relay.dev/graphql/connections.htm#sec-Forward-pagination-arguments

I understand it as being two bodies of queries, queries with a 'first' parameter, and queries with **only** a 'last' parameter.
For 'first' queries, order by asc or desc does not change
1. after + asc -> (> after) + asc
4. after + desc -> (< after) + desc
5. before + asc -> (< before) + asc
6. before + desc -> (> before) + desc

'Last' queries are a bit more complex. They require one more reversal of the result set.
1. after + asc -> (> after + desc) + reverse
2. after + desc -> (< after + asc) + reverse
3. before + asc -> (< before + desc) + reverse
4. before + desc -> (> before + asc) + reverse

Note that the ordering by cursor (> after, < after, etc.) is consistent regardless of the combination of first or last. 'Last' queries then invert the direction of sorting (for db implementations), which requires one more reversal to arrive at the correct ordering.

Assuming 12 checkpoints, 0 to 11:
Examples (in test):
// first: 4, after: "6" -> checkpoints 7, 8, 9, 10
// first: 4, after: "6", before: "8" -> checkpoints 7
// first: 4, before: "6" -> checkpoints 0, 1, 2, 3
// last: 4, after: "6" -> checkpoints 8,9,10,11
// last: 4, before: "6" -> checkpoints 2, 3, 4, 5
// last: 4, before: "6", after: "3" -> checkpoints 4, 5

## Test Plan 
New test checkpoint_connection_pagination.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
