### PR TITLE
[docs] Fix typo in brew command 

### DIFF
--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -22,7 +22,7 @@ export PATH="/opt/homebrew/opt/postgresql@15/bin:$PATH"
 Postgres must run as a service in the background for other tools to communicate with.  If it was installed using homebrew, it can be started as a service with:
 
 ``` sh
-brew service start postgresql@version
+brew services start postgresql@version
 ```
 
 ### Local Development(Recommended)


### PR DESCRIPTION
## Description 

Fixes typo in the command. It should be `brew services` instead of `brew service`. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
