### PR TITLE
[TransactionEffects/API] Lamport Version

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -163,7 +163,7 @@ Response: {
           "effects": {
             "status": "SUCCESS",
             "errors": null,
-            "lamportVersion": 2,
+            "lamportVersion": 3,
             "dependencies": [
               {
                 "digest": "C5AEGK7kAtcPQotXhpzmgaAZFyTu5GtnkmcfNXFAubXk"

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1651,11 +1651,10 @@ type TransactionBlockEffects {
 	"""
 	status: ExecutionStatus
 	"""
-	The latest version of all objects that have been created or modified by this transaction,
-	immediately following this transaction.  A system transaction that does not modify or create
-	objects will not have a lamport version.
+	The latest version of all objects (apart from packages) that have been created or modified
+	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: Int
+	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
 	"""

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -57,19 +57,10 @@ impl TransactionBlockEffects {
         })
     }
 
-    /// The latest version of all objects that have been created or modified by this transaction,
-    /// immediately following this transaction.  A system transaction that does not modify or create
-    /// objects will not have a lamport version.
-    async fn lamport_version(&self) -> Option<u64> {
-        if let Some(((_id, version, _digest), _owner)) = self.native.created().first() {
-            Some(version.value())
-        } else if let Some(((_id, version, _digest), _owner)) = self.native.mutated().first() {
-            Some(version.value())
-        } else if let Some(((_id, version, _digest), _owner)) = self.native.unwrapped().first() {
-            Some(version.value())
-        } else {
-            None
-        }
+    /// The latest version of all objects (apart from packages) that have been created or modified
+    /// by this transaction, immediately following this transaction.
+    async fn lamport_version(&self) -> u64 {
+        self.native.lamport_version().value()
     }
 
     /// The reason for a transaction failure, if it did fail.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1655,11 +1655,10 @@ type TransactionBlockEffects {
 	"""
 	status: ExecutionStatus
 	"""
-	The latest version of all objects that have been created or modified by this transaction,
-	immediately following this transaction.  A system transaction that does not modify or create
-	objects will not have a lamport version.
+	The latest version of all objects (apart from packages) that have been created or modified
+	by this transaction, immediately following this transaction.
 	"""
-	lamportVersion: Int
+	lamportVersion: Int!
 	"""
 	The reason for a transaction failure, if it did fail.
 	"""

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -107,6 +107,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
         self.modified_at_versions.clone()
     }
+
+    fn lamport_version(&self) -> SequenceNumber {
+        SequenceNumber::lamport_increment(self.modified_at_versions.iter().map(|(_, v)| *v))
+    }
+
     fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)> {
         unimplemented!("Only supposed by v2 and above");
     }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -81,6 +81,10 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             .collect()
     }
 
+    fn lamport_version(&self) -> SequenceNumber {
+        self.lamport_version
+    }
+
     fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)> {
         self.changed_objects
             .iter()

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -363,6 +363,9 @@ pub trait TransactionEffectsAPI {
     fn executed_epoch(&self) -> EpochId;
     fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)>;
 
+    /// The version assigned to all output objects (apart from packages).
+    fn lamport_version(&self) -> SequenceNumber;
+
     /// Metadata of objects prior to modification. This includes any object that exists in the
     /// store prior to this transaction and is modified in this transaction.
     /// It includes objects that are mutated, wrapped and deleted.


### PR DESCRIPTION
##  Description

Expose lamport version from both Effects v1 and Effects v2 via the `TransactionEffectsAPI`.  This is mainly to serve the GraphQL API which needs to return this for both kinds of effect.

This corrects another edge case of the existing GraphQL implementation of `lamportVersion`: If the only object created by a transaction is a package, then the previous GraphQL implementation would incorrectly suggest that the package's version is the transaction's lamport version.  This is not correct, because package versioning is treated specially.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- transactions
```

##  Stack

- #14929 
- #14930 
- #14934
- #14935 
- #14961 
- #14974
- #15013
- #15014
- #15015
- #15016
- #15018
- #15020
- #15021
- #15036 
- #15037 
- #15038 
- #15039 
- #15040
- #15041
- #15042 
- #15043
- #15044 
- #15074 