### PR TITLE
Hydrate enoki flow session on mount

### DIFF
--- a/.changeset/heavy-mayflies-think.md
+++ b/.changeset/heavy-mayflies-think.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+Hydrate the session on mount

--- a/sdk/enoki/src/EnokiFlow.ts
+++ b/sdk/enoki/src/EnokiFlow.ts
@@ -8,7 +8,7 @@ import { fromB64, toB64 } from '@mysten/sui.js/utils';
 import type { ZkLoginSignatureInputs } from '@mysten/sui.js/zklogin';
 import { decodeJwt } from 'jose';
 import type { WritableAtom } from 'nanostores';
-import { atom, onSet } from 'nanostores';
+import { atom, onMount, onSet } from 'nanostores';
 
 import type { Encryption } from './encryption.js';
 import { createDefaultEncryption } from './encryption.js';
@@ -88,6 +88,11 @@ export class EnokiFlow {
 
 		this.$zkLoginState = atom(storedState || {});
 		this.$zkLoginSession = atom({ initialized: false, value: null });
+
+		// Hydrate the session on mount:
+		onMount(this.$zkLoginSession, () => {
+			this.getSession();
+		});
 
 		onSet(this.$zkLoginState, ({ newValue }) => {
 			this.#store.set(this.#storageKeys.STATE, JSON.stringify(newValue));


### PR DESCRIPTION
## Description 

The enoki flow session isn't always hydrated, which means the user needs to start the hydration with `flow.getSession()`, which isn't really ideal. This updates to start hydrating the session once the store is mounted.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
