### PR TITLE
[GraphQL/TransactionBlock] Remove inputState (for now)

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 6315600,  storage_rebate: 
 task 2 'create-checkpoint'. lines 21-21:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 23-87:
+task 3 'run-graphql'. lines 23-86:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -68,7 +68,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
                   "digest": "9dppxTwUWhC8nVH4Djdv71K75Ze4HEXe5ZU3NcX3TrK"
@@ -77,7 +76,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xa4a7220856bab19ccaa904d168baa3d733b59c8c067cdcc300502ac352f679af",
                   "digest": "9AR9zGFB4aPcZzniVTVqRTYHwUASw5PXPYsTtomT8jyB"
@@ -86,7 +84,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xcadb6deed476a072959bd1a031809d737240ccde7917495e16aa9793d6419a74",
                   "digest": "PaCSXQ5RCkt2vc6w2NfZMNBvoCYyM9H6uJJtx1KgEyj"
@@ -122,15 +119,15 @@ Response: {
   }
 }
 
-task 4 'upgrade'. lines 89-107:
+task 4 'upgrade'. lines 88-106:
 created: object(4,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 6589200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 5 'create-checkpoint'. lines 109-109:
+task 5 'create-checkpoint'. lines 108-108:
 Checkpoint created: 2
 
-task 6 'run-graphql'. lines 111-176:
+task 6 'run-graphql'. lines 110-174:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -190,7 +187,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
                   "digest": "765g4rih8tpnzb9gHEHArtZ3Ye7SJ3CJUapLVUsdcd6K"
@@ -199,7 +195,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xa4a7220856bab19ccaa904d168baa3d733b59c8c067cdcc300502ac352f679af",
                   "digest": "Hyz4RaTV3cApJs911rX9CURmBd7amvComK4hoNrX7Dmg"
@@ -208,7 +203,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x260de89d19ced9a26b7efba21d133f71987aa80696228f1dee6178961d0e07be",
                   "digest": "9jMyF1w9TTRgvXdsWAn8d5awmQXYD4gUe1qX586UwWVt"
@@ -244,15 +238,15 @@ Response: {
   }
 }
 
-task 7 'programmable'. lines 178-187:
+task 7 'programmable'. lines 176-185:
 created: object(7,0), object(7,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3328800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8 'create-checkpoint'. lines 189-189:
+task 8 'create-checkpoint'. lines 187-187:
 Checkpoint created: 3
 
-task 9 'run-graphql'. lines 191-265:
+task 9 'run-graphql'. lines 189-262:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -309,7 +303,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
                   "digest": "6bbvaLxYq6Fj8bVvhvKkeZM3u27ecvwe9hGkbdsSXd2e",
@@ -331,7 +324,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x505c5f4993a1fe74c5492945104578ca55d6275a15d64ecc21de6b7b5ef34804",
                   "digest": "5ayrZbSq44X3WqnwNsVvNHGs21YntWobKUoFZQbvVMyw",
@@ -354,7 +346,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x82ff2affd2e0447baea51fb07098dd4192c38424f41e291c7b47bcae5be0f37c",
                   "digest": "choJQNN7TWytitxF59W6QgnECZkzL28oT77TSkLvox7",
@@ -403,14 +394,14 @@ Response: {
   }
 }
 
-task 10 'programmable'. lines 267-268:
+task 10 'programmable'. lines 264-265:
 Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: None, command: None } }
 
-task 11 'create-checkpoint'. lines 270-270:
+task 11 'create-checkpoint'. lines 267-267:
 Checkpoint created: 4
 
-task 12 'run-graphql'. lines 272-337:
+task 12 'run-graphql'. lines 269-333:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -467,7 +458,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x11c5cd8906fc48629f168f5a13a75c8ca77f69ae1ec15edfda29789f1d9638d9",
                   "digest": "EW31fn6wtJxosHoPLnhPNp8tNQgCctYMksKDMY6St4y5"

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -59,7 +59,6 @@ module P0::m {
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 
@@ -148,7 +147,6 @@ module P0::m {
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 
@@ -228,7 +226,6 @@ module P0::m {
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState {
                         location
                         digest
@@ -309,7 +306,6 @@ module P0::m {
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -1,6 +1,6 @@
 processed 8 tasks
 
-task 1 'run-graphql'. lines 8-72:
+task 1 'run-graphql'. lines 8-71:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -75,7 +75,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000001",
                   "digest": "FvLv2TuVhx1Ga8oCLW4gZmiBnQpT7XkSdGBo753kApGD"
@@ -84,7 +83,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000002",
                   "digest": "CcD7UEtUeyPhcnqdxS5GFRTQ9xRsx71wZ3fRcGsaKEUp"
@@ -93,7 +91,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000003",
                   "digest": "4VXaAMUGRedbhHDoNifrFx2iYeC8n5qB1W6BDsUvJc3h"
@@ -102,7 +99,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000005",
                   "digest": "EVK8EKnUhpqHEGHYX8da98qWhQT965WLxanbCZnwaT1Y"
@@ -111,7 +107,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000006",
                   "digest": "D1mkJGFbzAZmXfD3ktF38Endz9LtnML94B5kuyQEhR1e"
@@ -120,7 +115,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000007",
                   "digest": "2aRjNBbkQWJToXLL74Wzv2GDu9sWcFPd5XXgvrgk7FAC"
@@ -129,7 +123,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x000000000000000000000000000000000000000000000000000000000000dee9",
                   "digest": "FX5F5Ex6asvjDd5xU8VBua8eSGp9YAh7rBse6LJsxwBa"
@@ -138,7 +131,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x14498a4368db5cefb6ec2fe91cf18636c5d8fc08b91e3d1417ccb0866e8b95d4",
                   "digest": "94HmeZ5AZqsm4X4HStQEkJqiuQWQWogMRepMzHNcfXVS"
@@ -147,7 +139,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x168e8bf1317ef81399ea9fabee9e217067a257731903b45ca4915c8d049b3940",
                   "digest": "8qJceXqDUSngLbk1rpquzALgcT4WtKfhM78LXepgZmtf"
@@ -156,7 +147,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x1ca7fcc2fe39d93fd041dbcbcc30b33a366b44cab26acd52e5d99f6cf2a0a6e7",
                   "digest": "5ZKMLAipLWCy8rkKBWVbf3NVbdEtna81wwNvt37PVdhj"
@@ -165,7 +155,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x3fa556a7dadc08367a52a6eb4a3b602abbc21446c1f703d2ac46866a403d718e",
                   "digest": "BUFgjXdbMvsknRVvLDefPKCzir7EPpkPmhinUQpD6SKy"
@@ -174,7 +163,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x41a7f84bd3a02e7e5bea80580e40cec419d40ef9925a51cf0128ad84b40f8041",
                   "digest": "9tGfLEvq5kUWYBUaMVSH3Qu996sAv5XAPEXGUFcYecpU"
@@ -183,7 +171,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x46ea41cad4b69f493f5cf7fcb41c96e63ea97c206107d9b25d29a7d28f683ca7",
                   "digest": "D5vv7Xzd6uDWFuYTSEFvNgfXrRsXSDna9v7h4BK7xQcW"
@@ -192,7 +179,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
                   "digest": "BWHXYvVDVbLrXAWL91Bgid4Pu9oDyF8hZqNoFsZ6HM7w"
@@ -201,7 +187,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
                   "digest": "68NRbjATuQoyL78VTc3Gd96h2xoGmevmCpoAQzM7jghG"
@@ -210,7 +195,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xd73b7dd2e4b15b4030f2d1af51a8e8335d37c9723565005f498df27d8a6d3a4d",
                   "digest": "2b3gYd9RreACiq2Cxv2LJyLS8PWHeXfDNeECYbVaf8FR"
@@ -244,10 +228,10 @@ Response: {
   }
 }
 
-task 3 'create-checkpoint'. lines 76-76:
+task 3 'create-checkpoint'. lines 75-75:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 78-145:
+task 4 'run-graphql'. lines 77-143:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -294,7 +278,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000006",
                   "digest": "G7kvXbP2RrfuNizWxggZ3FBc8XAUPCKpSkxEb5hdCExK"
@@ -328,10 +311,10 @@ Response: {
   }
 }
 
-task 6 'advance-epoch'. lines 149-149:
+task 6 'advance-epoch'. lines 147-147:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 151-219:
+task 7 'run-graphql'. lines 149-216:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -380,7 +363,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000005",
                   "digest": "5jzahJer9cg4yJaBZhjpEAbLtzHcKguzMtFBc1poL5fS"
@@ -389,7 +371,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
                   "digest": "Y4W89QnJVPhaMeoExCsfdQhF5bs5RELi5xjLgAy1h6a"
@@ -398,7 +379,6 @@ Response: {
               {
                 "idCreated": true,
                 "idDeleted": null,
-                "inputState": null,
                 "outputState": {
                   "location": "0xa84a25da7fef87ac6141a4920a87564ddb5bd8964333f04e7bd49facb831ba43",
                   "digest": "2dUtbkQSCPJewe9WJsxvAdu1rft1AVXwXMuWYFkYnAxr"
@@ -407,7 +387,6 @@ Response: {
               {
                 "idCreated": null,
                 "idDeleted": true,
-                "inputState": null,
                 "outputState": null
               }
             ],

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -44,7 +44,6 @@
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 
@@ -117,7 +116,6 @@
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 
@@ -191,7 +189,6 @@
                     idCreated
                     idDeleted
 
-                    inputState { location digest }
                     outputState { location digest }
                 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1009,7 +1009,6 @@ type Object implements ObjectOwner {
 }
 
 type ObjectChange {
-	inputState: Object
 	outputState: Object
 	idCreated: Boolean
 	idDeleted: Boolean

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1013,7 +1013,6 @@ type Object implements ObjectOwner {
 }
 
 type ObjectChange {
-	inputState: Object
 	outputState: Object
 	idCreated: Boolean
 	idDeleted: Boolean


### PR DESCRIPTION
## Description

...until we have Object History. Currently, at best we can return `null` for the input state, because we're viewing a transaction, so by definition, any object input state is no longer live -- it's historical.

Relatedly, the `IndexedObjectChange::Wrapped` was translated as having an output state which is not possible.  The ObjectID and version in that change represents the state of the object *before* it was wrapped (i.e. an input state), but again, we wouldn't be able to access it in the

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 
- #15039 
- #15040
- #15041
