### PR TITLE
[framework] adds freeze_policy method to the token module

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/token.move
+++ b/crates/sui-framework/packages/sui-framework/sources/token.move
@@ -50,6 +50,8 @@ module sui::token {
     /// Using `confirm_request_mut` without `spent_balance`. Immutable version
     /// of the function must be used instead.
     const EUseImmutableConfirm: u64 = 7;
+    /// Using incorrect cap for the `freeze_policy` method.
+    const EIncorrectCap: u64 = 8;
 
     // === Protected Actions ===
 
@@ -153,6 +155,21 @@ module sui::token {
     /// shared after initialization.
     public fun share_policy<T>(policy: TokenPolicy<T>) {
         transfer::share_object(policy)
+    }
+
+    /// Freeze the `TokenPolicy`. After freezing, the `TokenPolicy` can no longer
+    /// be modified. Consumes the `TokenPolicyCap` as it becomes useless after
+    /// the object has been put into an immutable state.
+    ///
+    /// Warning: this action should only be performed in rare cases as the
+    /// consequences are irreversible. Changing or removing a frozen policy is
+    /// not possible.
+    public fun freeze_policy<T>(policy: TokenPolicy<T>, cap: TokenPolicyCap<T>) {
+        let TokenPolicyCap { id, for } = cap;
+        
+        assert!(object::id(&policy) == for, EIncorrectCap);
+        transfer::freeze_object(policy);
+        object::delete(id);
     }
 
     // === Protected Actions ===

--- a/examples/move/token/sources/coffee.move
+++ b/examples/move/token/sources/coffee.move
@@ -23,6 +23,7 @@ module examples::coffee {
     /// OTW for the Token.
     struct COFFEE has drop {}
 
+    #[lint_allow(coin_field)]
     /// The shop that sells Coffee and allows to buy a Coffee if the customer
     /// has 10 COFFEE points.
     struct CoffeeShop has key {

--- a/examples/move/token/sources/fast_token.move
+++ b/examples/move/token/sources/fast_token.move
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This example extends on the `simple_token` example but uses immutable policies
+/// which are published every once in X epochs. This allows for fast-path
+/// execution while still allowing for policy updates; but comes with a burden
+/// of supporting and republishing policies.
+///
+/// Step-by-step:
+/// 1. Create a new currency, acquire the TreasuryCap
+/// 2. Decide the interval while a single TokenPolicy is active
+/// 3. Use the `new_policy_until_epoch` function to create a policy which will
+///   be valid until the given epoch. TokenPolicy will be shared.
+/// 4. Every X epochs run the `new_policy_until_epoch` function again to create
+///  a new policy.
+///
+/// Benefits:
+/// - Fast-path execution - immutable objects are treated as public constants
+///
+/// Drawbacks:
+/// - Requires extra managemenet to support and republish policies
+/// - Storage is not reclaimable - old policies will be kept in the storage
+///   forever
+/// - Denylist needs to be copied every time a new policy is created
+/// - Cost of a mistake is high - if a policy is published with a mistake, it
+///   cannot be fixed.
+module examples::fast_token {
+    use std::option;
+    use sui::transfer;
+    use sui::coin::{Self, TreasuryCap};
+    use sui::tx_context::{sender, epoch, TxContext};
+
+    use sui::token::{Self, TokenPolicy, TokenPolicyCap};
+
+    // import rules and use them for this app
+    use examples::denylist_rule::{Self, Denylist};
+    use examples::before_epoch_rule::{Self, BeforeEpoch};
+
+    /// Trying to set a policy with an epoch in the past will fail.
+    const EInvalidEpoch: u64 = 0;
+
+    /// OTW and the type for the Token.
+    struct FAST_TOKEN has drop {}
+
+    // Most of the magic happens in the initializer for the demonstration
+    // purposes; however half of what's happening here could be implemented as
+    // a single / set of PTBs.
+    fun init(otw: FAST_TOKEN, ctx: &mut TxContext) {
+        let treasury_cap = create_currency(otw, ctx);
+        transfer::public_transfer(treasury_cap, sender(ctx));
+    }
+
+    /// Create and freeze a `TokenPolicy` with denylist and before-epoch rules.
+    public fun new_policy_until_epoch(
+        treasury: &mut TreasuryCap<FAST_TOKEN>,
+        denylist: vector<address>,
+        epoch: u64,
+        ctx: &mut TxContext
+    ) {
+        assert!(epoch(ctx) < epoch, EInvalidEpoch);
+        let (policy, cap) = token::new_policy(treasury, ctx);
+
+        // denylist must be copied every time
+        denylist_rule::add_records(&mut policy, &cap, denylist, ctx);
+
+        // set the epoch until this policy is valid
+        before_epoch_rule::set_epoch(&mut policy, &cap, epoch, ctx);
+
+        set_rules(&mut policy, &cap, ctx);
+        token::freeze_policy(policy, cap);
+    }
+
+    /// Internal: not necessary, but moving this call to a separate function for
+    /// better visibility of the Closed Loop setup in `init` and easier testing.
+    public(friend) fun set_rules<T>(
+        policy: &mut TokenPolicy<T>,
+        cap: &TokenPolicyCap<T>,
+        ctx: &mut TxContext
+    ) {
+        // Create a denylist rule and add it to every action
+        // Now all actions are allowed but require a denylist
+        token::add_rule_for_action<T, Denylist>(policy, cap, token::spend_action(), ctx);
+        token::add_rule_for_action<T, Denylist>(policy, cap, token::to_coin_action(), ctx);
+        token::add_rule_for_action<T, Denylist>(policy, cap, token::transfer_action(), ctx);
+        token::add_rule_for_action<T, Denylist>(policy, cap, token::from_coin_action(), ctx);
+
+        // Same with the before-epoch rule
+        // Now all actions are allowed but require a denylist and before-epoch verification
+        token::add_rule_for_action<T, BeforeEpoch>(policy, cap, token::spend_action(), ctx);
+        token::add_rule_for_action<T, BeforeEpoch>(policy, cap, token::to_coin_action(), ctx);
+        token::add_rule_for_action<T, BeforeEpoch>(policy, cap, token::transfer_action(), ctx);
+        token::add_rule_for_action<T, BeforeEpoch>(policy, cap, token::from_coin_action(), ctx);
+    }
+
+    /// Internal: not necessary, but moving this call to a separate function for
+    /// better visibility of the Closed Loop setup in `init`.
+    fun create_currency<T: drop>(
+        otw: T,
+        ctx: &mut TxContext
+    ): TreasuryCap<T> {
+        let (treasury_cap, metadata) = coin::create_currency(
+            otw, 6,
+            b"SMPL",
+            b"Simple Token",
+            b"Token that showcases denylist",
+            option::none(),
+            ctx
+        );
+
+        transfer::public_freeze_object(metadata);
+        treasury_cap
+    }
+}

--- a/examples/move/token/sources/rules/epoch_rule.move
+++ b/examples/move/token/sources/rules/epoch_rule.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// An example of a Rule for the Closed Loop Token which sets the Policy for a
+/// limited number of epochs. Works like a timelock but uses epochs as the unit.
+///
+/// The epoch setting is inclusive, i.e. the request is valid before the set epoch.
+/// Example: if epoch is 3, the request is valid until the end of epoch 2.
+module examples::before_epoch_rule {
+    use sui::tx_context::{epoch, TxContext};
+    use sui::token::{
+        Self,
+        TokenPolicy,
+        TokenPolicyCap,
+        ActionRequest
+    };
+
+    /// The Configuration for the rule is missing.
+    const ENotConfigured: u64 = 0;
+    /// Current epoch is too late for the request.
+    const EEpochTooLate: u64 = 1;
+
+    /// The Rule witness.
+    struct BeforeEpoch has drop {}
+
+    /// The Rule config.
+    struct Config has store, drop {
+        epoch: u64
+    }
+
+    /// Verifies that the current epoch is not later than the set epoch.
+    /// Aborts if the config is not set or if the current epoch is too late.
+    public fun verify<T>(
+        policy: &TokenPolicy<T>,
+        request: &mut ActionRequest<T>,
+        ctx: &mut TxContext
+    ) {
+        assert!(token::has_rule_config<T, BeforeEpoch>(policy), ENotConfigured);
+
+        let config: &Config = token::rule_config(BeforeEpoch {}, policy);
+        let before_epoch = config.epoch;
+
+        assert!(epoch(ctx) < before_epoch, EEpochTooLate);
+        token::add_approval(BeforeEpoch {}, request, ctx);
+    }
+
+    /// Sets the epoch for the rule. Configurable - can be changed at any time
+    /// if the Policy supports mutability (not frozen).
+    public fun set_epoch<T>(
+        policy: &mut TokenPolicy<T>,
+        cap: &TokenPolicyCap<T>,
+        epoch: u64,
+        ctx: &mut TxContext
+    ) {
+        // if there's no stored config for the rule, add a new one
+        if (!token::has_rule_config<T, BeforeEpoch>(policy)) {
+            let config = Config { epoch };
+            token::add_rule_config(BeforeEpoch {}, policy, cap, config, ctx);
+        } else {
+            let config: &mut Config = token::rule_config_mut(
+                BeforeEpoch {}, policy, cap
+            );
+
+            config.epoch = epoch;
+        }
+    }
+}


### PR DESCRIPTION
## Description 

Starts the conversation around immutable policies.

## Test Plan 

TBD

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
