### PR TITLE
Narwhal only benchmark using aws orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11204,6 +11204,7 @@ dependencies = [
  "eyre",
  "futures",
  "mysten-metrics",
+ "narwhal-config",
  "prettytable-rs",
  "prometheus-parse",
  "reqwest",

--- a/crates/sui-aws-orchestrator/Cargo.toml
+++ b/crates/sui-aws-orchestrator/Cargo.toml
@@ -29,8 +29,9 @@ prometheus-parse.workspace = true
 
 mysten-metrics.workspace = true
 sui-config = { path = "../sui-config" }
+narwhal-config.workspace = true
 sui-types = { path = "../sui-types" }
-sui-swarm-config =  { path = "../sui-swarm-config" }
+sui-swarm-config = { path = "../sui-swarm-config" }
 workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-aws-orchestrator/README.md
+++ b/crates/sui-aws-orchestrator/README.md
@@ -81,7 +81,22 @@ Instances listed with a green number are available and ready for use, while inst
 Also keep in mind that there is nothing stopping you from running the `deploy` command multiple times if you find your self
 needing more instances down the line.
 
-## Step 4. Running benchmarks
+## Step 4. Choose protocol
+
+There is support to benchmark either Sui or Narwhal only. To choose which protocol to benchmark, you can set the `Protocol` & `BenchmarkType` field [here](https://github.com/MystenLabs/sui/blob/main/crates/sui-aws-orchestrator/src/main.rs#L33-L34)
+
+```
+// Sui
+use protocol::sui::{SuiBenchmarkType, SuiProtocol};
+type Protocol = SuiProtocol;
+type BenchmarkType = SuiBenchmarkType;
+// Narwhal
+use protocol::narwhal::{NarwhalBenchmarkType, NarwhalProtocol};
+type Protocol = NarwhalProtocol;
+type BenchmarkType = NarwhalBenchmarkType;
+```
+
+## Step 5. Running benchmarks
 
 Running benchmarks involves installing the specified version of the codebase on the remote machines and running one validator and one load generator per instance. For example, the following command benchmarks a committee of 10 validators under a constant load of 200 tx/s for 3 minutes:
 
@@ -91,7 +106,7 @@ cargo run --bin sui-aws-orchestrator -- benchmark --committee 10 fixed-load --lo
 
 In a network of 10 validators, each with a corresponding load generator, each load generator submits a fixed load of 20 tx/s. Performance measurements are collected by regularly scraping the Prometheus metrics exposed by the load generators. The `sui-aws-orchestrator` binary provides additional commands to run a specific number of load generators on separate machines.
 
-## Step 5. Monitoring
+## Step 6. Monitoring
 
 The orchestrator provides facilities to monitor metrics on clients and nodes. The orchestrator deploys a [Prometheus](https://prometheus.io) instance and a [Grafana](https://grafana.com) instance on a dedicated remote machine. Grafana is then available on the address printed on stdout (e.g., `http://3.83.97.12:3000`) with the default username and password both set to `admin`. You can either create a [new dashboard](https://grafana.com/docs/grafana/latest/getting-started/build-first-dashboard/) or [import](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/#import-a-dashboard) the example dashboards located in the `./assets` folder.
 

--- a/crates/sui-aws-orchestrator/assets/grafana-dashboard-narwhal-only.json
+++ b/crates/sui-aws-orchestrator/assets/grafana-dashboard-narwhal-only.json
@@ -1,0 +1,6310 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 266,
+      "panels": [],
+      "title": "Client",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 268,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(rate(num_submitted{job=~\"$validator\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "num_submitted",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(rate(num_success{job=~\"$validator\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "num_success",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by() (rate(num_error{job=~\"$validator\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "num_error",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "TPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 269,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(benchmark_duration{job=~\"$validator\"})",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "benchmark_duration",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 78,
+      "panels": [],
+      "title": "Health overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Fixed-UID-testbed"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "min": 0.5,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.667
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "id": 258,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Fixed-UID-testbed"
+          },
+          "editorMode": "code",
+          "expr": "sum(current_voting_right{job=~\"$validator\"} and rate(current_round{job=~\"$validator\"}[$__interval]) > 0) / 10000",
+          "instant": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Percentage of stake that increments consensus rounds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The rate of the current round growth. This is reported by the proposer - which forms the next header to be broadcasted by a node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Round / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) (rate(current_round{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Current round growth speed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The current round the node is in. This is reported by the proposer - which forms the next header to be broadcasted by a node. The numbers across the nodes shouldn't differ much - if not the same.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Round",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                0,
+                10
+              ],
+              "fill": "dot"
+            },
+            "lineWidth": 2,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) (current_round{job=~\"$validator\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current round (timeline)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Fixed-UID-testbed"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "id": 260,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Fixed-UID-testbed"
+          },
+          "editorMode": "code",
+          "expr": "current_voting_right{job=~\"$validator\"} / 10000",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Voting power distribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Epoch number",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 22
+      },
+      "id": 197,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "current_epoch{job=~\"$validator\"}",
+          "hide": false,
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Current Epoch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Num of primary peers connected per host",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Num peers connected",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                0,
+                10
+              ],
+              "fill": "dot"
+            },
+            "lineWidth": 3,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "id": 244,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (primary_network_peer_connected{job=~\"$validator\", type=\"other_primary\"})",
+          "hide": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Primary network connectivity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Shows the lag (diff) between the median reported last committed round and the specific host's last committed round. The color scheme shows how far behind nodes are.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green"
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "orange",
+                "value": 150
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 8,
+        "x": 0,
+        "y": 32
+      },
+      "id": 185,
+      "interval": "2m",
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (last_committed_round{job=~\"$validator\"})",
+          "format": "time_series",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "quantile(0.5, last_committed_round{job=~\"$validator\"})",
+          "format": "time_series",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0,
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": []
+              },
+              "reducer": {
+                "params": [],
+                "type": "avg"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "name": "Expression",
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$B - $A",
+          "hide": false,
+          "reducer": "max",
+          "refId": "*",
+          "type": "math"
+        }
+      ],
+      "title": "Last commit round lag",
+      "type": "status-history"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The nodes that are proposing in rounds during time. When a node advances a round then this will be a green box with \"YES\" text in it. Otherwise a red box with \"NO\" text will be rendered",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 1.5,
+                "result": {
+                  "color": "dark-green",
+                  "index": 0
+                },
+                "to": 1000
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "super-light-green",
+                  "index": 1
+                },
+                "to": 1.5
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 0.5,
+                "result": {
+                  "color": "yellow",
+                  "index": 2
+                },
+                "to": 1
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 0.1,
+                "result": {
+                  "color": "orange",
+                  "index": 3
+                },
+                "to": 0.5
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "red",
+                  "index": 4
+                },
+                "to": 0.1
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "transparent",
+                  "index": 5
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "id": 184,
+      "interval": "2m",
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (job) (rate(certificates_created{job=~\"$validator\"}[5m]))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes proposing certified headers",
+      "type": "status-history"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red"
+              },
+              {
+                "color": "dark-orange",
+                "value": 70
+              },
+              {
+                "color": "dark-yellow",
+                "value": 80
+              },
+              {
+                "color": "dark-green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 203,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": " sum by(job) (primary_network_peer_connected{job=~\"$validator\", type=\"other_primary\"})",
+          "interval": "2m",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Primary connected to other primaries (number)",
+      "type": "status-history"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 43,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "Consensus ordering attempts per sec",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "txn / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 47
+          },
+          "id": 69,
+          "interval": "1m",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, sum by (job) (rate(sequencing_certificate_attempt{job=~\"$validator\"}[5m])))",
+              "legendFormat": "Consensus adapter input rate",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, sum (rate(sequencing_acknowledge_latency_count{job=~\"$validator\"}[5m])))",
+              "hide": false,
+              "legendFormat": "NW input rate",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, sum by (job) (rate(consensus_handler_processed{job=~\"$validator\"}[5m])))",
+              "hide": false,
+              "legendFormat": "NW output rate",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Input / output rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Fixed-UID-testbed"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 47
+          },
+          "id": 256,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "clamp(quantile(0.67, histogram_quantile(0.5, sum(rate(sequencing_certificate_latency_bucket{job=~\"$validator\"}[5m])) by(job, le))), 0, 30)",
+              "instant": false,
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "clamp(quantile(0.67, histogram_quantile(0.95, sum(rate(sequencing_certificate_latency_bucket{job=~\"$validator\"}[5m])) by(job, le))), 0, 30)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "p95",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "p50 and p95 Consensus Adapter e2e latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Fixed-UID-testbed"
+          },
+          "description": "Percentage of requests that got submitted more than once",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 47
+          },
+          "id": 212,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position=\"1\"}[5m]))\n/\nsum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!=\"not_submitted\"}[5m]))",
+              "hide": false,
+              "legendFormat": "Attempt #2",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position=\"2\"}[5m]))\n/\nsum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!=\"not_submitted\"}[5m]))",
+              "hide": false,
+              "legendFormat": "Attempt #3",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position=\"3\"}[5m]))\n/\nsum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!=\"not_submitted\"}[5m]))",
+              "hide": false,
+              "legendFormat": "Attempt #4",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position=\"4\"}[5m]))\n/\nsum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!=\"not_submitted\"}[5m]))",
+              "hide": false,
+              "legendFormat": "Attempt #5",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Fixed-UID-testbed"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!~\"(0|1|2|3|4|not_submitted)\"}[5m]))\n/\nsum (rate(sequencing_certificate_latency_count{job=~\"$validator\", position!=\"not_submitted\"}[5m]))",
+              "hide": false,
+              "legendFormat": "Attempt #6+",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Submission amplification",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "Ideally we want the low-score NW validators to not submit transactions",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Transactions / sec",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 57
+          },
+          "id": 45,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(sequencing_acknowledge_latency_count{job=~\"$validator\"}[5m]))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Submission rate by authority",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 1
+                  },
+                  {
+                    "color": "purple",
+                    "value": 100
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 200
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 57
+          },
+          "id": 233,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (authority) (consensus_handler_scores{job=~\"$validator\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Avg score per host",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 70,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red"
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  },
+                  {
+                    "color": "orange",
+                    "value": 100
+                  },
+                  {
+                    "color": "green",
+                    "value": 200
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 57
+          },
+          "id": 241,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (authority) (consensus_handler_scores{job=~\"$validator\"})",
+              "legendFormat": "{{authority}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Score per host change",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "PeerId\\(([a-z0-9]{5}).*\\)",
+                "renamePattern": "$1..."
+              }
+            }
+          ],
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "As reported by consensus handler to every host",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 1
+                  },
+                  {
+                    "color": "purple",
+                    "value": 100
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 200
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 67
+          },
+          "id": 240,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (job) (consensus_handler_num_low_scoring_authorities{job=~\"$validator\"})",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Num low scoring authorities",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 1
+                  },
+                  {
+                    "color": "purple",
+                    "value": 100
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 200
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 67
+          },
+          "id": 265,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (job) (num_of_bad_nodes{job=~\"$validator\"})",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Num of bad nodes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "This is a median value across validators",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 67
+          },
+          "id": 228,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, histogram_quantile(0.95, sum by(le, job) (rate(created_batch_latency_bucket{job=~\"$validator\"}[5m]))))",
+              "hide": false,
+              "legendFormat": "batch_creation",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, histogram_quantile(0.95, sum by(le, job) (rate(proposer_batch_latency_bucket{job=~\"$validator\"}[5m]))))",
+              "hide": false,
+              "legendFormat": "batch_to_header",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(header_to_certificate_latency_bucket{job=~\"$validator\"}[5m]))))",
+              "hide": false,
+              "legendFormat": "header_to_cert",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(certificate_commit_latency_bucket{job=~\"$validator\"}[5m]))))",
+              "hide": false,
+              "legendFormat": "cert_to_commit",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "p95: txn to commit stacked breakdown",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "Individual submissions by each authority",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 1
+                  },
+                  {
+                    "color": "purple",
+                    "value": 100
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 200
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 77
+          },
+          "id": 242,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, sequencing_in_flight_submissions{job=~\"$validator\"})",
+              "hide": false,
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.75, sequencing_in_flight_submissions{job=~\"$validator\"})",
+              "hide": false,
+              "legendFormat": "p75",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Inflight submissions per validator",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "Each authority is doing latency estimates in order to determine the retry intervals.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "dtdurationms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 77
+          },
+          "id": 237,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "clamp(sequencing_estimated_latency{job=~\"$validator\"}, 0, 60000)",
+              "hide": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Consensus Adapter latency estimates",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Load Fractions",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 77
+          },
+          "id": 217,
+          "interval": "1m",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Environment}"
+              },
+              "editorMode": "code",
+              "expr": "avg by (name) (sum by(job,name) (rate(monitored_scope_duration_ns{job=~\"$validator\", name=~\"HandleConsensusOutput|HandleConsensusTransaction|VerifyConsensusTransaction\"}[5m])) / 1000000000)",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Consensus Handler Utilization",
+          "type": "timeseries"
+        }
+      ],
+      "title": "NW behavior from Sui POV",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 89,
+      "panels": [],
+      "title": "Channel and Critical Section Utilizations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Num of processed entries per sec per validator",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Entries / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "id": 87,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job,channel) (rate(label_replace({__name__=~\"tx.*total\", job=~\"$validator\"},\"channel\",\"$1\",\"__name__\", \"(.+)\")[5m:])) ",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Internal channels throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Num of pending entries per channel per validator",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Entries",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed+area"
+            }
+          },
+          "mappings": [],
+          "max": 1100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 700
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job,channel) (label_replace({__name__=~\"tx_.*\", __name__!~\"tx.*total\", job=~\"$validator\"}, \"channel\", \"$1\", \"__name__\", \"(.+)\"))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Internal channels: num pending elements",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "When we receive a certificate for processing we are checking for their parents in our internal storage. If we are missing those, we suspend the processing (with reason \"missing_parents\") and we are trying to fetch those from the other primary nodes. The processing of the certificate resumes only when all their parents are fetched.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Load Fractions",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "id": 5,
+      "interval": "1m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (name) (sum by(job,name) (rate(monitored_scope_duration_ns{job=~\"$validator\", name!~\"CheckpointNotifyRead|ValidateBatch\"}[5m])) / 1000000000)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Critical Section Load",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Consensus Advance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "All the even rounds that failed to commit because of leader not found or not supported",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 71
+      },
+      "id": 205,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(leader_election{job=~\"$validator\", outcome=\"not_found\"}[5m])) / sum (rate(leader_election{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "Leader not found",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(leader_election{job=~\"$validator\", outcome=\"not_enough_support\"}[5m])) / sum (rate(leader_election{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "Not enough support for leader",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pct of rounds that fail to commit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The latest committed round by consensus. On a healthy cluster those numbers shouldn't differ much from each other - if not being almost the exact same",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 71
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(host) (last_committed_round{job=~\"$validator\"})",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Last committed round",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Delta between current round and last committed round. Should not grow.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Rounds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 71
+      },
+      "id": 85,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (current_round) - sum by (job) (last_committed_round{job=~\"$validator\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Commit round depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The latest committed round by consensus. On a healthy cluster those numbers shouldn't differ much from each other - if not being almost the exact same",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 199
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 81
+      },
+      "id": 13,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (last_committed_round{jjob=~\"$validator\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Last committed round",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "In a perfect case every even NW round should generate a commit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 81
+      },
+      "id": 206,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(consensus_commit_rounds_latency_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "hide": false,
+          "legendFormat": "{{host}}-commit",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "1 / rate(current_round{job=~\"$validator\"}[5m])",
+          "hide": false,
+          "legendFormat": "{{host}}-round",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average interval of NW rounds and p95 NW commits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The number of NW certificates in the committed sub-dag",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 81
+      },
+      "id": 163,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "committed_certificates{job=~\"$validator\",pct=\"50\"}",
+          "hide": false,
+          "legendFormat": "{{host}}-p50",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "committed_certificates{job=~\"$validator\",pct=\"95\"}",
+          "hide": false,
+          "legendFormat": "{{host}}-p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NW cert distribution per committed sub-dag",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 73,
+      "panels": [],
+      "title": "Data dissemination",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Since both certs and batches are processed in the consensus handler we can do the math",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 92
+      },
+      "id": 161,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (rate(consensus_handler_processed{job=~\"$validator\"}[5m]))\n/\nsum by (job) (rate(consensus_handler_processed_batches{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Average num of certificates per batch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Batch composition, sealing and delivering to the primary",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 92
+      },
+      "id": 151,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(created_batch_latency_bucket{job=~\"$validator\"}[5m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(created_batch_latency_bucket{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Batch generation latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 92
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.05, sum(rate(created_batch_size_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "legendFormat": "p05",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum(rate(created_batch_size_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "hide": false,
+          "legendFormat": "p25",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(created_batch_size_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum(rate(created_batch_size_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(created_batch_size_bucket{job=~\"$validator\"}[5m])) by (le))",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Batch size distribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Each batch should be delivered to 2f+1 of other workers prior to further processing",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 103
+      },
+      "id": 214,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "parallel_worker_batches{job=~\"$validator\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inflight Batches ",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 114
+      },
+      "id": 222,
+      "panels": [],
+      "title": "Proposer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Time between batch creation and the moment it's included in a header proposal (both p50 and p95 are medians across validators).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 115
+      },
+      "id": 145,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(le, job) (rate(proposer_batch_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(le, job) (rate(proposer_batch_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Batch to Header Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The number of batches waiting to be included in headers in the proposer. A high number shows that batches are not assigned to headers - or the proposed headers don't make it to a successful commit , thus they are returned back to the proposer for re-proposal",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Num batches",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 115
+      },
+      "id": 209,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, sum by(job) (num_of_pending_batches_in_proposer{job=~\"$validator\"}))",
+          "hide": false,
+          "legendFormat": "pct50",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.95, sum by(job) (num_of_pending_batches_in_proposer{job=~\"$validator\"}))",
+          "hide": false,
+          "legendFormat": "pct95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Num of pending batches in proposer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The distribution of the batches per header across the validators.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Num batches",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 115
+      },
+      "id": 220,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (reason, le) (rate(num_of_batch_digests_in_header_bucket{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "{{reason}}-p50",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (reason, le) (rate(num_of_batch_digests_in_header_bucket{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "{{reason}}-p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Num batches per header",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "The time it takes for a certificate from the moment it gets created up to the moment it gets committed (median across validators).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 126
+      },
+      "id": 136,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(job,le) (rate(certificate_commit_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(certificate_commit_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Certificate to Commit Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 137
+      },
+      "id": 224,
+      "panels": [],
+      "title": "DAG advancement",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Time it takes for a header to be materialized to a certificate (median across validators)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 138
+      },
+      "id": 148,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(job,le) (rate(header_to_certificate_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(header_to_certificate_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Header to Certificate Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Time it takes for a new proposal to be generated",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 138
+      },
+      "id": 243,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(job,le) (rate(proposal_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(proposal_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Round advancement latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 138
+      },
+      "id": 168,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le, route) (rate(primary_outbound_request_latency_bucket{job=~\"$validator\",route=~\".*PrimaryToPrimary.*\"}[5m])))",
+          "hide": false,
+          "legendFormat": "{{route}}-p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Primary to Primary Latency by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Certificate is suspended until its parents are retrieved by the node. The dedup and dedup_locked correspond to the cases, in which the same certificate is received while being suspended.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Certificate per sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 149
+      },
+      "id": 219,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "avg by(reason) (rate(certificates_suspended{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Suspended certificates by reason (avg across validators)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Percentiles across validators\nThe value might be larger than 1 in case the same cert is suspended multiple times.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Certificate per sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 149
+      },
+      "id": 229,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5,\nsum by (job) (rate(certificates_suspended{job=~\"$validator\"}[5m]))\n/\nsum by (job) (rate(certificates_processed{job=~\"$validator\"}[5m]))\n)",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.75,\nsum by (job) (rate(certificates_suspended{job=~\"$validator\"}[5m]))\n/\nsum by (job) (rate(certificates_processed{job=~\"$validator\"}[5m]))\n)",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.95,\nsum by (job) (rate(certificates_suspended{job=~\"$validator\"}[5m]))\n/\nsum by (job) (rate(certificates_processed{job=~\"$validator\"}[5m]))\n)",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ratio of suspended to processed certificates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 149
+      },
+      "id": 175,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le, route) (rate(worker_outbound_request_latency_bucket{job=~\"$validator\", route=~\".*WorkerToWorker.*\"}[5m])))",
+          "hide": false,
+          "legendFormat": "{{route}}-p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Worker to Worker Request Latency by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Counts all the processed fetched certificates, triggered by the missing parents.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Certificate per sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 160
+      },
+      "id": 236,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, rate(certificate_fetcher_num_certificates_processed{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.75, rate(certificate_fetcher_num_certificates_processed{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.95, rate(certificate_fetcher_num_certificates_processed{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Fetched certificates per sec for missing ancestors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 160
+      },
+      "id": 250,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (rate(certificates_processed{job=~\"$validator\", source=\"other\"}[5m]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Certificates processed (other)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 160
+      },
+      "id": 262,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(primary_inbound_response_size_bucket{route=\"/narwhal.PrimaryToPrimary/FetchCertificates\", job=~\"$validator\"}[5m])) by (le, job))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fetch Certificates Response Size - p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 171
+      },
+      "id": 249,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (rate(certificates_processed{job=~\"$validator\", source=\"own\"}[5m]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Certificates processed (own)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "In case the delta between outbound and inbound latencies is high, it could be a sign of rate limiting or contention on the handler.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 171
+      },
+      "id": 230,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(route) (rate(primary_outbound_request_latency_sum{job=~\"$validator\",route=~\".*PrimaryToPrimary.*\"}[5m])) / sum by(route) (rate(primary_outbound_request_latency_count{job=~\"$validator\",route=~\".*PrimaryToPrimary.*\"}[5m]))\n-\nsum by(route) (rate(primary_inbound_request_latency_sum{job=~\"$validator\",route=~\".*PrimaryToPrimary.*\"}[5m])) / sum by(route) (rate(primary_inbound_request_latency_count{job=~\"$validator\",route=~\".*PrimaryToPrimary.*\"}[5m]))",
+          "hide": false,
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(route) (rate(worker_outbound_request_latency_sum{job=~\"$validator\", route=~\".*WorkerToWorker.*\"}[5m])) / sum by(route) (rate(worker_outbound_request_latency_count{job=~\"$validator\", route=~\".*WorkerToWorker.*\"}[5m]))\n-\nsum by(route) (rate(worker_inbound_request_latency_sum{job=~\"$validator\", route=~\".*WorkerToWorker.*\"}[5m])) / sum by(route) (rate(worker_inbound_request_latency_count{job=~\"$validator\", route=~\".*WorkerToWorker.*\"}[5m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound vs Inbound Latency Gap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "RPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 171
+      },
+      "id": 231,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, sum by(job) (rate(primary_outbound_request_latency_count{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "primary_outbound",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, sum by(job) (rate(worker_outbound_request_latency_count{job=~\"$validator\"}[5m])))\n",
+          "hide": false,
+          "legendFormat": "worker_outbound",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, sum by(job) (rate(primary_inbound_request_latency_count{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "primary_inbound",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, sum by(job) (rate(worker_inbound_request_latency_count{job=~\"$validator\"}[5m])))",
+          "hide": false,
+          "legendFormat": "worker_inbound",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Anemo rps per validator",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 182
+      },
+      "id": 132,
+      "panels": [],
+      "title": "Executor",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Time between cert creation and the moment it has reached the executor (median across validators).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 183
+      },
+      "id": 139,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(job,le) (rate(subscriber_certificate_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(subscriber_certificate_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Certificate to Subscriber Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Latency between the time when the batch has been created and the moment it has been fetched for execution (median across validators)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 183
+      },
+      "id": 142,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.5, sum by(job,le) (rate(batch_execution_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.5, histogram_quantile(0.95, sum by(job,le) (rate(batch_execution_latency_bucket{job=~\"$validator\"}[5m]))))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Batch to Execution Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 194
+      },
+      "id": 109,
+      "panels": [],
+      "title": "NW Network",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Num of primary peers connected per host",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Num peers connected",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                0,
+                10
+              ],
+              "fill": "dot"
+            },
+            "lineWidth": 3,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 195
+      },
+      "id": 261,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (worker_network_peer_connected{job=~\"$validator\", type=\"other_worker\"})",
+          "hide": false,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Worker network connectivity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Congestion events for primary and worker connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 195
+      },
+      "id": 254,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (rate(worker_network_peer_congestion_events{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "key": "Q-a68ca97d-edc4-4cc5-bc7f-003175cce0c3-8",
+          "legendFormat": "worker-{{host}}",
+          "range": true,
+          "refId": "worker_network_peer_congestion_events"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (rate(primary_network_peer_congestion_events{job=~\"$validator\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "key": "Q-a68ca97d-edc4-4cc5-bc7f-003175cce0c3-8",
+          "legendFormat": "primary-{{host}}",
+          "range": true,
+          "refId": "primary_network_peer_congestion_events"
+        }
+      ],
+      "title": "Congestion Events ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Packet loss for primary and worker connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 195
+      },
+      "id": 252,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (rate(worker_network_peer_lost_packets{job=~\"$validator\"}[5m])) / sum by(job) (rate(worker_network_peer_sent_packets{job=~\"$validator\"}[5m])) * 100",
+          "hide": false,
+          "instant": false,
+          "key": "Q-a68ca97d-edc4-4cc5-bc7f-003175cce0c3-8",
+          "legendFormat": "worker-{{host}}",
+          "range": true,
+          "refId": "worker_network_peer_lost_packets"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job) (rate(primary_network_peer_lost_packets{job=~\"$validator\"}[5m])) / sum by(job) (rate(primary_network_peer_sent_packets{job=~\"$validator\"}[5m])) * 100",
+          "hide": false,
+          "instant": false,
+          "key": "Q-a68ca97d-edc4-4cc5-bc7f-003175cce0c3-8",
+          "legendFormat": "primary-{{host}}",
+          "range": true,
+          "refId": "primary_network_peer_lost_packets"
+        }
+      ],
+      "title": "Packet Loss %",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "revision": 1,
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "testbed",
+          "value": "Fixed-UID-testbed"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "Environment",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${Environment}"
+        },
+        "definition": "label_values(job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator",
+        "multi": true,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sui Validators - Narwhal Only",
+  "uid": "SpRJIxL4z",
+  "version": 10,
+  "weekStart": ""
+}

--- a/crates/sui-aws-orchestrator/src/main.rs
+++ b/crates/sui-aws-orchestrator/src/main.rs
@@ -10,7 +10,7 @@ use eyre::{Context, Result};
 use faults::FaultsType;
 use measurement::MeasurementsCollection;
 use orchestrator::Orchestrator;
-use protocol::sui::{SuiBenchmarkType, SuiProtocol};
+use protocol::narwhal::{NarwhalBenchmarkType, NarwhalProtocol};
 use settings::{CloudProvider, Settings};
 use ssh::SshConnectionManager;
 use testbed::Testbed;
@@ -30,8 +30,8 @@ pub mod ssh;
 pub mod testbed;
 
 /// NOTE: Link these types to the correct protocol.
-type Protocol = SuiProtocol;
-type BenchmarkType = SuiBenchmarkType;
+type Protocol = NarwhalProtocol;
+type BenchmarkType = NarwhalBenchmarkType;
 
 #[derive(Parser)]
 #[command(author, version, about = "Testbed orchestrator", long_about = None)]
@@ -280,7 +280,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 .wrap_err("Failed to load testbed setup commands")?;
 
             let protocol_commands = Protocol::new(&settings);
-            let sui_benchmark_type = BenchmarkType::from_str(&benchmark_type)?;
+            let benchmark_type = BenchmarkType::from_str(&benchmark_type)?;
 
             let load = match load_type {
                 Load::FixedLoad { loads } => {
@@ -306,7 +306,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             };
 
             let generator = BenchmarkParametersGenerator::new(committee, load)
-                .with_benchmark_type(sui_benchmark_type)
+                .with_benchmark_type(benchmark_type)
                 .with_custom_duration(duration)
                 .with_faults(fault_type);
 

--- a/crates/sui-aws-orchestrator/src/main.rs
+++ b/crates/sui-aws-orchestrator/src/main.rs
@@ -29,7 +29,10 @@ pub mod settings;
 pub mod ssh;
 pub mod testbed;
 
-/// NOTE: Link these types to the correct protocol.
+/// NOTE: Link these types to the correct protocol. Either Sui or Narwhal.
+// use protocol::sui::{SuiBenchmarkType, SuiProtocol};
+// type Protocol = SuiProtocol;
+// type BenchmarkType = SuiBenchmarkType;
 type Protocol = NarwhalProtocol;
 type BenchmarkType = NarwhalBenchmarkType;
 

--- a/crates/sui-aws-orchestrator/src/measurement.rs
+++ b/crates/sui-aws-orchestrator/src/measurement.rs
@@ -96,7 +96,7 @@ impl Measurement {
             .iter()
             .find(|x| x.metric == M::BENCHMARK_DURATION)
             .map(|x| match x.value {
-                prometheus_parse::Value::Counter(value) => Duration::from_secs(value as u64),
+                prometheus_parse::Value::Gauge(value) => Duration::from_secs(value as u64),
                 _ => panic!("Unexpected scraped value"),
             })
             .unwrap_or_default();

--- a/crates/sui-aws-orchestrator/src/measurement.rs
+++ b/crates/sui-aws-orchestrator/src/measurement.rs
@@ -340,7 +340,7 @@ mod test {
     fn prometheus_parse() {
         let report = r#"
             # HELP benchmark_duration Duration of the benchmark
-            # TYPE benchmark_duration counter
+            # TYPE benchmark_duration gauge
             benchmark_duration 30
             # HELP latency_s Total time in seconds to return a response
             # TYPE latency_s histogram

--- a/crates/sui-aws-orchestrator/src/orchestrator.rs
+++ b/crates/sui-aws-orchestrator/src/orchestrator.rs
@@ -441,8 +441,12 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         // Select the instances to run.
         let (clients, nodes, _) = self.select_instances(parameters)?;
 
-        // Regularly scrape the client metrics.
-        let metrics_commands = self.protocol_commands.clients_metrics_command(clients);
+        // Regularly scrape the client
+        let mut metrics_commands = self.protocol_commands.clients_metrics_command(clients);
+
+        // TODO: Remove this when narwhal client latency metrics are available.
+        // We will be getting latency metrics directly from narwhal nodes instead from the nw client
+        metrics_commands.append(&mut self.protocol_commands.nodes_metrics_command(nodes.clone()));
 
         let mut aggregator = MeasurementsCollection::new(&self.settings, parameters.clone());
         let mut metrics_interval = time::interval(self.scrape_interval);

--- a/crates/sui-aws-orchestrator/src/protocol/mod.rs
+++ b/crates/sui-aws-orchestrator/src/protocol/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     client::Instance,
 };
 
+pub mod narwhal;
 pub mod sui;
 
 /// The minimum interface that the protocol should implement to allow benchmarks from
@@ -55,7 +56,7 @@ pub trait ProtocolCommands<T: BenchmarkType> {
 pub trait ProtocolMetrics {
     /// The name of the metric reporting the total duration of the benchmark (in seconds).
     const BENCHMARK_DURATION: &'static str;
-    /// The name of the metric reporting the total number of finalized transactions/
+    /// The name of the metric reporting the total number of finalized transactions
     const TOTAL_TRANSACTIONS: &'static str;
     /// The name of the metric reporting the latency buckets.
     const LATENCY_BUCKETS: &'static str;

--- a/crates/sui-aws-orchestrator/src/protocol/narwhal.rs
+++ b/crates/sui-aws-orchestrator/src/protocol/narwhal.rs
@@ -1,0 +1,275 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    fmt::{Debug, Display},
+    path::PathBuf,
+    str::FromStr,
+};
+
+use crate::{
+    benchmark::{BenchmarkParameters, BenchmarkType},
+    client::Instance,
+    settings::Settings,
+};
+use narwhal_config::PrometheusMetricsParameters;
+use serde::{Deserialize, Serialize};
+
+use super::{ProtocolCommands, ProtocolMetrics};
+
+const NUM_WORKERS: usize = 1;
+const BASE_PORT: usize = 5000;
+
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NarwhalBenchmarkType {
+    /// The size of each transaciton in bytes
+    size: usize,
+}
+
+impl Debug for NarwhalBenchmarkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.size)
+    }
+}
+
+impl Display for NarwhalBenchmarkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "tx size {}b", self.size)
+    }
+}
+
+impl FromStr for NarwhalBenchmarkType {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            size: s.parse::<usize>()?.min(1000000),
+        })
+    }
+}
+
+impl BenchmarkType for NarwhalBenchmarkType {}
+
+/// All configurations information to run a narwhal client or validator.
+pub struct NarwhalProtocol {
+    working_dir: PathBuf,
+}
+
+impl ProtocolCommands<NarwhalBenchmarkType> for NarwhalProtocol {
+    fn protocol_dependencies(&self) -> Vec<&'static str> {
+        vec![
+            // Install typical narwhal dependencies.
+            "sudo apt-get -y install curl git-all clang cmake gcc libssl-dev pkg-config libclang-dev",
+            "sudo apt-get -y install libpq-dev",
+        ]
+    }
+
+    fn db_directories(&self) -> Vec<PathBuf> {
+        let consensus_db = [&self.working_dir, &format!("db-*").into()]
+            .iter()
+            .collect();
+
+        let narwhal_config = [&self.working_dir].iter().collect();
+        vec![consensus_db, narwhal_config]
+    }
+
+    fn genesis_command<'a, I>(&self, instances: I) -> String
+    where
+        I: Iterator<Item = &'a Instance>,
+    {
+        let working_dir = self.working_dir.display();
+        let ips = instances
+            .map(|x| x.main_ip.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let genesis = [
+            "cargo run --release --bin narwhal-node benchmark-genesis",
+            &format!(
+                " --working-directory {working_dir} --ips {ips} --num-workers {NUM_WORKERS} --base-port {BASE_PORT}"
+            ),
+        ]
+        .join(" ");
+
+        [
+            &format!("mkdir -p {working_dir}"),
+            "source $HOME/.cargo/env",
+            &genesis,
+        ]
+        .join(" && ")
+    }
+
+    fn monitor_command<I>(&self, _instances: I) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        vec![]
+    }
+
+    fn node_command<I>(
+        &self,
+        instances: I,
+        _parameters: &BenchmarkParameters<NarwhalBenchmarkType>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        let working_dir = self.working_dir.clone();
+
+        instances
+            .into_iter()
+            .enumerate()
+            .map(|(i, instance)| {
+                let primary_keys: PathBuf = [&working_dir, &format!("primary-{i}-key.json").into()]
+                    .iter()
+                    .collect();
+                let primary_network_keys: PathBuf = [
+                    &working_dir,
+                    &format!("primary-{i}-network-key.json").into(),
+                ]
+                .iter()
+                .collect();
+                // todo: add logic for multiple workers
+                let worker_keys: PathBuf = [&working_dir, &format!("worker-{i}-key.json").into()]
+                    .iter()
+                    .collect();
+                let committee: PathBuf = [&working_dir, &format!("committee.json").into()]
+                    .iter()
+                    .collect();
+                let workers: PathBuf = [&working_dir, &format!("workers.json").into()]
+                    .iter()
+                    .collect();
+                let store: PathBuf = [&working_dir, &format!("db-{i}").into()].iter().collect();
+                let parameters: PathBuf = [&working_dir, &format!("parameters.json").into()]
+                    .iter()
+                    .collect();
+
+                let run = [
+                    "RUST_LOG=debug cargo run --release --bin narwhal-node run ",
+                    &format!(
+                        "--primary-keys {} --primary-network-keys {} ",
+                        primary_keys.display(),
+                        primary_network_keys.display()
+                    ),
+                    &format!(
+                        "--worker-keys {} --committee {} --workers {} ",
+                        worker_keys.display(),
+                        committee.display(),
+                        workers.display()
+                    ),
+                    &format!(
+                        "--store {} --parameters {} benchmark 0",
+                        store.display(),
+                        parameters.display()
+                    ),
+                ]
+                .join(" ");
+                let command = ["source $HOME/.cargo/env", &run].join(" && ");
+
+                (instance, command)
+            })
+            .collect()
+    }
+
+    fn client_command<I>(
+        &self,
+        instances: I,
+        parameters: &BenchmarkParameters<NarwhalBenchmarkType>,
+    ) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        let clients: Vec<_> = instances.into_iter().collect();
+        // 2 ports used per authority so add 2 * num authorities to base port
+        let mut worker_base_port = BASE_PORT + (2 * clients.len());
+
+        let transaction_addresses: Vec<_> = clients
+            .iter()
+            .map(|instance| {
+                let transaction_address =
+                    format!("http://{}:{}", instance.main_ip, worker_base_port);
+                worker_base_port += 2;
+                transaction_address
+            })
+            .collect();
+
+        clients
+            .into_iter()
+            .enumerate()
+            .map(|(i, instance)| {
+                let run = [
+                    "RUST_LOG=info cargo run --release --features benchmark --bin narwhal-benchmark-client -- ",
+                    &format!(
+                        "--addr {} --size {} --rate {} --nodes {} --client-metric-port {}",
+                        transaction_addresses[i],
+                        parameters.benchmark_type.size,
+                        parameters.load / parameters.nodes,
+                        transaction_addresses.join(","),
+                        Self::CLIENT_METRICS_PORT
+                    ),
+                ]
+                .join(" ");
+                let command = ["source $HOME/.cargo/env", &run].join(" && ");
+
+                (instance, command)
+            })
+            .collect()
+    }
+}
+
+impl NarwhalProtocol {
+    const CLIENT_METRICS_PORT: u16 = 8081;
+
+    /// Make a new instance of the Narwhal protocol commands generator.
+    pub fn new(settings: &Settings) -> Self {
+        Self {
+            working_dir: [&settings.working_dir, &"narwhal_config".into()]
+                .iter()
+                .collect(),
+        }
+    }
+}
+
+impl ProtocolMetrics for NarwhalProtocol {
+    const BENCHMARK_DURATION: &'static str = "benchmark_duration";
+    const TOTAL_TRANSACTIONS: &'static str = "latency_s_count";
+    const LATENCY_BUCKETS: &'static str = "latency_s";
+    const LATENCY_SUM: &'static str = "latency_s_sum";
+    const LATENCY_SQUARED_SUM: &'static str = "latency_squared_s";
+
+    fn nodes_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        instances
+            .into_iter()
+            .map(|instance| {
+                let path = format!(
+                    "{}:{}{}",
+                    instance.main_ip,
+                    PrometheusMetricsParameters::DEFAULT_PORT,
+                    mysten_metrics::METRICS_ROUTE
+                );
+                (instance, path)
+            })
+            .collect()
+    }
+
+    fn clients_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        instances
+            .into_iter()
+            .map(|instance| {
+                let path = format!(
+                    "{}:{}{}",
+                    instance.main_ip,
+                    Self::CLIENT_METRICS_PORT,
+                    mysten_metrics::METRICS_ROUTE
+                );
+                (instance, path)
+            })
+            .collect()
+    }
+}

--- a/crates/sui-aws-orchestrator/src/protocol/narwhal.rs
+++ b/crates/sui-aws-orchestrator/src/protocol/narwhal.rs
@@ -65,7 +65,7 @@ impl ProtocolCommands<NarwhalBenchmarkType> for NarwhalProtocol {
     }
 
     fn db_directories(&self) -> Vec<PathBuf> {
-        let consensus_db = [&self.working_dir, &format!("db-*").into()]
+        let consensus_db = [&self.working_dir, &"db-*".to_string().into()]
             .iter()
             .collect();
 
@@ -133,14 +133,14 @@ impl ProtocolCommands<NarwhalBenchmarkType> for NarwhalProtocol {
                 let worker_keys: PathBuf = [&working_dir, &format!("worker-{i}-key.json").into()]
                     .iter()
                     .collect();
-                let committee: PathBuf = [&working_dir, &format!("committee.json").into()]
+                let committee: PathBuf = [&working_dir, &"committee.json".to_string().into()]
                     .iter()
                     .collect();
-                let workers: PathBuf = [&working_dir, &format!("workers.json").into()]
+                let workers: PathBuf = [&working_dir, &"workers.json".to_string().into()]
                     .iter()
                     .collect();
                 let store: PathBuf = [&working_dir, &format!("db-{i}").into()].iter().collect();
-                let parameters: PathBuf = [&working_dir, &format!("parameters.json").into()]
+                let parameters: PathBuf = [&working_dir, &"parameters.json".to_string().into()]
                     .iter()
                     .collect();
 
@@ -231,11 +231,11 @@ impl NarwhalProtocol {
 }
 
 impl ProtocolMetrics for NarwhalProtocol {
-    const BENCHMARK_DURATION: &'static str = "benchmark_duration";
-    const TOTAL_TRANSACTIONS: &'static str = "latency_s_count";
-    const LATENCY_BUCKETS: &'static str = "latency_s";
-    const LATENCY_SUM: &'static str = "latency_s_sum";
-    const LATENCY_SQUARED_SUM: &'static str = "latency_squared_s";
+    const BENCHMARK_DURATION: &'static str = "narwhal_benchmark_duration";
+    const TOTAL_TRANSACTIONS: &'static str = "narwhal_client_latency_s_count";
+    const LATENCY_BUCKETS: &'static str = "narwhal_client_latency_s";
+    const LATENCY_SUM: &'static str = "narwhal_client_latency_s_sum";
+    const LATENCY_SQUARED_SUM: &'static str = "narwhal_client_latency_squared_s";
 
     fn nodes_metrics_path<I>(&self, instances: I) -> Vec<(Instance, String)>
     where

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -10,13 +10,13 @@ use futures::FutureExt;
 use futures::{stream::FuturesUnordered, StreamExt};
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
-use prometheus::HistogramVec;
+use prometheus::register_histogram_vec_with_registry;
 use prometheus::IntCounterVec;
 use prometheus::Registry;
 use prometheus::{register_counter_vec_with_registry, register_gauge_vec_with_registry};
-use prometheus::{register_histogram_vec_with_registry, register_int_counter_with_registry};
 use prometheus::{register_int_counter_vec_with_registry, CounterVec};
-use prometheus::{GaugeVec, IntCounter};
+use prometheus::{register_int_gauge_with_registry, GaugeVec};
+use prometheus::{HistogramVec, IntGauge};
 use rand::seq::SliceRandom;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::OnceCell;
@@ -46,7 +46,7 @@ use tracing::{debug, error, info, warn};
 use super::Interval;
 use super::{BenchmarkStats, StressStats};
 pub struct BenchMetrics {
-    pub benchmark_duration: IntCounter,
+    pub benchmark_duration: IntGauge,
     pub num_success: IntCounterVec,
     pub num_error: IntCounterVec,
     pub num_submitted: IntCounterVec,
@@ -66,7 +66,7 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
 impl BenchMetrics {
     fn new(registry: &Registry) -> Self {
         BenchMetrics {
-            benchmark_duration: register_int_counter_with_registry!(
+            benchmark_duration: register_int_gauge_with_registry!(
                 "benchmark_duration",
                 "Duration of the benchmark",
                 registry,
@@ -711,12 +711,9 @@ async fn run_bench_worker(
                 let latency = start.elapsed();
                 let time_from_start = total_benchmark_start_time.elapsed();
 
-                if let Some(delta) = time_from_start
-                    .as_secs()
-                    .checked_sub(metrics_cloned.benchmark_duration.get())
-                {
-                    metrics_cloned.benchmark_duration.inc_by(delta);
-                }
+                metrics_cloned
+                    .benchmark_duration
+                    .set(time_from_start.as_secs() as i64);
 
                 let square_latency_ms = latency.as_secs_f64().powf(2.0);
                 metrics_cloned

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -148,6 +148,8 @@ impl Display for AuthorityIdentifier {
 }
 
 impl Committee {
+    pub const DEFAULT_FILENAME: &'static str = "committee.json";
+
     /// Any committee should be created via the CommitteeBuilder - this is intentionally be marked as
     /// private method.
     fn new(authorities: BTreeMap<PublicKey, Authority>, epoch: Epoch) -> Self {

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -189,6 +189,8 @@ pub struct Parameters {
 }
 
 impl Parameters {
+    pub const DEFAULT_FILENAME: &'static str = "parameters.json";
+
     fn default_header_num_of_batches_threshold() -> usize {
         32
     }
@@ -325,6 +327,8 @@ impl Default for PrometheusMetricsParameters {
 }
 
 impl PrometheusMetricsParameters {
+    pub const DEFAULT_PORT: usize = 9184;
+
     fn with_available_port(&self) -> Self {
         let mut params = self.clone();
         let default = Self::default();
@@ -464,6 +468,8 @@ impl std::fmt::Display for WorkerCache {
 }
 
 impl WorkerCache {
+    pub const DEFAULT_FILENAME: &'static str = "workers.json";
+
     /// Returns the current epoch.
     pub fn epoch(&self) -> Epoch {
         self.epoch

--- a/narwhal/node/src/benchmark_client.rs
+++ b/narwhal/node/src/benchmark_client.rs
@@ -1,11 +1,15 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use bytes::{BufMut as _, BytesMut};
-use clap::Parser;
+use bytes::BytesMut;
+use clap::*;
 use eyre::Context;
 use futures::{future::join_all, StreamExt};
-use rand::Rng;
+use narwhal_node::metrics::BenchMetrics;
+use prometheus::Registry;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::str::FromStr;
+use std::time::SystemTime;
 use tokio::{
     net::TcpStream,
     time::{interval, sleep, Duration, Instant},
@@ -21,20 +25,31 @@ use url::Url;
 /// * the size of the transactions via the --size property
 /// * the worker address <ADDR> to send the transactions to. A url format is expected ex http://127.0.0.1:7000
 /// * the rate of sending transactions via the --rate parameter
-/// Optionally the --nodes parameter can be passed where a list (comma separated string) of worker addresses
+/// Optionally the --nodes parameter can be passed where a list of worker addresses
 /// should be passed. The benchmarking client will first try to connect to all of those nodes before start sending
 /// any transactions. That confirms the system is up and running and ready to start processing the transactions.
 #[derive(Parser)]
-#[command(author, version, about)]
+#[clap(name = "Narwhal Stress Testing Framework")]
 struct App {
     /// The network address of the node where to send txs. A url format is expected ex 'http://127.0.0.1:7000'
-    addr: String,
+    #[clap(long, value_parser = parse_url, global = true)]
+    addr: Url,
     /// The size of each transaciton in bytes
+    #[clap(long, default_value = "512", global = true)]
     size: usize,
     /// The rate (txs/s) at which to send the transactions
+    #[clap(long, default_value = "100", global = true)]
     rate: u64,
-    /// Network addresses, comma separated, that must be reachable before starting the benchmark.
-    nodes: String,
+    /// Network addresses that must be reachable before starting the benchmark.
+    #[clap(long, value_delimiter = ',', value_parser = parse_url, global = true)]
+    nodes: Vec<Url>,
+    /// Optional duration of the benchmark in seconds. If not provided the benchmark will run forever.
+    #[clap(long, global = true)]
+    duration: Option<u64>,
+    #[clap(long, default_value = "0.0.0.0", global = true)]
+    client_metric_host: String,
+    #[clap(long, default_value = "8081", global = true)]
+    client_metric_port: u16,
 }
 
 #[tokio::main]
@@ -57,20 +72,27 @@ async fn main() -> Result<(), eyre::Report> {
 
     set_global_default(subscriber).expect("Failed to set subscriber");
 
-    let target = app.addr.parse::<Url>().with_context(|| {
-        format!(
-            "Invalid url format {}. Should provide something like http://127.0.0.1:7000",
-            app.addr,
-        )
-    })?;
+    let registry_service = mysten_metrics::start_prometheus_server(
+        format!("{}:{}", app.client_metric_host, app.client_metric_port)
+            .parse()
+            .unwrap(),
+    );
+    let registry: Registry = registry_service.default_registry();
+    mysten_metrics::init_metrics(&registry);
+    let metrics = BenchMetrics::new(&registry);
+
+    let target = app.addr;
     let size = app.size;
     let rate = app.rate;
-    let nodes = app
-        .nodes
-        .split(',')
-        .map(|x| x.parse::<Url>())
-        .collect::<Result<Vec<_>, _>>()
-        .with_context(|| format!("Invalid url format {}", app.nodes))?;
+    let nodes = app.nodes;
+
+    let duration: Option<Duration> = match app.duration {
+        Some(d) => {
+            info!("Benchmark Duration: {d}");
+            Some(Duration::from_secs(d))
+        }
+        None => None,
+    };
 
     info!("Node address: {target}");
 
@@ -85,9 +107,11 @@ async fn main() -> Result<(), eyre::Report> {
         size,
         rate,
         nodes,
+        duration,
+        metrics,
     };
 
-    // Wait for all nodes to be online and synchronized.
+    // Wait for all nodes to be online and synchronized, if any.
     client.wait().await;
 
     // Start the benchmark.
@@ -99,35 +123,31 @@ struct Client {
     size: usize,
     rate: u64,
     nodes: Vec<Url>,
+    duration: Option<Duration>,
+    metrics: BenchMetrics,
 }
 
 impl Client {
+    const TARGET_BATCH_INTERVAL: Duration = Duration::from_millis(100);
+
     pub async fn send(&self) -> Result<(), eyre::Report> {
-        // We are distributing the transactions that need to be sent
-        // within a second to sub-buckets. The precision here represents
-        // the number of such buckets within the period of 1 second.
-        const PRECISION: u64 = 20;
-        // The BURST_DURATION represents the period for each bucket we
-        // have split. For example if precision is 20 the 1 second (1000ms)
-        // will be split in 20 buckets where each one will be 50ms apart.
-        // Basically we are looking to send a list of transactions every 50ms.
-        const BURST_DURATION: u64 = 1000 / PRECISION;
-
-        let burst = self.rate / PRECISION;
-
-        if burst == 0 {
-            return Err(eyre::Report::msg(format!(
-                "Transaction rate is too low, should be at least {} tx/s and multiples of {}",
-                PRECISION, PRECISION
-            )));
-        }
-
         // The transaction size must be at least 16 bytes to ensure all txs are different.
-        if self.size < 9 {
+        if self.size < 16 {
             return Err(eyre::Report::msg(
-                "Transaction size must be at least 9 bytes",
+                "Transaction size must be at least 16 bytes",
             ));
         }
+
+        let transactions_per_100ms = (self.rate + 9) / 10;
+
+        let mut counter = 0;
+        let mut rng = StdRng::seed_from_u64(self.target.port().unwrap() as u64);
+        let mut random: u64 = rng.gen(); // 8 bytes
+        let interval = interval(Self::TARGET_BATCH_INTERVAL);
+        tokio::pin!(interval);
+
+        let start_time = Instant::now();
+        let end_time = self.duration.map(|d| Instant::now() + d);
 
         // Connect to the mempool.
         let mut client = TransactionsClient::connect(self.target.as_str().to_owned())
@@ -135,56 +155,77 @@ impl Client {
             .context(format!("failed to connect to {}", self.target))?;
 
         // Submit all transactions.
-        let mut counter = 0;
-        let mut r = rand::thread_rng().gen();
-        let interval = interval(Duration::from_millis(BURST_DURATION));
-        tokio::pin!(interval);
-
-        // NOTE: This log entry is used to compute performance.
-        info!("Start sending transactions");
-
-        'main: loop {
+        info!("Sending transactions...");
+        loop {
             interval.as_mut().tick().await;
+
+            if let Some(end) = end_time {
+                if Instant::now() > end {
+                    break;
+                }
+            }
+
+            let time_from_start = start_time.elapsed();
+            if let Some(delta) = time_from_start
+                .as_secs()
+                .checked_sub(self.metrics.benchmark_duration.get())
+            {
+                self.metrics.benchmark_duration.inc_by(delta);
+            }
+
+            let size = self.size;
+            let timestamp = (timestamp_utc().as_millis() as u64).to_le_bytes();
+            random += counter;
+            let stream = tokio_stream::iter(0..transactions_per_100ms).map(move |x| {
+                random += x + 1;
+
+                let mut transaction = BytesMut::with_capacity(size);
+                let zeros = vec![0u8; size - 8 - 8]; // 8 bytes timestamp + 8 bytes random
+                transaction.extend_from_slice(&timestamp); // 8 bytes
+                transaction.extend_from_slice(&random.to_le_bytes()); // 8 bytes
+                transaction.extend_from_slice(&zeros[..]);
+
+                TransactionProto {
+                    transaction: transaction.into(),
+                }
+            });
+
+            counter += transactions_per_100ms;
+
             let now = Instant::now();
 
-            let mut tx = BytesMut::with_capacity(self.size);
-            let size = self.size;
-            let stream = tokio_stream::iter(0..burst).map(move |x| {
-                if x == counter % burst {
-                    // NOTE: This log entry is used to compute performance.
-                    info!("Sending sample transaction {counter}");
-
-                    tx.put_u8(0u8); // Sample txs start with 0.
-                    tx.put_u64(counter); // This counter identifies the tx.
-                } else {
-                    r += 1;
-                    tx.put_u8(1u8); // Standard txs start with 1.
-                    tx.put_u64(r); // Ensures all clients send different txs.
-                };
-
-                tx.resize(size, 0u8);
-                let bytes = tx.split().freeze();
-                TransactionProto { transaction: bytes }
-            });
+            let recorded_count = self.metrics.num_submitted.get();
+            self.metrics.num_submitted.inc_by(transactions_per_100ms);
 
             if let Err(e) = client.submit_transaction_stream(stream).await {
                 warn!("Failed to send transaction: {e}");
-                break 'main;
-            }
+                self.metrics.num_error.inc_by(transactions_per_100ms);
+            } else {
+                let latency_s = now.elapsed().as_secs_f64();
+                let latency_squared_s = latency_s.powf(2.0);
+                for _ in 0..transactions_per_100ms {
+                    // record client latencies per transaction
+                    self.metrics.latency_s.observe(latency_s);
+                    self.metrics.latency_squared_s.inc_by(latency_squared_s);
+                }
 
-            if now.elapsed().as_millis() > BURST_DURATION as u128 {
-                // NOTE: This log entry is used to compute performance.
-                warn!("Transaction rate too high for this client");
+                self.metrics.num_success.inc_by(transactions_per_100ms);
+
+                info!(
+                    "Submmitted {counter} total transactions at rate ~ {} tx/s",
+                    counter / time_from_start.as_secs().max(1)
+                );
             }
-            counter += 1;
         }
         Ok(())
     }
 
     pub async fn wait(&self) {
         // Wait for all nodes to be online.
-        info!("Waiting for all nodes to be online...");
-        join_all(self.nodes.iter().cloned().map(|address| {
+        let mut all_nodes = self.nodes.clone();
+        all_nodes.push(self.target.clone());
+        join_all(all_nodes.iter().cloned().map(|address| {
+            info!("Waiting for {address} to be online...");
             tokio::spawn(async move {
                 while TcpStream::connect(&*address.socket_addrs(|| None).unwrap())
                     .await
@@ -196,4 +237,14 @@ impl Client {
         }))
         .await;
     }
+}
+
+fn parse_url(s: &str) -> Result<Url, url::ParseError> {
+    Url::from_str(s)
+}
+
+pub fn timestamp_utc() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
 }

--- a/narwhal/node/src/benchmark_client.rs
+++ b/narwhal/node/src/benchmark_client.rs
@@ -139,7 +139,9 @@ impl Client {
 
         let mut handles = Vec::new();
 
-        let num_parallel_tasks = 10;
+        // TODO: figure out how to scale the client without needing to scale tasks
+        // Current results are showing about 10 tx/s per task.
+        let num_parallel_tasks = self.rate.min(25000);
         let rate_per_task = self.rate / num_parallel_tasks;
         let target_tx_interval: Duration = Duration::from_millis(1000 / rate_per_task);
         info!(

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -46,11 +46,12 @@ use sui_types::{
 };
 use telemetry_subscribers::TelemetryGuards;
 use tokio::sync::mpsc::channel;
-#[cfg(feature = "benchmark")]
-use tracing::subscriber::set_global_default;
+// TODO: remove when old benchmark code is removed
+// #[cfg(feature = "benchmark")]
+// use tracing::subscriber::set_global_default;
+// #[cfg(feature = "benchmark")]
+// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing::{info, warn};
-#[cfg(feature = "benchmark")]
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use worker::TrivialTransactionValidator;
 
 #[derive(Parser)]
@@ -277,7 +278,7 @@ fn benchmark_genesis(
     base_port: usize,
 ) -> Result<()> {
     tracing::info!("Generating benchmark genesis files");
-    fs::create_dir_all(&working_directory).wrap_err(format!(
+    fs::create_dir_all(working_directory).wrap_err(format!(
         "Failed to create directory '{}'",
         working_directory.display()
     ))?;
@@ -350,7 +351,7 @@ fn benchmark_genesis(
     tracing::info!("Generated committee file: {}", committee_path.display());
 
     committee
-        .export(&committee_path.as_path().as_os_str().to_str().unwrap())
+        .export(committee_path.as_path().as_os_str().to_str().unwrap())
         .expect("Failed to export committee file");
 
     // Generate workers keys
@@ -390,15 +391,10 @@ fn benchmark_genesis(
 
             let worker_info = WorkerInfo {
                 name: worker_network_key,
-                transactions: Multiaddr::try_from(format!(
-                    "/ip4/{}/tcp/{}/http",
-                    ip.to_string(),
-                    worker_base_port
-                ))
-                .unwrap(),
+                transactions: Multiaddr::try_from(format!("/ip4/{ip}/tcp/{worker_base_port}/http"))
+                    .unwrap(),
                 worker_address: Multiaddr::try_from(format!(
-                    "/ip4/{}/udp/{}",
-                    ip.to_string(),
+                    "/ip4/{ip}/udp/{}",
                     worker_base_port + 1
                 ))
                 .unwrap(),
@@ -413,7 +409,7 @@ fn benchmark_genesis(
     }
 
     worker_cache
-        .export(&workers_path.as_path().as_os_str().to_str().unwrap())
+        .export(workers_path.as_path().as_os_str().to_str().unwrap())
         .expect("Failed to export workers file");
 
     // Generate node parameters config
@@ -430,7 +426,7 @@ fn benchmark_genesis(
         ..Default::default()
     };
     parameters
-        .export(&parameters_path.as_path().as_os_str().to_str().unwrap())
+        .export(parameters_path.as_path().as_os_str().to_str().unwrap())
         .expect("Failed to export parameters file");
     tracing::info!(
         "Generated (public) parameters file: {}",

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -7,30 +7,43 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
-
 use clap::{Parser, Subcommand};
-use config::{ChainIdentifier, Committee, Import, Parameters, WorkerCache, WorkerId};
+use config::{
+    ChainIdentifier, Committee, CommitteeBuilder, Epoch, Export, Import, Parameters,
+    PrometheusMetricsParameters, WorkerCache, WorkerId, WorkerIndex, WorkerInfo,
+};
 use crypto::{KeyPair, NetworkKeyPair};
-use eyre::Context;
-use fastcrypto::traits::KeyPair as _;
-use mysten_metrics::RegistryService;
+use eyre::{Context, Result};
+use fastcrypto::traits::{EncodeDecodeBase64, KeyPair as _};
+use futures::join;
+use mysten_metrics::start_prometheus_server;
 use narwhal_node as node;
 use narwhal_node::primary_node::PrimaryNode;
 use narwhal_node::worker_node::WorkerNode;
 use network::client::NetworkClient;
 use node::{
     execution_state::SimpleExecutionState,
-    metrics::{primary_metrics_registry, start_prometheus_server, worker_metrics_registry},
+    metrics::{primary_metrics_registry, worker_metrics_registry},
 };
 use prometheus::Registry;
-use std::path::{Path, PathBuf};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 use storage::{CertificateStoreCacheMetrics, NodeStorage};
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_network_keypair_from_file,
     write_authority_keypair_to_file, write_keypair_to_file,
 };
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
-use sui_types::crypto::{get_key_pair_from_rng, AuthorityKeyPair, SuiKeyPair};
+use sui_types::{
+    crypto::{
+        get_key_pair_from_rng, AuthorityKeyPair, AuthorityPublicKey, NetworkPublicKey, SuiKeyPair,
+    },
+    multiaddr::Multiaddr,
+};
 use telemetry_subscribers::TelemetryGuards;
 use tokio::sync::mpsc::channel;
 #[cfg(feature = "benchmark")]
@@ -53,6 +66,27 @@ struct App {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Generate a committee, workers and the parameters config files of all validators
+    /// from a list of initial peers. This is only suitable for benchmarks as it exposes all keys.
+    BenchmarkGenesis {
+        #[clap(
+            long,
+            value_name = "ADDR",
+            num_args(1..),
+            value_delimiter = ',',
+            help = "A list of ip addresses to generate a genesis suitable for benchmarks"
+        )]
+        ips: Vec<String>,
+        /// The working directory where the files will be generated.
+        #[clap(long, value_name = "FILE", default_value = "genesis")]
+        working_directory: PathBuf,
+        /// The number of workers per authority
+        #[clap(long, value_name = "NUM", default_value = "1")]
+        num_workers: usize,
+        /// The base port
+        #[clap(long, value_name = "PORT", default_value = "5000")]
+        base_port: usize,
+    },
     /// Save an encoded bls12381 keypair (Base64 encoded `privkey`) to file
     GenerateKeys {
         /// The file where to save the encoded authority key pair
@@ -109,6 +143,11 @@ enum NodeType {
         /// The worker Id
         id: WorkerId,
     },
+    /// Run a primary & worker in the same process as part of benchmark
+    Benchmark {
+        /// The worker Id
+        worker_id: WorkerId,
+    },
 }
 
 #[tokio::main]
@@ -135,6 +174,12 @@ async fn main() -> Result<(), eyre::Report> {
     let _guard = setup_telemetry(tracing_level, network_tracing_level, None);
 
     match &app.command {
+        Commands::BenchmarkGenesis {
+            ips,
+            working_directory,
+            num_workers,
+            base_port,
+        } => benchmark_genesis(ips, working_directory, *num_workers, *base_port)?,
         Commands::GenerateKeys { filename } => {
             let keypair: AuthorityKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
             write_authority_keypair_to_file(&keypair, filename).unwrap();
@@ -186,20 +231,25 @@ async fn main() -> Result<(), eyre::Report> {
                 .unwrap()
                 .id();
 
-            let registry = match subcommand {
-                NodeType::Primary => primary_metrics_registry(authority_id),
-                NodeType::Worker { id } => worker_metrics_registry(*id, authority_id),
+            let (primary_registry, worker_registry) = match subcommand {
+                NodeType::Primary => (Some(primary_metrics_registry(authority_id)), None),
+                NodeType::Worker { id } => (None, Some(worker_metrics_registry(*id, authority_id))),
+                NodeType::Benchmark { worker_id } => (
+                    Some(primary_metrics_registry(authority_id)),
+                    Some(worker_metrics_registry(*worker_id, authority_id)),
+                ),
             };
 
+            // TODO: re-enable telemetry if needed, otherwise remove when old benchmark code is removed
             // In benchmarks, transactions are not deserializable => many errors at the debug level
             // Moreover, we need RFC 3339 timestamps to parse properly => we use a custom subscriber.
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "benchmark")] {
-                    setup_benchmark_telemetry(tracing_level, network_tracing_level)?;
-                } else {
-                    let _guard = setup_telemetry(tracing_level, network_tracing_level, Some(&registry));
-                }
-            }
+            // cfg_if::cfg_if! {
+            //     if #[cfg(feature = "benchmark")] {
+            //         setup_benchmark_telemetry(tracing_level, network_tracing_level)?;
+            //     } else {
+            //         let _guard = setup_telemetry(tracing_level, network_tracing_level, Some(&registry));
+            //     }
+            // }
             run(
                 subcommand,
                 workers,
@@ -209,11 +259,183 @@ async fn main() -> Result<(), eyre::Report> {
                 primary_keypair,
                 primary_network_keypair,
                 worker_keypair,
-                registry,
+                primary_registry,
+                worker_registry,
             )
             .await?
         }
     }
+
+    Ok(())
+}
+
+/// Generate all the genesis files required for benchmarks.
+fn benchmark_genesis(
+    ips: &Vec<String>,
+    working_directory: &PathBuf,
+    num_workers: usize,
+    base_port: usize,
+) -> Result<()> {
+    tracing::info!("Generating benchmark genesis files");
+    fs::create_dir_all(&working_directory).wrap_err(format!(
+        "Failed to create directory '{}'",
+        working_directory.display()
+    ))?;
+
+    // Use rng seed so that runs across multiple instances generate the same configs.
+    let mut rng = StdRng::seed_from_u64(0);
+
+    // Generate primary keys
+    let mut primary_names = Vec::new();
+    let primary_key_files = (0..ips.len())
+        .map(|i| {
+            let mut path = working_directory.clone();
+            path.push(format!("primary-{}-key.json", i));
+            path
+        })
+        .collect::<Vec<_>>();
+
+    for filename in primary_key_files {
+        let keypair: AuthorityKeyPair = get_key_pair_from_rng(&mut rng).1;
+        write_authority_keypair_to_file(&keypair, filename).unwrap();
+        let pk = keypair.public().to_string();
+        primary_names.push(pk);
+    }
+
+    // Generate primary network keys
+    let mut primary_network_names = Vec::new();
+    let primary_network_key_files = (0..ips.len())
+        .map(|i| {
+            let mut path = working_directory.clone();
+            path.push(format!("primary-{}-network-key.json", i));
+            path
+        })
+        .collect::<Vec<_>>();
+
+    for filename in primary_network_key_files {
+        let network_keypair: NetworkKeyPair = get_key_pair_from_rng(&mut rng).1;
+        let pk = network_keypair.public().to_string();
+        write_keypair_to_file(&SuiKeyPair::Ed25519(network_keypair), filename).unwrap();
+        primary_network_names.push(pk);
+    }
+
+    // todo: add the option for remote workers and multiple workers
+    let mut addresses = BTreeMap::new();
+    for (pk, (network_pk, ip)) in primary_names
+        .iter()
+        .zip(primary_network_names.iter().zip(ips.iter()))
+    {
+        addresses.insert(pk.clone(), (network_pk.clone(), ip.clone()));
+    }
+
+    // Generate committee config
+    let mut committee_path = working_directory.clone();
+    committee_path.push(Committee::DEFAULT_FILENAME);
+    let mut committee_builder = CommitteeBuilder::new(Epoch::default());
+    for (i, (pk, (network_pk, ip))) in addresses.iter().enumerate() {
+        let primary_address: Multiaddr = format!("/ip4/{}/udp/{}", ip, base_port + i)
+            .parse()
+            .unwrap();
+        let protocol_key = AuthorityPublicKey::decode_base64(pk.as_str().trim())?.clone();
+        let network_key = NetworkPublicKey::decode_base64(network_pk.as_str().trim())?.clone();
+        committee_builder = committee_builder.add_authority(
+            protocol_key,
+            1, // todo: make stake configurable
+            primary_address,
+            network_key,
+            ip.to_string(),
+        );
+    }
+    let committee = committee_builder.build();
+    tracing::info!("Generated committee file: {}", committee_path.display());
+
+    committee
+        .export(&committee_path.as_path().as_os_str().to_str().unwrap())
+        .expect("Failed to export committee file");
+
+    // Generate workers keys
+    let mut worker_names = Vec::new();
+    // todo: add the option for remote workers and multiple workers
+    let worker_key_files = (0..num_workers * ips.len())
+        .map(|i| {
+            let mut path = working_directory.clone();
+            path.push(format!("worker-{i}-key.json"));
+            path
+        })
+        .collect::<Vec<_>>();
+
+    for filename in worker_key_files {
+        let network_keypair: NetworkKeyPair = get_key_pair_from_rng(&mut rng).1;
+        let pk = network_keypair.public().to_string();
+        write_keypair_to_file(&SuiKeyPair::Ed25519(network_keypair), filename).unwrap();
+        worker_names.push(pk);
+    }
+
+    // Generate workers config
+    let mut workers_path = working_directory.clone();
+    workers_path.push(WorkerCache::DEFAULT_FILENAME);
+    let mut worker_cache = WorkerCache {
+        workers: BTreeMap::new(),
+        epoch: Epoch::default(),
+    };
+    // 2 ports used per authority so add 2 * num authorities to base port
+    let mut worker_base_port = base_port + (2 * primary_names.len());
+
+    for (i, (pk, ip)) in primary_names.iter().zip(ips.iter()).enumerate() {
+        let mut workers = BTreeMap::new();
+        for j in 0..num_workers {
+            let worker_network_key =
+                NetworkPublicKey::decode_base64(worker_names[i * num_workers + j].as_str().trim())?
+                    .clone();
+
+            let worker_info = WorkerInfo {
+                name: worker_network_key,
+                transactions: Multiaddr::try_from(format!(
+                    "/ip4/{}/tcp/{}/http",
+                    ip.to_string(),
+                    worker_base_port
+                ))
+                .unwrap(),
+                worker_address: Multiaddr::try_from(format!(
+                    "/ip4/{}/udp/{}",
+                    ip.to_string(),
+                    worker_base_port + 1
+                ))
+                .unwrap(),
+            };
+            worker_base_port += 2;
+            workers.insert(j as WorkerId, worker_info);
+        }
+        let protocol_key = AuthorityPublicKey::decode_base64(pk.as_str().trim())?.clone();
+        worker_cache
+            .workers
+            .insert(protocol_key, WorkerIndex(workers));
+    }
+
+    worker_cache
+        .export(&workers_path.as_path().as_os_str().to_str().unwrap())
+        .expect("Failed to export workers file");
+
+    // Generate node parameters config
+    let mut parameters_path = working_directory.clone();
+    parameters_path.push(Parameters::DEFAULT_FILENAME);
+    let parameters = Parameters {
+        prometheus_metrics: PrometheusMetricsParameters {
+            socket_addr: Multiaddr::try_from(format!(
+                "/ip4/0.0.0.0/tcp/{}/http",
+                PrometheusMetricsParameters::DEFAULT_PORT
+            ))
+            .unwrap(),
+        },
+        ..Default::default()
+    };
+    parameters
+        .export(&parameters_path.as_path().as_os_str().to_str().unwrap())
+        .expect("Failed to export parameters file");
+    tracing::info!(
+        "Generated (public) parameters file: {}",
+        parameters_path.display()
+    );
 
     Ok(())
 }
@@ -241,41 +463,43 @@ fn setup_telemetry(
     guard
 }
 
-#[cfg(feature = "benchmark")]
-fn setup_benchmark_telemetry(
-    tracing_level: &str,
-    network_tracing_level: &str,
-) -> Result<(), eyre::Report> {
-    let custom_directive = "narwhal_executor=info";
-    let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
-        .parse(format!(
-            "{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},{custom_directive}"
-        ))?;
+// TODO: re-enable telemetry if needed, otherwise remove when old benchmark code is removed
+// #[cfg(feature = "benchmark")]
+// fn setup_benchmark_telemetry(
+//     tracing_level: &str,
+//     network_tracing_level: &str,
+// ) -> Result<(), eyre::Report> {
+//     let custom_directive = "narwhal_executor=info";
+//     let filter = EnvFilter::builder()
+//         .with_default_directive(LevelFilter::INFO.into())
+//         .parse(format!(
+//             "{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},{custom_directive}"
+//         ))?;
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or(filter);
+//     let env_filter = EnvFilter::try_from_default_env().unwrap_or(filter);
 
-    let timer = tracing_subscriber::fmt::time::UtcTime::rfc_3339();
-    let subscriber_builder = tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(env_filter)
-        .with_timer(timer)
-        .with_ansi(false);
-    let subscriber = subscriber_builder.with_writer(std::io::stderr).finish();
-    set_global_default(subscriber).expect("Failed to set subscriber");
-    Ok(())
-}
+//     let timer = tracing_subscriber::fmt::time::UtcTime::rfc_3339();
+//     let subscriber_builder = tracing_subscriber::fmt::Subscriber::builder()
+//         .with_env_filter(env_filter)
+//         .with_timer(timer)
+//         .with_ansi(false);
+//     let subscriber = subscriber_builder.with_writer(std::io::stderr).finish();
+//     set_global_default(subscriber).expect("Failed to set subscriber");
+//     Ok(())
+// }
 
 // Runs either a worker or a primary.
 async fn run(
     node_type: &NodeType,
     workers: &str,
     parameters: Option<&str>,
-    store: &Path,
+    store_path: &Path,
     committee: Committee,
     primary_keypair: KeyPair,
     primary_network_keypair: NetworkKeyPair,
     worker_keypair: NetworkKeyPair,
-    registry: Registry,
+    primary_registry: Option<Registry>,
+    worker_registry: Option<Registry>,
 ) -> Result<(), eyre::Report> {
     // Read the workers and node's keypair from file.
     let worker_cache =
@@ -289,12 +513,22 @@ async fn run(
         None => Parameters::default(),
     };
 
+    // spin up prometheus server exporter
+    let prom_address = parameters.prometheus_metrics.socket_addr.clone();
+    info!(
+        "Starting Prometheus HTTP metrics endpoint at {}",
+        prom_address
+    );
+    let registry_service = start_prometheus_server(
+        prom_address
+            .to_socket_addr()
+            .expect("failed to convert Multiaddr to SocketAddr"),
+    );
+
     // Make the data store.
-    let registry_service = RegistryService::new(Registry::new());
     let certificate_store_cache_metrics =
         CertificateStoreCacheMetrics::new(&registry_service.default_registry());
-
-    let store = NodeStorage::reopen(store, Some(certificate_store_cache_metrics));
+    let store = NodeStorage::reopen(store_path, Some(certificate_store_cache_metrics.clone()));
 
     let client = NetworkClient::new_from_keypair(&primary_network_keypair);
 
@@ -304,7 +538,7 @@ async fn run(
     // Check whether to run a primary, a worker, or an entire authority.
     let (primary, worker) = match node_type {
         NodeType::Primary => {
-            let primary = PrimaryNode::new(parameters.clone(), registry_service);
+            let primary = PrimaryNode::new(parameters.clone(), registry_service.clone());
 
             primary
                 .start(
@@ -327,7 +561,7 @@ async fn run(
                 *id,
                 ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown),
                 parameters.clone(),
-                registry_service,
+                registry_service.clone(),
             );
 
             worker
@@ -345,20 +579,80 @@ async fn run(
 
             (None, Some(worker))
         }
+        NodeType::Benchmark { worker_id } => {
+            let primary = PrimaryNode::new(parameters.clone(), registry_service.clone());
+
+            primary
+                .start(
+                    primary_keypair.copy(),
+                    primary_network_keypair,
+                    committee.clone(),
+                    ChainIdentifier::unknown(),
+                    ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown),
+                    worker_cache.clone(),
+                    client.clone(),
+                    &store,
+                    SimpleExecutionState::new(_tx_transaction_confirmation),
+                )
+                .await?;
+
+            let worker = WorkerNode::new(
+                *worker_id,
+                ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown),
+                parameters.clone(),
+                registry_service.clone(),
+            );
+
+            let mut worker_store_path = PathBuf::new();
+            if let Some(parent) = store_path.parent() {
+                worker_store_path.push(parent);
+            }
+            if let Some(file_name) = store_path.file_name().and_then(|name| name.to_str()) {
+                worker_store_path.push(format!("{}-{}", file_name, worker_id));
+            } else {
+                worker_store_path.push(format!("worker-db-{}", worker_id));
+            }
+            let worker_store =
+                NodeStorage::reopen(worker_store_path, Some(certificate_store_cache_metrics));
+
+            worker
+                .start(
+                    primary_keypair.public().clone(),
+                    worker_keypair,
+                    committee,
+                    worker_cache,
+                    client,
+                    &worker_store,
+                    TrivialTransactionValidator,
+                    None,
+                )
+                .await?;
+
+            (Some(primary), Some(worker))
+        }
     };
 
-    // spin up prometheus server exporter
-    let prom_address = parameters.prometheus_metrics.socket_addr;
-    info!(
-        "Starting Prometheus HTTP metrics endpoint at {}",
-        prom_address
-    );
-    let _metrics_server_handle = start_prometheus_server(prom_address, &registry);
+    if let Some(registry) = worker_registry {
+        registry_service.add(registry);
+    }
 
-    if let Some(primary) = primary {
-        primary.wait().await;
-    } else if let Some(worker) = worker {
-        worker.wait().await;
+    if let Some(registry) = primary_registry {
+        registry_service.add(registry);
+    }
+
+    match (primary, worker) {
+        (Some(primary), Some(worker)) => {
+            join!(primary.wait(), worker.wait());
+        }
+        (Some(primary), None) => {
+            primary.wait().await;
+        }
+        (None, Some(worker)) => {
+            worker.wait().await;
+        }
+        (None, None) => {
+            warn!("No primary or worker node was started");
+        }
     }
 
     // If this expression is reached, the program ends and all other tasks terminate.

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -629,10 +629,12 @@ async fn run(
     };
 
     if let Some(registry) = worker_registry {
+        mysten_metrics::init_metrics(&registry);
         registry_service.add(registry);
     }
 
     if let Some(registry) = primary_registry {
+        mysten_metrics::init_metrics(&registry);
         registry_service.add(registry);
     }
 

--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -4,13 +4,73 @@ use axum::{routing::get, Extension, Router};
 use config::{AuthorityIdentifier, WorkerId};
 use mysten_metrics::{metrics, spawn_logged_monitored_task};
 use mysten_network::multiaddr::Multiaddr;
-use prometheus::Registry;
+use prometheus::{
+    register_counter_with_registry, register_histogram_with_registry,
+    register_int_counter_with_registry, Counter, Histogram, IntCounter, Registry,
+};
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
 const METRICS_ROUTE: &str = "/metrics";
 const PRIMARY_METRICS_PREFIX: &str = "narwhal_primary";
 const WORKER_METRICS_PREFIX: &str = "narwhal_worker";
+
+pub struct BenchMetrics {
+    pub benchmark_duration: IntCounter,
+    pub num_success: IntCounter,
+    pub num_error: IntCounter,
+    pub num_submitted: IntCounter,
+    pub latency_s: Histogram,
+    pub latency_squared_s: Counter,
+}
+
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.1, 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.5, 5., 10., 20., 30., 60., 90.,
+];
+
+impl BenchMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        BenchMetrics {
+            benchmark_duration: register_int_counter_with_registry!(
+                "benchmark_duration",
+                "Duration of the benchmark",
+                registry,
+            )
+            .unwrap(),
+            num_success: register_int_counter_with_registry!(
+                "num_success",
+                "Total number of transaction success",
+                registry,
+            )
+            .unwrap(),
+            num_error: register_int_counter_with_registry!(
+                "num_error",
+                "Total number of transaction errors",
+                registry,
+            )
+            .unwrap(),
+            num_submitted: register_int_counter_with_registry!(
+                "num_submitted",
+                "Total number of transaction submitted to narwhal",
+                registry,
+            )
+            .unwrap(),
+            latency_s: register_histogram_with_registry!(
+                "latency_s",
+                "Total time in seconds to return a response",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            latency_squared_s: register_counter_with_registry!(
+                "latency_squared_s",
+                "Square of total time in seconds to return a response",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
 
 pub fn new_registry() -> Registry {
     Registry::new_custom(None, None).unwrap()

--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -6,7 +6,8 @@ use mysten_metrics::{metrics, spawn_logged_monitored_task};
 use mysten_network::multiaddr::Multiaddr;
 use prometheus::{
     register_counter_with_registry, register_histogram_with_registry,
-    register_int_counter_with_registry, Counter, Histogram, IntCounter, Registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry, Counter, Histogram,
+    IntCounter, IntGauge, Registry,
 };
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
@@ -15,55 +16,56 @@ const METRICS_ROUTE: &str = "/metrics";
 const PRIMARY_METRICS_PREFIX: &str = "narwhal_primary";
 const WORKER_METRICS_PREFIX: &str = "narwhal_worker";
 
-pub struct BenchMetrics {
-    pub benchmark_duration: IntCounter,
-    pub num_success: IntCounter,
-    pub num_error: IntCounter,
-    pub num_submitted: IntCounter,
-    pub latency_s: Histogram,
-    pub latency_squared_s: Counter,
+#[derive(Clone)]
+pub struct NarwhalBenchMetrics {
+    pub narwhal_benchmark_duration: IntGauge,
+    pub narwhal_client_num_success: IntCounter,
+    pub narwhal_client_num_error: IntCounter,
+    pub narwhal_client_num_submitted: IntCounter,
+    pub narwhal_client_latency_s: Histogram,
+    pub narwhal_client_latency_squared_s: Counter,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.1, 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.5, 5., 10., 20., 30., 60., 90.,
 ];
 
-impl BenchMetrics {
+impl NarwhalBenchMetrics {
     pub fn new(registry: &Registry) -> Self {
-        BenchMetrics {
-            benchmark_duration: register_int_counter_with_registry!(
-                "benchmark_duration",
+        NarwhalBenchMetrics {
+            narwhal_benchmark_duration: register_int_gauge_with_registry!(
+                "narwhal_benchmark_duration",
                 "Duration of the benchmark",
                 registry,
             )
             .unwrap(),
-            num_success: register_int_counter_with_registry!(
-                "num_success",
+            narwhal_client_num_success: register_int_counter_with_registry!(
+                "narwhal_client_num_success",
                 "Total number of transaction success",
                 registry,
             )
             .unwrap(),
-            num_error: register_int_counter_with_registry!(
-                "num_error",
+            narwhal_client_num_error: register_int_counter_with_registry!(
+                "narwhal_client_num_error",
                 "Total number of transaction errors",
                 registry,
             )
             .unwrap(),
-            num_submitted: register_int_counter_with_registry!(
-                "num_submitted",
+            narwhal_client_num_submitted: register_int_counter_with_registry!(
+                "narwhal_client_num_submitted",
                 "Total number of transaction submitted to narwhal",
                 registry,
             )
             .unwrap(),
-            latency_s: register_histogram_with_registry!(
-                "latency_s",
+            narwhal_client_latency_s: register_histogram_with_registry!(
+                "narwhal_client_latency_s",
                 "Total time in seconds to return a response",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
-            latency_squared_s: register_counter_with_registry!(
-                "latency_squared_s",
+            narwhal_client_latency_squared_s: register_counter_with_registry!(
+                "narwhal_client_latency_squared_s",
                 "Square of total time in seconds to return a response",
                 registry,
             )


### PR DESCRIPTION
## Description 

Added narwhal only benchmark using aws-orchestrator. Once stable we can remove the old narwhal benchmark suite (which is currently broken) 

Some changes were made to narwhal genesis and usage can be found here

- benchmark config generator

`RUST_LOG=info cargo run --release --bin narwhal-node benchmark-genesis  --working-directory ~/benchmark --ips 127.0.0.1,127.0.0.1,127.0.0.1,127.0.0.1 --num-workers 1 --base-port 5000`

- running benchmark setup (worker + primary in process)

`RUST_LOG=debug cargo run --release --bin narwhal-node run --primary-keys ~/benchmark/primary-3-key.json --primary-network-keys ~/benchmark/primary-3-network-key.json --worker-keys ~/benchmark/worker-3-key.json --committee ~/benchmark/committee.json --workers ~/benchmark/workers.json --store ~/benchmark/db-3 --parameters ~/benchmark/parameters.json benchmark`

## Test Plan 

Ran benchmark in aws. Will need to followup with some more fixes on how metrics are gathered for the benchmark results & investigate why the client output is not reaching expected numbers

```
--------------------------------
 Benchmark Summary
--------------------------------
 Benchmark type:   tx size 512b

 Nodes:            10
 Faults:           no faults
 Load:             200 tx/s
 Duration:         147 s

 TPS:              87 tx/s
 Latency (avg):    212 ms
 Latency (stdev):  2 ms
--------------------------------
```
