### PR TITLE
[GraphQL/Move] MoveStruct

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -1,0 +1,390 @@
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1 'run-graphql'. lines 6-50:
+Response: {
+  "data": {
+    "object": {
+      "asMovePackage": {
+        "coin": {
+          "struct": {
+            "name": "Coin",
+            "abilities": [
+              "STORE",
+              "KEY"
+            ],
+            "typeParameters": [
+              {
+                "constraints": [],
+                "isPhantom": true
+              }
+            ],
+            "fields": [
+              {
+                "name": "id",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::object::UID",
+                  "signature": {
+                    "ref": null,
+                    "body": {
+                      "struct": {
+                        "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                        "module": "object",
+                        "type": "UID",
+                        "type_parameters": []
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name": "balance",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<$0>",
+                  "signature": {
+                    "ref": null,
+                    "body": {
+                      "struct": {
+                        "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                        "module": "balance",
+                        "type": "Balance",
+                        "type_parameters": [
+                          {
+                            "typeParameter": 0
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "tx_context": {
+          "struct": {
+            "name": "TxContext",
+            "abilities": [
+              "DROP"
+            ],
+            "typeParameters": [],
+            "fields": [
+              {
+                "name": "sender",
+                "type": {
+                  "repr": "address",
+                  "signature": {
+                    "ref": null,
+                    "body": "address"
+                  }
+                }
+              },
+              {
+                "name": "tx_hash",
+                "type": {
+                  "repr": "vector<u8>",
+                  "signature": {
+                    "ref": null,
+                    "body": {
+                      "vector": "u8"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "epoch",
+                "type": {
+                  "repr": "u64",
+                  "signature": {
+                    "ref": null,
+                    "body": "u64"
+                  }
+                }
+              },
+              {
+                "name": "epoch_timestamp_ms",
+                "type": {
+                  "repr": "u64",
+                  "signature": {
+                    "ref": null,
+                    "body": "u64"
+                  }
+                }
+              },
+              {
+                "name": "ids_created",
+                "type": {
+                  "repr": "u64",
+                  "signature": {
+                    "ref": null,
+                    "body": "u64"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 2 'publish'. lines 52-56:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5213600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 58-58:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 60-100:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da",
+                  "asMovePackage": {
+                    "module": {
+                      "struct": {
+                        "name": "S",
+                        "abilities": [
+                          "COPY",
+                          "DROP"
+                        ],
+                        "typeParameters": [],
+                        "fields": [
+                          {
+                            "name": "x",
+                            "type": {
+                              "repr": "u64",
+                              "signature": {
+                                "ref": null,
+                                "body": "u64"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "location": "0xdf601378bf61c199cf63011e1f0bcdc5518b118726bb33808ed455fa595d123e",
+                  "asMovePackage": null
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 5 'upgrade'. lines 102-108:
+created: object(5,0)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6049600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 6 'create-checkpoint'. lines 110-110:
+Checkpoint created: 2
+
+task 7 'run-graphql'. lines 112-167:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "location": "0xdf601378bf61c199cf63011e1f0bcdc5518b118726bb33808ed455fa595d123e",
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "location": "0x0ce0fe064fd500775e2ffaeeb5807df0c18026c6ba4b1ab4f9ec4f571c05419e",
+                  "asMovePackage": {
+                    "module": {
+                      "s": {
+                        "module": {
+                          "moduleId": {
+                            "package": {
+                              "asObject": {
+                                "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da"
+                              }
+                            }
+                          }
+                        },
+                        "name": "S",
+                        "abilities": [
+                          "COPY",
+                          "DROP"
+                        ],
+                        "typeParameters": [],
+                        "fields": [
+                          {
+                            "name": "x",
+                            "type": {
+                              "repr": "u64",
+                              "signature": {
+                                "ref": null,
+                                "body": "u64"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "t": {
+                        "module": {
+                          "moduleId": {
+                            "package": {
+                              "asObject": {
+                                "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da"
+                              }
+                            }
+                          }
+                        },
+                        "name": "T",
+                        "abilities": [],
+                        "typeParameters": [
+                          {
+                            "constraints": [
+                              "DROP"
+                            ],
+                            "isPhantom": false
+                          }
+                        ],
+                        "fields": [
+                          {
+                            "name": "y",
+                            "type": {
+                              "repr": "u64",
+                              "signature": {
+                                "ref": null,
+                                "body": "u64"
+                              }
+                            }
+                          },
+                          {
+                            "name": "s",
+                            "type": {
+                              "repr": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da::m::S",
+                              "signature": {
+                                "ref": null,
+                                "body": {
+                                  "struct": {
+                                    "package": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da",
+                                    "module": "m",
+                                    "type": "S",
+                                    "type_parameters": []
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "name": "u",
+                            "type": {
+                              "repr": "$0",
+                              "signature": {
+                                "ref": null,
+                                "body": {
+                                  "typeParameter": 0
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "v": {
+                        "name": "V",
+                        "fields": [
+                          {
+                            "name": "t",
+                            "type": {
+                              "repr": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da::m::T<0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da::m::S>"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 169-203:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": {
+                    "module": {
+                      "s": {
+                        "module": {
+                          "struct": null
+                        }
+                      },
+                      "t": {
+                        "module": {
+                          "struct": {
+                            "name": "T"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -1,0 +1,203 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 P1=0x0 --accounts A --simulator
+
+//# run-graphql
+
+# Tests on existing system types
+{
+    object(address: "0x2") {
+        asMovePackage {
+            # Look-up a type that has generics, including phantoms.
+            coin: module(name: "coin") {
+                struct(name: "Coin") {
+                    name
+                    abilities
+                    typeParameters {
+                        constraints
+                        isPhantom
+                    }
+                    fields {
+                        name
+                        type {
+                            repr
+                            signature
+                        }
+                    }
+                }
+            }
+
+            tx_context: module(name: "tx_context") {
+                struct(name: "TxContext") {
+                    name
+                    abilities
+                    typeParameters {
+                        constraints
+                        isPhantom
+                    }
+                    fields {
+                        name
+                        type {
+                            repr
+                            signature
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+//# publish --upgradeable --sender A
+
+module P0::m {
+    struct S has copy, drop { x: u64 }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+
+# Check the contents of P0::m::S that was just published, this acts as
+# a reference for when we run the same transaction against the
+# upgraded package.
+fragment Structs on Object {
+    location
+    asMovePackage {
+        module(name: "m") {
+            struct(name: "S") {
+                name
+                abilities
+                typeParameters {
+                    constraints
+                    isPhantom
+                }
+                fields {
+                    name
+                    type {
+                        repr
+                        signature
+                    }
+                }
+            }
+        }
+    }
+}
+
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                objectChanges {
+                    outputState {
+                        ...Structs
+                    }
+                }
+            }
+        }
+    }
+}
+
+//# upgrade --package P0 --upgrade-capability 2,1 --sender A
+
+module P1::m {
+    struct S has copy, drop { x: u64 }
+    struct T<U: drop> { y: u64, s: S, u: U }
+    struct V { t: T<S> }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+
+# Run a similar query as above again, but on the upgraded package, to
+# see the IDs of types as they appear in the new package -- they will
+# all be the runtime ID.
+fragment FullStruct on MoveStruct {
+    module { moduleId { package { asObject { location } } } }
+    name
+    abilities
+    typeParameters {
+        constraints
+        isPhantom
+    }
+    fields {
+        name
+        type {
+            repr
+            signature
+        }
+    }
+}
+
+fragment Structs on Object {
+    location
+    asMovePackage {
+        module(name: "m") {
+            s: struct(name: "S") { ...FullStruct }
+            t: struct(name: "T") { ...FullStruct }
+
+            # V is a special type that exists to show the
+            # representations of S and T, so we don't need to query as
+            # many fields for it.
+            v: struct(name: "V") {
+                name
+                fields {
+                    name
+                    type { repr }
+                }
+            }
+        }
+    }
+}
+
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                objectChanges {
+                    outputState {
+                        ...Structs
+                    }
+                }
+            }
+        }
+    }
+}
+
+//# run-graphql
+
+# But we can still confirm that we can roundtrip the `T` struct from
+# its own module, but cannot reach `T` from `S`'s defining module.
+
+fragment ReachT on MoveStruct {
+    module { struct(name: "T") { name } }
+}
+
+fragment Structs on Object {
+    asMovePackage {
+        module(name: "m") {
+            # S should not be able to reach T from its own module
+            s: struct(name: "S") { ...ReachT }
+
+            # But T should
+            t: struct(name: "T") { ...ReachT }
+        }
+    }
+}
+
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                objectChanges {
+                    outputState {
+                        ...Structs
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -530,6 +530,13 @@ type Linkage {
 	version: Int!
 }
 
+enum MoveAbility {
+	COPY
+	DROP
+	KEY
+	STORE
+}
+
 """
 The contents of a Move Value, corresponding to the following recursive type:
 
@@ -545,6 +552,11 @@ type MoveData =
 """
 scalar MoveData
 
+type MoveField {
+	name: String!
+	type: OpenMoveType
+}
+
 """
 Represents a module in Move, a library that defines struct types
 and functions that operate on these types.
@@ -557,6 +569,10 @@ type MoveModule {
 	functions from this module).
 	"""
 	friendConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
+	"""
+	Look-up the definition of a struct defined in this module, by its name.
+	"""
+	struct(name: String!): MoveStruct
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""
@@ -658,6 +674,40 @@ type MovePackage {
 	"""
 	bcs: Base64
 	asObject: Object!
+}
+
+"""
+Description of a type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	The module this struct was originally defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's (unqualified) type name.
+	"""
+	name: String!
+	"""
+	Abilities this struct has.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	Constraints on the struct's formal type parameters.  Move bytecode does not name type
+	parameters, so when they are referenced (e.g. in field types) they are identified by their
+	index in this list.
+	"""
+	typeParameters: [MoveStructTypeParameter!]
+	"""
+	The names and types of the struct's fields.  Field types reference type parameters, by their
+	index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+}
+
+type MoveStructTypeParameter {
+	constraints: [MoveAbility!]!
+	isPhantom: Boolean!
 }
 
 """
@@ -892,6 +942,46 @@ interface ObjectOwner {
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
+
+"""
+Represents types that could contain references or free type parameters.  Such types can appear
+as function parameters, in fields of structs, or as actual type parameter.
+"""
+type OpenMoveType {
+	"""
+	Structured representation of the type signature.
+	"""
+	signature: OpenMoveTypeSignature
+	"""
+	Flat representation of the type signature, as a displayable string.
+	"""
+	repr: String
+}
+
+"""
+The shape of an abstract Move Type (a type that can contain free type parameters, and can optionally be taken by reference), corresponding to the following recursive type:
+
+type OpenMoveTypeSignature = {
+  ref: ("&" | "&mut")?,
+  body: OpenMoveTypeSignatureBody,
+}
+
+type OpenMoveTypeSignatureBody =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: OpenMoveTypeSignatureBody }
+  | {
+      struct {
+        package: string,
+        module: string,
+        type: string,
+        typeParameters: [OpenMoveTypeSignatureBody]
+      }
+    }
+  | { typeParameter: number }
+"""
+scalar OpenMoveTypeSignature
 
 type Owner implements ObjectOwner {
 	asAddress: Address

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -1057,7 +1057,6 @@ type MoveModule {
 }
 
 type MoveStruct {
-  id : ID!
   module: MoveModule!
   name: String!
   abilities: [MoveAbility]

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -21,12 +21,12 @@ pub(crate) mod json;
 pub(crate) mod move_module;
 pub(crate) mod move_object;
 pub(crate) mod move_package;
+pub(crate) mod move_struct;
 pub(crate) mod move_type;
 pub(crate) mod move_value;
 pub(crate) mod name_service;
 pub(crate) mod object;
 pub(crate) mod object_change;
-#[allow(dead_code)] // TODO: Remove when integrated
 pub(crate) mod open_move_type;
 pub(crate) mod owner;
 pub(crate) mod protocol_config;

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -57,7 +57,7 @@ impl MovePackage {
     /// A representation of the module called `name` in this package, including the
     /// structs and functions it defines.
     async fn module(&self, name: String) -> Result<Option<MoveModule>> {
-        self.module_impl(&name)
+        self.module_impl(&name).extend()
     }
 
     /// Paginate through the MoveModules defined in this package.
@@ -194,11 +194,11 @@ impl MovePackage {
             .map_err(|e| Error::Internal(format!("Error reading package: {e}")))
     }
 
-    pub(crate) fn module_impl(&self, name: &str) -> Result<Option<MoveModule>> {
+    pub(crate) fn module_impl(&self, name: &str) -> Result<Option<MoveModule>, Error> {
         use PackageCacheError as E;
         match (
             self.native.serialized_module_map().get(name),
-            self.parsed_package().extend()?.module(name),
+            self.parsed_package()?.module(name),
         ) {
             (Some(native), Ok(parsed)) => Ok(Some(MoveModule {
                 native: native.clone(),
@@ -206,9 +206,9 @@ impl MovePackage {
             })),
 
             (None, _) | (_, Err(E::ModuleNotFound(_, _))) => Ok(None),
-            (_, Err(e)) => {
-                Err(Error::Internal(format!("Unexpected error fetching module: {e}")).extend())
-            }
+            (_, Err(e)) => Err(Error::Internal(format!(
+                "Unexpected error fetching module: {e}"
+            ))),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_struct.rs
+++ b/crates/sui-graphql-rpc/src/types/move_struct.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use move_binary_format::file_format::AbilitySet;
+use sui_package_resolver::StructDef;
+
+use crate::context_data::db_data_provider::PgManager;
+use crate::error::Error;
+
+use super::{
+    move_module::MoveModule,
+    open_move_type::{MoveAbility, OpenMoveType},
+    sui_address::SuiAddress,
+};
+
+pub(crate) struct MoveStruct {
+    defining_id: SuiAddress,
+    module: String,
+    name: String,
+    abilities: Vec<MoveAbility>,
+    type_parameters: Vec<MoveStructTypeParameter>,
+    fields: Vec<MoveField>,
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct MoveStructTypeParameter {
+    constraints: Vec<MoveAbility>,
+    is_phantom: bool,
+}
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+pub(crate) struct MoveField {
+    name: String,
+    #[graphql(skip)]
+    type_: OpenMoveType,
+}
+
+/// Description of a type, defined in a Move module.
+#[Object]
+impl MoveStruct {
+    /// The module this struct was originally defined in.
+    async fn module(&self, ctx: &Context<'_>) -> Result<MoveModule> {
+        let Some(module) = ctx
+            .data_unchecked::<PgManager>()
+            .fetch_move_module(self.defining_id, &self.module)
+            .await
+            .extend()?
+        else {
+            return Err(Error::Internal(format!(
+                "Failed to load module for struct: {}::{}::{}",
+                self.defining_id, self.module, self.name,
+            )))
+            .extend();
+        };
+
+        Ok(module)
+    }
+
+    /// The struct's (unqualified) type name.
+    async fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Abilities this struct has.
+    async fn abilities(&self) -> Option<&Vec<MoveAbility>> {
+        Some(&self.abilities)
+    }
+
+    /// Constraints on the struct's formal type parameters.  Move bytecode does not name type
+    /// parameters, so when they are referenced (e.g. in field types) they are identified by their
+    /// index in this list.
+    async fn type_parameters(&self) -> Option<&Vec<MoveStructTypeParameter>> {
+        Some(&self.type_parameters)
+    }
+
+    /// The names and types of the struct's fields.  Field types reference type parameters, by their
+    /// index in the defining struct's `typeParameters` list.
+    async fn fields(&self) -> Option<&Vec<MoveField>> {
+        Some(&self.fields)
+    }
+}
+
+#[ComplexObject]
+impl MoveField {
+    #[graphql(name = "type")]
+    async fn type_(&self) -> Option<&OpenMoveType> {
+        Some(&self.type_)
+    }
+}
+
+impl MoveStruct {
+    pub(crate) fn new(module: String, name: String, def: StructDef) -> Self {
+        let type_parameters = def
+            .type_params
+            .into_iter()
+            .map(|param| MoveStructTypeParameter {
+                constraints: abilities(param.constraints),
+                is_phantom: param.is_phantom,
+            })
+            .collect();
+
+        let fields = def
+            .fields
+            .into_iter()
+            .map(|(name, signature)| MoveField {
+                name,
+                type_: signature.into(),
+            })
+            .collect();
+
+        MoveStruct {
+            defining_id: SuiAddress::from(def.defining_id),
+            module,
+            name,
+            abilities: abilities(def.abilities),
+            type_parameters,
+            fields,
+        }
+    }
+}
+
+fn abilities(set: AbilitySet) -> Vec<MoveAbility> {
+    set.into_iter().map(MoveAbility::from).collect()
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -534,6 +534,13 @@ type Linkage {
 	version: Int!
 }
 
+enum MoveAbility {
+	COPY
+	DROP
+	KEY
+	STORE
+}
+
 """
 The contents of a Move Value, corresponding to the following recursive type:
 
@@ -549,6 +556,11 @@ type MoveData =
 """
 scalar MoveData
 
+type MoveField {
+	name: String!
+	type: OpenMoveType
+}
+
 """
 Represents a module in Move, a library that defines struct types
 and functions that operate on these types.
@@ -561,6 +573,10 @@ type MoveModule {
 	functions from this module).
 	"""
 	friendConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
+	"""
+	Look-up the definition of a struct defined in this module, by its name.
+	"""
+	struct(name: String!): MoveStruct
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""
@@ -662,6 +678,40 @@ type MovePackage {
 	"""
 	bcs: Base64
 	asObject: Object!
+}
+
+"""
+Description of a type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	The module this struct was originally defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's (unqualified) type name.
+	"""
+	name: String!
+	"""
+	Abilities this struct has.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	Constraints on the struct's formal type parameters.  Move bytecode does not name type
+	parameters, so when they are referenced (e.g. in field types) they are identified by their
+	index in this list.
+	"""
+	typeParameters: [MoveStructTypeParameter!]
+	"""
+	The names and types of the struct's fields.  Field types reference type parameters, by their
+	index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+}
+
+type MoveStructTypeParameter {
+	constraints: [MoveAbility!]!
+	isPhantom: Boolean!
 }
 
 """
@@ -896,6 +946,46 @@ interface ObjectOwner {
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
+
+"""
+Represents types that could contain references or free type parameters.  Such types can appear
+as function parameters, in fields of structs, or as actual type parameter.
+"""
+type OpenMoveType {
+	"""
+	Structured representation of the type signature.
+	"""
+	signature: OpenMoveTypeSignature
+	"""
+	Flat representation of the type signature, as a displayable string.
+	"""
+	repr: String
+}
+
+"""
+The shape of an abstract Move Type (a type that can contain free type parameters, and can optionally be taken by reference), corresponding to the following recursive type:
+
+type OpenMoveTypeSignature = {
+  ref: ("&" | "&mut")?,
+  body: OpenMoveTypeSignatureBody,
+}
+
+type OpenMoveTypeSignatureBody =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: OpenMoveTypeSignatureBody }
+  | {
+      struct {
+        package: string,
+        module: string,
+        type: string,
+        typeParameters: [OpenMoveTypeSignatureBody]
+      }
+    }
+  | { typeParameter: number }
+"""
+scalar OpenMoveTypeSignature
 
 type Owner implements ObjectOwner {
 	asAddress: Address

--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     StructNotFound(AccountAddress, String, String),
 
     #[error("Expected {0} type parameters, but got {1}")]
-    TypeArityMismatch(u16, usize),
+    TypeArityMismatch(usize, usize),
 
     #[error("Type Parameter {0} out of bounds ({1})")]
     TypeParamOOB(u16, usize),


### PR DESCRIPTION
## Description

Add `MoveStruct` + supporting GraphQL types, and `MoveModule.struct` for querying structs from modules.

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration \
  -- structs.move
```

## Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 