### PR TITLE
[GraphQL/TransactionBlock] BalanceChange Representation

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -56,10 +56,22 @@ type Balance {
 	totalBalance: BigInt
 }
 
+"""
+Effects to the balance (sum of coin values per coin type) owned by an address or object.
+"""
 type BalanceChange {
+	"""
+	The address or object whose balance has changed.
+	"""
 	owner: Owner
-	amount: BigInt
+	"""
+	The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
+	"""
 	coinType: MoveType
+	"""
+	The signed balance change.
+	"""
+	amount: BigInt
 }
 
 type BalanceConnection {
@@ -1687,6 +1699,10 @@ type TransactionBlockEffects {
 	The effect this transaction had on objects on-chain.
 	"""
 	objectChanges: [ObjectChange!]
+	"""
+	The effect this transaction had on the balances (sum of coin values per coin type) of
+	addresses and objects.
+	"""
 	balanceChanges: [BalanceChange!]
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+use sui_json_rpc_types::BalanceChange as StoredBalanceChange;
+use sui_types::object::Owner as NativeOwner;
+
+use super::{big_int::BigInt, move_type::MoveType, owner::Owner, sui_address::SuiAddress};
+use crate::error::Error;
+
+pub(crate) struct BalanceChange {
+    // TODO: Move this type into indexer crates, rather than JSON-RPC.
+    stored: StoredBalanceChange,
+}
+
+/// Effects to the balance (sum of coin values per coin type) owned by an address or object.
+#[Object]
+impl BalanceChange {
+    /// The address or object whose balance has changed.
+    async fn owner(&self) -> Option<Owner> {
+        use NativeOwner as O;
+
+        match self.stored.owner {
+            O::AddressOwner(addr) | O::ObjectOwner(addr) => Some(Owner {
+                address: SuiAddress::from(addr),
+            }),
+
+            O::Shared { .. } | O::Immutable => None,
+        }
+    }
+
+    /// The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
+    async fn coin_type(&self) -> Option<MoveType> {
+        Some(MoveType::new(
+            self.stored
+                .coin_type
+                .to_canonical_string(/* with_prefix */ true),
+        ))
+    }
+
+    /// The signed balance change.
+    async fn amount(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.stored.amount))
+    }
+}
+
+impl BalanceChange {
+    pub(crate) fn read(bytes: &[u8]) -> Result<Self, Error> {
+        let stored = bcs::from_bytes(bytes)
+            .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;
+
+        Ok(Self { stored })
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/big_int.rs
+++ b/crates/sui-graphql-rpc/src/types/big_int.rs
@@ -63,7 +63,7 @@ macro_rules! impl_From {
     }
 }
 
-impl_From!(u8, u16, u32, i64, u64, u128, U256);
+impl_From!(u8, u16, u32, i64, u64, i128, u128, U256);
 
 #[cfg(test)]
 mod tests {
@@ -100,8 +100,18 @@ mod tests {
         assert_eq!(BigInt::from(123_456u32), BigInt("123456".to_string()));
 
         assert_eq!(
+            BigInt::from(-12_345_678_901i64),
+            BigInt("-12345678901".to_string()),
+        );
+
+        assert_eq!(
             BigInt::from(12_345_678_901u64),
             BigInt("12345678901".to_string()),
+        );
+
+        assert_eq!(
+            BigInt::from(-123_456_789_012_345_678_901i128),
+            BigInt("-123456789012345678901".to_string()),
         );
 
         assert_eq!(

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod address;
 pub(crate) mod balance;
+pub(crate) mod balance_change;
 pub(crate) mod base64;
 pub(crate) mod big_int;
 pub(crate) mod checkpoint;

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -60,10 +60,22 @@ type Balance {
 	totalBalance: BigInt
 }
 
+"""
+Effects to the balance (sum of coin values per coin type) owned by an address or object.
+"""
 type BalanceChange {
+	"""
+	The address or object whose balance has changed.
+	"""
 	owner: Owner
-	amount: BigInt
+	"""
+	The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
+	"""
 	coinType: MoveType
+	"""
+	The signed balance change.
+	"""
+	amount: BigInt
 }
 
 type BalanceConnection {
@@ -1691,6 +1703,10 @@ type TransactionBlockEffects {
 	The effect this transaction had on objects on-chain.
 	"""
 	objectChanges: [ObjectChange!]
+	"""
+	The effect this transaction had on the balances (sum of coin values per coin type) of
+	addresses and objects.
+	"""
 	balanceChanges: [BalanceChange!]
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.


### PR DESCRIPTION
##  Description

Represent a `BalanceChange` using the underlying indexer representation (like `Object` and `TransactionBlockEffects`) and document it.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 
- #15039 
- #15040
- #15041
- #15042 