### PR TITLE
Migrate wallet standard docs to sui docs site

### DIFF
--- a/docs/content/sidebars/standards.js
+++ b/docs/content/sidebars/standards.js
@@ -21,11 +21,7 @@ const standards = [
 		],
 	},
 	'standards/display',
-	{
-		type: 'link',
-		label: 'Wallet Kit',
-		href: 'https://sui-typescript-docs.vercel.app/wallet-kit',
-	},
+	'standards/wallet-standard',
 	{
 		type: 'category',
 		label: 'Closed Loop Token',

--- a/docs/content/standards.mdx
+++ b/docs/content/standards.mdx
@@ -3,16 +3,14 @@ title: Sui Standards Overview
 sidebar_label: Overview
 ---
 
-import { Cards, Card } from "../site/src/components/Cards"
+import { Card, Cards } from '../site/src/components/Cards';
 
 Standards on the Sui blockchain are features, frameworks, or apps that you can extend or customize.
 
 <Cards>
-<Card title="Deepbook" href="standards/deepbook"/>
-<Card title="Kiosk" href="standards/kiosk"/>
-<Card title="Closed Loop Token" href="standards/closed-loop-token"/>
-<Card title="Wallet Kit" href="https://sui-typescript-docs.vercel.app/wallet-kit/getting-started">
-Wallet adapters are a low-level concept that normalize all wallet interactions into a single API, making it possible for dApps to have consistent interactions with wallets. Wallet Kit comes pre-configured with all supported wallet adapters, so you don't need to manually install or configure them.
-</Card>
-<Card title="Sui Object Display" href="standards/display"/>
+	<Card title="Deepbook" href="standards/deepbook" />
+	<Card title="Kiosk" href="standards/kiosk" />
+	<Card title="Closed Loop Token" href="standards/closed-loop-token" />
+	<Card title="Wallet Standard" href="standards/wallet-standard" />
+	<Card title="Sui Object Display" href="standards/display" />
 </Cards>

--- a/docs/content/standards/wallet-adapter.mdx
+++ b/docs/content/standards/wallet-adapter.mdx
@@ -1,6 +1,0 @@
----
-title: Wallet Adapter
-draft: true
----
-
-Content coming soon

--- a/docs/content/standards/wallet-standard.mdx
+++ b/docs/content/standards/wallet-standard.mdx
@@ -1,5 +1,6 @@
 ---
 title: Wallet Standard
+description: Wallet adapters are a low-level concept that normalize all wallet interactions into a single API, making it possible for dApps to have consistent interactions with wallets. Wallet Kit comes pre-configured with all supported wallet adapters, so you don't need to manually install or configure them.
 ---
 
 Browser extension wallets built for Sui are defined using the [Wallet Standard](https://github.com/wallet-standard/wallet-standard/). This is a cross-chain standard that defines how wallets can automatically be discovered and interacted with from dApps.

--- a/docs/content/standards/wallet-standard.mdx
+++ b/docs/content/standards/wallet-standard.mdx
@@ -1,11 +1,10 @@
-# Wallet Standard
+---
+title: Wallet Standard
+---
 
-Browser extension wallets built for Sui are defined using the
-[Wallet Standard](https://github.com/wallet-standard/wallet-standard/). This is a cross-chain
-standard that defines how wallets can automatically be discovered and interacted with from dApps.
+Browser extension wallets built for Sui are defined using the [Wallet Standard](https://github.com/wallet-standard/wallet-standard/). This is a cross-chain standard that defines how wallets can automatically be discovered and interacted with from dApps.
 
-If you are building a wallet, we publish a helper library `@mysten/wallet-standard` which provides
-types and utilities that make it simple to get started.
+If you are building a wallet, we publish a helper library `@mysten/wallet-standard` which provides types and utilities that make it simple to get started.
 
 ### Creating a wallet interface
 


### PR DESCRIPTION
## Description 

Migrating this doc to the sui docs site and updating the name from "Wallet Kit" (not the standard thing) to "Wallet Standard".

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
