### PR TITLE
indexer: object history with partition

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS objects;
+DROP TABLE IF EXISTS objects_history;

--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
@@ -34,3 +34,28 @@ CREATE INDEX objects_owner ON objects (owner_type, owner_id) WHERE owner_type BE
 CREATE INDEX objects_coin ON objects (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
 CREATE INDEX objects_checkpoint_sequence_number ON objects (checkpoint_sequence_number);
 CREATE INDEX objects_type ON objects (object_type);
+
+-- similar to objects table, except that
+-- 1. the primary key to store multiple object versions and partitions by checkpoint_sequence_number
+-- 2. allow null values in some columns for deleted / wrapped objects
+-- 3. object_status to mark the status of the object, which is either Active or WrappedOrDeleted
+CREATE TABLE objects_history (
+    object_id                   bytea         NOT NULL,
+    object_version              bigint        NOT NULL,
+    object_status               smallint      NOT NULL,
+    object_digest               bytea,
+    checkpoint_sequence_number  bigint        NOT NULL,
+    owner_type                  smallint,
+    owner_id                    bytea,
+    object_type                 text,
+    serialized_object           bytea,
+    coin_type                   text,
+    coin_balance                bigint,
+    df_kind                     smallint,
+    df_name                     bytea,
+    df_object_type              text,
+    df_object_id                bytea,
+    CONSTRAINT objects_history_pk PRIMARY KEY (object_id, object_version, checkpoint_sequence_number)
+) PARTITION BY RANGE (checkpoint_sequence_number);
+CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
+-- TODO(gegaowp): add corresponding indices for consistent reads of objects_history table

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -144,7 +144,8 @@ async fn commit_checkpoints<S>(
             state.persist_events(events_batch),
             state.persist_displays(display_updates_batch),
             state.persist_packages(packages_batch),
-            state.persist_objects(object_changes_batch),
+            state.persist_objects(object_changes_batch.clone()),
+            state.persist_object_history(object_changes_batch),
         ];
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -8,13 +8,11 @@ pub mod tx_processor;
 
 use std::collections::BTreeMap;
 
-use sui_types::base_types::ObjectRef;
-
 use crate::{
     models_v2::display::StoredDisplay,
     types_v2::{
-        IndexedCheckpoint, IndexedEpochInfo, IndexedEvent, IndexedObject, IndexedPackage,
-        IndexedTransaction, TxIndex,
+        IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent, IndexedObject,
+        IndexedPackage, IndexedTransaction, TxIndex,
     },
 };
 
@@ -30,10 +28,10 @@ pub struct CheckpointDataToCommit {
     pub epoch: Option<EpochToCommit>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TransactionObjectChangesToCommit {
     pub changed_objects: Vec<IndexedObject>,
-    pub deleted_objects: Vec<ObjectRef>,
+    pub deleted_objects: Vec<IndexedDeletedObject>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -56,6 +56,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_transactions_chunks: Histogram,
     pub checkpoint_db_commit_latency_transactions_chunks_transformation: Histogram,
     pub checkpoint_db_commit_latency_objects: Histogram,
+    pub checkpoint_db_commit_latency_objects_history: Histogram,
     pub checkpoint_db_commit_latency_objects_chunks: Histogram,
     pub checkpoint_db_commit_latency_events: Histogram,
     pub checkpoint_db_commit_latency_events_chunks: Histogram,
@@ -319,6 +320,12 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            checkpoint_db_commit_latency_objects_history: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_objects_history",
+                "Time spent commiting objects history",
+                DB_COMMIT_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
             checkpoint_db_commit_latency_objects_chunks: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_objects_chunks",
                 "Time spent commiting objects chunks",

--- a/crates/sui-indexer/src/models_v2/objects.rs
+++ b/crates/sui-indexer/src/models_v2/objects.rs
@@ -15,8 +15,8 @@ use sui_types::object::Object;
 use sui_types::object::ObjectRead;
 
 use crate::errors::IndexerError;
-use crate::schema_v2::objects;
-use crate::types_v2::IndexedObject;
+use crate::schema_v2::{objects, objects_history};
+use crate::types_v2::{IndexedDeletedObject, IndexedObject, ObjectStatus};
 
 #[derive(Queryable)]
 pub struct DynamicFieldColumn {
@@ -61,9 +61,83 @@ pub struct StoredObject {
 }
 
 #[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_history, primary_key(object_id, object_version, checkpoint_sequence_number))]
+pub struct StoredHistoryObject {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_status: i16,
+    pub object_digest: Option<Vec<u8>>,
+    pub checkpoint_sequence_number: i64,
+    pub owner_type: Option<i16>,
+    pub owner_id: Option<Vec<u8>>,
+    pub object_type: Option<String>,
+    pub serialized_object: Option<Vec<u8>>,
+    pub coin_type: Option<String>,
+    pub coin_balance: Option<i64>,
+    pub df_kind: Option<i16>,
+    pub df_name: Option<Vec<u8>>,
+    pub df_object_type: Option<String>,
+    pub df_object_id: Option<Vec<u8>>,
+}
+
+impl From<StoredObject> for StoredHistoryObject {
+    fn from(o: StoredObject) -> Self {
+        Self {
+            object_id: o.object_id,
+            object_version: o.object_version,
+            object_status: ObjectStatus::Active as i16,
+            object_digest: Some(o.object_digest),
+            checkpoint_sequence_number: o.checkpoint_sequence_number,
+            owner_type: Some(o.owner_type),
+            owner_id: o.owner_id,
+            object_type: o.object_type,
+            serialized_object: Some(o.serialized_object),
+            coin_type: o.coin_type,
+            coin_balance: o.coin_balance,
+            df_kind: o.df_kind,
+            df_name: o.df_name,
+            df_object_type: o.df_object_type,
+            df_object_id: o.df_object_id,
+        }
+    }
+}
+
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects, primary_key(object_id))]
 pub struct StoredDeletedObject {
     pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub checkpoint_sequence_number: i64,
+}
+
+impl From<IndexedDeletedObject> for StoredDeletedObject {
+    fn from(o: IndexedDeletedObject) -> Self {
+        Self {
+            object_id: o.object_id.to_vec(),
+            object_version: o.object_version as i64,
+            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
+        }
+    }
+}
+
+#[derive(Queryable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_history, primary_key(object_id, object_version, checkpoint_sequence_number))]
+pub struct StoredDeletedHistoryObject {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_status: i16,
+    pub checkpoint_sequence_number: i64,
+}
+
+impl From<StoredDeletedObject> for StoredDeletedHistoryObject {
+    fn from(o: StoredDeletedObject) -> Self {
+        Self {
+            object_id: o.object_id,
+            object_version: o.object_version,
+            object_status: ObjectStatus::WrappedOrDeleted as i16,
+            checkpoint_sequence_number: o.checkpoint_sequence_number,
+        }
+    }
 }
 
 impl From<IndexedObject> for StoredObject {

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -155,6 +155,46 @@ diesel::table! {
 }
 
 diesel::table! {
+    objects_history (object_id, object_version, checkpoint_sequence_number) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        object_status -> Int2,
+        object_digest -> Nullable<Bytea>,
+        checkpoint_sequence_number -> Int8,
+        owner_type -> Nullable<Int2>,
+        owner_id -> Nullable<Bytea>,
+        object_type -> Nullable<Text>,
+        serialized_object -> Nullable<Bytea>,
+        coin_type -> Nullable<Text>,
+        coin_balance -> Nullable<Int8>,
+        df_kind -> Nullable<Int2>,
+        df_name -> Nullable<Bytea>,
+        df_object_type -> Nullable<Text>,
+        df_object_id -> Nullable<Bytea>,
+    }
+}
+
+diesel::table! {
+    objects_history_partition_0 (object_id, object_version, checkpoint_sequence_number) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        object_status -> Int2,
+        object_digest -> Nullable<Bytea>,
+        checkpoint_sequence_number -> Int8,
+        owner_type -> Nullable<Int2>,
+        owner_id -> Nullable<Bytea>,
+        object_type -> Nullable<Text>,
+        serialized_object -> Nullable<Bytea>,
+        coin_type -> Nullable<Text>,
+        coin_balance -> Nullable<Int8>,
+        df_kind -> Nullable<Int2>,
+        df_name -> Nullable<Bytea>,
+        df_object_type -> Nullable<Text>,
+        df_object_id -> Nullable<Bytea>,
+    }
+}
+
+diesel::table! {
     packages (package_id) {
         package_id -> Bytea,
         move_package -> Bytea,
@@ -269,6 +309,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     move_call_metrics,
     move_calls,
     objects,
+    objects_history,
+    objects_history_partition_0,
     packages,
     transactions,
     transactions_partition_0,

--- a/crates/sui-indexer/src/store/indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/indexer_store_v2.rs
@@ -38,6 +38,11 @@ pub trait IndexerStoreV2 {
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
 
+    async fn persist_object_history(
+        &self,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError>;
+
     async fn persist_checkpoints(
         &self,
         checkpoints: Vec<IndexedCheckpoint>,

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -209,6 +209,11 @@ pub enum OwnerType {
     Shared = 3,
 }
 
+pub enum ObjectStatus {
+    Active = 0,
+    WrappedOrDeleted = 1,
+}
+
 impl TryFrom<i16> for OwnerType {
     type Error = IndexerError;
 
@@ -243,7 +248,7 @@ pub enum DynamicFieldKind {
     DynamicObject = 1,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct IndexedObject {
     pub object_id: ObjectID,
     pub object_version: u64,
@@ -286,6 +291,13 @@ impl IndexedObject {
             df_info,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexedDeletedObject {
+    pub object_id: ObjectID,
+    pub object_version: u64,
+    pub checkpoint_sequence_number: u64,
 }
 
 #[derive(Debug)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -501,7 +501,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cluster = self.cluster.as_ref().unwrap();
                 let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
                 cluster
-                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(15))
+                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(30))
                     .await;
 
                 let used_variables = self.resolve_graphql_variables(&variables)?;


### PR DESCRIPTION
## Description 

Add objects_history table with partitions, where
- each new object version will be appended to the table with a new row
- deleted, wrapped, unwrapped_then_deleted will be marked as WrappedOrDeleted in the object_status column

This is to unblock checkpoint consistent read (CSR) on RPC 2.0 graphQL server

## Test Plan 

local run and make sure that objects_history can be populated with partitions

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
