### PR TITLE
indexer: system states for graphQL

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/epoch/epoch.exp
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/epoch.exp
@@ -43,12 +43,12 @@ Response: {
   "data": {
     "epoch": {
       "validatorSet": {
-        "totalStake": "20000010003000000"
+        "totalStake": "20000010002000000"
       },
       "totalGasFees": "1000000",
       "totalStakeRewards": "1000000",
       "totalStakeSubsidies": "0",
-      "fundSize": "16096040",
+      "fundSize": "15098160",
       "fundInflow": "1976000",
       "fundOutflow": "978120",
       "netInflow": "997880"

--- a/crates/sui-indexer/migrations_v2/2023-08-19-044052_epochs/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044052_epochs/up.sql
@@ -1,11 +1,13 @@
 CREATE TABLE epochs
 (
     epoch                           BIGINT      PRIMARY KEY,
-    validators                      bytea[]     NOT NULL,
     first_checkpoint_id             BIGINT      NOT NULL,
     epoch_start_timestamp           BIGINT      NOT NULL,
     reference_gas_price             BIGINT      NOT NULL,
     protocol_version                BIGINT      NOT NULL,
+    total_stake                     BIGINT      NOT NULL,
+    storage_fund_balance            BIGINT      NOT NULL,
+    system_state                    bytea       NOT NULL,
     -- The following fields are nullable because they are filled in
     -- only at the end of an epoch.
     epoch_total_transactions        BIGINT,
@@ -16,17 +18,11 @@ CREATE TABLE epochs
     storage_fund_reinvestment       BIGINT,
     storage_charge                  BIGINT,
     storage_rebate                  BIGINT,
-    storage_fund_balance            BIGINT,
     stake_subsidy_amount            BIGINT,
     total_gas_fees                  BIGINT,
     total_stake_rewards_distributed BIGINT,
     leftover_storage_fund_inflow    BIGINT,
-    -- total stake after advancing to the next epoch
-    new_total_stake                 BIGINT,
     -- bcs serialized Vec<EpochCommitment> bytes, found in last CheckpointSummary
     -- of the epoch
-    epoch_commitments               bytea,
-    -- They are here as part of EndofEpochData that would be returned in `get_epoch(s)`
-    next_epoch_reference_gas_price  BIGINT,
-    next_epoch_protocol_version     BIGINT
+    epoch_commitments               bytea
 );

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -238,6 +238,7 @@ where
                 new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                     system_state,
                     0, //first_checkpoint_id
+                    None,
                 ),
             }));
         }
@@ -286,6 +287,7 @@ where
             new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                 system_state,
                 checkpoint_summary.sequence_number + 1, // first_checkpoint_id
+                Some(&event),
             ),
         }))
     }

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -183,7 +183,7 @@ async fn commit_checkpoints<S>(
             .tap_err(|e| {
                 error!("Failed to advance epoch with error: {}", e.to_string());
             })
-            .expect("Persisting data into DB should not fail.");
+            .expect("Advancing epochs in DB should not fail.");
         metrics.total_epoch_committed.inc();
     }
 

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -7,46 +7,43 @@ use crate::errors::IndexerError;
 use crate::schema_v2::epochs;
 use crate::types_v2::IndexedEpochInfo;
 use sui_json_rpc_types::{EndOfEpochInfo, EpochInfo};
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
 #[diesel(table_name = epochs)]
 pub struct StoredEpochInfo {
     pub epoch: i64,
-    pub validators: Vec<Option<Vec<u8>>>,
     pub first_checkpoint_id: i64,
     pub epoch_start_timestamp: i64,
     pub reference_gas_price: i64,
     pub protocol_version: i64,
+    pub total_stake: i64,
+    pub storage_fund_balance: i64,
+    pub system_state: Vec<u8>,
     pub epoch_total_transactions: Option<i64>,
     pub last_checkpoint_id: Option<i64>,
     pub epoch_end_timestamp: Option<i64>,
     pub storage_fund_reinvestment: Option<i64>,
     pub storage_charge: Option<i64>,
     pub storage_rebate: Option<i64>,
-    pub storage_fund_balance: Option<i64>,
     pub stake_subsidy_amount: Option<i64>,
     pub total_gas_fees: Option<i64>,
     pub total_stake_rewards_distributed: Option<i64>,
     pub leftover_storage_fund_inflow: Option<i64>,
-    pub new_total_stake: Option<i64>,
     pub epoch_commitments: Option<Vec<u8>>,
-    pub next_epoch_reference_gas_price: Option<i64>,
-    pub next_epoch_protocol_version: Option<i64>,
 }
 
 impl StoredEpochInfo {
     pub fn from_epoch_beginning_info(e: &IndexedEpochInfo) -> Self {
         Self {
             epoch: e.epoch as i64,
-            validators: e
-                .validators
-                .iter()
-                .map(|v| Some(bcs::to_bytes(v).unwrap()))
-                .collect(),
             first_checkpoint_id: e.first_checkpoint_id as i64,
             epoch_start_timestamp: e.epoch_start_timestamp as i64,
             reference_gas_price: e.reference_gas_price as i64,
             protocol_version: e.protocol_version as i64,
+            total_stake: e.total_stake as i64,
+            storage_fund_balance: e.storage_fund_balance as i64,
+            system_state: e.system_state.clone(),
             ..Default::default()
         }
     }
@@ -60,28 +57,26 @@ impl StoredEpochInfo {
             storage_fund_reinvestment: e.storage_fund_reinvestment.map(|v| v as i64),
             storage_charge: e.storage_charge.map(|v| v as i64),
             storage_rebate: e.storage_rebate.map(|v| v as i64),
-            storage_fund_balance: e.storage_fund_balance.map(|v| v as i64),
             stake_subsidy_amount: e.stake_subsidy_amount.map(|v| v as i64),
             total_gas_fees: e.total_gas_fees.map(|v| v as i64),
             total_stake_rewards_distributed: e.total_stake_rewards_distributed.map(|v| v as i64),
             leftover_storage_fund_inflow: e.leftover_storage_fund_inflow.map(|v| v as i64),
-            new_total_stake: e.new_total_stake.map(|v| v as i64),
             epoch_commitments: e
                 .epoch_commitments
                 .as_ref()
                 .map(|v| bcs::to_bytes(&v).unwrap()),
-            next_epoch_reference_gas_price: e.next_epoch_reference_gas_price.map(|v| v as i64),
-            next_epoch_protocol_version: e.next_epoch_protocol_version.map(|v| v as i64),
 
             // For the following fields:
             // we don't update these columns when persisting EndOfEpoch data.
             // However if the data is partial, diesel would interpret them
             // as Null and hence cause errors.
-            validators: vec![],
             first_checkpoint_id: 0,
             epoch_start_timestamp: 0,
             reference_gas_price: 0,
             protocol_version: 0,
+            total_stake: 0,
+            storage_fund_balance: 0,
+            system_state: vec![],
         }
     }
 }
@@ -92,12 +87,12 @@ impl From<&StoredEpochInfo> for Option<EndOfEpochInfo> {
             reference_gas_price: (info.reference_gas_price as u64),
             protocol_version: (info.protocol_version as u64),
             last_checkpoint_id: info.last_checkpoint_id.map(|v| v as u64)?,
-            total_stake: info.new_total_stake.map(|v| v as u64)?,
+            total_stake: info.total_stake as u64,
+            storage_fund_balance: info.storage_fund_balance as u64,
             epoch_end_timestamp: info.epoch_end_timestamp.map(|v| v as u64)?,
             storage_fund_reinvestment: info.storage_fund_reinvestment.map(|v| v as u64)?,
             storage_charge: info.storage_charge.map(|v| v as u64)?,
             storage_rebate: info.storage_rebate.map(|v| v as u64)?,
-            storage_fund_balance: info.storage_fund_balance.map(|v| v as u64)?,
             stake_subsidy_amount: info.stake_subsidy_amount.map(|v| v as u64)?,
             total_gas_fees: info.total_gas_fees.map(|v| v as u64)?,
             total_stake_rewards_distributed: info
@@ -113,24 +108,16 @@ impl TryFrom<StoredEpochInfo> for EpochInfo {
 
     fn try_from(value: StoredEpochInfo) -> Result<Self, Self::Error> {
         let epoch = value.epoch as u64;
-
         let end_of_epoch_info = (&value).into();
-
-        let validators = value
-            .validators
-            .into_iter()
-            .flatten()
-            .map(|v| {
-                bcs::from_bytes(&v).map_err(|_| {
-                    IndexerError::PersistentStorageDataCorruptionError(format!(
-                        "Failed to deserialize `validators` for epoch {epoch}",
-                    ))
-                })
-            })
-            .collect::<Result<Vec<_>, IndexerError>>()?;
+        let system_state: SuiSystemStateSummary =
+            bcs::from_bytes(&value.system_state).map_err(|_| {
+                IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "Failed to deserialize `system_state` for epoch {epoch}",
+                ))
+            })?;
         Ok(EpochInfo {
             epoch: value.epoch as u64,
-            validators,
+            validators: system_state.active_validators,
             epoch_total_transactions: value.epoch_total_transactions.unwrap_or(0) as u64,
             first_checkpoint_id: value.first_checkpoint_id as u64,
             epoch_start_timestamp: value.epoch_start_timestamp as u64,
@@ -138,4 +125,15 @@ impl TryFrom<StoredEpochInfo> for EpochInfo {
             reference_gas_price: Some(value.reference_gas_price as u64),
         })
     }
+}
+
+#[derive(Queryable)]
+pub struct EpochId {
+    pub id: i64,
+}
+
+#[derive(Queryable)]
+pub struct EpochSystemState {
+    pub epoch: i64,
+    pub system_state: Vec<u8>,
 }

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -74,26 +74,24 @@ diesel::table! {
 diesel::table! {
     epochs (epoch) {
         epoch -> Int8,
-        validators -> Array<Nullable<Bytea>>,
         first_checkpoint_id -> Int8,
         epoch_start_timestamp -> Int8,
         reference_gas_price -> Int8,
         protocol_version -> Int8,
+        total_stake -> Int8,
+        storage_fund_balance -> Int8,
+        system_state -> Bytea,
         epoch_total_transactions -> Nullable<Int8>,
         last_checkpoint_id -> Nullable<Int8>,
         epoch_end_timestamp -> Nullable<Int8>,
         storage_fund_reinvestment -> Nullable<Int8>,
         storage_charge -> Nullable<Int8>,
         storage_rebate -> Nullable<Int8>,
-        storage_fund_balance -> Nullable<Int8>,
         stake_subsidy_amount -> Nullable<Int8>,
         total_gas_fees -> Nullable<Int8>,
         total_stake_rewards_distributed -> Nullable<Int8>,
         leftover_storage_fund_inflow -> Nullable<Int8>,
-        new_total_stake -> Nullable<Int8>,
         epoch_commitments -> Nullable<Bytea>,
-        next_epoch_reference_gas_price -> Nullable<Int8>,
-        next_epoch_protocol_version -> Nullable<Int8>,
     }
 }
 

--- a/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
@@ -653,19 +653,13 @@ impl PgIndexerStoreV2 {
                                 .eq(excluded(epochs::storage_fund_reinvestment)),
                             epochs::storage_charge.eq(excluded(epochs::storage_charge)),
                             epochs::storage_rebate.eq(excluded(epochs::storage_rebate)),
-                            epochs::storage_fund_balance.eq(excluded(epochs::storage_fund_balance)),
                             epochs::stake_subsidy_amount.eq(excluded(epochs::stake_subsidy_amount)),
                             epochs::total_gas_fees.eq(excluded(epochs::total_gas_fees)),
                             epochs::total_stake_rewards_distributed
                                 .eq(excluded(epochs::total_stake_rewards_distributed)),
                             epochs::leftover_storage_fund_inflow
                                 .eq(excluded(epochs::leftover_storage_fund_inflow)),
-                            epochs::new_total_stake.eq(excluded(epochs::new_total_stake)),
                             epochs::epoch_commitments.eq(excluded(epochs::epoch_commitments)),
-                            epochs::next_epoch_reference_gas_price
-                                .eq(excluded(epochs::next_epoch_reference_gas_price)),
-                            epochs::next_epoch_protocol_version
-                                .eq(excluded(epochs::next_epoch_protocol_version)),
                         ))
                         .execute(conn)?;
                 }


### PR DESCRIPTION
## Description 

GraphQL server also needs system state object for each epoch.
Instead of adding it to the existing epochs table, this PR adds a new table b/c epoch rows have been sorta heavy and cause extra latency on Explorer, so we will want to keep it lean.

## Test Plan 

local run to make sure system states table is populated for each epoch

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
