### PR TITLE
[GraphQL/TransactionBlock] TransactionBlockEffects representation

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1643,22 +1643,18 @@ type TransactionBlockEdge {
 }
 
 type TransactionBlockEffects {
-	status: ExecutionStatus!
-	errors: String
+	transactionBlock: TransactionBlock!
+	status: ExecutionStatus
 	lamportVersion: Int
-	balanceChanges: [BalanceChange]
-	"""
-	UTC timestamp in milliseconds since epoch (1/1/1970)
-	representing the time when the checkpoint that contains
-	this transaction was created
-	"""
-	timestamp: DateTime
-	checkpoint: Checkpoint
-	dependencies: [TransactionBlock]
-	epoch: Epoch
+	errors: String
+	dependencies: [TransactionBlock!]
 	gasEffects: GasEffects
-	objectChanges: [ObjectChange]
-	transactionBlock: TransactionBlock
+	objectChanges: [ObjectChange!]
+	balanceChanges: [BalanceChange!]
+	timestamp: DateTime
+	epoch: Epoch
+	checkpoint: Checkpoint
+	bcs: Base64
 }
 
 input TransactionBlockFilter {

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -846,17 +846,17 @@ type MakeMoveVecTransaction {
 type TransactionSignature
 
 type TransactionBlockEffects {
-  status: ExecutionStatus!
+  transactionBlock: TransactionBlock!
+  status: ExecutionStatus
 
   errors: String
-  transactionBlock: TransactionBlock
-  dependencies: [TransactionBlock]
+  dependencies: [TransactionBlock!]
 
   lamportVersion: Int
   gasEffects: GasEffects
-  objectReads: [Object]
-  objectChanges: [ObjectChange]
-  balanceChanges: [BalanceChange]
+  objectReads: [Object!]
+  objectChanges: [ObjectChange!]
+  balanceChanges: [BalanceChange!]
   timestamp: DateTime
   epoch: Epoch
   checkpoint: Checkpoint

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1647,22 +1647,18 @@ type TransactionBlockEdge {
 }
 
 type TransactionBlockEffects {
-	status: ExecutionStatus!
-	errors: String
+	transactionBlock: TransactionBlock!
+	status: ExecutionStatus
 	lamportVersion: Int
-	balanceChanges: [BalanceChange]
-	"""
-	UTC timestamp in milliseconds since epoch (1/1/1970)
-	representing the time when the checkpoint that contains
-	this transaction was created
-	"""
-	timestamp: DateTime
-	checkpoint: Checkpoint
-	dependencies: [TransactionBlock]
-	epoch: Epoch
+	errors: String
+	dependencies: [TransactionBlock!]
 	gasEffects: GasEffects
-	objectChanges: [ObjectChange]
-	transactionBlock: TransactionBlock
+	objectChanges: [ObjectChange!]
+	balanceChanges: [BalanceChange!]
+	timestamp: DateTime
+	epoch: Epoch
+	checkpoint: Checkpoint
+	bcs: Base64
 }
 
 input TransactionBlockFilter {


### PR DESCRIPTION
## Description

Use the representation applied to `Object` in #14752 (storing the indexer and native representations internal to the type) on `TransactionBlockEffects`, with most further conversions relegated to an `#[Object]` impl block.

Additionally fields that return vectors return nullable vectors of non-nullable elements.

This change in representation needs to be propagated further -- to `BalanceChange`, `ObjectChange`, `TransactionBlock` etc -- to be done in future PRs.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 