### PR TITLE
[graphql] more lenient timeout for checkpoint catch up

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -230,26 +230,43 @@ pub async fn start_test_indexer_v2(
 }
 
 impl ExecutorCluster {
-    pub async fn wait_for_checkpoint_catchup(&self, checkpoint: u64, timeout: Duration) {
-        async fn inner(s: &ExecutorCluster, checkpoint: u64) {
-            let mut highest_checkpoint = s
+    pub async fn wait_for_checkpoint_catchup(&self, checkpoint: u64, base_timeout: Duration) {
+        async fn inner(s: &ExecutorCluster, checkpoint: u64, base_timeout: Duration) {
+            let current_checkpoint = s
                 .indexer_store
                 .get_latest_tx_checkpoint_sequence_number()
                 .await
                 .unwrap()
                 .unwrap();
-            while highest_checkpoint < checkpoint {
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                highest_checkpoint = s
-                    .indexer_store
-                    .get_latest_tx_checkpoint_sequence_number()
-                    .await
-                    .unwrap()
-                    .unwrap();
+
+            let checkpoint_diff = checkpoint.saturating_sub(current_checkpoint);
+            let total_timeout = base_timeout.mul_f64(checkpoint_diff as f64);
+
+            let timeout_future = tokio::time::sleep(total_timeout);
+            tokio::pin!(timeout_future);
+
+            let mut highest_checkpoint = current_checkpoint;
+            loop {
+                if highest_checkpoint >= checkpoint {
+                    break;
+                }
+
+                tokio::select! {
+                    _ = &mut timeout_future => {
+                        panic!("Timeout waiting for indexer to catchup to checkpoint {}", checkpoint);
+                    }
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                        highest_checkpoint = s
+                            .indexer_store
+                            .get_latest_tx_checkpoint_sequence_number()
+                            .await
+                            .unwrap()
+                            .unwrap();
+                    }
+                }
             }
         }
-        tokio::time::timeout(timeout, inner(self, checkpoint))
-            .await
-            .expect("Timeout waiting for indexer to catchup to checkpoint");
+
+        inner(self, checkpoint, base_timeout).await;
     }
 }


### PR DESCRIPTION
## Description 

Since it's possible to create more than one checkpoint before running a graphql command, the hardcoded 10 second catch up may not be enough. Naively set max timeout = diff(indexer, simulator) * base time out secs

## Test Plan 

ci 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
