### PR TITLE
[GraphQL/TransactionBlock][EASY] Doc comments for effect types

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -507,9 +507,24 @@ enum Feature {
 
 
 type GasCostSummary {
+	"""
+	Gas paid for executing this transaction.
+	"""
 	computationCost: BigInt
+	"""
+	Gas paid for the data stored on-chain by this transaction.
+	"""
 	storageCost: BigInt
+	"""
+	Part of storage cost that can be reclaimed by cleaning up data created by this transaction
+	(when objects are deleted or an object is modified, whch is treated as a deletion followed
+	by a creation).
+	"""
 	storageRebate: BigInt
+	"""
+	Part of storage cost that is not reclaimed when data created by this transaction is cleaned
+	up.
+	"""
 	nonRefundableStorageFee: BigInt
 }
 
@@ -1643,17 +1658,52 @@ type TransactionBlockEdge {
 }
 
 type TransactionBlockEffects {
+	"""
+	The transaction that ran to produce these effects.
+	"""
 	transactionBlock: TransactionBlock!
+	"""
+	Whether the transaction executed successfully or not.
+	"""
 	status: ExecutionStatus
+	"""
+	The latest version of all objects that have been created or modified by this transaction,
+	immediately following this transaction.  A system transaction that does not modify or create
+	objects will not have a lamport version.
+	"""
 	lamportVersion: Int
+	"""
+	The reason for a transaction failure, if it did fail.
+	"""
 	errors: String
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
 	dependencies: [TransactionBlock!]
+	"""
+	Effects to the gas object.
+	"""
 	gasEffects: GasEffects
+	"""
+	The effect this transaction had on objects on-chain.
+	"""
 	objectChanges: [ObjectChange!]
 	balanceChanges: [BalanceChange!]
+	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
 	timestamp: DateTime
+	"""
+	The epoch this transaction was finalized in.
+	"""
 	epoch: Epoch
+	"""
+	The checkpoint this transaction was finalized in.
+	"""
 	checkpoint: Checkpoint
+	"""
+	Base64 encoded bcs serialization of the on-chain transaction effects.
+	"""
 	bcs: Base64
 }
 

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -84,18 +84,25 @@ impl GasInput {
 
 #[Object]
 impl GasCostSummary {
+    /// Gas paid for executing this transaction.
     async fn computation_cost(&self) -> Option<BigInt> {
         Some(BigInt::from(self.computation_cost))
     }
 
+    /// Gas paid for the data stored on-chain by this transaction.
     async fn storage_cost(&self) -> Option<BigInt> {
         Some(BigInt::from(self.storage_cost))
     }
 
+    /// Part of storage cost that can be reclaimed by cleaning up data created by this transaction
+    /// (when objects are deleted or an object is modified, whch is treated as a deletion followed
+    /// by a creation).
     async fn storage_rebate(&self) -> Option<BigInt> {
         Some(BigInt::from(self.storage_rebate))
     }
 
+    /// Part of storage cost that is not reclaimed when data created by this transaction is cleaned
+    /// up.
     async fn non_refundable_storage_fee(&self) -> Option<BigInt> {
         Some(BigInt::from(self.non_refundable_storage_fee))
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -511,9 +511,24 @@ enum Feature {
 
 
 type GasCostSummary {
+	"""
+	Gas paid for executing this transaction.
+	"""
 	computationCost: BigInt
+	"""
+	Gas paid for the data stored on-chain by this transaction.
+	"""
 	storageCost: BigInt
+	"""
+	Part of storage cost that can be reclaimed by cleaning up data created by this transaction
+	(when objects are deleted or an object is modified, whch is treated as a deletion followed
+	by a creation).
+	"""
 	storageRebate: BigInt
+	"""
+	Part of storage cost that is not reclaimed when data created by this transaction is cleaned
+	up.
+	"""
 	nonRefundableStorageFee: BigInt
 }
 
@@ -1647,17 +1662,52 @@ type TransactionBlockEdge {
 }
 
 type TransactionBlockEffects {
+	"""
+	The transaction that ran to produce these effects.
+	"""
 	transactionBlock: TransactionBlock!
+	"""
+	Whether the transaction executed successfully or not.
+	"""
 	status: ExecutionStatus
+	"""
+	The latest version of all objects that have been created or modified by this transaction,
+	immediately following this transaction.  A system transaction that does not modify or create
+	objects will not have a lamport version.
+	"""
 	lamportVersion: Int
+	"""
+	The reason for a transaction failure, if it did fail.
+	"""
 	errors: String
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
 	dependencies: [TransactionBlock!]
+	"""
+	Effects to the gas object.
+	"""
 	gasEffects: GasEffects
+	"""
+	The effect this transaction had on objects on-chain.
+	"""
 	objectChanges: [ObjectChange!]
 	balanceChanges: [BalanceChange!]
+	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
 	timestamp: DateTime
+	"""
+	The epoch this transaction was finalized in.
+	"""
 	epoch: Epoch
+	"""
+	The checkpoint this transaction was finalized in.
+	"""
 	checkpoint: Checkpoint
+	"""
+	Base64 encoded bcs serialization of the on-chain transaction effects.
+	"""
 	bcs: Base64
 }
 


### PR DESCRIPTION
## Description

Fill out doc comments for the various effect-related types that don't have them.

## Test Plan

Snapshot tests:

```
sui-graphql-rpc$ cargo nextest run
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 
- #15039 
- #15040
