### PR TITLE
[graphql/easy] Fix coin connection doc comments

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -909,9 +909,8 @@ type Query {
 	transactionBlock(digest: String!): TransactionBlock
 	"""
 	The coin objects that exist in the network.
-	The type field is a string of the inner type of the coin
-	by which to filter. If no type is provided, it will use the default SUI coin type,
-	0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI.
+	The type field is a string of the inner type of the coin by which to filter.
+	If no type is provided, it will default to 0x2::sui::SUI.
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -117,9 +117,8 @@ impl Query {
     }
 
     /// The coin objects that exist in the network.
-    /// The type field is a string of the inner type of the coin
-    /// by which to filter. If no type is provided, it will use the default SUI coin type,
-    /// 0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI.
+    /// The type field is a string of the inner type of the coin by which to filter.
+    /// If no type is provided, it will default to 0x2::sui::SUI.
     async fn coin_connection(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -913,9 +913,8 @@ type Query {
 	transactionBlock(digest: String!): TransactionBlock
 	"""
 	The coin objects that exist in the network.
-	The type field is a string of the inner type of the coin
-	by which to filter. If no type is provided, it will use the default SUI coin type,
-	0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI.
+	The type field is a string of the inner type of the coin by which to filter.
+	If no type is provided, it will default to 0x2::sui::SUI.
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection


### PR DESCRIPTION
## Description 

Once #14965 lands, this PR fixes the doc comments in the `coinConnection` for the `Query` type. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
