### PR TITLE
[move-compiler] Coin field linter fix

### DIFF
--- a/crates/sui-move-build/src/linters/coin_field.rs
+++ b/crates/sui-move-build/src/linters/coin_field.rs
@@ -73,7 +73,7 @@ fn is_field_coin_type(sp!(_, t): &N::Type) -> bool {
         T::Apply(_, tname, _) => {
             let sp!(_, tname) = tname;
             if let N::TypeName_::ModuleType(mident, sname) = tname {
-                return is_mident_sui_coin(mident) || sname.value() == COIN_STRUCT_NAME.into();
+                return is_mident_sui_coin(mident) && sname.value() == COIN_STRUCT_NAME.into();
             }
             false
         }

--- a/crates/sui-move-build/src/linters/coin_field.rs
+++ b/crates/sui-move-build/src/linters/coin_field.rs
@@ -4,16 +4,13 @@
 //! This analysis flags uses of the sui::coin::Coin struct in fields of other structs. In most cases
 //! it's preferable to use sui::balance::Balance instead to save space.
 
-use move_command_line_common::{address::NumericalAddress, parser::NumberFormat};
 use move_compiler::{
     diag,
     diagnostics::codes::{custom, DiagnosticInfo, Severity},
-    expansion::ast as E,
     naming::ast as N,
-    shared::{program_info::TypingProgramInfo, CompilationEnv, Identifier},
+    shared::{program_info::TypingProgramInfo, CompilationEnv},
     typing::{ast as T, visitor::TypingVisitor},
 };
-use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
 
@@ -72,23 +69,8 @@ fn is_field_coin_type(sp!(_, t): &N::Type) -> bool {
         T::Ref(_, inner_t) => is_field_coin_type(inner_t),
         T::Apply(_, tname, _) => {
             let sp!(_, tname) = tname;
-            if let N::TypeName_::ModuleType(mident, sname) = tname {
-                return is_mident_sui_coin(mident) && sname.value() == COIN_STRUCT_NAME.into();
-            }
-            false
+            tname.is(SUI_PKG_NAME, COIN_MOD_NAME, COIN_STRUCT_NAME)
         }
         T::Unit | T::Param(_) | T::Var(_) | T::Anything | T::UnresolvedError => false,
-    }
-}
-
-fn is_mident_sui_coin(sp!(_, mident): &E::ModuleIdent) -> bool {
-    use E::Address as A;
-    if mident.module.value() != COIN_MOD_NAME.into() {
-        return false;
-    }
-    let sui_addr = NumericalAddress::new(AccountAddress::TWO.into_bytes(), NumberFormat::Hex);
-    match mident.address {
-        A::Numerical { value: addr, .. } => addr.value == sui_addr,
-        A::NamedUnassigned(n) => n.value == SUI_PKG_NAME.into(),
     }
 }

--- a/crates/sui-move-build/tests/linter/coin_field.exp
+++ b/crates/sui-move-build/tests/linter/coin_field.exp
@@ -1,38 +1,22 @@
 warning[Lint W03001]: sub-optimal 'sui::coin::Coin' field type
-   ┌─ tests/linter/coin_field.move:10:12
+   ┌─ tests/linter/coin_field.move:11:12
    │
-10 │     struct S2 has key, store {
+11 │     struct S2 has key, store {
    │            ^^ The field 'c' of 'S2' has type 'sui::coin::Coin'
-11 │         id: UID,
-12 │         c: Coin<S1>,
+12 │         id: UID,
+13 │         c: Coin<S1>,
    │         - Storing 'sui::balance::Balance' in this field will typically be more space-efficient
    │
    = This warning can be suppressed with '#[lint_allow(coin_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09009]: unused struct field
-   ┌─ tests/linter/coin_field.move:12:9
-   │
-12 │         c: Coin<S1>,
-   │         ^ The 'c' field of the 'S2' type is unused
-   │
-   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W03001]: sub-optimal 'sui::coin::Coin' field type
-   ┌─ tests/linter/coin_field.move:23:12
+   ┌─ tests/linter/coin_field.move:25:12
    │
-23 │     struct S2 has key, store {
+25 │     struct S2 has key, store {
    │            ^^ The field 'c' of 'S2' has type 'sui::coin::Coin'
-24 │         id: UID,
-25 │         c: Balance<S1>,
+26 │         id: UID,
+27 │         c: Balance<S1>,
    │         - Storing 'sui::balance::Balance' in this field will typically be more space-efficient
    │
    = This warning can be suppressed with '#[lint_allow(coin_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W09009]: unused struct field
-   ┌─ tests/linter/coin_field.move:25:9
-   │
-25 │         c: Balance<S1>,
-   │         ^ The 'c' field of the 'S2' type is unused
-   │
-   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/crates/sui-move-build/tests/linter/coin_field.move
+++ b/crates/sui-move-build/tests/linter/coin_field.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(unused_field)]
 module 0x42::test1 {
     use sui::coin::Coin;
     use sui::object::UID;
@@ -13,6 +14,7 @@ module 0x42::test1 {
     }
 }
 
+#[allow(unused_field)]
 module 0x42::test2 {
     use sui::coin::Coin as Balance;
     use sui::object::UID;
@@ -23,5 +25,20 @@ module 0x42::test2 {
     struct S2 has key, store {
         id: UID,
         c: Balance<S1>,
+    }
+}
+
+#[allow(unused_field)]
+module 0x42::test3 {
+    use sui::coin::TreasuryCap;
+    use sui::object::UID;
+
+    struct S1 {}
+
+    // guards against an already fixed silly bug that incorrectly identified Coin by module name
+    // rather than by module name AND struct name
+    struct S2 has key, store {
+        id: UID,
+        cap: TreasuryCap<S1>,
     }
 }


### PR DESCRIPTION
## Description 

This fixes a coin-field linter bug - Coin was identified by module name only rather than by module name AND struct name...

## Test Plan 

Added a test checking that the spurious linter warning message is not generated.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Coin-field linter will no longer generate a spurious warning message when a field of a given object is from the `coin` module but is not a `Coin` itself.