### PR TITLE
[graphql][fix] e2e tests do not run if pg_backend flag is provided

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -428,9 +428,9 @@ jobs:
           POSTGRES_PASSWORD: postgrespw
      - name: tests-requiring-postgres
        run: |
-         cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration pg_backend
-         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration pg_backend
-         cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration pg_backend
+         cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration
+         cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration
 
        env:
          POSTGRES_HOST: localhost

--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
@@ -8,7 +8,7 @@ gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 
 task 2 'create-checkpoint'. lines 19-19:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 21-56:
+task 3 'run-graphql'. lines 21-62:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -96,7 +96,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 59-99:
+task 4 'run-graphql'. lines 65-113:
 Response: {
   "data": {
     "transactionBlockConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
@@ -18,26 +18,26 @@ Response: {
             "objectChanges": [
               {
                 "outputState": {
-                  "location": "0xd9645e1129b10332bfee7418d49d28780422c2b3a5d8cac0b4a89839c71ad0c1",
+                  "location": "0x962d07ca41195ae05098e86b43656fc76bc67e348a891994154a4597432eb84f",
                   "asMovePackage": null
                 }
               },
               {
                 "outputState": {
-                  "location": "0x6c38433df7c85db6313a3b28c4d6a1bbee8ef2b05d53a05347e53246a8573012",
+                  "location": "0x4cba7b35c765a6efb34d585f9e1768587fda06e90c6a76bc026ddcda4cbf1d57",
                   "asMovePackage": {
                     "module": {
                       "moduleId": {
                         "name": "m",
                         "package": {
                           "asObject": {
-                            "location": "0x6c38433df7c85db6313a3b28c4d6a1bbee8ef2b05d53a05347e53246a8573012"
+                            "location": "0x4cba7b35c765a6efb34d585f9e1768587fda06e90c6a76bc026ddcda4cbf1d57"
                           }
                         }
                       },
                       "fileFormatVersion": 6,
-                      "bytes": "oRzrCwYAAAAIAQAGAgYKAxARBCEEBSUfB0QiCGZADKYBMAAFAQMBBgEADAEAAQIBAgAABAABAQIAAgIBAAEHBQEBAAIEAAYCAwYLAAEJAAEDAQYLAAEIAQABCQABBgsAAQkAAQgBBENvaW4DU1VJA2JhcgRjb2luA2ZvbwFtA3N1aQV2YWx1ZWw4Qz33yF22MTo7KMTWobvujvKwXVOgU0flMkaoVzASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAQAAAwULATgACwAWAgEBAAADCAYqAAAAAAAAAAoAOAEGKwAAAAAAAAALADgBGAIA",
-                      "disassembly": "// Move bytecode v6\nmodule 6c38433df7c85db6313a3b28c4d6a1bbee8ef2b05d53a05347e53246a8573012.m {\nuse 0000000000000000000000000000000000000000000000000000000000000002::coin;\nuse 0000000000000000000000000000000000000000000000000000000000000002::sui;\n\n\n\n\npublic foo<Ty0: drop>(Arg0: u64, Arg1: &Coin<Ty0>): u64 {\nB0:\n\t0: MoveLoc[1](Arg1: &Coin<Ty0>)\n\t1: Call coin::value<Ty0>(&Coin<Ty0>): u64\n\t2: MoveLoc[0](Arg0: u64)\n\t3: Add\n\t4: Ret\n}\npublic bar(Arg0: &Coin<SUI>): u64 {\nB0:\n\t0: LdU64(42)\n\t1: CopyLoc[0](Arg0: &Coin<SUI>)\n\t2: Call foo<SUI>(u64, &Coin<SUI>): u64\n\t3: LdU64(43)\n\t4: MoveLoc[0](Arg0: &Coin<SUI>)\n\t5: Call foo<SUI>(u64, &Coin<SUI>): u64\n\t6: Mul\n\t7: Ret\n}\n}"
+                      "bytes": "oRzrCwYAAAAIAQAGAgYKAxARBCEEBSUfB0QiCGZADKYBMAAFAQMBBgEADAEAAQIBAgAABAABAQIAAgIBAAEHBQEBAAIEAAYCAwYLAAEJAAEDAQYLAAEIAQABCQABBgsAAQkAAQgBBENvaW4DU1VJA2JhcgRjb2luA2ZvbwFtA3N1aQV2YWx1ZUy6ezXHZabvs01YX54XaFh/2gbpDGp2vAJt3NpMvx1XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAQAAAwULATgACwAWAgEBAAADCAYqAAAAAAAAAAoAOAEGKwAAAAAAAAALADgBGAIA",
+                      "disassembly": "// Move bytecode v6\nmodule 4cba7b35c765a6efb34d585f9e1768587fda06e90c6a76bc026ddcda4cbf1d57.m {\nuse 0000000000000000000000000000000000000000000000000000000000000002::coin;\nuse 0000000000000000000000000000000000000000000000000000000000000002::sui;\n\n\n\n\npublic foo<Ty0: drop>(Arg0: u64, Arg1: &Coin<Ty0>): u64 {\nB0:\n\t0: MoveLoc[1](Arg1: &Coin<Ty0>)\n\t1: Call coin::value<Ty0>(&Coin<Ty0>): u64\n\t2: MoveLoc[0](Arg0: u64)\n\t3: Add\n\t4: Ret\n}\npublic bar(Arg0: &Coin<SUI>): u64 {\nB0:\n\t0: LdU64(42)\n\t1: CopyLoc[0](Arg0: &Coin<SUI>)\n\t2: Call foo<SUI>(u64, &Coin<SUI>): u64\n\t3: LdU64(43)\n\t4: MoveLoc[0](Arg0: &Coin<SUI>)\n\t5: Call foo<SUI>(u64, &Coin<SUI>): u64\n\t6: Mul\n\t7: Ret\n}\n}"
                     }
                   }
                 }


### PR DESCRIPTION
## Description 

Locally, these tests do not run unless pg_backend is removed. Checked and our previous PRs also skipped the e2e tests. Removing pg_backend should allow the tests to run.

## Test Plan 

CI tests do not skip e2e tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
