### PR TITLE
Update formal snapshot docs

### DIFF
--- a/docs/content/guides/operator/formal-snapshot.mdx
+++ b/docs/content/guides/operator/formal-snapshot.mdx
@@ -38,24 +38,6 @@ Full nodes do not take formal snapshots by default. To enable this feature:
    - `google-service-account`: Path to a GCS service account json file containing signing credentials.
    - `aws-region`: Region where buck exists.
    - `object-store-connection-limit`: Number of simultaneous connections to the object store.
-4. Currently, formal snapshots leverage database checkpoints (this will change soon). Add an entry to the config file for `db-checkpoint-config`. Using Amazon's S3 service as an example:
-   ```yaml
-   db-checkpoint-config:
-     perform-db-checkpoints-at-epoch-end: true
-     perform-index-db-checkpoints-at-epoch-end: true
-     object-store-config:
-       object-store: "S3"
-       bucket: "<BUCKET-NAME>"
-       aws-access-key-id: “<ACCESS-KEY>”
-       aws-secret-access-key: “<SHARED-KEY>”
-       aws-region: "<BUCKET-REGION>"
-       object-store-connection-limit: 20
-   ```
-   - `object-store`: The remote object store to upload snapshots. Set as Amazon's `S3` service in the example.
-   - `bucket`: The S3 bucket name to store the snapshots.
-   - `aws-access-key-id` and `aws-secret-access-key`: AWS authentication information with write access to the bucket.
-   - `aws-region`: Region where buck exists.
-   - `object-store-connection-limit`: Number of simultaneous connections to the object store.
 4. Save the sui-node.yaml file and restart the node.
 
 ## Restoring from formal snapshots
@@ -80,7 +62,7 @@ When you restore a Full node from a snapshot, write it to the path `/opt/sui/db/
 
 :::
 
-## S3 buckets used per environment
+## GCS Buckets used per environment
 
 Mysten operated buckets. To access the Mysten operated buckets, you still need to provide valid credentials for signed access to GCS (snapshot bucket hosting) and AWS (archival hosting).
 


### PR DESCRIPTION
## Description 
We have removed the requirement to specify a `db-checkpoint-config` in order to write formal snapshots. Fix the docs to reflect this.

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
