### PR TITLE
[Framework] Adds `take_locked` function to Kiosk

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -364,6 +364,7 @@ module sui::kiosk {
     public fun list<T: key + store>(
         self: &mut Kiosk, cap: &KioskOwnerCap, id: ID, price: u64
     ) {
+        assert!(price > 0, EIncorrectAmount);
         assert!(has_access(self, cap), ENotOwner);
         assert!(has_item_with_type<T>(self, id), EItemNotFound);
         assert!(!is_listed_exclusively(self, id), EListedExclusively);


### PR DESCRIPTION
## Description 

Normalizing a common behavior, usually achieved by listing for 0 and purchasing for 0.

> This PR acts as a conversation starter for new Kiosk features; there's a common set of requirements / features which tend to accumulate and which we need to address next year. 

## Test Plan 

TBD

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
