### PR TITLE
[GraphQL/TransactionBlock] Improve error representation

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -1,0 +1,29 @@
+processed 5 tasks
+
+task 1 'publish'. lines 6-12:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3450400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 14-15:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::bang (function index 0) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("bang") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("P0::m::bang at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 3 'create-checkpoint'. lines 17-17:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 19-31:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Move Runtime Abort. Location: 9c2718c66ae46ab0923bc19f94e1cfbb19dd493316a9734976329e0da7a052d6::m::bang (function index 0) at offset 1, Abort Code: 42 in 1st command."
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.exp
@@ -1,18 +1,18 @@
-processed 5 tasks
+processed 8 tasks
 
-task 1 'publish'. lines 6-12:
+task 1 'publish'. lines 6-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 3450400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'programmable'. lines 14-15:
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::bang (function index 0) at offset 1, Abort Code: 42
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("bang") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("P0::m::bang at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+task 2 'programmable'. lines 13-14:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::boom (function index 1) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("boom") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("P0::m::boom at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
-task 3 'create-checkpoint'. lines 17-17:
+task 3 'create-checkpoint'. lines 16-16:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 19-31:
+task 4 'run-graphql'. lines 18-30:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -20,7 +20,30 @@ Response: {
         {
           "effects": {
             "status": "FAILURE",
-            "errors": "Move Runtime Abort. Location: 9c2718c66ae46ab0923bc19f94e1cfbb19dd493316a9734976329e0da7a052d6::m::bang (function index 0) at offset 1, Abort Code: 42 in 1st command."
+            "errors": "Move Runtime Abort. Location: e19b1c610bb23fd99383d137b5d08a933b45cbfb8a3e6261b34647bdfe61bc76::m::boom (function index 1) at offset 1, Abort Code: 42 in 1st command."
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 5 'programmable'. lines 32-35:
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::boom (function index 1) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("boom") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("P0::m::boom at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(2) } }
+
+task 6 'create-checkpoint'. lines 37-37:
+Checkpoint created: 2
+
+task 7 'run-graphql'. lines 39-52:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "status": "FAILURE",
+            "errors": "Move Runtime Abort. Location: e19b1c610bb23fd99383d137b5d08a933b45cbfb8a3e6261b34647bdfe61bc76::m::boom (function index 1) at offset 1, Abort Code: 42 in 3rd command."
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 --simulator
+
+//# publish
+
+module P0::m {
+    public fun bang() {
+        abort 42
+    }
+}
+
+//# programmable
+//> P0::m::bang()
+
+//# create-checkpoint
+
+//# run-graphql
+
+# The last transaction should have failed, what's its error message?
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                status
+                errors
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
@@ -6,19 +6,40 @@
 //# publish
 
 module P0::m {
-    public fun bang() {
-        abort 42
-    }
+    public fun tick(): u64 { 42 }
+    public fun boom() { abort 42 }
 }
 
 //# programmable
-//> P0::m::bang()
+//> P0::m::boom()
 
 //# create-checkpoint
 
 //# run-graphql
 
 # The last transaction should have failed, what's its error message?
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                status
+                errors
+            }
+        }
+    }
+}
+
+//# programmable
+//> 0: P0::m::tick();
+//> 1: P0::m::tick();
+//> P0::m::boom()
+
+//# create-checkpoint
+
+//# run-graphql
+
+# Check the transaction command ordinal is correct if the abort
+# happens at a later command.
 {
     transactionBlockConnection(last: 1) {
         nodes {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -445,7 +445,7 @@ Response: {
           },
           "effects": {
             "status": "FAILURE",
-            "errors": "UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }",
+            "errors": "Unused result without the drop ability. Command result 0, return value 0",
             "lamportVersion": null,
             "dependencies": [
               {

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -88,12 +88,23 @@ impl TransactionBlockEffects {
             NativeExecutionStatus::Failure {
                 error,
                 command: None,
-            } => Some(format!("{error:?}")),
+            } => Some(error.to_string()),
 
             NativeExecutionStatus::Failure {
                 error,
                 command: Some(command),
-            } => Some(format!("{error:?} in command {command}")),
+            } => {
+                // Convert the command index into an ordinal.
+                let command = command + 1;
+                let suffix = match command % 10 {
+                    1 => "st",
+                    2 => "nd",
+                    3 => "rd",
+                    _ => "th",
+                };
+
+                Some(format!("{error} in {command}{suffix} command."))
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Use the `error`'s `Display` impl rather than its `Debug` impl, so that the error message becomes a human-readable sentence, and represent the command as a 1-indexed ordinal number with a suffix so it's more obvious whether it's 1- or 0-indexed.

## Test Plan

E2E tests (including new ones)

```
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 