### PR TITLE
[GraphQL/TransactionBlock] TransactionBlock representation

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1649,25 +1649,26 @@ type SystemParameters {
 
 type TransactionBlock {
 	"""
-	The effects field captures the results to the chain of executing this transaction
+	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
+	This serves as a unique id for the block on chain.
 	"""
-	effects: TransactionBlockEffects
+	digest: String!
 	"""
-	The address of the user sending this transaction block
+	The address corresponding to the public key that signed this transaction.
 	"""
 	sender: Address
 	"""
-	The transaction block data in BCS format.
-	This includes data on the sender, inputs, sponsor, gas inputs, individual transactions, and user signatures.
-	"""
-	bcs: Base64
-	"""
-	The gas input field provides information on what objects were used as gas
-	As well as the owner of the gas object(s) and information on the gas price and budget
-	If the owner of the gas object(s) is not the same as the sender,
-	the transaction block is a sponsored transaction block.
+	The gas input field provides information on what objects were used as gas as well as the
+	owner of the gas object(s) and information on the gas price and budget.
+	
+	If the owner of the gas object(s) is not the same as the sender, the transaction block is a
+	sponsored transaction block.
 	"""
 	gasInput: GasInput
+	"""
+	The type of transaction this is as well as the commmands and/or parameters comprising the
+	transaction of this kind.
+	"""
 	kind: TransactionBlockKind
 	"""
 	A list of all signatures, Base64-encoded, from senders, and potentially the gas owner if
@@ -1675,16 +1676,19 @@ type TransactionBlock {
 	"""
 	signatures: [Base64!]
 	"""
-	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
-	This serves as a unique id for the block on chain
+	The effects field captures the results to the chain of executing this transaction.
 	"""
-	digest: String!
+	effects: TransactionBlockEffects
 	"""
-	This field is set by senders of a transaction block
-	It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid
-	By default, there is no deadline for when a transaction must execute
+	This field is set by senders of a transaction block. It is an epoch reference that sets a
+	deadline after which validators will no longer consider the transaction valid. By default,
+	there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
+	"""
+	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	"""
+	bcs: Base64
 }
 
 type TransactionBlockConnection {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1666,7 +1666,7 @@ type TransactionBlock {
 	"""
 	gasInput: GasInput
 	"""
-	The type of transaction this is as well as the commmands and/or parameters comprising the
+	The type of this transaction as well as the commmands and/or parameters comprising the
 	transaction of this kind.
 	"""
 	kind: TransactionBlockKind

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,37 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use async_graphql::*;
+use fastcrypto::encoding::{Base58, Encoding};
+use sui_indexer::models_v2::transactions::StoredTransaction;
+use sui_types::transaction::{
+    SenderSignedData as NativeSenderSignedData, TransactionDataAPI, TransactionExpiration,
+};
+
+use crate::{context_data::db_data_provider::PgManager, error::Error};
 
 use super::{
-    address::Address, base64::Base64, digest::Digest, epoch::Epoch, gas::GasInput,
-    sui_address::SuiAddress, transaction_block_effects::TransactionBlockEffects,
+    address::Address, base64::Base64, epoch::Epoch, gas::GasInput, sui_address::SuiAddress,
+    transaction_block_effects::TransactionBlockEffects,
     transaction_block_kind::TransactionBlockKind,
 };
-use crate::context_data::db_data_provider::PgManager;
-use async_graphql::*;
 
-#[derive(SimpleObject, Clone)]
-#[graphql(complex)]
+#[derive(Clone)]
 pub(crate) struct TransactionBlock {
-    #[graphql(skip)]
-    pub digest: Digest,
-    /// The effects field captures the results to the chain of executing this transaction
-    pub effects: Option<TransactionBlockEffects>,
-    /// The address of the user sending this transaction block
-    pub sender: Option<Address>,
-    /// The transaction block data in BCS format.
-    /// This includes data on the sender, inputs, sponsor, gas inputs, individual transactions, and user signatures.
-    pub bcs: Option<Base64>,
-    /// The gas input field provides information on what objects were used as gas
-    /// As well as the owner of the gas object(s) and information on the gas price and budget
-    /// If the owner of the gas object(s) is not the same as the sender,
-    /// the transaction block is a sponsored transaction block.
-    pub gas_input: Option<GasInput>,
-    #[graphql(skip)]
-    pub epoch_id: Option<u64>,
-    pub kind: Option<TransactionBlockKind>,
-    /// A list of all signatures, Base64-encoded, from senders, and potentially the gas owner if
-    /// this is a sponsored transaction.
-    pub signatures: Option<Vec<Base64>>,
+    /// Representation of transaction data in the Indexer's Store. The indexer stores the
+    /// transaction data and its effects together, in one table.
+    pub stored: StoredTransaction,
+
+    /// Deserialized representation of `stored.raw_transaction`.
+    pub native: NativeSenderSignedData,
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
@@ -62,28 +53,87 @@ pub(crate) struct TransactionBlockFilter {
     pub transaction_ids: Option<Vec<String>>,
 }
 
-#[ComplexObject]
+#[Object]
 impl TransactionBlock {
     /// A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
-    /// This serves as a unique id for the block on chain
+    /// This serves as a unique id for the block on chain.
     async fn digest(&self) -> String {
-        self.digest.to_string()
+        Base58::encode(&self.stored.transaction_digest)
     }
 
-    /// This field is set by senders of a transaction block
-    /// It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid
-    /// By default, there is no deadline for when a transaction must execute
+    /// The address corresponding to the public key that signed this transaction.
+    async fn sender(&self) -> Option<Address> {
+        let sender = self.native.transaction_data().sender();
+        Some(Address {
+            address: SuiAddress::from(sender),
+        })
+    }
+
+    /// The gas input field provides information on what objects were used as gas as well as the
+    /// owner of the gas object(s) and information on the gas price and budget.
+    ///
+    /// If the owner of the gas object(s) is not the same as the sender, the transaction block is a
+    /// sponsored transaction block.
+    async fn gas_input(&self) -> Option<GasInput> {
+        Some(GasInput::from(self.native.transaction_data().gas_data()))
+    }
+
+    /// The type of transaction this is as well as the commmands and/or parameters comprising the
+    /// transaction of this kind.
+    async fn kind(&self) -> Option<TransactionBlockKind> {
+        Some(TransactionBlockKind::from(
+            self.native.transaction_data().kind(),
+        ))
+    }
+
+    /// A list of all signatures, Base64-encoded, from senders, and potentially the gas owner if
+    /// this is a sponsored transaction.
+    async fn signatures(&self) -> Option<Vec<Base64>> {
+        Some(
+            self.native
+                .tx_signatures()
+                .iter()
+                .map(|s| Base64::from(s.as_ref()))
+                .collect(),
+        )
+    }
+
+    /// The effects field captures the results to the chain of executing this transaction.
+    async fn effects(&self) -> Result<Option<TransactionBlockEffects>> {
+        Ok(Some(
+            TransactionBlockEffects::try_from(self.stored.clone()).extend()?,
+        ))
+    }
+
+    /// This field is set by senders of a transaction block. It is an epoch reference that sets a
+    /// deadline after which validators will no longer consider the transaction valid. By default,
+    /// there is no deadline for when a transaction must execute.
     async fn expiration(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        match self.epoch_id {
-            None => Ok(None),
-            Some(epoch_id) => {
-                let epoch = ctx
-                    .data_unchecked::<PgManager>()
-                    .fetch_epoch_strict(epoch_id)
-                    .await
-                    .extend()?;
-                Ok(Some(epoch))
-            }
-        }
+        let TransactionExpiration::Epoch(id) = self.native.transaction_data().expiration() else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            ctx.data_unchecked::<PgManager>()
+                .fetch_epoch_strict(*id)
+                .await
+                .extend()?,
+        ))
+    }
+
+    /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+    async fn bcs(&self) -> Option<Base64> {
+        Some(Base64::from(&self.stored.raw_transaction))
+    }
+}
+
+impl TryFrom<StoredTransaction> for TransactionBlock {
+    type Error = Error;
+
+    fn try_from(stored: StoredTransaction) -> Result<Self, Error> {
+        let native = bcs::from_bytes(&stored.raw_transaction)
+            .map_err(|e| Error::Internal(format!("Error deserializing transaction block: {e}")))?;
+
+        Ok(TransactionBlock { stored, native })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -78,7 +78,7 @@ impl TransactionBlock {
         Some(GasInput::from(self.native.transaction_data().gas_data()))
     }
 
-    /// The type of transaction this is as well as the commmands and/or parameters comprising the
+    /// The type of this transaction as well as the commmands and/or parameters comprising the
     /// transaction of this kind.
     async fn kind(&self) -> Option<TransactionBlockKind> {
         Some(TransactionBlockKind::from(

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -35,18 +35,8 @@ pub enum ExecutionStatus {
 #[Object]
 impl TransactionBlockEffects {
     /// The transaction that ran to produce these effects.
-    async fn transaction_block(&self, ctx: &Context<'_>) -> Result<TransactionBlock> {
-        let digest = self.native.transaction_digest().to_string();
-        ctx.data_unchecked::<PgManager>()
-            .fetch_tx(digest.as_str())
-            .await
-            .extend()?
-            .ok_or_else(|| {
-                Error::Internal(format!(
-                    "Failed to get transaction {digest} from its effects"
-                ))
-            })
-            .extend()
+    async fn transaction_block(&self) -> Result<TransactionBlock> {
+        TransactionBlock::try_from(self.stored.clone()).extend()
     }
 
     /// Whether the transaction executed successfully or not.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1653,25 +1653,26 @@ type SystemParameters {
 
 type TransactionBlock {
 	"""
-	The effects field captures the results to the chain of executing this transaction
+	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
+	This serves as a unique id for the block on chain.
 	"""
-	effects: TransactionBlockEffects
+	digest: String!
 	"""
-	The address of the user sending this transaction block
+	The address corresponding to the public key that signed this transaction.
 	"""
 	sender: Address
 	"""
-	The transaction block data in BCS format.
-	This includes data on the sender, inputs, sponsor, gas inputs, individual transactions, and user signatures.
-	"""
-	bcs: Base64
-	"""
-	The gas input field provides information on what objects were used as gas
-	As well as the owner of the gas object(s) and information on the gas price and budget
-	If the owner of the gas object(s) is not the same as the sender,
-	the transaction block is a sponsored transaction block.
+	The gas input field provides information on what objects were used as gas as well as the
+	owner of the gas object(s) and information on the gas price and budget.
+	
+	If the owner of the gas object(s) is not the same as the sender, the transaction block is a
+	sponsored transaction block.
 	"""
 	gasInput: GasInput
+	"""
+	The type of transaction this is as well as the commmands and/or parameters comprising the
+	transaction of this kind.
+	"""
 	kind: TransactionBlockKind
 	"""
 	A list of all signatures, Base64-encoded, from senders, and potentially the gas owner if
@@ -1679,16 +1680,19 @@ type TransactionBlock {
 	"""
 	signatures: [Base64!]
 	"""
-	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
-	This serves as a unique id for the block on chain
+	The effects field captures the results to the chain of executing this transaction.
 	"""
-	digest: String!
+	effects: TransactionBlockEffects
 	"""
-	This field is set by senders of a transaction block
-	It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid
-	By default, there is no deadline for when a transaction must execute
+	This field is set by senders of a transaction block. It is an epoch reference that sets a
+	deadline after which validators will no longer consider the transaction valid. By default,
+	there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
+	"""
+	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	"""
+	bcs: Base64
 }
 
 type TransactionBlockConnection {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1670,7 +1670,7 @@ type TransactionBlock {
 	"""
 	gasInput: GasInput
 	"""
-	The type of transaction this is as well as the commmands and/or parameters comprising the
+	The type of this transaction as well as the commmands and/or parameters comprising the
 	transaction of this kind.
 	"""
 	kind: TransactionBlockKind


### PR DESCRIPTION
## Description

Represent a `TransactionBlock` by its stored form and its native form, similar to `TransactionBlockEffects`, `Object`, etc.  This simplifies the process of translating between transactions and their effects.

This PR also cleans up the doc comments for the fields of `TransactionBlock` and orders its fields as in the draft schema.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack

- #15095
- #15145 