### PR TITLE
[rust-sdk] improve the examples docs by renaming actions to commands

### DIFF
--- a/crates/sui-sdk/examples/programmable_transactions_api.rs
+++ b/crates/sui-sdk/examples/programmable_transactions_api.rs
@@ -16,14 +16,14 @@ use sui_sdk::{
 use utils::setup_for_write;
 
 // This example shows how to use programmable transactions to chain multiple
-// actions into one transaction. Specifically, the example retrieves two addresses
+// commands into one transaction. Specifically, the example retrieves two addresses
 // from the local wallet, and then
 // 1) finds a coin from the active address that has Sui,
 // 2) splits the coin into one coin of 1000 MIST and the rest,
 // 3  transfers the split coin to second Sui address,
 // 4) signs the transaction,
 // 5) executes it.
-// For some of these actions it prints some output.
+// For some of these commands it prints some output.
 // Finally, at the end of the program it prints the number of coins for the
 // Sui address that received the coin.
 // If you run this program several times, you should see the number of coins
@@ -42,7 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
     let coin = coins.data.into_iter().next().unwrap();
 
-    // programmable transactions allows the user to bundle a number of actions into one transaction
+    // programmable transactions allows the user to bundle a number of commands into one transaction
     let mut ptb = ProgrammableTransactionBuilder::new();
 
     // 2) split coin


### PR DESCRIPTION
## Description 

Commands is the term that is being used to describe building a transaction, so this PR uses this term in the Rust SDK examples in favor of actions

## Test Plan 

Code documentation updated, no tests needed.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
