### PR TITLE
[shared object deletion] Simplify checks

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.exp
@@ -19,8 +19,8 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 82-82:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::add_child_object (function index 10) at offset 0, Abort Code: 4
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 10, instruction: 0, function_name: Some("add_child_object") }, 4) at command Some(0)
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5 'view-object'. lines 84-84:
 Owner: Shared

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.exp
@@ -1,0 +1,24 @@
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-20:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4810800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 22-22:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'view-object'. lines 24-24:
+Owner: Shared
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 4 'programmable'. lines 26-27:
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// test valid usages of shared coin
+
+//# init --addresses test=0x0 --accounts A --shared-object-deletion true
+
+//# publish
+
+module test::m1 {
+    use sui::sui::SUI;
+    use sui::coin;
+
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public fun mint_shared(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+}
+
+//# run test::m1::mint_shared
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,0)
+//> MergeCoins(Gas, [Input(0)])
+

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.exp
@@ -1,0 +1,38 @@
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-21:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4993200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 23-25:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'programmable'. lines 27-29:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'run'. lines 31-31:
+created: object(4,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'view-object'. lines 33-35:
+Owner: Shared
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 6 'programmable'. lines 36-40:
+created: object(6,0)
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 7 'programmable'. lines 41-44:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses p=0x0 q=0x0 q_2=0x0 r=0x0 s=0x0 --accounts A
+
+//# publish
+module p::m {
+    use sui::sui::SUI;
+    use sui::coin;
+
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public fun sharer<T: key + store>(x: T) {
+        transfer::public_share_object(x);
+    }
+
+    public fun mint_shared(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+}
+
+//# programmable --sender A --inputs 10
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+
+//# programmable --sender A --inputs 10
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: p::m::sharer<sui::coin::Coin<sui::sui::SUI>>(Result(0));
+
+//# run p::m::mint_shared
+
+//# view-object 4,0
+
+// This is OK -- split off from a shared object and transfer the split-off coin
+//# programmable --sender A --inputs 0 object(4,0) @A
+//> 0: SplitCoins(Input(1), [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(2));
+
+// This is not OK -- split off from a shared object and transfer shared object
+//# programmable --sender A --inputs 0 object(4,0) @A
+//> 0: SplitCoins(Input(1), [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(2));
+//> 2: TransferObjects([Input(1)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.exp
@@ -19,5 +19,5 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'programmable'. lines 32-33:
-Error: Transaction Effects Status: Invalid command argument at 0. Shared object operations such a wrapping, freezing, or converting to owned are not allowed.
-Debug of error: CommandArgumentError { arg_idx: 0, kind: SharedObjectOperationNotAllowed } at command Some(0)
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.exp
@@ -19,8 +19,8 @@ Version: 2
 Contents: a::m::Inner {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'run'. lines 48-48:
-Error: Transaction Effects Status: Wrapping a shared object is not allowed.
-Debug of error: SharedObjectWrapped at command None
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5 'run'. lines 50-50:
 created: object(5,0)

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.exp
@@ -19,8 +19,8 @@ Version: 2
 Contents: a::m::Inner {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'run'. lines 48-48:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::add_child_object (function index 10) at offset 0, Abort Code: 4
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 10, instruction: 0, function_name: Some("add_child_object") }, 4) at command Some(0)
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5 'run'. lines 50-50:
 created: object(5,0)
@@ -33,5 +33,6 @@ Version: 4
 Contents: a::m::Inner {id: sui::object::UID {id: sui::object::ID {bytes: fake(5,0)}}}
 
 task 7 'run'. lines 54-54:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::dynamic_field::add_child_object (function index 10) at offset 0, Abort Code: 4
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 10, instruction: 0, function_name: Some("add_child_object") }, 4) at command Some(0)
+created: object(7,0)
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 3465600,  storage_rebate: 2204532, non_refundable_storage_fee: 22268

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.exp
@@ -1,0 +1,46 @@
+processed 10 tasks
+
+task 1 'publish'. lines 6-49:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6900800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 51-51:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 53-53:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 55-55:
+Owner: Shared
+Version: 3
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 5 'view-object'. lines 57-59:
+Owner: Shared
+Version: 4
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}
+
+task 6 'programmable'. lines 60-62:
+mutated: object(0,0), object(2,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 3430944, non_refundable_storage_fee: 34656
+
+task 7 'run'. lines 64-64:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'view-object'. lines 66-68:
+Owner: Shared
+Version: 6
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 9 'programmable'. lines 69-74:
+created: object(9,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use std::vector;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        let o = Obj2 { id: object::new(ctx) };
+        transfer::public_share_object(o)
+    }
+
+    public fun delete(o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        deleter(o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun deleter(o2: Obj2) {
+        let Obj2 { id } = o2;
+        object::delete(id);
+    }
+
+    public fun pop_coin(o2: vector<Coin<SUI>>): Coin<SUI> {
+        let o = vector::pop_back(&mut o2);
+        vector::destroy_empty(o2);
+        o
+    }
+
+    public fun share_coin(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+}
+
+//# run t2::o2::create
+
+//# run t2::o2::create
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+// Make MoveVec and then delete
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::delete(Result(0));
+
+//# run t2::o2::mint_shared_coin
+
+//# view-object 7,0
+
+// Reshare the shared object after making the move v
+//# programmable --inputs 0 object(7,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+//> 4: t2::o2::share_coin(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
@@ -1,0 +1,92 @@
+processed 22 tasks
+
+task 1 'publish'. lines 6-101:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10852800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 103-103:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 105-105:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 107-107:
+Owner: Shared
+Version: 3
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 5 'view-object'. lines 109-111:
+Owner: Shared
+Version: 4
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}
+
+task 6 'programmable'. lines 112-116:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 7 'programmable'. lines 117-121:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 8 'programmable'. lines 122-126:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 9 'programmable'. lines 127-131:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 10 'programmable'. lines 132-137:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 11 'programmable'. lines 138-143:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 12 'programmable'. lines 144-149:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 13 'programmable'. lines 150-155:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 14 'programmable'. lines 156-159:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 15 'run'. lines 161-161:
+created: object(15,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16 'view-object'. lines 163-166:
+Owner: Shared
+Version: 14
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(15,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 17 'programmable'. lines 167-173:
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 1, return value 0
+Debug of error: UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 } at command None
+
+task 18 'programmable'. lines 174-182:
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Debug of error: VMVerificationOrDeserializationError at command Some(4)
+
+task 19 'programmable'. lines 183-191:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(4)
+
+task 20 'programmable'. lines 192-199:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(4)
+
+task 21 'programmable'. lines 200-205:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
@@ -1,0 +1,205 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use std::vector;
+    use sui::dynamic_field as df;
+    use sui::dynamic_object_field as dof;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun pop_coin(o2: vector<Coin<SUI>>): Coin<SUI> {
+        let o = vector::pop_back(&mut o2);
+        vector::destroy_empty(o2);
+        o
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        let o = Obj2 { id: object::new(ctx) };
+        transfer::public_share_object(o)
+    }
+
+    public fun delete(o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        deleter(o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun freezee(o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        freezer(o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun dof(parent: &mut Obj2, o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        dofer(parent, o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun df(parent: &mut Obj2, o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        dfer(parent, o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun transfer(o2: vector<Obj2>) {
+        let o = vector::pop_back(&mut o2);
+        transferer(o);
+        vector::destroy_empty(o2);
+    }
+
+    public fun pop_it(o2: vector<Obj2>): Obj2 {
+        let o = vector::pop_back(&mut o2);
+        vector::destroy_empty(o2);
+        o
+    }
+
+    public fun deleter(o2: Obj2) {
+        let Obj2 { id } = o2;
+        object::delete(id);
+    }
+
+    public fun freezer(o2: Obj2) {
+        transfer::freeze_object(o2);
+    }
+
+    public fun dofer(parent: &mut Obj2, o2: Obj2) {
+        dof::add(&mut parent.id, 0, o2);
+    }
+
+    public fun dfer(parent: &mut Obj2, o2: Obj2) {
+        df::add(&mut parent.id, 0, o2);
+    }
+
+    public fun transferer(o2: Obj2) {
+        transfer::transfer(o2, @0x0);
+    }
+
+    public fun sharer(o2: Obj2) {
+        transfer::share_object(o2);
+    }
+
+    public fun share_coin(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+}
+
+//# run t2::o2::create
+
+//# run t2::o2::create
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+// Make MoveVec and then try to freeze
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::freezee(Result(0));
+
+// Make MoveVec and then try to add as dof
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::dof(Input(0), Result(0));
+
+// Make MoveVec and then try to add as df
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::df(Input(0), Result(0));
+
+// Make MoveVec and then try to transfer it
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::transfer(Result(0));
+
+// Make MoveVec pop and return it, then try to freeze
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::pop_it(Result(0));
+//> 2: t2::o2::freezer(Result(1));
+
+// Make MoveVec pop and return it, then try to add as dof
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::pop_it(Result(0));
+//> 2: t2::o2::dofer(Input(0), Result(1));
+
+// Make MoveVec pop and return it, then try to add as df
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::pop_it(Result(0));
+//> 2: t2::o2::dfer(Input(0), Result(1));
+
+// Make MoveVec pop and return it, then try to transfer it
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
+//> 1: t2::o2::pop_it(Result(0));
+//> 2: t2::o2::transferer(Result(1));
+
+// Make MoveVec pop and return it, then try to transfer it with PT transfer
+//# programmable --inputs object(3,0) @0x0
+//> 0: MakeMoveVec<t2::o2::Obj2>([Input(0)]);
+//> 1: t2::o2::pop_it(Result(0));
+//> 2: TransferObjects([Result(1)], Input(1));
+
+//# run t2::o2::mint_shared_coin
+
+//# view-object 15,0
+
+// This is OK -- split off from a shared object and transfer the split-off coin
+// But fails because we need to reshare the shared object
+//# programmable --inputs 0 object(15,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+
+// Try to call public_share_object directly -- this should fail
+//# programmable --inputs 0 object(15,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+//> 4: sui::transfer::public_share_object(Input(1));
+
+// Try to reshare the shared object -- this should fail since the input was
+// used for the `MakeMoveVec` call
+//# programmable --inputs 0 object(15,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+//> 4: t2::o2::share_coin(Input(1));
+
+// Try to transfer the shared object -- this should fail since the input was
+// used for the `MakeMoveVec` call
+//# programmable --inputs 0 object(15,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+//> 4: TransferObjects([Input(1)], Input(2));
+
+// Try to transfer the shared object 
+//# programmable --inputs 0 object(15,0) @0x0
+//> 0: MakeMoveVec([Input(1)]);
+//> 1: t2::o2::pop_coin(Result(0));
+//> 2: SplitCoins(Result(1), [Input(0)]);
+//> 3: TransferObjects([Result(2)], Input(2));
+//> 4: TransferObjects([Result(1)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.exp
@@ -1,0 +1,104 @@
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 13-63:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9264400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 65-65:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 67-67:
+created: object(3,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 69-69:
+Owner: Shared
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 5 'view-object'. lines 71-74:
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 6 'programmable'. lines 75-79:
+mutated: object(0,0), object(3,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 7 'run'. lines 81-81:
+created: object(7,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'run'. lines 83-83:
+created: object(8,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9 'run'. lines 85-85:
+created: object(9,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10 'view-object'. lines 87-87:
+Owner: Account Address ( A )
+Version: 5
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 11 'view-object'. lines 89-89:
+Owner: Shared
+Version: 6
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(8,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 12 'view-object'. lines 91-93:
+Owner: Shared
+Version: 7
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(9,0)}}}
+
+task 13 'programmable'. lines 94-98:
+mutated: object(0,0), object(9,0)
+deleted: object(7,0), object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 4160772, non_refundable_storage_fee: 42028
+
+task 14 'run'. lines 100-100:
+created: object(14,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 15 'run'. lines 102-102:
+created: object(15,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16 'run'. lines 104-104:
+created: object(16,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 17 'view-object'. lines 106-106:
+Owner: Shared
+Version: 8
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(14,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 18 'view-object'. lines 108-108:
+Owner: Shared
+Version: 9
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(15,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 19 'view-object'. lines 110-112:
+Owner: Shared
+Version: 10
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(16,0)}}}
+
+task 20 'programmable'. lines 113-115:
+mutated: object(0,0), object(16,0)
+deleted: object(14,0), object(15,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 4160772, non_refundable_storage_fee: 42028

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --accounts A --shared-object-deletion true
+
+// Merge:
+// shared into owned -> Can do anything, SO is deleted
+// owned into shared -> SO restrictions apply (DF, DOF, Transfer, Freeze, Delete)
+// shared into shared -> SO restrictions apply (DF, DOF, Transfer, Freeze, Delete)
+
+// tfer, then abort
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as df;
+    use sui::dynamic_object_field as dof;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun mint_shared_obj(ctx: &mut TxContext) {
+        transfer::public_share_object(Obj2 { id: object::new(ctx) });
+    }
+
+    public fun mint_owned_coin(ctx: &mut TxContext) {
+        transfer::public_transfer(coin::zero<SUI>(ctx), @A)
+    }
+
+    public fun deleter(o2: Coin<SUI>) {
+        coin::destroy_zero(o2);
+    }
+
+    public fun freezer(o2: Coin<SUI>) {
+        transfer::public_freeze_object(o2);
+    }
+
+    public fun dofer(parent: &mut Obj2, o2: Coin<SUI>) {
+        dof::add(&mut parent.id, 0, o2);
+    }
+
+    public fun dfer(parent: &mut Obj2, o2: Coin<SUI>) {
+        df::add(&mut parent.id, 0, o2);
+    }
+
+    public fun transferer(o2: Coin<SUI>) {
+        transfer::public_transfer(o2, @0x0);
+    }
+
+    public fun sharer(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+}
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_owned_coin
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+// Merge shared into owned -- after that the shared object is deleted and its
+// just a normal owned object
+//# programmable --sender A --inputs object(2,0) object(3,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::transferer(Input(1));
+
+// **Merge owned into shared**
+
+//# run t2::o2::mint_owned_coin
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_obj
+
+//# view-object 7,0
+
+//# view-object 8,0
+
+//# view-object 9,0
+
+// Merge and then delete it -- should work fine
+//# programmable --sender A --inputs object(7,0) object(8,0) object(9,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::deleter(Input(1));
+
+// **Merge shared into shared**
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_obj
+
+//# view-object 14,0
+
+//# view-object 15,0
+
+//# view-object 16,0
+
+// Merge and then delete it -- should work fine
+//# programmable --sender A --inputs object(14,0) object(15,0) object(16,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::deleter(Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.exp
@@ -1,0 +1,109 @@
+processed 24 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 13-65:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9264400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 67-67:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 69-69:
+created: object(3,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'run'. lines 71-71:
+created: object(4,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'view-object'. lines 73-73:
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 6 'view-object'. lines 75-75:
+Owner: Shared
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 7 'view-object'. lines 77-79:
+Owner: Shared
+Version: 5
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}}
+
+task 8 'programmable'. lines 80-84:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 9 'programmable'. lines 85-89:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 10 'programmable'. lines 90-94:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 11 'programmable'. lines 95-99:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 12 'programmable'. lines 100-104:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 13 'run'. lines 106-106:
+created: object(13,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 14 'run'. lines 108-108:
+created: object(14,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 15 'run'. lines 110-110:
+created: object(15,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16 'view-object'. lines 112-112:
+Owner: Shared
+Version: 6
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(13,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 17 'view-object'. lines 114-114:
+Owner: Shared
+Version: 7
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(14,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 18 'view-object'. lines 116-118:
+Owner: Shared
+Version: 8
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(15,0)}}}
+
+task 19 'programmable'. lines 119-123:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 20 'programmable'. lines 124-128:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 21 'programmable'. lines 129-133:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 22 'programmable'. lines 134-138:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 23 'programmable'. lines 139-141:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --accounts A --shared-object-deletion true
+
+// Merge:
+// shared into owned -> Can do anything, SO is deleted
+// owned into shared -> SO restrictions apply (DF, DOF, Transfer, Freeze, Delete)
+// shared into shared -> SO restrictions apply (DF, DOF, Transfer, Freeze, Delete)
+
+// tfer, then abort
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as df;
+    use sui::dynamic_object_field as dof;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun mint_shared_obj(ctx: &mut TxContext) {
+        transfer::public_share_object(Obj2 { id: object::new(ctx) });
+    }
+
+    public fun mint_owned_coin(ctx: &mut TxContext) {
+        transfer::public_transfer(coin::zero<SUI>(ctx), @A)
+    }
+
+    public fun deleter(o2: Coin<SUI>) {
+        coin::destroy_zero(o2);
+    }
+
+    public fun freezer(o2: Coin<SUI>) {
+        transfer::public_freeze_object(o2);
+    }
+
+    public fun dofer(parent: &mut Obj2, o2: Coin<SUI>) {
+        dof::add(&mut parent.id, 0, o2);
+    }
+
+    public fun dfer(parent: &mut Obj2, o2: Coin<SUI>) {
+        df::add(&mut parent.id, 0, o2);
+    }
+
+    public fun transferer(o2: Coin<SUI>) {
+        transfer::public_transfer(o2, @0x0);
+    }
+
+    public fun sharer(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+}
+
+// **Merge owned into shared**
+
+//# run t2::o2::mint_owned_coin
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_obj
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+//# view-object 4,0
+
+// Merge and then try to freeze
+//# programmable --sender A --inputs object(2,0) object(3,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::freezer(Input(1));
+
+// Merge and then try to add as dof
+//# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::dofer(Input(2), Input(1));
+
+// Merge and then try to add as df
+//# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::dfer(Input(2), Input(1));
+
+// Merge and then try to transfer it
+//# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::transferer(Input(1));
+
+// Merge and then try to transfer it with PTB transfer
+//# programmable --sender A --inputs object(2,0) object(3,0) object(4,0) @A
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: TransferObjects([Input(1)], Input(3));
+
+// **Merge shared into shared**
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_coin
+
+//# run t2::o2::mint_shared_obj
+
+//# view-object 13,0
+
+//# view-object 14,0
+
+//# view-object 15,0
+
+// Merge and then try to freeze
+//# programmable --sender A --inputs object(13,0) object(14,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::freezer(Input(1));
+
+// Merge and then try to add as dof
+//# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::dofer(Input(2), Input(1));
+
+// Merge and then try to add as df
+//# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::dfer(Input(2), Input(1));
+
+// Merge and then try to transfer it
+//# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: t2::o2::transferer(Input(1));
+
+// Merge and then try to transfer it with PTB transfer
+//# programmable --sender A --inputs object(13,0) object(14,0) object(15,0) @A
+//> 0: MergeCoins(Input(1), [Input(0)]);
+//> 1: TransferObjects([Input(1)], Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.exp
@@ -1,0 +1,51 @@
+processed 11 tasks
+
+task 1 'publish'. lines 6-38:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6384000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 40-40:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 42-42:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 44-44:
+Owner: Shared
+Version: 3
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 5 'view-object'. lines 46-48:
+Owner: Shared
+Version: 4
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}
+
+task 6 'programmable'. lines 49-51:
+mutated: object(0,0), object(2,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 3430944, non_refundable_storage_fee: 34656
+
+task 7 'run'. lines 53-53:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'view-object'. lines 55-57:
+Owner: Shared
+Version: 6
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 9 'programmable'. lines 58-64:
+created: object(9,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 10 'programmable'. lines 65-69:
+created: object(10,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        let o = Obj2 { id: object::new(ctx) };
+        transfer::public_share_object(o)
+    }
+
+    public fun deleter(o2: Obj2) {
+        let Obj2 { id } = o2;
+        object::delete(id);
+    }
+
+    public fun id<T>(i: T): T { i }
+
+    public fun share_coin(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+}
+
+//# run t2::o2::create
+
+//# run t2::o2::create
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+// Make MoveVec and then delete
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
+//> 1: t2::o2::deleter(Result(0));
+
+//# run t2::o2::mint_shared_coin
+
+//# view-object 7,0
+
+// Reshare the shared object after making the move v
+//# programmable --inputs 0 object(7,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: t2::o2::share_coin(Result(0));
+
+// Try to call public_share_object directly -- this should work because the coin has `store`.
+//# programmable --inputs 0 object(7,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.exp
@@ -1,0 +1,68 @@
+processed 16 tasks
+
+task 1 'publish'. lines 6-60:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 8869200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 62-62:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 64-64:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 66-66:
+Owner: Shared
+Version: 3
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 5 'view-object'. lines 68-70:
+Owner: Shared
+Version: 4
+Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}
+
+task 6 'programmable'. lines 71-75:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 7 'programmable'. lines 76-80:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 8 'programmable'. lines 81-85:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 9 'programmable'. lines 86-88:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 10 'run'. lines 90-90:
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11 'view-object'. lines 92-94:
+Owner: Shared
+Version: 9
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(10,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 0u64}}
+
+task 12 'programmable'. lines 95-101:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
+
+task 13 'programmable'. lines 102-108:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
+
+task 14 'programmable'. lines 109-115:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
+
+task 15 'programmable'. lines 116-120:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+
+//# publish
+
+module t2::o2 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as df;
+    use sui::dynamic_object_field as dof;
+    use sui::sui::SUI;
+    use sui::coin::{Self, Coin};
+
+    struct Obj2 has key, store {
+        id: UID,
+    }
+
+    public fun mint_shared_coin(ctx: &mut TxContext) {
+        transfer::public_share_object(coin::zero<SUI>(ctx))
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        let o = Obj2 { id: object::new(ctx) };
+        transfer::public_share_object(o)
+    }
+
+    public fun deleter(o2: Obj2) {
+        let Obj2 { id } = o2;
+        object::delete(id);
+    }
+
+    public fun freezer(o2: Obj2) {
+        transfer::freeze_object(o2);
+    }
+
+    public fun dofer(parent: &mut Obj2, o2: Obj2) {
+        dof::add(&mut parent.id, 0, o2);
+    }
+
+    public fun dfer(parent: &mut Obj2, o2: Obj2) {
+        df::add(&mut parent.id, 0, o2);
+    }
+
+    public fun transferer(o2: Obj2) {
+        transfer::transfer(o2, @0x0);
+    }
+
+    public fun sharer(o2: Obj2) {
+        transfer::share_object(o2);
+    }
+
+    public fun share_coin(o2: Coin<SUI>) {
+        transfer::public_share_object(o2);
+    }
+
+    public fun id<T>(i: T): T { i }
+}
+
+//# run t2::o2::create
+
+//# run t2::o2::create
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+// pass through a move function and then try to freeze
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
+//> 1: t2::o2::freezer(Result(0));
+
+// pass through a move function and then try to add as dof
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
+//> 1: t2::o2::dofer(Input(0), Result(0));
+
+// pass through a move function and then try to add as df
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
+//> 1: t2::o2::dfer(Input(0), Result(0));
+
+// pass through a move function and then try to transfer it
+//# programmable --inputs object(2,0) object(3,0)
+//> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
+//> 1: t2::o2::transferer(Result(0));
+
+//# run t2::o2::mint_shared_coin
+
+//# view-object 10,0
+
+// Try to double-use the input
+//# programmable --inputs 0 object(10,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+
+// Try to double-use the input using a user-defined function
+//# programmable --inputs 0 object(10,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: t2::o2::share_coin(Input(1));
+
+// Try to transfer the shared object and double-use the input
+//# programmable --inputs 0 object(10,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: TransferObjects([Input(1)], Input(2));
+
+// Try to transfer the shared object 
+//# programmable --inputs 0 object(10,0) @0x0
+//> 0: t2::o2::id<sui::coin::Coin<sui::sui::SUI>>(Input(1));
+//> 1: SplitCoins(Result(0), [Input(0)]);
+//> 2: TransferObjects([Result(1)], Input(2));
+//> 3: TransferObjects([Result(0)], Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/shared/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/freeze.exp
@@ -16,5 +16,5 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'run'. lines 35-35:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::freeze_object_impl (function index 9) at offset 0, Abort Code: 4
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 9, instruction: 0, function_name: Some("freeze_object_impl") }, 4) at command Some(0)
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/transfer.exp
@@ -16,5 +16,5 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'run'. lines 34-34:
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::transfer_impl (function index 11) at offset 0, Abort Code: 0
-Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 11, instruction: 0, function_name: Some("transfer_impl") }, 0) at command Some(0)
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/wrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/wrap.exp
@@ -16,5 +16,5 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
 task 4 'run'. lines 38-38:
-Error: Transaction Effects Status: Wrapping a shared object is not allowed.
-Debug of error: SharedObjectWrapped at command None
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -1,28 +1,47 @@
-processed 6 tasks
+processed 10 tasks
 
 init:
 A: object(0,0), B: object(0,1)
 
-task 1 'publish'. lines 8-21:
+task 1 'publish'. lines 8-28:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 4902000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5525200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run'. lines 23-23:
+task 2 'run'. lines 30-30:
 created: object(2,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3 'view-object'. lines 25-25:
+task 3 'run'. lines 32-32:
+created: object(3,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'view-object'. lines 34-34:
 Owner: Shared
 Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
 
-task 4 'transfer-object'. lines 27-27:
-Error: Transaction Effects Status: Invalid command argument at 0. Shared object operations such a wrapping, freezing, or converting to owned are not allowed.
-Debug of error: CommandArgumentError { arg_idx: 0, kind: SharedObjectOperationNotAllowed } at command Some(0)
+task 5 'view-object'. lines 36-36:
+Owner: Shared
+Version: 4
+Contents: test::m::S2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}
 
-task 5 'view-object'. lines 29-29:
+task 6 'transfer-object'. lines 38-38:
+Error: Transaction Effects Status: Invalid Transfer Object, object does not have public transfer.
+Debug of error: InvalidTransferObject at command Some(0)
+
+task 7 'transfer-object'. lines 40-40:
+Error: Transaction Effects Status: The shared object operation is not allowed.
+Debug of error: SharedObjectOperationNotAllowed at command None
+
+task 8 'view-object'. lines 42-42:
 Owner: Shared
 Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 9 'view-object'. lines 44-44:
+Owner: Shared
+Version: 5
+Contents: test::m::S2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// tests TransferObject should fail for a shared object
+// tests TransferObject should fail for a shared object with and without store
 
 //# init --accounts A B --addresses test=0x0 --shared-object-deletion true
 
@@ -14,16 +14,31 @@ module test::m {
 
     struct S has key { id: UID }
 
-    public entry fun mint_s(ctx: &mut TxContext) {
+    struct S2 has key, store { id: UID }
+
+    public fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);
         transfer::share_object(S { id })
+    }
+
+    public fun mint_s2(ctx: &mut TxContext) {
+        let id = object::new(ctx);
+        transfer::share_object(S2 { id })
     }
 }
 
 //# run test::m::mint_s
 
+//# run test::m::mint_s2
+
 //# view-object 2,0
+
+//# view-object 3,0
 
 //# transfer-object 2,0 --sender A --recipient B
 
+//# transfer-object 3,0 --sender A --recipient B
+
 //# view-object 2,0
+
+//# view-object 3,0

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -34,7 +34,7 @@ use sui_types::committee::EpochId;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::{ExecutionError, SuiError};
 use sui_types::execution_status::ExecutionFailureStatus::{
-    InputObjectDeleted, MoveAbort, SharedObjectWrapped,
+    InputObjectDeleted, SharedObjectOperationNotAllowed,
 };
 use sui_types::transaction::{ObjectArg, VerifiedCertificate};
 
@@ -1516,7 +1516,10 @@ async fn test_wrap_not_allowed() {
         .await
         .unwrap();
 
-    assert!(matches!(error.unwrap().kind(), SharedObjectWrapped));
+    assert!(matches!(
+        error.unwrap().kind(),
+        SharedObjectOperationNotAllowed
+    ));
 
     let new_version = user_1.get_object_latest_version(shared_obj_id);
     assert_eq!(new_version, 4.into());
@@ -1573,7 +1576,10 @@ async fn test_convert_to_owned_not_allowed() {
         .await
         .unwrap();
 
-    assert!(matches!(error.unwrap().kind(), MoveAbort(..)));
+    assert!(matches!(
+        error.unwrap().kind(),
+        SharedObjectOperationNotAllowed
+    ));
 
     let new_version = user_1.get_object_latest_version(shared_obj_id);
     assert_eq!(new_version, 4.into());
@@ -1602,7 +1608,10 @@ async fn test_freeze_not_allowed() {
         .await
         .unwrap();
 
-    assert!(matches!(error.unwrap().kind(), MoveAbort(..)));
+    assert!(matches!(
+        error.unwrap().kind(),
+        SharedObjectOperationNotAllowed
+    ));
 
     let new_version = user_1.get_object_latest_version(shared_obj_id);
     assert_eq!(new_version, 4.into());

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -419,7 +419,7 @@ ExecutionFailureStatus:
     30:
       SuiMoveVerificationTimedout: UNIT
     31:
-      SharedObjectWrapped: UNIT
+      SharedObjectOperationNotAllowed: UNIT
     32:
       InputObjectDeleted: UNIT
 ExecutionStatus:

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::test_scenario_tests {
-    use sui::dynamic_field as df;
     use sui::object;
     use sui::test_scenario as ts;
     use sui::transfer;
@@ -450,7 +449,7 @@ module sui::test_scenario_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = transfer::ESharedObjectOperationNotSupported)]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
     fun test_invalid_shared_usage() {
         let sender = @0x0;
         let scenario = ts::begin(sender);
@@ -718,7 +717,7 @@ module sui::test_scenario_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = df::ESharedObjectOperationNotSupported)]
+    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
     fun test_dynamic_object_field_shared_misuse() {
         let sender = @0x0;
         let scenario = ts::begin(sender);

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -183,8 +183,8 @@ pub enum ExecutionFailureStatus {
     )]
     SuiMoveVerificationTimedout,
 
-    #[error("Wrapping a shared object is not allowed.")]
-    SharedObjectWrapped,
+    #[error("The shared object operation is not allowed.")]
+    SharedObjectOperationNotAllowed,
 
     #[error("Certificate cannot be executed due to a dependency on a deleted shared object")]
     InputObjectDeleted,

--- a/crates/sui-types/tests/staged/exec_failure_status.yaml
+++ b/crates/sui-types/tests/staged/exec_failure_status.yaml
@@ -30,5 +30,5 @@
 28: WrittenObjectsTooLarge
 29: CertificateDenied
 30: SuiMoveVerificationTimedout
-31: SharedObjectWrapped
+31: SharedObjectOperationNotAllowed
 32: InputObjectDeleted

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -5,7 +5,7 @@ pub use checked::*;
 
 #[sui_macros::with_checked_arithmetic]
 mod checked {
-    use std::collections::{BTreeSet, HashSet};
+    use std::collections::BTreeSet;
     use std::{
         borrow::Borrow,
         collections::{BTreeMap, HashMap},
@@ -405,19 +405,6 @@ mod checked {
                 return Err(CommandArgumentError::InvalidObjectByValue);
             }
 
-            // ensure we don't transfer shared objects to new owners
-            if matches!(
-                input_metadata_opt,
-                Some(InputObjectMetadata::InputObject {
-                    owner: Owner::Shared { .. },
-                    ..
-                })
-            ) && matches!(command_kind, CommandKind::TransferObjects)
-                && shared_obj_deletion_enabled
-            {
-                return Err(CommandArgumentError::SharedObjectOperationNotAllowed);
-            }
-
             let val = if is_copyable {
                 val_opt.as_ref().unwrap().clone()
             } else {
@@ -718,7 +705,6 @@ mod checked {
             }
 
             let object_runtime: ObjectRuntime = native_extensions.remove();
-            let external_transfers = additional_writes.keys().copied().collect::<HashSet<_>>();
 
             let RuntimeResults {
                 writes,
@@ -731,18 +717,6 @@ mod checked {
                 remaining_events.is_empty(),
                 "Events should be taken after every Move call"
             );
-
-            for id in by_value_shared_objects {
-                if !writes.contains_key(&id)
-                    && !deleted_object_ids.contains_key(&id)
-                    && !external_transfers.contains(&id)
-                {
-                    return Err(ExecutionError::new(
-                        ExecutionErrorKind::SharedObjectWrapped,
-                        Some(format!("Wrapping shared object {} not allowed", id).into()),
-                    ));
-                }
-            }
 
             loaded_runtime_objects.extend(loaded_child_objects);
 
@@ -808,6 +782,42 @@ mod checked {
                 };
                 let object = Object::new_move(move_object, recipient, tx_digest);
                 written_objects.insert(id, object);
+            }
+
+            // Before finishing, ensure that any shared object taken by value by the transaction is either:
+            // 1. Mutated (and still has a shared ownership); or
+            // 2. Deleted.
+            // Otherwise, the shared object operation is not allowed and we fail the transaction.
+            for id in &by_value_shared_objects {
+                // If it's been written it must have been reshared so must still have an ownership
+                // of `Shared`.
+                if let Some(obj) = written_objects.get(id) {
+                    if !obj.is_shared() {
+                        return Err(ExecutionError::new(
+                            ExecutionErrorKind::SharedObjectOperationNotAllowed,
+                            Some(
+                                format!(
+                                    "Shared object operation on {} not allowed: \
+                                     cannot be frozen, transferred, or wrapped",
+                                    id
+                                )
+                                .into(),
+                            ),
+                        ));
+                    }
+                } else {
+                    // If it's not in the written objects, the object must have been deleted. Otherwise
+                    // it's an error.
+                    if !deleted_object_ids.contains_key(id) {
+                        return Err(ExecutionError::new(
+                            ExecutionErrorKind::SharedObjectOperationNotAllowed,
+                            Some(
+                                format!("Shared object operation on {} not allowed: \
+                                         shared objects used by value must be re-shared if not deleted", id).into(),
+                            ),
+                        ));
+                    }
+                }
             }
 
             let user_events = user_events

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transfer::{object_is_shared, E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED};
 use crate::{
     get_nested_struct_field, get_object_id,
     object_runtime::{object_store::ObjectResult, ObjectRuntime},
@@ -228,13 +227,6 @@ pub fn add_child_object(
             .dynamic_field_add_child_object_struct_tag_cost_per_byte
             * struct_tag_size.into()
     );
-
-    if object_is_shared(context, &child)? {
-        return Ok(NativeResult::err(
-            context.gas_used(),
-            E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED,
-        ));
-    }
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
     object_runtime.add_child_object(

--- a/sui-execution/next-vm/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/next-vm/sui-move-natives/src/dynamic_field.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transfer::{object_is_shared, E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED};
 use crate::{
     get_nested_struct_field, get_object_id,
     object_runtime::{object_store::ObjectResult, ObjectRuntime},
@@ -228,13 +227,6 @@ pub fn add_child_object(
             .dynamic_field_add_child_object_struct_tag_cost_per_byte
             * struct_tag_size.into()
     );
-
-    if object_is_shared(context, &child)? {
-        return Ok(NativeResult::err(
-            context.gas_used(),
-            E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED,
-        ));
-    }
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
     object_runtime.add_child_object(

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -738,7 +738,7 @@ mod checked {
                     && !external_transfers.contains(&id)
                 {
                     return Err(ExecutionError::new(
-                        ExecutionErrorKind::SharedObjectWrapped,
+                        ExecutionErrorKind::SharedObjectOperationNotAllowed,
                         Some(format!("Wrapping shared object {} not allowed", id).into()),
                     ));
                 }

--- a/sui-execution/v1/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/v1/sui-move-natives/src/dynamic_field.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transfer::{object_is_shared, E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED};
 use crate::{
     get_nested_struct_field, get_object_id,
     object_runtime::{object_store::ObjectResult, ObjectRuntime},
@@ -228,13 +227,6 @@ pub fn add_child_object(
             .dynamic_field_add_child_object_struct_tag_cost_per_byte
             * struct_tag_size.into()
     );
-
-    if object_is_shared(context, &child)? {
-        return Ok(NativeResult::err(
-            context.gas_used(),
-            E_SHARED_OBJECT_OPERATION_NOT_SUPPORTED,
-        ));
-    }
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
     object_runtime.add_child_object(


### PR DESCRIPTION
## Description 

Simplifies checks when taking a shared object by value so they're less ad-hoc

## Test Plan 

Make sure existing tests pass, and added additional tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
