### PR TITLE
move: build writes toolchain version to Move.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12212,7 +12212,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "0.0.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "datatest-stable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ members = [
 ]
 
 [workspace.package]
-# This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, and sui crates.
+# This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
 version = "1.16.0"
 
 [profile.release]

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -199,8 +199,14 @@ async fn test_generate_lock_file() {
     let mut build_config = BuildConfig::new_for_testing();
     build_config.config.lock_file = Some(lock_file_path.clone());
     build_config
-        .build(path)
+        .clone()
+        .build(path.clone())
         .expect("Move package did not build");
+    // Update the lock file with placeholder compiler version so this isn't bumped every release.
+    build_config
+        .config
+        .update_lock_file_toolchain_version(&path, "0.0.1".into())
+        .expect("Could not update lock file");
 
     let mut lock_file_contents = String::new();
     File::open(lock_file_path)
@@ -240,6 +246,11 @@ async fn test_generate_lock_file() {
         dependencies = [
           { name = "MoveStdlib" },
         ]
+
+        [move.toolchain-version]
+        compiler-version = "0.0.1"
+        edition = "legacy"
+        flavor = "sui"
     "#]];
     expected.assert_eq(lock_file_contents.as_str());
 }

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-move-build"
-version = "0.0.0"
+version.workspace = true
 edition = "2021"
 authors = ["Mysten Labs <eng@mystenlabs.com>"]
 description = "Logic for building Sui Move Packages"

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -145,12 +145,23 @@ impl BuildConfig {
         let print_diags_to_stderr = self.print_diags_to_stderr;
         let run_bytecode_verifier = self.run_bytecode_verifier;
         let resolution_graph = self.resolution_graph(&path)?;
-        build_from_resolution_graph(
-            path,
+        let result = build_from_resolution_graph(
+            path.clone(),
             resolution_graph,
             run_bytecode_verifier,
             print_diags_to_stderr,
-        )
+        );
+        if let Ok(ref compiled) = result {
+            compiled
+                .package
+                .compiled_package_info
+                .build_flags
+                .update_lock_file_toolchain_version(&path, env!("CARGO_PKG_VERSION").into())
+                .map_err(|e| SuiError::ModuleBuildFailure {
+                    error: format!("Failed to update Move.lock toolchain version: {e}"),
+                })?;
+        }
+        result
     }
 
     pub fn resolution_graph(mut self, path: &Path) -> SuiResult<ResolvedGraph> {

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -82,7 +82,8 @@ fn update_lock_file_toolchain_version() {
     build_config.default_flavor = Some(Flavor::Sui);
     build_config.default_edition = Some(Edition::E2024_ALPHA);
     build_config.lock_file = Some(lock_path.clone());
-    let _ = build_config.update_lock_file_toolchain_version("0.0.1".into());
+    let _ =
+        build_config.update_lock_file_toolchain_version(&pkg.path().to_path_buf(), "0.0.1".into());
 
     let mut lock_file = File::open(lock_path).unwrap();
     let toolchain_version =


### PR DESCRIPTION
## Description 

As in title, see inline for more.

## Test Plan 

Updated tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
