### PR TITLE
[cli] Display aliases when calling `sui client addresses`

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -113,10 +113,10 @@ impl Display for Keystore {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Alias {
-    alias: String,
-    public_key_base64: String,
+    pub alias: String,
+    pub public_key_base64: String,
 }
 
 #[derive(Default)]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -698,11 +698,19 @@ impl SuiClientCommands {
             }
             SuiClientCommands::Addresses => {
                 let active_address = context.active_address()?;
-                let addresses = context.config.keystore.addresses();
-                SuiClientCommandResult::Addresses(AddressesOutput {
-                    addresses,
+                let addresses = context
+                    .config
+                    .keystore
+                    .addresses_with_alias()
+                    .into_iter()
+                    .map(|(address, alias)| (alias.alias.to_string(), *address))
+                    .collect::<Vec<_>>();
+
+                let output = AddressesOutput {
                     active_address,
-                })
+                    addresses,
+                };
+                SuiClientCommandResult::Addresses(output)
             }
             SuiClientCommands::DynamicFieldQuery { id, cursor, limit } => {
                 let client = context.get_client().await?;
@@ -1474,9 +1482,22 @@ impl Display for SuiClientCommandResult {
         let mut writer = String::new();
         match self {
             SuiClientCommandResult::Addresses(addresses) => {
-                let json_obj = json!(addresses);
-                let mut table = json_to_table(&json_obj);
-                let style = TableStyle::rounded().horizontals([]);
+                let mut builder = TableBuilder::default();
+                builder.set_header(vec!["alias", "address", "active address"]);
+                for address in &addresses.addresses {
+                    let active_address = if address.1 == addresses.active_address {
+                        "*".to_string()
+                    } else {
+                        "".to_string()
+                    };
+                    builder.push_record([
+                        address.0.to_string(),
+                        address.1.to_string(),
+                        active_address,
+                    ]);
+                }
+                let mut table = builder.build();
+                let style = TableStyle::rounded();
                 table.with(style);
                 write!(f, "{}", table)?
             }
@@ -1848,7 +1869,7 @@ impl SuiClientCommandResult {
 #[serde(rename_all = "camelCase")]
 pub struct AddressesOutput {
     pub active_address: SuiAddress,
-    pub addresses: Vec<SuiAddress>,
+    pub addresses: Vec<(String, SuiAddress)>,
 }
 
 #[derive(Serialize)]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -704,7 +704,7 @@ impl SuiClientCommands {
                     .addresses_with_alias()
                     .into_iter()
                     .map(|(address, alias)| (alias.alias.to_string(), *address))
-                    .collect::<Vec<_>>();
+                    .collect();
 
                 let output = AddressesOutput {
                     active_address,
@@ -1484,17 +1484,13 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::Addresses(addresses) => {
                 let mut builder = TableBuilder::default();
                 builder.set_header(vec!["alias", "address", "active address"]);
-                for address in &addresses.addresses {
-                    let active_address = if address.1 == addresses.active_address {
+                for (alias, address) in &addresses.addresses {
+                    let active_address = if address == &addresses.active_address {
                         "*".to_string()
                     } else {
                         "".to_string()
                     };
-                    builder.push_record([
-                        address.0.to_string(),
-                        address.1.to_string(),
-                        active_address,
-                    ]);
+                    builder.push_record([alias.to_string(), address.to_string(), active_address]);
                 }
                 let mut table = builder.build();
                 let style = TableStyle::rounded();

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -131,7 +131,7 @@ async fn handle_command(
                 let addresses = addresses
                     .addresses
                     .iter()
-                    .map(|addr| format!("{addr}"))
+                    .map(|addr| format!("{}", addr.1))
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::flag("--address"), addresses.clone());
                 cache.insert(CacheKey::flag("--to"), addresses);


### PR DESCRIPTION
## Description 

Add support for showing aliases when calling `sui client addresses`.

## Test Plan 

<img width="1266" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/39357d92-bf87-44de-a3c2-7f9dd4c379eb">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added support for showing the aliases when calling the `sui client addresses` command. If you used to call this command passing the `--json` flag, the update will break the format. For each address, it will also give return the alias, so each item in the address array will be an array itself, containing two elements: alias and address.