### PR TITLE
[GraphQL/MoveModule] Remove MoveModuleId

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
@@ -36,19 +36,13 @@ Response: {
                       "all": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m0"
-                            }
+                            "name": "m0"
                           },
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           },
                           {
-                            "moduleId": {
-                              "name": "m2"
-                            }
+                            "name": "m2"
                           }
                         ],
                         "pageInfo": {
@@ -59,14 +53,10 @@ Response: {
                       "after": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           },
                           {
-                            "moduleId": {
-                              "name": "m2"
-                            }
+                            "name": "m2"
                           }
                         ],
                         "pageInfo": {
@@ -77,14 +67,10 @@ Response: {
                       "before": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m0"
-                            }
+                            "name": "m0"
                           },
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           }
                         ],
                         "pageInfo": {
@@ -129,9 +115,7 @@ Response: {
                       "prefix": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           }
                         ],
                         "pageInfo": {
@@ -142,14 +126,10 @@ Response: {
                       "prefixAll": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           },
                           {
-                            "moduleId": {
-                              "name": "m2"
-                            }
+                            "name": "m2"
                           }
                         ],
                         "pageInfo": {
@@ -160,9 +140,7 @@ Response: {
                       "suffix": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           }
                         ],
                         "pageInfo": {
@@ -173,14 +151,10 @@ Response: {
                       "suffixAll": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m0"
-                            }
+                            "name": "m0"
                           },
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           }
                         ],
                         "pageInfo": {
@@ -233,24 +207,16 @@ Response: {
                       "friendConnection": {
                         "nodes": [
                           {
-                            "moduleId": {
-                              "name": "m0"
-                            }
+                            "name": "m0"
                           },
                           {
-                            "moduleId": {
-                              "name": "m1"
-                            }
+                            "name": "m1"
                           },
                           {
-                            "moduleId": {
-                              "name": "m2"
-                            }
+                            "name": "m2"
                           },
                           {
-                            "moduleId": {
-                              "name": "m3"
-                            }
+                            "name": "m3"
                           }
                         ]
                       }

--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.move
@@ -26,21 +26,21 @@ fragment ModuleFriends on Object {
             # Fetch the names of all friend modules and check that there are no
             # pages on either side.
             all: friendConnection {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
 
             # After is an exclusive lower bound, so only expect two modules in
             # the page, and an indication there's a previous page.
             after: friendConnection(after: "0") {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
 
             # Before is an exclusive upper bound, so only expect two modules in
             # the page, and an indication there's a next page.
             before: friendConnection(before: "2") {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
         }
@@ -70,28 +70,28 @@ fragment ModuleFriends on Object {
             # Limit the number of elements in the page using `first` and skip
             # elements using `after`.
             prefix: friendConnection(after: "0", first: 1) {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
 
             # This limit has no effect because there were only two nodes in the
             # page to begin with.
             prefixAll: friendConnection(after: "0", first: 2) {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
 
             # Limit the number of elements in the page using `last` and skip
             # elements from the end using `before`.
             suffix: friendConnection(before: "2", last: 1) {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
 
             # This limit has no effect because there were only two nodes in the
             # page to begin with.
             suffixAll: friendConnection(before: "2", last: 2) {
-                nodes { moduleId { name } }
+                nodes { name }
                 pageInfo { hasNextPage hasPreviousPage }
             }
         }
@@ -140,7 +140,7 @@ fragment ModuleFriends on Object {
     asMovePackage {
         module(name: "n") {
             friendConnection {
-                nodes { moduleId { name } }
+                nodes { name }
             }
         }
     }

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
@@ -101,11 +101,9 @@ Response: {
                     "module": {
                       "function": {
                         "module": {
-                          "moduleId": {
-                            "package": {
-                              "asObject": {
-                                "location": "0xda58ca32c842f4b99770ee4d3e9d9e57d1bf08873c05a7d24bec66e68abb153f"
-                              }
+                          "package": {
+                            "asObject": {
+                              "location": "0xda58ca32c842f4b99770ee4d3e9d9e57d1bf08873c05a7d24bec66e68abb153f"
                             }
                           }
                         },
@@ -186,11 +184,9 @@ Response: {
                     "module": {
                       "f": {
                         "module": {
-                          "moduleId": {
-                            "package": {
-                              "asObject": {
-                                "location": "0xa6d3465548585644e0afd1db8de8382bb660456bd569edc7b4320da00453fbd0"
-                              }
+                          "package": {
+                            "asObject": {
+                              "location": "0xa6d3465548585644e0afd1db8de8382bb660456bd569edc7b4320da00453fbd0"
                             }
                           }
                         },
@@ -220,11 +216,9 @@ Response: {
                       },
                       "g": {
                         "module": {
-                          "moduleId": {
-                            "package": {
-                              "asObject": {
-                                "location": "0xa6d3465548585644e0afd1db8de8382bb660456bd569edc7b4320da00453fbd0"
-                              }
+                          "package": {
+                            "asObject": {
+                              "location": "0xa6d3465548585644e0afd1db8de8382bb660456bd569edc7b4320da00453fbd0"
                             }
                           }
                         },

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.move
@@ -49,7 +49,7 @@ module P0::m {
 
 # Get the signature of a function published in a third-party package
 fragment Signature on MoveFunction {
-    module { moduleId { package { asObject { location } } } }
+    module { package { asObject { location } } }
     name
     visibility
     isEntry
@@ -96,7 +96,7 @@ module P0::m {
 
 # Get the signature of a function published in a third-party package
 fragment Signature on MoveFunction {
-    module { moduleId { package { asObject { location } } } }
+    module { package { asObject { location } } }
     name
     visibility
     isEntry

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
@@ -8,7 +8,7 @@ gas summary: computation_cost: 1000000, storage_cost: 6004000,  storage_rebate: 
 task 2 'create-checkpoint'. lines 33-33:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 35-68:
+task 3 'run-graphql'. lines 35-63:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -27,12 +27,10 @@ Response: {
                   "location": "0x2f86be7a9efd6db3d7229ac487191db02084ea261b66135f75873dd1c09b2c81",
                   "asMovePackage": {
                     "module": {
-                      "moduleId": {
-                        "name": "m",
-                        "package": {
-                          "asObject": {
-                            "location": "0x2f86be7a9efd6db3d7229ac487191db02084ea261b66135f75873dd1c09b2c81"
-                          }
+                      "name": "m",
+                      "package": {
+                        "asObject": {
+                          "location": "0x2f86be7a9efd6db3d7229ac487191db02084ea261b66135f75873dd1c09b2c81"
                         }
                       },
                       "fileFormatVersion": 6,
@@ -50,7 +48,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 70-102:
+task 4 'run-graphql'. lines 65-97:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -71,19 +69,13 @@ Response: {
                     "all": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "m"
-                          }
+                          "name": "m"
                         },
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         },
                         {
-                          "moduleId": {
-                            "name": "o"
-                          }
+                          "name": "o"
                         }
                       ],
                       "pageInfo": {
@@ -94,14 +86,10 @@ Response: {
                     "after": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         },
                         {
-                          "moduleId": {
-                            "name": "o"
-                          }
+                          "name": "o"
                         }
                       ],
                       "pageInfo": {
@@ -112,14 +100,10 @@ Response: {
                     "before": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "m"
-                          }
+                          "name": "m"
                         },
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         }
                       ],
                       "pageInfo": {
@@ -138,7 +122,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 104-139:
+task 5 'run-graphql'. lines 99-134:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -159,9 +143,7 @@ Response: {
                     "prefix": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         }
                       ],
                       "pageInfo": {
@@ -172,14 +154,10 @@ Response: {
                     "prefixAll": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         },
                         {
-                          "moduleId": {
-                            "name": "o"
-                          }
+                          "name": "o"
                         }
                       ],
                       "pageInfo": {
@@ -190,14 +168,10 @@ Response: {
                     "prefixExcess": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         },
                         {
-                          "moduleId": {
-                            "name": "o"
-                          }
+                          "name": "o"
                         }
                       ],
                       "pageInfo": {
@@ -208,9 +182,7 @@ Response: {
                     "suffix": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         }
                       ],
                       "pageInfo": {
@@ -221,14 +193,10 @@ Response: {
                     "suffixAll": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "m"
-                          }
+                          "name": "m"
                         },
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         }
                       ],
                       "pageInfo": {
@@ -239,14 +207,10 @@ Response: {
                     "suffixExcess": {
                       "nodes": [
                         {
-                          "moduleId": {
-                            "name": "m"
-                          }
+                          "name": "m"
                         },
                         {
-                          "moduleId": {
-                            "name": "n"
-                          }
+                          "name": "n"
                         }
                       ],
                       "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.move
@@ -38,14 +38,9 @@ fragment Modules on Object {
     location
     asMovePackage {
         module(name: "m") {
-            moduleId {
-                name
-                package {
-                    asObject {
-                        location
-                    }
-                }
-            }
+            name
+            package { asObject { location } }
+
             fileFormatVersion
             bytes
             disassembly
@@ -69,7 +64,7 @@ fragment Modules on Object {
 
 //# run-graphql
 fragment NodeNames on MoveModuleConnection {
-    nodes { moduleId { name } }
+    nodes { name }
     pageInfo { hasNextPage hasPreviousPage }
 }
 
@@ -103,7 +98,7 @@ fragment Modules on Object {
 
 //# run-graphql
 fragment NodeNames on MoveModuleConnection {
-    nodes { moduleId { name } }
+    nodes { name }
     pageInfo { hasNextPage hasPreviousPage }
 }
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -231,11 +231,9 @@ Response: {
                     "module": {
                       "s": {
                         "module": {
-                          "moduleId": {
-                            "package": {
-                              "asObject": {
-                                "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da"
-                              }
+                          "package": {
+                            "asObject": {
+                              "location": "0x8c1ea70fe9be060cbd9cf2b15d8e10efa6adfa11fb582645a33930be7f0c07da"
                             }
                           }
                         },
@@ -260,11 +258,9 @@ Response: {
                       },
                       "t": {
                         "module": {
-                          "moduleId": {
-                            "package": {
-                              "asObject": {
-                                "location": "0x0ce0fe064fd500775e2ffaeeb5807df0c18026c6ba4b1ab4f9ec4f571c05419e"
-                              }
+                          "package": {
+                            "asObject": {
+                              "location": "0x0ce0fe064fd500775e2ffaeeb5807df0c18026c6ba4b1ab4f9ec4f571c05419e"
                             }
                           }
                         },

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -115,7 +115,7 @@ module P1::m {
 # see the IDs of types as they appear in the new package -- they will
 # all be the runtime ID.
 fragment FullStruct on MoveStruct {
-    module { moduleId { package { asObject { location } } } }
+    module { package { asObject { location } } }
     name
     abilities
     typeParameters {

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -724,7 +724,7 @@
 >    }
 >  ) {
 >    nodes {
->      sendingModuleId {
+>      sendingModule {
 >        name
 >        package {
 >          asObject {

--- a/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
@@ -5,7 +5,7 @@
     }
   ) {
     nodes {
-      sendingModuleId {
+      sendingModule {
         name
         package {
           asObject {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -371,10 +371,6 @@ type Epoch {
 
 type Event {
 	"""
-	Package id and module name of Move module that the event was emitted in
-	"""
-	sendingModuleId: MoveModuleId
-	"""
 	Package, module, and type of the event
 	"""
 	eventType: MoveType
@@ -391,6 +387,10 @@ type Event {
 	Base64 encoded bcs bytes of the Move event
 	"""
 	bcs: Base64
+	"""
+	The Move module that the event was emitted in.
+	"""
+	sendingModule: MoveModule
 }
 
 type EventConnection {
@@ -634,8 +634,18 @@ Represents a module in Move, a library that defines struct types
 and functions that operate on these types.
 """
 type MoveModule {
+	"""
+	The package that this Move module was defined in
+	"""
+	package: MovePackage!
+	"""
+	The module's (unqualified) name.
+	"""
+	name: String!
+	"""
+	Format version of this module's bytecode.
+	"""
 	fileFormatVersion: Int!
-	moduleId: MoveModuleId!
 	"""
 	Modules that this module considers friends (these modules can access `public(friend)`
 	functions from this module).
@@ -694,14 +704,6 @@ type MoveModuleEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
-}
-
-type MoveModuleId {
-	name: String!
-	"""
-	The package that this Move module was defined in
-	"""
-	package: MovePackage!
 }
 
 type MoveObject {

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -84,7 +84,7 @@ type Query {
     last: Int,
     before: String,
   ): CheckpointConnection
-  
+
   coinConnection(
     first: Int,
     after: String,
@@ -905,7 +905,7 @@ type BalanceChange {
 
 type Event {
   # Module that the event was emitted by
-  sendingModuleId: MoveModuleId
+  sendingModule: MoveModule
 
   # Type of the event being sent
   eventType: MoveType
@@ -997,11 +997,6 @@ type TypeOrigin {
   package: SuiAddress!
 }
 
-type MoveModuleId {
-  package: MovePackage!
-  name: String!
-}
-
 enum MoveAbility {
   COPY
   DROP
@@ -1025,9 +1020,10 @@ type MoveFunctionTypeParameter {
 }
 
 type MoveModule {
-  fileFormatVersion: Int!
+  package: SuiAddress!
+  name: String!
 
-  moduleId: MoveModuleId!
+  fileFormatVersion: Int!
 
   friendConnection(
     first: Int,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -20,7 +20,7 @@ use crate::{
         epoch::Epoch,
         event::{Event, EventFilter},
         gas::{GasCostSummary, GasInput},
-        move_module::{MoveModule, MoveModuleId},
+        move_module::MoveModule,
         move_object::MoveObject,
         move_package::MovePackage,
         move_type::MoveType,
@@ -1263,10 +1263,8 @@ impl PgManager {
             connection.edges.extend(results.into_iter().map(|e| {
                 let cursor = String::from(e.id);
                 let event = Event {
-                    sending_module_id: Some(MoveModuleId {
-                        package: SuiAddress::from_array(**e.package_id),
-                        name: e.transaction_module.to_string(),
-                    }),
+                    sending_package: SuiAddress::from(e.package_id),
+                    sending_module: e.transaction_module.to_string(),
                     event_type: Some(MoveType::new(
                         e.type_.to_canonical_string(/* with_prefix */ true),
                     )),

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -375,10 +375,6 @@ type Epoch {
 
 type Event {
 	"""
-	Package id and module name of Move module that the event was emitted in
-	"""
-	sendingModuleId: MoveModuleId
-	"""
 	Package, module, and type of the event
 	"""
 	eventType: MoveType
@@ -395,6 +391,10 @@ type Event {
 	Base64 encoded bcs bytes of the Move event
 	"""
 	bcs: Base64
+	"""
+	The Move module that the event was emitted in.
+	"""
+	sendingModule: MoveModule
 }
 
 type EventConnection {
@@ -638,8 +638,18 @@ Represents a module in Move, a library that defines struct types
 and functions that operate on these types.
 """
 type MoveModule {
+	"""
+	The package that this Move module was defined in
+	"""
+	package: MovePackage!
+	"""
+	The module's (unqualified) name.
+	"""
+	name: String!
+	"""
+	Format version of this module's bytecode.
+	"""
 	fileFormatVersion: Int!
-	moduleId: MoveModuleId!
 	"""
 	Modules that this module considers friends (these modules can access `public(friend)`
 	functions from this module).
@@ -698,14 +708,6 @@ type MoveModuleEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
-}
-
-type MoveModuleId {
-	name: String!
-	"""
-	The package that this Move module was defined in
-	"""
-	package: MovePackage!
 }
 
 type MoveObject {


### PR DESCRIPTION
## Description

Merge `MoveModuleId` with `MoveModule` by introducing fields to the latter containing the module's package and name, and replace the reference to `MoveModuleId` in `Event` with `MoveModule`.

## Test Plan

Fixed up E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018