### PR TITLE
Merge `latest` to `next-vm`

### DIFF
--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
@@ -138,15 +138,9 @@ impl Interpreter {
                     function.clone(),
                     &ty_args,
                 )
-                .map_err(|e| match function.module_id() {
-                    Some(id) => e
-                        .at_code_offset(function.index(), 0)
-                        .finish(Location::Module(id.clone())),
-                    None => PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(
-                            "Unexpected native function not located in a module".to_owned(),
-                        )
-                        .finish(Location::Undefined),
+                .map_err(|e| {
+                    e.at_code_offset(function.index(), 0)
+                        .finish(Location::Module(function.module_id().clone()))
                 })?;
 
             profile_close_frame!(gas_meter, function.pretty_string());
@@ -228,13 +222,7 @@ impl Interpreter {
                     profile_open_frame!(gas_meter, func_name.clone());
 
                     // Charge gas
-                    let module_id = func
-                        .module_id()
-                        .ok_or_else(|| {
-                            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                                .with_message("Failed to get native function module id".to_string())
-                        })
-                        .map_err(|e| set_err_info!(current_frame, e))?;
+                    let module_id = func.module_id();
                     gas_meter
                         .charge_call(
                             module_id,
@@ -284,13 +272,7 @@ impl Interpreter {
                     profile_open_frame!(gas_meter, func_name.clone());
 
                     // Charge gas
-                    let module_id = func
-                        .module_id()
-                        .ok_or_else(|| {
-                            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                                .with_message("Failed to get native function module id".to_string())
-                        })
-                        .map_err(|e| set_err_info!(current_frame, e))?;
+                    let module_id = func.module_id();
                     gas_meter
                         .charge_call_generic(
                             module_id,
@@ -389,21 +371,15 @@ impl Interpreter {
             function.clone(),
             ty_args,
         )
-        .map_err(|e| match function.module_id() {
-            Some(id) => {
-                let e = if resolver.loader().vm_config().error_execution_state {
-                    e.with_exec_state(self.get_internal_state())
-                } else {
-                    e
-                };
-                e.at_code_offset(function.index(), 0)
-                    .finish(Location::Module(id.clone()))
-            }
-            None => {
-                let err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Unexpected native function not located in a module".to_owned());
-                self.set_location(err)
-            }
+        .map_err(|e| {
+            let id = function.module_id();
+            let e = if resolver.loader().vm_config().error_execution_state {
+                e.with_exec_state(self.get_internal_state())
+            } else {
+                e
+            };
+            e.at_code_offset(function.index(), 0)
+                .finish(Location::Module(id.clone()))
         })
     }
 
@@ -716,9 +692,9 @@ impl Interpreter {
         let func = &frame.function;
 
         debug_write!(buf, "    [{}] ", idx)?;
-        if let Some(module) = func.module_id() {
-            debug_write!(buf, "{}::{}::", module.address(), module.name(),)?;
-        }
+        let module = func.module_id();
+        debug_write!(buf, "{}::{}::", module.address(), module.name(),)?;
+
         debug_write!(buf, "{}", func.name())?;
         let ty_args = frame.ty_args();
         let mut ty_tags = vec![];
@@ -861,12 +837,12 @@ impl Interpreter {
             .iter()
             .rev()
             .take(count)
-            .filter_map(|frame| {
-                Some((
-                    frame.function.module_id()?.clone(),
+            .map(|frame| {
+                (
+                    frame.function.module_id().clone(),
                     frame.function.index(),
                     frame.pc,
-                ))
+                )
             })
             .collect();
         ExecutionState::new(stack_trace)
@@ -1633,10 +1609,7 @@ impl Frame {
     }
 
     fn location(&self) -> Location {
-        match self.function.module_id() {
-            None => Location::Script,
-            Some(id) => Location::Module(id.clone()),
-        }
+        Location::Module(self.function.module_id().clone())
     }
 
     fn check_depth_of_type(resolver: &Resolver, ty: &Type) -> PartialVMResult<u64> {

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/loader.rs
@@ -8,15 +8,14 @@ use crate::{
     session::LoadedFunctionInstantiation,
 };
 use move_binary_format::{
-    access::{ModuleAccess, ScriptAccess},
+    access::ModuleAccess,
     binary_views::BinaryIndexedView,
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        AbilitySet, Bytecode, CompiledModule, CompiledScript, Constant, ConstantPoolIndex,
-        FieldHandleIndex, FieldInstantiationIndex, FunctionDefinition, FunctionDefinitionIndex,
-        FunctionHandleIndex, FunctionInstantiationIndex, Signature, SignatureIndex, SignatureToken,
-        StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation, TableIndex,
-        TypeParameterIndex,
+        AbilitySet, Bytecode, CompiledModule, Constant, ConstantPoolIndex, FieldHandleIndex,
+        FieldInstantiationIndex, FunctionDefinition, FunctionDefinitionIndex, FunctionHandleIndex,
+        FunctionInstantiationIndex, SignatureIndex, SignatureToken, StructDefInstantiationIndex,
+        StructDefinitionIndex, StructFieldInformation, TableIndex, TypeParameterIndex,
     },
     IndexKind,
 };
@@ -36,7 +35,6 @@ use move_vm_types::{
     loaded_data::runtime_types::{CachedStructIndex, DepthFormula, StructType, Type},
 };
 use parking_lot::RwLock;
-use sha3::{Digest, Sha3_256};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt::Debug,
@@ -44,8 +42,6 @@ use std::{
     sync::Arc,
 };
 use tracing::error;
-
-type ScriptHash = [u8; 32];
 
 // A simple cache that offers both a HashMap and a Vector lookup.
 // Values are forced into a `Arc` so they can be used from multiple thread.
@@ -90,49 +86,6 @@ where
 
     fn len(&self) -> usize {
         self.binaries.len()
-    }
-}
-
-// A script cache is a map from the hash value of a script and the `Script` itself.
-// Script are added in the cache once verified and so getting a script out the cache
-// does not require further verification (except for parameters and type parameters)
-struct ScriptCache {
-    scripts: BinaryCache<ScriptHash, LoadedScript>,
-}
-
-impl ScriptCache {
-    fn new() -> Self {
-        Self {
-            scripts: BinaryCache::new(),
-        }
-    }
-
-    fn get(&self, hash: &ScriptHash) -> Option<(Arc<Function>, Vec<Type>, Vec<Type>)> {
-        self.scripts.get(hash).map(|script| {
-            (
-                script.entry_point(),
-                script.parameter_tys.clone(),
-                script.return_tys.clone(),
-            )
-        })
-    }
-
-    fn insert(
-        &mut self,
-        hash: ScriptHash,
-        script: LoadedScript,
-    ) -> PartialVMResult<(Arc<Function>, Vec<Type>, Vec<Type>)> {
-        match self.get(&hash) {
-            Some(cached) => Ok(cached),
-            None => {
-                let script = self.scripts.insert(hash, script)?;
-                Ok((
-                    script.entry_point(),
-                    script.parameter_tys.clone(),
-                    script.return_tys.clone(),
-                ))
-            }
-        }
     }
 }
 
@@ -599,12 +552,11 @@ impl ModuleCache {
 // Loader
 //
 
-// A Loader is responsible to load scripts and modules and holds the cache of all loaded
+// A Loader is responsible to load modules and holds the cache of all loaded
 // entities. Each cache is protected by a `RwLock`. Operation in the Loader must be thread safe
 // (operating on values on the stack) and when cache needs updating the mutex must be taken.
 // The `pub(crate)` API is what a Loader offers to the runtime.
 pub(crate) struct Loader {
-    scripts: RwLock<ScriptCache>,
     module_cache: RwLock<ModuleCache>,
     type_cache: RwLock<TypeCache>,
     natives: NativeFunctions,
@@ -614,7 +566,6 @@ pub(crate) struct Loader {
 impl Loader {
     pub(crate) fn new(natives: NativeFunctions, vm_config: VMConfig) -> Self {
         Self {
-            scripts: RwLock::new(ScriptCache::new()),
             module_cache: RwLock::new(ModuleCache::new()),
             type_cache: RwLock::new(TypeCache::new()),
             natives,
@@ -634,115 +585,6 @@ impl Loader {
             .get(&module)
             .and_then(|module| module.metadata.iter().find(|md| md.key == key))
             .cloned()
-    }
-
-    //
-    // Script verification and loading
-    //
-
-    // Scripts are verified and dependencies are loaded.
-    // Effectively that means modules are cached from leaf to root in the dependency DAG.
-    // If a dependency error is found, loading stops and the error is returned.
-    // However all modules cached up to that point stay loaded.
-
-    // Entry point for script execution (`MoveVM::execute_script`).
-    // Verifies the script if it is not in the cache of scripts loaded.
-    // Type parameters are checked as well after every type is loaded.
-    pub(crate) fn load_script(
-        &self,
-        script_blob: &[u8],
-        ty_args: &[Type],
-        data_store: &impl DataStore,
-    ) -> VMResult<(Arc<Function>, LoadedFunctionInstantiation)> {
-        // retrieve or load the script
-        let mut sha3_256 = Sha3_256::new();
-        sha3_256.update(script_blob);
-        let hash_value: [u8; 32] = sha3_256.finalize().into();
-
-        let link_context = data_store.link_context();
-        let mut scripts = self.scripts.write();
-        let (main, parameters, return_) = match scripts.get(&hash_value) {
-            Some(cached) => cached,
-            None => {
-                let ver_script = self.deserialize_and_verify_script(script_blob, data_store)?;
-                let script = LoadedScript::new(
-                    ver_script,
-                    link_context,
-                    &hash_value,
-                    &self.module_cache.read(),
-                )?;
-                scripts
-                    .insert(hash_value, script)
-                    .map_err(|e| e.finish(Location::Script))?
-            }
-        };
-
-        // verify type arguments
-        self.verify_ty_args(main.type_parameters(), ty_args)
-            .map_err(|e| e.finish(Location::Script))?;
-        let instantiation = LoadedFunctionInstantiation {
-            parameters,
-            return_,
-        };
-        Ok((main, instantiation))
-    }
-
-    // The process of deserialization and verification is not and it must not be under lock.
-    // So when publishing modules through the dependency DAG it may happen that a different
-    // thread had loaded the module after this process fetched it from storage.
-    // Caching will take care of that by asking for each dependency module again under lock.
-    fn deserialize_and_verify_script(
-        &self,
-        script: &[u8],
-        data_store: &impl DataStore,
-    ) -> VMResult<CompiledScript> {
-        let script = match CompiledScript::deserialize_with_max_version(
-            script,
-            self.vm_config.max_binary_format_version,
-        ) {
-            Ok(script) => script,
-            Err(err) => {
-                error!("[VM] deserializer for script returned error: {:?}", err,);
-                let msg = format!("Deserialization error: {:?}", err);
-                return Err(PartialVMError::new(StatusCode::CODE_DESERIALIZATION_ERROR)
-                    .with_message(msg)
-                    .finish(Location::Script));
-            }
-        };
-
-        match self.verify_script(&script) {
-            Ok(_) => {
-                // verify and load dependencies, fetching the verified compiled module.
-                let deps: VMResult<Vec<_>> = script
-                    .immediate_dependencies()
-                    .into_iter()
-                    .map(|dep| Ok(self.load_module(&dep, data_store)?.0))
-                    .collect();
-
-                // verify script linkage
-                dependencies::verify_script(&script, deps?.iter().map(Arc::as_ref))?;
-
-                Ok(script)
-            }
-            Err(err) => {
-                error!(
-                    "[VM] bytecode verifier returned errors for script: {:?}",
-                    err
-                );
-                Err(err)
-            }
-        }
-    }
-
-    // Script verification steps.
-    // See `verify_module()` for module verification steps.
-    fn verify_script(&self, script: &CompiledScript) -> VMResult<()> {
-        fail::fail_point!("verifier-failpoint-3", |_| { Ok(()) });
-
-        move_bytecode_verifier::verify_script_with_config_unmetered(
-            &self.vm_config.verifier,
-            script,
-        )
     }
 
     //
@@ -826,7 +668,6 @@ impl Loader {
     //
     // This step performs all verification steps to load the module without loading it.
     // The module is not added to the code cache. It is simply published to the data cache.
-    // See `verify_script()` for script verification steps.
     //
     // If a module `M` is published together with a bundle of modules (i.e., a vector of modules),
     // the `bundle_verified` argument tracks the modules that have already been verified in the
@@ -1271,8 +1112,7 @@ impl Loader {
     }
 
     // Verify the kind (constraints) of an instantiation.
-    // Both function and script invocation use this function to verify correctness
-    // of type arguments provided
+    // Function invocations call this function to verify correctness of type arguments provided
     fn verify_ty_args<'a, I>(&self, constraints: I, ty_args: &[Type]) -> PartialVMResult<()>
     where
         I: IntoIterator<Item = &'a AbilitySet>,
@@ -1313,16 +1153,6 @@ impl Loader {
             .compiled_module_at(&loaded.id)
             .expect("ModuleId on Function must exist");
         (compiled, loaded)
-    }
-
-    fn get_script(&self, hash: &ScriptHash) -> Arc<LoadedScript> {
-        Arc::clone(
-            self.scripts
-                .read()
-                .scripts
-                .get(hash)
-                .expect("Script hash on Function must exist"),
-        )
     }
 
     pub(crate) fn get_struct_type(&self, idx: CachedStructIndex) -> Option<Arc<StructType>> {
@@ -1383,13 +1213,10 @@ impl Loader {
 // Resolver
 //
 
-// A simple wrapper for a `Module` or a `Script` in the `Resolver`
-enum BinaryType {
-    Module {
-        compiled: Arc<CompiledModule>,
-        loaded: Arc<LoadedModule>,
-    },
-    Script(Arc<LoadedScript>),
+// A simple wrapper for a `Module` in the `Resolver`
+struct BinaryType {
+    compiled: Arc<CompiledModule>,
+    loaded: Arc<LoadedModule>,
 }
 
 // A Resolver is a simple and small structure allocated on the stack and used by the
@@ -1406,12 +1233,7 @@ impl<'a> Resolver<'a> {
         compiled: Arc<CompiledModule>,
         loaded: Arc<LoadedModule>,
     ) -> Self {
-        let binary = BinaryType::Module { compiled, loaded };
-        Self { loader, binary }
-    }
-
-    fn for_script(loader: &'a Loader, script: Arc<LoadedScript>) -> Self {
-        let binary = BinaryType::Script(script);
+        let binary = BinaryType { compiled, loaded };
         Self { loader, binary }
     }
 
@@ -1420,10 +1242,7 @@ impl<'a> Resolver<'a> {
     //
 
     pub(crate) fn constant_at(&self, idx: ConstantPoolIndex) -> &Constant {
-        match &self.binary {
-            BinaryType::Module { compiled, .. } => compiled.constant_at(idx),
-            BinaryType::Script(script) => script.script.constant_at(idx),
-        }
+        self.binary.compiled.constant_at(idx)
     }
 
     //
@@ -1431,10 +1250,7 @@ impl<'a> Resolver<'a> {
     //
 
     pub(crate) fn function_from_handle(&self, idx: FunctionHandleIndex) -> Arc<Function> {
-        let idx = match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.function_at(idx.0),
-            BinaryType::Script(script) => script.function_at(idx.0),
-        };
+        let idx = self.binary.loaded.function_at(idx.0);
         self.loader.function_at(idx)
     }
 
@@ -1442,10 +1258,7 @@ impl<'a> Resolver<'a> {
         &self,
         idx: FunctionInstantiationIndex,
     ) -> Arc<Function> {
-        let func_inst = match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.function_instantiation_at(idx.0),
-            BinaryType::Script(script) => script.function_instantiation_at(idx.0),
-        };
+        let func_inst = self.binary.loaded.function_instantiation_at(idx.0);
         self.loader.function_at(func_inst.handle)
     }
 
@@ -1454,10 +1267,7 @@ impl<'a> Resolver<'a> {
         idx: FunctionInstantiationIndex,
         type_params: &[Type],
     ) -> PartialVMResult<Vec<Type>> {
-        let func_inst = match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.function_instantiation_at(idx.0),
-            BinaryType::Script(script) => script.function_instantiation_at(idx.0),
-        };
+        let func_inst = &self.binary.loaded.function_instantiation_at(idx.0);
         let mut instantiation = vec![];
         for ty in &func_inst.instantiation {
             instantiation.push(self.subst(ty, type_params)?);
@@ -1479,10 +1289,7 @@ impl<'a> Resolver<'a> {
     //
 
     pub(crate) fn get_struct_type(&self, idx: StructDefinitionIndex) -> Type {
-        let struct_def = match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.struct_at(idx),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
-        };
+        let struct_def = self.binary.loaded.struct_at(idx);
         Type::Struct(struct_def)
     }
 
@@ -1491,10 +1298,7 @@ impl<'a> Resolver<'a> {
         idx: StructDefInstantiationIndex,
         ty_args: &[Type],
     ) -> PartialVMResult<Type> {
-        let struct_inst = match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.struct_instantiation_at(idx.0),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
-        };
+        let struct_inst = self.binary.loaded.struct_instantiation_at(idx.0);
 
         // Before instantiating the type, count the # of nodes of all type arguments plus
         // existing type instantiation.
@@ -1519,10 +1323,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn single_type_at(&self, idx: SignatureIndex) -> &Type {
-        match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.single_type_at(idx),
-            BinaryType::Script(script) => script.single_type_at(idx),
-        }
+        self.binary.loaded.single_type_at(idx)
     }
 
     pub(crate) fn instantiate_single_type(
@@ -1547,31 +1348,19 @@ impl<'a> Resolver<'a> {
     //
 
     pub(crate) fn field_offset(&self, idx: FieldHandleIndex) -> usize {
-        match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.field_offset(idx),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
-        }
+        self.binary.loaded.field_offset(idx)
     }
 
     pub(crate) fn field_instantiation_offset(&self, idx: FieldInstantiationIndex) -> usize {
-        match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.field_instantiation_offset(idx),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
-        }
+        self.binary.loaded.field_instantiation_offset(idx)
     }
 
     pub(crate) fn field_count(&self, idx: StructDefinitionIndex) -> u16 {
-        match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.field_count(idx.0),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
-        }
+        self.binary.loaded.field_count(idx.0)
     }
 
     pub(crate) fn field_instantiation_count(&self, idx: StructDefInstantiationIndex) -> u16 {
-        match &self.binary {
-            BinaryType::Module { loaded, .. } => loaded.field_instantiation_count(idx.0),
-            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
-        }
+        self.binary.loaded.field_instantiation_count(idx.0)
     }
 
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<R::MoveTypeLayout> {
@@ -1834,208 +1623,6 @@ impl LoadedModule {
     }
 }
 
-/// A `LoadedScript` is very similar to a `CompiledScript` but data is "transformed" to a
-/// representation more appropriate to execution.
-/// When code executes, indexes in instructions are resolved against runtime structures
-/// (rather then "compiled") to make available data needed for execution
-/// #[derive(Debug)]
-struct LoadedScript {
-    // primitive pools
-    script: CompiledScript,
-
-    // types as indexes into the Loader type list
-    // REVIEW: why is this unused?
-    #[allow(dead_code)]
-    struct_refs: Vec<CachedStructIndex>,
-
-    // functions as indexes into the Loader function list
-    function_refs: Vec<usize>,
-    // materialized instantiations, whether partial or not
-    function_instantiations: Vec<FunctionInstantiation>,
-
-    // entry point
-    main: Arc<Function>,
-
-    // parameters of main
-    parameter_tys: Vec<Type>,
-
-    // return values
-    return_tys: Vec<Type>,
-
-    // a map of single-token signature indices to type
-    single_signature_token_map: BTreeMap<SignatureIndex, Type>,
-}
-
-impl LoadedScript {
-    fn new(
-        script: CompiledScript,
-        link_context: AccountAddress,
-        script_hash: &ScriptHash,
-        cache: &ModuleCache,
-    ) -> VMResult<Self> {
-        let script_view = BinaryIndexedView::Script(&script);
-        let mut struct_refs = vec![];
-        for struct_handle in script.struct_handles() {
-            let struct_name = script.identifier_at(struct_handle.name);
-            let module_handle = script.module_handle_at(struct_handle.module);
-            let module_id = ModuleId::new(
-                *script.address_identifier_at(module_handle.address),
-                script.identifier_at(module_handle.name).to_owned(),
-            );
-            struct_refs.push(
-                cache
-                    .resolve_struct_by_name(struct_name, &module_id)
-                    .map_err(|e| e.finish(Location::Script))?
-                    .0,
-            );
-        }
-
-        let mut function_refs = vec![];
-        for func_handle in script.function_handles().iter() {
-            let func_name = script.identifier_at(func_handle.name);
-            let module_handle = script.module_handle_at(func_handle.module);
-            let module_id = ModuleId::new(
-                *script.address_identifier_at(module_handle.address),
-                script.identifier_at(module_handle.name).to_owned(),
-            );
-            let ref_idx = cache
-                .resolve_function_by_name(func_name, &module_id, link_context)
-                .map_err(|err| err.finish(Location::Undefined))?;
-            function_refs.push(ref_idx);
-        }
-
-        let mut function_instantiations = vec![];
-        for func_inst in script.function_instantiations() {
-            let handle = function_refs[func_inst.handle.0 as usize];
-            let mut instantiation = vec![];
-            for ty in &script.signature_at(func_inst.type_parameters).0 {
-                instantiation.push(
-                    cache
-                        .make_type(script_view, ty)
-                        .map_err(|e| e.finish(Location::Script))?,
-                );
-            }
-            function_instantiations.push(FunctionInstantiation {
-                handle,
-                instantiation,
-            });
-        }
-
-        let scope = Scope::Script(*script_hash);
-
-        let code: Vec<Bytecode> = script.code.code.clone();
-        let parameters = script.parameters;
-        let parameters_len = script_view.signature_at(parameters).0.len();
-        let locals_len = parameters_len + script_view.signature_at(script.code.locals).0.len();
-        let parameter_tys = script_view
-            .signature_at(parameters)
-            .0
-            .iter()
-            .map(|tok| cache.make_type(script_view, tok))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-        let return_ = SignatureIndex(0);
-        let return_len = 0;
-        let return_tys = Signature(vec![])
-            .0
-            .iter()
-            .map(|tok| cache.make_type(script_view, tok))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-        let type_parameters = script.type_parameters.clone();
-        // TODO: main does not have a name. Revisit.
-        let name = Identifier::new("main").unwrap();
-        let (native, def_is_native) = (None, false); // Script entries cannot be native
-        let main: Arc<Function> = Arc::new(Function {
-            file_format_version: script.version(),
-            index: FunctionDefinitionIndex(0),
-            code,
-            parameters,
-            return_,
-            type_parameters,
-            native,
-            def_is_native,
-            scope,
-            name,
-            parameters_len,
-            locals_len,
-            return_len,
-        });
-
-        let mut single_signature_token_map = BTreeMap::new();
-        for bc in &script.code.code {
-            match bc {
-                Bytecode::VecPack(si, _)
-                | Bytecode::VecLen(si)
-                | Bytecode::VecImmBorrow(si)
-                | Bytecode::VecMutBorrow(si)
-                | Bytecode::VecPushBack(si)
-                | Bytecode::VecPopBack(si)
-                | Bytecode::VecUnpack(si, _)
-                | Bytecode::VecSwap(si) => {
-                    if !single_signature_token_map.contains_key(si) {
-                        let ty = match script.signature_at(*si).0.get(0) {
-                            None => {
-                                return Err(PartialVMError::new(
-                                    StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                )
-                                .with_message(
-                                    "the type argument for vector-related bytecode \
-                                                expects one and only one signature token"
-                                        .to_owned(),
-                                )
-                                .finish(Location::Script));
-                            }
-                            Some(sig_token) => sig_token,
-                        };
-                        single_signature_token_map.insert(
-                            *si,
-                            cache
-                                .make_type(script_view, ty)
-                                .map_err(|e| e.finish(Location::Script))?,
-                        );
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        Ok(Self {
-            script,
-            struct_refs,
-            function_refs,
-            function_instantiations,
-            main,
-            parameter_tys,
-            return_tys,
-            single_signature_token_map,
-        })
-    }
-
-    fn entry_point(&self) -> Arc<Function> {
-        self.main.clone()
-    }
-
-    fn function_at(&self, idx: u16) -> usize {
-        self.function_refs[idx as usize]
-    }
-
-    fn function_instantiation_at(&self, idx: u16) -> &FunctionInstantiation {
-        &self.function_instantiations[idx as usize]
-    }
-
-    fn single_type_at(&self, idx: SignatureIndex) -> &Type {
-        self.single_signature_token_map.get(&idx).unwrap()
-    }
-}
-
-// A simple wrapper for the "owner" of the function (Module or Script)
-#[derive(Debug)]
-enum Scope {
-    Module(ModuleId),
-    Script(ScriptHash),
-}
-
 // A runtime function
 // #[derive(Debug)]
 // https://github.com/rust-lang/rust/issues/70263
@@ -2049,7 +1636,7 @@ pub(crate) struct Function {
     type_parameters: Vec<AbilitySet>,
     native: Option<NativeFunction>,
     def_is_native: bool,
-    scope: Scope,
+    module: ModuleId,
     name: Identifier,
     parameters_len: usize,
     locals_len: usize,
@@ -2078,7 +1665,6 @@ impl Function {
         } else {
             (None, false)
         };
-        let scope = Scope::Module(module_id);
         let parameters = handle.parameters;
         let parameters_len = module.signature_at(parameters).0.len();
         // Native functions do not have a code unit
@@ -2101,7 +1687,7 @@ impl Function {
             type_parameters,
             native,
             def_is_native,
-            scope,
+            module: module_id,
             name,
             parameters_len,
             locals_len,
@@ -2114,11 +1700,8 @@ impl Function {
         self.file_format_version
     }
 
-    pub(crate) fn module_id(&self) -> Option<&ModuleId> {
-        match &self.scope {
-            Scope::Module(module_id) => Some(module_id),
-            Scope::Script(_) => None,
-        }
+    pub(crate) fn module_id(&self) -> &ModuleId {
+        &self.module
     }
 
     pub(crate) fn index(&self) -> FunctionDefinitionIndex {
@@ -2130,16 +1713,8 @@ impl Function {
         link_context: AccountAddress,
         loader: &'a Loader,
     ) -> Resolver<'a> {
-        match &self.scope {
-            Scope::Module(module_id) => {
-                let (compiled, loaded) = loader.get_module(link_context, module_id);
-                Resolver::for_module(loader, compiled, loaded)
-            }
-            Scope::Script(script_hash) => {
-                let script = loader.get_script(script_hash);
-                Resolver::for_script(loader, script)
-            }
-        }
+        let (compiled, loaded) = loader.get_module(link_context, &self.module);
+        Resolver::for_module(loader, compiled, loaded)
     }
 
     pub(crate) fn local_count(&self) -> usize {
@@ -2167,15 +1742,23 @@ impl Function {
     }
 
     pub(crate) fn pretty_string(&self) -> String {
-        match &self.scope {
-            Scope::Script(_) => "Script::main".into(),
-            Scope::Module(id) => format!(
-                "0x{}::{}::{}",
-                id.address(),
-                id.name().as_str(),
-                self.name.as_str()
-            ),
-        }
+        let id = &self.module;
+        format!(
+            "0x{}::{}::{}",
+            id.address(),
+            id.name().as_str(),
+            self.name.as_str()
+        )
+    }
+
+    pub(crate) fn pretty_short_string(&self) -> String {
+        let id = &self.module;
+        format!(
+            "0x{}::{}::{}",
+            id.address().short_str_lossless(),
+            id.name().as_str(),
+            self.name.as_str()
+        )
     }
 
     pub(crate) fn is_native(&self) -> bool {

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/runtime.rs
@@ -442,44 +442,6 @@ impl VMRuntime {
         )
     }
 
-    // See Session::execute_script for what contracts to follow.
-    pub(crate) fn execute_script(
-        &self,
-        script: impl Borrow<[u8]>,
-        type_arguments: Vec<Type>,
-        serialized_args: Vec<impl Borrow<[u8]>>,
-        data_store: &mut impl DataStore,
-        gas_meter: &mut impl GasMeter,
-        extensions: &mut NativeContextExtensions,
-    ) -> VMResult<SerializedReturnValues> {
-        // load the script, perform verification
-        let (
-            func,
-            LoadedFunctionInstantiation {
-                parameters,
-                return_,
-            },
-        ) = self
-            .loader
-            .load_script(script.borrow(), &type_arguments, data_store)?;
-        #[cfg(debug_assertions)]
-        {
-            let rem = gas_meter.remaining_gas().into();
-            gas_meter.set_profiler(GasProfiler::init_default_cfg(func.pretty_string(), rem));
-        }
-        // execute the function
-        self.execute_function_impl(
-            func,
-            type_arguments,
-            parameters,
-            return_,
-            serialized_args,
-            data_store,
-            gas_meter,
-            extensions,
-        )
-    }
-
     pub(crate) fn loader(&self) -> &Loader {
         &self.loader
     }

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/session.rs
@@ -124,39 +124,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         )
     }
 
-    /// Execute a transaction script.
-    ///
-    /// The Move VM MUST return a user error (in other words, an error that's not an invariant
-    /// violation) if
-    ///   - The script fails to deserialize or verify. Not all expressible signatures are valid.
-    ///     See `move_bytecode_verifier::script_signature` for the rules.
-    ///   - Type arguments refer to a non-existent type.
-    ///   - Arguments (senders included) fail to deserialize or fail to match the signature of the
-    ///     script function.
-    ///
-    /// If any other error occurs during execution, the Move VM MUST propagate that error back to
-    /// the caller.
-    /// Besides, no user input should cause the Move VM to return an invariant violation.
-    ///
-    /// In case an invariant violation occurs, the whole Session should be considered corrupted and
-    /// one shall not proceed with effect generation.
-    pub fn execute_script(
-        &mut self,
-        script: impl Borrow<[u8]>,
-        ty_args: Vec<Type>,
-        args: Vec<impl Borrow<[u8]>>,
-        gas_meter: &mut impl GasMeter,
-    ) -> VMResult<SerializedReturnValues> {
-        self.runtime.execute_script(
-            script,
-            ty_args,
-            args,
-            &mut self.data_cache,
-            gas_meter,
-            &mut self.native_extensions,
-        )
-    }
-
     /// Publish the given module.
     ///
     /// The Move VM MUST return a user error, i.e., an error that's not an invariant violation, if
@@ -235,19 +202,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
                 .map_err(|e| e.finish(Location::Undefined)),
             remote,
         )
-    }
-
-    /// Load a script and all of its types into cache
-    pub fn load_script(
-        &self,
-        script: impl Borrow<[u8]>,
-        ty_args: &[Type],
-    ) -> VMResult<LoadedFunctionInstantiation> {
-        let (_, instantiation) =
-            self.runtime
-                .loader()
-                .load_script(script.borrow(), ty_args, &self.data_cache)?;
-        Ok(instantiation)
     }
 
     /// Load a module, a function, and all of its types into cache

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -9,10 +9,10 @@ use move_binary_format::{
     errors::{VMError, VMResult},
     file_format::{
         empty_module, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModule,
-        CompiledScript, FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
-        IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex,
-        SignatureToken, StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex,
-        TableIndex, TypeSignature, Visibility,
+        FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex, IdentifierIndex,
+        ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
+        StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TableIndex,
+        TypeSignature, Visibility,
     },
 };
 use move_core_types::{
@@ -25,112 +25,6 @@ use move_core_types::{
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_types::gas::UnmeteredGasMeter;
-
-// make a script with a given signature for main.
-fn make_script(parameters: Signature) -> Vec<u8> {
-    let mut blob = vec![];
-    let mut signatures = vec![Signature(vec![])];
-    let parameters_idx = match signatures
-        .iter()
-        .enumerate()
-        .find(|(_, s)| *s == &parameters)
-    {
-        Some((idx, _)) => SignatureIndex(idx as TableIndex),
-        None => {
-            signatures.push(parameters);
-            SignatureIndex((signatures.len() - 1) as TableIndex)
-        }
-    };
-    CompiledScript {
-        version: move_binary_format::file_format_common::VERSION_MAX,
-        module_handles: vec![],
-        struct_handles: vec![],
-        function_handles: vec![],
-
-        function_instantiations: vec![],
-
-        signatures,
-
-        identifiers: vec![],
-        address_identifiers: vec![],
-        constant_pool: vec![],
-        metadata: vec![],
-
-        type_parameters: vec![],
-        parameters: parameters_idx,
-        code: CodeUnit {
-            locals: SignatureIndex(0),
-            code: vec![Bytecode::LdU64(0), Bytecode::Abort],
-        },
-    }
-    .serialize(&mut blob)
-    .expect("script must serialize");
-    blob
-}
-
-// make a script with an external function that has the same signature as
-// the main. That allows us to pass resources and make the verifier happy that
-// they are consumed.
-// Dependencies check happens after main signature check, so we should expect
-// a signature check error.
-fn make_script_with_non_linking_structs(parameters: Signature) -> Vec<u8> {
-    let mut blob = vec![];
-    let mut signatures = vec![Signature(vec![])];
-    let parameters_idx = match signatures
-        .iter()
-        .enumerate()
-        .find(|(_, s)| *s == &parameters)
-    {
-        Some((idx, _)) => SignatureIndex(idx as TableIndex),
-        None => {
-            signatures.push(parameters);
-            SignatureIndex((signatures.len() - 1) as TableIndex)
-        }
-    };
-    CompiledScript {
-        version: move_binary_format::file_format_common::VERSION_MAX,
-        module_handles: vec![ModuleHandle {
-            address: AddressIdentifierIndex(0),
-            name: IdentifierIndex(0),
-        }],
-        struct_handles: vec![StructHandle {
-            module: ModuleHandleIndex(0),
-            name: IdentifierIndex(1),
-            abilities: AbilitySet::EMPTY,
-            type_parameters: vec![],
-        }],
-        function_handles: vec![FunctionHandle {
-            module: ModuleHandleIndex(0),
-            name: IdentifierIndex(2),
-            parameters: SignatureIndex(1),
-            return_: SignatureIndex(0),
-            type_parameters: vec![],
-        }],
-
-        function_instantiations: vec![],
-
-        signatures,
-
-        identifiers: vec![
-            Identifier::new("one").unwrap(),
-            Identifier::new("two").unwrap(),
-            Identifier::new("three").unwrap(),
-        ],
-        address_identifiers: vec![AccountAddress::random()],
-        constant_pool: vec![],
-        metadata: vec![],
-
-        type_parameters: vec![],
-        parameters: parameters_idx,
-        code: CodeUnit {
-            locals: SignatureIndex(0),
-            code: vec![Bytecode::LdU64(0), Bytecode::Abort],
-        },
-    }
-    .serialize(&mut blob)
-    .expect("script must serialize");
-    blob
-}
 
 fn make_module_with_function(
     visibility: Visibility,
@@ -280,35 +174,6 @@ fn combine_signers_and_args(
         .map(|s| MoveValue::Signer(s).simple_serialize().unwrap())
         .chain(non_signer_args)
         .collect()
-}
-
-fn call_script_with_args_ty_args_signers(
-    script: Vec<u8>,
-    non_signer_args: Vec<Vec<u8>>,
-    ty_arg_tags: Vec<TypeTag>,
-    signers: Vec<AccountAddress>,
-) -> VMResult<()> {
-    let move_vm = MoveVM::new(vec![]).unwrap();
-    let remote_view = RemoteStore::new();
-    let mut session = move_vm.new_session(&remote_view);
-
-    let ty_args = ty_arg_tags
-        .into_iter()
-        .map(|tag| session.load_type(&tag))
-        .collect::<VMResult<_>>()?;
-
-    session
-        .execute_script(
-            script,
-            ty_args,
-            combine_signers_and_args(signers, non_signer_args),
-            &mut UnmeteredGasMeter,
-        )
-        .map(|_| ())
-}
-
-fn call_script(script: Vec<u8>, args: Vec<Vec<u8>>) -> VMResult<()> {
-    call_script_with_args_ty_args_signers(script, args, vec![], vec![])
 }
 
 fn call_script_function_with_args_ty_args_signers(
@@ -632,66 +497,6 @@ fn general_cases() -> Vec<(
             None,
         ),
     ]
-}
-
-#[test]
-fn check_script() {
-    //
-    // Bad signatures
-    //
-    for signature in deprecated_bad_signatures() {
-        let num_args = signature.0.len();
-        let dummy_args = vec![MoveValue::Bool(false); num_args];
-        let script = make_script_with_non_linking_structs(signature);
-        let status = call_script(script, serialize_values(&dummy_args))
-            .err()
-            .unwrap()
-            .major_status();
-        assert_eq!(status, StatusCode::LINKER_ERROR);
-    }
-
-    //
-    // Good signatures
-    //
-    for (signature, args) in good_signatures_and_arguments() {
-        // Body of the script is just an abort, so `ABORTED` means the script was accepted and ran
-        let expected_status = StatusCode::ABORTED;
-        let script = make_script(signature);
-        assert_eq!(
-            call_script(script, serialize_values(&args))
-                .err()
-                .unwrap()
-                .major_status(),
-            expected_status
-        )
-    }
-
-    //
-    // Mismatched Cases
-    //
-    for (signature, args, error) in mismatched_cases() {
-        let script = make_script(signature);
-        assert_eq!(
-            call_script(script, serialize_values(&args))
-                .err()
-                .unwrap()
-                .major_status(),
-            error
-        );
-    }
-
-    for (signature, args, signers, expected_status_opt) in general_cases() {
-        // Body of the script is just an abort, so `ABORTED` means the script was accepted and ran
-        let expected_status = expected_status_opt.unwrap_or(StatusCode::ABORTED);
-        let script = make_script(signature);
-        assert_eq!(
-            call_script_with_args_ty_args_signers(script, serialize_values(&args), vec![], signers)
-                .err()
-                .unwrap()
-                .major_status(),
-            expected_status
-        );
-    }
 }
 
 #[test]

--- a/sui-execution/next-vm/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/next-vm/sui-verifier/src/id_leak_verifier.rs
@@ -34,6 +34,7 @@ use sui_types::{
     clock::CLOCK_MODULE_NAME,
     error::{ExecutionError, VMMVerifierErrorSubStatusCode},
     id::OBJECT_MODULE_NAME,
+    randomness_state::RANDOMNESS_MODULE_NAME,
     sui_system_state::SUI_SYSTEM_MODULE_NAME,
     SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
 };
@@ -83,11 +84,17 @@ const SUI_AUTHENTICATOR_STATE_CREATE: FunctionIdent = (
     AUTHENTICATOR_STATE_MODULE_NAME,
     ident_str!("create"),
 );
+const SUI_RANDOMNESS_STATE_CREATE: FunctionIdent = (
+    &SUI_FRAMEWORK_ADDRESS,
+    RANDOMNESS_MODULE_NAME,
+    ident_str!("create"),
+);
 const FRESH_ID_FUNCTIONS: &[FunctionIdent] = &[OBJECT_NEW, OBJECT_NEW_UID_FROM_HASH, TS_NEW_OBJECT];
 const FUNCTIONS_TO_SKIP: &[FunctionIdent] = &[
     SUI_SYSTEM_CREATE,
     SUI_CLOCK_CREATE,
     SUI_AUTHENTICATOR_STATE_CREATE,
+    SUI_RANDOMNESS_STATE_CREATE,
 ];
 
 impl AbstractValue {


### PR DESCRIPTION
## Description 

Moving the latest changes in `latest` (and particularly the removal of `Script`) into `next-vm`.
Run the script to do it and things looks decent. @tnowacki take a look but I assume most of the removal was not in the execution layer.

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
