### PR TITLE
Enoki SDK improvements

### DIFF
--- a/.changeset/new-humans-join.md
+++ b/.changeset/new-humans-join.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+Make enoki flow session observable. Expose state parameter on useAuthCallback.

--- a/sdk/enoki/src/react.tsx
+++ b/sdk/enoki/src/react.tsx
@@ -32,8 +32,14 @@ export function useZkLogin() {
 	return useStore(flow.$zkLoginState);
 }
 
+export function useZkLoginSession() {
+	const flow = useEnokiFlow();
+	return useStore(flow.$zkLoginSession).value;
+}
+
 export function useAuthCallback() {
 	const flow = useEnokiFlow();
+	const [state, setState] = useState<string | null>(null);
 	const [handled, setHandled] = useState(false);
 	const [hash, setHash] = useState<string | null>(null);
 
@@ -50,7 +56,7 @@ export function useAuthCallback() {
 
 		(async () => {
 			try {
-				await flow.handleAuthCallback(hash);
+				setState(await flow.handleAuthCallback(hash));
 
 				window.location.hash = '';
 			} finally {
@@ -59,5 +65,5 @@ export function useAuthCallback() {
 		})();
 	}, [hash, flow]);
 
-	return handled;
+	return { handled, state };
 }


### PR DESCRIPTION
## Description 

Some minor updates to the Enoki SDK that are needed after attempting to integrate into the zkSend codebase:
- The session is currently not observable, which means there's no way to get the users' JWT consistently in React. `getSession` _mostly_ works but there is a timing issue if you call it before the `authCallback` has processed. I updated this state to be observable (the API here is not really ideal, but we kind of know that _all_ of theses APIs are weird and will need to be rethought once we have more usage).
- `useAuthCallback` didn't expose the returned state parameter, which is often used to track auth redirects. The hook now returns the state parameter so that this functionality can be implemented.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
