### PR TITLE
move: set Move.lock path via function param

### DIFF
--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -218,15 +218,15 @@ impl BuildConfig {
             .set_silence_warnings(self.silence_warnings)
     }
 
-    pub fn update_lock_file_toolchain_version(&self, compiler_version: String) -> Result<()> {
+    pub fn update_lock_file_toolchain_version(
+        &self,
+        path: PathBuf,
+        compiler_version: String,
+    ) -> Result<()> {
         let Some(lock_file) = self.lock_file.as_ref() else {
             return Ok(());
         };
-        let install_dir = self
-            .install_dir
-            .clone()
-            .unwrap_or_else(|| PathBuf::from("."));
-        let mut lock = LockFile::from(install_dir, lock_file)?;
+        let mut lock = LockFile::from(path, lock_file)?;
         lock.seek(SeekFrom::Start(0))?;
         update_compiler_toolchain(
             &mut lock,

--- a/external-crates/move/crates/move-package/src/lock_file/mod.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/mod.rs
@@ -61,8 +61,8 @@ impl LockFile {
     }
 
     /// Creates a temporary copy of an existing lock file in a sub-directory of `install_dir` and returns the handle.
-    pub fn from(install_dir: PathBuf, lock_file: &PathBuf) -> Result<LockFile> {
-        let mut locks_dir = install_dir;
+    pub fn from(path: PathBuf, lock_file: &PathBuf) -> Result<LockFile> {
+        let mut locks_dir = path;
         locks_dir.extend([
             CompiledPackageLayout::Root.path(),
             CompiledPackageLayout::LockFiles.path(),

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -82,7 +82,8 @@ fn update_lock_file_toolchain_version() {
     build_config.default_flavor = Some(Flavor::Sui);
     build_config.default_edition = Some(Edition::E2024_ALPHA);
     build_config.lock_file = Some(lock_path.clone());
-    let _ = build_config.update_lock_file_toolchain_version("0.0.1".into());
+    let _ =
+        build_config.update_lock_file_toolchain_version(pkg.path().to_path_buf(), "0.0.1".into());
 
     let mut lock_file = File::open(lock_path).unwrap();
     let toolchain_version =


### PR DESCRIPTION
## Description 

Set up for next PR.

I thought I could rely on `BuildConfig.install_dir` to give the package path, but it turns out it is generally `None` despite the[ docs saying it is set to the current directory by default](https://sourcegraph.com/github.com/MystenLabs/sui@aa1ba3641993013e15510797f52eb16481199901/-/blob/external-crates/move/crates/move-package/src/lib.rs?L57-59) (maybe we mean that, when this value is `None`, it is the current directory). Either way it's confusing so I'll just use the handle to the package path.

## Test Plan 

Update existing test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
