### PR TITLE
[graphql/rpc] chore: config cleanups

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -268,6 +268,7 @@ impl Cluster for LocalNewCluster {
                 options.pg_address.clone(),
                 None,
                 None,
+                None,
             );
 
             start_graphql_server(graphql_connection_config.clone()).await;

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -20,12 +20,22 @@ const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
 
 const DEFAULT_IDE_TITLE: &str = "Sui GraphQL IDE";
 
+// Default values for the server connection configuration.
+pub(crate) const DEFAULT_SERVER_CONNECTION_PORT: u16 = 8000;
+pub(crate) const DEFAULT_SERVER_CONNECTION_HOST: &str = "127.0.0.1";
+pub(crate) const DEFAULT_SERVER_DB_URL: &str =
+    "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2";
+pub(crate) const DEFAULT_SERVER_DB_POOL_SIZE: u32 = 3;
+pub(crate) const DEFAULT_SERVER_PROM_HOST: &str = "0.0.0.0";
+pub(crate) const DEFAULT_SERVER_PROM_PORT: u16 = 9184;
+
 /// Configuration on connections for the RPC, passed in as command-line arguments.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 pub struct ConnectionConfig {
     pub(crate) port: u16,
     pub(crate) host: String,
     pub(crate) db_url: String,
+    pub(crate) db_pool_size: u32,
     pub(crate) prom_url: String,
     pub(crate) prom_port: u16,
 }
@@ -98,6 +108,7 @@ impl ConnectionConfig {
         port: Option<u16>,
         host: Option<String>,
         db_url: Option<String>,
+        db_pool_size: Option<u32>,
         prom_url: Option<String>,
         prom_port: Option<u16>,
     ) -> Self {
@@ -106,6 +117,7 @@ impl ConnectionConfig {
             port: port.unwrap_or(default.port),
             host: host.unwrap_or(default.host),
             db_url: db_url.unwrap_or(default.db_url),
+            db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
             prom_url: prom_url.unwrap_or(default.prom_url),
             prom_port: prom_port.unwrap_or(default.prom_port),
         }
@@ -120,6 +132,10 @@ impl ConnectionConfig {
 
     pub fn db_url(&self) -> String {
         self.db_url.clone()
+    }
+
+    pub fn db_pool_size(&self) -> u32 {
+        self.db_pool_size
     }
 
     pub fn server_address(&self) -> String {
@@ -184,11 +200,12 @@ impl ServiceConfig {
 impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
-            port: 8000,
-            host: "127.0.0.1".to_string(),
-            db_url: "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2".to_string(),
-            prom_url: "0.0.0.0".to_string(),
-            prom_port: 9184,
+            port: DEFAULT_SERVER_CONNECTION_PORT,
+            host: DEFAULT_SERVER_CONNECTION_HOST.to_string(),
+            db_url: DEFAULT_SERVER_DB_URL.to_string(),
+            db_pool_size: DEFAULT_SERVER_DB_POOL_SIZE,
+            prom_url: DEFAULT_SERVER_PROM_HOST.to_string(),
+            prom_port: DEFAULT_SERVER_PROM_PORT,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::Limits,
+    config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
     types::{
         address::{Address, AddressTransactionBlockRelationship},
@@ -135,8 +135,15 @@ impl PgManager {
 
     /// Create a new underlying reader, which is used by this type as well as other data providers.
     pub(crate) fn reader(db_url: impl Into<String>) -> Result<IndexerReader, Error> {
+        Self::reader_with_config(db_url, DEFAULT_SERVER_DB_POOL_SIZE)
+    }
+
+    pub(crate) fn reader_with_config(
+        db_url: impl Into<String>,
+        pool_size: u32,
+    ) -> Result<IndexerReader, Error> {
         let mut config = PgConnectionPoolConfig::default();
-        config.set_pool_size(3);
+        config.set_pool_size(pool_size);
         IndexerReader::new_with_config(db_url, config)
             .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
     }

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
             prom_host,
             prom_port,
         } => {
-            let connection = ConnectionConfig::new(port, host, db_url, prom_host, prom_port);
+            let connection = ConnectionConfig::new(port, host, db_url, None, prom_host, prom_port);
             let service_config = service_config(config);
             let _guard = telemetry_subscribers::TelemetryConfig::new()
                 .with_env()

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -53,8 +53,11 @@ impl Server {
             ServerBuilder::new(config.connection.port, config.connection.host.clone());
 
         let name_service_config = config.name_service.clone();
-        let reader = PgManager::reader(config.connection.db_url.clone())
-            .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
+        let reader = PgManager::reader_with_config(
+            config.connection.db_url.clone(),
+            config.connection.db_pool_size,
+        )
+        .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
         let pg_conn_pool = PgManager::new(reader.clone(), config.service.limits);
         let package_store = DbPackageStore(reader);
         let package_cache = PackageStoreWithLruCache::new(package_store);


### PR DESCRIPTION
## Description 

Removes use of magic number 3 for db pool size and puts it under config attr.

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
