### PR TITLE
[graphql][feature] include defaultPageSize in ServiceConfig

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1102,6 +1102,11 @@
 >    enabledFeatures
 >    maxQueryDepth
 >    maxQueryNodes
+>    maxDbQueryCost
+>    defaultPageSize
+>    maxPageSize
+>    requestTimeoutMs
+>    maxQueryPayloadSize
 >  }
 >}</pre>
 

--- a/crates/sui-graphql-rpc/examples/service_config/service_config.graphql
+++ b/crates/sui-graphql-rpc/examples/service_config/service_config.graphql
@@ -5,5 +5,10 @@
     enabledFeatures
     maxQueryDepth
     maxQueryNodes
+    maxDbQueryCost
+    defaultPageSize
+    maxPageSize
+    requestTimeoutMs
+    maxQueryPayloadSize
   }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1084,6 +1084,10 @@ type ServiceConfig {
 	"""
 	maxDbQueryCost: BigInt!
 	"""
+	Default number of elements allowed on a single page of a connection.
+	"""
+	defaultPageSize: BigInt!
+	"""
 	Maximum number of elements allowed on a single page of a connection.
 	"""
 	maxPageSize: BigInt!

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -184,6 +184,11 @@ impl ServiceConfig {
         BigInt::from(self.limits.max_db_query_cost)
     }
 
+    /// Default number of elements allowed on a single page of a connection.
+    async fn default_page_size(&self) -> BigInt {
+        BigInt::from(self.limits.default_page_size)
+    }
+
     /// Maximum number of elements allowed on a single page of a connection.
     async fn max_page_size(&self) -> BigInt {
         BigInt::from(self.limits.max_page_size)

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1088,6 +1088,10 @@ type ServiceConfig {
 	"""
 	maxDbQueryCost: BigInt!
 	"""
+	Default number of elements allowed on a single page of a connection.
+	"""
+	defaultPageSize: BigInt!
+	"""
 	Maximum number of elements allowed on a single page of a connection.
 	"""
 	maxPageSize: BigInt!


### PR DESCRIPTION
## Description 

include defaultPageSize as a field in ServiceConfig

## Test Plan 

update snapshots

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
