### PR TITLE
Add snowflake anlytics schemas

### DIFF
--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/checkpoint.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/checkpoint.sql
@@ -1,0 +1,70 @@
+// Define the checkpoint table schema
+CREATE
+    OR REPLACE TABLE CHECKPOINT
+(
+    checkpoint_digest                   STRING
+        CONSTRAINT checkpoint_digest_unique UNIQUE    NOT NULL,
+    sequence_number                     NUMBER(20, 0)
+        CONSTRAINT sequence_num_pk PRIMARY KEY        NOT NULL,
+    epoch                               NUMBER(20, 0) NOT NULL,
+    timestamp_ms                        NUMBER(20, 0) NOT NULL,
+    previous_checkpoint_digest          STRING,
+    end_of_epoch                        BOOLEAN       NOT NULL,
+    total_gas_cost                      NUMBER(20, 0) NOT NULL,
+    computation_cost                    NUMBER(20, 0) NOT NULL,
+    storage_cost                        NUMBER(20, 0) NOT NULL,
+    storage_rebate                      NUMBER(20, 0) NOT NULL,
+    non_refundable_storage_fee          NUMBER(20, 0) NOT NULL,
+    total_transaction_blocks            NUMBER(20, 0) NOT NULL,
+    total_transactions                  NUMBER(20, 0) NOT NULL,
+    total_successful_transaction_blocks NUMBER(20, 0) NOT NULL,
+    total_successful_transactions       NUMBER(20, 0) NOT NULL,
+    network_total_transaction           NUMBER(20, 0) NOT NULL,
+    validator_signature                 STRING        NOT NULL
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the checkpoint stage
+CREATE OR REPLACE STAGE checkpoints_parquet_stage
+    URL = '&{checkpoints_bucket}/checkpoints/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE checkpoint_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        COPY INTO CHECKPOINT (checkpoint_digest, sequence_number, epoch, timestamp_ms, previous_checkpoint_digest,
+                              end_of_epoch, total_gas_cost, computation_cost, storage_cost, storage_rebate,
+                              non_refundable_storage_fee, total_transaction_blocks, total_transactions,
+                              total_successful_transaction_blocks, total_successful_transactions,
+                              network_total_transaction, validator_signature)
+            from (SELECT t.$1:checkpoint_digest                   as checkpoint_digest,
+                         t.$1:sequence_number                     as sequence_number,
+                         t.$1:epoch                               as epoch,
+                         t.$1:timestamp_ms                        as timestamp_ms,
+                         t.$1:previous_checkpoint_digest          as previous_checkpoint_digest,
+                         t.$1:end_of_epoch                        as end_of_epoch,
+                         t.$1:total_gas_cost                      as total_gas_cost,
+                         t.$1:computation_cost                    as computation_cost,
+                         t.$1:storage_cost                        as storage_cost,
+                         t.$1:storage_rebate                      as storage_rebate,
+                         t.$1:non_refundable_storage_fee          as non_refundable_storage_fee,
+                         t.$1:total_transaction_blocks            as total_transaction_blocks,
+                         t.$1:total_transactions                  as total_transactions,
+                         t.$1:total_successful_transaction_blocks as total_successful_transaction_blocks,
+                         t.$1:total_successful_transactions       as total_successful_transactions,
+                         t.$1:network_total_transaction           as network_total_transaction,
+                         t.$1:validator_signature                 as validator_signature
+                  from @checkpoints_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/event.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/event.sql
@@ -1,0 +1,60 @@
+CREATE OR REPLACE TABLE EVENT
+(
+    transaction_digest STRING        NOT NULL,
+    event_index        NUMBER(20, 0) NOT NULL,
+    checkpoint         NUMBER(20, 0) NOT NULL,
+    epoch              NUMBER(20, 0) NOT NULL,
+    timestamp_ms       NUMBER(20, 0) NOT NULL,
+    sender             STRING        NOT NULL,
+    package            STRING        NOT NULL,
+    module             STRING        NOT NULL,
+    event_type         STRING        NOT NULL,
+    bcs                STRING        NOT NULL,
+    event_json         VARIANT
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the object stage
+CREATE OR REPLACE STAGE events_parquet_stage
+    URL = '&{checkpoints_bucket}/events/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE event_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        copy into EVENT (transaction_digest,
+                         event_index,
+                         checkpoint,
+                         epoch,
+                         timestamp_ms,
+                         sender,
+                         package,
+                         module,
+                         event_type,
+                         bcs,
+                         event_json)
+            from (SELECT t.$1:transaction_digest     as transaction_digest,
+                         t.$1:event_index            as event_index,
+                         t.$1:checkpoint             as checkpoint,
+                         t.$1:epoch                  as epoch,
+                         t.$1:timestamp_ms           as timestamp_ms,
+                         t.$1:sender                 as sender,
+                         t.$1:package                as package,
+                         t.$1:module                 as module,
+                         t.$1:event_type             as event_type,
+                         t.$1:bcs                    as bcs,
+                         parse_json(t.$1:event_json) as event_json
+                  from @events_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/move_call.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/move_call.sql
@@ -1,0 +1,48 @@
+
+CREATE OR REPLACE TABLE MOVE_CALL(
+                                     transaction_digest STRING NOT NULL,
+                                     checkpoint NUMBER(20, 0) NOT NULL,
+                                     epoch NUMBER(20, 0) NOT NULL,
+                                     timestamp_ms NUMBER(20, 0) NOT NULL,
+                                     package STRING NOT NULL,
+                                     module STRING NOT NULL,
+                                     function_ STRING NOT NULL
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the object stage
+CREATE OR REPLACE STAGE move_call_parquet_stage
+    URL = '&{checkpoints_bucket}/move_call/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE move_call_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        copy into MOVE_CALL (transaction_digest,
+                         checkpoint,
+                         epoch,
+                         timestamp_ms,
+                         package,
+                         module,
+                         function_)
+            from (SELECT t.$1:transaction_digest     as transaction_digest,
+                         t.$1:checkpoint             as checkpoint,
+                         t.$1:epoch                  as epoch,
+                         t.$1:timestamp_ms           as timestamp_ms,
+                         t.$1:package                as package,
+                         t.$1:module                 as module,
+                         t.$1:function_              as function_
+                  from @move_call_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/object.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/object.sql
@@ -1,0 +1,68 @@
+CREATE OR REPLACE TABLE OBJECT
+(
+    object_id              STRING        NOT NULL,
+    version                NUMBER(20, 0) NOT NULL,
+    digest                 STRING        NOT NULL,
+    type                   STRING,
+    checkpoint             NUMBER(20, 0) NOT NULL,
+    epoch                  NUMBER(20, 0) NOT NULL,
+    timestamp_ms           NUMBER(20, 0) NOT NULL,
+    owner_type             STRING        NOT NULL,
+    owner_address          STRING,
+    object_status          STRING,
+    initial_shared_version NUMBER(20, 0),
+    previous_transaction   STRING        NOT NULL,
+    has_public_transfer    BOOLEAN       NOT NULL,
+    storage_rebate         NUMBER(20, 0) NOT NULL,
+    bcs                    STRING        NOT NULL,
+    coin_type              STRING,
+    coin_balance           NUMBER(20, 0),
+    struct_tag             STRING,
+    object_json            variant
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the object stage
+CREATE OR REPLACE STAGE objects_parquet_stage
+    URL = '&{checkpoints_bucket}/objects/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE object_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        copy into OBJECT (object_id, version, digest, type, checkpoint, epoch, timestamp_ms, owner_type, owner_address,
+                          object_status, initial_shared_version, previous_transaction, has_public_transfer,
+                          storage_rebate, bcs, coin_type, coin_balance, struct_tag, object_json)
+            from (SELECT t.$1:object_id               as object_id,
+                         t.$1:version                 as version,
+                         t.$1:digest                  as digest,
+                         t.$1:type_                   as type,
+                         t.$1:checkpoint              as checkpoint,
+                         t.$1:epoch                   as epoch,
+                         t.$1:timestamp_ms            as timestamp_ms,
+                         t.$1:owner_type              as owner_type,
+                         t.$1:owner_address           as owner_address,
+                         t.$1:object_status           as object_status,
+                         t.$1:initial_shared_version  as initial_shared_version,
+                         t.$1:previous_transaction    as previous_transaction,
+                         t.$1:has_public_transfer     as has_public_transfer,
+                         t.$1:storage_rebate          as storage_rebate,
+                         t.$1:bcs                     as bcs,
+                         t.$1:coin_type               as coin_type,
+                         t.$1:coin_balance            as coin_balance,
+                         t.$1:struct_tag              as struct_tag,
+                         parse_json(t.$1:object_json) as object_json
+                  from @objects_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/package.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/package.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE TABLE MOVE_PACKAGE
+(
+    package_id         STRING        NOT NULL,
+    checkpoint         NUMBER(20, 0) NOT NULL,
+    epoch              NUMBER(20, 0) NOT NULL,
+    timestamp_ms       NUMBER(20, 0) NOT NULL,
+    bcs                STRING        NOT NULL,
+    transaction_digest STRING
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the object stage
+CREATE OR REPLACE STAGE packages_parquet_stage
+    URL = '&{checkpoints_bucket}/move_package/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE package_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        copy into MOVE_PACKAGE (package_id, checkpoint, epoch, timestamp_ms, bcs, transaction_digest)
+            from (SELECT t.$1:package_id         as package_id,
+                         t.$1:checkpoint         as checkpoint,
+                         t.$1:epoch              as epoch,
+                         t.$1:timestamp_ms       as timestamp_ms,
+                         t.$1:bcs                as bcs,
+                         t.$1:transaction_digest as transaction_digest
+                  from @packages_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/setup.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/setup.sql
@@ -1,0 +1,19 @@
+// set checkpoints_bucket as a variable or pass it in the command line
+// This sets up an external stage backed by a gcs bucket used for reading checkpoint data from
+CREATE STORAGE INTEGRATION checkpoints_data_loader
+    TYPE = EXTERNAL_STAGE
+    STORAGE_PROVIDER = GCS
+    ENABLED = TRUE
+    STORAGE_ALLOWED_LOCATIONS = ('&{checkpoints_bucket}/checkpoints', '&{checkpoints_bucket}/events','&{checkpoints_bucket}/move_call.sql','&{checkpoints_bucket}/move_package','&{checkpoints_bucket}/objects','&{checkpoints_bucket}/transaction_objects','&{checkpoints_bucket}/transactions');
+
+// This sets up pubsub_subscription_id as the pubsub topic subscriber id
+CREATE NOTIFICATION INTEGRATION checkpoints_data_loader_notification
+    TYPE = QUEUE
+    NOTIFICATION_PROVIDER = GCP_PUBSUB
+    ENABLED = true
+    GCP_PUBSUB_SUBSCRIPTION_NAME = '&{pubsub_subscription_id}';
+
+// This sets up the parquet file format used for all queries
+CREATE OR REPLACE File Format parquet_format
+    TYPE = parquet
+    SNAPPY_COMPRESSION = TRUE;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/transaction.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/transaction.sql
@@ -1,0 +1,112 @@
+CREATE OR REPLACE TABLE TRANSACTION
+(
+    transaction_digest         STRING        NOT NULL,
+    checkpoint                 NUMBER(20, 0) NOT NULL,
+    epoch                      NUMBER(20, 0) NOT NULL,
+    timestamp_ms               NUMBER(20, 0) NOT NULL,
+    sender                     STRING        NOT NULL,
+    transaction_kind           STRING        NOT NULL,
+    is_system_txn              BOOLEAN       NOT NULL,
+    is_sponsored_tx            BOOLEAN       NOT NULL,
+    transaction_count          NUMBER(20, 0) NOT NULL,
+    execution_success          BOOLEAN       NOT NULL,
+    input                      NUMBER(20, 0) NOT NULL,
+    shared_input               NUMBER(20, 0) NOT NULL,
+    gas_coins                  NUMBER(20, 0) NOT NULL,
+    created                    NUMBER(20, 0) NOT NULL,
+    mutated                    NUMBER(20, 0) NOT NULL,
+    deleted                    NUMBER(20, 0) NOT NULL,
+    transfers                  NUMBER(20, 0) NOT NULL,
+    split_coins                NUMBER(20, 0) NOT NULL,
+    merge_coins                NUMBER(20, 0) NOT NULL,
+    publish                    NUMBER(20, 0) NOT NULL,
+    upgrade                    NUMBER(20, 0) NOT NULL,
+    others                     NUMBER(20, 0) NOT NULL,
+    move_calls                 NUMBER(20, 0) NOT NULL,
+    packages                   STRING,
+    gas_owner                  STRING        NOT NULL,
+    gas_object_id              STRING        NOT NULL,
+    gas_object_sequence        NUMBER(20, 0) NOT NULL,
+    gas_object_digest          STRING        NOT NULL,
+    gas_budget                 NUMBER(20, 0) NOT NULL,
+    total_gas_cost             NUMBER(20, 0) NOT NULL,
+    computation_cost           NUMBER(20, 0) NOT NULL,
+    storage_cost               NUMBER(20, 0) NOT NULL,
+    storage_rebate             NUMBER(20, 0) NOT NULL,
+    non_refundable_storage_fee NUMBER(20, 0) NOT NULL,
+    gas_price                  NUMBER(20, 0) NOT NULL,
+    raw_transaction            STRING        NOT NULL,
+    has_zklogin_sig            BOOLEAN,
+    has_upgraded_multisig      BOOLEAN
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the transaction stage
+CREATE OR REPLACE STAGE transaction_parquet_stage
+    URL = '&{checkpoints_bucket}/transactions/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE transaction_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        COPY INTO TRANSACTION (transaction_digest, checkpoint, epoch, timestamp_ms, sender,
+                               transaction_kind, is_system_txn, is_sponsored_tx, transaction_count, execution_success,
+                               input, shared_input, gas_coins,
+                               created, mutated, deleted, transfers, split_coins, merge_coins, publish, upgrade, others,
+                               move_calls, packages, gas_owner, gas_object_id, gas_object_sequence, gas_object_digest,
+                               gas_budget, total_gas_cost, computation_cost, storage_cost, storage_rebate,
+                               non_refundable_storage_fee,
+                               gas_price, raw_transaction, has_zklogin_sig, has_upgraded_multisig
+            )
+            from (SELECT t.$1:transaction_digest         as transaction_digest,
+                         t.$1:checkpoint                 as checkpoint,
+                         t.$1:epoch                      as epoch,
+                         t.$1:timestamp_ms               as timestamp_ms,
+                         t.$1:sender                     as sender,
+                         t.$1:transaction_kind           as transaction_kind,
+                         t.$1:is_system_txn              as is_system_txn,
+                         t.$1:is_sponsored_tx            as is_sponsored_tx,
+                         t.$1:transaction_count          as transaction_count,
+                         t.$1:execution_success          as execution_success,
+                         t.$1:input                      as input,
+                         t.$1:shared_input               as shared_input,
+                         t.$1:gas_coins                  as gas_coins,
+                         t.$1:created                    as created,
+                         t.$1:mutated                    as mutated,
+                         t.$1:deleted                    as deleted,
+                         t.$1:transfers                  as transfers,
+                         t.$1:split_coins                as split_coins,
+                         t.$1:merge_coins                as merge_coins,
+                         t.$1:publish                    as publish,
+                         t.$1:upgrade                    as upgrade,
+                         t.$1:others                     as others,
+                         t.$1:move_calls                 as move_calls,
+                         t.$1:packages                   as packages,
+                         t.$1:gas_owner                  as gas_owner,
+                         t.$1:gas_object_id              as gas_object_id,
+                         t.$1:gas_object_sequence        as gas_object_sequence,
+                         t.$1:gas_object_digest          as gas_object_digest,
+                         t.$1:gas_budget                 as gas_budget,
+                         t.$1:total_gas_cost             as total_gas_cost,
+                         t.$1:computation_cost           as computation_cost,
+                         t.$1:storage_cost               as storage_cost,
+                         t.$1:storage_rebate             as storage_rebate,
+                         t.$1:non_refundable_storage_fee as non_refundable_storage_fee,
+                         t.$1:gas_price                  as gas_price,
+                         t.$1:raw_transaction            as raw_transaction,
+                         t.$1:has_zklogin_sig            as has_zklogin_sig,
+                         t.$1:has_upgraded_multisig      as has_upgraded_multisig
+                  from @transaction_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;

--- a/crates/sui-analytics-indexer/src/store/snowflake/schemas/transaction_objects.sql
+++ b/crates/sui-analytics-indexer/src/store/snowflake/schemas/transaction_objects.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE TABLE TRANSACTION_OBJECT
+(
+    object_id          STRING        NOT NULL,
+    version            NUMBER(20, 0),
+    transaction_digest STRING        NOT NULL,
+    checkpoint         NUMBER(20, 0) NOT NULL,
+    epoch              NUMBER(20, 0) NOT NULL,
+    timestamp_ms       NUMBER(20, 0) NOT NULL,
+    input_kind         STRING,
+    object_status      STRING
+) STAGE_FILE_FORMAT = parquet_format
+    STAGE_COPY_OPTIONS =
+(
+    ABORT_STATEMENT
+)
+    ENABLE_SCHEMA_EVOLUTION = TRUE
+    CLUSTER BY
+(
+    timestamp_ms
+);
+
+// Define the object stage
+CREATE OR REPLACE STAGE transaction_objects_parquet_stage
+    URL = '&{checkpoints_bucket}/transaction_objects/'
+    STORAGE_INTEGRATION = checkpoints_data_loader
+    FILE_FORMAT = parquet_format;
+
+// Set up the checkpoint auto ingestion pipe
+CREATE
+    OR REPLACE PIPE transaction_object_pipe
+    AUTO_INGEST = true
+    INTEGRATION = 'CHECKPOINTS_DATA_LOADER_NOTIFICATION'
+    AS
+        copy into TRANSACTION_OBJECT (object_id, version, transaction_digest, checkpoint, epoch, timestamp_ms,
+                                      input_kind, object_status)
+            from (SELECT t.$1:object_id          as object_id,
+                         t.$1:version            as version,
+                         t.$1:transaction_digest as transaction_digest,
+                         t.$1:checkpoint         as checkpoint,
+                         t.$1:epoch              as epoch,
+                         t.$1:timestamp_ms       as timestamp_ms,
+                         t.$1:input_kind         as input_kind,
+                         t.$1:object_status      as object_status
+                  from @transaction_objects_parquet_stage (file_format => 'parquet_format', pattern => '.*[.]parquet') t)
+            file_format = parquet_format;


### PR DESCRIPTION
## Description 

Add schemas for setting up analytics suite in snowflake. This is a snapshot of the existing schemas which can be reused to bootstrap analytics framework

## Test Plan 

Followed schemas in this PR to set up parquet based data ingestion
