### PR TITLE
[data ingestion] mvp for checkpoint consumer daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,6 +4429,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -5329,6 +5350,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,6 +5721,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -7652,6 +7713,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.3.3",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.5",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -11470,6 +11550,34 @@ dependencies = [
  "sui-types",
  "test-cluster",
  "tokio",
+ "workspace-hack",
+]
+
+[[package]]
+name = "sui-data-ingestion"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-s3",
+ "backoff",
+ "bcs",
+ "futures",
+ "mysten-metrics",
+ "notify",
+ "prometheus",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "sui-storage",
+ "sui-types",
+ "telemetry-subscribers",
+ "tempfile",
+ "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
@@ -15371,6 +15479,7 @@ dependencies = [
  "ff 0.12.1",
  "ff 0.13.0",
  "ff_derive",
+ "filetime",
  "findshlibs",
  "fixed-hash 0.7.0",
  "fixed-hash 0.8.0",
@@ -15383,6 +15492,7 @@ dependencies = [
  "form_urlencoded",
  "fragile",
  "fs_extra",
+ "fsevent-sys",
  "funty 1.1.0",
  "funty 2.0.0",
  "futures",
@@ -15466,6 +15576,8 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.0.2",
  "indicatif",
+ "inotify",
+ "inotify-sys",
  "inout",
  "inquire",
  "insta",
@@ -15611,6 +15723,7 @@ dependencies = [
  "nom",
  "nonzero_ext",
  "normalize-line-endings",
+ "notify",
  "ntapi 0.4.0",
  "ntest",
  "ntest_test_cases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
     "crates/sui-config",
     "crates/sui-core",
     "crates/sui-cost",
+    "crates/sui-data-ingestion",
     "crates/sui-e2e-tests",
     "crates/sui-enum-compat-util",
     "crates/sui-faucet",
@@ -361,6 +362,7 @@ msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "1a5
 multiaddr = "0.17.0"
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5" }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5" }
+notify = "6.1.1"
 ntest = "0.9.0"
 num-bigint = "0.4.3"
 num_cpus = "1.15.0"
@@ -563,6 +565,7 @@ sui-cluster-test = { path = "crates/sui-cluster-test" }
 sui-config = { path = "crates/sui-config" }
 sui-core = { path = "crates/sui-core" }
 sui-cost = { path = "crates/sui-cost" }
+sui-data-ingestion = { path = "crates/sui-data-ingestion" }
 sui-e2e-tests = { path = "crates/sui-e2e-tests" }
 sui-enum-compat-util = { path = "crates/sui-enum-compat-util" }
 sui-faucet = { path = "crates/sui-faucet" }

--- a/crates/sui-data-ingestion/Cargo.toml
+++ b/crates/sui-data-ingestion/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "sui-data-ingestion"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+anyhow.workplace = true
+async-trait.workspace = true
+aws-config.workspace = true
+aws-sdk-dynamodb.workspace = true
+aws-sdk-s3.workspace = true
+backoff.workspace = true
+bcs.workspace = true
+futures.workspace = true
+mysten-metrics.workspace = true
+notify.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+prometheus.workspace = true
+telemetry-subscribers.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+sui-storage.workspace = true
+sui-types.workspace = true
+workspace-hack.workspace = true
+
+[dev-dependencies]
+rand.workspace = true
+tempfile.workspace = true
+sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-data-ingestion/src/executor.rs
+++ b/crates/sui-data-ingestion/src/executor.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper};
+use crate::reader::LocalReader;
+use crate::worker_pool::WorkerPool;
+use crate::workers::Worker;
+use crate::DataIngestionMetrics;
+use anyhow::Result;
+use futures::Future;
+use mysten_metrics::spawn_monitored_task;
+use std::path::PathBuf;
+use std::pin::Pin;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::oneshot;
+use tokio::sync::{broadcast, mpsc};
+
+pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 1000;
+
+pub struct IndexerExecutor<P> {
+    pools: Vec<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    progress_store: ProgressStoreWrapper<P>,
+    /// used to broadcast new checkpoint to worker pools
+    pool_sender: broadcast::Sender<CheckpointData>,
+    pool_progress_sender: mpsc::Sender<(String, CheckpointSequenceNumber)>,
+    pool_progress_receiver: mpsc::Receiver<(String, CheckpointSequenceNumber)>,
+    metrics: DataIngestionMetrics,
+}
+
+impl<P: ProgressStore> IndexerExecutor<P> {
+    pub fn new(progress_store: P, metrics: DataIngestionMetrics) -> Self {
+        let (pool_progress_sender, pool_progress_receiver) =
+            mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        Self {
+            pools: vec![],
+            progress_store: ProgressStoreWrapper::new(progress_store),
+            pool_progress_sender,
+            pool_progress_receiver,
+            pool_sender: broadcast::channel(MAX_CHECKPOINTS_IN_PROGRESS).0,
+            metrics,
+        }
+    }
+
+    /// Registers new worker pool in executor
+    pub async fn register<W: Worker + 'static>(&mut self, pool: WorkerPool<W>) -> Result<()> {
+        let checkpoint_number = self.progress_store.load(pool.task_name.clone()).await?;
+        self.pools.push(Box::pin(pool.run(
+            checkpoint_number,
+            self.pool_sender.subscribe(),
+            self.pool_progress_sender.clone(),
+        )));
+        Ok(())
+    }
+
+    /// Main executor loop
+    pub async fn run(
+        mut self,
+        path: PathBuf,
+        mut exit_receiver: oneshot::Receiver<()>,
+    ) -> Result<ExecutorProgress> {
+        let (checkpoint_reader, mut checkpoint_recv, gc_sender, _exit_sender) =
+            LocalReader::initialize(path);
+        let mut reader_checkpoint_number = self.progress_store.min_watermark()?;
+        spawn_monitored_task!(checkpoint_reader.run(reader_checkpoint_number));
+
+        for pool in std::mem::take(&mut self.pools) {
+            spawn_monitored_task!(pool);
+        }
+        loop {
+            tokio::select! {
+                Some(checkpoint) = checkpoint_recv.recv() => {
+                    self.pool_sender.send(checkpoint)?;
+                }
+                Some((task_name, sequence_number)) = self.pool_progress_receiver.recv() => {
+                    self.progress_store.save(task_name.clone(), sequence_number).await?;
+                    let seq_number = self.progress_store.min_watermark()?;
+                    if seq_number > reader_checkpoint_number {
+                        gc_sender.send(seq_number).await?;
+                        reader_checkpoint_number = seq_number;
+                    }
+                    self.metrics.last_uploaded_checkpoint.with_label_values(&[&task_name]).set(sequence_number as i64);
+                }
+                _ = &mut exit_receiver => break,
+            }
+        }
+        Ok(self.progress_store.stats())
+    }
+}

--- a/crates/sui-data-ingestion/src/lib.rs
+++ b/crates/sui-data-ingestion/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod executor;
+mod metrics;
+mod progress_store;
+mod reader;
+#[cfg(test)]
+mod tests;
+mod worker_pool;
+mod workers;
+
+pub use executor::IndexerExecutor;
+pub use metrics::DataIngestionMetrics;
+pub use progress_store::{DynamoDBProgressStore, FileProgressStore};
+pub use worker_pool::WorkerPool;
+pub use workers::{S3TaskConfig, S3Worker, Worker};

--- a/crates/sui-data-ingestion/src/main.rs
+++ b/crates/sui-data-ingestion/src/main.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use prometheus::Registry;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::PathBuf;
+use sui_data_ingestion::{DataIngestionMetrics, DynamoDBProgressStore, S3TaskConfig, S3Worker};
+use sui_data_ingestion::{IndexerExecutor, WorkerPool};
+use tokio::signal;
+use tokio::sync::oneshot;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+enum Task {
+    S3(S3TaskConfig),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct TaskConfig {
+    #[serde(flatten)]
+    task: Task,
+    concurrency: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+struct ProgressStoreConfig {
+    pub aws_access_key_id: String,
+    pub aws_secret_access_key: String,
+    pub aws_region: String,
+    pub table_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IndexerConfig {
+    path: PathBuf,
+    tasks: Vec<TaskConfig>,
+    progress_store: ProgressStoreConfig,
+    #[serde(default = "default_metrics_host")]
+    metrics_host: String,
+    #[serde(default = "default_metrics_port")]
+    metrics_port: u16,
+}
+
+fn default_metrics_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_metrics_port() -> u16 {
+    8081
+}
+
+fn setup_env(exit_sender: oneshot::Sender<()>) {
+    let default_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |panic| {
+        default_hook(panic);
+        std::process::exit(12);
+    }));
+
+    tokio::spawn(async {
+        signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+        exit_sender
+            .send(())
+            .expect("Failed to gracefully process shutdown");
+    });
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (exit_sender, exit_receiver) = oneshot::channel();
+    setup_env(exit_sender);
+
+    let args: Vec<String> = env::args().collect();
+    assert_eq!(args.len(), 2, "configuration yaml file is required");
+    let config: IndexerConfig = serde_yaml::from_str(&std::fs::read_to_string(&args[1])?)?;
+
+    // setup metrics
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
+    let registry_service = mysten_metrics::start_prometheus_server(
+        format!("{}:{}", config.metrics_host, config.metrics_port).parse()?,
+    );
+    let registry: Registry = registry_service.default_registry();
+    mysten_metrics::init_metrics(&registry);
+    let metrics = DataIngestionMetrics::new(&registry);
+
+    let progress_store = DynamoDBProgressStore::new(
+        &config.progress_store.aws_access_key_id,
+        &config.progress_store.aws_secret_access_key,
+        config.progress_store.aws_region,
+        config.progress_store.table_name,
+    )
+    .await;
+    let mut executor = IndexerExecutor::new(progress_store, metrics);
+    for task_config in config.tasks {
+        let worker = match task_config.task {
+            Task::S3(s3_config) => S3Worker::new(s3_config).await,
+        };
+        let worker_pool = WorkerPool::new(worker, task_config.concurrency);
+        executor.register(worker_pool).await?;
+    }
+    executor.run(config.path, exit_receiver).await?;
+    Ok(())
+}

--- a/crates/sui-data-ingestion/src/metrics.rs
+++ b/crates/sui-data-ingestion/src/metrics.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
+
+#[derive(Clone)]
+pub struct DataIngestionMetrics {
+    pub last_uploaded_checkpoint: IntGaugeVec,
+}
+
+impl DataIngestionMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            last_uploaded_checkpoint: register_int_gauge_vec_with_registry!(
+                "last_uploaded_checkpoint",
+                "Number of uploaded checkpoints.",
+                &["task"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}

--- a/crates/sui-data-ingestion/src/progress_store/dynamodb.rs
+++ b/crates/sui-data-ingestion/src/progress_store/dynamodb.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::progress_store::ProgressStore;
+use anyhow::Result;
+use async_trait::async_trait;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::Client;
+use aws_sdk_s3::config::{Credentials, Region};
+use std::str::FromStr;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+pub struct DynamoDBProgressStore {
+    client: Client,
+    table_name: String,
+}
+
+impl DynamoDBProgressStore {
+    pub async fn new(
+        aws_access_key_id: &str,
+        aws_secret_access_key: &str,
+        aws_region: String,
+        table_name: String,
+    ) -> Self {
+        let credentials = Credentials::new(
+            aws_access_key_id,
+            aws_secret_access_key,
+            None,
+            None,
+            "dynamodb",
+        );
+        let aws_config = aws_config::from_env()
+            .credentials_provider(credentials)
+            .region(Region::new(aws_region))
+            .load()
+            .await;
+        let client = Client::new(&aws_config);
+        Self { client, table_name }
+    }
+}
+
+#[async_trait]
+impl ProgressStore for DynamoDBProgressStore {
+    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber> {
+        let item = self
+            .client
+            .get_item()
+            .table_name(self.table_name.clone())
+            .key("task_name", AttributeValue::S(task_name))
+            .send()
+            .await?;
+        if let Some(output) = item.item() {
+            if let AttributeValue::S(checkpoint_number) = &output["state"] {
+                return Ok(CheckpointSequenceNumber::from_str(checkpoint_number)?);
+            }
+        }
+        Ok(0)
+    }
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        self.client
+            .put_item()
+            .table_name(self.table_name.clone())
+            .item("task_name", AttributeValue::S(task_name))
+            .item("state", AttributeValue::S(checkpoint_number.to_string()))
+            .send()
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/sui-data-ingestion/src/progress_store/file.rs
+++ b/crates/sui-data-ingestion/src/progress_store/file.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::progress_store::ProgressStore;
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Number, Value};
+use std::path::PathBuf;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+pub struct FileProgressStore {
+    path: PathBuf,
+}
+
+impl FileProgressStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[async_trait]
+impl ProgressStore for FileProgressStore {
+    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber> {
+        let content: Value = serde_json::from_slice(&std::fs::read(self.path.clone())?)?;
+        Ok(content
+            .get(&task_name)
+            .and_then(|v| v.as_u64())
+            .unwrap_or_default())
+    }
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        let mut content: Value = serde_json::from_slice(&std::fs::read(self.path.clone())?)?;
+        content[task_name] = Value::Number(Number::from(checkpoint_number));
+        std::fs::write(self.path.clone(), serde_json::to_string_pretty(&content)?)?;
+        Ok(())
+    }
+}

--- a/crates/sui-data-ingestion/src/progress_store/mod.rs
+++ b/crates/sui-data-ingestion/src/progress_store/mod.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+mod dynamodb;
+mod file;
+pub use dynamodb::DynamoDBProgressStore;
+pub use file::FileProgressStore;
+
+pub type ExecutorProgress = HashMap<String, CheckpointSequenceNumber>;
+
+#[async_trait]
+pub trait ProgressStore: Send {
+    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber>;
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> Result<()>;
+}
+
+pub struct ProgressStoreWrapper<P> {
+    progress_store: P,
+    pending_state: ExecutorProgress,
+}
+
+#[async_trait]
+impl<P: ProgressStore> ProgressStore for ProgressStoreWrapper<P> {
+    async fn load(&mut self, task_name: String) -> Result<CheckpointSequenceNumber> {
+        let watermark = self.progress_store.load(task_name.clone()).await?;
+        self.pending_state.insert(task_name, watermark);
+        Ok(watermark)
+    }
+
+    async fn save(
+        &mut self,
+        task_name: String,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        self.progress_store
+            .save(task_name.clone(), checkpoint_number)
+            .await?;
+        self.pending_state.insert(task_name, checkpoint_number);
+        Ok(())
+    }
+}
+
+impl<P: ProgressStore> ProgressStoreWrapper<P> {
+    pub fn new(progress_store: P) -> Self {
+        Self {
+            progress_store,
+            pending_state: HashMap::new(),
+        }
+    }
+
+    pub fn min_watermark(&self) -> Result<CheckpointSequenceNumber> {
+        self.pending_state
+            .values()
+            .min()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("pools can't be empty"))
+    }
+
+    pub fn stats(&self) -> ExecutorProgress {
+        self.pending_state.clone()
+    }
+}

--- a/crates/sui-data-ingestion/src/reader.rs
+++ b/crates/sui-data-ingestion/src/reader.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::executor::MAX_CHECKPOINTS_IN_PROGRESS;
+use anyhow::Result;
+use notify::RecursiveMode;
+use notify::Watcher;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+use sui_storage::blob::Blob;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+/// Implements a checkpoint reader that monitors a local directory.
+/// Designed for setups where the indexer daemon is colocated with FN.
+/// This implementation is push-based and utilizes the inotify API.
+pub struct LocalReader {
+    path: PathBuf,
+    checkpoint_sender: mpsc::Sender<CheckpointData>,
+    processed_receiver: mpsc::Receiver<CheckpointSequenceNumber>,
+    exit_receiver: oneshot::Receiver<()>,
+}
+
+impl LocalReader {
+    /// Represents a single iteration of the reader.
+    /// Reads files in a local directory, validates them, and forwards `CheckpointData` to the executor.
+    async fn read_files(
+        &self,
+        current_checkpoint_number: CheckpointSequenceNumber,
+    ) -> Result<CheckpointSequenceNumber> {
+        let mut files = vec![];
+        for entry in fs::read_dir(self.path.clone())? {
+            let entry = entry?;
+            let filename = entry.file_name();
+            if let Some(sequence_number) = Self::checkpoint_number_from_file_path(&filename) {
+                if sequence_number >= current_checkpoint_number {
+                    files.push((sequence_number, entry.path()));
+                }
+            }
+        }
+        files.sort();
+        for (idx, (sequence_number, filename)) in files.iter().enumerate() {
+            assert_eq!(
+                *sequence_number,
+                current_checkpoint_number + idx as u64,
+                "checkpoint sequence should not have any gaps"
+            );
+            let checkpoint = Blob::from_bytes::<CheckpointData>(&fs::read(filename)?)?;
+            self.checkpoint_sender.send(checkpoint).await?;
+        }
+        Ok(current_checkpoint_number + files.len() as u64)
+    }
+
+    /// Cleans the local directory by removing all processed checkpoint files.
+    fn gc_processed_files(&self, watermark: CheckpointSequenceNumber) -> Result<()> {
+        for entry in fs::read_dir(self.path.clone())? {
+            let entry = entry?;
+            let filename = entry.file_name();
+            if let Some(sequence_number) = Self::checkpoint_number_from_file_path(&filename) {
+                if sequence_number < watermark {
+                    fs::remove_file(entry.path())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn checkpoint_number_from_file_path(file_name: &OsString) -> Option<CheckpointSequenceNumber> {
+        file_name
+            .to_str()
+            .and_then(|s| s.rfind('.').map(|pos| &s[..pos]))
+            .and_then(|s| s.parse().ok())
+    }
+
+    pub fn initialize(
+        path: PathBuf,
+    ) -> (
+        Self,
+        mpsc::Receiver<CheckpointData>,
+        mpsc::Sender<CheckpointSequenceNumber>,
+        oneshot::Sender<()>,
+    ) {
+        let (checkpoint_sender, checkpoint_recv) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        let (processed_sender, processed_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        let (exit_sender, exit_receiver) = oneshot::channel();
+        let reader = Self {
+            path,
+            checkpoint_sender,
+            processed_receiver,
+            exit_receiver,
+        };
+        (reader, checkpoint_recv, processed_sender, exit_sender)
+    }
+
+    pub async fn run(mut self, mut checkpoint_number: CheckpointSequenceNumber) {
+        let (inotify_sender, mut inotify_recv) = mpsc::channel(1);
+        std::fs::create_dir_all(self.path.clone()).expect("failed to create a directory");
+        let mut watcher = notify::recommended_watcher(move |res| {
+            if let Err(err) = res {
+                eprintln!("watch error: {:?}", err);
+            }
+            inotify_sender
+                .blocking_send(())
+                .expect("Failed to send inotify update");
+        })
+        .expect("Failed to init inotify");
+
+        watcher
+            .watch(&self.path, RecursiveMode::NonRecursive)
+            .expect("Inotify watcher failed");
+
+        checkpoint_number = self
+            .read_files(checkpoint_number)
+            .await
+            .expect("Failed to read checkpoint files");
+
+        loop {
+            tokio::select! {
+                Some(_) = inotify_recv.recv() => {
+                    checkpoint_number = self.read_files(checkpoint_number)
+                        .await
+                        .expect("Failed to read checkpoint files");
+                }
+                Some(gc_checkpoint_number) = self.processed_receiver.recv() => {
+                    self.gc_processed_files(gc_checkpoint_number).expect("Failed to clean the directory");
+                }
+                _ = &mut self.exit_receiver => break,
+            }
+        }
+    }
+}

--- a/crates/sui-data-ingestion/src/tests.rs
+++ b/crates/sui-data-ingestion/src/tests.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::progress_store::ExecutorProgress;
+use crate::workers::Worker;
+use crate::{DataIngestionMetrics, FileProgressStore, IndexerExecutor, WorkerPool};
+use anyhow::Result;
+use async_trait::async_trait;
+use prometheus::Registry;
+use rand::prelude::StdRng;
+use rand::SeedableRng;
+use std::path::PathBuf;
+use std::time::Duration;
+use sui_storage::blob::{Blob, BlobEncoding};
+use sui_types::crypto::KeypairTraits;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::gas::GasCostSummary;
+use sui_types::messages_checkpoint::{
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+    SignedCheckpointSummary,
+};
+use sui_types::utils::make_committee_key;
+use tempfile::NamedTempFile;
+use tokio::sync::oneshot;
+
+async fn add_worker_pool<W: Worker + 'static>(
+    indexer: &mut IndexerExecutor<FileProgressStore>,
+    worker: W,
+    concurrency: usize,
+) -> Result<()> {
+    let worker_pool = WorkerPool::new(worker, concurrency);
+    indexer.register(worker_pool).await?;
+    Ok(())
+}
+
+async fn run(
+    indexer: IndexerExecutor<FileProgressStore>,
+    path: Option<PathBuf>,
+    duration: Option<Duration>,
+) -> Result<ExecutorProgress> {
+    let (sender, recv) = oneshot::channel();
+    match duration {
+        None => indexer.run(path.unwrap_or_else(temp_dir), recv).await,
+        Some(duration) => {
+            let handle = tokio::task::spawn(async move {
+                indexer.run(path.unwrap_or_else(temp_dir), recv).await
+            });
+            tokio::time::sleep(duration).await;
+            drop(sender);
+            handle.await?
+        }
+    }
+}
+
+struct ExecutorBundle {
+    executor: IndexerExecutor<FileProgressStore>,
+    _progress_file: NamedTempFile,
+}
+
+#[derive(Clone)]
+struct TestWorker;
+
+#[async_trait]
+impl Worker for TestWorker {
+    async fn process_checkpoint(&self, _checkpoint: CheckpointData) -> Result<()> {
+        Ok(())
+    }
+    fn name(&self) -> &'static str {
+        "test"
+    }
+}
+
+#[tokio::test]
+async fn empty_pools() {
+    let bundle = create_executor_bundle();
+    let result = run(bundle.executor, None, None).await;
+    assert!(result.is_err());
+    if let Err(err) = result {
+        assert!(err.to_string().contains("pools can't be empty"));
+    }
+}
+
+#[tokio::test]
+async fn basic_flow() {
+    let mut bundle = create_executor_bundle();
+    add_worker_pool(&mut bundle.executor, TestWorker, 5)
+        .await
+        .unwrap();
+    let path = temp_dir();
+    for checkpoint_number in 0..20 {
+        let bytes = mock_checkpoint_data_bytes(checkpoint_number);
+        std::fs::write(path.join(format!("{}.chk", checkpoint_number)), bytes).unwrap();
+    }
+    let result = run(bundle.executor, Some(path), Some(Duration::from_secs(1))).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().get(TestWorker.name()), Some(&20));
+}
+
+fn temp_dir() -> std::path::PathBuf {
+    tempfile::tempdir()
+        .expect("Failed to open temporary directory")
+        .into_path()
+}
+
+fn create_executor_bundle() -> ExecutorBundle {
+    let progress_file = NamedTempFile::new().unwrap();
+    let path = progress_file.path().to_path_buf();
+    std::fs::write(path.clone(), "{}").unwrap();
+    let progress_store = FileProgressStore::new(path);
+    let executor =
+        IndexerExecutor::new(progress_store, DataIngestionMetrics::new(&Registry::new()));
+    ExecutorBundle {
+        executor,
+        _progress_file: progress_file,
+    }
+}
+
+const RNG_SEED: [u8; 32] = [
+    21, 23, 199, 200, 234, 250, 252, 178, 94, 15, 202, 178, 62, 186, 88, 137, 233, 192, 130, 157,
+    179, 179, 65, 9, 31, 249, 221, 123, 225, 112, 199, 247,
+];
+
+fn mock_checkpoint_data_bytes(seq_number: CheckpointSequenceNumber) -> Vec<u8> {
+    let mut rng = StdRng::from_seed(RNG_SEED);
+    let (keys, committee) = make_committee_key(&mut rng);
+    let contents = CheckpointContents::new_with_digests_only_for_tests(vec![]);
+    let summary = CheckpointSummary::new(
+        0,
+        seq_number,
+        0,
+        &contents,
+        None,
+        GasCostSummary::default(),
+        None,
+        0,
+    );
+
+    let sign_infos: Vec<_> = keys
+        .iter()
+        .map(|k| {
+            let name = k.public().into();
+            SignedCheckpointSummary::sign(committee.epoch, &summary, k, name)
+        })
+        .collect();
+
+    let checkpoint_data = CheckpointData {
+        checkpoint_summary: CertifiedCheckpointSummary::new(summary, sign_infos, &committee)
+            .unwrap(),
+        checkpoint_contents: contents,
+        transactions: vec![],
+    };
+    Blob::encode(&checkpoint_data, BlobEncoding::Bcs)
+        .unwrap()
+        .to_bytes()
+}

--- a/crates/sui-data-ingestion/src/worker_pool.rs
+++ b/crates/sui-data-ingestion/src/worker_pool.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::executor::MAX_CHECKPOINTS_IN_PROGRESS;
+use crate::workers::Worker;
+use mysten_metrics::spawn_monitored_task;
+use std::collections::HashSet;
+use std::sync::Arc;
+use sui_types::full_checkpoint_content::CheckpointData;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::oneshot;
+use tokio::sync::{broadcast, mpsc};
+use tracing::info;
+
+pub struct WorkerPool<W: Worker> {
+    pub task_name: String,
+    concurrency: usize,
+    worker: Arc<W>,
+}
+
+impl<W: Worker + 'static> WorkerPool<W> {
+    pub fn new(worker: W, concurrency: usize) -> Self {
+        Self {
+            task_name: worker.name().to_string(),
+            concurrency,
+            worker: Arc::new(worker),
+        }
+    }
+    pub async fn run(
+        self,
+        mut current_checkpoint_number: CheckpointSequenceNumber,
+        mut checkpoint_receiver: broadcast::Receiver<CheckpointData>,
+        executor_progress_sender: mpsc::Sender<(String, CheckpointSequenceNumber)>,
+    ) {
+        info!(
+            "Starting indexing pipeline {} with concurrency {}",
+            self.task_name, self.concurrency
+        );
+        let mut updates: HashSet<u64> = HashSet::new();
+
+        let (progress_sender, mut progress_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        let mut workers = vec![];
+
+        // spawn child workers
+        for _ in 0..self.concurrency {
+            let (worker_sender, mut worker_recv) =
+                mpsc::channel::<CheckpointData>(MAX_CHECKPOINTS_IN_PROGRESS);
+            let (term_sender, mut term_receiver) = oneshot::channel::<()>();
+            let cloned_progress_sender = progress_sender.clone();
+            workers.push((worker_sender, term_sender));
+
+            let worker = self.worker.clone();
+            spawn_monitored_task!(async move {
+                loop {
+                    tokio::select! {
+                        _ = &mut term_receiver => break,
+                        Some(checkpoint) = worker_recv.recv() => {
+                            let backoff = backoff::ExponentialBackoff::default();
+                            backoff::future::retry(backoff, || async {
+                                worker
+                                    .clone()
+                                    .process_checkpoint(checkpoint.clone())
+                                    .await
+                                    .map_err(backoff::Error::transient)
+                            })
+                            .await
+                            .expect("checkpoint processing failed for checkpoint");
+                            cloned_progress_sender
+                                .send(checkpoint.checkpoint_summary.sequence_number)
+                                .await
+                                .expect("failed to update progress");
+                        }
+                    }
+                }
+            });
+        }
+        // main worker pool loop
+        loop {
+            tokio::select! {
+                checkpoint_result = checkpoint_receiver.recv() => {
+                    match checkpoint_result {
+                        Ok(checkpoint) => {
+                            let sequence_number = checkpoint.checkpoint_summary.sequence_number;
+                            if sequence_number < current_checkpoint_number {
+                                continue;
+                            }
+                            let worker_id = (sequence_number % self.concurrency as u64) as usize;
+                            workers[worker_id].0.send(checkpoint).await.expect("failed to dispatch a task");
+                        }
+                        Err(_) => break,
+                    }
+                }
+                Some(status_update) = progress_receiver.recv() => {
+                    updates.insert(status_update);
+                    if status_update == current_checkpoint_number {
+                        while updates.remove(&current_checkpoint_number) {
+                            current_checkpoint_number += 1;
+                        }
+                        executor_progress_sender
+                            .send((self.task_name.clone(), current_checkpoint_number))
+                            .await
+                            .expect("Failed to send progress update to the executor");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-data-ingestion/src/workers/mod.rs
+++ b/crates/sui-data-ingestion/src/workers/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use async_trait::async_trait;
+use sui_types::full_checkpoint_content::CheckpointData;
+mod s3;
+pub use s3::{S3TaskConfig, S3Worker};
+
+#[async_trait]
+pub trait Worker: Send + Sync + Clone {
+    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()>;
+    fn name(&self) -> &'static str;
+}

--- a/crates/sui-data-ingestion/src/workers/s3.rs
+++ b/crates/sui-data-ingestion/src/workers/s3.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Worker;
+use anyhow::Result;
+use async_trait::async_trait;
+use aws_sdk_s3 as s3;
+use aws_sdk_s3::config::{Credentials, Region};
+use serde::{Deserialize, Serialize};
+use sui_storage::blob::{Blob, BlobEncoding};
+use sui_types::full_checkpoint_content::CheckpointData;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct S3TaskConfig {
+    pub aws_access_key_id: String,
+    pub aws_secret_access_key: String,
+    pub aws_region: String,
+    pub bucket_name: String,
+}
+
+#[derive(Clone)]
+pub struct S3Worker {
+    client: s3::Client,
+    bucket_name: String,
+}
+
+impl S3Worker {
+    pub async fn new(config: S3TaskConfig) -> Self {
+        let credentials = Credentials::new(
+            &config.aws_access_key_id,
+            &config.aws_secret_access_key,
+            None,
+            None,
+            "s3",
+        );
+        let aws_config = aws_config::from_env()
+            .credentials_provider(credentials)
+            .region(Region::new(config.aws_region))
+            .load()
+            .await;
+        let client = s3::Client::new(&aws_config);
+        Self {
+            client,
+            bucket_name: config.bucket_name,
+        }
+    }
+}
+
+#[async_trait]
+impl Worker for S3Worker {
+    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
+        let bytes = Blob::encode(&checkpoint, BlobEncoding::Bcs)?.to_bytes();
+        self.client
+            .put_object()
+            .bucket(self.bucket_name.clone())
+            .key(format!(
+                "{}.chk",
+                checkpoint.checkpoint_summary.sequence_number
+            ))
+            .body(bytes.into())
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "s3"
+    }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -299,6 +299,7 @@ fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
 ff-594e8ee84c453af0 = { package = "ff", version = "0.13", features = ["derive"] }
 ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
+filetime = { version = "0.2", default-features = false }
 fixed-hash-c38e5c1d305a1b54 = { package = "fixed-hash", version = "0.8", default-features = false, features = ["std"] }
 fixed-hash-ca01ad9e24f5d932 = { package = "fixed-hash", version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
@@ -507,6 +508,7 @@ no-std-compat = { version = "0.4", default-features = false, features = ["alloc"
 nom = { version = "7" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
+notify = { version = "6" }
 ntest = { version = "0.9", default-features = false }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.4" }
@@ -1164,6 +1166,7 @@ fdlimit = { version = "0.2", default-features = false }
 ff-594e8ee84c453af0 = { package = "ff", version = "0.13", features = ["derive"] }
 ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
 ff_derive = { version = "0.13", default-features = false }
+filetime = { version = "0.2", default-features = false }
 fixed-hash-c38e5c1d305a1b54 = { package = "fixed-hash", version = "0.8", default-features = false, features = ["std"] }
 fixed-hash-ca01ad9e24f5d932 = { package = "fixed-hash", version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
@@ -1390,6 +1393,7 @@ no-std-compat = { version = "0.4", default-features = false, features = ["alloc"
 nom = { version = "7" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
+notify = { version = "6" }
 ntest = { version = "0.9", default-features = false }
 ntest_test_cases = { version = "0.9", default-features = false }
 ntest_timeout = { version = "0.9", default-features = false }
@@ -1806,6 +1810,7 @@ errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features 
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 eth-keystore = { version = "0.5", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
+fsevent-sys = { version = "4", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
@@ -1849,6 +1854,7 @@ errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features 
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 eth-keystore = { version = "0.5", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
+fsevent-sys = { version = "4", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
@@ -1889,6 +1895,8 @@ debugid = { version = "0.8", default-features = false }
 eth-keystore = { version = "0.5", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+inotify = { version = "0.9", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
@@ -1931,6 +1939,8 @@ debugid = { version = "0.8", default-features = false }
 eth-keystore = { version = "0.5", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+inotify = { version = "0.9", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }


### PR DESCRIPTION
initial minimal version of data ingestion daemon

### Structure 
The `IndexerExecutor` drives the process, employing the following components:
* reader to consume new `CheckpointData` (currently, only `LocalReader` is available, subscribing to changes in the local directory through the `inotify` API).
* progress store to track the progress of individual pipelines
* vector of `WorkerPool`, with each pool dedicated to a specific type of task.
Example usage can be found in the `basic_flow` test

### Flow
The Executor reads the current set of watermarks from the progress store and initializes worker pools and readers. The reader sends updates to the executor, which, in turn, broadcasts tasks to the pools. Each pool manages its own set of workers, with concurrency defined per pool and adjustable based on specific task requirements.
Upon receiving new checkpoint, the pool determines the worker to utilize and proxies the task accordingly. Tasks are processed in parallel and can finish in a random order. Once a continuous sequence from the previous known watermark is formed, the worker pool reports the progress to the executor, which updates the progress store.
When all worker pools are done with a given checkpoint, the reader is notified to clean the directory.

### Idempotence
Tasks are expected to be idempotent. For certain tasks, one approach to achieving idempotence is to verify at the start of the task whether it has already been processed. Alternatively, for some of the workflows, a concurrency of 1 can be used. In such cases, idempotence is irrelevant

### Misc notes
PR contains basic implementation of DynamoDB-based progress store and a workflow that uploads checkpoint files to a S3 bucket.  
**Next steps**:
* add a S3 based reader for backfills

