### PR TITLE
[indexer] output response using short format for coin type

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1440,7 +1440,10 @@ impl IndexerReader {
         tracing::debug!("get coin balances query: {query}");
         let coin_balances =
             self.run_query(|conn| diesel::sql_query(query).load::<CoinBalance>(conn))?;
-        Ok(coin_balances.into_iter().map(|cb| cb.into()).collect())
+        coin_balances
+            .into_iter()
+            .map(|cb| cb.try_into())
+            .collect::<IndexerResult<Vec<_>>>()
     }
 
     pub fn get_latest_network_metrics(&self) -> IndexerResult<NetworkMetrics> {

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -357,6 +357,21 @@ mod tests {
     }
 
     #[test]
+    fn test_output_format_coin_balance() {
+        let test_obj = Object::new_gas_for_testing();
+        let indexed_obj = IndexedObject::from_object(1, test_obj, None);
+
+        let stored_obj = StoredObject::from(indexed_obj);
+        let test_balance = CoinBalance {
+            coin_type: stored_obj.coin_type.unwrap(),
+            coin_num: 1,
+            coin_balance: 100,
+        };
+        let balance = Balance::try_from(test_balance).unwrap();
+        assert_eq!(balance.coin_type, "0x2::sui::SUI");
+    }
+
+    #[test]
     fn test_vec_of_coin_sui_conversion() {
         // 0xe7::vec_coin::VecCoin<vector<0x2::coin::Coin<0x2::sui::SUI>>>
         let vec_coins_type = TypeTag::Vector(Box::new(

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -353,10 +353,7 @@ mod tests {
         let stored_obj = StoredObject::from(indexed_obj);
 
         let sui_coin = SuiCoin::try_from(stored_obj).unwrap();
-        assert_eq!(
-            sui_coin.coin_type,
-            "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-        );
+        assert_eq!(sui_coin.coin_type, "0x2::sui::SUI");
     }
 
     #[test]


### PR DESCRIPTION
## Description 

We switched to use long canonical format for object types and caused confusion for clients. 
This PR makes sure that for coin read API, the short format is still being output.

## Test Plan 

tested locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
