### PR TITLE
[graphql/rpc] testing infra: add object id mapping to varoables

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -104,7 +104,7 @@ Response: {
   }
 }
 
-task 16 'run-graphql'. lines 92-116:
+task 16 'run-graphql'. lines 92-124:
 Response: {
   "data": {
     "address": {
@@ -124,11 +124,17 @@ Response: {
           }
         ]
       }
+    },
+    "object": {
+      "version": 3,
+      "owner": {
+        "location": "0x0000000000000000000000000000000000000000000000000000000000000042"
+      }
     }
   }
 }
 
-task 17 'view-graphql-variables'. lines 119-120:
+task 17 'view-graphql-variables'. lines 127-128:
 Name: A
 Type: SuiAddress!
 Value: "0x42"
@@ -152,6 +158,30 @@ Value: "0xDEE9"
 Name: deepbook_opt
 Type: SuiAddress
 Value: "0xDEE9"
+
+Name: obj_0_0
+Type: SuiAddress!
+Value: "0x962d07ca41195ae05098e86b43656fc76bc67e348a891994154a4597432eb84f"
+
+Name: obj_0_0_opt
+Type: SuiAddress
+Value: "0x962d07ca41195ae05098e86b43656fc76bc67e348a891994154a4597432eb84f"
+
+Name: obj_1_0
+Type: SuiAddress!
+Value: "0xb214f63e7e7cea32dc57edba9c924524f44a7bb50e72d0e102265219d4de7d0e"
+
+Name: obj_1_0_opt
+Type: SuiAddress
+Value: "0xb214f63e7e7cea32dc57edba9c924524f44a7bb50e72d0e102265219d4de7d0e"
+
+Name: obj_2_0
+Type: SuiAddress!
+Value: "0x5dee0c408687d51a12f9edd765733887eb5d784bf38a8511195cf2bc64e3d801"
+
+Name: obj_2_0_opt
+Type: SuiAddress
+Value: "0x5dee0c408687d51a12f9edd765733887eb5d784bf38a8511195cf2bc64e3d801"
 
 Name: std
 Type: SuiAddress!

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -89,7 +89,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables Test A
+//# run-graphql --variables Test A obj_2_0
 {
   address(address: $Test) {
     objectConnection{
@@ -113,6 +113,14 @@ module Test::M1 {
       }
     }
   }
+
+  object(address: $obj_2_0) {
+    version
+    owner {
+      location
+    }
+  }
+
 }
 
 

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -239,7 +239,7 @@ impl ExecutorCluster {
                 .unwrap()
                 .unwrap();
             while highest_checkpoint < checkpoint {
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 highest_checkpoint = s
                     .indexer_store
                     .get_latest_tx_checkpoint_sequence_number()

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -957,23 +957,21 @@ impl<'a> SuiTestAdapter<'a> {
 
     fn graphql_variables(&self) -> BTreeMap<String, GraphqlQueryVariable> {
         let mut variables = BTreeMap::new();
-        let named_addrs: Vec<_> = self
+        let named_addrs = self
             .compiled_state
             .named_address_mapping
             .iter()
-            .map(|(name, addr)| (name.clone(), addr.to_string()))
-            .collect();
+            .map(|(name, addr)| (name.clone(), addr.to_string()));
 
-        let objects: Vec<_> = self
+        let objects = self
             .object_enumeration
             .iter()
             .filter_map(|(oid, fid)| match fid {
                 FakeID::Known(_) => None,
                 FakeID::Enumerated(x, y) => Some((format!("obj_{x}_{y}"), oid.to_string())),
-            })
-            .collect();
+            });
 
-        for (name, addr) in named_addrs.iter().chain(objects.iter()) {
+        for (name, addr) in named_addrs.chain(objects) {
             let addr = addr.to_string();
 
             // Required variant

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -957,7 +957,23 @@ impl<'a> SuiTestAdapter<'a> {
 
     fn graphql_variables(&self) -> BTreeMap<String, GraphqlQueryVariable> {
         let mut variables = BTreeMap::new();
-        for (name, addr) in &self.compiled_state.named_address_mapping {
+        let named_addrs: Vec<_> = self
+            .compiled_state
+            .named_address_mapping
+            .iter()
+            .map(|(name, addr)| (name.clone(), addr.to_string()))
+            .collect();
+
+        let objects: Vec<_> = self
+            .object_enumeration
+            .iter()
+            .filter_map(|(oid, fid)| match fid {
+                FakeID::Known(_) => None,
+                FakeID::Enumerated(x, y) => Some((format!("obj_{x}_{y}"), oid.to_string())),
+            })
+            .collect();
+
+        for (name, addr) in named_addrs.iter().chain(objects.iter()) {
             let addr = addr.to_string();
 
             // Required variant


### PR DESCRIPTION
## Description 

Followup of [this](https://github.com/MystenLabs/sui/pull/14957) PR which now allows the objects manipulated to be accessible as variables.
Object of name `FakeID(x,y)` will now have mapping `obj_x_y` and `obj_x_y_opt` variables.


## Test Plan 

Integration test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
