### PR TITLE
[move-stdlib] Add new unit_test::poison function

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/unit_test.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/unit_test.move
@@ -4,12 +4,12 @@
 #[test_only]
 /// Module providing testing functionality. Only included for tests.
 module std::unit_test {
-    /// Return a `num_signers` number of unique signer values. No ordering or
-    /// starting value guarantees are made, only that the order and values of
-    /// the signers in the returned vector is deterministic.
-    ///
-    /// This function is also used to poison modules compiled in `test` mode.
+
+    /// DEPRECATED
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+
+    /// This function is used to poison modules compiled in `test` mode.
     /// This will cause a linking failure if an attempt is made to publish a
     /// test module in a VM that isn't in unit test mode.
-    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+    native public fun poison();
 }

--- a/external-crates/move/crates/move-stdlib/sources/unit_test.move
+++ b/external-crates/move/crates/move-stdlib/sources/unit_test.move
@@ -1,12 +1,12 @@
 #[test_only]
 /// Module providing testing functionality. Only included for tests.
 module std::unit_test {
-    /// Return a `num_signers` number of unique signer values. No ordering or
-    /// starting value guarantees are made, only that the order and values of
-    /// the signers in the returned vector is deterministic.
-    ///
-    /// This function is also used to poison modules compiled in `test` mode.
+
+    /// DEPRECATED
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+
+    /// This function is used to poison modules compiled in `test` mode.
     /// This will cause a linking failure if an attempt is made to publish a
     /// test module in a VM that isn't in unit test mode.
-    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+    native public fun poison();
 }

--- a/external-crates/move/crates/move-stdlib/src/natives/mod.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/mod.rs
@@ -96,6 +96,9 @@ impl GasParameters {
                     base_cost: 0.into(),
                     unit_cost: 0.into(),
                 },
+                poison: unit_test::PoisonGasParameters {
+                    base_cost: 0.into(),
+                },
             },
         }
     }

--- a/external-crates/move/crates/move-stdlib/src/natives/unit_test.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/unit_test.rs
@@ -76,7 +76,7 @@ fn native_poison(
     gas_params: &PoisonGasParameters,
     context: &mut NativeContext,
     ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
+    args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());

--- a/external-crates/move/crates/move-stdlib/src/natives/unit_test.rs
+++ b/external-crates/move/crates/move-stdlib/src/natives/unit_test.rs
@@ -67,19 +67,49 @@ pub fn make_native_create_signers_for_testing(
     )
 }
 
+#[derive(Debug, Clone)]
+pub struct PoisonGasParameters {
+    pub base_cost: InternalGas,
+}
+
+fn native_poison(
+    gas_params: &PoisonGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.is_empty());
+    let cost = gas_params.base_cost;
+    native_charge_gas_early_exit!(context, cost);
+    Ok(NativeResult::ok(context.gas_used(), smallvec![]))
+}
+
+pub fn make_native_poison(gas_params: PoisonGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_poison(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
 /***************************************************************************************************
  * module
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub create_signers_for_testing: CreateSignersForTestingGasParameters,
+    pub poison: PoisonGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [(
-        "create_signers_for_testing",
-        make_native_create_signers_for_testing(gas_params.create_signers_for_testing),
-    )];
+    let natives = [
+        (
+            "create_signers_for_testing",
+            make_native_create_signers_for_testing(gas_params.create_signers_for_testing),
+        ),
+        ("poison", make_native_poison(gas_params.poison)),
+    ];
 
     make_module_natives(natives)
 }

--- a/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.exp
+++ b/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.exp
@@ -1,3 +1,4 @@
 Running Move unit tests
 [ PASS    ] 0x1::M::poison_call
-Test result: OK. Total tests: 1; passed: 1; failed: 0
+[ PASS    ] 0x1::M::poison_call_OLD
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.move
+++ b/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.move
@@ -2,7 +2,12 @@ module 0x1::M {
     use std::unit_test;
 
     #[test]
-    fun poison_call() {
+    fun poison_call_OLD() {
         unit_test::create_signers_for_testing(0);
+    }
+
+    #[test]
+    fun poison_call() {
+        unit_test::poison();
     }
 }

--- a/external-crates/move/move-execution/next-vm/crates/move-stdlib/sources/unit_test.move
+++ b/external-crates/move/move-execution/next-vm/crates/move-stdlib/sources/unit_test.move
@@ -1,12 +1,12 @@
 #[test_only]
 /// Module providing testing functionality. Only included for tests.
 module std::unit_test {
-    /// Return a `num_signers` number of unique signer values. No ordering or
-    /// starting value guarantees are made, only that the order and values of
-    /// the signers in the returned vector is deterministic.
-    ///
-    /// This function is also used to poison modules compiled in `test` mode.
+
+    /// DEPRECATED
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+
+    /// This function is used to poison modules compiled in `test` mode.
     /// This will cause a linking failure if an attempt is made to publish a
     /// test module in a VM that isn't in unit test mode.
-    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+    native public fun poison();
 }

--- a/external-crates/move/move-execution/next-vm/crates/move-stdlib/src/natives/unit_test.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-stdlib/src/natives/unit_test.rs
@@ -67,19 +67,49 @@ pub fn make_native_create_signers_for_testing(
     )
 }
 
+#[derive(Debug, Clone)]
+pub struct PoisonGasParameters {
+    pub base_cost: InternalGas,
+}
+
+fn native_poison(
+    gas_params: &PoisonGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.is_empty());
+    let cost = gas_params.base_cost;
+    native_charge_gas_early_exit!(context, cost);
+    Ok(NativeResult::ok(context.gas_used(), smallvec![]))
+}
+
+pub fn make_native_poison(gas_params: PoisonGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_poison(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
 /***************************************************************************************************
  * module
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub create_signers_for_testing: CreateSignersForTestingGasParameters,
+    pub poison: PoisonGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [(
-        "create_signers_for_testing",
-        make_native_create_signers_for_testing(gas_params.create_signers_for_testing),
-    )];
+    let natives = [
+        (
+            "create_signers_for_testing",
+            make_native_create_signers_for_testing(gas_params.create_signers_for_testing),
+        ),
+        ("poison", make_native_poison(gas_params.poison)),
+    ];
 
     make_module_natives(natives)
 }


### PR DESCRIPTION
## Description 

- This will replace create_signers_for_testing
- #14994 is blocked (and probably rightfully so) as we have some projects in examples that download the stdlib from testnet. Those examples were failing in the signer removal PR since the new `unit_test::poison` function did not exist in that stdlib.
- We can land this smaller change and wait for it to get pulled into testnet before landing the breaking change

## Test Plan 

- Added a new test to call the poison function

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
