### PR TITLE
indexer: object snapshot for cp consistent read

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/down.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/down.sql
@@ -1,3 +1,3 @@
--- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS objects;
 DROP TABLE IF EXISTS objects_history;
+DROP TABLE IF EXISTS objects_snapshot;

--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
@@ -59,3 +59,24 @@ CREATE TABLE objects_history (
 ) PARTITION BY RANGE (checkpoint_sequence_number);
 CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 -- TODO(gegaowp): add corresponding indices for consistent reads of objects_history table
+
+-- snapshot table by folding objects_history table until certain epoch,
+-- effectively the snapshot of objects at the same epoch,
+-- except that it also includes deleted or wrapped objects with the corresponding object_status.
+CREATE TABLE objects_snapshot (
+    object_id                   bytea         PRIMARY KEY,
+    object_version              bigint        NOT NULL,
+    object_status               smallint      NOT NULL,
+    object_digest               bytea,
+    checkpoint_sequence_number  bigint        NOT NULL,
+    owner_type                  smallint,
+    owner_id                    bytea,
+    object_type                 text,
+    serialized_object           bytea,
+    coin_type                   text,
+    coin_balance                bigint,
+    df_kind                     smallint,
+    df_name                     bytea,
+    df_object_type              text,
+    df_object_id                bytea
+);

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -195,6 +195,26 @@ diesel::table! {
 }
 
 diesel::table! {
+    objects_snapshot (object_id) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        object_status -> Int2,
+        object_digest -> Nullable<Bytea>,
+        checkpoint_sequence_number -> Int8,
+        owner_type -> Nullable<Int2>,
+        owner_id -> Nullable<Bytea>,
+        object_type -> Nullable<Text>,
+        serialized_object -> Nullable<Bytea>,
+        coin_type -> Nullable<Text>,
+        coin_balance -> Nullable<Int8>,
+        df_kind -> Nullable<Int2>,
+        df_name -> Nullable<Bytea>,
+        df_object_type -> Nullable<Text>,
+        df_object_id -> Nullable<Bytea>,
+    }
+}
+
+diesel::table! {
     packages (package_id) {
         package_id -> Bytea,
         move_package -> Bytea,
@@ -311,6 +331,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     objects,
     objects_history,
     objects_history_partition_0,
+    objects_snapshot,
     packages,
     transactions,
     transactions_partition_0,

--- a/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
@@ -704,15 +704,21 @@ impl PgIndexerStoreV2 {
                 let table_partitions = self.partition_manager.get_table_partitions()?;
                 for (table, last_partition) in table_partitions {
                     self.partition_manager.advance_table_epoch_partition(
-                        table,
+                        table.clone(),
                         last_partition,
                         &epoch_partition_data,
                     )?;
+                    // update objects_snapshot with objects_history of last epoch
+                    if table == *"objects_history" {
+                        self.partition_manager
+                            .update_objects_snapshot(&epoch_partition_data)?;
+                    }
                 }
             } else {
                 tracing::error!("Last epoch: {} from PostgresDB is None.", last_epoch_id);
             }
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

impl objects_snapshot table, instead of taking literal snapshots from objects, this snapshot is generated by folding the objects_history and only keeping data with max object version to avoid requirements of DB snapshot features and the related migration costs.


## Test Plan 

- local run to make sure snapshot table is populated
- verify that after generating snapshot from a epoch, total number of objects in snapshot is equal to distinct object id in the past partitions of objects_history

```
checking after epoch 9, where the next cp is 699410

SELECT COUNT(DISTINCT object_id) from objects_history WHERE checkpoint_sequence_number < 699410;
2079

SELECT COUNT(*) FROM objects_snapshot;
2079
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
