### PR TITLE
[1/n][move-enums] IR and Move tooling changes

### DIFF
--- a/external-crates/move/RELEASES.md
+++ b/external-crates/move/RELEASES.md
@@ -1,0 +1,432 @@
+# Move Version 1.5
+
+Version 1.5 of Move includes a new package system, a number of bug fixes, and other improvements.
+
+## Highlights
+
+* Packages: The Move package system is a new feature to allow Move programmers to
+more easily re-use code and share it across projects.
+More details are available in the package [change description](changes/7-packages.md).
+* The Move Prover has extensive changes related to global invariants and specification
+variables, along with many other enhancements and bug fixes.
+
+## Move Language
+
+[Named address](changes/5-named-addresses.md)
+values are now expected to be specified in packages rather than
+in the source code. The address values are then passed on the command line to the
+compiler, with the expectation that developers will no longer invoke the compiler
+directly but will instead build via the package system. Thus, named address
+declarations in Move can no longer specify the address values
+([#8880](https://github.com/diem/diem/pull/8880)).
+
+## Compiler
+
+* The Move compiler now makes a distinction between errors and non-fatal warnings,
+so that it can report warning messages without causing a compilation to fail
+([#8881](https://github.com/diem/diem/pull/8881)).
+The parser is also a little bit better about continuing after certain kinds of errors
+([#9175](https://github.com/diem/diem/pull/9175)).
+* Performance: Removed an unnecessary copy
+of the source code in memory to speed up build times by about 5%
+([#8893](https://github.com/diem/diem/pull/8893))
+and used string interning in the compiler to further reduce both build times
+and memory use by another 30%
+([#8874](https://github.com/diem/diem/pull/8874)).
+* Checking for phantom types: the compiler now reports warnings for non-phantom
+parameters that are either unused or used in a phantom position
+([#8740](https://github.com/diem/diem/pull/8740)).
+* Attributes: The compiler now reports better error messages for attributes, especially
+for "known" attributes that are expected to be used in certain ways
+([#9249](https://github.com/diem/diem/pull/9249)).
+
+## Prover
+
+* Global invariants: This release of the Move Prover includes extensive changes
+related to global invariants. In previous releases, verification may have been
+skipped for global invariants quantified over a generic memory and then evaluated
+in a generic Move function. The solution provides more holistic support for type parameters
+in the Move Prover. In particular, specifications for generic global invariants
+previously written as `invariant forall t: type: ...` should now be written as
+`invariant<T> ...` to express that the invariant applies to a generic type `T`.
+Another important change is the addition of an invariant suspension scheme which
+allows the verification of a global invariant to be deferred to a different
+location (instead of right after the relevant bytecode). These schemas include
+`disable_invariants_in_body` which postpones the evaluation to the end of the
+function and `delegate_invariants_to_caller` which lifts the evaluation to the
+caller side. This feature allows verification of more (or stronger) global
+invariants as the caller side has more context to evaluate the
+invariant. Internally, the bytecode transformation pipeline is updated such
+that all global invariants related to a function are instrumented at
+the appropriate locations. The monomorphization pass is updated to
+instantiate type parameters on both the global invariant side and function
+side.
+* Specification variables (a.k.a., ghost variables): Specification variable
+declarations can now optionally include an
+initializer: for example, `global spec_var: num = 1`.
+Specification variables can also now be updated in
+a function spec block, for example: `update spec_var = spec_var + 1`.
+The new implementation of specification variables maps them to
+regular global "ghost" memory. Access to specification variables is mapped to
+accessing this memory (at address `@0`), so that memory usage and global
+invariant analysis can be applied uniformly to specification variables.
+* Added new `--unconditional-abort-as-inconsistency` flag to treat
+functions that do not return (i.e., abort unconditionally) as inconsistency violations
+([#8861](https://github.com/diem/diem/pull/8861)).
+* Added new `--ignore-pragma-opaque-when-possible` flag to ignore the `opaque` pragma
+when possible
+([#8843](https://github.com/diem/diem/pull/8843))
+and a related `--ignore-pragma-opaque-internal-only` flag that only applies to internal
+functions
+([#8862](https://github.com/diem/diem/pull/8862)).
+* Added the `is_signer` native specification function to the Signer module
+in the standard library, along with support for that function in the Prover
+([#8868](https://github.com/diem/diem/pull/8868)).
+* Loop invariants: Added new `invariant` syntax which can be used in loop
+headers to specify invariant conditions for those loops
+([#8890](https://github.com/diem/diem/pull/8890) and
+ [#8945](https://github.com/diem/diem/pull/8945)).
+* The `--dump-bytecode` command line option now emits the bytecode dumps
+in the parent directory of the output and uses a new naming convention for
+the output files
+([#9052](https://github.com/diem/diem/pull/9052)).
+* The documentation generator has been extended to show the backward call graph
+in addition to the forward call graph
+([#9239](https://github.com/diem/diem/pull/9239)).
+* The `spec_address_of` native specification function has been replaced by the
+`address_of` Move function, which can also be used in specifications
+([#9261](https://github.com/diem/diem/pull/9261)).
+
+**Fixed bugs:**
+
+* Crash in `move_model::ty::Type::replace`
+([#9155](https://github.com/diem/diem/issues/9155)).
+* The `choose` operator was handled incorrectly
+([#8865](https://github.com/diem/diem/pull/8865)).
+* Variable scope issue with shadowing of let-bound names in schemas
+([#8854](https://github.com/diem/diem/issues/8854)).
+* Uninterpreted functions should not have an `inline` attribute
+([#8995](https://github.com/diem/diem/issues/8995)).
+* The `--generate-only` flag was ignored
+([#9092](https://github.com/diem/diem/pull/9092)).
+* Boogie name resolution error: "use of undeclared function"
+([#9156](https://github.com/diem/diem/issues/9156)).
+
+## Standard Library
+
+An experimental module for capability-based access control has been added
+to the "nursery" area of the standard library
+([#9305](https://github.com/diem/diem/pull/9305)).
+
+## Documentation
+
+The Move language documentation has been updated for both named addresses
+([#9195](https://github.com/diem/diem/pull/9195))
+and phantom types
+([#9263](https://github.com/diem/diem/pull/9263)) and
+ [#9339](https://github.com/diem/diem/pull/9339)),
+as well as for the new Move packages
+([#9241](https://github.com/diem/diem/pull/9241)).
+
+## Miscellaneous
+
+* For internal testing within the Move project, this release introduces a new
+"transactional-tests" infrastructure (see the
+`testing-infra/transactional-test-runner` directory). Many existing tests have
+been migrated to use this and we will continue that migration over time.
+Note that this testing framework is intended for internal use:
+most testing of Move code should continue to use Move unit tests.
+* The Move IR compiler, which is now only intended for internal testing purposes,
+has some significant updates in this release. This tool is not intended for
+external use so there is no documentation of the new IR syntax.
+* The `MoveStorage` trait has been renamed to `MoveResolver` and moved to the
+`move-core-types` crate so that it can be used without pulling in the VM as a
+dependency
+([#8886](https://github.com/diem/diem/pull/8886)).
+* The `MoveStruct` type in `move-core-types` has been generalized to an enum that
+can also specify the field names
+([#8901](https://github.com/diem/diem/pull/8901)).
+* The compiler's `AddressBytes` struct has been renamed to `NumericalAddress`
+and changed into a wrapper around `AccountAddress`
+([#9282](https://github.com/diem/diem/pull/9282)).
+* Added a "generate struct-layouts" sandbox command to the Move CLI to dump
+struct layouts in YAML format
+([#9073](https://github.com/diem/diem/pull/9073)).
+
+**Fixed bugs:**
+
+* Fixed disassembler crash for scripts without source mappings
+([#9005](https://github.com/diem/diem/pull/9005)).
+* Fixed a problem with unit tests where an abort from native function
+was not reported as an error
+([#9143](https://github.com/diem/diem/pull/9143)).
+
+
+# Move Version 1.4
+
+Version 1.4 of Move (released along with Diem Core version 1.4) includes named addresses,
+phantom type parameters, a new version of the bytecode format, and a number of bug fixes
+and other improvements.
+
+## Highlights
+
+* Move Language Enhancements: This version of Move adds support for two new language features,
+described in more detail in separate change descriptions:
+    * [Named Addresses](changes/5-named-addresses.md): This allows names to be used in
+      place of numerical values in any spot where addresses are used. (Some aspects of this
+      feature were already included in Move version 1.3.)
+    * [Phantom Type Parameters](changes/6-phantom-type-params.md): Type parameters for generic
+      structs can now be declared `phantom` when they are not used for anything except
+      compile-time type checking. This avoids the need for spurious abilities to satisfy the
+      type checker.
+* Version 3 of the Move bytecode format: The bytecode format has been changed to support
+phantom type parameters. The Move VM still reads and processes older versions of the Move
+bytecode, but new bytecode files will require the new Move VM version.
+
+## Compiler
+
+* Error messages from the compiler have been significantly revised, after updating the compiler
+to use a recent version of the `codespan-reporting` crate
+([#8812](https://github.com/diem/diem/pull/8812)).
+* Fixed a report of memory leaks in the compiler by adding an internal pool of symbols
+and using it to record source file names
+([#8742](https://github.com/diem/diem/pull/8742)).
+* Improved compiler performance by about 60% by rewriting the code for handling scoped aliases
+([#8804](https://github.com/diem/diem/pull/8804)).
+
+## Prover
+
+* Set up a new lab to compare cvc5 with z3 in benchmarks
+([#8732](https://github.com/diem/diem/pull/8732)).
+* Improved error message if the Boogie command cannot be found
+([#8778](https://github.com/diem/diem/pull/8778)).
+* Fixed an inconsistency in global invariant processing that was exposed by using
+the `disable_invariants_in_body` pragma
+([#8840](https://github.com/diem/diem/pull/8840)).
+Verifying global invariants remains an active area of development so there may
+still be some related issues in this release.
+
+## VM
+
+* Added VM support for publishing multiple modules in a single transaction
+([#8555](https://github.com/diem/diem/pull/8555)).
+This allows publishing a set of interdependent modules that are verified and link-checked
+together.
+* Improved logging of errors when deserializing Move modules
+([#8681](https://github.com/diem/diem/pull/8681)).
+* Fixed performance problems when loading and verifying friend modules. In addition to
+caching the results of deserializing and verifying modules, the loader has been
+significantly refactored to be more robust and to improve its internal APIs
+([#8832](https://github.com/diem/diem/pull/8832)).
+
+## Command Line Interpreter (CLI)
+
+* The `move compile` command now includes the Move standard library by default
+([#8679](https://github.com/diem/diem/pull/8679)).
+* Split out the Diem-specific part of the CLI to a new `df-cli` tool
+([#8615](https://github.com/diem/diem/pull/8615))
+and refactored the Move CLI so that `df-cli` (or other clients) can
+extend it with new subcommands
+([#8764](https://github.com/diem/diem/pull/8764)).
+
+## Miscellaneous
+
+* Updated the Move language book to use abilities
+([#8582](https://github.com/diem/diem/pull/8582)).
+The documentation still needs more updates to catch up with the latest features.
+* Finished the process of removing Cargo dependencies on Diem crates,
+continuing our effort to make Move usable apart from Diem.
+* Refactored various command line tools to share common code in a new
+`move-command-line-common` crate
+([#8680](https://github.com/diem/diem/pull/8680)).
+* Enhanced the Move bytecode disassembler to print the bytecode version
+([#8690](https://github.com/diem/diem/pull/8690)).
+* Removed the deprecated `CompiledScript::into_module` method
+([#8655](https://github.com/diem/diem/pull/8655)).
+* Removed the `CompiledModuleMut` and `CompiledScriptMut` types
+([#8667](https://github.com/diem/diem/pull/8667))
+along with the `into_inner`, `as_inner`, and `freeze` methods from the
+`CompiledModule` and `CompiledScript` types
+([#8712](https://github.com/diem/diem/pull/8712)).
+
+
+# Move Version 1.3
+
+Version 1.3 of Move (released along with Diem Core version 1.3) introduces some syntax changes
+to the Move language so that you may need to update Move source code when moving to this release.
+The bytecode format remains the same as in version 1.2.
+
+## Highlights
+
+The main highlight of this release is a new language feature for unit testing.
+This provides an easy way to test individual functions and features in Move.
+More details are available in the unit testing [change description](changes/4-unit-testing.md).
+
+## Move Language
+
+In addition to the new unit testing feature, this release includes a few other changes to the
+Move language:
+
+* Added new module address syntax, e.g., `module 0x1::M`, to specify the address of a module
+from within Move code
+([#7915](https://github.com/diem/diem/pull/7915)).
+This replaces the compiler's `--sender` option to specify the address on the command line.
+
+* The syntax for an address value is changed to `@` followed by a number
+([#8285](https://github.com/diem/diem/pull/8285)).
+Previously an account address value was specified
+as a hexadecimal value with an `0x` prefix, and hexadecimal values could not be
+used as ordinary integer numbers. With this change, addresses and numbers can be
+specified as either decimal and hexadecimal values, and the `@` prefix distinguishes
+the address values.
+
+* Introduced a general syntax for attributes in Move
+([#8169](https://github.com/diem/diem/pull/8169)).
+Move attributes are based on the Rust attribute syntax, which is in turn based on
+the standards found in ECMA-334 and ECMA-335. Attributes can currently be attached to
+address blocks, modules, scripts, and any module top level member. They are currently
+used for unit testing, and other attributes may be defined in the future.
+
+## Compiler
+
+* Removed the compiler's `--sender` option. Instead of specifying the address on the command line,
+you can use the new module address syntax in the Move code
+([#7915](https://github.com/diem/diem/pull/7915)).
+* Fixed crashes during internal testing with a precompiled standard library
+when error messages reference the precompiled files
+([#8344](https://github.com/diem/diem/pull/8344)).
+
+## Prover
+
+The syntax for specifications in Move is still in development and is
+documented separately from the rest of the language. This release includes a
+number of changes for Move specifications:
+
+* Extended and renamed builtin functions
+* New `let` binding semantics (`let x = E` and `let post y = E`)
+* Support for axiom for constraining uninterpreted specification functions
+* New `choose x where p` and `choose min i where p` expression forms
+* New invariant syntax (`module M { invariant p; }`) for global invariants
+* New syntax for function and struct specifications (`spec f` instead of `spec fun f`)
+* New syntax for specification modules which can be put into separate files
+* Removed `succeeds_if`
+* Removed `invariant module`
+* Removed `type<T>()` expression
+
+In addition to the specification changes, the Move Prover has been improved with
+bug fixes and some larger changes, including:
+
+* Overhauled handling of global invariants
+* Changed to perform monomorphization of generics in the Prover backend and memory model,
+which has helped the Prover run faster and avoid timeouts.
+
+## Standard Library
+
+* Added a `BitVector` module
+([#8315](https://github.com/diem/diem/pull/8315)).
+* Added a `Vault` module for capability-based secure storage
+([#8396](https://github.com/diem/diem/pull/8396)).
+
+## VM
+
+* Renamed `gas_schedule::CostStrategy` to `GasStatus` and cleaned up some of its APIs
+([#7797](https://github.com/diem/diem/pull/7797)).
+* Encapsulated both the `ChangeSet` and `AccountChangeSet` types so that their fields must be
+accessed by API functions, which also enforce a new invariant that the `AccountChangeSet` is
+not empty
+([#8288](https://github.com/diem/diem/pull/8288)).
+* Added a missing bounds check in the bytecode verifier for the `self_module_handle_idx` field
+([#8389](https://github.com/diem/diem/pull/8389)).
+
+## Miscellaneous
+
+* Fixed the Move disassembler to work correctly with abilities
+([#8128](https://github.com/diem/diem/pull/8128)).
+* Renamed the `vm` Rust crate to `move-binary-format`,
+which is a much better description of its contents.
+([#8161](https://github.com/diem/diem/pull/8161)).
+* Removed a number of dependencies on Diem crates,
+continuing our effort to make Move usable apart from Diem.
+* Added an `ident_str!` macro to create const `IdentStr` values
+([#8300](https://github.com/diem/diem/pull/8300)).
+* Refactored the `MoveResource` trait to add a separate `MoveStructType` trait
+([#8346](https://github.com/diem/diem/pull/8346)).
+* Added back the Move language documentation files, now in the `mdBook` format
+([#8450](https://github.com/diem/diem/pull/8450)).
+* Fixed the Move script binding generator so that the generated code is valid
+when there are no transaction scripts or script functions
+([#8465](https://github.com/diem/diem/pull/8465)).
+
+
+# Move Version 1.2
+
+Version 1.2 of Move (released along with Diem Core version 1.2) includes several new language features, a new version of the bytecode format, significant improvements to the Move Prover, and numerous bug fixes.
+
+## Highlights
+
+* Move Language Enhancements: This version of Move adds support for three new language features. Each of these is described in more detail in separate change descriptions.
+    * [Friend Visibility](changes/1-friend-visibility.md): a new visibility modifier that allows a function to be called only by a set of declared `friend` modules.
+    * [Script Visibility](changes/2-script-visibility.md): a new visibility modifier that allows a function to be called only from a transaction or another script function.
+    * [Abilities](changes/3-abilities.md): a generalization of the existing `resource`/`struct` distinction to enable more fine-grained control over the operations allowed on a record value.
+* Version 2 of the Move bytecode format: The bytecode format has been changed to support the new features. The Move VM still reads and processes older versions of the Move bytecode, but new bytecode files will require the new Move VM version.
+* Move Prover: verification speed improvements of 2x and more via new internal architecture.
+
+## VM
+
+This release includes several changes and enhancements:
+
+* Arguments to Move functions are now specified as BCS-serialized values ([#7170](https://github.com/diem/diem/pull/7170)) and the VM also returns serialized values ([#7599](https://github.com/diem/diem/pull/7599)). The VM’s `execute_function` API now returns the serialized return values ([#7671](https://github.com/diem/diem/pull/7671)).
+* The VM’s file format deserializer now supports versioning so that it can seamlessly read multiple versions of Move bytecode files ([#7323](https://github.com/diem/diem/pull/7323)).
+* The VM’s module publishing API now allows republishing an existing module, as long as the updated module is backward compatible with the previous version ([#7143](https://github.com/diem/diem/pull/7143)). This includes a new bytecode verifier check for module updates that introduce cyclic dependencies ([#7234](https://github.com/diem/diem/pull/7234)) and related checks for cyclic dependencies when building and loading the standard library ([#7475](https://github.com/diem/diem/pull/7475)).
+* A new  `InternalGasUnits` type has been introduced to distinguish the unscaled units within the VM from the scaled `GasUnits` type ([#7448](https://github.com/diem/diem/pull/7448)).
+
+**Fixed bugs:**
+
+* Creating a normalized struct type now correctly uses the module handle associated with the `DatatypeHandleIndex` rather than the module containing the declaration ([#7321](https://github.com/diem/diem/pull/7321)).
+* The expected output files for internal tests no longer used colons in the file names, for the sake of file systems that do not support that ([#7770](https://github.com/diem/diem/issues/7770)).
+* The `parse_type_tag` function can now handle struct names containing underscores ([#7151](https://github.com/diem/diem/issues/7151)).
+* Missing signature checks for the `MoveToGeneric`, `ImmBorrowFieldGeneric`, and `MutBorrowFieldGeneric`  instructions have been added to the bytecode verifier ([#7752](https://github.com/diem/diem/pull/7752)).
+
+## Standard Library
+
+To make it easier to use Move for projects besides Diem, we are working toward separating the parts of Move that are specific to Diem. There is much more to do, but in this release, the standard library has been separated into two parts: `move-stdlib` ([#7633](https://github.com/diem/diem/pull/7633)) and `diem-framework` ([#7529](https://github.com/diem/diem/pull/7529)).
+
+## Compiler
+
+Besides adding support for the new language features mentioned above, the compiler in this release includes a number of fixes and usability enhancements:
+
+* Attempting to use a global storage builtin, e.g., `move_to`, in a script context will no longer crash the compiler ([#4577](https://github.com/diem/diem/issues/4577)).
+* Hex strings with an odd number of characters are no longer accepted by the compiler ([#6577](https://github.com/diem/diem/issues/6577)).
+* A `let` binding with a name starting with an underscore, e.g., `_x`, can now be used later in the code: the underscore prefix merely disables the compiler diagnostic about unused locals ([#6786](https://github.com/diem/diem/pull/6786)).
+* Fixed a compiler crash when a `break` is used outside of a loop ([#7560](https://github.com/diem/diem/issues/7560)).
+* Added a missing check for recursive types when binding to a local variable, which fixed a compiler crash with a stack overflow ([#7562](https://github.com/diem/diem/issues/7562)).
+* Fixed a compiler crash for an infinite loop with unreachable exits ([#7568](https://github.com/diem/diem/issues/7568)).
+* Fixed a compiler crash due to an unassigned local used in an equality comparison ([#7569](https://github.com/diem/diem/issues/7569)).
+* Fixed a compiler crash due to borrowing a divergent expression ([#7570](https://github.com/diem/diem/issues/7570)).
+* Fixed a compiler crash due to a missing constraint for references in the type checker ([#7573](https://github.com/diem/diem/issues/7573)).
+* Fixed a compiler crash related to expressions with short-circuiting ([#7574](https://github.com/diem/diem/issues/7574)).
+* Fixed an incorrect code generation bug that could occur when a function parameter is assigned a new value exactly once in the function ([#7370](https://github.com/diem/diem/pull/7370)).
+* Fixed the bytecode source map mapping from local names to indexes so that function parameters go before locals ([#7371](https://github.com/diem/diem/pull/7371)).
+* Fixed a compiler crash when a struct is assigned without specifying its fields ([#7385](https://github.com/diem/diem/issues/7385)).
+* Fixed a compiler crash when attempting to put a `spec` block inside a `spec` context ([#7387](https://github.com/diem/diem/issues/7387)).
+* An integer literal value that is too large for its declared type will no longer cause a compiler crash ([#7388](https://github.com/diem/diem/issues/7388)).
+* Fixed a compiler crash caused by incorrect number of type parameters in pack/unpack expressions ([#7401](https://github.com/diem/diem/pull/7401)).
+* Module names and module members are now restricted from starting with underscores (‘_’) , which also avoids a crash ([#7572](https://github.com/diem/diem/issues/7572)).
+* Prover specifications are now included in the compiler’s dependency ordering calculation ([#7960](https://github.com/diem/diem/pull/7960)).
+* Modified the compiler optimization to remove fall-through jumps so that loop headers are not coalesced, which improves the prover’s ability to handle loop specifications ([#8049](https://github.com/diem/diem/pull/8049)).
+
+## Command Line Interpreter (CLI)
+
+The Move CLI has been enhanced in several ways:
+
+* The CLI now supports safe module republishing with checks for breaking changes ([#6753](https://github.com/diem/diem/pull/6753)).
+* Added a new `doctor` command to detect inconsistencies in storage ([#6971](https://github.com/diem/diem/pull/6971), [#7010](https://github.com/diem/diem/pull/7010), and [#7013](https://github.com/diem/diem/pull/7013)).
+* The `publish` command’s `—-dry-run` option has been removed ([#6957](https://github.com/diem/diem/pull/6957)). Use the equivalent "check" command instead.
+* The `test` command has a new `--create` option to create test scaffolding ([#6969](https://github.com/diem/diem/pull/6969)).
+* The verbose output with the `-v` option now includes the number of bytes written ([#7757](https://github.com/diem/diem/pull/7757)).
+
+## Other Tools
+
+* Created a new bytecode-to-source explorer tool for Move ([#7508](https://github.com/diem/diem/pull/7508)).
+* The resource viewer can now be better used to traverse data structures because the fields of `AnnotatedMoveStruct` are no longer private and `AnnotatedMoveValue::Vector` preserves the type information for its elements ([#7166](https://github.com/diem/diem/pull/7166)).
+* The `diem-writeset-generator` and `diem-transaction-replay` tools have been significantly enhanced to support the process of upgrading the Diem Framework.

--- a/external-crates/move/crates/bytecode-verifier-libfuzzer/fuzz_targets/code_unit.rs
+++ b/external-crates/move/crates/bytecode-verifier-libfuzzer/fuzz_targets/code_unit.rs
@@ -3,12 +3,11 @@
 
 #![no_main]
 use move_binary_format::file_format::{
-    empty_module, AbilitySet, CodeUnit, Constant, FieldDefinition, FunctionDefinition,
-    FunctionHandle, FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature,
-    SignatureIndex,
+    empty_module, AbilitySet, CodeUnit, Constant, DatatypeHandle, DatatypeHandleIndex,
+    FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex, IdentifierIndex,
+    ModuleHandleIndex, Signature, SignatureIndex,
     SignatureToken::{Address, Bool, U128, U64},
-    StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature,
-    Visibility,
+    StructDefinition, StructFieldInformation, TypeSignature, Visibility,
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use std::str::FromStr;
@@ -19,7 +18,7 @@ fuzz_target!(|code_unit: CodeUnit| {
     let mut module = empty_module();
     module.version = 5;
 
-    module.struct_handles.push(StructHandle {
+    module.datatype_handles.push(DatatypeHandle {
         module: ModuleHandleIndex(0),
         name: IdentifierIndex(1),
         abilities: AbilitySet::ALL,
@@ -63,7 +62,7 @@ fuzz_target!(|code_unit: CodeUnit| {
     });
 
     module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(0),
+        struct_handle: DatatypeHandleIndex(0),
         field_information: StructFieldInformation::Declared(vec![FieldDefinition {
             name: IdentifierIndex::new(3),
             signature: TypeSignature(Address),

--- a/external-crates/move/crates/bytecode-verifier-libfuzzer/fuzz_targets/mixed.rs
+++ b/external-crates/move/crates/bytecode-verifier-libfuzzer/fuzz_targets/mixed.rs
@@ -3,12 +3,11 @@
 
 #![no_main]
 use move_binary_format::file_format::{
-    empty_module, AbilitySet, Bytecode, CodeUnit, Constant, FieldDefinition, FunctionDefinition,
-    FunctionHandle, FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature,
-    SignatureIndex, SignatureToken,
+    empty_module, AbilitySet, Bytecode, CodeUnit, Constant, DatatypeHandle, DatatypeHandleIndex,
+    FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex, IdentifierIndex,
+    ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     SignatureToken::{Address, Bool},
-    StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature,
-    Visibility,
+    StructDefinition, StructFieldInformation, TypeSignature, Visibility,
 };
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use std::str::FromStr;
@@ -28,7 +27,7 @@ fuzz_target!(|mix: Mixed| {
     let mut module = empty_module();
     module.version = 5;
 
-    module.struct_handles.push(StructHandle {
+    module.datatype_handles.push(DatatypeHandle {
         module: ModuleHandleIndex(0),
         name: IdentifierIndex(1),
         abilities: mix.abilities,
@@ -72,7 +71,7 @@ fuzz_target!(|mix: Mixed| {
     });
 
     module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(0),
+        struct_handle: DatatypeHandleIndex(0),
         field_information: StructFieldInformation::Declared(vec![FieldDefinition {
             name: IdentifierIndex::new(3),
             signature: TypeSignature(Address),
@@ -82,6 +81,7 @@ fuzz_target!(|mix: Mixed| {
     let code_unit = CodeUnit {
         code: mix.code,
         locals: SignatureIndex(0),
+        jump_tables: vec![],
     };
 
     let fun_def = FunctionDefinition {

--- a/external-crates/move/crates/invalid-mutations/src/bounds.rs
+++ b/external-crates/move/crates/invalid-mutations/src/bounds.rs
@@ -5,8 +5,8 @@
 use move_binary_format::{
     errors::{bounds_error, PartialVMError},
     file_format::{
-        AddressIdentifierIndex, CompiledModule, FunctionHandleIndex, IdentifierIndex,
-        ModuleHandleIndex, SignatureIndex, StructDefinitionIndex, StructHandleIndex, TableIndex,
+        AddressIdentifierIndex, CompiledModule, DatatypeHandleIndex, FunctionHandleIndex,
+        IdentifierIndex, ModuleHandleIndex, SignatureIndex, StructDefinitionIndex, TableIndex,
     },
     internals::ModuleIndex,
     views::{ModuleView, SignatureTokenView},
@@ -49,17 +49,17 @@ impl PointerKind {
 
         match src_kind {
             ModuleHandle => &[One(AddressIdentifier), One(Identifier)],
-            StructHandle => &[One(ModuleHandle), One(Identifier)],
+            DatatypeHandle => &[One(ModuleHandle), One(Identifier)],
             FunctionHandle => &[
                 One(ModuleHandle),
                 One(Identifier),
                 One(Signature),
                 One(Signature),
             ],
-            StructDefinition => &[One(StructHandle), Star(StructHandle)],
+            StructDefinition => &[One(DatatypeHandle), Star(DatatypeHandle)],
             FunctionDefinition => &[One(FunctionHandle), One(Signature)],
             FriendDeclaration => &[One(AddressIdentifier), One(Identifier)],
-            Signature => &[Star(StructHandle)],
+            Signature => &[Star(DatatypeHandle)],
             FieldHandle => &[One(StructDefinition)],
             _ => &[],
         }
@@ -75,7 +75,7 @@ impl PointerKind {
 
 pub static VALID_POINTER_SRCS: &[IndexKind] = &[
     IndexKind::ModuleHandle,
-    IndexKind::StructHandle,
+    IndexKind::DatatypeHandle,
     IndexKind::FunctionHandle,
     IndexKind::FieldHandle,
     IndexKind::StructDefinition,
@@ -273,11 +273,11 @@ impl ApplyOutOfBoundsContext {
             (ModuleHandle, Identifier) => {
                 self.module.module_handles[src_idx].name = IdentifierIndex(new_idx)
             }
-            (StructHandle, ModuleHandle) => {
-                self.module.struct_handles[src_idx].module = ModuleHandleIndex(new_idx)
+            (DatatypeHandle, ModuleHandle) => {
+                self.module.datatype_handles[src_idx].module = ModuleHandleIndex(new_idx)
             }
-            (StructHandle, Identifier) => {
-                self.module.struct_handles[src_idx].name = IdentifierIndex(new_idx)
+            (DatatypeHandle, Identifier) => {
+                self.module.datatype_handles[src_idx].name = IdentifierIndex(new_idx)
             }
             (FunctionHandle, ModuleHandle) => {
                 self.module.function_handles[src_idx].module = ModuleHandleIndex(new_idx)
@@ -288,8 +288,8 @@ impl ApplyOutOfBoundsContext {
             (FunctionHandle, Signature) => {
                 self.module.function_handles[src_idx].parameters = SignatureIndex(new_idx)
             }
-            (StructDefinition, StructHandle) => {
-                self.module.struct_defs[src_idx].struct_handle = StructHandleIndex(new_idx)
+            (StructDefinition, DatatypeHandle) => {
+                self.module.struct_defs[src_idx].struct_handle = DatatypeHandleIndex(new_idx)
             }
             (FunctionDefinition, FunctionHandle) => {
                 self.module.function_defs[src_idx].function = FunctionHandleIndex(new_idx)
@@ -301,11 +301,11 @@ impl ApplyOutOfBoundsContext {
                     .unwrap()
                     .locals = SignatureIndex(new_idx)
             }
-            (Signature, StructHandle) => {
+            (Signature, DatatypeHandle) => {
                 let (actual_src_idx, arg_idx) = self.sig_structs[src_idx];
                 src_idx = actual_src_idx.into_index();
                 self.module.signatures[src_idx].0[arg_idx]
-                    .debug_set_sh_idx(StructHandleIndex(new_idx));
+                    .debug_set_sh_idx(DatatypeHandleIndex(new_idx));
             }
             (FieldHandle, StructDefinition) => {
                 self.module.field_handles[src_idx].owner = StructDefinitionIndex(new_idx)
@@ -351,12 +351,12 @@ impl ApplyOutOfBoundsContext {
     }
 }
 
-fn struct_handle(token: &SignatureToken) -> Option<StructHandleIndex> {
+fn struct_handle(token: &SignatureToken) -> Option<DatatypeHandleIndex> {
     use SignatureToken::*;
 
     match token {
-        Struct(sh_idx) => Some(*sh_idx),
-        StructInstantiation(sh_idx, _) => Some(*sh_idx),
+        Datatype(sh_idx) => Some(*sh_idx),
+        DatatypeInstantiation(sh_idx, _) => Some(*sh_idx),
         Reference(token) | MutableReference(token) => struct_handle(token),
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | Vector(_)
         | TypeParameter(_) => None,

--- a/external-crates/move/crates/invalid-mutations/src/bounds/code_unit.rs
+++ b/external-crates/move/crates/invalid-mutations/src/bounds/code_unit.rs
@@ -8,7 +8,8 @@ use move_binary_format::{
         Bytecode, CodeOffset, CompiledModule, ConstantPoolIndex, FieldHandleIndex,
         FieldInstantiationIndex, FunctionDefinitionIndex, FunctionHandleIndex,
         FunctionInstantiationIndex, LocalIndex, SignatureIndex, StructDefInstantiationIndex,
-        StructDefinitionIndex, TableIndex,
+        StructDefinitionIndex, TableIndex, VariantHandleIndex, VariantInstantiationHandleIndex,
+        VariantJumpTableIndex,
     },
     internals::ModuleIndex,
     IndexKind,
@@ -182,6 +183,7 @@ impl<'a> ApplyCodeUnitBoundsContext<'a> {
         let code = func_def.code.as_mut().unwrap();
         let locals_len = self.module.signatures[func_handle.parameters.into_index()].len()
             + self.module.signatures[code.locals.into_index()].len();
+        let jump_table_len = code.jump_tables.len();
         let code = &mut code.code;
         let code_len = code.len();
 
@@ -397,6 +399,78 @@ impl<'a> ApplyCodeUnitBoundsContext<'a> {
                         SignatureIndex,
                         VecSwap
                     ),
+                    PackVariant(_) => new_bytecode! {
+                        variant_handle_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantHandleIndex,
+                        PackVariant
+                    },
+                    PackVariantGeneric(_) => new_bytecode! {
+                        variant_inst_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantInstantiationHandleIndex,
+                       PackVariantGeneric
+                    },
+                    UnpackVariant(_) => new_bytecode! {
+                        variant_handle_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantHandleIndex,
+                        UnpackVariant
+                    },
+                    UnpackVariantImmRef(_) => new_bytecode! {
+                        variant_handle_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantHandleIndex,
+                        UnpackVariantImmRef
+                    },
+                    UnpackVariantMutRef(_) => new_bytecode! {
+                        variant_handle_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantHandleIndex,
+                        UnpackVariantMutRef
+                    },
+                    UnpackVariantGeneric(_) => new_bytecode! {
+                        variant_inst_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantInstantiationHandleIndex,
+                       UnpackVariantGeneric
+                    },
+                    UnpackVariantGenericImmRef(_) => new_bytecode! {
+                        variant_inst_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantInstantiationHandleIndex,
+                        UnpackVariantGenericImmRef
+                    },
+                    UnpackVariantGenericMutRef(_) => new_bytecode! {
+                        variant_inst_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantInstantiationHandleIndex,
+                        UnpackVariantGenericMutRef
+                    },
+                    VariantSwitch(_) => new_bytecode! {
+                        jump_table_len,
+                        current_fdef,
+                        bytecode_idx,
+                        offset,
+                        VariantJumpTableIndex,
+                        VariantSwitch
+                    },
 
                     // List out the other options explicitly so there's a compile error if a new
                     // bytecode gets added.
@@ -459,7 +533,16 @@ fn is_interesting(bytecode: &Bytecode) -> bool {
         | VecPushBack(_)
         | VecPopBack(_)
         | VecUnpack(..)
-        | VecSwap(_) => true,
+        | VecSwap(_)
+        | PackVariant(_)
+        | PackVariantGeneric(_)
+        | UnpackVariant(_)
+        | UnpackVariantImmRef(_)
+        | UnpackVariantMutRef(_)
+        | UnpackVariantGeneric(_)
+        | UnpackVariantGenericImmRef(_)
+        | UnpackVariantGenericMutRef(_)
+        | VariantSwitch(_) => true,
         // Deprecated bytecodes
         ExistsDeprecated(_)
         | ExistsGenericDeprecated(_)
@@ -471,6 +554,7 @@ fn is_interesting(bytecode: &Bytecode) -> bool {
         | MoveFromGenericDeprecated(_)
         | MoveToDeprecated(_)
         | MoveToGenericDeprecated(_) => false,
+
         // List out the other options explicitly so there's a compile error if a new
         // bytecode gets added.
         FreezeRef | Pop | Ret | LdU8(_) | LdU16(_) | LdU32(_) | LdU64(_) | LdU128(_)

--- a/external-crates/move/crates/module-generation/src/generator.rs
+++ b/external-crates/move/crates/module-generation/src/generator.rs
@@ -131,9 +131,9 @@ impl<'a> ModuleGenerator<'a> {
                 let struct_ident = {
                     let struct_name = struct_def.name;
                     let module_name = ModuleName::module_self();
-                    QualifiedStructIdent::new(module_name, struct_name)
+                    QualifiedDatatypeIdent::new(module_name, struct_name)
                 };
-                Type::Struct(struct_ident, ty_instants)
+                Type::Datatype(struct_ident, ty_instants)
             }
             6 => Type::U16,
             7 => Type::U32,
@@ -178,7 +178,7 @@ impl<'a> ModuleGenerator<'a> {
         }
     }
 
-    fn struct_type_parameters(&mut self) -> Vec<StructTypeParameter> {
+    fn struct_type_parameters(&mut self) -> Vec<DatatypeTypeParameter> {
         // Don't generate type parameters if we're generating simple types only
         if self.options.simple_types_only {
             vec![]
@@ -220,7 +220,7 @@ impl<'a> ModuleGenerator<'a> {
         FunctionSignature::new(formals, vec![], ty_params)
     }
 
-    fn struct_fields(&mut self, ty_params: &[StructTypeParameter]) -> StructDefinitionFields {
+    fn struct_fields(&mut self, ty_params: &[DatatypeTypeParameter]) -> StructDefinitionFields {
         let num_fields = self
             .gen
             .gen_range(self.options.min_fields..self.options.max_fields);
@@ -264,7 +264,7 @@ impl<'a> ModuleGenerator<'a> {
     }
 
     fn struct_def(&mut self, abilities: BTreeSet<Ability>) {
-        let name = StructName(self.identifier().into());
+        let name = DatatypeName(self.identifier().into());
         let type_parameters = self.struct_type_parameters();
         let fields = self.struct_fields(&type_parameters);
         let strct = StructDefinition_ {
@@ -337,6 +337,7 @@ impl<'a> ModuleGenerator<'a> {
             imports: Self::imports(callable_modules),
             explicit_dependency_declarations: Vec::new(),
             structs: Vec::new(),
+            enums: Vec::new(),
             functions: Vec::new(),
             constants: Vec::new(),
         };

--- a/external-crates/move/crates/move-bytecode-source-map/src/source_map.rs
+++ b/external-crates/move/crates/move-bytecode-source-map/src/source_map.rs
@@ -7,9 +7,9 @@ use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
     file_format::{
-        AbilitySet, CodeOffset, CodeUnit, ConstantPoolIndex, FunctionDefinitionIndex, LocalIndex,
-        MemberCount, ModuleHandleIndex, SignatureIndex, StructDefinition, StructDefinitionIndex,
-        TableIndex,
+        AbilitySet, CodeOffset, CodeUnit, ConstantPoolIndex, EnumDefinition, EnumDefinitionIndex,
+        FunctionDefinitionIndex, LocalIndex, MemberCount, ModuleHandleIndex, SignatureIndex,
+        StructDefinition, StructDefinitionIndex, TableIndex, VariantTag,
     },
 };
 use move_command_line_common::files::FileHash;
@@ -39,6 +39,19 @@ pub struct StructSourceMap {
     /// Note that fields to a struct source map need to be added in the order of the fields in the
     /// struct definition.
     pub fields: Vec<Loc>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EnumSourceMap {
+    /// The source declaration location of the enum
+    pub definition_location: Loc,
+
+    /// Important: type parameters need to be added in the order of their declaration
+    pub type_parameters: Vec<SourceName>,
+
+    /// Note that variants to an enum source map need to be added in the order of the variants in the
+    /// enum definition.
+    pub variants: Vec<(SourceName, Vec<Loc>)>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -81,6 +94,9 @@ pub struct SourceMap {
     // A mapping of `StructDefinitionIndex` to source map for each struct/resource.
     struct_map: BTreeMap<TableIndex, StructSourceMap>,
 
+    // A mapping of `EnumDefinitionIndex` to source map for each enum (and its variants)
+    enum_map: BTreeMap<TableIndex, EnumSourceMap>,
+
     // A mapping of `FunctionDefinitionIndex` to the soure map for that function.
     // For scripts, this map has a single element that points to a source map corresponding to the
     // script's "main" function.
@@ -121,7 +137,7 @@ impl StructSourceMap {
         struct_def: &StructDefinition,
         default_loc: Loc,
     ) -> Result<()> {
-        let struct_handle = view.struct_handle_at(struct_def.struct_handle);
+        let struct_handle = view.datatype_handle_at(struct_def.struct_handle);
 
         // Add dummy locations for the fields
         match struct_def.declared_field_count() {
@@ -130,6 +146,54 @@ impl StructSourceMap {
         }
 
         for i in 0..struct_handle.type_parameters.len() {
+            let name = format!("Ty{}", i);
+            self.add_type_parameter((name, default_loc))
+        }
+        Ok(())
+    }
+}
+
+impl EnumSourceMap {
+    pub fn new(definition_location: Loc) -> Self {
+        Self {
+            definition_location,
+            type_parameters: Vec::new(),
+            variants: Vec::new(),
+        }
+    }
+
+    pub fn add_type_parameter(&mut self, type_name: SourceName) {
+        self.type_parameters.push(type_name)
+    }
+
+    pub fn get_type_parameter_name(&self, type_parameter_idx: usize) -> Option<SourceName> {
+        self.type_parameters.get(type_parameter_idx).cloned()
+    }
+
+    pub fn add_variant_location(&mut self, variant: SourceName, field_locs: Vec<Loc>) {
+        self.variants.push((variant, field_locs))
+    }
+
+    pub fn get_variant_location(&self, variant_tag: u16) -> Option<(SourceName, Vec<Loc>)> {
+        self.variants.get(variant_tag as usize).cloned()
+    }
+
+    pub fn dummy_enum_map(
+        &mut self,
+        view: &BinaryIndexedView,
+        enum_def: &EnumDefinition,
+        default_loc: Loc,
+    ) -> Result<()> {
+        let enum_handle = view.datatype_handle_at(enum_def.enum_handle);
+
+        // Add dummy locations for the variants
+        for (i, variant) in enum_def.variants.iter().enumerate() {
+            let field_locs = (0..variant.fields.len()).map(|_| default_loc).collect();
+            let name = format!("Variant{}", i);
+            self.variants.push(((name, default_loc), field_locs))
+        }
+
+        for i in 0..enum_handle.type_parameters.len() {
             let name = format!("Ty{}", i);
             self.add_type_parameter((name, default_loc))
         }
@@ -275,6 +339,7 @@ impl SourceMap {
             definition_location,
             module_name,
             struct_map: BTreeMap::new(),
+            enum_map: BTreeMap::new(),
             function_map: BTreeMap::new(),
             constant_map: BTreeMap::new(),
         }
@@ -408,6 +473,16 @@ impl SourceMap {
                 )) })
     }
 
+    pub fn add_top_level_enum_mapping(
+        &mut self,
+        enum_def_idx: EnumDefinitionIndex,
+        location: Loc,
+    ) -> Result<()> {
+        self.enum_map.insert(enum_def_idx.0, EnumSourceMap::new(location)).map_or(Ok(()), |_| { Err(format_err!(
+                "Multiple enums at same struct definition index encountered when constructing source map"
+                )) })
+    }
+
     pub fn add_const_mapping(
         &mut self,
         const_idx: ConstantPoolIndex,
@@ -470,6 +545,55 @@ impl SourceMap {
             .ok_or_else(|| format_err!("Unable to get struct type parameter name"))
     }
 
+    pub fn get_struct_source_map(
+        &self,
+        struct_def_idx: StructDefinitionIndex,
+    ) -> Result<&StructSourceMap> {
+        self.struct_map
+            .get(&struct_def_idx.0)
+            .ok_or_else(|| format_err!("Unable to get struct source map"))
+    }
+
+    pub fn add_enum_variant_mapping(
+        &mut self,
+        enum_def_idx: EnumDefinitionIndex,
+        variant_name: SourceName,
+        field_locs: Vec<Loc>,
+    ) -> Result<()> {
+        let enum_entry = self
+            .enum_map
+            .get_mut(&enum_def_idx.0)
+            .ok_or_else(|| format_err!("variant_name add file mapping to undefined enum index"))?;
+        enum_entry.add_variant_location(variant_name, field_locs);
+        Ok(())
+    }
+
+    pub fn get_enum_field_name(
+        &self,
+        enum_def_idx: EnumDefinitionIndex,
+        variant_tag: VariantTag,
+    ) -> Option<SourceName> {
+        self.enum_map
+            .get(&enum_def_idx.0)
+            .and_then(|enum_source_map| {
+                enum_source_map
+                    .get_variant_location(variant_tag)
+                    .map(|x| x.0)
+            })
+    }
+
+    pub fn add_enum_type_parameter_mapping(
+        &mut self,
+        enum_def_idx: EnumDefinitionIndex,
+        name: SourceName,
+    ) -> Result<()> {
+        let enum_entry = self.enum_map.get_mut(&enum_def_idx.0).ok_or_else(|| {
+            format_err!("Tried to add enum type parameter mapping to undefined enum index")
+        })?;
+        enum_entry.add_type_parameter(name);
+        Ok(())
+    }
+
     pub fn get_function_source_map(
         &self,
         fdef_idx: FunctionDefinitionIndex,
@@ -479,13 +603,21 @@ impl SourceMap {
             .ok_or_else(|| format_err!("Unable to get function source map"))
     }
 
-    pub fn get_struct_source_map(
+    pub fn get_enum_source_map(&self, enum_def_idx: EnumDefinitionIndex) -> Result<&EnumSourceMap> {
+        self.enum_map
+            .get(&enum_def_idx.0)
+            .ok_or_else(|| format_err!("Unable to get enum source map {}", enum_def_idx.0))
+    }
+
+    pub fn get_enum_type_parameter_name(
         &self,
-        struct_def_idx: StructDefinitionIndex,
-    ) -> Result<&StructSourceMap> {
-        self.struct_map
-            .get(&struct_def_idx.0)
-            .ok_or_else(|| format_err!("Unable to get struct source map"))
+        enum_def_idx: EnumDefinitionIndex,
+        type_parameter_idx: usize,
+    ) -> Result<SourceName> {
+        self.enum_map
+            .get(&enum_def_idx.0)
+            .and_then(|enum_source_map| enum_source_map.get_type_parameter_name(type_parameter_idx))
+            .ok_or_else(|| format_err!("Unable to get enum type parameter name"))
     }
 
     /// Create a 'dummy' source map for a compiled module or script. This is useful for e.g. disassembling
@@ -562,6 +694,18 @@ impl SourceMap {
                 .get_mut(&(struct_idx as TableIndex))
                 .ok_or_else(|| format_err!("Unable to get struct map while generating dummy"))?
                 .dummy_struct_map(view, struct_def, default_loc)?;
+        }
+
+        for (enum_idx, enum_def) in view.enum_defs().into_iter().flatten().enumerate() {
+            empty_source_map.add_top_level_enum_mapping(
+                EnumDefinitionIndex(enum_idx as TableIndex),
+                default_loc,
+            )?;
+            empty_source_map
+                .enum_map
+                .get_mut(&(enum_idx as TableIndex))
+                .ok_or_else(|| format_err!("Unable to get enum map while generating dummy"))?
+                .dummy_enum_map(view, enum_def, default_loc)?;
         }
 
         for const_idx in 0..view.constant_pool().len() {

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::module_cache::GetModule;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use move_binary_format::{
     access::ModuleAccess,
-    file_format::{SignatureToken, StructDefinition, StructFieldInformation, StructHandleIndex},
-    normalized::{Struct, Type},
+    file_format::{
+        DatatypeHandleIndex, DatatypeTyParameter, EnumDefinition, SignatureToken, StructDefinition,
+        StructFieldInformation,
+    },
+    normalized::{Enum, Struct, Type},
     CompiledModule,
 };
 use move_core_types::{
@@ -16,7 +19,7 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
-use serde_reflection::{ContainerFormat, Format, Named, Registry};
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{borrow::Borrow, collections::BTreeMap, fmt::Write};
 
 /// Name of the Move `address` type in the serde registry
@@ -37,6 +40,20 @@ macro_rules! check_depth {
             anyhow::bail!("Exceeded max value recursion depth when creating struct layout")
         }
     };
+}
+
+enum Container {
+    Struct(Struct),
+    Enum(Enum),
+}
+
+impl Container {
+    fn type_parameters(&self) -> &[DatatypeTyParameter] {
+        match self {
+            Container::Struct(s) => &s.type_parameters,
+            Container::Enum(e) => &e.type_parameters,
+        }
+    }
 }
 
 /// Type for building a registry of serde-reflection friendly struct layouts for Move types.
@@ -126,13 +143,13 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
     }
 
     /// Add layouts for all types used in `t` to the registry
-    pub fn build_struct_layout(&mut self, s: &StructTag) -> Result<Format> {
+    pub fn build_data_layout(&mut self, s: &StructTag) -> Result<Format> {
         let serde_type_args = s
             .type_params
             .iter()
             .map(|t| self.build_type_layout(t.clone()))
             .collect::<Result<Vec<Format>>>()?;
-        self.build_struct_layout_(&s.module_id(), &s.name, &serde_type_args, 0)
+        self.build_data_layout_(&s.module_id(), &s.name, &serde_type_args, 0)
     }
 
     fn build_normalized_type_layout(
@@ -164,7 +181,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
                     .map(|t| self.build_normalized_type_layout(t, input_type_args, depth + 1))
                     .collect::<Result<Vec<Format>>>()?;
                 let declaring_module = ModuleId::new(*address, module.clone());
-                self.build_struct_layout_(&declaring_module, name, &serde_type_args, depth + 1)?
+                self.build_data_layout_(&declaring_module, name, &serde_type_args, depth + 1)?
             }
             Vector(inner_t) => {
                 if matches!(inner_t.as_ref(), U8) {
@@ -183,7 +200,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         })
     }
 
-    fn build_struct_layout_(
+    fn build_data_layout_(
         &mut self,
         module_id: &ModuleId,
         name: &Identifier,
@@ -200,36 +217,42 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .get_module_by_id(module_id)
             .map_err(|e| anyhow::format_err!("{:?}", e))?
             .expect("Failed to resolve module");
-        let def = declaring_module
-            .borrow()
-            .find_struct_def_by_name(name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Could not find struct named {} in module {}",
-                    name,
-                    declaring_module.borrow().name()
-                )
-            });
-        let normalized_struct = Struct::new(declaring_module.borrow(), def).1;
+        let def = match (
+            declaring_module.borrow().find_struct_def_by_name(name),
+            declaring_module.borrow().find_enum_def_by_name(name),
+        ) {
+            (Some(struct_def), None) => {
+                Container::Struct(Struct::new(declaring_module.borrow(), struct_def).1)
+            }
+            (None, Some(enum_def)) => {
+                Container::Enum(Enum::new(declaring_module.borrow(), enum_def).1)
+            }
+            (Some(_), Some(_)) => panic!("Found both struct and enum with name {}", name),
+            (None, None) => panic!(
+                "Could not find datatype named {} in module {}",
+                name,
+                declaring_module.borrow().name()
+            ),
+        };
         assert_eq!(
-            normalized_struct.type_parameters.len(),
+            def.type_parameters().len(),
             type_arguments.len(),
             "Wrong number of type arguments for struct"
         );
 
         let generics: Vec<String> = type_arguments
             .iter()
-            .zip(normalized_struct.type_parameters.iter())
+            .zip(def.type_parameters().iter())
             .filter(|(_, type_param)| {
                 // do not include phantom type arguments in the struct key, since they do not affect the struct layout
                 !(self.config.ignore_phantom_types && type_param.is_phantom)
             })
             .map(|(type_arg, _)| print_format_type(type_arg, depth))
             .collect::<Result<_>>()?;
-        let mut struct_key = String::new();
+        let mut type_key = String::new();
         if !self.config.omit_addresses {
             write!(
-                struct_key,
+                type_key,
                 "{}{}",
                 module_id.address(),
                 self.config.separator.as_deref().unwrap_or("::")
@@ -237,7 +260,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .unwrap();
         }
         write!(
-            struct_key,
+            type_key,
             "{}{}{}",
             module_id.name(),
             self.config.separator.as_deref().unwrap_or("::"),
@@ -246,7 +269,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         .unwrap();
         if !generics.is_empty() {
             write!(
-                struct_key,
+                type_key,
                 "{}{}{}",
                 self.config.separator.as_deref().unwrap_or("<"),
                 generics.join(self.config.separator.as_deref().unwrap_or(",")),
@@ -255,30 +278,41 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .unwrap()
         }
         if self.config.shallow {
-            return Ok(Format::TypeName(struct_key));
+            return Ok(Format::TypeName(type_key));
         }
 
-        if let Some(old_struct) = self.registry.get(&struct_key) {
+        if let Some(old_datatype) = self.registry.get(&type_key) {
             if self.config.omit_addresses || self.config.separator.is_some() {
                 // check for conflicts (e.g., 0x1::M::T and 0x2::M::T that both get stripped to M::T because
                 // omit_addresses is on)
-                if old_struct.clone()
-                    != self.generate_serde_struct(normalized_struct, type_arguments, depth)?
+                if old_datatype.clone()
+                    != self.generate_serde_container(def, type_arguments, depth)?
                 {
                     panic!(
                         "Name conflict: multiple structs with name {}, but different addresses",
-                        struct_key
+                        type_key
                     )
                 }
             }
         } else {
             // not found--generate and update registry
-            let serde_struct =
-                self.generate_serde_struct(normalized_struct, type_arguments, depth)?;
-            self.registry.insert(struct_key.clone(), serde_struct);
+            let serde_data = self.generate_serde_container(def, type_arguments, depth)?;
+            self.registry.insert(type_key.clone(), serde_data);
         }
 
-        Ok(Format::TypeName(struct_key))
+        Ok(Format::TypeName(type_key))
+    }
+
+    fn generate_serde_container(
+        &mut self,
+        container: Container,
+        type_arguments: &[Format],
+        depth: u64,
+    ) -> Result<ContainerFormat> {
+        match container {
+            Container::Struct(s) => self.generate_serde_struct(s, type_arguments, depth),
+            Container::Enum(e) => self.generate_serde_enum(e, type_arguments, depth),
+        }
     }
 
     fn generate_serde_struct(
@@ -301,6 +335,53 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .collect::<Result<Vec<Named<Format>>>>()?;
         Ok(ContainerFormat::Struct(fields))
     }
+
+    fn generate_serde_enum(
+        &mut self,
+        normalized_enum: Enum,
+        type_arguments: &[Format],
+        depth: u64,
+    ) -> Result<ContainerFormat> {
+        check_depth!(depth);
+        let variants = normalized_enum
+            .variants
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let fields = v
+                    .fields
+                    .iter()
+                    .map(|f| {
+                        self.build_normalized_type_layout(&f.type_, type_arguments, depth)
+                            .map(|value| Named {
+                                name: f.name.to_string(),
+                                value,
+                            })
+                    })
+                    .collect::<Result<Vec<Named<Format>>>>();
+                fields.map(|fields| {
+                    if fields.is_empty() {
+                        (
+                            i as u32,
+                            Named {
+                                name: v.name.to_string(),
+                                value: VariantFormat::Unit,
+                            },
+                        )
+                    } else {
+                        (
+                            i as u32,
+                            Named {
+                                name: v.name.to_string(),
+                                value: VariantFormat::Struct(fields),
+                            },
+                        )
+                    }
+                })
+            })
+            .collect::<Result<BTreeMap<u32, Named<VariantFormat>>>>()?;
+        Ok(ContainerFormat::Enum(variants))
+    }
 }
 
 fn print_format_type(t: &Format, depth: u64) -> Result<String> {
@@ -320,7 +401,7 @@ fn print_format_type(t: &Format, depth: u64) -> Result<String> {
 }
 
 pub enum TypeLayoutBuilder {}
-pub enum StructLayoutBuilder {}
+pub enum DatatypeLayoutBuilder {}
 
 impl TypeLayoutBuilder {
     /// Construct a WithTypes `TypeLayout` with fields from `t`.
@@ -346,9 +427,7 @@ impl TypeLayoutBuilder {
             Vector(elem_t) => {
                 A::MoveTypeLayout::Vector(Box::new(Self::build(elem_t, resolver, depth + 1)?))
             }
-            Struct(s) => {
-                A::MoveTypeLayout::Struct(StructLayoutBuilder::build(s, resolver, depth + 1)?)
-            }
+            Struct(s) => DatatypeLayoutBuilder::build(s, resolver, depth + 1)?.into_layout(),
         })
     }
 
@@ -369,27 +448,25 @@ impl TypeLayoutBuilder {
                 resolver,
                 depth + 1,
             )?)),
-            Struct(shi) => A::MoveTypeLayout::Struct(StructLayoutBuilder::build_from_handle_idx(
-                m,
-                *shi,
-                vec![],
-                resolver,
-                depth + 1,
-            )?),
-            StructInstantiation(shi, type_actuals) => {
+            Datatype(shi) => {
+                DatatypeLayoutBuilder::build_from_handle_idx(m, *shi, vec![], resolver, depth + 1)?
+                    .into_layout()
+            }
+            DatatypeInstantiation(shi, type_actuals) => {
                 let actual_layouts = type_actuals
                     .iter()
                     .map(|t| {
                         Self::build_from_signature_token(m, t, type_arguments, resolver, depth + 1)
                     })
                     .collect::<Result<Vec<_>>>()?;
-                A::MoveTypeLayout::Struct(StructLayoutBuilder::build_from_handle_idx(
+                DatatypeLayoutBuilder::build_from_handle_idx(
                     m,
                     *shi,
                     actual_layouts,
                     resolver,
                     depth + 1,
-                )?)
+                )?
+                .into_layout()
             }
             TypeParameter(i) => type_arguments[*i as usize].clone(),
             Bool => A::MoveTypeLayout::Bool,
@@ -406,11 +483,15 @@ impl TypeLayoutBuilder {
     }
 }
 
-impl StructLayoutBuilder {
+impl DatatypeLayoutBuilder {
     /// Construct an expanded `TypeLayout` from `s`.
     /// Panics if `resolver` cannot resolved a module whose types are referenced directly or
     /// transitively by `s`.
-    fn build(s: &StructTag, resolver: &impl GetModule, depth: u64) -> Result<A::MoveStructLayout> {
+    fn build(
+        s: &StructTag,
+        resolver: &impl GetModule,
+        depth: u64,
+    ) -> Result<A::MoveDatatypeLayout> {
         check_depth!(depth);
         let type_arguments = s
             .type_params
@@ -420,7 +501,49 @@ impl StructLayoutBuilder {
         Self::build_from_name(&s.module_id(), &s.name, type_arguments, resolver, depth)
     }
 
-    fn build_from_definition(
+    fn build_from_enum_definition(
+        m: &CompiledModule,
+        e: &EnumDefinition,
+        type_arguments: Vec<A::MoveTypeLayout>,
+        resolver: &impl GetModule,
+        depth: u64,
+    ) -> Result<A::MoveEnumLayout> {
+        let e_handle = m.datatype_handle_at(e.enum_handle);
+        if e_handle.type_parameters.len() != type_arguments.len() {
+            bail!("Wrong number of type arguments for enum")
+        }
+
+        let mut variants = BTreeMap::new();
+        for (i, variant) in e.variants.iter().enumerate() {
+            let name = m.identifier_at(variant.variant_name).to_owned();
+            let mut fields = vec![];
+            for field in &variant.fields {
+                let ty = TypeLayoutBuilder::build_from_signature_token(
+                    m,
+                    &field.signature.0,
+                    &type_arguments,
+                    resolver,
+                    depth,
+                )?;
+                let name = m.identifier_at(field.name).to_owned();
+                fields.push(A::MoveFieldLayout::new(name, ty));
+            }
+            variants.insert((name, i as u16), fields);
+        }
+
+        let mid = m.self_id();
+        let type_params: Vec<TypeTag> = type_arguments.iter().map(|t| t.into()).collect();
+        let type_ = StructTag {
+            address: *mid.address(),
+            module: mid.name().to_owned(),
+            name: m.identifier_at(e_handle.name).to_owned(),
+            type_params,
+        };
+
+        Ok(A::MoveEnumLayout { type_, variants })
+    }
+
+    fn build_from_struct_definition(
         m: &CompiledModule,
         s: &StructDefinition,
         type_arguments: Vec<A::MoveTypeLayout>,
@@ -428,7 +551,7 @@ impl StructLayoutBuilder {
         depth: u64,
     ) -> Result<A::MoveStructLayout> {
         check_depth!(depth);
-        let s_handle = m.struct_handle_at(s.struct_handle);
+        let s_handle = m.datatype_handle_at(s.struct_handle);
         if s_handle.type_parameters.len() != type_arguments.len() {
             bail!("Wrong number of type arguments for struct")
         }
@@ -475,38 +598,62 @@ impl StructLayoutBuilder {
         type_arguments: Vec<A::MoveTypeLayout>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveStructLayout> {
+    ) -> Result<A::MoveDatatypeLayout> {
         check_depth!(depth);
         let module = match resolver.get_module_by_id(declaring_module) {
             Err(_) | Ok(None) => bail!("Could not find module"),
             Ok(Some(m)) => m,
         };
-        let def = module
-            .borrow()
-            .find_struct_def_by_name(name)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Could not find struct named {} in module {}",
-                    name,
-                    declaring_module
-                )
-            })?;
-        Self::build_from_definition(module.borrow(), def, type_arguments, resolver, depth)
+        match (
+            module.borrow().find_struct_def_by_name(name),
+            module.borrow().find_enum_def_by_name(name),
+        ) {
+            (Some(struct_def), None) => Ok(A::MoveDatatypeLayout::Struct(
+                Self::build_from_struct_definition(
+                    module.borrow(),
+                    struct_def,
+                    type_arguments,
+                    resolver,
+                    depth,
+                )?,
+            )),
+            (None, Some(enum_def)) => Ok(A::MoveDatatypeLayout::Enum(
+                Self::build_from_enum_definition(
+                    module.borrow(),
+                    enum_def,
+                    type_arguments,
+                    resolver,
+                    depth,
+                )?,
+            )),
+            (Some(_), Some(_)) => panic!("Found both struct and enum with name {}", name),
+            (None, None) => panic!(
+                "Could not find struct/enum named {} in module {}",
+                name,
+                module.borrow().name()
+            ),
+        }
     }
 
     fn build_from_handle_idx(
         m: &CompiledModule,
-        s: StructHandleIndex,
+        s: DatatypeHandleIndex,
         type_arguments: Vec<A::MoveTypeLayout>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveStructLayout> {
+    ) -> Result<A::MoveDatatypeLayout> {
         check_depth!(depth);
         if let Some(def) = m.find_struct_def(s) {
             // declared internally
-            Self::build_from_definition(m, def, type_arguments, resolver, depth)
+            Ok(A::MoveDatatypeLayout::Struct(
+                Self::build_from_struct_definition(m, def, type_arguments, resolver, depth)?,
+            ))
+        } else if let Some(def) = m.find_enum_def(s) {
+            Ok(A::MoveDatatypeLayout::Enum(
+                Self::build_from_enum_definition(m, def, type_arguments, resolver, depth)?,
+            ))
         } else {
-            let handle = m.struct_handle_at(s);
+            let handle = m.datatype_handle_at(s);
             let name = m.identifier_at(handle.name);
             let declaring_module = m.module_id_for_handle(m.module_handle_at(handle.module));
             // declared externally

--- a/external-crates/move/crates/move-bytecode-utils/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/lib.rs
@@ -10,7 +10,7 @@ use crate::dependency_graph::DependencyGraph;
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
-    file_format::{CompiledModule, SignatureToken, StructHandleIndex},
+    file_format::{CompiledModule, DatatypeHandleIndex, SignatureToken},
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
@@ -103,9 +103,9 @@ impl<'a> Modules<'a> {
 
 pub fn resolve_struct<'a>(
     view: &'a BinaryIndexedView,
-    sidx: StructHandleIndex,
+    sidx: DatatypeHandleIndex,
 ) -> (&'a AccountAddress, &'a IdentStr, &'a IdentStr) {
-    let shandle = view.struct_handle_at(sidx);
+    let shandle = view.datatype_handle_at(sidx);
     let mhandle = view.module_handle_at(shandle.module);
     let address = view.address_identifier_at(mhandle.address);
     let module_name = view.identifier_at(mhandle.name);
@@ -133,8 +133,8 @@ pub fn format_signature_token(view: &BinaryIndexedView, t: &SignatureToken) -> S
         }
         SignatureToken::TypeParameter(i) => format!("T{}", i),
 
-        SignatureToken::Struct(idx) => format_signature_token_struct(view, *idx, &[]),
-        SignatureToken::StructInstantiation(idx, ty_args) => {
+        SignatureToken::Datatype(idx) => format_signature_token_struct(view, *idx, &[]),
+        SignatureToken::DatatypeInstantiation(idx, ty_args) => {
             format_signature_token_struct(view, *idx, ty_args)
         }
     }
@@ -142,7 +142,7 @@ pub fn format_signature_token(view: &BinaryIndexedView, t: &SignatureToken) -> S
 
 pub fn format_signature_token_struct(
     view: &BinaryIndexedView,
-    sidx: StructHandleIndex,
+    sidx: DatatypeHandleIndex,
     ty_args: &[SignatureToken],
 ) -> String {
     let (address, module_name, struct_name) = resolve_struct(view, sidx);

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/generate.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/generate.rs
@@ -41,7 +41,7 @@ pub fn generate_struct_layouts(
                     shallow,
                 },
             );
-            layout_builder.build_struct_layout(&struct_tag)?;
+            layout_builder.build_data_layout(&struct_tag)?;
             let layout = serde_yaml::to_string(layout_builder.registry())?;
             state.save_struct_layouts(&layout)?;
             println!("{}", layout);

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -163,12 +163,13 @@ pub(crate) fn explain_publish_error(
             let new_api = normalized::Module::new(module);
 
             if (Compatibility {
-                check_struct_and_pub_function_linking: false,
-                check_struct_layout: true,
+                check_datatype_and_pub_function_linking: false,
+                check_datatype_layout: true,
                 check_friend_linking: false,
                 check_private_entry_linking: true,
                 disallowed_new_abilities: AbilitySet::EMPTY,
-                disallow_change_struct_type_params: false,
+                disallow_change_datatype_type_params: false,
+                disallow_new_variants: false,
             })
             .check(&old_api, &new_api)
             .is_err()
@@ -177,12 +178,13 @@ pub(crate) fn explain_publish_error(
                 // structs of this type. but probably a bad idea
                 println!("Layout API for structs of module {} has changed. Need to do a data migration of published structs", module_id)
             } else if (Compatibility {
-                check_struct_and_pub_function_linking: true,
-                check_struct_layout: false,
+                check_datatype_and_pub_function_linking: true,
+                check_datatype_layout: false,
                 check_friend_linking: false,
                 check_private_entry_linking: true,
                 disallowed_new_abilities: AbilitySet::EMPTY,
-                disallow_change_struct_type_params: false,
+                disallow_change_datatype_type_params: false,
+                disallow_new_variants: false,
             })
             .check(&old_api, &new_api)
             .is_err()

--- a/external-crates/move/crates/move-command-line-common/src/values.rs
+++ b/external-crates/move/crates/move-command-line-common/src/values.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::bail;
 use move_core_types::{
     account_address::AccountAddress,
-    identifier::{self},
+    identifier,
     runtime_value::{MoveStruct, MoveValue},
 };
 use std::fmt::{self, Display};

--- a/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/ast.rs
@@ -274,6 +274,7 @@ impl AstDebug for MoveValue {
                 w.write("]");
             }
             V::Struct(_) => panic!("ICE struct constants not supported"),
+            V::Variant(_) => panic!("ICE enum constants not supported"),
             V::Signer(_) => panic!("ICE signer constants not supported"),
         }
     }

--- a/external-crates/move/crates/move-compiler/src/interface_generator.rs
+++ b/external-crates/move/crates/move-compiler/src/interface_generator.rs
@@ -7,8 +7,8 @@ use anyhow::{anyhow, Result};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        Ability, AbilitySet, CompiledModule, FunctionDefinition, ModuleHandle, SignatureToken,
-        StructDefinition, StructFieldInformation, StructHandleIndex, StructTypeParameter,
+        Ability, AbilitySet, CompiledModule, DatatypeHandleIndex, DatatypeTyParameter,
+        FunctionDefinition, ModuleHandle, SignatureToken, StructDefinition, StructFieldInformation,
         TypeParameterIndex, Visibility,
     },
 };
@@ -183,7 +183,7 @@ fn write_friend_decl(ctx: &mut Context, fdecl: &ModuleHandle) -> String {
 fn write_struct_def(ctx: &mut Context, sdef: &StructDefinition) -> String {
     let mut out = String::new();
 
-    let shandle = ctx.module.struct_handle_at(sdef.struct_handle);
+    let shandle = ctx.module.datatype_handle_at(sdef.struct_handle);
 
     push_line!(
         out,
@@ -278,7 +278,7 @@ fn write_ability(ab: Ability) -> String {
     .to_string()
 }
 
-fn write_struct_type_parameters(tps: &[StructTypeParameter]) -> String {
+fn write_struct_type_parameters(tps: &[DatatypeTyParameter]) -> String {
     if tps.is_empty() {
         return "".to_string();
     }
@@ -354,8 +354,8 @@ fn write_signature_token(ctx: &mut Context, t: &SignatureToken) -> String {
         SignatureToken::Address => "address".to_string(),
         SignatureToken::Signer => "signer".to_string(),
         SignatureToken::Vector(inner) => format!("vector<{}>", write_signature_token(ctx, inner)),
-        SignatureToken::Struct(idx) => write_struct_handle_type(ctx, *idx),
-        SignatureToken::StructInstantiation(idx, types) => {
+        SignatureToken::Datatype(idx) => write_struct_handle_type(ctx, *idx),
+        SignatureToken::DatatypeInstantiation(idx, types) => {
             let n = write_struct_handle_type(ctx, *idx);
             let tys = types
                 .iter()
@@ -372,8 +372,8 @@ fn write_signature_token(ctx: &mut Context, t: &SignatureToken) -> String {
     }
 }
 
-fn write_struct_handle_type(ctx: &mut Context, idx: StructHandleIndex) -> String {
-    let struct_handle = ctx.module.struct_handle_at(idx);
+fn write_struct_handle_type(ctx: &mut Context, idx: DatatypeHandleIndex) -> String {
+    let struct_handle = ctx.module.datatype_handle_at(idx);
     let struct_module_handle = ctx.module.module_handle_at(struct_handle.module);
     let struct_module_id = ctx.module.module_id_for_handle(struct_module_handle);
     let module_alias = ctx.module_alias(struct_module_id).clone();

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/context.rs
@@ -63,7 +63,7 @@ impl<'a> Context<'a> {
         dependency_orderings: &HashMap<ModuleIdent, usize>,
         struct_declarations: &HashMap<
             (ModuleIdent, StructName),
-            (BTreeSet<IR::Ability>, Vec<IR::StructTypeParameter>),
+            (BTreeSet<IR::Ability>, Vec<IR::DatatypeTypeParameter>),
         >,
         function_declarations: &HashMap<
             (ModuleIdent, FunctionName),
@@ -95,7 +95,7 @@ impl<'a> Context<'a> {
                 dependency_order,
                 IR::ModuleDependency {
                     name: ir_name,
-                    structs,
+                    datatypes: structs,
                     functions,
                 },
             ));
@@ -108,10 +108,10 @@ impl<'a> Context<'a> {
     fn insert_struct_dependency(
         module_dependencies: &mut BTreeMap<
             ModuleIdent,
-            (Vec<IR::StructDependency>, Vec<IR::FunctionDependency>),
+            (Vec<IR::DatatypeDependency>, Vec<IR::FunctionDependency>),
         >,
         module: ModuleIdent,
-        struct_dep: IR::StructDependency,
+        struct_dep: IR::DatatypeDependency,
     ) {
         module_dependencies
             .entry(module)
@@ -123,7 +123,7 @@ impl<'a> Context<'a> {
     fn insert_function_dependency(
         module_dependencies: &mut BTreeMap<
             ModuleIdent,
-            (Vec<IR::StructDependency>, Vec<IR::FunctionDependency>),
+            (Vec<IR::DatatypeDependency>, Vec<IR::FunctionDependency>),
         >,
         module: ModuleIdent,
         function_dep: IR::FunctionDependency,
@@ -138,11 +138,11 @@ impl<'a> Context<'a> {
     fn struct_dependencies(
         struct_declarations: &HashMap<
             (ModuleIdent, StructName),
-            (BTreeSet<Ability>, Vec<IR::StructTypeParameter>),
+            (BTreeSet<Ability>, Vec<IR::DatatypeTypeParameter>),
         >,
         module_dependencies: &mut BTreeMap<
             ModuleIdent,
-            (Vec<IR::StructDependency>, Vec<IR::FunctionDependency>),
+            (Vec<IR::DatatypeDependency>, Vec<IR::FunctionDependency>),
         >,
         seen_structs: BTreeSet<(ModuleIdent, StructName)>,
     ) {
@@ -155,15 +155,15 @@ impl<'a> Context<'a> {
     fn struct_dependency(
         struct_declarations: &HashMap<
             (ModuleIdent, StructName),
-            (BTreeSet<Ability>, Vec<IR::StructTypeParameter>),
+            (BTreeSet<Ability>, Vec<IR::DatatypeTypeParameter>),
         >,
         module: &ModuleIdent,
         sname: StructName,
-    ) -> IR::StructDependency {
+    ) -> IR::DatatypeDependency {
         let key = (*module, sname);
         let (abilities, type_formals) = struct_declarations.get(&key).unwrap().clone();
         let name = Self::translate_struct_name(sname);
-        IR::StructDependency {
+        IR::DatatypeDependency {
             abilities,
             name,
             type_formals,
@@ -177,7 +177,7 @@ impl<'a> Context<'a> {
         >,
         module_dependencies: &mut BTreeMap<
             ModuleIdent,
-            (Vec<IR::StructDependency>, Vec<IR::FunctionDependency>),
+            (Vec<IR::DatatypeDependency>, Vec<IR::FunctionDependency>),
         >,
         seen_structs: &mut BTreeSet<(ModuleIdent, StructName)>,
         seen_functions: BTreeSet<(ModuleIdent, FunctionName)>,
@@ -234,8 +234,8 @@ impl<'a> Context<'a> {
         IR::ModuleName(s)
     }
 
-    fn translate_struct_name(n: StructName) -> IR::StructName {
-        IR::StructName(n.0.value)
+    fn translate_struct_name(n: StructName) -> IR::DatatypeName {
+        IR::DatatypeName(n.0.value)
     }
 
     fn translate_constant_name(n: ConstantName) -> IR::ConstantName {
@@ -250,7 +250,7 @@ impl<'a> Context<'a> {
     // Name resolution
     //**********************************************************************************************
 
-    pub fn struct_definition_name(&self, m: &ModuleIdent, s: StructName) -> IR::StructName {
+    pub fn struct_definition_name(&self, m: &ModuleIdent, s: StructName) -> IR::DatatypeName {
         assert!(
             self.is_current_module(m),
             "ICE invalid struct definition lookup"
@@ -262,7 +262,7 @@ impl<'a> Context<'a> {
         &mut self,
         m: &ModuleIdent,
         s: StructName,
-    ) -> IR::QualifiedStructIdent {
+    ) -> IR::QualifiedDatatypeIdent {
         let mname = if self.is_current_module(m) {
             IR::ModuleName::module_self()
         } else {
@@ -270,7 +270,7 @@ impl<'a> Context<'a> {
             Self::ir_module_alias(m)
         };
         let n = Self::translate_struct_name(s);
-        IR::QualifiedStructIdent::new(mname, n)
+        IR::QualifiedDatatypeIdent::new(mname, n)
     }
 
     pub fn function_definition_name(&self, m: &ModuleIdent, f: FunctionName) -> IR::FunctionName {

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -39,7 +39,7 @@ fn extract_decls(
     prog: &G::Program,
 ) -> (
     HashMap<ModuleIdent, usize>,
-    HashMap<(ModuleIdent, StructName), (BTreeSet<IR::Ability>, Vec<IR::StructTypeParameter>)>,
+    HashMap<(ModuleIdent, StructName), (BTreeSet<IR::Ability>, Vec<IR::DatatypeTypeParameter>)>,
     HashMap<
         (ModuleIdent, FunctionName),
         (BTreeSet<(ModuleIdent, StructName)>, IR::FunctionSignature),
@@ -136,7 +136,7 @@ fn module(
     dependency_orderings: &HashMap<ModuleIdent, usize>,
     struct_declarations: &HashMap<
         (ModuleIdent, StructName),
-        (BTreeSet<IR::Ability>, Vec<IR::StructTypeParameter>),
+        (BTreeSet<IR::Ability>, Vec<IR::DatatypeTypeParameter>),
     >,
     function_declarations: &HashMap<
         (ModuleIdent, FunctionName),
@@ -156,6 +156,8 @@ fn module(
     } = mdef;
     let mut context = Context::new(compilation_env, package_name, Some(&ident));
     let structs = struct_defs(&mut context, &ident, gstructs);
+    // TODO(enums): Add enum defs here!
+    let enums = vec![];
     let constants = constants(&mut context, &ident, gconstants);
     let (collected_function_infos, functions) = functions(&mut context, &ident, gfunctions);
 
@@ -195,6 +197,7 @@ fn module(
         imports,
         explicit_dependency_declarations,
         structs,
+        enums,
         constants,
         functions,
     };
@@ -636,7 +639,7 @@ fn field(f: Field) -> IR::Field {
 fn struct_definition_name(
     context: &mut Context,
     sp!(_, t_): H::Type,
-) -> (IR::StructName, Vec<IR::Type>) {
+) -> (IR::DatatypeName, Vec<IR::Type>) {
     match t_ {
         H::Type_::Single(st) => struct_definition_name_single(context, st),
         _ => panic!("ICE expected single type"),
@@ -646,7 +649,7 @@ fn struct_definition_name(
 fn struct_definition_name_single(
     context: &mut Context,
     sp!(_, st_): H::SingleType,
-) -> (IR::StructName, Vec<IR::Type>) {
+) -> (IR::DatatypeName, Vec<IR::Type>) {
     match st_ {
         H::SingleType_::Ref(_, bt) | H::SingleType_::Base(bt) => {
             struct_definition_name_base(context, bt)
@@ -657,7 +660,7 @@ fn struct_definition_name_single(
 fn struct_definition_name_base(
     context: &mut Context,
     sp!(_, bt_): H::BaseType,
-) -> (IR::StructName, Vec<IR::Type>) {
+) -> (IR::DatatypeName, Vec<IR::Type>) {
     use H::{BaseType_ as B, TypeName_ as TN};
     match bt_ {
         B::Apply(_, sp!(_, TN::ModuleType(m, s)), tys) => (
@@ -693,7 +696,7 @@ fn fun_type_parameters(tps: Vec<TParam>) -> Vec<(IR::TypeVar, BTreeSet<IR::Abili
         .collect()
 }
 
-fn struct_type_parameters(tps: Vec<StructTypeParameter>) -> Vec<IR::StructTypeParameter> {
+fn struct_type_parameters(tps: Vec<StructTypeParameter>) -> Vec<IR::DatatypeTypeParameter> {
     tps.into_iter()
         .map(|StructTypeParameter { is_phantom, param }| {
             let name = type_var(param.user_specified_name);
@@ -735,7 +738,7 @@ fn base_type(context: &mut Context, sp!(_, bt_): H::BaseType) -> IR::Type {
         B::Apply(_, sp!(_, TN::ModuleType(m, s)), tys) => {
             let n = context.qualified_struct_name(&m, s);
             let tys = base_types(context, tys);
-            IRT::Struct(n, tys)
+            IRT::Datatype(n, tys)
         }
         B::Param(TParam {
             user_specified_name,

--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -11,10 +11,11 @@ use move_binary_format::{
     binary_views::BinaryIndexedView,
     control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
     file_format::{
-        Ability, AbilitySet, Bytecode, CodeUnit, Constant, FieldHandleIndex, FunctionDefinition,
-        FunctionDefinitionIndex, FunctionHandle, ModuleHandle, Signature, SignatureIndex,
-        SignatureToken, StructDefinition, StructDefinitionIndex, StructFieldInformation,
-        StructTypeParameter, TableIndex, TypeSignature, Visibility,
+        Ability, AbilitySet, Bytecode, CodeUnit, Constant, DatatypeTyParameter, EnumDefinition,
+        EnumDefinitionIndex, FieldHandleIndex, FunctionDefinition, FunctionDefinitionIndex,
+        FunctionHandle, JumpTableInner, ModuleHandle, Signature, SignatureIndex, SignatureToken,
+        StructDefinition, StructDefinitionIndex, StructFieldInformation, TableIndex, TypeSignature,
+        Visibility,
     },
 };
 use move_bytecode_source_map::{
@@ -232,6 +233,26 @@ impl<'a> Disassembler<'a> {
         }
     }
 
+    fn get_enum_def(&self, enum_definition_index: EnumDefinitionIndex) -> Result<&EnumDefinition> {
+        if enum_definition_index.0 as usize
+            >= self
+                .source_mapper
+                .bytecode
+                .enum_defs()
+                .map_or(0, |d| d.len())
+        {
+            bail!("Invalid enum definition index supplied when marking enum")
+        }
+        match self
+            .source_mapper
+            .bytecode
+            .enum_def_at(enum_definition_index)
+        {
+            Ok(definition) => Ok(definition),
+            Err(err) => Err(Error::new(err)),
+        }
+    }
+
     //***************************************************************************
     // Code Coverage Helpers
     //***************************************************************************
@@ -306,7 +327,7 @@ impl<'a> Disassembler<'a> {
         let struct_handle = self
             .source_mapper
             .bytecode
-            .struct_handle_at(struct_def.struct_handle);
+            .datatype_handle_at(struct_def.struct_handle);
         let struct_name = self
             .source_mapper
             .bytecode
@@ -354,7 +375,7 @@ impl<'a> Disassembler<'a> {
         let struct_handle = self
             .source_mapper
             .bytecode
-            .struct_handle_at(struct_definition.struct_handle);
+            .datatype_handle_at(struct_definition.struct_handle);
         let name = self
             .source_mapper
             .bytecode
@@ -435,7 +456,11 @@ impl<'a> Disassembler<'a> {
         }
     }
 
-    fn format_function_body(locals: Vec<String>, bytecode: Vec<String>) -> String {
+    fn format_function_body(
+        locals: Vec<String>,
+        bytecode: Vec<String>,
+        jump_tables: Vec<String>,
+    ) -> String {
         if locals.is_empty() && bytecode.is_empty() {
             "".to_string()
         } else {
@@ -444,6 +469,7 @@ impl<'a> Disassembler<'a> {
                 .enumerate()
                 .map(|(local_idx, local)| format!("L{}:\t{}", local_idx, local))
                 .chain(bytecode)
+                .chain(jump_tables)
                 .collect();
             format!(" {{\n{}\n}}", body_iter.join("\n"))
         }
@@ -478,17 +504,17 @@ impl<'a> Disassembler<'a> {
             SignatureToken::U256 => "u256".to_string(),
             SignatureToken::Address => "address".to_string(),
             SignatureToken::Signer => "signer".to_string(),
-            SignatureToken::Struct(struct_handle_idx) => self
+            SignatureToken::Datatype(struct_handle_idx) => self
                 .source_mapper
                 .bytecode
                 .identifier_at(
                     self.source_mapper
                         .bytecode
-                        .struct_handle_at(struct_handle_idx)
+                        .datatype_handle_at(struct_handle_idx)
                         .name,
                 )
                 .to_string(),
-            SignatureToken::StructInstantiation(struct_handle_idx, instantiation) => {
+            SignatureToken::DatatypeInstantiation(struct_handle_idx, instantiation) => {
                 let instantiation = instantiation
                     .into_iter()
                     .map(|tok| self.disassemble_sig_tok(tok, type_param_context))
@@ -500,7 +526,7 @@ impl<'a> Disassembler<'a> {
                     .identifier_at(
                         self.source_mapper
                             .bytecode
-                            .struct_handle_at(struct_handle_idx)
+                            .datatype_handle_at(struct_handle_idx)
                             .name,
                     )
                     .to_string();
@@ -926,6 +952,45 @@ impl<'a> Disassembler<'a> {
         }
     }
 
+    fn disassemble_jump_tables(&self, code: &CodeUnit) -> Result<Vec<String>> {
+        if !self.options.print_code || code.jump_tables.is_empty() {
+            return Ok(vec!["".to_string()]);
+        }
+
+        let mut jump_tables = vec!["Jump tables:".to_string()];
+
+        for (i, jt) in code.jump_tables.iter().enumerate() {
+            let enum_def = self.get_enum_def(jt.head_enum)?;
+            let enum_handle = self
+                .source_mapper
+                .bytecode
+                .datatype_handle_at(enum_def.enum_handle);
+            let enum_source_map = self
+                .source_mapper
+                .source_map
+                .get_enum_source_map(jt.head_enum)?;
+            let enum_name = self.source_mapper.bytecode.identifier_at(enum_handle.name);
+            let JumpTableInner::Full(jt) = &jt.jump_table;
+            let jt: Vec<_> = jt
+                .iter()
+                .enumerate()
+                .map(|(tag, jump_loc)| {
+                    let enum_name = enum_source_map
+                        .get_variant_location(tag as u16)
+                        .map(|((name, _), _)| name)
+                        .unwrap_or(format!("Variant{}", tag));
+                    format!("{} => jump {}", enum_name, jump_loc)
+                })
+                .collect();
+            jump_tables.push(format!(
+                "[{i}]:\tvariant_switch {} {{\n\t\t{}\n\t}}",
+                enum_name,
+                jt.join("\n\t\t")
+            ))
+        }
+        Ok(jump_tables)
+    }
+
     fn disassemble_bytecode(
         &self,
         function_source_map: &FunctionSourceMap,
@@ -982,9 +1047,9 @@ impl<'a> Disassembler<'a> {
         Ok(instrs)
     }
 
-    fn disassemble_struct_type_formals(
+    fn disassemble_datatype_type_formals(
         source_map_ty_params: &[SourceName],
-        type_parameters: &[StructTypeParameter],
+        type_parameters: &[DatatypeTyParameter],
     ) -> String {
         let ty_params: Vec<String> = source_map_ty_params
             .iter()
@@ -1146,7 +1211,8 @@ impl<'a> Disassembler<'a> {
                     self.disassemble_locals(function_source_map, code.locals, params.len())?;
                 let bytecode =
                     self.disassemble_bytecode(function_source_map, name, parameters, code)?;
-                Self::format_function_body(locals, bytecode)
+                let jump_tables = self.disassemble_jump_tables(code)?;
+                Self::format_function_body(locals, bytecode, jump_tables)
             }
             None => "".to_string(),
         };
@@ -1167,7 +1233,7 @@ impl<'a> Disassembler<'a> {
         let struct_handle = self
             .source_mapper
             .bytecode
-            .struct_handle_at(struct_definition.struct_handle);
+            .datatype_handle_at(struct_definition.struct_handle);
         let struct_source_map = self
             .source_mapper
             .source_map
@@ -1210,7 +1276,7 @@ impl<'a> Disassembler<'a> {
             .identifier_at(struct_handle.name)
             .to_string();
 
-        let ty_params = Self::disassemble_struct_type_formals(
+        let ty_params = Self::disassemble_datatype_type_formals(
             &struct_source_map.type_parameters,
             &struct_handle.type_parameters,
         );
@@ -1241,6 +1307,80 @@ impl<'a> Disassembler<'a> {
             ty_params = ty_params,
             abilities = abilities,
             fields = &fields.join(",\n\t"),
+        ))
+    }
+
+    pub fn disassemble_enum_def(&self, enum_def_idx: EnumDefinitionIndex) -> Result<String> {
+        let enum_definition = self.get_enum_def(enum_def_idx)?;
+        let enum_handle = self
+            .source_mapper
+            .bytecode
+            .datatype_handle_at(enum_definition.enum_handle);
+        let enum_source_map = self
+            .source_mapper
+            .source_map
+            .get_enum_source_map(enum_def_idx)?;
+
+        let mut variants_formatted = vec![];
+        for variant in &enum_definition.variants {
+            let variant_name = self
+                .source_mapper
+                .bytecode
+                .identifier_at(variant.variant_name);
+            let mut variant_fields = vec![];
+            for field_definition in &variant.fields {
+                let type_sig = &field_definition.signature;
+                let field_name = self
+                    .source_mapper
+                    .bytecode
+                    .identifier_at(field_definition.name);
+                let ty_str =
+                    self.disassemble_sig_tok(type_sig.0.clone(), &enum_source_map.type_parameters)?;
+                variant_fields.push(format!("{}: {}", field_name, ty_str))
+            }
+            variants_formatted.push(format!(
+                "{} {{ {} }}",
+                variant_name,
+                variant_fields.join(", ")
+            ));
+        }
+
+        let abilities = if enum_handle.abilities == AbilitySet::EMPTY {
+            String::new()
+        } else {
+            let ability_vec: Vec<_> = enum_handle
+                .abilities
+                .into_iter()
+                .map(Self::format_ability)
+                .collect();
+            format!(" has {}", ability_vec.join(", "))
+        };
+
+        let name = self
+            .source_mapper
+            .bytecode
+            .identifier_at(enum_handle.name)
+            .to_string();
+
+        let ty_params = Self::disassemble_datatype_type_formals(
+            &enum_source_map.type_parameters,
+            &enum_handle.type_parameters,
+        );
+
+        if let Some(first_elem) = variants_formatted.first_mut() {
+            first_elem.insert_str(0, "{\n\t");
+        }
+
+        if let Some(last_elem) = variants_formatted.last_mut() {
+            last_elem.push_str("\n}");
+        }
+
+        Ok(format!(
+            "enum {name}{ty_params}{abilities} {variants}",
+            name = name,
+            ty_params = ty_params,
+            abilities = abilities,
+            variants = &variants_formatted.join(",\n\t"),
         ))
     }
 
@@ -1284,6 +1424,14 @@ impl<'a> Disassembler<'a> {
             .struct_defs()
             .map_or(0, |d| d.len()))
             .map(|i| self.disassemble_struct_def(StructDefinitionIndex(i as TableIndex)))
+            .collect::<Result<Vec<String>>>()?;
+
+        let enum_defs: Vec<String> = (0..self
+            .source_mapper
+            .bytecode
+            .enum_defs()
+            .map_or(0, |d| d.len()))
+            .map(|i| self.disassemble_enum_def(EnumDefinitionIndex(i as TableIndex)))
             .collect::<Result<Vec<String>>>()?;
 
         let constants: Vec<String> = self
@@ -1345,11 +1493,12 @@ impl<'a> Disassembler<'a> {
             )
         };
         Ok(format!(
-            "// Move bytecode v{version}\n{header} {{{imports}\n{struct_defs}\n\n{function_defs}\n{constant_pool_string}}}",
+            "// Move bytecode v{version}\n{header} {{{imports}\n{struct_defs}\n\n{enum_defs}\n\n{function_defs}\n{constant_pool_string}}}",
             version = version,
             header = header,
             imports = &imports_str,
             struct_defs = &struct_defs.join("\n"),
+            enum_defs = &enum_defs.join("\n"),
             function_defs = &function_defs.join("\n"),
         ))
     }

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lexer.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lexer.rs
@@ -88,6 +88,8 @@ pub enum Tok {
     RBrace,
     LSquare,
     RSquare,
+    Enum,
+    VariantSwitch,
 }
 
 pub struct Lexer<'input> {
@@ -425,6 +427,8 @@ fn get_name_token(name: &str) -> Tok {
         "script" => Tok::Script,
         "struct" => Tok::Struct,
         "true" => Tok::True,
+        "enum" => Tok::Enum,
+        "variant_switch" => Tok::VariantSwitch,
         _ => Tok::NameValue,
     }
 }

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
@@ -240,7 +240,7 @@ fn parse_field_ident(tokens: &mut Lexer) -> Result<FieldIdent, ParseError<Loc, a
         start_loc,
         end_loc,
         FieldIdent_ {
-            struct_name: StructName(name),
+            struct_name: DatatypeName(name),
             type_actuals,
             field,
         },
@@ -572,9 +572,11 @@ fn parse_unary_exp(tokens: &mut Lexer) -> Result<Exp, ParseError<Loc, anyhow::Er
 //     <f: Sp<QualifiedFunctionName>> <exp: Sp<CallOrTerm>> => Exp::FunctionCall(f, Box::new(exp)),
 // }
 
-fn parse_call(tokens: &mut Lexer) -> Result<Exp, ParseError<Loc, anyhow::Error>> {
-    let start_loc = tokens.start_loc();
-    let f = parse_qualified_function_name(tokens)?;
+fn parse_call(
+    tokens: &mut Lexer,
+    f: FunctionCall,
+    start_loc: usize,
+) -> Result<Exp, ParseError<Loc, anyhow::Error>> {
     let exp = parse_call_or_term(tokens)?;
     let end_loc = tokens.previous_end_loc();
     Ok(spanned(
@@ -601,7 +603,6 @@ fn parse_call_or_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyho
         | Tok::VecUnpack(_)
         | Tok::VecSwap
         | Tok::Freeze
-        | Tok::DotNameValue
         | Tok::ToU8
         | Tok::ToU16
         | Tok::ToU32
@@ -611,6 +612,26 @@ fn parse_call_or_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyho
             let f = parse_qualified_function_name(tokens)?;
             let exp = parse_call_or_term(tokens)?;
             Ok(Exp_::FunctionCall(f, Box::new(exp)))
+        }
+        Tok::DotNameValue => {
+            let f = parse_qualified_function_name(tokens)?;
+            if tokens.peek() == Tok::LBrace {
+                let FunctionCall_::ModuleFunctionCall {
+                    module: ModuleName(enum_name),
+                    name: FunctionName(variant_name),
+                    type_actuals,
+                } = f.value
+                else {
+                    return Err(ParseError::InvalidToken {
+                        location: f.loc,
+                        message: "Invalid variant pack call".to_string(),
+                    });
+                };
+                parse_variant_pack_(tokens, enum_name, variant_name, type_actuals)
+            } else {
+                let exp = parse_call_or_term(tokens)?;
+                Ok(Exp_::FunctionCall(f, Box::new(exp)))
+            }
         }
         _ => parse_term_(tokens),
     }
@@ -653,7 +674,24 @@ fn parse_pack_(
     let fs = parse_comma_list(tokens, &[Tok::RBrace], parse_field_exp, true)?;
     consume_token(tokens, Tok::RBrace)?;
     Ok(Exp_::Pack(
-        StructName(name),
+        DatatypeName(name),
+        type_actuals,
+        fs.into_iter().collect::<Vec<_>>(),
+    ))
+}
+
+fn parse_variant_pack_(
+    tokens: &mut Lexer,
+    enum_name: Symbol,
+    variant_name: Symbol,
+    type_actuals: Vec<Type>,
+) -> Result<Exp_, ParseError<Loc, anyhow::Error>> {
+    consume_token(tokens, Tok::LBrace)?;
+    let fs = parse_comma_list(tokens, &[Tok::RBrace], parse_field_exp, true)?;
+    consume_token(tokens, Tok::RBrace)?;
+    Ok(Exp_::PackVariant(
+        DatatypeName(enum_name),
+        VariantName(variant_name),
         type_actuals,
         fs.into_iter().collect::<Vec<_>>(),
     ))
@@ -716,13 +754,13 @@ fn parse_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyhow::Error
 
 fn parse_qualified_struct_ident(
     tokens: &mut Lexer,
-) -> Result<QualifiedStructIdent, ParseError<Loc, anyhow::Error>> {
+) -> Result<QualifiedDatatypeIdent, ParseError<Loc, anyhow::Error>> {
     let module_dot_struct = parse_dot_name(tokens)?;
     let v: Vec<&str> = module_dot_struct.split('.').collect();
     assert!(v.len() == 2);
     let m: ModuleName = ModuleName(Symbol::from(v[0]));
-    let n: StructName = StructName(Symbol::from(v[1]));
-    Ok(QualifiedStructIdent::new(m, n))
+    let n: DatatypeName = DatatypeName(Symbol::from(v[1]));
+    Ok(QualifiedDatatypeIdent::new(m, n))
 }
 
 // ModuleName: ModuleName = {
@@ -914,11 +952,58 @@ fn parse_unpack_(
     consume_token(tokens, Tok::Equal)?;
     let e = parse_exp(tokens)?;
     Ok(Statement_::Unpack(
-        StructName(name),
+        DatatypeName(name),
         type_actuals,
         bindings.into_iter().collect(),
         Box::new(e),
     ))
+}
+
+// <enum>.<variant>("<" <type_actuals> ">")? { <bindings> } (&|&mut)? = <exp>
+fn parse_variant_unpack_(
+    tokens: &mut Lexer,
+    enum_name: Symbol,
+    variant_name: Symbol,
+    type_actuals: Vec<Type>,
+    unpack_type: UnpackType,
+) -> Result<Statement_, ParseError<Loc, anyhow::Error>> {
+    consume_token(tokens, Tok::LBrace)?;
+    let bindings = parse_comma_list(tokens, &[Tok::RBrace], parse_field_bindings, true)?;
+    consume_token(tokens, Tok::RBrace)?;
+    consume_token(tokens, Tok::Equal)?;
+    let e = parse_exp(tokens)?;
+    Ok(Statement_::UnpackVariant(
+        DatatypeName(enum_name),
+        VariantName(variant_name),
+        type_actuals,
+        bindings.into_iter().collect(),
+        Box::new(e),
+        unpack_type,
+    ))
+}
+
+// variant_switch <enum_name> e { (<variant_name> => <lbl>)* }
+fn parse_variant_switch_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, anyhow::Error>> {
+    let name = parse_name(tokens)?;
+    let e = parse_exp(tokens)?;
+    consume_token(tokens, Tok::LBrace)?;
+    let lbls = parse_comma_list(tokens, &[Tok::RBrace], parse_variant_switch_arm, true)?;
+    consume_token(tokens, Tok::RBrace)?;
+    Ok(Statement_::VariantSwitch(
+        DatatypeName(name),
+        lbls,
+        Box::new(e),
+    ))
+}
+
+// <variant_name> : <lbl>
+fn parse_variant_switch_arm(
+    tokens: &mut Lexer,
+) -> Result<(VariantName, BlockLabel), ParseError<Loc, anyhow::Error>> {
+    let v = parse_name(tokens)?;
+    consume_token(tokens, Tok::Colon)?;
+    let lbl = parse_label(tokens)?;
+    Ok((VariantName(v), lbl))
 }
 
 /// Parses a statement.
@@ -993,6 +1078,10 @@ fn parse_statement_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, an
             let (name, tys) = parse_name_and_type_actuals(tokens)?;
             parse_unpack_(tokens, name, tys)
         }
+        Tok::VariantSwitch => {
+            consume_token(tokens, Tok::VariantSwitch)?;
+            parse_variant_switch_(tokens)
+        }
         Tok::VecPack(_)
         | Tok::VecLen
         | Tok::VecImmBorrow
@@ -1002,13 +1091,67 @@ fn parse_statement_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, an
         | Tok::VecUnpack(_)
         | Tok::VecSwap
         | Tok::Freeze
-        | Tok::DotNameValue
         | Tok::ToU8
         | Tok::ToU16
         | Tok::ToU32
         | Tok::ToU64
         | Tok::ToU128
-        | Tok::ToU256 => Ok(Statement_::Exp(Box::new(parse_call(tokens)?))),
+        | Tok::DotNameValue
+        | Tok::ToU256 => {
+            let start_loc = tokens.start_loc();
+            let f = parse_qualified_function_name(tokens)?;
+            if tokens.peek() == Tok::LBrace {
+                let FunctionCall_::ModuleFunctionCall {
+                    module: ModuleName(enum_name),
+                    name: FunctionName(variant_name),
+                    type_actuals,
+                } = f.value
+                else {
+                    return Err(ParseError::InvalidToken {
+                        location: f.loc,
+                        message: "Invalid variant unpack call".to_string(),
+                    });
+                };
+                parse_variant_unpack_(
+                    tokens,
+                    enum_name,
+                    variant_name,
+                    type_actuals,
+                    UnpackType::ByValue,
+                )
+            } else {
+                Ok(Statement_::Exp(Box::new(parse_call(tokens, f, start_loc)?)))
+            }
+        }
+        x @ (Tok::Amp | Tok::AmpMut) => {
+            let start_loc = current_token_loc(tokens);
+            tokens.advance()?;
+            let f = parse_qualified_function_name(tokens)?;
+            if tokens.peek() == Tok::LBrace {
+                let FunctionCall_::ModuleFunctionCall {
+                    module: ModuleName(enum_name),
+                    name: FunctionName(variant_name),
+                    type_actuals,
+                } = f.value
+                else {
+                    return Err(ParseError::InvalidToken {
+                        location: f.loc,
+                        message: "Invalid variant unpack call".to_string(),
+                    });
+                };
+                let unpack_type = match x {
+                    Tok::Amp => UnpackType::ByImmRef,
+                    Tok::AmpMut => UnpackType::ByMutRef,
+                    _ => unreachable!(),
+                };
+                parse_variant_unpack_(tokens, enum_name, variant_name, type_actuals, unpack_type)
+            } else {
+                Err(ParseError::InvalidToken {
+                    location: start_loc,
+                    message: format!("invalid token kind for statement {:?}", x),
+                })
+            }
+        }
         Tok::LParen => {
             tokens.advance()?;
             let start = tokens.start_loc();
@@ -1214,7 +1357,7 @@ fn parse_type(tokens: &mut Lexer) -> Result<Type, ParseError<Loc, anyhow::Error>
         Tok::DotNameValue => {
             let s = parse_qualified_struct_ident(tokens)?;
             let tys = parse_type_actuals(tokens)?;
-            Type::Struct(s, tys)
+            Type::Datatype(s, tys)
         }
         Tok::Amp => {
             tokens.advance()?;
@@ -1249,7 +1392,7 @@ fn parse_type_var(tokens: &mut Lexer) -> Result<TypeVar, ParseError<Loc, anyhow:
 
 fn parse_type_parameter_with_phantom_decl(
     tokens: &mut Lexer,
-) -> Result<StructTypeParameter, ParseError<Loc, anyhow::Error>> {
+) -> Result<DatatypeTypeParameter, ParseError<Loc, anyhow::Error>> {
     let is_phantom = if tokens.peek() == Tok::NameValue && tokens.content() == "phantom" {
         tokens.advance()?;
         true
@@ -1575,6 +1718,72 @@ fn parse_struct_decl(
     ))
 }
 
+// EnumDecl: EnumDefinition = {
+//     "enum" <name_and_type_parameters:
+//     NameAndTypeFormals> ("has" <Ability> ("," <Ability)*)? "{" <data: Comma<VariantDecl>> "}"
+//     => { ... }
+// }
+fn parse_enum_decl(tokens: &mut Lexer) -> Result<EnumDefinition, ParseError<Loc, anyhow::Error>> {
+    let start_loc = tokens.start_loc();
+
+    consume_token(tokens, Tok::Enum)?;
+
+    let (name, type_parameters) =
+        parse_name_and_type_parameters(tokens, parse_type_parameter_with_phantom_decl)?;
+
+    let mut abilities = BTreeSet::new();
+    if tokens.peek() == Tok::NameValue && tokens.content() == "has" {
+        tokens.advance()?;
+        let abilities_vec =
+            parse_comma_list(tokens, &[Tok::LBrace, Tok::Semicolon], parse_ability, false)?;
+        for (ability, location) in abilities_vec {
+            let was_new_element = abilities.insert(ability);
+            if !was_new_element {
+                return Err(ParseError::User {
+                    location,
+                    error: anyhow!("Duplicate ability '{}'", ability),
+                });
+            }
+        }
+    }
+
+    consume_token(tokens, Tok::LBrace)?;
+    let variants = parse_comma_list(tokens, &[Tok::RBrace], parse_variant_decl, true)?;
+    consume_token(tokens, Tok::RBrace)?;
+    let end_loc = tokens.previous_end_loc();
+    Ok(spanned(
+        tokens.file_hash(),
+        start_loc,
+        end_loc,
+        EnumDefinition_::new(abilities, name, type_parameters, variants),
+    ))
+}
+
+// VariantDecl: VariantDecl = {
+//     <name_and_type_parameters:
+//     NameAndTypeFormals> "{" <data: Comma<FieldDecl>> "}"
+//     => { ... }
+// }
+fn parse_variant_decl(
+    tokens: &mut Lexer,
+) -> Result<VariantDefinition, ParseError<Loc, anyhow::Error>> {
+    let start_loc = tokens.start_loc();
+
+    let name = parse_name(tokens)?;
+
+    consume_token(tokens, Tok::LBrace)?;
+    let fields = parse_comma_list(tokens, &[Tok::RBrace], parse_field_decl, true)?;
+    consume_token(tokens, Tok::RBrace)?;
+
+    let end_loc = tokens.previous_end_loc();
+    Ok(spanned(
+        tokens.file_hash(),
+        start_loc,
+        end_loc,
+        VariantDefinition_::new(name, fields),
+    ))
+}
+
 // ModuleIdent: ModuleIdent = {
 //     <a: AccountAddress> "." <m: ModuleName> => ModuleIdent::new(m, a),
 // }
@@ -1636,6 +1845,7 @@ fn parse_import_decl(
 //         <friends: (FriendDecl)*>
 //         <imports: (ImportDecl)*>
 //         <structs: (StructDecl)*>
+//         <enums: (EnumDecl)*>
 //         <functions: (FunctionDecl)*>
 //     "}" =>? ModuleDefinition::new(n, imports, structs, functions),
 // }
@@ -1643,6 +1853,10 @@ fn parse_import_decl(
 fn is_struct_decl(tokens: &mut Lexer) -> Result<bool, ParseError<Loc, anyhow::Error>> {
     let t = tokens.peek();
     Ok(t == Tok::Struct || (t == Tok::Native && tokens.lookahead()? == Tok::Struct))
+}
+
+fn is_enum_decl(tokens: &mut Lexer) -> bool {
+    tokens.peek() == Tok::Enum
 }
 
 fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
@@ -1666,6 +1880,11 @@ fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, 
         structs.push(parse_struct_decl(tokens)?);
     }
 
+    let mut enums: Vec<EnumDefinition> = vec![];
+    while is_enum_decl(tokens) {
+        enums.push(parse_enum_decl(tokens)?);
+    }
+
     let mut functions: Vec<(FunctionName, Function)> = vec![];
     while tokens.peek() != Tok::RBrace {
         functions.push(parse_function_decl(tokens)?);
@@ -1681,6 +1900,7 @@ fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, 
         imports,
         vec![],
         structs,
+        enums,
         vec![],
         functions,
     ))

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -7,10 +7,11 @@ use anyhow::{bail, format_err, Result};
 use move_binary_format::{
     file_format::{
         Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, Constant,
-        FieldDefinition, FunctionDefinition, FunctionSignature, ModuleHandle, Signature,
-        SignatureToken, StructDefinition, StructDefinitionIndex, StructFieldInformation,
-        StructHandleIndex, StructTypeParameter, TableIndex, TypeParameterIndex, TypeSignature,
-        Visibility,
+        DatatypeHandleIndex, DatatypeTyParameter, EnumDefinition, EnumDefinitionIndex,
+        FieldDefinition, FunctionDefinition, FunctionSignature, JumpTableInner, ModuleHandle,
+        Signature, SignatureToken, StructDefinition, StructDefinitionIndex, StructFieldInformation,
+        TableIndex, TypeParameterIndex, TypeSignature, VariantDefinition, VariantJumpTable,
+        VariantJumpTableIndex, Visibility,
     },
     file_format_common::VERSION_MAX,
 };
@@ -48,6 +49,12 @@ macro_rules! record_src_loc {
             .source_map
             .add_struct_field_mapping($idx, $field.loc)?;
     }};
+    (variant: $context:expr, $idx: expr, $variant:expr, $field_locs:expr) => {{
+        let source_name = ($variant.value.name.0.as_str().to_owned(), $variant.loc);
+        $context
+            .source_map
+            .add_enum_variant_mapping($idx, source_name, $field_locs)?;
+    }};
     (function_type_formals: $context:expr, $var:expr) => {
         for (ty_var, _) in $var.iter() {
             let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
@@ -78,6 +85,20 @@ macro_rules! record_src_loc {
         $context
             .source_map
             .add_top_level_struct_mapping($context.current_struct_definition_index(), $location)?;
+    };
+    (enum_type_formals: $context:expr, $var:expr) => {
+        for (_, ty_var, _) in $var.iter() {
+            let source_name = (ty_var.value.0.as_str().to_owned(), ty_var.loc);
+            $context.source_map.add_enum_type_parameter_mapping(
+                $context.current_enum_definition_index(),
+                source_name,
+            )?;
+        }
+    };
+    (enum_decl: $context:expr, $location:expr) => {
+        $context
+            .source_map
+            .add_top_level_enum_mapping($context.current_enum_definition_index(), $location)?;
     };
     (const_decl: $context:expr, $const_index:expr, $name:expr) => {
         $context.source_map.add_const_mapping($const_index, $name)?;
@@ -339,15 +360,25 @@ pub fn compile_module<'a>(
         module.explicit_dependency_declarations,
     )?;
 
-    // Explicitly declare all structs as they will be included even if not used
+    // Explicitly declare all structs and enums as they will be included even if not used
     for s in &module.structs {
         let abilities = abilities(&s.value.abilities);
-        let ident = QualifiedStructIdent {
+        let ident = QualifiedDatatypeIdent {
             module: self_name,
             name: s.value.name.clone(),
         };
-        let type_parameters = struct_type_parameters(&s.value.type_formals);
-        context.declare_struct_handle_index(ident, abilities, type_parameters)?;
+        let type_parameters = datatype_type_parameters(&s.value.type_formals);
+        context.declare_datatype_handle_index(ident, abilities, type_parameters)?;
+    }
+
+    for s in &module.enums {
+        let abilities = abilities(&s.value.abilities);
+        let ident = QualifiedDatatypeIdent {
+            module: self_name,
+            name: s.value.name.clone(),
+        };
+        let type_parameters = datatype_type_parameters(&s.value.type_formals);
+        context.declare_datatype_handle_index(ident, abilities, type_parameters)?;
     }
 
     for ir_constant in module.constants {
@@ -364,12 +395,13 @@ pub fn compile_module<'a>(
 
     // Compile definitions
     let struct_defs = compile_structs(&mut context, &self_name, module.structs)?;
+    let enum_defs = compile_enums(&mut context, &self_name, module.enums)?;
     let function_defs = compile_functions(&mut context, &self_name, module.functions)?;
 
     let (
         MaterializedPools {
             module_handles,
-            struct_handles,
+            datatype_handles,
             function_handles,
             field_handles,
             signatures,
@@ -378,7 +410,10 @@ pub fn compile_module<'a>(
             constant_pool,
             function_instantiations,
             struct_def_instantiations,
+            enum_def_instantiations,
             field_instantiations,
+            variant_handles,
+            variant_instantiation_handles,
         },
         _compiled_deps,
         source_map,
@@ -387,7 +422,7 @@ pub fn compile_module<'a>(
         version: VERSION_MAX,
         module_handles,
         self_module_handle_idx,
-        struct_handles,
+        datatype_handles,
         function_handles,
         field_handles,
         friend_decls,
@@ -401,6 +436,10 @@ pub fn compile_module<'a>(
         metadata: vec![],
         struct_defs,
         function_defs,
+        enum_defs,
+        enum_def_instantiations,
+        variant_handles,
+        variant_instantiation_handles,
     };
     Ok((module, source_map))
 }
@@ -417,7 +456,7 @@ fn compile_explicit_dependency_declarations(
     for dependency in dependencies {
         let ModuleDependency {
             name: mname,
-            structs,
+            datatypes,
             functions,
         } = dependency;
         let current_module = outer_context.module_ident(&mname)?;
@@ -428,16 +467,16 @@ fn compile_explicit_dependency_declarations(
         )?;
         compile_imports(&mut context, imports.clone())?;
         let self_module_handle_idx = context.module_handle_index(&mname)?;
-        for struct_dep in structs {
-            let StructDependency {
+        for data_dep in datatypes {
+            let DatatypeDependency {
                 abilities: abs,
                 name,
                 type_formals: tys,
-            } = struct_dep;
-            let sname = QualifiedStructIdent::new(mname, name);
+            } = data_dep;
+            let sname = QualifiedDatatypeIdent::new(mname, name);
             let ability_set = abilities(&abs);
-            let kinds = struct_type_parameters(&tys);
-            context.declare_struct_handle_index(sname, ability_set, kinds)?;
+            let kinds = datatype_type_parameters(&tys);
+            context.declare_datatype_handle_index(sname, ability_set, kinds)?;
         }
         for function_dep in functions {
             let FunctionDependency { name, signature } = function_dep;
@@ -448,7 +487,7 @@ fn compile_explicit_dependency_declarations(
         let (
             MaterializedPools {
                 module_handles,
-                struct_handles,
+                datatype_handles,
                 function_handles,
                 field_handles,
                 signatures,
@@ -457,7 +496,10 @@ fn compile_explicit_dependency_declarations(
                 constant_pool,
                 function_instantiations,
                 struct_def_instantiations,
+                enum_def_instantiations,
                 field_instantiations,
+                variant_handles,
+                variant_instantiation_handles,
             },
             compiled_deps,
             _source_map,
@@ -466,7 +508,7 @@ fn compile_explicit_dependency_declarations(
             version: VERSION_MAX,
             module_handles,
             self_module_handle_idx,
-            struct_handles,
+            datatype_handles,
             function_handles,
             field_handles,
             friend_decls: vec![],
@@ -480,6 +522,10 @@ fn compile_explicit_dependency_declarations(
             metadata: vec![],
             struct_defs: vec![],
             function_defs: vec![],
+            enum_defs: vec![],
+            enum_def_instantiations,
+            variant_handles,
+            variant_instantiation_handles,
         };
         dependencies_acc = compiled_deps;
         dependencies_acc.insert(
@@ -525,10 +571,10 @@ fn type_parameter_indexes<'a>(
     Ok(m)
 }
 
-fn struct_type_parameters(ast_tys: &[ast::StructTypeParameter]) -> Vec<StructTypeParameter> {
+fn datatype_type_parameters(ast_tys: &[ast::DatatypeTypeParameter]) -> Vec<DatatypeTyParameter> {
     ast_tys
         .iter()
-        .map(|(is_phantom, _, abs)| StructTypeParameter {
+        .map(|(is_phantom, _, abs)| DatatypeTyParameter {
             constraints: abilities(abs),
             is_phantom: *is_phantom,
         })
@@ -589,14 +635,14 @@ fn compile_type(
                 SignatureToken::Reference(inner_token)
             }
         }
-        Type::Struct(ident, tys) => {
-            let sh_idx = context.struct_handle_index(ident.clone())?;
+        Type::Datatype(ident, tys) => {
+            let sh_idx = context.datatype_handle_index(ident.clone())?;
 
             if tys.is_empty() {
-                SignatureToken::Struct(sh_idx)
+                SignatureToken::Datatype(sh_idx)
             } else {
                 let tokens = compile_types(context, type_parameters, tys)?;
-                SignatureToken::StructInstantiation(sh_idx, tokens)
+                SignatureToken::DatatypeInstantiation(sh_idx, tokens)
             }
         }
         Type::TypeParameter(ty_var) => {
@@ -639,11 +685,11 @@ fn compile_structs(
 ) -> Result<Vec<StructDefinition>> {
     let mut struct_defs = vec![];
     for s in structs {
-        let sident = QualifiedStructIdent {
+        let sident = QualifiedDatatypeIdent {
             module: *self_name,
             name: s.value.name.clone(),
         };
-        let sh_idx = context.struct_handle_index(sident.clone())?;
+        let sh_idx = context.datatype_handle_index(sident.clone())?;
         record_src_loc!(struct_decl: context, s.loc);
         record_src_loc!(struct_type_formals: context, &s.value.type_formals);
         let m = type_parameter_indexes(s.value.type_formals.iter().map(|formal| &formal.1))?;
@@ -660,7 +706,7 @@ fn compile_structs(
 fn compile_fields(
     context: &mut Context,
     type_parameters: &HashMap<TypeVar_, TypeParameterIndex>,
-    sh_idx: StructHandleIndex,
+    sh_idx: DatatypeHandleIndex,
     sd_idx: StructDefinitionIndex,
     sfields: StructDefinitionFields,
 ) -> Result<StructFieldInformation> {
@@ -681,6 +727,65 @@ fn compile_fields(
             StructFieldInformation::Declared(decl_fields)
         }
     })
+}
+
+fn compile_enums(
+    context: &mut Context,
+    self_name: &ModuleName,
+    enums: Vec<ast::EnumDefinition>,
+) -> Result<Vec<EnumDefinition>> {
+    let mut enum_defs = vec![];
+    for s in enums {
+        let sident = QualifiedDatatypeIdent {
+            module: *self_name,
+            name: s.value.name.clone(),
+        };
+        let eh_idx = context.datatype_handle_index(sident.clone())?;
+        record_src_loc!(enum_decl: context, s.loc);
+        record_src_loc!(enum_type_formals: context, &s.value.type_formals);
+        let m = type_parameter_indexes(s.value.type_formals.iter().map(|formal| &formal.1))?;
+        let ed_idx = context.declare_enum_definition_index(s.value.name)?;
+        let variant_definitions = compile_variants(context, &m, eh_idx, ed_idx, s.value.variants)?;
+        enum_defs.push(EnumDefinition {
+            enum_handle: eh_idx,
+            variants: variant_definitions,
+        });
+    }
+    Ok(enum_defs)
+}
+
+fn compile_variants(
+    context: &mut Context,
+    type_parameters: &HashMap<TypeVar_, TypeParameterIndex>,
+    eh_idx: DatatypeHandleIndex,
+    ed_idx: EnumDefinitionIndex,
+    variants: Vec<ast::VariantDefinition>,
+) -> Result<Vec<VariantDefinition>> {
+    let mut variant_outputs = vec![];
+    for (i, variant) in variants.into_iter().enumerate() {
+        let variant_name = context.identifier_index(variant.value.name.0)?;
+        let field_count = variant.value.fields.len();
+        context.declare_variant(eh_idx, ed_idx, variant.value.name.clone(), field_count, i);
+        let mut decl_fields = vec![];
+        let mut field_locs = vec![];
+        for (f, ty) in variant.value.fields.into_iter() {
+            let name = context.identifier_index(f.value.0)?;
+            field_locs.push(f.loc);
+            let sig_token = compile_type(context, type_parameters, &ty)?;
+            decl_fields.push(FieldDefinition {
+                name,
+                signature: TypeSignature(sig_token),
+            });
+        }
+        record_src_loc!(variant: context, ed_idx, variant, field_locs);
+        variant_outputs.push(VariantDefinition {
+            enum_def: ed_idx,
+            variant_name,
+            fields: decl_fields,
+        })
+    }
+
+    Ok(variant_outputs)
 }
 
 fn compile_functions(
@@ -804,9 +909,11 @@ fn compile_function_body(
         record_src_loc!(local: context, var_);
     }
 
+    let (code, jump_tables) = compile_blocks(context, &mut function_frame, blocks)?;
     Ok(CodeUnit {
         locals: context.signature_index(locals_signature)?,
-        code: compile_blocks(context, &mut function_frame, blocks)?,
+        code,
+        jump_tables,
     })
 }
 
@@ -818,8 +925,9 @@ fn compile_blocks(
     context: &mut Context,
     function_frame: &mut FunctionFrame,
     blocks: Vec<Block>,
-) -> Result<Vec<Bytecode>> {
+) -> Result<(Vec<Bytecode>, Vec<VariantJumpTable>)> {
     let mut code = vec![];
+    let mut jump_tables = vec![];
     let mut label_to_index: HashMap<BlockLabel_, u16> = HashMap::new();
     for block in blocks {
         compile_block(
@@ -827,12 +935,13 @@ fn compile_blocks(
             function_frame,
             &mut label_to_index,
             &mut code,
+            &mut jump_tables,
             block.value,
         )?;
     }
     let fake_to_actual = context.build_index_remapping(label_to_index);
-    remap_branch_offsets(&mut code, &fake_to_actual);
-    Ok(code)
+    remap_branch_offsets(&mut code, &mut jump_tables, &fake_to_actual);
+    Ok((code, jump_tables))
 }
 
 /// Translates a block's statements to bytecode instructions.
@@ -841,12 +950,20 @@ fn compile_block(
     function_frame: &mut FunctionFrame,
     label_to_index: &mut HashMap<BlockLabel_, u16>,
     code: &mut Vec<Bytecode>,
+    jump_tables: &mut Vec<VariantJumpTable>,
     block: Block_,
 ) -> Result<()> {
     label_to_index.insert(block.label.value.clone(), code.len() as u16);
     context.label_index(block.label.value)?;
     for statement in block.statements {
-        compile_statement(context, function_frame, label_to_index, code, statement)?;
+        compile_statement(
+            context,
+            function_frame,
+            label_to_index,
+            code,
+            jump_tables,
+            statement,
+        )?;
     }
     Ok(())
 }
@@ -861,6 +978,7 @@ fn compile_statement(
     function_frame: &mut FunctionFrame,
     label_to_index: &mut HashMap<BlockLabel_, u16>,
     code: &mut Vec<Bytecode>,
+    jump_tables: &mut Vec<VariantJumpTable>,
     statement: Statement,
 ) -> Result<()> {
     make_push_instr!(context, code);
@@ -947,8 +1065,86 @@ fn compile_statement(
                 push_instr!(field_.loc, st_loc);
             }
         }
+        Statement_::UnpackVariant(name, variant_name, tys, bindings, e, unpack_type) => {
+            let tokens = Signature(compile_types(
+                context,
+                function_frame.type_parameters(),
+                &tys,
+            )?);
+
+            compile_expression(context, function_frame, code, *e)?;
+
+            let def_idx = context.enum_definition_index(&name)?;
+            let qname = QualifiedDatatypeIdent {
+                module: ModuleName::module_self(),
+                name,
+            };
+            let dt_idx = context.datatype_handle_index(qname)?;
+            let (eh_idx, tag) = context.variant(dt_idx, variant_name)?;
+            if tys.is_empty() {
+                let handle_idx = context.variant_handle_index(eh_idx, tag as u16)?;
+                let bytecode = match unpack_type {
+                    UnpackType::ByValue => Bytecode::UnpackVariant(handle_idx),
+                    UnpackType::ByImmRef => Bytecode::UnpackVariantImmRef(handle_idx),
+                    UnpackType::ByMutRef => Bytecode::UnpackVariantMutRef(handle_idx),
+                };
+                push_instr!(statement.loc, bytecode);
+            } else {
+                let type_parameters_id = context.signature_index(tokens)?;
+                let eh_idx = context.enum_instantiation_index(def_idx, type_parameters_id)?;
+                let handle_idx = context.variant_instantiation_handle_index(eh_idx, tag as u16)?;
+                let bytecode = match unpack_type {
+                    UnpackType::ByValue => Bytecode::UnpackVariantGeneric(handle_idx),
+                    UnpackType::ByImmRef => Bytecode::UnpackVariantGenericImmRef(handle_idx),
+                    UnpackType::ByMutRef => Bytecode::UnpackVariantGenericMutRef(handle_idx),
+                };
+
+                push_instr!(statement.loc, bytecode);
+            }
+            function_frame.pop()?;
+
+            for (field_, lhs_variable) in bindings.iter().rev() {
+                let loc_idx = function_frame.get_local(&lhs_variable.value)?;
+                let st_loc = Bytecode::StLoc(loc_idx);
+                push_instr!(field_.loc, st_loc);
+            }
+        }
+        Statement_::VariantSwitch(name, lbls, e) => {
+            compile_expression(context, function_frame, code, *e)?;
+            let def_idx = context.enum_definition_index(&name)?;
+            let qname = QualifiedDatatypeIdent {
+                module: ModuleName::module_self(),
+                name,
+            };
+            let eh_idx = context.datatype_handle_index(qname)?;
+            let idx = compile_jump_table(context, jump_tables, def_idx, eh_idx, lbls)?;
+            push_instr!(statement.loc, Bytecode::VariantSwitch(idx));
+        }
     }
     Ok(())
+}
+
+fn compile_jump_table(
+    context: &mut Context,
+    jump_tables: &mut Vec<VariantJumpTable>,
+    def_idx: EnumDefinitionIndex,
+    eh_idx: DatatypeHandleIndex,
+    lbls: Vec<(VariantName, BlockLabel)>,
+) -> Result<VariantJumpTableIndex> {
+    let mut jump_table = vec![];
+    for (i, (name, lbl)) in lbls.into_iter().enumerate() {
+        let (_, tag) = context.variant(eh_idx, name.clone())?;
+        if i != tag {
+            bail!("Variant switch defined out of order for variant {}", name);
+        }
+        jump_table.push(context.label_index(lbl.value)?);
+    }
+    let jt_idx = VariantJumpTableIndex(jump_tables.len() as TableIndex);
+    jump_tables.push(VariantJumpTable {
+        head_enum: def_idx,
+        jump_table: JumpTableInner::Full(jump_table),
+    });
+    Ok(jt_idx)
 }
 
 fn compile_lvalues(
@@ -1067,11 +1263,11 @@ fn compile_expression(
             let def_idx = context.struct_definition_index(&name)?;
 
             let self_name = ModuleName::module_self();
-            let ident = QualifiedStructIdent {
+            let ident = QualifiedDatatypeIdent {
                 module: self_name,
                 name: name.clone(),
             };
-            let sh_idx = context.struct_handle_index(ident)?;
+            let sh_idx = context.datatype_handle_index(ident)?;
 
             let num_fields = fields.len();
             for (field_order, (field, e)) in fields.into_iter().enumerate() {
@@ -1186,11 +1382,11 @@ fn compile_expression(
             // field instruction that references the correct field handle index.
             // We can't know what the index of the field is without determining
             // the type of the underlying struct.
-            let struct_ident = QualifiedStructIdent {
+            let struct_ident = QualifiedDatatypeIdent {
                 module: ModuleName::module_self(),
                 name: field.value.struct_name,
             };
-            let sh_idx = context.struct_handle_index(struct_ident)?;
+            let sh_idx = context.datatype_handle_index(struct_ident)?;
             let (def_idx, _, field_offset) = context.field(sh_idx, field.value.field.value)?;
 
             function_frame.pop()?;
@@ -1231,6 +1427,39 @@ fn compile_expression(
             for e in exps {
                 compile_expression(context, function_frame, code, e)?;
             }
+        }
+        Exp_::PackVariant(name, variant_name, ast_tys, fields) => {
+            let sig_tys = compile_types(context, function_frame.type_parameters(), &ast_tys)?;
+            let tokens = Signature(sig_tys);
+            let type_actuals_id = context.signature_index(tokens)?;
+            let def_idx = context.enum_definition_index(&name)?;
+
+            let self_name = ModuleName::module_self();
+            let ident = QualifiedDatatypeIdent {
+                module: self_name,
+                name: name.clone(),
+            };
+            let sh_idx = context.datatype_handle_index(ident)?;
+            let num_fields = fields.len();
+            let (eh_idx, tag) = context.variant(sh_idx, variant_name)?;
+
+            for (_, e) in fields.into_iter() {
+                compile_expression(context, function_frame, code, e)?;
+            }
+
+            if ast_tys.is_empty() {
+                let handle = context.variant_handle_index(eh_idx, tag as u16)?;
+                push_instr!(exp.loc, Bytecode::PackVariant(handle));
+            } else {
+                let ei_idx = context.enum_instantiation_index(def_idx, type_actuals_id)?;
+                let handle = context.variant_instantiation_handle_index(ei_idx, tag as u16)?;
+                push_instr!(exp.loc, Bytecode::PackVariantGeneric(handle));
+            }
+
+            for _ in 0..num_fields {
+                function_frame.pop()?;
+            }
+            function_frame.push()?;
         }
     };
     Ok(())
@@ -1398,7 +1627,7 @@ fn compile_constant(_context: &mut Context, ty: Type, value: MoveValue) -> Resul
             Type::TypeParameter(_) => {
                 bail!("Type parameters are not supported in constant type layouts")
             }
-            Type::Struct(_ident, _tys) => {
+            Type::Datatype(_ident, _tys) => {
                 bail!("TODO Structs are not *yet* supported in constant type layouts")
             }
         })
@@ -1435,17 +1664,25 @@ fn compile_function_body_bytecode(
     let sig_idx = context.signature_index(locals_signature)?;
 
     let mut code = vec![];
+    let mut jump_tables = vec![];
     let mut label_to_index: HashMap<BlockLabel_, u16> = HashMap::new();
     for (label, block) in blocks {
         label_to_index.insert(label.clone(), code.len() as u16);
         context.label_index(label)?;
-        compile_bytecode_block(context, &mut function_frame, &mut code, block)?;
+        compile_bytecode_block(
+            context,
+            &mut function_frame,
+            &mut code,
+            &mut jump_tables,
+            block,
+        )?;
     }
     let fake_to_actual = context.build_index_remapping(label_to_index);
-    remap_branch_offsets(&mut code, &fake_to_actual);
+    remap_branch_offsets(&mut code, &mut jump_tables, &fake_to_actual);
     Ok(CodeUnit {
         locals: sig_idx,
         code,
+        jump_tables,
     })
 }
 
@@ -1453,10 +1690,11 @@ fn compile_bytecode_block(
     context: &mut Context,
     function_frame: &mut FunctionFrame,
     code: &mut Vec<Bytecode>,
+    jump_tables: &mut Vec<VariantJumpTable>,
     block: BytecodeBlock,
 ) -> Result<()> {
     for instr in block {
-        compile_bytecode(context, function_frame, code, instr)?
+        compile_bytecode(context, function_frame, code, jump_tables, instr)?
     }
     Ok(())
 }
@@ -1465,6 +1703,7 @@ fn compile_bytecode(
     context: &mut Context,
     function_frame: &mut FunctionFrame,
     code: &mut Vec<Bytecode>,
+    jump_tables: &mut Vec<VariantJumpTable>,
     sp!(loc, instr_): IRBytecode,
 ) -> Result<()> {
     make_push_instr!(context, code);
@@ -1557,11 +1796,11 @@ fn compile_bytecode(
             Bytecode::ImmBorrowLoc(function_frame.get_local(&v_)?)
         }
         IRBytecode_::MutBorrowField(name, tys, sp!(_, field_)) => {
-            let qualified_struct_name = QualifiedStructIdent {
+            let qualified_struct_name = QualifiedDatatypeIdent {
                 module: ModuleName::module_self(),
                 name,
             };
-            let sh_idx = context.struct_handle_index(qualified_struct_name)?;
+            let sh_idx = context.datatype_handle_index(qualified_struct_name)?;
             let (def_idx, _, field_offset) = context.field(sh_idx, field_)?;
 
             let fh_idx = context.field_handle_index(def_idx, field_offset as u16)?;
@@ -1579,11 +1818,11 @@ fn compile_bytecode(
             }
         }
         IRBytecode_::ImmBorrowField(name, tys, sp!(_, field_)) => {
-            let qualified_struct_name = QualifiedStructIdent {
+            let qualified_struct_name = QualifiedDatatypeIdent {
                 module: ModuleName::module_self(),
                 name,
             };
-            let sh_idx = context.struct_handle_index(qualified_struct_name)?;
+            let sh_idx = context.datatype_handle_index(qualified_struct_name)?;
             let (def_idx, _, field_offset) = context.field(sh_idx, field_)?;
 
             let fh_idx = context.field_handle_index(def_idx, field_offset as u16)?;
@@ -1660,18 +1899,92 @@ fn compile_bytecode(
             let sig = Signature(vec![tokens]);
             Bytecode::VecSwap(context.signature_index(sig)?)
         }
+        IRBytecode_::PackVariant(name, variant_name, tys) => {
+            let tokens = Signature(compile_types(
+                context,
+                function_frame.type_parameters(),
+                &tys,
+            )?);
+            let type_actuals_id = context.signature_index(tokens)?;
+            let def_idx = context.enum_definition_index(&name)?;
+            let qualified_enum_name = QualifiedDatatypeIdent {
+                module: ModuleName::module_self(),
+                name,
+            };
+            let dt_idx = context.datatype_handle_index(qualified_enum_name)?;
+            let (eh_idx, tag) = context.variant(dt_idx, variant_name)?;
+            if tys.is_empty() {
+                let handle = context.variant_handle_index(eh_idx, tag as u16)?;
+                Bytecode::PackVariant(handle)
+            } else {
+                let ei_idx = context.enum_instantiation_index(def_idx, type_actuals_id)?;
+                let handle = context.variant_instantiation_handle_index(ei_idx, tag as u16)?;
+                Bytecode::PackVariantGeneric(handle)
+            }
+        }
+        IRBytecode_::UnpackVariant(name, variant_name, tys, unpack_type) => {
+            let tokens = Signature(compile_types(
+                context,
+                function_frame.type_parameters(),
+                &tys,
+            )?);
+            let type_actuals_id = context.signature_index(tokens)?;
+            let def_idx = context.enum_definition_index(&name)?;
+            let qualified_enum_name = QualifiedDatatypeIdent {
+                module: ModuleName::module_self(),
+                name,
+            };
+            let dt_idx = context.datatype_handle_index(qualified_enum_name)?;
+            let (eh_idx, tag) = context.variant(dt_idx, variant_name)?;
+            if tys.is_empty() {
+                let handle = context.variant_handle_index(eh_idx, tag as u16)?;
+                match unpack_type {
+                    UnpackType::ByValue => Bytecode::UnpackVariant(handle),
+                    UnpackType::ByImmRef => Bytecode::UnpackVariantImmRef(handle),
+                    UnpackType::ByMutRef => Bytecode::UnpackVariantMutRef(handle),
+                }
+            } else {
+                let ei_idx = context.enum_instantiation_index(def_idx, type_actuals_id)?;
+                let handle = context.variant_instantiation_handle_index(ei_idx, tag as u16)?;
+                match unpack_type {
+                    UnpackType::ByValue => Bytecode::UnpackVariantGeneric(handle),
+                    UnpackType::ByImmRef => Bytecode::UnpackVariantGenericImmRef(handle),
+                    UnpackType::ByMutRef => Bytecode::UnpackVariantGenericMutRef(handle),
+                }
+            }
+        }
+        IRBytecode_::VariantSwitch(name, lbls) => {
+            let def_idx = context.enum_definition_index(&name)?;
+            let qname = QualifiedDatatypeIdent {
+                module: ModuleName::module_self(),
+                name,
+            };
+            let eh_idx = context.datatype_handle_index(qname)?;
+            let table_idx = compile_jump_table(context, jump_tables, def_idx, eh_idx, lbls)?;
+            Bytecode::VariantSwitch(table_idx)
+        }
     };
     push_instr!(loc, ff_instr);
     Ok(())
 }
 
-fn remap_branch_offsets(code: &mut Vec<Bytecode>, fake_to_actual: &HashMap<u16, u16>) {
+fn remap_branch_offsets(
+    code: &mut Vec<Bytecode>,
+    jump_tables: &mut [VariantJumpTable],
+    fake_to_actual: &HashMap<u16, u16>,
+) {
     for instr in code {
         match instr {
             Bytecode::BrTrue(offset) | Bytecode::BrFalse(offset) | Bytecode::Branch(offset) => {
                 *offset = fake_to_actual[offset]
             }
             _ => (),
+        }
+    }
+    for jt in jump_tables.iter_mut() {
+        let JumpTableInner::Full(ref mut jump_table) = jt.jump_table;
+        for offset in jump_table.iter_mut() {
+            *offset = fake_to_actual[offset]
         }
     }
 }

--- a/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
@@ -6,12 +6,15 @@ use anyhow::{bail, format_err, Result};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        AbilitySet, AddressIdentifierIndex, CodeOffset, Constant, ConstantPoolIndex, FieldHandle,
-        FieldHandleIndex, FieldInstantiation, FieldInstantiationIndex, FunctionDefinitionIndex,
-        FunctionHandle, FunctionHandleIndex, FunctionInstantiation, FunctionInstantiationIndex,
-        FunctionSignature, IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature,
-        SignatureIndex, SignatureToken, StructDefInstantiation, StructDefInstantiationIndex,
-        StructDefinitionIndex, StructHandle, StructHandleIndex, StructTypeParameter, TableIndex,
+        AbilitySet, AddressIdentifierIndex, CodeOffset, Constant, ConstantPoolIndex,
+        DatatypeHandle, DatatypeHandleIndex, DatatypeTyParameter, EnumDefInstantiation,
+        EnumDefInstantiationIndex, EnumDefinitionIndex, FieldHandle, FieldHandleIndex,
+        FieldInstantiation, FieldInstantiationIndex, FunctionDefinitionIndex, FunctionHandle,
+        FunctionHandleIndex, FunctionInstantiation, FunctionInstantiationIndex, FunctionSignature,
+        IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex,
+        SignatureToken, StructDefInstantiation, StructDefInstantiationIndex, StructDefinitionIndex,
+        TableIndex, VariantHandle, VariantHandleIndex, VariantInstantiationHandle,
+        VariantInstantiationHandleIndex,
     },
     CompiledModule,
 };
@@ -22,8 +25,8 @@ use move_core_types::{
 };
 use move_ir_types::{
     ast::{
-        BlockLabel_, ConstantName, Field_, FunctionName, ModuleIdent, ModuleName,
-        QualifiedStructIdent, StructName,
+        BlockLabel_, ConstantName, DatatypeName, Field_, FunctionName, ModuleIdent, ModuleName,
+        QualifiedDatatypeIdent, VariantName,
     },
     location::Loc,
 };
@@ -68,7 +71,7 @@ pub struct CompiledDependencyView<'a> {
     functions: HashMap<&'a IdentStr, TableIndex>,
 
     module_pool: &'a [ModuleHandle],
-    struct_pool: &'a [StructHandle],
+    datatype_pool: &'a [DatatypeHandle],
     function_pool: &'a [FunctionHandle],
     identifiers: &'a [Identifier],
     address_identifiers: &'a [AccountAddress],
@@ -82,11 +85,11 @@ impl<'a> CompiledDependencyView<'a> {
 
         let self_handle = dep.self_handle_idx();
 
-        for shandle in dep.struct_handles() {
+        for shandle in dep.datatype_handles() {
             let mhandle = dep.module_handle_at(shandle.module);
             let mname = dep.identifier_at(mhandle.name);
             let sname = dep.identifier_at(shandle.name);
-            // get_or_add_item gets the proper struct handle index, as `dep.struct_handles()` is
+            // get_or_add_item gets the proper struct handle index, as `dep.datatype_handles()` is
             // properly ordered
             get_or_add_item(&mut structs, (mname, sname))?;
         }
@@ -107,7 +110,7 @@ impl<'a> CompiledDependencyView<'a> {
             structs,
             functions,
             module_pool: dep.module_handles(),
-            struct_pool: dep.struct_handles(),
+            datatype_pool: dep.datatype_handles(),
             function_pool: dep.function_handles(),
             identifiers: dep.identifiers(),
             address_identifiers: dep.address_identifiers(),
@@ -115,8 +118,8 @@ impl<'a> CompiledDependencyView<'a> {
         })
     }
 
-    fn source_struct_info(&self, idx: StructHandleIndex) -> Option<(ModuleIdent, StructName)> {
-        let handle = self.struct_pool.get(idx.0 as usize)?;
+    fn source_struct_info(&self, idx: DatatypeHandleIndex) -> Option<(ModuleIdent, DatatypeName)> {
+        let handle = self.datatype_pool.get(idx.0 as usize)?;
         let module_handle = self.module_pool.get(handle.module.0 as usize)?;
         let address = *self
             .address_identifiers
@@ -132,7 +135,7 @@ impl<'a> CompiledDependencyView<'a> {
             address,
             name: module,
         };
-        let name = StructName(
+        let name = DatatypeName(
             self.identifiers
                 .get(handle.name.0 as usize)?
                 .as_str()
@@ -141,13 +144,17 @@ impl<'a> CompiledDependencyView<'a> {
         Some((ident, name))
     }
 
-    fn struct_handle(&self, module: &ModuleName, name: &StructName) -> Option<&'a StructHandle> {
+    fn datatype_handle(
+        &self,
+        module: &ModuleName,
+        name: &DatatypeName,
+    ) -> Option<&'a DatatypeHandle> {
         self.structs
             .get(&(
                 ident_str(module.0.as_str()).ok()?,
                 ident_str(name.0.as_str()).ok()?,
             ))
-            .and_then(|idx| self.struct_pool.get(*idx as usize))
+            .and_then(|idx| self.datatype_pool.get(*idx as usize))
     }
 
     fn function_signature(&self, name: &FunctionName) -> Option<FunctionSignature> {
@@ -211,13 +218,15 @@ pub struct MaterializedPools {
     /// Module handle pool
     pub module_handles: Vec<ModuleHandle>,
     /// Struct handle pool
-    pub struct_handles: Vec<StructHandle>,
+    pub datatype_handles: Vec<DatatypeHandle>,
     /// Function handle pool
     pub function_handles: Vec<FunctionHandle>,
     /// Field handle pool
     pub field_handles: Vec<FieldHandle>,
     /// Struct instantiation pool
     pub struct_def_instantiations: Vec<StructDefInstantiation>,
+    /// Enum instantiation pool
+    pub enum_def_instantiations: Vec<EnumDefInstantiation>,
     /// Function instantiation pool
     pub function_instantiations: Vec<FunctionInstantiation>,
     /// Field instantiation pool
@@ -230,6 +239,8 @@ pub struct MaterializedPools {
     pub address_identifiers: Vec<AccountAddress>,
     /// Constant pool
     pub constant_pool: Vec<Constant>,
+    pub variant_handles: Vec<VariantHandle>,
+    pub variant_instantiation_handles: Vec<VariantInstantiationHandle>,
 }
 
 /// Compilation context for a single compilation unit (module or script).
@@ -242,29 +253,34 @@ pub(crate) struct Context<'a> {
     // helpers
     aliases: HashMap<ModuleIdent, ModuleName>,
     modules: HashMap<ModuleName, (ModuleIdent, ModuleHandle)>,
-    structs: HashMap<QualifiedStructIdent, StructHandle>,
-    struct_defs: HashMap<StructName, TableIndex>,
+    structs: HashMap<QualifiedDatatypeIdent, DatatypeHandle>,
+    struct_defs: HashMap<DatatypeName, TableIndex>,
+    enum_defs: HashMap<DatatypeName, TableIndex>,
     named_constants: HashMap<ConstantName, TableIndex>,
     labels: HashMap<BlockLabel_, u16>,
 
     // queryable pools
     // TODO: lookup for Fields is not that seemless after binary format changes
     // We need multiple lookups or a better representation for fields
-    fields: HashMap<(StructHandleIndex, Field_), (StructDefinitionIndex, SignatureToken, usize)>,
+    fields: HashMap<(DatatypeHandleIndex, Field_), (StructDefinitionIndex, SignatureToken, usize)>,
     function_handles: HashMap<(ModuleName, FunctionName), (FunctionHandle, FunctionHandleIndex)>,
     function_signatures: HashMap<(ModuleName, FunctionName), FunctionSignature>,
+    variants: HashMap<(DatatypeHandleIndex, VariantName), (EnumDefinitionIndex, usize, usize)>,
 
     // Simple pools
     module_handles: HashMap<ModuleHandle, TableIndex>,
-    struct_handles: HashMap<StructHandle, TableIndex>,
+    datatype_handles: HashMap<DatatypeHandle, TableIndex>,
     signatures: HashMap<Signature, TableIndex>,
     identifiers: HashMap<Identifier, TableIndex>,
     address_identifiers: HashMap<AccountAddress, TableIndex>,
     constant_pool: HashMap<Constant, TableIndex>,
     field_handles: HashMap<FieldHandle, TableIndex>,
     struct_instantiations: HashMap<StructDefInstantiation, TableIndex>,
+    enum_instantiations: HashMap<EnumDefInstantiation, TableIndex>,
     function_instantiations: HashMap<FunctionInstantiation, TableIndex>,
     field_instantiations: HashMap<FieldInstantiation, TableIndex>,
+    variant_handles: HashMap<VariantHandle, TableIndex>,
+    variant_instantiation_handles: HashMap<VariantInstantiationHandle, TableIndex>,
 
     // The current function index that we are on
     current_function_index: FunctionDefinitionIndex,
@@ -288,15 +304,18 @@ impl<'a> Context<'a> {
             modules: HashMap::new(),
             structs: HashMap::new(),
             struct_defs: HashMap::new(),
+            enum_defs: HashMap::new(),
             named_constants: HashMap::new(),
             labels: HashMap::new(),
             fields: HashMap::new(),
+            variants: HashMap::new(),
             function_handles: HashMap::new(),
             function_signatures: HashMap::new(),
             module_handles: HashMap::new(),
-            struct_handles: HashMap::new(),
+            datatype_handles: HashMap::new(),
             field_handles: HashMap::new(),
             struct_instantiations: HashMap::new(),
+            enum_instantiations: HashMap::new(),
             function_instantiations: HashMap::new(),
             field_instantiations: HashMap::new(),
             signatures: HashMap::new(),
@@ -305,6 +324,8 @@ impl<'a> Context<'a> {
             constant_pool: HashMap::new(),
             current_function_index: FunctionDefinitionIndex::new(0),
             source_map: SourceMap::new(decl_location, current_module),
+            variant_handles: HashMap::new(),
+            variant_instantiation_handles: HashMap::new(),
         };
 
         Ok(context)
@@ -362,7 +383,7 @@ impl<'a> Context<'a> {
         let materialized_pools = MaterializedPools {
             function_handles,
             module_handles: Self::materialize_map(self.module_handles),
-            struct_handles: Self::materialize_map(self.struct_handles),
+            datatype_handles: Self::materialize_map(self.datatype_handles),
             field_handles: Self::materialize_map(self.field_handles),
             signatures: Self::materialize_map(self.signatures),
             identifiers: Self::materialize_map(self.identifiers),
@@ -370,7 +391,12 @@ impl<'a> Context<'a> {
             constant_pool: Self::materialize_map(self.constant_pool),
             function_instantiations: Self::materialize_map(self.function_instantiations),
             struct_def_instantiations: Self::materialize_map(self.struct_instantiations),
+            enum_def_instantiations: Self::materialize_map(self.enum_instantiations),
             field_instantiations: Self::materialize_map(self.field_instantiations),
+            variant_handles: Self::materialize_map(self.variant_handles),
+            variant_instantiation_handles: Self::materialize_map(
+                self.variant_instantiation_handles,
+            ),
         };
         (materialized_pools, self.dependencies, self.source_map)
     }
@@ -436,6 +462,30 @@ impl<'a> Context<'a> {
         )?))
     }
 
+    pub fn variant_handle_index(
+        &mut self,
+        enum_def: EnumDefinitionIndex,
+        variant: u16,
+    ) -> Result<VariantHandleIndex> {
+        let variant_handle = VariantHandle { enum_def, variant };
+        Ok(VariantHandleIndex(get_or_add_item(
+            &mut self.variant_handles,
+            variant_handle,
+        )?))
+    }
+
+    pub fn variant_instantiation_handle_index(
+        &mut self,
+        enum_def: EnumDefInstantiationIndex,
+        variant: u16,
+    ) -> Result<VariantInstantiationHandleIndex> {
+        let variant_handle = VariantInstantiationHandle { enum_def, variant };
+        Ok(VariantInstantiationHandleIndex(get_or_add_item(
+            &mut self.variant_instantiation_handles,
+            variant_handle,
+        )?))
+    }
+
     /// Get the struct instantiation index for the alias, adds it if missing.
     pub fn struct_instantiation_index(
         &mut self,
@@ -449,6 +499,22 @@ impl<'a> Context<'a> {
         Ok(StructDefInstantiationIndex(get_or_add_item(
             &mut self.struct_instantiations,
             struct_inst,
+        )?))
+    }
+
+    /// Get the enum instantiation index for the alias, adds it if missing.
+    pub fn enum_instantiation_index(
+        &mut self,
+        def: EnumDefinitionIndex,
+        type_parameters: SignatureIndex,
+    ) -> Result<EnumDefInstantiationIndex> {
+        let enum_inst = EnumDefInstantiation {
+            def,
+            type_parameters,
+        };
+        Ok(EnumDefInstantiationIndex(get_or_add_item(
+            &mut self.enum_instantiations,
+            enum_inst,
         )?))
     }
 
@@ -524,7 +590,7 @@ impl<'a> Context<'a> {
     /// Get the field index, fails if it is not bound.
     pub fn field(
         &self,
-        s: StructHandleIndex,
+        s: DatatypeHandleIndex,
         f: Field_,
     ) -> Result<(StructDefinitionIndex, SignatureToken, usize)> {
         match self.fields.get(&(s, f.clone())) {
@@ -533,11 +599,29 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub fn variant(
+        &self,
+        s: DatatypeHandleIndex,
+        f: VariantName,
+    ) -> Result<(EnumDefinitionIndex, usize)> {
+        match self.variants.get(&(s, f.clone())) {
+            None => bail!("Unbound variant {}", f),
+            Some((edef, _, tag)) => Ok((*edef, *tag)),
+        }
+    }
+
     /// Get the struct definition index, fails if it is not bound.
-    pub fn struct_definition_index(&self, s: &StructName) -> Result<StructDefinitionIndex> {
+    pub fn struct_definition_index(&self, s: &DatatypeName) -> Result<StructDefinitionIndex> {
         match self.struct_defs.get(s) {
             None => bail!("Missing struct definition for {}", s),
             Some(idx) => Ok(StructDefinitionIndex(*idx)),
+        }
+    }
+
+    pub fn enum_definition_index(&self, s: &DatatypeName) -> Result<EnumDefinitionIndex> {
+        match self.enum_defs.get(s) {
+            None => bail!("Missing enum definition for {}", s),
+            Some(idx) => Ok(EnumDefinitionIndex(*idx)),
         }
     }
 
@@ -557,6 +641,11 @@ impl<'a> Context<'a> {
     pub fn current_struct_definition_index(&self) -> StructDefinitionIndex {
         let idx = self.struct_defs.len();
         StructDefinitionIndex(idx as TableIndex)
+    }
+
+    pub fn current_enum_definition_index(&self) -> EnumDefinitionIndex {
+        let idx = self.enum_defs.len();
+        EnumDefinitionIndex(idx as TableIndex)
     }
 
     //**********************************************************************************************
@@ -590,34 +679,34 @@ impl<'a> Context<'a> {
 
     /// Given an identifier and basic "signature" information, creates a struct handle
     /// and adds it to the pool.
-    pub fn declare_struct_handle_index(
+    pub fn declare_datatype_handle_index(
         &mut self,
-        sname: QualifiedStructIdent,
+        sname: QualifiedDatatypeIdent,
         abilities: AbilitySet,
-        type_parameters: Vec<StructTypeParameter>,
-    ) -> Result<StructHandleIndex> {
-        self.declare_struct_handle_index_with_abilities(sname, abilities, type_parameters)
+        type_parameters: Vec<DatatypeTyParameter>,
+    ) -> Result<DatatypeHandleIndex> {
+        self.declare_datatype_handle_index_with_abilities(sname, abilities, type_parameters)
     }
 
-    fn declare_struct_handle_index_with_abilities(
+    fn declare_datatype_handle_index_with_abilities(
         &mut self,
-        sname: QualifiedStructIdent,
+        sname: QualifiedDatatypeIdent,
         abilities: AbilitySet,
-        type_parameters: Vec<StructTypeParameter>,
-    ) -> Result<StructHandleIndex> {
+        type_parameters: Vec<DatatypeTyParameter>,
+    ) -> Result<DatatypeHandleIndex> {
         let module = self.module_handle_index(&sname.module)?;
         let name = self.identifier_index(sname.name.0)?;
         self.structs.insert(
             sname.clone(),
-            StructHandle {
+            DatatypeHandle {
                 module,
                 name,
                 abilities,
                 type_parameters,
             },
         );
-        Ok(StructHandleIndex(get_or_add_item_ref(
-            &mut self.struct_handles,
+        Ok(DatatypeHandleIndex(get_or_add_item_ref(
+            &mut self.datatype_handles,
             self.structs.get(&sname).unwrap(),
         )?))
     }
@@ -625,7 +714,7 @@ impl<'a> Context<'a> {
     /// Given an identifier, declare the struct definition index.
     pub fn declare_struct_definition_index(
         &mut self,
-        s: StructName,
+        s: DatatypeName,
     ) -> Result<StructDefinitionIndex> {
         let idx = self.struct_defs.len();
         if idx > TABLE_MAX_SIZE {
@@ -635,6 +724,22 @@ impl<'a> Context<'a> {
         // need to handle duplicates
         Ok(StructDefinitionIndex(
             *self.struct_defs.entry(s).or_insert(idx as TableIndex),
+        ))
+    }
+
+    /// Given an identifier, declare the enum definition index.
+    pub fn declare_enum_definition_index(
+        &mut self,
+        s: DatatypeName,
+    ) -> Result<EnumDefinitionIndex> {
+        let idx = self.enum_defs.len();
+        if idx > TABLE_MAX_SIZE {
+            bail!("too many struct definitions {}", s)
+        }
+        // TODO: Add the decl of the struct definition name here
+        // need to handle duplicates
+        Ok(EnumDefinitionIndex(
+            *self.enum_defs.entry(s).or_insert(idx as TableIndex),
         ))
     }
 
@@ -695,7 +800,7 @@ impl<'a> Context<'a> {
     /// Given a struct handle and a field, adds it to the pool.
     pub fn declare_field(
         &mut self,
-        s: StructHandleIndex,
+        s: DatatypeHandleIndex,
         sd_idx: StructDefinitionIndex,
         f: Field_,
         token: SignatureToken,
@@ -705,6 +810,20 @@ impl<'a> Context<'a> {
         self.fields
             .entry((s, f))
             .or_insert((sd_idx, token, decl_order));
+    }
+
+    pub fn declare_variant(
+        &mut self,
+        s: DatatypeHandleIndex,
+        ed_idx: EnumDefinitionIndex,
+        f: VariantName,
+        field_count: usize,
+        tag: usize,
+    ) {
+        // need to handle duplicates
+        self.variants
+            .entry((s, f))
+            .or_insert((ed_idx, field_count, tag));
     }
 
     //**********************************************************************************************
@@ -722,16 +841,16 @@ impl<'a> Context<'a> {
         })
     }
 
-    fn dep_struct_handle(
+    fn dep_datatype_handle(
         &mut self,
-        s: &QualifiedStructIdent,
-    ) -> Result<(AbilitySet, Vec<StructTypeParameter>)> {
+        s: &QualifiedDatatypeIdent,
+    ) -> Result<(AbilitySet, Vec<DatatypeTyParameter>)> {
         if s.module == ModuleName::module_self() {
             bail!("Unbound struct {}", s)
         }
         let mident = *self.module_ident(&s.module)?;
         let dep = self.dependency(&mident)?;
-        match dep.struct_handle(&mident.name, &s.name) {
+        match dep.datatype_handle(&mident.name, &s.name) {
             None => bail!("Unbound struct {}", s),
             Some(shandle) => Ok((shandle.abilities, shandle.type_parameters.clone())),
         }
@@ -740,12 +859,15 @@ impl<'a> Context<'a> {
     /// Given an identifier, find the struct handle index.
     /// Creates the handle and adds it to the pool if it it is the *first* time it looks
     /// up the struct in a dependency.
-    pub fn struct_handle_index(&mut self, s: QualifiedStructIdent) -> Result<StructHandleIndex> {
+    pub fn datatype_handle_index(
+        &mut self,
+        s: QualifiedDatatypeIdent,
+    ) -> Result<DatatypeHandleIndex> {
         match self.structs.get(&s) {
-            Some(sh) => Ok(StructHandleIndex(*self.struct_handles.get(sh).unwrap())),
+            Some(sh) => Ok(DatatypeHandleIndex(*self.datatype_handles.get(sh).unwrap())),
             None => {
-                let (abilities, type_parameters) = self.dep_struct_handle(&s)?;
-                self.declare_struct_handle_index_with_abilities(s, abilities, type_parameters)
+                let (abilities, type_parameters) = self.dep_datatype_handle(&s)?;
+                self.declare_datatype_handle_index_with_abilities(s, abilities, type_parameters)
             }
         }
     }
@@ -778,35 +900,35 @@ impl<'a> Context<'a> {
                 let correct_inner = self.reindex_signature_token(dep, *inner)?;
                 SignatureToken::MutableReference(Box::new(correct_inner))
             }
-            SignatureToken::Struct(orig_sh_idx) => {
+            SignatureToken::Datatype(orig_sh_idx) => {
                 let dep_info = self.dependency(dep)?;
                 let (mident, sname) = dep_info
                     .source_struct_info(orig_sh_idx)
                     .ok_or_else(|| format_err!("Malformed dependency"))?;
                 let module_name = *self.module_alias(&mident)?;
-                let sident = QualifiedStructIdent {
+                let sident = QualifiedDatatypeIdent {
                     module: module_name,
                     name: sname,
                 };
-                let correct_sh_idx = self.struct_handle_index(sident)?;
-                SignatureToken::Struct(correct_sh_idx)
+                let correct_sh_idx = self.datatype_handle_index(sident)?;
+                SignatureToken::Datatype(correct_sh_idx)
             }
-            SignatureToken::StructInstantiation(orig_sh_idx, inners) => {
+            SignatureToken::DatatypeInstantiation(orig_sh_idx, inners) => {
                 let dep_info = self.dependency(dep)?;
                 let (mident, sname) = dep_info
                     .source_struct_info(orig_sh_idx)
                     .ok_or_else(|| format_err!("Malformed dependency"))?;
                 let module_name = *self.module_alias(&mident)?;
-                let sident = QualifiedStructIdent {
+                let sident = QualifiedDatatypeIdent {
                     module: module_name,
                     name: sname,
                 };
-                let correct_sh_idx = self.struct_handle_index(sident)?;
+                let correct_sh_idx = self.datatype_handle_index(sident)?;
                 let correct_inners = inners
                     .into_iter()
                     .map(|t| self.reindex_signature_token(dep, t))
                     .collect::<Result<_>>()?;
-                SignatureToken::StructInstantiation(correct_sh_idx, correct_inners)
+                SignatureToken::DatatypeInstantiation(correct_sh_idx, correct_inners)
             }
         })
     }

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -60,6 +60,8 @@ pub struct ModuleDefinition {
     pub explicit_dependency_declarations: Vec<ModuleDependency>,
     /// the structs (including resources) that the module defines
     pub structs: Vec<StructDefinition>,
+    /// The enums that the module defines
+    pub enums: Vec<EnumDefinition>,
     /// the constants that the script defines. Only a utility, the identifiers are not carried into
     /// the Move bytecode
     pub constants: Vec<Constant>,
@@ -72,8 +74,8 @@ pub struct ModuleDefinition {
 pub struct ModuleDependency {
     /// Qualified identifer of the dependency
     pub name: ModuleName,
-    /// The structs (including resources) that the dependency defines
-    pub structs: Vec<StructDependency>,
+    /// The data types (including resources) that the dependency defines
+    pub datatypes: Vec<DatatypeDependency>,
     /// The signatures of functions that the dependency defines
     pub functions: Vec<FunctionDependency>,
 }
@@ -155,7 +157,7 @@ pub enum Type {
     /// `vector`
     Vector(Box<Type>),
     /// A module defined struct
-    Struct(QualifiedStructIdent, Vec<Type>),
+    Datatype(QualifiedDatatypeIdent, Vec<Type>),
     /// A reference type, the bool flag indicates whether the reference is mutable
     Reference(bool, Box<Type>),
     /// A type parameter
@@ -163,18 +165,18 @@ pub enum Type {
 }
 
 //**************************************************************************************************
-// Structs
+// Data Types
 //**************************************************************************************************
 
 /// Identifier for a struct definition. Tells us where to look in the storage layer to find the
 /// code associated with the interface
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct QualifiedStructIdent {
+pub struct QualifiedDatatypeIdent {
     /// Module name and address in which the struct is contained
     pub module: ModuleName,
     /// Name for the struct class. Should be unique among structs published under the same
     /// module+address
-    pub name: StructName,
+    pub name: DatatypeName,
 }
 
 /// The field newtype
@@ -193,7 +195,7 @@ pub type Field = Spanned<Field_>;
 #[derive(Clone, Debug, PartialEq)]
 pub struct FieldIdent_ {
     /// The name of the struct type on which the field is declared.
-    pub struct_name: StructName,
+    pub struct_name: DatatypeName,
     /// For generic struct types, the type parameters used to instantiate the
     /// struct type (this is an empty vector for non-generic struct types).
     pub type_actuals: Vec<Type>,
@@ -206,12 +208,16 @@ pub type FieldIdent = Spanned<FieldIdent_>;
 /// A field map
 pub type Fields<T> = Vec<(Field, T)>;
 
-/// Newtype for the name of a struct
+/// Newtype for the name of a data type
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct StructName(pub Symbol);
+pub struct DatatypeName(pub Symbol);
+
+/// Newtype for the name of a variant
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct VariantName(pub Symbol);
 
 /// A struct type parameter with its constraints and whether it's declared as phantom.
-pub type StructTypeParameter = (bool, TypeVar, BTreeSet<Ability>);
+pub type DatatypeTypeParameter = (bool, TypeVar, BTreeSet<Ability>);
 
 /// A Move struct
 #[derive(Clone, Debug, PartialEq)]
@@ -219,9 +225,9 @@ pub struct StructDefinition_ {
     /// The declared abilities for the struct
     pub abilities: BTreeSet<Ability>,
     /// Human-readable name for the struct that also serves as a nominal type
-    pub name: StructName,
+    pub name: DatatypeName,
     /// The list of formal type arguments
-    pub type_formals: Vec<StructTypeParameter>,
+    pub type_formals: Vec<DatatypeTypeParameter>,
     /// the fields each instance has
     pub fields: StructDefinitionFields,
 }
@@ -230,13 +236,13 @@ pub type StructDefinition = Spanned<StructDefinition_>;
 
 /// An explicit struct dependency
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StructDependency {
+pub struct DatatypeDependency {
     /// The declared abilities for the struct
     pub abilities: BTreeSet<Ability>,
     /// Human-readable name for the struct that also serves as a nominal type
-    pub name: StructName,
+    pub name: DatatypeName,
     /// The list of formal type arguments
-    pub type_formals: Vec<StructTypeParameter>,
+    pub type_formals: Vec<DatatypeTypeParameter>,
 }
 
 /// The fields of a Move struct definition
@@ -248,8 +254,34 @@ pub enum StructDefinitionFields {
     Native,
 }
 
+/// A Move enum
+#[derive(Clone, Debug, PartialEq)]
+pub struct EnumDefinition_ {
+    /// The declared abilities for the struct
+    pub abilities: BTreeSet<Ability>,
+    /// Human-readable name for the struct that also serves as a nominal type
+    pub name: DatatypeName,
+    /// The list of formal type arguments
+    pub type_formals: Vec<DatatypeTypeParameter>,
+    /// the fields each instance has
+    pub variants: VariantDefinitions,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VariantDefinition_ {
+    pub name: VariantName,
+    pub fields: Fields<Type>,
+}
+
+pub type VariantDefinition = Spanned<VariantDefinition_>;
+
+pub type VariantDefinitions = Vec<VariantDefinition>;
+
+/// The type of a EnumDefinition along with its source location information
+pub type EnumDefinition = Spanned<EnumDefinition_>;
+
 //**************************************************************************************************
-// Structs
+// Constants
 //**************************************************************************************************
 
 /// Newtype for the name of a constant
@@ -412,6 +444,13 @@ pub enum LValue_ {
 }
 pub type LValue = Spanned<LValue_>;
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnpackType {
+    ByValue,
+    ByImmRef,
+    ByMutRef,
+}
+
 /// A [`Block_`] is composed of zero or more "statements," which can be translated into one or more
 /// bytecode instructions.
 #[derive(Debug, Clone, PartialEq)]
@@ -433,7 +472,18 @@ pub enum Statement_ {
     /// `jump_if_false (e) lbl`
     JumpIfFalse(Box<Exp>, BlockLabel),
     /// `n { f_1: x_1, ... , f_j: x_j  } = e`
-    Unpack(StructName, Vec<Type>, Fields<Var>, Box<Exp>),
+    Unpack(DatatypeName, Vec<Type>, Fields<Var>, Box<Exp>),
+    /// `e::v { f_1: x_1, ... , f_j: x_j  } = e`
+    UnpackVariant(
+        DatatypeName,
+        VariantName,
+        Vec<Type>,
+        Fields<Var>,
+        Box<Exp>,
+        UnpackType,
+    ),
+    /// `variant_switch (e) [(v1, lbl_1), ..., (v_n, lbl_n)]`
+    VariantSwitch(DatatypeName, Vec<(VariantName, BlockLabel)>, Box<Exp>),
 }
 /// A [`Statement_`] with a location.
 pub type Statement = Spanned<Statement_>;
@@ -555,7 +605,7 @@ pub enum Exp_ {
     /// Returns a fresh `StructInstance` whose type and kind (resource or otherwise)
     /// as the current struct class (i.e., the class of the method we're currently executing).
     /// `n { f_1: e_1, ... , f_j: e_j }`
-    Pack(StructName, Vec<Type>, ExpFields),
+    Pack(DatatypeName, Vec<Type>, ExpFields),
     /// `&e.f`, `&mut e.f`
     Borrow {
         /// mutable or not
@@ -575,6 +625,9 @@ pub enum Exp_ {
     FunctionCall(FunctionCall, Box<Exp>),
     /// (e_1, e_2, e_3, ..., e_j)
     ExprList(Vec<Exp>),
+    /// Takes the given field values and instantiates the variant of the enum.
+    /// `e::v { f_1: e_1, ... , f_j: e_j }`
+    PackVariant(DatatypeName, VariantName, Vec<Type>, ExpFields),
 }
 
 /// The type for a `Exp_` and its location
@@ -622,15 +675,15 @@ pub enum Bytecode_ {
     MoveLoc(Var),
     StLoc(Var),
     Call(ModuleName, FunctionName, Vec<Type>),
-    Pack(StructName, Vec<Type>),
-    Unpack(StructName, Vec<Type>),
+    Pack(DatatypeName, Vec<Type>),
+    Unpack(DatatypeName, Vec<Type>),
     ReadRef,
     WriteRef,
     FreezeRef,
     MutBorrowLoc(Var),
     ImmBorrowLoc(Var),
-    MutBorrowField(StructName, Vec<Type>, Field),
-    ImmBorrowField(StructName, Vec<Type>, Field),
+    MutBorrowField(DatatypeName, Vec<Type>, Field),
+    ImmBorrowField(DatatypeName, Vec<Type>, Field),
     Add,
     Sub,
     Mul,
@@ -659,6 +712,9 @@ pub enum Bytecode_ {
     VecPopBack(Type),
     VecUnpack(Type, u64),
     VecSwap(Type),
+    PackVariant(DatatypeName, VariantName, Vec<Type>),
+    UnpackVariant(DatatypeName, VariantName, Vec<Type>, UnpackType),
+    VariantSwitch(DatatypeName, Vec<(VariantName, BlockLabel)>),
 }
 pub type Bytecode = Spanned<Bytecode_>;
 
@@ -725,6 +781,7 @@ impl ModuleDefinition {
         imports: Vec<ImportDefinition>,
         explicit_dependency_declarations: Vec<ModuleDependency>,
         structs: Vec<StructDefinition>,
+        enums: Vec<EnumDefinition>,
         constants: Vec<Constant>,
         functions: Vec<(FunctionName, Function)>,
     ) -> Self {
@@ -735,6 +792,7 @@ impl ModuleDefinition {
             imports,
             explicit_dependency_declarations,
             structs,
+            enums,
             constants,
             functions,
         }
@@ -755,8 +813,8 @@ impl Ability {
 
 impl Type {
     /// Creates a new struct type
-    pub fn r#struct(ident: QualifiedStructIdent, type_actuals: Vec<Type>) -> Type {
-        Type::Struct(ident, type_actuals)
+    pub fn r#struct(ident: QualifiedDatatypeIdent, type_actuals: Vec<Type>) -> Type {
+        Type::Datatype(ident, type_actuals)
     }
 
     /// Creates a new reference type from its mutability and underlying type
@@ -780,10 +838,10 @@ impl Type {
     }
 }
 
-impl QualifiedStructIdent {
+impl QualifiedDatatypeIdent {
     /// Creates a new StructType handle from the name of the module alias and the name of the struct
-    pub fn new(module: ModuleName, name: StructName) -> Self {
-        QualifiedStructIdent { module, name }
+    pub fn new(module: ModuleName, name: DatatypeName) -> Self {
+        QualifiedDatatypeIdent { module, name }
     }
 
     /// Accessor for the module alias
@@ -792,7 +850,7 @@ impl QualifiedStructIdent {
     }
 
     /// Accessor for the struct name
-    pub fn name(&self) -> &StructName {
+    pub fn name(&self) -> &DatatypeName {
         &self.name
     }
 }
@@ -817,12 +875,12 @@ impl StructDefinition_ {
     pub fn move_declared(
         abilities: BTreeSet<Ability>,
         name: Symbol,
-        type_formals: Vec<StructTypeParameter>,
+        type_formals: Vec<DatatypeTypeParameter>,
         fields: Fields<Type>,
     ) -> Self {
         StructDefinition_ {
             abilities,
-            name: StructName(name),
+            name: DatatypeName(name),
             type_formals,
             fields: StructDefinitionFields::Move { fields },
         }
@@ -833,13 +891,38 @@ impl StructDefinition_ {
     pub fn native(
         abilities: BTreeSet<Ability>,
         name: Symbol,
-        type_formals: Vec<StructTypeParameter>,
+        type_formals: Vec<DatatypeTypeParameter>,
     ) -> Self {
         StructDefinition_ {
             abilities,
-            name: StructName(name),
+            name: DatatypeName(name),
             type_formals,
             fields: StructDefinitionFields::Native,
+        }
+    }
+}
+
+impl EnumDefinition_ {
+    pub fn new(
+        abilities: BTreeSet<Ability>,
+        name: Symbol,
+        type_formals: Vec<DatatypeTypeParameter>,
+        variants: VariantDefinitions,
+    ) -> Self {
+        Self {
+            abilities,
+            name: DatatypeName(name),
+            type_formals,
+            variants,
+        }
+    }
+}
+
+impl VariantDefinition_ {
+    pub fn new(name: Symbol, fields: Fields<Type>) -> Self {
+        Self {
+            name: VariantName(name),
+            fields,
         }
     }
 }
@@ -947,7 +1030,7 @@ impl Exp_ {
     }
 
     /// Creates a new pack/struct-instantiation `Exp` with no location information
-    pub fn instantiate(n: StructName, tys: Vec<Type>, s: ExpFields) -> Exp {
+    pub fn instantiate(n: DatatypeName, tys: Vec<Type>, s: ExpFields) -> Exp {
         Spanned::unsafe_no_loc(Exp_::Pack(n, tys, s))
     }
 
@@ -1078,6 +1161,12 @@ impl fmt::Display for ModuleDefinition {
         }
         writeln!(f, ")")?;
 
+        writeln!(f, "Enums(")?;
+        for enum_def in &self.enums {
+            writeln!(f, "{}, ", enum_def)?;
+        }
+        writeln!(f, ")")?;
+
         writeln!(f, "Constants(")?;
         for constant in &self.constants {
             writeln!(f, "{};", constant)?;
@@ -1103,7 +1192,7 @@ impl fmt::Display for ImportDefinition {
 impl fmt::Display for ModuleDependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Dependency({}, ", &self.name)?;
-        for sdep in &self.structs {
+        for sdep in &self.datatypes {
             writeln!(f, "{}, ", sdep)?
         }
         for fdep in &self.functions {
@@ -1113,7 +1202,7 @@ impl fmt::Display for ModuleDependency {
     }
 }
 
-impl fmt::Display for StructDependency {
+impl fmt::Display for DatatypeDependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -1151,6 +1240,31 @@ impl fmt::Display for StructDefinition_ {
     }
 }
 
+impl fmt::Display for EnumDefinition_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Enum({}{}, ",
+            self.name,
+            format_struct_type_formals(&self.type_formals)
+        )?;
+        for variant in &self.variants {
+            writeln!(f, "{}", variant)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl fmt::Display for VariantDefinition_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Variant({}", self.name)?;
+        if !self.fields.is_empty() {
+            write!(f, "{}", format_fields(&self.fields))?;
+        }
+        writeln!(f, ")")
+    }
+}
+
 impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -1181,7 +1295,13 @@ impl fmt::Display for FieldIdent_ {
     }
 }
 
-impl fmt::Display for StructName {
+impl fmt::Display for DatatypeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for VariantName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -1265,7 +1385,7 @@ impl fmt::Display for FunctionSignature {
     }
 }
 
-impl fmt::Display for QualifiedStructIdent {
+impl fmt::Display for QualifiedDatatypeIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.module, self.name)
     }
@@ -1291,7 +1411,7 @@ fn format_fun_type_formals(formals: &[(TypeVar, BTreeSet<Ability>)]) -> String {
     }
 }
 
-fn format_struct_type_formals(formals: &[StructTypeParameter]) -> String {
+fn format_struct_type_formals(formals: &[DatatypeTypeParameter]) -> String {
     if formals.is_empty() {
         "".to_string()
     } else {
@@ -1323,7 +1443,7 @@ impl fmt::Display for Type {
             Type::Address => write!(f, "address"),
             Type::Signer => write!(f, "signer"),
             Type::Vector(ty) => write!(f, "vector<{}>", ty),
-            Type::Struct(ident, tys) => write!(f, "{}{}", ident, format_type_actuals(tys)),
+            Type::Datatype(ident, tys) => write!(f, "{}{}", ident, format_type_actuals(tys)),
             Type::Reference(is_mutable, t) => {
                 write!(f, "&{}{}", if *is_mutable { "mut " } else { "" }, t)
             }
@@ -1391,6 +1511,17 @@ impl fmt::Display for LValue_ {
     }
 }
 
+impl fmt::Display for UnpackType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            UnpackType::ByValue => "",
+            UnpackType::ByImmRef => "&",
+            UnpackType::ByMutRef => "&mut",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 impl fmt::Display for Statement_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -1422,6 +1553,37 @@ impl fmt::Display for Statement_ {
                     )),
                 e
             ),
+            Statement_::UnpackVariant(name, variant_name, tys, bindings, e, unpack_type) => {
+                write!(
+                    f,
+                    "{}{}::{}{} {{ {} }} = {}",
+                    unpack_type,
+                    name,
+                    variant_name,
+                    format_type_actuals(tys),
+                    bindings
+                        .iter()
+                        .fold(String::new(), |acc, (field, var)| format!(
+                            "{} {} : {},",
+                            acc, field, var
+                        )),
+                    e
+                )
+            }
+            Statement_::VariantSwitch(name, lbls, e) => {
+                write!(
+                    f,
+                    "variant_switch ({}: {}) {{ {} }}",
+                    e,
+                    name,
+                    lbls.iter()
+                        .enumerate()
+                        .fold(String::new(), |acc, (tag, (name, lbl))| format!(
+                            "{} {}:{} => {},",
+                            acc, name, tag, lbl
+                        ))
+                )
+            }
         }
     }
 }
@@ -1539,6 +1701,19 @@ impl fmt::Display for Exp_ {
                     write!(f, "({})", intersperse(exps, ", "))
                 }
             }
+            Exp_::PackVariant(name, variant_name, tys, exps) => {
+                write!(
+                    f,
+                    "{}::{}{}{{{}}}",
+                    name,
+                    variant_name,
+                    format_type_actuals(tys),
+                    exps.iter().fold(String::new(), |acc, (field, op)| format!(
+                        "{} {} : {},",
+                        acc, field, op,
+                    ))
+                )
+            }
         }
     }
 }
@@ -1622,6 +1797,38 @@ impl fmt::Display for Bytecode_ {
             Bytecode_::VecPopBack(ty) => write!(f, "VecPopBack {}", ty),
             Bytecode_::VecUnpack(ty, n) => write!(f, "VecUnpack {} {}", ty, n),
             Bytecode_::VecSwap(ty) => write!(f, "VecSwap {}", ty),
+            Bytecode_::PackVariant(name, variant_name, tys) => {
+                write!(
+                    f,
+                    "PackVariant {}::{}{}",
+                    name,
+                    variant_name,
+                    format_type_actuals(tys)
+                )
+            }
+            Bytecode_::UnpackVariant(name, variant_name, tys, unpack_type) => {
+                write!(
+                    f,
+                    "UnpackVariant {}{}::{}{}",
+                    unpack_type,
+                    name,
+                    variant_name,
+                    format_type_actuals(tys)
+                )
+            }
+            Bytecode_::VariantSwitch(name, lbls) => {
+                write!(
+                    f,
+                    "VariantSwitch {}{}",
+                    name,
+                    lbls.iter()
+                        .enumerate()
+                        .fold(String::new(), |acc, (tag, (name, lbl))| format!(
+                            "{} {}:{} => {},",
+                            acc, name, tag, lbl
+                        ))
+                )
+            }
         }
     }
 }
@@ -1642,7 +1849,7 @@ fn format_move_value(v: &MoveValue) -> String {
                 .join(", ");
             format!("vector[{}]", items)
         }
-        MoveValue::Struct(_) | MoveValue::Signer(_) => {
+        MoveValue::Struct(_) | MoveValue::Signer(_) | MoveValue::Variant(_) => {
             panic!("Should be inexpressible as a constant")
         }
         MoveValue::U16(u) => format!("{}u16", u),

--- a/external-crates/move/crates/move-model/src/builder/exp_translator.rs
+++ b/external-crates/move/crates/move-model/src/builder/exp_translator.rs
@@ -439,7 +439,18 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             | (Type::Error, MoveValue::Vector(_))
             | (Type::Error, MoveValue::Struct(_))
             | (Type::Var(_), MoveValue::Vector(_))
-            | (Type::Var(_), MoveValue::Struct(_)) => {
+            | (Type::Var(_), MoveValue::Struct(_))
+            | (Type::Primitive(_), MoveValue::Variant(_))
+            | (Type::Tuple(_), MoveValue::Variant(_))
+            | (Type::Vector(_), MoveValue::Variant(_))
+            | (Type::Struct(_, _, _), MoveValue::Variant(_))
+            | (Type::TypeParameter(_), MoveValue::Variant(_))
+            | (Type::Reference(_, _), MoveValue::Variant(_))
+            | (Type::Fun(_, _), MoveValue::Variant(_))
+            | (Type::TypeDomain(_), MoveValue::Variant(_))
+            | (Type::ResourceDomain(_, _, _), MoveValue::Variant(_))
+            | (Type::Error, MoveValue::Variant(_))
+            | (Type::Var(_), MoveValue::Variant(_)) => {
                 self.error(
                     loc,
                     &format!("Not yet supported constant value: {:?}", value),

--- a/external-crates/move/crates/move-model/src/builder/module_builder.rs
+++ b/external-crates/move/crates/move-model/src/builder/module_builder.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{Constant, FunctionDefinitionIndex, StructDefinitionIndex},
-    views::{FunctionHandleView, StructHandleView},
+    views::{DatatypeHandleView, FunctionHandleView},
     CompiledModule,
 };
 use move_bytecode_source_map::source_map::SourceMap;
@@ -429,8 +429,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             .filter_map(|idx| {
                 let def_idx = StructDefinitionIndex(idx as u16);
                 let handle_idx = module.struct_def_at(def_idx).struct_handle;
-                let handle = module.struct_handle_at(handle_idx);
-                let view = StructHandleView::new(&module, handle);
+                let handle = module.datatype_handle_at(handle_idx);
+                let view = DatatypeHandleView::new(&module, handle);
                 let name = self.symbol_pool().make(view.name().as_str());
                 if let Some(entry) = self
                     .parent

--- a/external-crates/move/crates/move-model/src/lib.rs
+++ b/external-crates/move/crates/move-model/src/lib.rs
@@ -328,7 +328,7 @@ pub fn run_bytecode_model_builder<'a>(
         // add structs
         for (i, def) in m.struct_defs().iter().enumerate() {
             let def_idx = StructDefinitionIndex(i as u16);
-            let name = m.identifier_at(m.struct_handle_at(def.struct_handle).name);
+            let name = m.identifier_at(m.datatype_handle_at(def.struct_handle).name);
             let symbol = env.symbol_pool().make(name.as_str());
             let struct_id = StructId::new(symbol);
             let data =

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -41,14 +41,13 @@ use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{
         AddressIdentifierIndex, Bytecode, Constant as VMConstant, ConstantPoolIndex,
-        FunctionDefinitionIndex, FunctionHandleIndex, FunctionInstantiation, SignatureIndex,
-        SignatureToken, StructDefinitionIndex, StructFieldInformation, StructHandleIndex,
-        Visibility,
+        DatatypeHandleIndex, FunctionDefinitionIndex, FunctionHandleIndex, FunctionInstantiation,
+        SignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation, Visibility,
     },
     normalized::{FunctionRef, Type as MType},
     views::{
-        FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
-        StructDefinitionView, StructHandleView,
+        DatatypeHandleView, FieldDefinitionView, FunctionDefinitionView, FunctionHandleView,
+        SignatureTokenView, StructDefinitionView,
     },
     CompiledModule,
 };
@@ -1874,10 +1873,10 @@ impl<'env> ModuleEnv<'env> {
             }
             SignatureToken::TypeParameter(index) => Type::TypeParameter(*index),
             SignatureToken::Vector(bt) => Type::Vector(Box::new(self.globalize_signature(bt))),
-            SignatureToken::Struct(handle_idx) => {
-                let struct_view = StructHandleView::new(
+            SignatureToken::Datatype(handle_idx) => {
+                let struct_view = DatatypeHandleView::new(
                     &self.data.module,
-                    self.data.module.struct_handle_at(*handle_idx),
+                    self.data.module.datatype_handle_at(*handle_idx),
                 );
                 let declaring_module_env = self
                     .env
@@ -1888,10 +1887,10 @@ impl<'env> ModuleEnv<'env> {
                     .expect("undefined struct");
                 Type::Struct(declaring_module_env.data.id, struct_env.get_id(), vec![])
             }
-            SignatureToken::StructInstantiation(handle_idx, args) => {
-                let struct_view = StructHandleView::new(
+            SignatureToken::DatatypeInstantiation(handle_idx, args) => {
+                let struct_view = DatatypeHandleView::new(
                     &self.data.module,
-                    self.data.module.struct_handle_at(*handle_idx),
+                    self.data.module.datatype_handle_at(*handle_idx),
                 );
                 let declaring_module_env = self
                     .env
@@ -2028,7 +2027,7 @@ enum StructInfo {
         def_idx: StructDefinitionIndex,
 
         /// The handle index of this struct in its module.
-        handle_idx: StructHandleIndex,
+        handle_idx: DatatypeHandleIndex,
     },
 }
 
@@ -2069,7 +2068,7 @@ impl<'env> StructEnv<'env> {
     pub fn get_identifier(&self) -> Option<Identifier> {
         match &self.data.info {
             StructInfo::Declared { handle_idx, .. } => {
-                let handle = self.module_env.data.module.struct_handle_at(*handle_idx);
+                let handle = self.module_env.data.module.datatype_handle_at(*handle_idx);
                 Some(
                     self.module_env
                         .data
@@ -2130,7 +2129,7 @@ impl<'env> StructEnv<'env> {
                     .module_env
                     .data
                     .module
-                    .struct_handle_at(def.struct_handle);
+                    .datatype_handle_at(def.struct_handle);
                 handle.abilities
             }
         }
@@ -2197,7 +2196,7 @@ impl<'env> StructEnv<'env> {
                 self.module_env
                     .data
                     .module
-                    .struct_handle_at(def.struct_handle)
+                    .datatype_handle_at(def.struct_handle)
                     .type_parameters[idx]
                     .is_phantom
             }

--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
@@ -1289,6 +1289,15 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                     None,
                 ))
             }
+            MoveBytecode::PackVariant(_)
+            | MoveBytecode::PackVariantGeneric(_)
+            | MoveBytecode::UnpackVariant(_)
+            | MoveBytecode::UnpackVariantImmRef(_)
+            | MoveBytecode::UnpackVariantMutRef(_)
+            | MoveBytecode::UnpackVariantGeneric(_)
+            | MoveBytecode::UnpackVariantGenericImmRef(_)
+            | MoveBytecode::UnpackVariantGenericMutRef(_)
+            | MoveBytecode::VariantSwitch(_) => unimplemented!(),
         }
     }
 

--- a/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
@@ -12,7 +12,8 @@ use move_binary_format::{
     file_format::{
         Bytecode, ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex,
         FunctionHandleIndex, FunctionInstantiationIndex, SignatureIndex,
-        StructDefInstantiationIndex, StructDefinitionIndex,
+        StructDefInstantiationIndex, StructDefinitionIndex, VariantHandleIndex,
+        VariantInstantiationHandleIndex, VariantJumpTableIndex,
     },
     file_format_common::{instruction_key, Opcodes},
 };
@@ -627,6 +628,39 @@ pub fn zero_cost_instruction_table() -> Vec<(Bytecode, GasCost)> {
         (CastU16, GasCost::new(0, 0)),
         (CastU32, GasCost::new(0, 0)),
         (CastU256, GasCost::new(0, 0)),
+        (PackVariant(VariantHandleIndex::new(0)), GasCost::new(0, 0)),
+        (
+            PackVariantGeneric(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariant(VariantHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariantImmRef(VariantHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariantMutRef(VariantHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariantGeneric(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariantGenericImmRef(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            UnpackVariantGenericMutRef(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
+        (
+            VariantSwitch(VariantJumpTableIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
     ]
 }
 
@@ -775,6 +809,39 @@ pub fn bytecode_instruction_costs() -> Vec<(Bytecode, GasCost)> {
         (CastU16, GasCost::new(2, 1)),
         (CastU32, GasCost::new(2, 1)),
         (CastU256, GasCost::new(2, 1)),
+        (PackVariant(VariantHandleIndex::new(0)), GasCost::new(2, 1)),
+        (
+            PackVariantGeneric(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariant(VariantHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariantImmRef(VariantHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariantMutRef(VariantHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariantGeneric(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariantGenericImmRef(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            UnpackVariantGenericMutRef(VariantInstantiationHandleIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
+        (
+            VariantSwitch(VariantJumpTableIndex::new(0)),
+            GasCost::new(2, 1),
+        ),
     ]
 }
 

--- a/external-crates/move/crates/test-generation/src/abstract_state.rs
+++ b/external-crates/move/crates/test-generation/src/abstract_state.rs
@@ -54,8 +54,8 @@ impl AbstractValue {
     pub fn new_primitive(token: SignatureToken) -> AbstractValue {
         assert!(
             match token {
-                SignatureToken::Struct(_)
-                | SignatureToken::StructInstantiation(_, _)
+                SignatureToken::Datatype(_)
+                | SignatureToken::DatatypeInstantiation(_, _)
                 | SignatureToken::Reference(_)
                 | SignatureToken::MutableReference(_)
                 | SignatureToken::Signer
@@ -93,7 +93,7 @@ impl AbstractValue {
     /// Create a new struct `AbstractValue` given its type and kind
     pub fn new_struct(token: SignatureToken, abilities: AbilitySet) -> AbstractValue {
         assert!(
-            matches!(token, SignatureToken::Struct(_)),
+            matches!(token, SignatureToken::Datatype(_)),
             "AbstractValue::new_struct must be applied with a struct type"
         );
         AbstractValue { token, abilities }
@@ -112,7 +112,7 @@ impl AbstractValue {
     fn is_generic_token(token: &SignatureToken) -> bool {
         match token {
             SignatureToken::TypeParameter(_) => true,
-            SignatureToken::StructInstantiation(_, _) => true,
+            SignatureToken::DatatypeInstantiation(_, _) => true,
             SignatureToken::Reference(tok) | SignatureToken::MutableReference(tok) => {
                 Self::is_generic_token(tok)
             }

--- a/external-crates/move/crates/test-generation/src/bytecode_generator.rs
+++ b/external-crates/move/crates/test-generation/src/bytecode_generator.rs
@@ -870,7 +870,7 @@ impl<'a> BytecodeGenerator<'a> {
             SignatureToken::U32 => vec![Bytecode::LdU32(0)],
             SignatureToken::U256 => vec![Bytecode::LdU256(U256::zero())],
             SignatureToken::Bool => vec![Bytecode::LdFalse],
-            SignatureToken::Struct(handle_idx) => {
+            SignatureToken::Datatype(handle_idx) => {
                 let struct_def_idx = module
                     .module
                     .struct_defs()
@@ -898,7 +898,7 @@ impl<'a> BytecodeGenerator<'a> {
                 )));
                 bytecodes
             }
-            SignatureToken::StructInstantiation(handle_idx, instantiation) => {
+            SignatureToken::DatatypeInstantiation(handle_idx, instantiation) => {
                 let struct_def_idx = module
                     .module
                     .struct_defs()

--- a/external-crates/move/crates/test-generation/src/summaries.rs
+++ b/external-crates/move/crates/test-generation/src/summaries.rs
@@ -491,5 +491,14 @@ pub fn instruction_summary(instruction: Bytecode, exact: bool) -> Summary {
         | Bytecode::VecPopBack(_)
         | Bytecode::VecUnpack(..)
         | Bytecode::VecSwap(_) => unimplemented!("Vector bytecode not supported yet"),
+        Bytecode::PackVariant(_)
+        | Bytecode::PackVariantGeneric(_)
+        | Bytecode::UnpackVariant(_)
+        | Bytecode::UnpackVariantImmRef(_)
+        | Bytecode::UnpackVariantMutRef(_)
+        | Bytecode::UnpackVariantGeneric(_)
+        | Bytecode::UnpackVariantGenericImmRef(_)
+        | Bytecode::UnpackVariantGenericMutRef(_)
+        | Bytecode::VariantSwitch(_) => unimplemented!("Variant bytecode not supported yet"),
     }
 }

--- a/external-crates/move/crates/test-generation/tests/struct_instructions.rs
+++ b/external-crates/move/crates/test-generation/tests/struct_instructions.rs
@@ -6,10 +6,10 @@ extern crate test_generation;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        empty_module, Ability, AbilitySet, Bytecode, CompiledModule, FieldDefinition, FieldHandle,
-        FieldHandleIndex, IdentifierIndex, ModuleHandleIndex, SignatureToken, StructDefinition,
-        StructDefinitionIndex, StructFieldInformation, StructHandle, StructHandleIndex, TableIndex,
-        TypeSignature,
+        empty_module, Ability, AbilitySet, Bytecode, CompiledModule, DatatypeHandle,
+        DatatypeHandleIndex, FieldDefinition, FieldHandle, FieldHandleIndex, IdentifierIndex,
+        ModuleHandleIndex, SignatureToken, StructDefinition, StructDefinitionIndex,
+        StructFieldInformation, TableIndex, TypeSignature,
     },
     views::{StructDefinitionView, ViewInternals},
 };
@@ -42,11 +42,11 @@ fn generate_module_with_struct(resource: bool) -> CompiledModule {
         });
     }
     let struct_def = StructDefinition {
-        struct_handle: StructHandleIndex(struct_index),
+        struct_handle: DatatypeHandleIndex(struct_index),
         field_information: StructFieldInformation::Declared(fields),
     };
     module.struct_defs.push(struct_def);
-    module.struct_handles = vec![StructHandle {
+    module.datatype_handles = vec![DatatypeHandle {
         module: ModuleHandleIndex::new(0),
         name: IdentifierIndex::new((struct_index + offset) as TableIndex),
         abilities: if resource {
@@ -79,7 +79,10 @@ fn create_struct_value(module: &CompiledModule) -> (AbstractValue, Vec<Signature
     )
     .unwrap();
     (
-        AbstractValue::new_struct(SignatureToken::Struct(struct_def.struct_handle), abilities),
+        AbstractValue::new_struct(
+            SignatureToken::Datatype(struct_def.struct_handle),
+            abilities,
+        ),
         tokens,
     )
 }


### PR DESCRIPTION
## Description 

Adds support for enums in the Move IR, and Move tooling (source maps, disassembler, etc). 

## Test Plan 

Tested in the PRs above this.

