### PR TITLE
Add comments to some `ProgrammableTransactionBuilder` methods in SDK API

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1619,19 +1619,33 @@ impl From<Command> for SuiCommand {
     }
 }
 
-/// An argument to a transaction in a programmable transaction block
+/// An argument to a transaction in a programmable transaction block.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub enum SuiArgument {
     /// The gas coin. The gas coin can only be used by-ref, except for with
     /// `TransferObjects`, which can use it by-value.
     GasCoin,
-    /// One of the input objects or primitive values (from
-    /// `ProgrammableTransactionBlock` inputs)
+    /// One of the input objects or primitive values (from `ProgrammableTransactionBlock`
+    /// inputs).
+    ///
+    /// Indexing is zero-based, meaning that `Input(0u16)` refers to the input of the PTB's first
+    /// command, `Input(1u16)` to the second, and so on.
     Input(u16),
     /// The result of another transaction (from `ProgrammableTransactionBlock` transactions)
+    ///
+    /// As with inputs, indexing is zero-based: `Output(u16)` refers to the out of the first
+    /// command, and so on.
     Result(u16),
     /// Like a `Result` but it accesses a nested result. Currently, the only usage
     /// of this is to access a value from a Move call with multiple return values.
+    ///
+    /// * The first component of the tuple is the index of the command which produces a
+    /// tuple with the desired result, and
+    /// * the second component is the index of the desired value in that tuple
+    ///
+    /// Indexing on either component of the tuple is zero based.
+    /// For example, to refer to the second output of the fourth command in a PTB, use
+    /// `NestedResult(3u16, 1u16)`
     NestedResult(u16, u16),
 }
 

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -237,7 +237,8 @@ pub enum CommandArgumentError {
         "Invalid usage of value. \
         Mutably borrowed values require unique usage. \
         Immutably borrowed values cannot be taken or borrowed mutably. \
-        Taken values cannot be used again."
+        Taken values cannot be used again. \
+        Taken values cannot be implicitly passed by mutable or immutable reference."
     )]
     InvalidValueUsage,
     #[error("Immutable objects cannot be passed by-value.")]

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -139,7 +139,13 @@ impl ProgrammableTransactionBuilder {
         Argument::Result(i as u16)
     }
 
-    /// Will fail to generate if given an empty ObjVec
+    /// Insert a new move call into the Programmable Transaction Block.
+    ///
+    /// If
+    /// * the move call needs data created in previous commands of the PTB, or/and
+    /// * it will create data to be used in later commands of the PTB,
+    ///
+    /// then consider using `ProgrammableTransactionBuilder::programmable_move_call` below.
     pub fn move_call(
         &mut self,
         package: ObjectID,
@@ -151,7 +157,7 @@ impl ProgrammableTransactionBuilder {
         let arguments = call_args
             .into_iter()
             .map(|a| self.input(a))
-            .collect::<Result<_, _>>()?;
+            .collect::<anyhow::Result<Vec<Argument>>>()?;
         self.command(Command::move_call(
             package,
             module,
@@ -162,6 +168,13 @@ impl ProgrammableTransactionBuilder {
         Ok(())
     }
 
+    /// Insert a new programmable move call into the Programmable Transaction Block being built.
+    ///
+    /// If the move call
+    /// * does not need data created in previous commands of the PTB, and
+    /// * it will not create data to be used in later commands of the PTB,
+    ///
+    /// then consider using `ProgrammableTransactionBuilder::move_call` above.
     pub fn programmable_move_call(
         &mut self,
         package: ObjectID,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -648,19 +648,33 @@ pub enum Command {
     Upgrade(Vec<Vec<u8>>, Vec<ObjectID>, ObjectID, Argument),
 }
 
-/// An argument to a programmable transaction command
+/// An argument to a programmable transaction command.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum Argument {
     /// The gas coin. The gas coin can only be used by-ref, except for with
     /// `TransferObjects`, which can use it by-value.
     GasCoin,
-    /// One of the input objects or primitive values (from
-    /// `ProgrammableTransaction` inputs)
+    /// One of the input objects or primitive values (from `ProgrammableTransactionBlock`
+    /// inputs).
+    ///
+    /// Indexing is zero-based, meaning that `Input(0u16)` refers to the input of the PTB's first
+    /// command, `Input(1u16)` to the second, and so on.
     Input(u16),
-    /// The result of another command (from `ProgrammableTransaction` commands)
+    /// The result of another transaction (from `ProgrammableTransactionBlock` transactions).
+    ///
+    /// As with inputs, indexing is zero-based: `Output(u16)` refers to the out of the first
+    /// command, and so on.
     Result(u16),
     /// Like a `Result` but it accesses a nested result. Currently, the only usage
     /// of this is to access a value from a Move call with multiple return values.
+    ///
+    /// * The first component of the tuple is the index of the command which produces a
+    /// tuple with the desired result, and
+    /// * the second component is the index of the desired value in that tuple
+    ///
+    /// Indexing on either component of the tuple is zero based.
+    /// For example, to refer to the second output of the fourth command in a PTB, use
+    /// `NestedResult(3u16, 1u16)`
     NestedResult(u16, u16),
 }
 


### PR DESCRIPTION
## Description 

Following #14793, I've added some comments to the API that believe are helpful to other users of the SDK.

@oxade if you don't believe this PR to be worthwhile, I can certainly close it.

## Test Plan 

Only documentation was added, so no tests required.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
