### PR TITLE
Add txn and effects as json in analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11125,6 +11125,7 @@ dependencies = [
  "prometheus",
  "rocksdb",
  "serde",
+ "serde_json",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "sui-analytics-indexer-derive",

--- a/crates/sui-analytics-indexer/Cargo.toml
+++ b/crates/sui-analytics-indexer/Cargo.toml
@@ -27,6 +27,7 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 url.workspace = true
+serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 parquet.workspace = true

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
+use serde::Serialize;
 use tracing::error;
 
 use sui_indexer::framework::Handler;
@@ -120,7 +121,8 @@ impl TransactionHandler {
                 error!("Mismatch in move calls count: commands {move_calls_count} != {move_calls} calls");
             }
         }
-
+        let transaction_json = serde_json::to_string(&transaction)?;
+        let effects_json = serde_json::to_string(&checkpoint_transaction.effects)?;
         let entry = TransactionEntry {
             transaction_digest,
             checkpoint,
@@ -169,6 +171,8 @@ impl TransactionHandler {
 
             has_zklogin_sig: transaction.has_zklogin_sig(),
             has_upgraded_multisig: transaction.has_upgraded_multisig(),
+            transaction_json: Some(transaction_json),
+            effects_json: Some(effects_json),
         };
         self.transactions.push(entry);
     }

--- a/crates/sui-analytics-indexer/src/tables.rs
+++ b/crates/sui-analytics-indexer/src/tables.rs
@@ -96,6 +96,8 @@ pub(crate) struct TransactionEntry {
     pub(crate) raw_transaction: String,
     pub(crate) has_zklogin_sig: bool,
     pub(crate) has_upgraded_multisig: bool,
+    pub(crate) transaction_json: Option<String>,
+    pub(crate) effects_json: Option<String>,
 }
 
 // Event information.


### PR DESCRIPTION
## Description 

Given the powerful json querying supported in analytics, we can benefit a lot from storing these structures as json. Also, we cannot extract every single detail out of these structs as columns without knowing what might be useful or needed in the future. 
For example - we recently wanted to look at user signatures for a transaction but it wasn't being captured in any field. If we have these as json, we can query anything in the future
## Test Plan 

Existing tests
