### PR TITLE
Early return status on auto connect

### DIFF
--- a/.changeset/five-cobras-boil.md
+++ b/.changeset/five-cobras-boil.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': patch
+---
+
+Early return on `useAutoConnectWallet` to improve account switching performance

--- a/sdk/dapp-kit/src/hooks/wallet/useAutoConnectWallet.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useAutoConnectWallet.ts
@@ -77,6 +77,10 @@ export function useAutoConnectWallet(): 'disabled' | 'idle' | 'attempted' {
 		return 'idle';
 	}
 
+	if (isConnected) {
+		return 'attempted';
+	}
+
 	if (!lastConnectedWalletName) {
 		return 'attempted';
 	}


### PR DESCRIPTION
## Description 

When integrating the new SDK into zkSend I noticed that switching the selected account would actually cause the UI to flicker. This happened because the `useAutoConnectWallet` would flip back to `idle` while the query was being resolved, which isn't the expected behavior. Now, we just early return in the hook if the wallet has been connected.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
