### PR TITLE
[graphql/rpc] enforce ban on directives

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -1,0 +1,42 @@
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1 'run-graphql'. lines 6-10:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Fields with directives are not supported",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
+}
+
+task 2 'run-graphql'. lines 12-40:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Fragments with directives are not supported",
+      "locations": [
+        {
+          "line": 1,
+          "column": 1
+        }
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
+}

--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# run-graphql
+
+{
+  chainIdentifier @deprecated
+}
+
+//# run-graphql
+
+fragment Modules on Object  @deprecated {
+    location
+    asMovePackage {
+        module(name: "m") {
+            name
+            package { asObject { location } }
+
+            fileFormatVersion
+            bytes
+            disassembly
+        }
+    }
+}
+
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                objectChanges {
+                    outputState {
+                        ...Modules
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description 

Until we formally support them, enforce ban on [directives](https://www.apollographql.com/docs/apollo-server/schema/directives/) which could be confusing if expected to work.

## Test Plan 

e2e test included and manual.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
