### PR TITLE
[graphql/rpc] testing: expose validator addresses in test infra

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -74,6 +74,10 @@ impl EpochState {
         &self.committee
     }
 
+    pub fn epoch_start_state(&self) -> &EpochStartSystemState {
+        &self.epoch_start_state
+    }
+
     pub fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_config().version
     }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -25,6 +25,7 @@ use sui_types::crypto::AuthoritySignature;
 use sui_types::error::SuiError;
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::{
     base_types::SuiAddress,
     committee::Committee,
@@ -265,6 +266,10 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
     pub fn keystore(&self) -> &KeyStore {
         &self.keystore
+    }
+
+    pub fn epoch_start_state(&self) -> &EpochStartSystemState {
+        self.epoch_state.epoch_start_state()
     }
 
     /// Return a handle to the internally held RNG.

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -145,19 +145,19 @@ Value: "0x42"
 
 Name: Test
 Type: SuiAddress!
-Value: "0x8F2732502E7B64AFF525EB4252FFCBCFAA1859525DE38A84AE84B3B1FBA298EF"
+Value: "0x8f2732502e7b64aff525eb4252ffcbcfaa1859525de38a84ae84b3b1fba298ef"
 
 Name: Test_opt
 Type: SuiAddress
-Value: "0x8F2732502E7B64AFF525EB4252FFCBCFAA1859525DE38A84AE84B3B1FBA298EF"
+Value: "0x8f2732502e7b64aff525eb4252ffcbcfaa1859525de38a84ae84b3b1fba298ef"
 
 Name: deepbook
 Type: SuiAddress!
-Value: "0xDEE9"
+Value: "0xdee9"
 
 Name: deepbook_opt
 Type: SuiAddress
-Value: "0xDEE9"
+Value: "0xdee9"
 
 Name: obj_0_0
 Type: SuiAddress!
@@ -206,3 +206,11 @@ Value: "0x3"
 Name: sui_system_opt
 Type: SuiAddress
 Value: "0x3"
+
+Name: validator_0
+Type: SuiAddress!
+Value: "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"
+
+Name: validator_0_opt
+Type: SuiAddress
+Value: "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 use sui_core::authority::authority_test_utils::send_and_confirm_transaction_with_execution_error;
 use sui_core::authority::AuthorityState;
+use sui_json_rpc::authority_state::StateRead;
 use sui_json_rpc_types::DevInspectResults;
 use sui_json_rpc_types::EventFilter;
 use sui_rest_api::node_state_getter::NodeStateGetter;
@@ -37,6 +38,8 @@ use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::object::Object;
 use sui_types::storage::ObjectKey;
 use sui_types::storage::ObjectStore;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
+use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::TransactionKind;
@@ -92,6 +95,8 @@ pub trait TransactionalAdapter: Send + Sync + ObjectStore + NodeStateGetter {
         tx_digest: &TransactionDigest,
         limit: usize,
     ) -> SuiResult<Vec<Event>>;
+
+    async fn get_active_validator_addresses(&self) -> SuiResult<Vec<SuiAddress>>;
 }
 
 #[async_trait::async_trait]
@@ -168,6 +173,23 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         _amount: u64,
     ) -> anyhow::Result<TransactionEffects> {
         unimplemented!("request_gas not supported")
+    }
+
+    async fn get_active_validator_addresses(&self) -> SuiResult<Vec<SuiAddress>> {
+        Ok(self
+            .fullnode
+            .get_system_state()
+            .map_err(|e| {
+                SuiError::SuiSystemStateReadError(format!(
+                    "Failed to get system state from fullnode: {}",
+                    e
+                ))
+            })?
+            .into_sui_system_state_summary()
+            .active_validators
+            .iter()
+            .map(|x| x.sui_address)
+            .collect::<Vec<_>>())
     }
 }
 
@@ -301,5 +323,11 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         amount: u64,
     ) -> anyhow::Result<TransactionEffects> {
         self.request_gas(address, amount)
+    }
+
+    async fn get_active_validator_addresses(&self) -> SuiResult<Vec<SuiAddress>> {
+        // TODO: this is a hack to get the validator addresses. Currently using start state
+        //       but we should have a better way to get this information after reconfig
+        Ok(self.epoch_start_state().get_validator_addresses())
     }
 }

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -22,6 +22,7 @@ pub trait EpochStartSystemStateTrait {
     fn safe_mode(&self) -> bool;
     fn epoch_start_timestamp_ms(&self) -> u64;
     fn epoch_duration_ms(&self) -> u64;
+    fn get_validator_addresses(&self) -> Vec<SuiAddress>;
     fn get_sui_committee(&self) -> Committee;
     fn get_narwhal_committee(&self) -> NarwhalCommittee;
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
@@ -121,6 +122,13 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
 
     fn epoch_duration_ms(&self) -> u64 {
         self.epoch_duration_ms
+    }
+
+    fn get_validator_addresses(&self) -> Vec<SuiAddress> {
+        self.active_validators
+            .iter()
+            .map(|validator| validator.sui_address)
+            .collect()
     }
 
     fn get_sui_committee(&self) -> Committee {

--- a/external-crates/move/crates/move-command-line-common/src/address.rs
+++ b/external-crates/move/crates/move-command-line-common/src/address.rs
@@ -120,6 +120,22 @@ impl fmt::UpperHex for NumericalAddress {
     }
 }
 
+impl fmt::LowerHex for NumericalAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let encoded = hex::encode(self.as_ref());
+        let dropped = encoded
+            .chars()
+            .skip_while(|c| c == &'0')
+            .collect::<String>();
+        let prefix = if f.alternate() { "0x" } else { "" };
+        if dropped.is_empty() {
+            write!(f, "{}0", prefix)
+        } else {
+            write!(f, "{}{}", prefix, dropped)
+        }
+    }
+}
+
 impl PartialOrd for NumericalAddress {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))


### PR DESCRIPTION
## Description 

Followup to [changes](https://github.com/MystenLabs/sui/pull/14959) which expose variables in testing infra.

Graphql variables are now available as `validator_x` and `validator_x_opt`, where x is an unsigned 0-based integer marking the position of the  validator in the list of validators.

The variables are also accessible as named addresses in the commands with `@validator_x`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
