### PR TITLE
move: set build config state from Move.lock toolchain version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12080,10 +12080,11 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "0.0.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "datatest-stable",
+ "expect-test",
  "fastcrypto",
  "move-binary-format",
  "move-bytecode-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ members = [
 ]
 
 [workspace.package]
-# This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, and sui crates.
+# This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
 version = "1.15.0"
 
 [profile.release]

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-move-build"
-version = "0.0.0"
+version.workspace = true
 edition = "2021"
 authors = ["Mysten Labs <eng@mystenlabs.com>"]
 description = "Logic for building Sui Move Packages"
@@ -30,6 +30,7 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 datatest-stable.workspace = true
+expect-test.workspace = true
 
 [[test]]
 name = "linter_tests"

--- a/crates/sui-move-build/tests/toolchain_version/fixture/a_no_toolchain_version/Move.toml
+++ b/crates/sui-move-build/tests/toolchain_version/fixture/a_no_toolchain_version/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "a"
+version = "0.0.1"
+
+[dependencies]
+
+[addresses]
+a = "0x0"

--- a/crates/sui-move-build/tests/toolchain_version/fixture/b_toolchain_version_2024/Move.toml
+++ b/crates/sui-move-build/tests/toolchain_version/fixture/b_toolchain_version_2024/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "a"
+version = "0.0.1"
+
+[dependencies]
+
+[addresses]
+a = "0x0"

--- a/crates/sui-move-build/tests/toolchain_version/fixture/c_toolchain_version_lock_override/Move.toml
+++ b/crates/sui-move-build/tests/toolchain_version/fixture/c_toolchain_version_lock_override/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "a"
+version = "0.0.1"
+
+[dependencies]
+
+[addresses]
+a = "0x0"

--- a/crates/sui-move-build/tests/toolchain_version_tests.rs
+++ b/crates/sui-move-build/tests/toolchain_version_tests.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use move_compiler::editions::{Edition, Flavor};
+use sui_move_build::{BuildConfig, CompiledPackage};
+
+#[test]
+fn no_toolchain_version() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend([
+        "tests",
+        "toolchain_version",
+        "fixture",
+        "a_no_toolchain_version",
+    ]);
+    let mut build_config = BuildConfig::new_for_testing();
+    build_config.config.lock_file = Some(path.join("Move.lock"));
+    let result = build_config.build(path).unwrap();
+    assert_eq!((Flavor::Sui, Edition::LEGACY), flavor_and_edition(&result));
+}
+
+#[test]
+fn toolchain_version_2024() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend([
+        "tests",
+        "toolchain_version",
+        "fixture",
+        "b_toolchain_version_2024",
+    ]);
+    let mut build_config = BuildConfig::new_for_testing();
+    build_config.config.lock_file = Some(path.join("Move.lock"));
+    let result = build_config.build(path).unwrap();
+    assert_eq!(
+        (Flavor::Sui, Edition::E2024_ALPHA),
+        flavor_and_edition(&result)
+    );
+}
+
+#[test]
+fn toolchain_version_lock_override() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend([
+        "tests",
+        "toolchain_version",
+        "fixture",
+        "c_toolchain_version_lock_override",
+    ]);
+    // The Move.lock file sets edition `legacy` but we pass in a config with `2024.alpha`.
+    let mut build_config = BuildConfig::new_for_testing();
+    build_config.config.default_edition = Some(Edition::E2024_ALPHA);
+    build_config.config.lock_file = Some(path.join("Move.lock"));
+    let result = build_config.build(path).unwrap();
+    assert_eq!(
+        (Flavor::Sui, Edition::E2024_ALPHA),
+        flavor_and_edition(&result)
+    );
+}
+
+fn flavor_and_edition(pkg: &CompiledPackage) -> (Flavor, Edition) {
+    let flavor = pkg
+        .package
+        .compiled_package_info
+        .build_flags
+        .default_flavor
+        .unwrap();
+    let edition = pkg
+        .package
+        .compiled_package_info
+        .build_flags
+        .default_edition
+        .unwrap();
+
+    (flavor, edition)
+}


### PR DESCRIPTION
## Description 

- Adds the part where we read `[move.toolchain-version]` from `Move.lock` and set `flavor` and `edition` in `BuildConfig`. 

- Exposes the workspace version to the `sui-move-build` crate where this logic is added, so that `env!("CARGO_PKG_VERSION")` sees `1.15.0` and not `0.0.0`. 

- Since we're not writing `[move.toolchain-version]` yet, this change is fairly benign (you'd have to manually change the `Move.lock` to change behavior).

## Test Plan 

Added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes