### PR TITLE
[cli/alias] Keytool update alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12100,6 +12100,7 @@ dependencies = [
  "bip32",
  "fastcrypto",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "shared-crypto",

--- a/crates/sui-keys/Cargo.toml
+++ b/crates/sui-keys/Cargo.toml
@@ -19,6 +19,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 shared-crypto.workspace = true
 sui-types.workspace = true
 workspace-hack.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -44,29 +44,20 @@ pub trait AccountKeystore: Send + Sync {
     ) -> Result<Signature, signature::Error>
     where
         T: Serialize;
-
     fn addresses(&self) -> Vec<SuiAddress> {
         self.keys().iter().map(|k| k.into()).collect()
     }
     fn addresses_with_alias(&self) -> Vec<(&SuiAddress, &Alias)>;
-
     fn aliases(&self) -> Vec<&Alias>;
-
-    /// Return the mutable Alias objects in the keystore.
-    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
-        self.aliases.values_mut().collect()
-    }
-
+    fn aliases_mut(&mut self) -> Vec<&mut Alias>;
     fn alias_names(&self) -> Vec<&str> {
         self.aliases()
             .into_iter()
             .map(|a| a.alias.as_str())
             .collect()
     }
-
     /// Get alias of address
     fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
-
     /// Check if an alias exists by its name
     fn alias_exists(&self, alias: &str) -> bool {
         self.alias_names().contains(&alias)
@@ -248,6 +239,11 @@ impl AccountKeystore for FileBasedKeystore {
 
     fn addresses_with_alias(&self) -> Vec<(&SuiAddress, &Alias)> {
         self.aliases.iter().collect::<Vec<_>>()
+    }
+
+    /// Return an array of `Alias`, consisting of every alias and its corresponding public key.
+    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
+        self.aliases.values_mut().collect()
     }
 
     fn keys(&self) -> Vec<PublicKey> {
@@ -540,6 +536,10 @@ impl AccountKeystore for InMemKeystore {
                     .collect::<HashSet<_>>(),
             )),
         }
+    }
+
+    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
+        self.aliases.values_mut().collect()
     }
 
     /// Updates an old alias to the new alias. If the new_alias is None,

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -207,6 +207,7 @@ impl AccountKeystore for FileBasedKeystore {
 
     fn addresses_with_alias(&self) -> Vec<(&SuiAddress, &Alias)> {
         self.aliases.iter().collect::<Vec<_>>()
+    }
 
     /// Return an array of `Alias`, consisting of every alias and its corresponding public key.
     fn aliases_mut(&mut self) -> Vec<&mut Alias> {

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -250,7 +250,7 @@ impl AccountKeystore for FileBasedKeystore {
         old_alias: &str,
         new_alias: Option<&str>,
     ) -> Result<String, anyhow::Error> {
-        if !self.alias_exists(&old_alias) {
+        if !self.alias_exists(old_alias) {
             bail!("The provided alias {old_alias} does not exist");
         } else {
             let new_alias_name = match new_alias {
@@ -535,7 +535,7 @@ impl AccountKeystore for InMemKeystore {
         old_alias: &str,
         new_alias: Option<&str>,
     ) -> Result<String, anyhow::Error> {
-        if !self.alias_exists(&old_alias) {
+        if !self.alias_exists(old_alias) {
             bail!("The provided alias {old_alias} does not exist");
         } else {
             let new_alias_name = match new_alias {

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -44,20 +44,29 @@ pub trait AccountKeystore: Send + Sync {
     ) -> Result<Signature, signature::Error>
     where
         T: Serialize;
+
     fn addresses(&self) -> Vec<SuiAddress> {
         self.keys().iter().map(|k| k.into()).collect()
     }
     fn addresses_with_alias(&self) -> Vec<(&SuiAddress, &Alias)>;
+
     fn aliases(&self) -> Vec<&Alias>;
-    fn aliases_mut(&mut self) -> Vec<&mut Alias>;
+
+    /// Return the mutable Alias objects in the keystore.
+    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
+        self.aliases.values_mut().collect()
+    }
+
     fn alias_names(&self) -> Vec<&str> {
         self.aliases()
             .into_iter()
             .map(|a| a.alias.as_str())
             .collect()
     }
+
     /// Get alias of address
     fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
+
     /// Check if an alias exists by its name
     fn alias_exists(&self, alias: &str) -> bool {
         self.alias_names().contains(&alias)
@@ -239,11 +248,6 @@ impl AccountKeystore for FileBasedKeystore {
 
     fn addresses_with_alias(&self) -> Vec<(&SuiAddress, &Alias)> {
         self.aliases.iter().collect::<Vec<_>>()
-    }
-
-    /// Return an array of `Alias`, consisting of every alias and its corresponding public key.
-    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
-        self.aliases.values_mut().collect()
     }
 
     fn keys(&self) -> Vec<PublicKey> {
@@ -536,10 +540,6 @@ impl AccountKeystore for InMemKeystore {
                     .collect::<HashSet<_>>(),
             )),
         }
-    }
-
-    fn aliases_mut(&mut self) -> Vec<&mut Alias> {
-        self.aliases.values_mut().collect()
     }
 
     /// Updates an old alias to the new alias. If the new_alias is None,

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -145,7 +145,18 @@ fn update_alias_test() {
     let aliases = keystore.alias_names();
     assert_eq!(vec!["new_alias"], aliases);
 
-    let update = keystore.update_alias("new_alias", None).unwrap();
+    // check that it errors on empty alias
+    assert!(keystore.update_alias("new_alias", Some(" ")).is_err());
+    assert!(keystore.update_alias("new_alias", Some("   ")).is_err());
+    // check that alias is trimmed
+    assert!(keystore.update_alias("new_alias", Some("  o ")).is_ok());
+    assert_eq!(vec!["o"], keystore.alias_names());
+    // check the regex works and new alias can be only [A-Za-z][A-Za-z0-9-_]*
+    assert!(keystore.update_alias("o", Some("_alias")).is_err());
+    assert!(keystore.update_alias("o", Some("-alias")).is_err());
+    assert!(keystore.update_alias("o", Some("123")).is_err());
+
+    let update = keystore.update_alias("o", None).unwrap();
     let aliases = keystore.alias_names();
     assert_eq!(vec![&update], aliases);
 }

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -9,7 +9,7 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use sui_keys::key_derive::generate_new_key;
 use tempfile::TempDir;
 
-use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, InMemKeystore, Keystore};
 use sui_types::crypto::{DefaultHash, SignatureScheme, SuiSignatureInner};
 use sui_types::{
     base_types::{SuiAddress, SUI_ADDRESS_LENGTH},
@@ -114,6 +114,62 @@ fn keystore_no_aliases() {
     keystore_path.set_extension("aliases");
     assert!(keystore_path.exists());
     assert_eq!(1, keystore.aliases().len());
+}
+
+#[test]
+fn update_alias_test() {
+    let temp_dir = TempDir::new().unwrap();
+    let keystore_path = temp_dir.path().join("sui.keystore");
+    let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
+    keystore
+        .generate_and_add_new_key(
+            SignatureScheme::ED25519,
+            Some("my_alias_test".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+    let aliases = keystore.alias_names();
+    assert_eq!(1, aliases.len());
+    assert_eq!(vec!["my_alias_test"], aliases);
+
+    let update = keystore.update_alias("alias_does_not_exist", None);
+    assert!(update.is_err());
+
+    let _ = keystore.update_alias("my_alias_test", Some("new_alias"));
+    let aliases = keystore.alias_names();
+    assert_eq!(vec!["new_alias"], aliases);
+
+    let update = keystore.update_alias("new_alias", None).unwrap();
+    let aliases = keystore.alias_names();
+    assert_eq!(vec![&update], aliases);
+}
+
+#[test]
+fn update_alias_in_memory_test() {
+    let mut keystore = Keystore::InMem(InMemKeystore::new_insecure_for_tests(0));
+    keystore
+        .generate_and_add_new_key(
+            SignatureScheme::ED25519,
+            Some("my_alias_test".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+    let aliases = keystore.alias_names();
+    assert_eq!(1, aliases.len());
+    assert_eq!(vec!["my_alias_test"], aliases);
+
+    let update = keystore.update_alias("alias_does_not_exist", None);
+    assert!(update.is_err());
+
+    let _ = keystore.update_alias("my_alias_test", Some("new_alias"));
+    let aliases = keystore.alias_names();
+    assert_eq!(vec!["new_alias"], aliases);
+
+    let update = keystore.update_alias("new_alias", None).unwrap();
+    let aliases = keystore.alias_names();
+    assert_eq!(vec![&update], aliases);
 }
 
 #[test]

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -133,6 +133,11 @@ fn update_alias_test() {
     assert_eq!(1, aliases.len());
     assert_eq!(vec!["my_alias_test"], aliases);
 
+    // read the alias file again and check if it was saved
+    let keystore1 = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
+    let aliases1 = keystore1.alias_names();
+    assert_eq!(vec!["my_alias_test"], aliases1);
+
     let update = keystore.update_alias("alias_does_not_exist", None);
     assert!(update.is_err());
 

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -431,22 +431,21 @@ impl KeyToolCommand {
     pub async fn execute(self, keystore: &mut Keystore) -> Result<CommandOutput, anyhow::Error> {
         let cmd_result = Ok(match self {
             KeyToolCommand::Alias { update } => {
-                let update_inputs = update;
-                match update_inputs.len() {
+                match update.len() {
                     0 =>  bail!("Please provide at least the old alias name"),
                     1 => {
-                        let old_alias = update_inputs.get(0).ok_or_else(|| anyhow!("Expected the old alias, but did not get any value."))?; 
-                        let new_alias = keystore.update_alias(old_alias, None)?; 
-                        CommandOutput::Alias(AliasUpdate { old_alias: old_alias.to_string() , new_alias  })
+                        let old_alias = update.get(0).ok_or_else(|| anyhow!("Expected the old alias, but did not get any value."))?;
+                        let new_alias = keystore.update_alias(old_alias, None)?;
+                        CommandOutput::Alias(AliasUpdate { old_alias: old_alias.to_string() , new_alias})
                     },
                     2 => {
-                        let old_alias = update_inputs.get(0).ok_or_else(|| anyhow!("Expected the old alias, but did not get any value."))?; 
-                        let new_alias = update_inputs.get(1).ok_or_else(|| anyhow!("Expected the new alias, but did not get any value."))?; 
+                        let old_alias = update.get(0).ok_or_else(|| anyhow!("Expected the old alias, but did not get any value."))?; 
+                        let new_alias = update.get(1).ok_or_else(|| anyhow!("Expected the new alias, but did not get any value."))?; 
                         keystore.update_alias(old_alias, Some(new_alias))?;
                         CommandOutput::Alias(AliasUpdate { old_alias: old_alias.to_string() , new_alias: new_alias.to_string()  })
                          
                     },
-                   _ =>  bail!("The command expects only an old and a new alias name, but instead got {} inputs", update_inputs.len())
+                   _ =>  bail!("The command expects only an old and a new alias name, but instead got {} inputs", update.len())
                 }
             }
 
@@ -1104,7 +1103,11 @@ impl Display for CommandOutput {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             CommandOutput::Alias(update) => {
-                write!(formatter, "Old alias {} was updated to {}", update.old_alias, update.new_alias)
+                write!(
+                    formatter, 
+                    "Old alias {} was updated to {}", 
+                    update.old_alias, update.new_alias
+                )
             }
             // Sign needs to be manually built because we need to wrap the very long
             // rawTxData string and rawIntentMsg strings into multiple rows due to

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::zklogin_commands_util::{perform_zk_login_test_tx, read_cli_line};
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use bip32::DerivationPath;
 use clap::*;
 use fastcrypto::ed25519::Ed25519KeyPair;
@@ -432,6 +432,12 @@ impl KeyToolCommand {
                 old_alias,
                 new_alias,
             } => {
+                if new_alias
+                    .as_ref()
+                    .is_some_and(|x| x.is_empty() || x.trim().is_empty())
+                {
+                    bail!("The new alias cannot be empty.");
+                }
                 let new_alias = keystore.update_alias(&old_alias, new_alias.as_deref())?;
                 CommandOutput::Alias(AliasUpdate {
                     old_alias,

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -442,8 +442,12 @@ impl KeyToolCommand {
                         let old_alias = update.get(0).ok_or_else(|| anyhow!("Expected the old alias, but did not get any value."))?; 
                         let new_alias = update.get(1).ok_or_else(|| anyhow!("Expected the new alias, but did not get any value."))?; 
                         keystore.update_alias(old_alias, Some(new_alias))?;
-                        CommandOutput::Alias(AliasUpdate { old_alias: old_alias.to_string() , new_alias: new_alias.to_string()  })
-                         
+                        CommandOutput::Alias(
+                            AliasUpdate {
+                                old_alias: old_alias.to_string(),
+                                new_alias: new_alias.to_string()
+                            }
+                        )
                     },
                    _ => bail!("The command expects only an old and a new alias name, but instead got {} inputs", update.len())
                 }
@@ -1104,8 +1108,8 @@ impl Display for CommandOutput {
         match self {
             CommandOutput::Alias(update) => {
                 write!(
-                    formatter, 
-                    "Old alias {} was updated to {}", 
+                    formatter,
+                    "Old alias {} was updated to {}",
                     update.old_alias, update.new_alias
                 )
             }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -445,7 +445,7 @@ impl KeyToolCommand {
                         CommandOutput::Alias(AliasUpdate { old_alias: old_alias.to_string() , new_alias: new_alias.to_string()  })
                          
                     },
-                   _ =>  bail!("The command expects only an old and a new alias name, but instead got {} inputs", update.len())
+                   _ => bail!("The command expects only an old and a new alias name, but instead got {} inputs", update.len())
                 }
             }
 


### PR DESCRIPTION
## Description 

Provide a new command for updating the alias of an address. The new command `keytool alias` has one flag `--update`, followed by an old alias that needs to be updated, and optionally, a new alias name. If there is no new alias given, a new random alias will be generated.

An example for using this command is: 
`sui keytool update-alias test high_yield_address`, which outputs the following text:

`Old alias test was updated to high_yield_address`

## Test Plan 

Two new tests for FileBasedKeystore and InMemKeystore.
<img width="869" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/2f3cecd1-d283-4a9d-8995-d3999888a9e9">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added support for updating an alias of an address in the Sui CLI. Try it out through this command: `sui keytool update-alias --help`