### PR TITLE
Fix narwhal/benchmark commands

### DIFF
--- a/narwhal/benchmark/benchmark/commands.py
+++ b/narwhal/benchmark/benchmark/commands.py
@@ -33,17 +33,17 @@ class CommandMaker:
     @staticmethod
     def generate_key(filename):
         assert isinstance(filename, str)
-        return f'./narwhal-node generate_keys --filename {filename}'
+        return f'./narwhal-node generate-keys --filename {filename}'
 
     @staticmethod
     def get_pub_key(filename):
         assert isinstance(filename, str)
-        return f'./narwhal-node get_pub_key --filename {filename}'
+        return f'./narwhal-node get-pub-key --filename {filename}'
 
     @staticmethod
     def generate_network_key(filename):
         assert isinstance(filename, str)
-        return f'./narwhal-node generate_network_keys --filename {filename}'
+        return f'./narwhal-node generate-network-keys --filename {filename}'
      
     @staticmethod
     def run_primary(primary_keys, primary_network_keys, worker_keys, committee, workers, store, parameters, debug=False):


### PR DESCRIPTION
## Description 

Fixes commands for the narwhal benchmark

## Test Plan 

Run the benchmark with `fab local`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
