### PR TITLE
[Package Resolver] Add function definition indexing

### DIFF
--- a/crates/sui-package-resolver/tests/packages/c0/sources/m.move
+++ b/crates/sui-package-resolver/tests/packages/c0/sources/m.move
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module c::m {
+    #[allow(unused_field)]
     struct T0 {
         t: a::n::T0,
         u: a::n::T1,
@@ -9,4 +10,11 @@ module c::m {
         w: a::m::T3,
         x: b::m::T0,
     }
+
+    public fun foo() {}
+
+    public(friend) fun bar(_t0: &T0, _t1: &mut a::n::T1): u64 { 42 }
+
+    #[allow(unused_function)]
+    fun baz(x: u8): (u16, u32) { ((x as u16), (x as u32)) }
 }


### PR DESCRIPTION
## Description

Calculate an index from function name to function definition index when reading a `Module`, in preparation for supporting function definition based look-ups in the GraphQL RPC.

## Test Plan

New unit tests:

```
sui-package-resolver$ cargo nextest run
```

## Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013