### PR TITLE
[cli] Fix bug where the address is not decoded from its PublicKey

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -115,8 +115,8 @@ impl Display for Keystore {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Alias {
-    pub alias: String,
-    pub public_key_base64: String,
+    alias: String,
+    public_key_base64: String,
 }
 
 #[derive(Default)]

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -56,6 +56,26 @@ fn create_alias_keystore_file_test() {
 }
 
 #[test]
+fn check_reading_aliases_file_correctly() {
+    // when reading the alias file containing alias + public key base 64,
+    // make sure the addresses are correctly converted back from pk
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut keystore_path = temp_dir.path().join("sui.keystore");
+    let keystore_path_keep = temp_dir.path().join("sui.keystore");
+    let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
+    let kp = keystore
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
+        .unwrap();
+    keystore_path.set_extension("aliases");
+    assert!(keystore_path.exists());
+
+    let new_keystore = Keystore::from(FileBasedKeystore::new(&keystore_path_keep).unwrap());
+    let addresses = new_keystore.addresses_with_alias();
+    assert_eq!(kp.0, *addresses.get(0).unwrap().0)
+}
+
+#[test]
 fn create_alias_if_not_exists_test() {
     let temp_dir = TempDir::new().unwrap();
     let keystore_path = temp_dir.path().join("sui.keystore");


### PR DESCRIPTION
## Description 

The SuiAddress should be decoded from `PublicKey` and not `SuiKeyPair`, as the alias file encodes the public key as base64. 

## Test Plan 

Added new test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed a bug where reading the alias file resulted in creating the wrong address.