### PR TITLE
wallet-ext: fix release workflow

### DIFF
--- a/apps/wallet/turbo.json
+++ b/apps/wallet/turbo.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["//"],
+	"pipeline": {
+		"build:prod": {
+			"dependsOn": ["^build"],
+			"outputs": ["dist/**"]
+		}
+	}
+}


### PR DESCRIPTION
## Description 

* we are using turbo now to build the wallet and the current command that we run in order to build it and release it is `pnpm wallet build:prod` but this fails because turbo doesn't know about the `build:prod` script
* this should fix the issue

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
