### PR TITLE
[graphql] set default page size separately from max page size

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -14,7 +14,8 @@ const MAX_QUERY_DEPTH: u32 = 20;
 const MAX_QUERY_NODES: u32 = 200;
 const MAX_QUERY_PAYLOAD_SIZE: u32 = 5_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
-const MAX_PAGE_SIZE: u64 = 50; // Maximum number of elements allowed on a page on a connection
+const DEFAULT_PAGE_SIZE: u64 = 20; // Default number of elements allowed on a page of a connection
+const MAX_PAGE_SIZE: u64 = 50; // Maximum number of elements allowed on a page of a connection
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 40_000;
 
@@ -65,6 +66,8 @@ pub struct Limits {
     pub(crate) max_query_payload_size: u32,
     #[serde(default)]
     pub(crate) max_db_query_cost: u64,
+    #[serde(default)]
+    pub(crate) default_page_size: u64,
     #[serde(default)]
     pub(crate) max_page_size: u64,
     #[serde(default)]
@@ -217,6 +220,7 @@ impl Default for Limits {
             max_query_nodes: MAX_QUERY_NODES,
             max_query_payload_size: MAX_QUERY_PAYLOAD_SIZE,
             max_db_query_cost: MAX_DB_QUERY_COST,
+            default_page_size: DEFAULT_PAGE_SIZE,
             max_page_size: MAX_PAGE_SIZE,
             request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         }
@@ -312,6 +316,7 @@ mod tests {
                 max-query-nodes = 300
                 max-query-payload-size = 2000
                 max-db-query-cost = 50
+                default-page-size = 20
                 max-page-size = 50
                 request-timeout-ms = 27000
             "#,
@@ -324,6 +329,7 @@ mod tests {
                 max_query_nodes: 300,
                 max_query_payload_size: 2000,
                 max_db_query_cost: 50,
+                default_page_size: 20,
                 max_page_size: 50,
                 request_timeout_ms: 27_000,
             },
@@ -381,6 +387,7 @@ mod tests {
                 max-query-nodes = 320
                 max-query-payload-size = 200
                 max-db-query-cost = 20
+                default-page-size = 10
                 max-page-size = 20
                 request-timeout-ms = 30000
 
@@ -396,6 +403,7 @@ mod tests {
                 max_query_nodes: 320,
                 max_query_payload_size: 200,
                 max_db_query_cost: 20,
+                default_page_size: 10,
                 max_page_size: 20,
                 request_timeout_ms: 30_000,
             },

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -582,7 +582,7 @@ impl PgManager {
         // TODO (wlmyng): even though we do not allow passing in both first and last,
         // per the cursor connection specs, if both are provided, from the response,
         // we need to take the first F from the left and then take the last L from the right.
-        Ok(first.or(last).unwrap_or(self.limits.max_page_size) as i64)
+        Ok(first.or(last).unwrap_or(self.limits.default_page_size) as i64)
     }
 
     pub(crate) async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>, Error> {

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -76,7 +76,7 @@ impl MovePackage {
             .map_err(|_| Error::Internal("Unable to fetch service configuration.".to_string()))
             .extend()?
             .limits
-            .max_page_size;
+            .default_page_size;
 
         // TODO: make cursor opaque.
         // for now it same as module name

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -268,8 +268,14 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_query_page_limit() {
-        test_query_page_limit_impl().await;
+    async fn test_query_default_page_limit() {
+        test_query_default_page_limit_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_query_max_page_limit() {
+        test_query_max_page_limit_impl().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description 

Default and max page size should be separate parameters, so providers don't incur the max cost every time a multiget is made. 

## Test Plan 

New e2e test checking that default page size set to 1 returns exactly 1.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
