### PR TITLE
[sui-tool] include libpq dynamic linked files in runtime docker layer

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -26,7 +26,10 @@ RUN cargo build --profile ${PROFILE} \
 # Production Image
 FROM debian:bullseye-slim AS runtime
 WORKDIR "$WORKDIR/sui"
-COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+
+# sui-tool needs libpq at runtime
+RUN apt-get update && apt-get install -y libpq5 libpq-dev
+
 COPY --from=builder /sui/target/release/sui-node /usr/local/bin
 COPY --from=builder /sui/target/release/sui /usr/local/bin
 COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -26,6 +26,7 @@ RUN cargo build --profile ${PROFILE} \
 # Production Image
 FROM debian:bullseye-slim AS runtime
 WORKDIR "$WORKDIR/sui"
+COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
 COPY --from=builder /sui/target/release/sui-node /usr/local/bin
 COPY --from=builder /sui/target/release/sui /usr/local/bin
 COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin


### PR DESCRIPTION
## Description 

The latest docker imager for sui-tools crashes when running sui-tool commands.

Example Ouput or see [Grafana Logs](https://metrics.sui.io/goto/UUPheANSg?orgId=1):
```
gorpig@gorpig ~/github/sui/docker/sui-tools
main $ docker run -it sha256:1221d5917607885bc70cc986e04326b3edc129e2da5059a0f58c5ed4bda9ceef sui-tool --version                                                                                                                           [18:12:50]
sui-tool: error while loading shared libraries: libpq.so.5: cannot open shared object file: No such file or directory
```

This issue only materialized in the last 24 hours. It appears that some postgres dependencies were added into sui-tool within that time frame and is likely the cause of the libpq requirement now.

I'm not sure if we should instead build statically linked binaries or not for this. Im not sure of a way to only do that for docker images.

## Test Plan 

To test this change I did a local docker build and ran sui-tool commands to verify it no longer breaks due to missing dynamic linked files in the runtime layer.

Output from local build + run
```
gorpig@gorpig ~/github/sui/docker/sui-tools
cg/sui_tool_docker_libpq* $ ./build.sh                                                                                                                                                                                                     [18:45:04]

Building sui-tools docker image
Dockerfile: 	/home/gorpig/github/sui/docker/sui-tools/Dockerfile
docker context: /home/gorpig/github/sui
build date: 	2023-11-29
git revision: 	be4e95cd4d-dirty

[+] Building 4.1s (24/24) FINISHED                                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 1.35kB                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                0.0s
 => => transferring context: 108B                                                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                                          0.2s
 => [internal] load metadata for docker.io/library/rust:1.73-bullseye                                                                                                                                                                            0.2s
 => [internal] load build context                                                                                                                                                                                                                0.4s
 => => transferring context: 1.14MB                                                                                                                                                                                                              0.4s
 => [runtime 1/9] FROM docker.io/library/debian:bullseye-slim@sha256:5aab272aa24713622bfac9dba239bc7488d9979b0d82d19a9dffccd99292154d                                                                                                            0.0s
 => [builder 1/9] FROM docker.io/library/rust:1.73-bullseye@sha256:fbc99ade5c476a8d602192a1bf8d50ae3361469c160d55a34379905ad4f82ae5                                                                                                              0.0s
 => CACHED [runtime 2/9] WORKDIR /sui                                                                                                                                                                                                            0.0s
 => CACHED [builder 2/9] WORKDIR /sui                                                                                                                                                                                                            0.0s
 => CACHED [builder 3/9] RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev                                                                                                                                                   0.0s
 => CACHED [builder 4/9] COPY Cargo.toml Cargo.lock ./                                                                                                                                                                                           0.0s
 => CACHED [builder 5/9] COPY crates crates                                                                                                                                                                                                      0.0s
 => CACHED [builder 6/9] COPY sui-execution sui-execution                                                                                                                                                                                        0.0s
 => CACHED [builder 7/9] COPY narwhal narwhal                                                                                                                                                                                                    0.0s
 => CACHED [builder 8/9] COPY external-crates external-crates                                                                                                                                                                                    0.0s
 => CACHED [builder 9/9] RUN cargo build --profile release     --bin sui-node     --bin sui     --bin sui-faucet     --bin stress     --bin sui-cluster-test     --bin sui-tool                                                                  0.0s
 => [runtime 3/9] COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu                                                                                                                                                        0.5s
 => [runtime 4/9] COPY --from=builder /sui/target/release/sui-node /usr/local/bin                                                                                                                                                                0.1s
 => [runtime 5/9] COPY --from=builder /sui/target/release/sui /usr/local/bin                                                                                                                                                                     0.1s
 => [runtime 6/9] COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin                                                                                                                                                              0.0s
 => [runtime 7/9] COPY --from=builder /sui/target/release/stress /usr/local/bin                                                                                                                                                                  0.1s
 => [runtime 8/9] COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin                                                                                                                                                        0.2s
 => [runtime 9/9] COPY --from=builder /sui/target/release/sui-tool /usr/local/bin                                                                                                                                                                0.1s
 => exporting to image                                                                                                                                                                                                                           1.3s
 => => exporting layers                                                                                                                                                                                                                          1.3s
 => => writing image sha256:ddf08e04be549c9743451db4933806bec4ca439056b5dd78ba315e4ba1c0cbf1                                                                                                                                                     0.0s

gorpig@gorpig ~/github/sui/docker/sui-tools
cg/sui_tool_docker_libpq* $ docker run -it sha256:ddf08e04be549c9743451db4933806bec4ca439056b5dd78ba315e4ba1c0cbf1 sui-tool --version                                                                                                      [18:45:11]
sui-tool 1.15.0-be4e95cd4d-dirty
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
