### PR TITLE
[graphql/rpc] easy: command to set ide title

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -34,6 +34,9 @@ pub enum Command {
         path: PathBuf,
     },
     StartServer {
+        /// The title to display at the top of the page
+        #[clap(short, long)]
+        ide_title: Option<String>,
         /// DB URL for data fetching
         #[clap(short, long)]
         db_url: Option<String>,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -76,6 +76,14 @@ impl Default for Ide {
     }
 }
 
+impl Ide {
+    pub fn new(ide_title: Option<String>) -> Self {
+        Self {
+            ide_title: ide_title.unwrap_or_default(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Experiments {

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use sui_graphql_rpc::commands::Command;
+use sui_graphql_rpc::config::Ide;
 use sui_graphql_rpc::config::{ConnectionConfig, ServerConfig, ServiceConfig};
 use sui_graphql_rpc::schema_sdl_export;
 use sui_graphql_rpc::server::builder::Server;
@@ -51,6 +52,7 @@ async fn main() {
             println!("Written examples to file: {:?}", file);
         }
         Command::StartServer {
+            ide_title,
             db_url,
             port,
             host,
@@ -68,6 +70,7 @@ async fn main() {
             let server_config = ServerConfig {
                 connection,
                 service: service_config,
+                ide: Ide::new(ide_title),
                 ..ServerConfig::default()
             };
 


### PR DESCRIPTION
## Description 

Makes it easy to set the title of the IDE. Helps when distinguishing different IDEs and to find the Sui mainnet vs testnet IDE.
Example:
`sui-graphql-rpc start-server --db-url postgres://0.0.0.0:5432/postgres  --ide-title mygql`

<img width="287" alt="ide_set" src="https://github.com/MystenLabs/sui/assets/93547199/762dd4de-c821-4742-b4d5-9126a8635a51">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
