### PR TITLE
[move-ide] Bundling of move-analyzer binary with the plugin

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/.vscodeignore
+++ b/external-crates/move/crates/move-analyzer/editors/code/.vscodeignore
@@ -6,9 +6,16 @@
 **/*
 !images/move.png
 !out/src/**/*
-!node_modules/**/*
+!node_modules/lru-cache/**/*
+!node_modules/command-exists/**/*
+!node_modules/vscode-jsonrpc/**/*
+!node_modules/vscode-languageclient/**/*
+!node_modules/vscode-languageserver-protocol/**/*
+!node_modules/vscode-languageserver-types/**/*
 !language-configuration.json
+!language-server/**/*
 !move.tmLanguage.json
 !package-lock.json
 !package.json
+!LICENSE
 !README.md

--- a/external-crates/move/crates/move-analyzer/editors/code/LICENSE
+++ b/external-crates/move/crates/move-analyzer/editors/code/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -38,8 +38,8 @@ usually `~/.cargo/bin`.
 If your `move-analyzer` binary is in a different location than the default one (`~/.sui/bib`),
 you may have the extension look for the binary at this new location by using the the VSCode's
 settings (`⌘,` on macOS, or use the menu item *Code > Preferences > Settings*). Search for the
-`move.server.path` setting, set it to the new location of the `move-analyzer` binary, and restart
-VSCode.
+`move.server.path` workspace setting, set it to the new location of the `move-analyzer` binary,
+and restart VSCode.
 
 ## What if everything else fails?
 

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -5,7 +5,7 @@ language [documentation](https://docs.sui.io/concepts/sui-move-concepts).
 
 # How to Install
 
-1. Open a new window in any Visual Studio Code application version 1.55.2 or greater.
+1. Open a new window in any Visual Studio Code application version 1.61.0 or greater.
 2. Open the command palette (`⇧⌘P` on macOS, or use the menu item *View > Command Palette...*) and
    type **Extensions: Install Extensions**. This will open a panel named *Extensions* in the
    sidebar of your Visual Studio Code window.
@@ -13,7 +13,33 @@ language [documentation](https://docs.sui.io/concepts/sui-move-concepts).
    should appear as one of the option in the list below the search bar. Click **Install**.
 4. Open any file that ends in `.move`.
 
+Installation of the extension will also install a platform-specific pre-built move-analyzer binary in
+the `~/.sui/bin` directory. The move-analyzer binary is responsible for the advanced features of this
+VSCode extension (e.g., go to definition, type on hover). Please see the [Troubleshooting][#troubleshooting]
+section for situations when the pre-built move-analyzer binary is not available for your platform.
+
 # Troubleshooting
+
+## What if pre-built move-analyzer binary is not available for my platform?
+
+The `move-analyzer` language server is a Rust program which you can install manually provided
+that you have Rust development already [installed](https://www.rust-lang.org/tools/install).
+This can be done in two steps:
+
+1. Invoke `cargo install --git https://github.com/MystenLabs/sui move-analyzer` to install the
+`move-analyzer` language server in your Cargo binary directory. On Linux, this is usually
+usually `~/.cargo/bin`.
+2. Copy the move-analyzer binary to `~/.sui/bin` which is its default location.
+
+## What if I want to use a move-analyzer binary in a different location?
+
+If your `move-analyzer` binary is in a different location than the default one (`~/.sui/bib`),
+you may have the extension look for the binary at this new location by using the the VSCode's
+settings (`⌘,` on macOS, or use the menu item *Code > Preferences > Settings*). Search for the
+`move.server.path` setting, set it to the new location of the `move-analyzer` binary, and restart
+VSCode.
+
+## What if everything else fails?
 
 Check [Sui Developer Forum](https://forums.sui.io/c/technical-support) to see if the problem
 has already been reported and, if not, report it there.

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -14,9 +14,11 @@ language [documentation](https://docs.sui.io/concepts/sui-move-concepts).
 4. Open any file that ends in `.move`.
 
 Installation of the extension will also install a platform-specific pre-built move-analyzer binary in
-the `~/.sui/bin` directory. The move-analyzer binary is responsible for the advanced features of this
-VSCode extension (e.g., go to definition, type on hover). Please see the [Troubleshooting][#troubleshooting]
-section for situations when the pre-built move-analyzer binary is not available for your platform.
+the `~/.sui/bin` directory, overwriting the existing binary if it already exists. The move-analyzer 
+binary is responsible for the advanced features of this VSCode extension (e.g., go to definition,
+type on hover). Please see the [Troubleshooting][#troubleshooting] section for situations when 
+the pre-built move-analyzer binary is not available for your platform or if you want to use move-analyzer
+binary stored in a different location.
 
 # Troubleshooting
 

--- a/external-crates/move/crates/move-analyzer/editors/code/README.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/README.md
@@ -14,32 +14,42 @@ language [documentation](https://docs.sui.io/concepts/sui-move-concepts).
 4. Open any file that ends in `.move`.
 
 Installation of the extension will also install a platform-specific pre-built move-analyzer binary in
-the `~/.sui/bin` directory, overwriting the existing binary if it already exists. The move-analyzer 
-binary is responsible for the advanced features of this VSCode extension (e.g., go to definition,
-type on hover). Please see the [Troubleshooting][#troubleshooting] section for situations when 
+the default directory (see [here](#what-if-i-want-to-use-a-move-analyzer-binary-in-a-different-location)
+for information on the location of this directory), overwriting the existing binary if it already exists.
+The move-analyzer binary is responsible for the advanced features of this VSCode extension (e.g., go to
+definition, type on hover). Please see [Troubleshooting](#troubleshooting) for situations when
 the pre-built move-analyzer binary is not available for your platform or if you want to use move-analyzer
 binary stored in a different location.
 
 # Troubleshooting
 
-## What if pre-built move-analyzer binary is not available for my platform?
+## What if the pre-built move-analyzer binary is not available for my platform?
+
+If you are on Windows, the following answer assumes that your Windows user name is `USER`.
 
 The `move-analyzer` language server is a Rust program which you can install manually provided
 that you have Rust development already [installed](https://www.rust-lang.org/tools/install).
 This can be done in two steps:
 
-1. Invoke `cargo install --git https://github.com/MystenLabs/sui move-analyzer` to install the
-`move-analyzer` language server in your Cargo binary directory. On Linux, this is usually
-usually `~/.cargo/bin`.
-2. Copy the move-analyzer binary to `~/.sui/bin` which is its default location.
+1. Install the move-analyzer installation prerequisites for your platform. They are the same
+as prerequisites for Sui installation - for Linux, macOS and Windows these prerequisites and
+their installation instructions can be found
+[here](https://docs.sui.io/guides/developer/getting-started/sui-install#additional-prerequisites-by-operating-system)
+2. Invoke `cargo install --git https://github.com/MystenLabs/sui move-analyzer` to install the
+`move-analyzer` language server in your Cargo binary directory, which is typically located
+in the `~/.cargo/bin` (macOS/Linux) or `C:\Users\USER\.cargo\bin` (Windows) directory.
+3. Copy the move-analyzer binary to `~/.sui/bin` (macOS/Linux) or `C:\Users\USER\.sui\bin`
+(Windows), which is its default location (create this directory if it does not exist).
 
 ## What if I want to use a move-analyzer binary in a different location?
 
-If your `move-analyzer` binary is in a different location than the default one (`~/.sui/bib`),
-you may have the extension look for the binary at this new location by using the the VSCode's
-settings (`⌘,` on macOS, or use the menu item *Code > Preferences > Settings*). Search for the
-`move.server.path` workspace setting, set it to the new location of the `move-analyzer` binary,
-and restart VSCode.
+If you are on Windows, the following answer assumes that your Windows user name is `USER`.
+
+If your `move-analyzer` binary is in a different directory than the default one (`~/.sui/bin`
+on macOS or Linux, or `C:\Users\USER\.sui\bin` on Windows), you may have the extension look
+for the binary at this new location by using VSCode's settings (`⌘,` on macOS, or use the menu
+item *Code > Preferences > Settings*). Search for the `move.server.path` workspace setting,
+set it to the new location of the `move-analyzer` binary, and restart VSCode.
 
 ## What if everything else fails?
 

--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "move-buddy",
+	"name": "move",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "move-buddy",
+			"name": "move",
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -19,7 +19,7 @@
 				"@types/glob": "^7.1.4",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "^14.17.22",
-				"@types/vscode": "^1.58.2",
+				"@types/vscode": "^1.61.0",
 				"@typescript-eslint/eslint-plugin": "^6.10.0",
 				"@typescript-eslint/parser": "^6.10.0",
 				"@vscode/test-electron": "^2.0.0",
@@ -36,7 +36,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"engines": {
-				"vscode": "^1.58.2"
+				"vscode": "^1.61.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -96,9 +96,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-			"integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+			"integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -249,28 +249,28 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-			"integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.84.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.1.tgz",
-			"integrity": "sha512-DB10vBRLEPA/us7p3gQilU2Tq5HDu6JWTyCpD9qtb7MKWIvJS5In9HU3YgVGCXf/miwHJiY62aXwjtUSMpT8HA==",
+			"version": "1.84.2",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.2.tgz",
+			"integrity": "sha512-LCe1FvCDMJKkPdLVGYhP0HRJ1PDop2gRVm/zFHiOKwYLBRS7vEV3uOOUId4HMV+L1IxqyS+IZXMmlSMRbZGIAw==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
-			"integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.12.0.tgz",
+			"integrity": "sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.10.0",
-				"@typescript-eslint/type-utils": "6.10.0",
-				"@typescript-eslint/utils": "6.10.0",
-				"@typescript-eslint/visitor-keys": "6.10.0",
+				"@typescript-eslint/scope-manager": "6.12.0",
+				"@typescript-eslint/type-utils": "6.12.0",
+				"@typescript-eslint/utils": "6.12.0",
+				"@typescript-eslint/visitor-keys": "6.12.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -296,15 +296,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
-			"integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.12.0.tgz",
+			"integrity": "sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.10.0",
-				"@typescript-eslint/types": "6.10.0",
-				"@typescript-eslint/typescript-estree": "6.10.0",
-				"@typescript-eslint/visitor-keys": "6.10.0",
+				"@typescript-eslint/scope-manager": "6.12.0",
+				"@typescript-eslint/types": "6.12.0",
+				"@typescript-eslint/typescript-estree": "6.12.0",
+				"@typescript-eslint/visitor-keys": "6.12.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -324,13 +324,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
-			"integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.12.0.tgz",
+			"integrity": "sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.10.0",
-				"@typescript-eslint/visitor-keys": "6.10.0"
+				"@typescript-eslint/types": "6.12.0",
+				"@typescript-eslint/visitor-keys": "6.12.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -341,13 +341,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
-			"integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.12.0.tgz",
+			"integrity": "sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.10.0",
-				"@typescript-eslint/utils": "6.10.0",
+				"@typescript-eslint/typescript-estree": "6.12.0",
+				"@typescript-eslint/utils": "6.12.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -368,9 +368,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
-			"integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.12.0.tgz",
+			"integrity": "sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -381,13 +381,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
-			"integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.12.0.tgz",
+			"integrity": "sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.10.0",
-				"@typescript-eslint/visitor-keys": "6.10.0",
+				"@typescript-eslint/types": "6.12.0",
+				"@typescript-eslint/visitor-keys": "6.12.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -408,17 +408,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
-			"integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.12.0.tgz",
+			"integrity": "sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.10.0",
-				"@typescript-eslint/types": "6.10.0",
-				"@typescript-eslint/typescript-estree": "6.10.0",
+				"@typescript-eslint/scope-manager": "6.12.0",
+				"@typescript-eslint/types": "6.12.0",
+				"@typescript-eslint/typescript-estree": "6.12.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -433,12 +433,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
-			"integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.12.0.tgz",
+			"integrity": "sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.10.0",
+				"@typescript-eslint/types": "6.12.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -623,9 +623,9 @@
 			]
 		},
 		"node_modules/big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+			"version": "1.6.52",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -1304,15 +1304,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-			"integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+			"integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.3",
-				"@eslint/js": "8.53.0",
+				"@eslint/js": "8.54.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -1578,9 +1578,9 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-			"integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
@@ -1588,7 +1588,7 @@
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -1978,9 +1978,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/MystenLabs/sui/issues"
 	},
 	"engines": {
-		"vscode": "^1.58.2"
+		"vscode": "^1.61.0"
 	},
 	"categories": [
 		"Programming Languages"
@@ -26,7 +26,8 @@
 	],
 	"main": "./out/src/main.js",
 	"activationEvents": [
-		"workspaceContains:Move.toml"
+		"workspaceContains:Move.toml",
+		"onLanguage:move"
 	],
 	"contributes": {
 		"commands": [
@@ -41,9 +42,13 @@
 			"title": "Move",
 			"properties": {
 				"move.server.path": {
-					"type": "string",
-					"default": "~/.sui/bin/move-analyzer",
-					"markdownDescription": "Path and filename of the move-analyzer executable, e.g. `~/.sui/bin/move-analyzer`."
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "scope": "machine-overridable",
+                    "default": null,
+                    "markdownDescription": "Path to rust-analyzer executable (points to `~/.sui/bin/move-analyzer` by default)."
 				},
 				"move.trace.server": {
 					"type": "string",
@@ -111,7 +116,7 @@
 		"@types/glob": "^7.1.4",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "^14.17.22",
-		"@types/vscode": "^1.58.2",
+		"@types/vscode": "^1.61.0",
 		"@typescript-eslint/eslint-plugin": "^6.10.0",
 		"@typescript-eslint/parser": "^6.10.0",
 		"@vscode/test-electron": "^2.0.0",

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
@@ -1,0 +1,99 @@
+#!/bin/zsh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is meant to be executed on MacOS (hence zsh use - to get associative arrays otherwise
+# unavailable in the bundled bash version).
+
+set -e
+
+usage() {
+    >&2 echo "Usage: $0 -pkg|-pub [-h]"
+    >&2 echo ""
+    >&2 echo "Options:"
+    >&2 echo " -pub          Publish extensions for all targets"
+    >&2 echo " -pkg          Package extensions for all targets"
+    >&2 echo " -h            Print this message"
+}
+
+clean_tmp_dir() {
+  test -d "$TMP_DIR" && rm -fr "$TMP_DIR"
+}
+
+if [[ "$@" == "" ]]; then
+    usage
+    exit 1
+fi
+
+for cmd in "$@"
+do
+    if [[ "$cmd" == "-h" ]]; then
+        usage
+        exit 0
+    elif [[ "$cmd" == "-pkg" ]]; then
+        OP="package"
+        OPTS="-o move-VSCODE_OS.vsix"
+    elif [[ "$cmd" == "-pub" ]]; then
+        OP="publish"
+        OPTS=""
+    else
+        usage
+        exit 1
+    fi
+done
+
+# these will have to change if we want a different network/version
+NETWORK="testnet"
+VERSION="1.13.0"
+
+# a map from os version identifiers in Sui's binary distribution to os version identifiers
+# representing VSCode's target platforms used for creating platform-specific plugin distributions
+declare -A SUPPORTED_OS
+SUPPORTED_OS[macos-arm64]=darwin-arm64
+SUPPORTED_OS[macos-x86_64]=darwin-x64
+SUPPORTED_OS[ubuntu-x86_64]=linux-x64
+SUPPORTED_OS[windows-x86_64]=win32-x64
+
+TMP_DIR=/Users/adamwelc/tmp/tmp
+TMP_DIR=$( mktemp -d -t vscode-create )
+trap "clean_tmp_dir $TMP_DIR" EXIT
+
+LANG_SERVER_DIR="language-server"
+
+rm -rf $LANG_SERVER_DIR
+mkdir $LANG_SERVER_DIR
+
+for DIST_OS VSCODE_OS in "${(@kv)SUPPORTED_OS}"; do
+    # Sui distribution identifier
+    SUI_DISTRO=$NETWORK"-v"$VERSION
+    # name of the Sui distribution archive file, for example sui-testnet-v1.13.0-macos-arm64.tgz
+    SUI_ARCHIVE="sui-"$SUI_DISTRO"-"$DIST_OS".tgz"
+    # a path to downloaded Sui archive
+    SUI_ARCHIVE_PATH=$TMP_DIR"/"$SUI_ARCHIVE
+
+    # download Sui archive file to a given location and uncompress it
+    curl https://github.com/MystenLabs/sui/releases/download/"$SUI_DISTRO"/"$SUI_ARCHIVE" -L -o $SUI_ARCHIVE_PATH
+    tar -xf $SUI_ARCHIVE_PATH --directory $TMP_DIR
+
+    # names of the move-analyzer binary, both the one becoming part of the extension ($SERVER_BIN)
+    # and the one in the Sui archive ($ARCHIVE_SERVER_BIN)
+    SERVER_BIN="move-analyzer"
+    ARCHIVE_SERVER_BIN=$SERVER_BIN"-"$DIST_OS
+    if [[ "$DIST_OS" == *"windows"* ]]; then
+        SERVER_BIN="$SERVER_BIN".exe
+        ARCHIVE_SERVER_BIN="$ARCHIVE_SERVER_BIN".exe
+    fi
+
+    # copy move-analyzer binary to the appropriate location where it's picked up when bundling the
+    # extension
+    SRC_SERVER_BIN_LOC=$TMP_DIR"/external-crates/move/target/release/"$ARCHIVE_SERVER_BIN
+    DST_SERVER_BIN_LOC=$LANG_SERVER_DIR"/"$SERVER_BIN
+    cp $SRC_SERVER_BIN_LOC $DST_SERVER_BIN_LOC
+
+    vsce "$OP" ${OPTS//VSCODE_OS/$VSCODE_OS} --target "$VSCODE_OS"
+done
+
+rm -rf $LANG_SERVER_DIR
+
+# build a "generic" version of the extension that does not bundle the move-analyzer binary
+vsce "$OP" ${OPTS//VSCODE_OS/generic}

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
@@ -32,7 +32,7 @@ do
         exit 0
     elif [[ "$cmd" == "-pkg" ]]; then
         OP="package"
-        OPTS="-o move-VSCODE_OS.vsix"
+        OPTS="-omove-VSCODE_OS.vsix"
     elif [[ "$cmd" == "-pub" ]]; then
         OP="publish"
         OPTS=""

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
@@ -54,7 +54,6 @@ SUPPORTED_OS[macos-x86_64]=darwin-x64
 SUPPORTED_OS[ubuntu-x86_64]=linux-x64
 SUPPORTED_OS[windows-x86_64]=win32-x64
 
-TMP_DIR=/Users/adamwelc/tmp/tmp
 TMP_DIR=$( mktemp -d -t vscode-create )
 trap "clean_tmp_dir $TMP_DIR" EXIT
 

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -56,7 +56,7 @@ export class Configuration {
      * Installs language server binary in the default location unless a user-specified
      * (but not default) server location already contains a server binary.
      *
-     * @returns `true` if server binary installation succeeded, `fase` otherwise.
+     * @returns `true` if server binary installation succeeded, `false` otherwise.
      */
     async installServerBinary(extensionContext: vscode.ExtensionContext): Promise<boolean> {
         log.info('Installing language server binary');
@@ -91,9 +91,9 @@ export class Configuration {
                     { modal: true },
                     items,
                 );
-                return Promise.resolve(false);
+                return false;
             } // Otherwise simply return and use the existing user-specified binary.
-            return Promise.resolve(true);
+            return true;
         }
 
         assert(serverPath === this.defaultServerPath);
@@ -105,14 +105,14 @@ export class Configuration {
                 await vscode.workspace.fs.delete(this.defaultServerPath);
             } else {
                 // Since there is no bundled binary, let's use the one that's in the (default) path.
-                return Promise.resolve(true);
+                return true;
             }
         }
 
         if (!bundledServerExists) {
             // See a comment earlier in this function for why we need to use modal messages. In this
             // particular case,  the extension would never activate and its settings that could be
-            // used to override location of the server binary would not be available,
+            // used to override location of the server binary would not be available.
             const items: vscode.MessageItem = { title: 'OK', isCloseAffordance: true };
             await vscode.window.showErrorMessage(
                 'Pre-built move-analyzer binary is not available for this platform. ' +
@@ -121,7 +121,7 @@ export class Configuration {
                 { modal: true },
                 items,
             );
-            return Promise.resolve(false);
+            return false;
         }
 
         // Check if directory to store server binary exists (create it if necessary).
@@ -135,6 +135,6 @@ export class Configuration {
 
         await vscode.workspace.fs.copy(bundledServerPath, this.defaultServerPath);
 
-        return Promise.resolve(true);
+        return true;
     }
 }

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -5,6 +5,9 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import * as Path from 'path';
+import { log } from './log';
+import { assert } from 'console';
+
 
 /**
  * User-defined configuration values, such as those specified in VS Code settings.
@@ -15,8 +18,24 @@ import * as Path from 'path';
 export class Configuration {
     private readonly configuration: vscode.WorkspaceConfiguration;
 
+    /** Default directory for the location of the language server binary */
+    private readonly defaultServerDir: vscode.Uri;
+
+    /** Name of the language server binary */
+    private readonly serverName: string;
+
+    /** Default path to the language server binary */
+    readonly defaultServerPath: vscode.Uri;
+
     constructor() {
         this.configuration = vscode.workspace.getConfiguration('move');
+        this.defaultServerDir = vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), '.sui', 'bin');
+        if (process.platform === 'win32') {
+            this.serverName = 'move-analyzer.exe';
+        } else {
+            this.serverName = 'move-analyzer';
+        }
+        this.defaultServerPath = vscode.Uri.joinPath(this.defaultServerDir, this.serverName);
     }
 
     /** A string representation of the configured values, for logging purposes. */
@@ -26,29 +45,96 @@ export class Configuration {
 
     /** The path to the move-analyzer executable. */
     get serverPath(): string {
-        const defaultName = 'move-analyzer';
-        let serverPath = this.configuration.get<string>('server.path', defaultName);
-        if (serverPath.length === 0) {
-            // The default value of the `server.path` setting is 'move-analyzer'.
-            // A user may have over-written this default with an empty string value, ''.
-            // An empty string cannot be an executable name, so instead use the default.
-            return defaultName;
-        }
-
-        if (serverPath === defaultName) {
-            // If the program set by the user is through PATH,
-            // it will return directly if specified
-            return defaultName;
-        }
-
+        const serverPath = this.configuration.get<string | null>('server.path') ?? this.defaultServerPath.fsPath;
         if (serverPath.startsWith('~/')) {
-            serverPath = os.homedir() + serverPath.slice('~'.length);
+            return os.homedir() + serverPath.slice('~'.length);
         }
-
-        if (process.platform === 'win32' && !serverPath.endsWith('.exe')) {
-            serverPath = serverPath + '.exe';
-        }
-
         return Path.resolve(serverPath);
+    }
+
+    /**
+     * Installs language server binary in the default location unless a user-specified
+     * (but not default) server location already contains a server binary.
+     *
+     * @returns `true` if server binary installation succeeded, `fase` otherwise.
+     */
+    async installServerBinary(extensionContext: vscode.ExtensionContext): Promise<boolean> {
+        log.info('Installing language server binary');
+
+        // Check if server binary is bundled with the extension
+        const bundledServerPath = vscode.Uri.joinPath(extensionContext.extensionUri,
+                                                    'language-server',
+                                                    this.serverName);
+        const bundledServerExists = await vscode.workspace.fs.stat(bundledServerPath).then(
+            () => true,
+            () => false,
+        );
+
+        const serverPath = vscode.Uri.file(this.serverPath);
+        const serverPathExists = await vscode.workspace.fs.stat(serverPath).then(
+            () => true,
+            () => false,
+        );
+
+        if (serverPath.fsPath !== this.defaultServerPath.fsPath) {
+            // User has overwritten default server path (need to compare paths as comparing URIs fails
+            // for some reason even if one is initialized from another).
+            if (!serverPathExists) {
+                // The server binary on user-overwritten path does not exist so warn the user about it.
+                // Need to use modal messages, otherwise the promise returned from is not resolved
+                // (and the extension blocks), which can confusing.
+                const items: vscode.MessageItem = { title: 'OK', isCloseAffordance: true };
+                await vscode.window.showInformationMessage(
+                    `The move-analyzer binary at the user-specified path ('${this.serverPath}') ` +
+                    'is not available. Put the binary in the path or reset user settings and ' +
+                    'reinstall the extension to use the bundled binary.',
+                    { modal: true },
+                    items,
+                );
+                return Promise.resolve(false);
+            } // Otherwise simply return and use the existing user-specified binary.
+            return Promise.resolve(true);
+        }
+
+        assert(serverPath === this.defaultServerPath);
+        if (serverPathExists) {
+            // If a binary is bundled with the extension, delete existing binary in the default location.
+            // If the user wants to use another binary, they must specify an alternative location
+            // (and the docs reflect this). If there is no bundled binary, used the existing one.
+            if (bundledServerExists) {
+                await vscode.workspace.fs.delete(this.defaultServerPath);
+            } else {
+                // Since there is no bundled binary, let's use the one that's in the (default) path.
+                return Promise.resolve(true);
+            }
+        }
+
+        if (!bundledServerExists) {
+            // See a comment earlier in this function for why we need to use modal messages. In this
+            // particular case,  the extension would never activate and its settings that could be
+            // used to override location of the server binary would not be available,
+            const items: vscode.MessageItem = { title: 'OK', isCloseAffordance: true };
+            await vscode.window.showErrorMessage(
+                'Pre-built move-analyzer binary is not available for this platform. ' +
+                'Follow the instructions in the move-analyzer Visual Studio Code extension ' +
+                'README to manually install the language server.',
+                { modal: true },
+                items,
+            );
+            return Promise.resolve(false);
+        }
+
+        // Check if directory to store server binary exists (create it if necessary).
+        const serverDirExists = await vscode.workspace.fs.stat(this.defaultServerDir).then(
+            () => true,
+            () => false,
+        );
+        if (!serverDirExists){
+            await vscode.workspace.fs.createDirectory(this.defaultServerDir);
+        }
+
+        await vscode.workspace.fs.copy(bundledServerPath, this.defaultServerPath);
+
+        return Promise.resolve(true);
     }
 }

--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -48,12 +48,56 @@ async function serverVersion(context: Readonly<Context>): Promise<void> {
  * so that you can wait for the activation to complete by await
  */
 export async function activate(extensionContext: Readonly<vscode.ExtensionContext>): Promise<void> {
+    const globalMoveVersionKey = 'move-version';
     const extension = new Extension();
     log.info(`${extension.identifier} version ${extension.version}`);
 
     const configuration = new Configuration();
     log.info(`configuration: ${configuration.toString()}`);
 
+    // VSCode does not provide a hook for install/update extension, and we don't want to attempt
+    // installation of move-analyzer binaries every time an extension is activated (e.g. after
+    // VSCode restart).
+    //
+    // On a happy path (when user does not mock with user settings), we install move-analyzer
+    // whenever the extension itself is installed or upgraded, and skip installation when
+    // the globally stored extension version number does not change. However, even in this
+    // case we want to run the move-analyzer installation procedure if the move-analyzer
+    // is for some reason unavailable (e.g., because the user messed up user settings between
+    // VSCode restarts).
+    //
+    // We also don't want to update the extension version in the global state until we know
+    // that move-analyzer installation succeeded as the global state change is permanent.
+
+    const lastMoveVersion = extensionContext.globalState.get(globalMoveVersionKey);
+    let doInstallBinary: boolean;
+    let updateGlobalExtVersion: boolean;
+    if (lastMoveVersion === null) {
+        // Installation (no global variable set).
+        doInstallBinary = true;
+        updateGlobalExtVersion = true;
+    } else if (lastMoveVersion === extension.version) {
+        // Not an installation or an update (same version as seen before).
+        const serverPathExists = await vscode.workspace.fs.stat(vscode.Uri.file(configuration.serverPath)).then(
+            () => true,
+            () => false,
+        );
+        doInstallBinary = !serverPathExists;
+        updateGlobalExtVersion = false;
+    } else {
+        // Update (different versions).
+        doInstallBinary = true;
+        updateGlobalExtVersion = true;
+    }
+
+    if (doInstallBinary) {
+        const success = await configuration.installServerBinary(extensionContext);
+        if (!success) {
+            return;
+        }
+    }
+
+    log.info('Creating extension context');
     const context = Context.create(extensionContext, configuration);
     // An error here -- for example, if the path to the `move-analyzer` binary that the user
     // specified in their settings is not valid -- prevents the extension from providing any
@@ -76,4 +120,8 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
     context.registerCommand('textDocumentDocumentSymbol', commands.textDocumentDocumentSymbol);
     context.registerCommand('textDocumentHover', commands.textDocumentHover);
     context.registerCommand('textDocumentCompletion', commands.textDocumentCompletion);
+
+    if (updateGlobalExtVersion) {
+        await extensionContext.globalState.update(globalMoveVersionKey, extension.version);
+    }
 }


### PR DESCRIPTION
## Description 

This PR adds bundling of platform-specific move-analyzer binary with the VSCode extension distribution itself. This seems like the current solution of choice (e.g., adopted by newer versions of rust-analyzer).

The PR includes required changes to TS code as well as a script responsible for packaging bundled extensions locally (for testing) as well as publishing them.

Added licensing information copied from the root of the Sui repository to have it included in VSCode Marketplace once the extension is published.

This PR is marked as not having user-visible impact as it's not a change to the existing extension but rather one of the initial steps to creating a new one.

## Test Plan 

I tested this pretty extensively manually on a Mac (not sure if it's even possible to automate this). I also tested bundled extension installation (as well as manual installation described in the Troubleshooting section) on Linux and Windows.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
