### PR TITLE
[cli] remove the 20 bytes address description

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -206,14 +206,14 @@ pub enum SuiClientCommands {
 
     /// Merge two coin objects into one coin
     MergeCoin {
-        /// Coin to merge into, in 20 bytes Hex string
+        /// The address of the coin to merge into.
         #[clap(long)]
         primary_coin: ObjectID,
-        /// Coin to be merged, in 20 bytes Hex string
+        /// The address of the coin to be merged.
         #[clap(long)]
         coin_to_merge: ObjectID,
-        /// ID of the gas object for gas payment, in 20 bytes Hex string
-        /// If not provided, a gas object with at least gas_budget value will be selected
+        /// The address of the gas object for gas payment.
+        /// If not provided, a gas object with at least gas_budget value will be selected.
         #[clap(long)]
         gas: Option<ObjectID>,
         /// Gas budget for this call


### PR DESCRIPTION
## Description 

Fixes the description of the `sui client merge-coin` command, by removing the reference to the 20 bytes address. This should close #10152. 

## Test Plan 

Just a CLI help description update, no tests are needed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed the description of the `sui client merge-coin` command, by removing the reference to the 20 bytes address.