### PR TITLE
move [EASY]: rename versioning -> version for toolchain config

### DIFF
--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -66,7 +66,7 @@ pub struct Dependency {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct ToolchainVersioning {
+pub struct ToolchainVersion {
     /// The Move compiler version used to compile this package.
     #[serde(rename = "compiler-version")]
     pub compiler_version: String,
@@ -110,10 +110,10 @@ impl Packages {
     }
 }
 
-impl ToolchainVersioning {
-    /// Read toolchain versioning info from the lock file. Returns successfully with None if
-    /// parsing the lock file succeeds but an entry for `[toolchain-versioning]` does not exist.
-    pub fn read(lock: &mut impl Read) -> Result<Option<ToolchainVersioning>> {
+impl ToolchainVersion {
+    /// Read toolchain version info from the lock file. Returns successfully with None if
+    /// parsing the lock file succeeds but an entry for `[toolchain-version]` does not exist.
+    pub fn read(lock: &mut impl Read) -> Result<Option<ToolchainVersion>> {
         let contents = {
             let mut buf = String::new();
             lock.read_to_string(&mut buf).context("Reading lock file")?;
@@ -122,13 +122,13 @@ impl ToolchainVersioning {
 
         #[derive(Deserialize)]
         struct TV {
-            #[serde(rename = "toolchain-versioning")]
-            toolchain_versioning: Option<ToolchainVersioning>,
+            #[serde(rename = "toolchain-version")]
+            toolchain_version: Option<ToolchainVersion>,
         }
         let Schema { move_: value } = toml::de::from_str::<Schema<TV>>(&contents)
             .context("Deserializing toolchain version")?;
 
-        Ok(value.toolchain_versioning)
+        Ok(value.toolchain_version)
     }
 }
 
@@ -185,12 +185,12 @@ pub fn update_compiler_toolchain(
     file.seek(SeekFrom::Start(0))?;
     let mut toml = toml_string.parse::<toml_edit::Document>()?;
     let move_table = toml["move"].as_table_mut().ok_or(std::fmt::Error)?;
-    let toolchain_versioning = toml::Value::try_from(ToolchainVersioning {
+    let toolchain_version = toml::Value::try_from(ToolchainVersion {
         compiler_version,
         edition,
         flavor,
     })?;
-    move_table["toolchain-versioning"] = to_toml_edit_value(&toolchain_versioning);
+    move_table["toolchain-version"] = to_toml_edit_value(&toolchain_version);
     write!(file, "{}", toml)?;
     file.flush()?;
     Ok(())

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -10,7 +10,7 @@ use std::{
 use tempfile::TempDir;
 
 use move_compiler::editions::{Edition, Flavor};
-use move_package::lock_file::schema::ToolchainVersioning;
+use move_package::lock_file::schema::ToolchainVersion;
 use move_package::lock_file::LockFile;
 use move_package::BuildConfig;
 
@@ -85,10 +85,10 @@ fn update_lock_file_toolchain_version() {
     let _ = build_config.update_lock_file_toolchain_version("0.0.1".into());
 
     let mut lock_file = File::open(lock_path).unwrap();
-    let toolchain_versioning =
-        ToolchainVersioning::read(&mut lock_file).expect("Invalid toolchain version");
+    let toolchain_version =
+        ToolchainVersion::read(&mut lock_file).expect("Invalid toolchain version");
     let toml =
-        toml::ser::to_string(&toolchain_versioning).expect("Unable to serialize toolchain version");
+        toml::ser::to_string(&toolchain_version).expect("Unable to serialize toolchain version");
 
     let expected = expect![[r#"
         compiler-version = "0.0.1"


### PR DESCRIPTION
## Description 

rename: `toolchain-versioning` -> `toolchain-version`

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
