### PR TITLE
Return more accurate error for missing input object

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -595,6 +595,47 @@ impl AuthorityStore {
         Ok(ret)
     }
 
+    /// Load a list of objects from the store by object reference.
+    /// If they are exist in the store, they are returned directly.
+    /// If any object missing, we try to figure out the best error to return.
+    /// If the object we are asking is currently locked at a future version, we know this
+    /// transaction is out-of-dated and we return a ObjectVersionUnavailableForConsumption,
+    /// which indicates this is not retriable.
+    /// Otherwise, we return a ObjectNotFound error, which indicates this is retriable.
+    pub fn multi_get_object_with_more_accurate_error_return(
+        &self,
+        object_refs: &[ObjectRef],
+    ) -> Result<Vec<Object>, SuiError> {
+        let objects = self.multi_get_object_by_key(
+            &object_refs.iter().map(ObjectKey::from).collect::<Vec<_>>(),
+        )?;
+        let mut result = Vec::new();
+        for (object_opt, object_ref) in objects.into_iter().zip(object_refs) {
+            match object_opt {
+                None => {
+                    let lock = self.get_latest_lock_for_object_id(object_ref.0)?;
+                    let error = if lock.1 >= object_ref.1 {
+                        UserInputError::ObjectVersionUnavailableForConsumption {
+                            provided_obj_ref: *object_ref,
+                            current_version: lock.1,
+                        }
+                    } else {
+                        UserInputError::ObjectNotFound {
+                            object_id: object_ref.0,
+                            version: Some(object_ref.1),
+                        }
+                    };
+                    return Err(SuiError::UserInputError { error });
+                }
+                Some(object) => {
+                    result.push(object);
+                }
+            }
+        }
+        assert_eq!(result.len(), object_refs.len());
+        Ok(result)
+    }
+
     /// Get many objects
     pub fn get_objects(&self, objects: &[ObjectID]) -> Result<Vec<Option<Object>>, SuiError> {
         let mut result = Vec::new();

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -596,10 +596,10 @@ impl AuthorityStore {
     }
 
     /// Load a list of objects from the store by object reference.
-    /// If they are exist in the store, they are returned directly.
+    /// If they exist in the store, they are returned directly.
     /// If any object missing, we try to figure out the best error to return.
     /// If the object we are asking is currently locked at a future version, we know this
-    /// transaction is out-of-dated and we return a ObjectVersionUnavailableForConsumption,
+    /// transaction is out-of-date and we return a ObjectVersionUnavailableForConsumption,
     /// which indicates this is not retriable.
     /// Otherwise, we return a ObjectNotFound error, which indicates this is retriable.
     pub fn multi_get_object_with_more_accurate_error_return(

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -42,6 +42,14 @@ impl TestTransactionBuilder {
         }
     }
 
+    pub fn sender(&self) -> SuiAddress {
+        self.sender
+    }
+
+    pub fn gas_object(&self) -> ObjectRef {
+        self.gas_object
+    }
+
     pub fn move_call(
         mut self,
         package_id: ObjectID,


### PR DESCRIPTION
## Description 

When an object is missing from the store, instead of always return ObjectNotFound, we try to be more smart about the error. This is important because different validators could have different view of an old object due to pruning. So when queried using an old object, we want validators to return a more consistent error result.

## Test Plan 

TODO: I will add some tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
