### PR TITLE
[GraphQL/TransactionBlock] No sender for system transactions

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -7,9 +7,7 @@ Response: {
       "nodes": [
         {
           "digest": "4maneZK422m9xLj5tELwFN3tSm1ZxA33hnM9dwffH6eb",
-          "sender": {
-            "location": "0x0000000000000000000000000000000000000000000000000000000000000000"
-          },
+          "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
           ],
@@ -252,9 +250,7 @@ Response: {
       "nodes": [
         {
           "digest": "CHyKA8xirNCGtcDMLJcxBZsxGyAA7DNrzDEVodxZzNn",
-          "sender": {
-            "location": "0x0000000000000000000000000000000000000000000000000000000000000000"
-          },
+          "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
           ],
@@ -334,9 +330,7 @@ Response: {
       "nodes": [
         {
           "digest": "fvUnamxVj1m1M4DZ8dryuzqrjYRvLDHNjexNwxc6HA7",
-          "sender": {
-            "location": "0x0000000000000000000000000000000000000000000000000000000000000000"
-          },
+          "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
           ],

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1654,7 +1654,8 @@ type TransactionBlock {
 	"""
 	digest: String!
 	"""
-	The address corresponding to the public key that signed this transaction.
+	The address corresponding to the public key that signed this transaction. System
+	transactions do not have senders.
 	"""
 	sender: Address
 	"""

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -3,8 +3,11 @@
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_indexer::models_v2::transactions::StoredTransaction;
-use sui_types::transaction::{
-    SenderSignedData as NativeSenderSignedData, TransactionDataAPI, TransactionExpiration,
+use sui_types::{
+    base_types::SuiAddress as NativeSuiAddress,
+    transaction::{
+        SenderSignedData as NativeSenderSignedData, TransactionDataAPI, TransactionExpiration,
+    },
 };
 
 use crate::{context_data::db_data_provider::PgManager, error::Error};
@@ -61,10 +64,11 @@ impl TransactionBlock {
         Base58::encode(&self.stored.transaction_digest)
     }
 
-    /// The address corresponding to the public key that signed this transaction.
+    /// The address corresponding to the public key that signed this transaction. System
+    /// transactions do not have senders.
     async fn sender(&self) -> Option<Address> {
         let sender = self.native.transaction_data().sender();
-        Some(Address {
+        (sender != NativeSuiAddress::ZERO).then(|| Address {
             address: SuiAddress::from(sender),
         })
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1658,7 +1658,8 @@ type TransactionBlock {
 	"""
 	digest: String!
 	"""
-	The address corresponding to the public key that signed this transaction.
+	The address corresponding to the public key that signed this transaction. System
+	transactions do not have senders.
 	"""
 	sender: Address
 	"""


### PR DESCRIPTION
## Description

System transactions have a sentinel `0x0` sender -- recognise that and represent that as the transaction having no sender, rather than providing access to the `0x0` address.

## Test Plan

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- transactions/system.move
```

## Stack

- #15095 
- #15145 
- #15146 