### PR TITLE
[graphql] Allow for shorthand representation of the coin type

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -234,7 +234,7 @@ impl PgManager {
             .map(|cursor| self.parse_obj_cursor(&cursor))
             .transpose()?;
         let coin_type = parse_to_type_tag(Some(coin_type))
-            .map_err(|_| Error::Internal("Invalid coin type.".to_string()))?
+            .map_err(|e| Error::Internal(e.to_string()))?
             .to_canonical_string(/* with_prefix */ true);
         let result: Option<Vec<StoredObject>> = self
             .run_query_async_with_cost(
@@ -864,7 +864,7 @@ impl PgManager {
     ) -> Result<Option<Balance>, Error> {
         let address = address.into_vec();
         let coin_type = parse_to_type_tag(coin_type)
-            .map_err(|_| Error::Internal("Invalid coin type.".to_string()))?
+            .map_err(|e| Error::Internal(e.to_string()))?
             .to_canonical_string(/* with_prefix */ true);
         let result = self.get_balance(address, coin_type).await?;
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -234,7 +234,7 @@ impl PgManager {
             .map(|cursor| self.parse_obj_cursor(&cursor))
             .transpose()?;
         let coin_type = parse_to_type_tag(Some(coin_type))
-            .map_err(|e| Error::Internal(e.to_string()))?
+            .map_err(|e| Error::InvalidCoinType(e.to_string()))?
             .to_canonical_string(/* with_prefix */ true);
         let result: Option<Vec<StoredObject>> = self
             .run_query_async_with_cost(
@@ -864,7 +864,7 @@ impl PgManager {
     ) -> Result<Option<Balance>, Error> {
         let address = address.into_vec();
         let coin_type = parse_to_type_tag(coin_type)
-            .map_err(|e| Error::Internal(e.to_string()))?
+            .map_err(|e| Error::InvalidCoinType(e.to_string()))?
             .to_canonical_string(/* with_prefix */ true);
         let result = self.get_balance(address, coin_type).await?;
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -233,7 +233,9 @@ impl PgManager {
             .or(before)
             .map(|cursor| self.parse_obj_cursor(&cursor))
             .transpose()?;
-
+        let coin_type = parse_to_type_tag(Some(coin_type))
+            .map_err(|_| Error::Internal("Invalid coin type.".to_string()))?
+            .to_canonical_string(/* with_prefix */ true);
         let result: Option<Vec<StoredObject>> = self
             .run_query_async_with_cost(
                 move || {
@@ -861,13 +863,8 @@ impl PgManager {
         coin_type: Option<String>,
     ) -> Result<Option<Balance>, Error> {
         let address = address.into_vec();
-        let coin_type_tag = parse_to_type_tag(coin_type);
-        if coin_type_tag.is_err() {
-            // The provided `coin_type` cannot be parsed to a type tag so return None here.
-            return Ok(None);
-        }
-        let coin_type = coin_type_tag
-            .unwrap()
+        let coin_type = parse_to_type_tag(coin_type)
+            .map_err(|_| Error::Internal("Invalid coin type.".to_string()))?
             .to_canonical_string(/* with_prefix */ true);
         let result = self.get_balance(address, coin_type).await?;
 

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -76,6 +76,8 @@ pub enum Error {
     DbValidation(#[from] DbValidationError),
     #[error("Provide one of digest or sequence_number, not both")]
     InvalidCheckpointQuery,
+    #[error("Invalid coin type: {0}")]
+    InvalidCoinType(String),
     #[error("String is not valid base58: {0}")]
     InvalidBase58(String),
     #[error("Invalid digest length: expected {expected}, actual {actual}")]
@@ -108,6 +110,7 @@ impl ErrorExtensions for Error {
             | Error::DomainParse(_)
             | Error::DbValidation(_)
             | Error::InvalidCheckpointQuery
+            | Error::InvalidCoinType(_)
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast
             | Error::_CursorNoReversePagination


### PR DESCRIPTION
## Description 

Allow for shorthand representation of the coin type.

## Test Plan 

<img width="2539" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/c223ed56-62d1-453a-9345-b9bd2137a9fe">

On Error:
<img width="2539" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/f2967a8b-77be-4695-a827-291bea7427ef">
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
