### PR TITLE
Add basic sponsorship functionality and demo

### DIFF
--- a/.changeset/happy-ducks-yell.md
+++ b/.changeset/happy-ducks-yell.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+Key storage off of the API key, and add APIs for transaction block sponsorship

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,15 +1505,27 @@ importers:
       '@types/react':
         specifier: ^18.2.15
         version: 18.2.15
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.7
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.3.2
+        version: 3.4.0(vite@4.4.11)
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+      vite:
+        specifier: ^4.4.4
+        version: 4.4.11(@types/node@20.4.2)(sass@1.63.6)
 
   sdk/kiosk:
     dependencies:
@@ -1591,6 +1603,8 @@ importers:
       wasm-pack:
         specifier: ^0.12.1
         version: 0.12.1
+
+  sdk/move-binary-format-wasm/pkg: {}
 
   sdk/suins-toolkit:
     dependencies:
@@ -24455,7 +24469,7 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.6.0
-      vite: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
+      vite: 4.4.11(@types/node@20.4.2)(sass@1.63.6)
       vite-node: 0.33.0(@types/node@20.4.2)(sass@1.63.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
@@ -24521,7 +24535,7 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.6.0
-      vite: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
+      vite: 4.4.11(@types/node@20.4.2)(sass@1.63.6)
       vite-node: 0.33.0(@types/node@20.4.2)(sass@1.63.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/sdk/enoki/demo/App.tsx
+++ b/sdk/enoki/demo/App.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getFullnodeUrl, SuiClient } from '@mysten/sui.js/client';
+import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { useState } from 'react';
+
+import { useAuthCallback, useEnokiFlow, useZkLogin } from '../src/react.tsx';
+
+export function App() {
+	const flow = useEnokiFlow();
+	const zkLogin = useZkLogin();
+	const [result, setResult] = useState<any>(null);
+
+	useAuthCallback();
+
+	return (
+		<div>
+			<div>Address: {zkLogin.address}</div>
+			<div>Provider: {zkLogin.provider}</div>
+			{!zkLogin.address ? (
+				<button
+					onClick={async () => {
+						window.location.href = await flow.createAuthorizationURL({
+							provider: 'google',
+							clientId: '705781974144-cltddr1ggjnuc3kaimtc881r2n5bderc.apps.googleusercontent.com',
+							redirectUrl: window.location.href.split('#')[0],
+						});
+					}}
+				>
+					Sign in with Google
+				</button>
+			) : (
+				<button onClick={() => flow.logout()}>Sign Out</button>
+			)}
+
+			{zkLogin.address && (
+				<button
+					onClick={async () => {
+						try {
+							const transactionBlock = new TransactionBlock();
+							transactionBlock.moveCall({
+								target:
+									'0xfa0e78030bd16672174c2d6cc4cd5d1d1423d03c28a74909b2a148eda8bcca16::clock::access',
+								arguments: [transactionBlock.object('0x6')],
+							});
+
+							const result = await flow.sponsorAndExecuteTransactionBlock({
+								network: 'testnet',
+								// @ts-expect-error: Type references not quite doing their thing:
+								client: new SuiClient({ url: getFullnodeUrl('testnet') }),
+								// @ts-expect-error: Type references not quite doing their thing:
+								transactionBlock,
+							});
+
+							setResult(result);
+						} catch (e) {
+							console.log(e);
+							setResult({ error: e });
+						}
+					}}
+				>
+					Sign transaction
+				</button>
+			)}
+
+			{result && <div>{JSON.stringify(result)}</div>}
+		</div>
+	);
+}

--- a/sdk/enoki/demo/index.html
+++ b/sdk/enoki/demo/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/main.tsx"></script>
+	</body>
+</html>

--- a/sdk/enoki/demo/main.tsx
+++ b/sdk/enoki/demo/main.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import { EnokiFlowProvider } from '../src/react.tsx';
+import { App } from './App.tsx';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<React.StrictMode>
+		<EnokiFlowProvider apiKey="enoki_apikey_ec23ee0a581fca24263243bc89f77bdf">
+			{/* <EnokiFlowProvider
+			apiUrl="http://localhost:3081/api/sdk"
+			apiKey="enoki_apikey_253ae80d76ce0ec48ee19d0c571092b8"
+		> */}
+			<App />
+		</EnokiFlowProvider>
+	</React.StrictMode>,
+);

--- a/sdk/enoki/demo/tsconfig.json
+++ b/sdk/enoki/demo/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
+
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["."],
+	"references": [{ "path": "../tsconfig.json" }, { "path": "../../typescript/" }]
+}

--- a/sdk/enoki/demo/vite.config.ts
+++ b/sdk/enoki/demo/vite.config.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [react()],
+});

--- a/sdk/enoki/package.json
+++ b/sdk/enoki/package.json
@@ -21,12 +21,12 @@
 	"files": [
 		"CHANGELOG.md",
 		"dist",
-		"react",
-		"src"
+		"react"
 	],
 	"scripts": {
 		"clean": "rm -rf tsconfig.tsbuildinfo ./dist",
 		"build": "build-package",
+		"demo": "vite ./demo",
 		"prepublishOnly": "pnpm build",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
@@ -47,9 +47,13 @@
 		"@mysten/build-scripts": "workspace:*",
 		"@types/node": "^20.4.2",
 		"@types/react": "^18.2.15",
+		"@types/react-dom": "^18.2.7",
+		"@vitejs/plugin-react-swc": "^3.3.2",
 		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
 		"tsx": "^3.12.7",
-		"typescript": "^5.1.6"
+		"typescript": "^5.1.6",
+		"vite": "^4.4.4"
 	},
 	"dependencies": {
 		"@mysten/sui.js": "workspace:*",

--- a/sdk/enoki/src/EnokiClient/index.ts
+++ b/sdk/enoki/src/EnokiClient/index.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+	CreateSponsoredTransactionBlockApiInput,
+	CreateSponsoredTransactionBlockApiResponse,
 	CreateZkLoginNonceApiInput,
 	CreateZkLoginNonceApiResponse,
 	CreateZkLoginZkpApiInput,
@@ -62,7 +64,7 @@ export class EnokiClient {
 	}
 
 	createZkLoginZkp(input: CreateZkLoginZkpApiInput) {
-		return this.#fetch<CreateZkLoginZkpApiResponse>('zklogin/kzp', {
+		return this.#fetch<CreateZkLoginZkpApiResponse>('zklogin/zkp', {
 			method: 'POST',
 			headers: {
 				[ZKLOGIN_HEADER]: input.jwt,
@@ -71,6 +73,19 @@ export class EnokiClient {
 				ephemeralPublicKey: input.ephemeralPublicKey.toSuiPublicKey(),
 				maxEpoch: input.maxEpoch,
 				randomness: input.randomness,
+			}),
+		});
+	}
+
+	createSponsoredTransactionBlock(input: CreateSponsoredTransactionBlockApiInput) {
+		return this.#fetch<CreateSponsoredTransactionBlockApiResponse>('transaction-blocks/sponsor', {
+			method: 'POST',
+			headers: {
+				[ZKLOGIN_HEADER]: input.jwt,
+			},
+			body: JSON.stringify({
+				network: input.network,
+				transactionBlockKindBytes: input.transactionBlockKindBytes,
 			}),
 		});
 	}

--- a/sdk/enoki/src/EnokiClient/type.ts
+++ b/sdk/enoki/src/EnokiClient/type.ts
@@ -40,3 +40,17 @@ export interface CreateZkLoginZkpApiInput {
 	maxEpoch: number;
 }
 export interface CreateZkLoginZkpApiResponse extends ZkLoginSignatureInputs {}
+
+export interface CreateSponsoredTransactionBlockApiInput {
+	network?: 'mainnet' | 'testnet';
+	jwt: string;
+	transactionBlockKindBytes: string;
+}
+
+export interface CreateSponsoredTransactionBlockApiResponse {
+	bytes: string;
+	signature: string;
+	digest: string;
+	expireAtTime: number;
+	expireAfterEpoch: number;
+}


### PR DESCRIPTION
## Description 

This adds the ability to sponsor and execute a transaction in the enoki SDK, and makes a couple tweaks to improve the SDK. I also added a demo app to test the Enoki SDK.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
