### PR TITLE
[graphql/rpc] separate graphiql title logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11732,6 +11732,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hex",
+ "http",
  "hyper",
  "insta",
  "lru 0.10.0",

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -19,6 +19,7 @@ diesel.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 futures.workspace = true
 hex.workspace = true
+http.workspace = true
 hyper.workspace = true
 lru.workspace = true
 move-binary-format.workspace = true
@@ -43,6 +44,7 @@ telemetry-subscribers.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tower.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -92,7 +92,7 @@ impl Default for Ide {
 impl Ide {
     pub fn new(ide_title: Option<String>) -> Self {
         Self {
-            ide_title: ide_title.unwrap_or_default(),
+            ide_title: ide_title.unwrap_or(DEFAULT_IDE_TITLE.to_string()),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -20,17 +20,22 @@ use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
 use async_graphql::{EmptyMutation, EmptySubscription};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::http::HeaderMap;
-use axum::routing::{post, MethodRouter};
+use axum::response::IntoResponse;
+use axum::routing::{post, MethodRouter, Route};
 use axum::{
     extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo},
     middleware,
 };
 use axum::{headers::Header, Router};
+use http::Request;
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
+use hyper::Body;
 use hyper::Server as HyperServer;
+use std::convert::Infallible;
 use std::{any::Any, net::SocketAddr, sync::Arc, time::Instant};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use tokio::sync::OnceCell;
+use tower::{Layer, Service};
 
 pub struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
@@ -50,8 +55,6 @@ pub(crate) struct ServerBuilder {
     host: String,
 
     schema: SchemaBuilder<Query, EmptyMutation, EmptySubscription>,
-    ide_title: Option<String>,
-
     router: Option<Router>,
 }
 
@@ -61,7 +64,6 @@ impl ServerBuilder {
             port,
             host,
             schema: async_graphql::Schema::build(Query, EmptyMutation, EmptySubscription),
-            ide_title: None,
             router: None,
         }
     }
@@ -90,11 +92,6 @@ impl ServerBuilder {
         self
     }
 
-    fn ide_title(mut self, name: String) -> Self {
-        self.ide_title = Some(name);
-        self
-    }
-
     fn build_schema(self) -> Schema<Query, EmptyMutation, EmptySubscription> {
         self.schema.finish()
     }
@@ -103,22 +100,13 @@ impl ServerBuilder {
         self,
     ) -> (
         String,
-        Option<String>,
         Schema<Query, EmptyMutation, EmptySubscription>,
         Router,
     ) {
         let address = self.address();
-        let ServerBuilder {
-            schema,
-            // TODO: remove this once we have expose layer in builder.
-            // This should be set in the builder.
-            ide_title,
-            router,
-            ..
-        } = self;
+        let ServerBuilder { schema, router, .. } = self;
         (
             address,
-            ide_title,
             schema.finish(),
             router.expect("Router not initialized"),
         )
@@ -142,14 +130,23 @@ impl ServerBuilder {
         self
     }
 
-    pub fn build(self) -> Result<Server, Error> {
-        let (address, ide_title, schema, router) = self.build_components();
+    pub fn layer<L>(mut self, layer: L) -> Self
+    where
+        L: Layer<Route> + Clone + Send + 'static,
+        L::Service: Service<Request<Body>> + Clone + Send + 'static,
+        <L::Service as Service<Request<Body>>>::Response: IntoResponse + 'static,
+        <L::Service as Service<Request<Body>>>::Error: Into<Infallible> + 'static,
+        <L::Service as Service<Request<Body>>>::Future: Send + 'static,
+    {
+        self.init_router();
+        self.router = self.router.map(|router| router.layer(layer));
+        self
+    }
 
-        let app = router
-            .layer(axum::extract::Extension(schema))
-            // TODO: remove this once we have expose layer in builder.
-            // This should be set in the builder.
-            .layer(axum::extract::Extension(ide_title));
+    pub fn build(self) -> Result<Server, Error> {
+        let (address, schema, router) = self.build_components();
+
+        let app = router.layer(axum::extract::Extension(schema));
 
         Ok(Server {
             server: axum::Server::bind(
@@ -161,9 +158,11 @@ impl ServerBuilder {
         })
     }
 
-    pub async fn from_yaml_config(path: &str) -> Result<Self, Error> {
+    pub async fn from_yaml_config(path: &str) -> Result<(Self, ServerConfig), Error> {
         let config = ServerConfig::from_yaml(path)?;
-        Self::from_config(&config).await
+        Self::from_config(&config)
+            .await
+            .map(|builder| (builder, config))
     }
 
     pub async fn from_config(config: &ServerConfig) -> Result<Self, Error> {
@@ -204,7 +203,6 @@ impl ServerBuilder {
             .context_data(pg_conn_pool)
             .context_data(Resolver::new(package_cache))
             .context_data(name_service_config)
-            .ide_title(config.ide.ide_title.clone())
             .context_data(Arc::new(metrics))
             .context_data(config.clone());
 

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -18,19 +18,28 @@ async fn graphiql(ide_title: axum::Extension<Option<String>>) -> impl axum::resp
 
 pub async fn start_graphiql_server(server_config: &ServerConfig) -> Result<(), Error> {
     info!("Starting server with config: {:?}", server_config);
-    start_graphiql_server_impl(ServerBuilder::from_config(server_config).await?).await
+    start_graphiql_server_impl(
+        ServerBuilder::from_config(server_config).await?,
+        server_config.clone(),
+    )
+    .await
 }
 
 pub async fn start_graphiql_server_from_cfg_path(server_config_path: &str) -> Result<(), Error> {
-    start_graphiql_server_impl(ServerBuilder::from_yaml_config(server_config_path).await?).await
+    let (server_builder, config) = ServerBuilder::from_yaml_config(server_config_path).await?;
+    start_graphiql_server_impl(server_builder, config).await
 }
 
-async fn start_graphiql_server_impl(server_builder: ServerBuilder) -> Result<(), Error> {
+async fn start_graphiql_server_impl(
+    server_builder: ServerBuilder,
+    config: ServerConfig,
+) -> Result<(), Error> {
     let address = server_builder.address();
 
     // Add GraphiQL IDE handler on GET request to `/`` endpoint
     let server = server_builder
         .route("/", axum::routing::get(graphiql))
+        .layer(axum::extract::Extension(Some(config.ide.ide_title.clone())))
         .build()?;
 
     info!("Launch GraphiQL IDE at: http://{}", address);


### PR DESCRIPTION
## Description 

Follow up of todo items from [PR](https://github.com/MystenLabs/sui/pull/15064)
The core builder logic is now fully separated from graphiql by removing the title setting logic.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
