### PR TITLE
[GraphQL/MoveType] Represent using TypeTag

### DIFF
--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -31,11 +31,7 @@ impl BalanceChange {
 
     /// The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
     async fn coin_type(&self) -> Option<MoveType> {
-        Some(MoveType::new(
-            self.stored
-                .coin_type
-                .to_canonical_string(/* with_prefix */ true),
-        ))
+        Some(MoveType::new(self.stored.coin_type.clone()))
     }
 
     /// The signed balance change.

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -77,10 +77,7 @@ impl DynamicField {
             .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
             .extend()?;
 
-        Ok(Some(MoveValue::new(
-            type_tag.to_canonical_string(true),
-            Base64::from(bcs),
-        )))
+        Ok(Some(MoveValue::new(type_tag, Base64::from(bcs))))
     }
 
     /// The actual data stored in the dynamic field.
@@ -118,7 +115,7 @@ impl DynamicField {
                 .extend()?;
 
             Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
-                type_tag.to_canonical_string(true),
+                type_tag,
                 Base64::from(bcs),
             ))))
         }

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -9,8 +9,8 @@ use super::{coin::Coin, object::Object};
 use crate::error::Error;
 use crate::types::stake::StakedSui;
 use async_graphql::*;
-use move_core_types::language_storage::StructTag;
 use sui_types::object::{Data, MoveObject as NativeMoveObject};
+use sui_types::TypeTag;
 
 #[derive(Clone)]
 pub(crate) struct MoveObject {
@@ -30,11 +30,8 @@ impl MoveObject {
     /// provides the flat representation of the type signature, and the bcs of the corresponding
     /// data
     async fn contents(&self) -> Option<MoveValue> {
-        let type_ = StructTag::from(self.native.type_().clone());
-        Some(MoveValue::new(
-            type_.to_canonical_string(/* with_prefix */ true),
-            self.native.contents().into(),
-        ))
+        let type_ = TypeTag::from(self.native.type_().clone());
+        Some(MoveValue::new(type_, self.native.contents().into()))
     }
 
     /// Determines whether a tx can transfer this object

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -111,8 +111,8 @@ impl MoveValue {
 }
 
 impl MoveValue {
-    pub fn new(repr: String, bcs: Base64) -> Self {
-        let type_ = MoveType::new(repr);
+    pub fn new(tag: TypeTag, bcs: Base64) -> Self {
+        let type_ = MoveType::new(tag);
         Self { type_, bcs }
     }
 
@@ -437,14 +437,15 @@ mod tests {
         layout: A::MoveTypeLayout,
         data: T,
     ) -> Result<MoveData, Error> {
-        let type_ = MoveType::new(tag.into());
+        let tag = TypeTag::from_str(tag.into().as_str()).unwrap();
+        let type_ = MoveType::new(tag);
         let bcs = Base64(bcs::to_bytes(&data).unwrap());
         MoveValue { type_, bcs }.data_impl(layout)
     }
 
     fn json<T: Serialize>(layout: A::MoveTypeLayout, data: T) -> Result<Json, Error> {
         let tag: TypeTag = (&layout).try_into().expect("Error fetching type tag");
-        let type_ = MoveType::new(tag.to_canonical_string(/* with_prefix */ true));
+        let type_ = MoveType::new(tag);
         let bcs = Base64(bcs::to_bytes(&data).unwrap());
         MoveValue { type_, bcs }.json_impl(layout)
     }


### PR DESCRIPTION
##  Description

Previously `MoveType` was represented using its string representation. This meant that everywhere we needed to create a `MoveType`, we had to be careful to ensure we canonicalised the string representation first. This PR flips things around so that the native representation relies on `TypeTag` and we derive the canonical form of it when requested (by the accessing the `repr` field).

This makes it harder (or impossible) to accidentally return a non-canonical type in a query response.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 
- #15039 
- #15040
- #15041
- #15042 
- #15043