### PR TITLE
[pruner config] make repeated parameters optional/default + add metric

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2164,6 +2164,7 @@ impl AuthorityState {
             checkpoint_store.clone(),
             store.objects_lock_table.clone(),
             pruning_config,
+            epoch_store.committee().authority_exists(&name),
             epoch_store.epoch_start_state().epoch_duration_ms(),
             prometheus_registry,
             indirect_objects_threshold,

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -31,7 +31,7 @@ use sui_types::{
 };
 use tokio::sync::oneshot::{self, Sender};
 use tokio::time::Instant;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use typed_store::{Map, TypedStoreError};
 
 use super::authority_store_tables::AuthorityPerpetualTables;
@@ -58,6 +58,8 @@ pub struct AuthorityStorePruningMetrics {
     pub num_pruned_objects: IntCounter,
     pub num_pruned_tombstones: IntCounter,
     pub last_pruned_effects_checkpoint: IntGauge,
+    pub num_epochs_to_retain_for_objects: IntGauge,
+    pub num_epochs_to_retain_for_checkpoints: IntGauge,
 }
 
 impl AuthorityStorePruningMetrics {
@@ -84,6 +86,18 @@ impl AuthorityStorePruningMetrics {
             last_pruned_effects_checkpoint: register_int_gauge_with_registry!(
                 "last_pruned_effects_checkpoint",
                 "Last pruned effects checkpoint",
+                registry
+            )
+            .unwrap(),
+            num_epochs_to_retain_for_objects: register_int_gauge_with_registry!(
+                "num_epochs_to_retain_for_objects",
+                "Number of epochs to retain for objects",
+                registry
+            )
+            .unwrap(),
+            num_epochs_to_retain_for_checkpoints: register_int_gauge_with_registry!(
+                "num_epochs_to_retain_for_checkpoints",
+                "Number of epochs to retain for checkpoints",
                 registry
             )
             .unwrap(),
@@ -527,16 +541,8 @@ impl AuthorityStorePruner {
             "Starting object pruning service with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
-        let tick_duration = Duration::from_millis(match config.pruning_run_delay_seconds {
-            None => {
-                if config.num_epochs_to_retain > 0 {
-                    min(epoch_duration_ms / 2, 60 * 60 * 1000)
-                } else {
-                    min(epoch_duration_ms / 2, 60 * 1000)
-                }
-            }
-            Some(duration_seconds) => duration_seconds * 1000,
-        });
+
+        let tick_duration = Duration::from_millis(min(epoch_duration_ms / 2, 60 * 1000));
         let pruning_initial_delay = if cfg!(msim) {
             Duration::from_millis(1)
         } else {
@@ -570,6 +576,15 @@ impl AuthorityStorePruner {
             });
         }
 
+        metrics
+            .num_epochs_to_retain_for_objects
+            .set(config.num_epochs_to_retain as i64);
+        metrics.num_epochs_to_retain_for_checkpoints.set(
+            config
+                .num_epochs_to_retain_for_checkpoints
+                .unwrap_or_default() as i64,
+        );
+
         tokio::task::spawn(async move {
             loop {
                 tokio::select! {
@@ -594,12 +609,23 @@ impl AuthorityStorePruner {
         perpetual_db: Arc<AuthorityPerpetualTables>,
         checkpoint_store: Arc<CheckpointStore>,
         objects_lock_table: Arc<RwLockTable<ObjectContentDigest>>,
-        pruning_config: AuthorityStorePruningConfig,
+        mut pruning_config: AuthorityStorePruningConfig,
+        is_validator: bool,
         epoch_duration_ms: u64,
         registry: &Registry,
         indirect_objects_threshold: usize,
         archive_readers: ArchiveReaderBalancer,
     ) -> Self {
+        if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX
+        {
+            warn!("Using objects pruner with num_epochs_to_retain = {} can lead to performance issues", pruning_config.num_epochs_to_retain);
+            if is_validator {
+                warn!("Resetting to aggressive pruner.");
+                pruning_config.num_epochs_to_retain = 0;
+            } else {
+                warn!("Consider using an aggressive pruner (num_epochs_to_retain = 0)");
+            }
+        }
         AuthorityStorePruner {
             _objects_pruner_cancel_handle: Self::setup_pruning(
                 pruning_config,

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -124,7 +124,7 @@ impl ValidatorConfigBuilder {
             ..Default::default()
         };
 
-        let mut pruning_config = AuthorityStorePruningConfig::validator_config();
+        let mut pruning_config = AuthorityStorePruningConfig::default();
         if self.force_unpruned_checkpoints {
             pruning_config.set_num_epochs_to_retain_for_checkpoints(None);
         }
@@ -387,7 +387,7 @@ impl FullnodeConfigBuilder {
             grpc_load_shed: None,
             grpc_concurrency_limit: None,
             p2p_config,
-            authority_store_pruning_config: AuthorityStorePruningConfig::fullnode_config(),
+            authority_store_pruning_config: AuthorityStorePruningConfig::default(),
             end_of_epoch_broadcast_channel_capacity:
                 default_end_of_epoch_broadcast_channel_capacity(),
             checkpoint_executor_config: Default::default(),

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -55,7 +55,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -165,7 +165,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -275,7 +275,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -385,7 +385,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -495,7 +495,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -605,7 +605,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
@@ -715,7 +715,7 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
-      num-epochs-to-retain: 2
+      num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128


### PR DESCRIPTION
* makes repeatable parameters optional (num_latest_epoch_dbs_to_retain, epoch_db_pruning_period_secs, max_checkpoints_in_batch, max_transactions_in_batch)
* adds metrics to represent following config parameters: num_epochs_to_retain, num_epochs_to_retain_for_checkpoints