### PR TITLE
Add local cache for package resolver in analytics

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -17,13 +17,14 @@ use crate::handlers::{
     ObjectStatusTracker,
 };
 
-use crate::package_store::LocalDBPackageStore;
+use crate::package_store::{LocalDBPackageStore, PackageCache};
 use crate::tables::ObjectEntry;
 use crate::FileType;
 
 pub struct ObjectHandler {
     objects: Vec<ObjectEntry>,
-    resolver: Resolver<LocalDBPackageStore>,
+    package_store: LocalDBPackageStore,
+    resolver: Resolver<PackageCache>,
 }
 
 #[async_trait::async_trait]
@@ -39,7 +40,7 @@ impl Handler for ObjectHandler {
         } = checkpoint_data;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {
-                self.resolver.package_store().update(object)?;
+                self.package_store.update(object)?;
             }
             self.process_transaction(
                 checkpoint_summary.epoch,
@@ -69,10 +70,11 @@ impl AnalyticsHandler<ObjectEntry> for ObjectHandler {
 
 impl ObjectHandler {
     pub fn new(store_path: &Path, rest_uri: &str) -> Self {
-        let store = LocalDBPackageStore::new(&store_path.join("object"), rest_uri);
+        let package_store = LocalDBPackageStore::new(&store_path.join("object"), rest_uri);
         ObjectHandler {
             objects: vec![],
-            resolver: Resolver::new(store),
+            package_store: package_store.clone(),
+            resolver: Resolver::new(PackageCache::new(package_store)),
         }
     }
     async fn process_transaction(

--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use move_core_types::account_address::AccountAddress;
-use sui_package_resolver::{error::Error as PackageResolverError, Package, PackageStore, Result};
+use sui_package_resolver::{
+    error::Error as PackageResolverError, Package, PackageStore, PackageStoreWithLruCache, Result,
+};
 use sui_rest_api::Client;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::object::Object;
@@ -64,6 +66,7 @@ impl PackageStoreTables {
 /// kept updated with latest version of package objects while iterating over checkpoints. If the
 /// local db is missing (or gets deleted), packages are fetched from a full node and local store is
 /// updated
+#[derive(Clone)]
 pub struct LocalDBPackageStore {
     package_store_tables: Arc<PackageStoreTables>,
     fallback_client: Client,
@@ -119,3 +122,5 @@ impl PackageStore for LocalDBPackageStore {
         Ok(Arc::new(Package::read(&object)?))
     }
 }
+
+pub(crate) type PackageCache = PackageStoreWithLruCache<LocalDBPackageStore>;


### PR DESCRIPTION
## Description 

Without this, package resolution is slow in parsing object as package. This keeps the parsed object in local cache which seems to be 10-20x faster

## Test Plan 

Running locally produces much faster results. And graphql uses the same setup, so this is just following the existing practice
