### PR TITLE
[GraphQL/MoveModule] Keep track of storage_id

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
@@ -1,9 +1,12 @@
-processed 5 tasks
+processed 8 tasks
+
+init:
+A: object(0,0)
 
 task 1 'publish'. lines 6-17:
-created: object(1,0)
+created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7379600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'create-checkpoint'. lines 19-19:
 Checkpoint created: 1
@@ -16,6 +19,11 @@ Response: {
         {
           "effects": {
             "objectChanges": [
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
               {
                 "outputState": {
                   "asMovePackage": null
@@ -111,6 +119,11 @@ Response: {
               },
               {
                 "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
                   "asMovePackage": {
                     "module": {
                       "prefix": {
@@ -174,6 +187,72 @@ Response: {
                           "hasNextPage": true,
                           "hasPreviousPage": false
                         }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 5 'upgrade'. lines 115-129:
+created: object(5,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 8139600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 6 'create-checkpoint'. lines 131-131:
+Checkpoint created: 2
+
+task 7 'run-graphql'. lines 133-161:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": {
+                    "module": {
+                      "friendConnection": {
+                        "nodes": [
+                          {
+                            "moduleId": {
+                              "name": "m0"
+                            }
+                          },
+                          {
+                            "moduleId": {
+                              "name": "m1"
+                            }
+                          },
+                          {
+                            "moduleId": {
+                              "name": "m2"
+                            }
+                          },
+                          {
+                            "moduleId": {
+                              "name": "m3"
+                            }
+                          }
+                        ]
                       }
                     }
                   }

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -263,7 +263,7 @@ Response: {
                           "moduleId": {
                             "package": {
                               "asObject": {
-                                "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da"
+                                "location": "0x0ce0fe064fd500775e2ffaeeb5807df0c18026c6ba4b1ab4f9ec4f571c05419e"
                               }
                             }
                           }

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -108,6 +108,7 @@ impl MovePackage {
             connection.edges.push(Edge::new(
                 name.clone(),
                 MoveModule {
+                    storage_id: self.super_.address,
                     native: native.clone(),
                     parsed: parsed.clone(),
                 },
@@ -201,6 +202,7 @@ impl MovePackage {
             self.parsed_package()?.module(name),
         ) {
             (Some(native), Ok(parsed)) => Ok(Some(MoveModule {
+                storage_id: self.super_.address,
                 native: native.clone(),
                 parsed: parsed.clone(),
             })),


### PR DESCRIPTION
## Description

Modules need to track which package they came from, separately from their self ID in bytecode.  This is required to support:

- fetching friends from an upgrade package.
- fetching modules from functions and structs that were first defined in upgraded packages.

## Test Plan

New E2E test:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --feature pg_integration          \
  -- friends.move
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014