### PR TITLE
[cli/alias] accept an address by its alias in `sui client` commands

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -1086,7 +1086,10 @@ pub async fn batch_transfer_gases(
 
 #[cfg(test)]
 mod tests {
-    use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
+    use sui::{
+        client_commands::{SuiClientCommandResult, SuiClientCommands},
+        key_identity::KeyIdentity,
+    };
     use sui_json_rpc_types::SuiExecutionStatus;
     use sui_sdk::wallet_context::WalletContext;
     use test_cluster::TestClusterBuilder;
@@ -1394,7 +1397,7 @@ mod tests {
         // Now we transfer one gas out
         let res = SuiClientCommands::PayAllSui {
             input_coins: vec![*bad_gas.id()],
-            recipient: SuiAddress::random_for_testing_only(),
+            recipient: KeyIdentity::Address(SuiAddress::random_for_testing_only()),
             gas_budget: 2_000_000,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
@@ -1617,7 +1620,7 @@ mod tests {
         // Transfer all valid gases away except for 1
         for gas in gases.iter().take(gases.len() - 1) {
             SuiClientCommands::TransferSui {
-                to: destination_address,
+                to: KeyIdentity::Address(destination_address),
                 sui_coin_object_id: *gas.id(),
                 gas_budget: 50000000,
                 amount: None,
@@ -1690,7 +1693,7 @@ mod tests {
         // Transfer all valid gases away
         for gas in gases {
             SuiClientCommands::TransferSui {
-                to: destination_address,
+                to: KeyIdentity::Address(destination_address),
                 sui_coin_object_id: *gas.id(),
                 gas_budget: 50000000,
                 amount: None,
@@ -1923,7 +1926,7 @@ mod tests {
     async fn get_current_gases(address: SuiAddress, context: &mut WalletContext) -> Vec<GasCoin> {
         // Get the latest list of gas
         let results = SuiClientCommands::Gas {
-            address: Some(address),
+            address: Some(KeyIdentity::Address(address)),
         }
         .execute(context)
         .await

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -275,7 +275,7 @@ impl AccountKeystore for FileBasedKeystore {
         self.addresses_with_alias()
             .iter()
             .find(|x| x.1.alias == alias)
-            .ok_or_else(|| anyhow!("Cannot find the address for given alias {alias}"))
+            .ok_or_else(|| anyhow!("Cannot resolve alias {alias} to an address"))
             .map(|x| x.0)
     }
 
@@ -534,7 +534,7 @@ impl AccountKeystore for InMemKeystore {
         self.addresses_with_alias()
             .iter()
             .find(|x| x.1.alias == alias)
-            .ok_or_else(|| anyhow!("Cannot find the address for given alias {alias}"))
+            .ok_or_else(|| anyhow!("Cannot resolve alias {alias} to an address"))
             .map(|x| x.0)
     }
 

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -59,6 +59,7 @@ pub trait AccountKeystore: Send + Sync {
     }
     /// Get alias of address
     fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
+    fn get_address_by_alias(&self, alias: String) -> Result<&SuiAddress, anyhow::Error>;
     /// Check if an alias exists by its name
     fn alias_exists(&self, alias: &str) -> bool {
         self.alias_names().contains(&alias)
@@ -269,7 +270,16 @@ impl AccountKeystore for FileBasedKeystore {
         }
     }
 
-    /// Get alias of address
+    /// Get the address by its alias
+    fn get_address_by_alias(&self, alias: String) -> Result<&SuiAddress, anyhow::Error> {
+        self.addresses_with_alias()
+            .iter()
+            .find(|x| x.1.alias == alias)
+            .ok_or_else(|| anyhow!("Cannot find the address for given alias {alias}"))
+            .map(|x| x.0)
+    }
+
+    /// Get the alias if it exists, or return an error if it does not exist.
     fn get_alias_by_address(&self, address: &SuiAddress) -> Result<String, anyhow::Error> {
         match self.aliases.get(address) {
             Some(alias) => Ok(alias.alias.clone()),
@@ -517,6 +527,15 @@ impl AccountKeystore for InMemKeystore {
             Some(alias) => Ok(alias.alias.clone()),
             None => bail!("Cannot find alias for address {address}"),
         }
+    }
+
+    /// Get the address by its alias
+    fn get_address_by_alias(&self, alias: String) -> Result<&SuiAddress, anyhow::Error> {
+        self.addresses_with_alias()
+            .iter()
+            .find(|x| x.1.alias == alias)
+            .ok_or_else(|| anyhow!("Cannot find the address for given alias {alias}"))
+            .map(|x| x.0)
     }
 
     /// This function returns an error if the provided alias already exists. If the alias

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -68,6 +68,8 @@ use tabled::{
 };
 use tracing::info;
 
+use crate::key_identity::{get_identity_address, KeyIdentity};
+
 macro_rules! serialize_or_execute {
     ($tx_data:expr, $serialize_unsigned:expr, $serialize_signed:expr, $context:expr, $result_variant:ident) => {{
         assert!(
@@ -197,11 +199,13 @@ pub enum SuiClientCommands {
     },
 
     /// Obtain all gas objects owned by the address.
+    /// An address' alias can be used instead of the address.
     #[clap(name = "gas")]
     Gas {
-        /// Address owning the objects
+        /// Address (or its alias) owning the objects
         #[clap(name = "owner_address")]
-        address: Option<SuiAddress>,
+        #[arg(value_parser)]
+        address: Option<KeyIdentity>,
     },
 
     /// Merge two coin objects into one coin
@@ -266,13 +270,13 @@ pub enum SuiClientCommands {
         #[clap(long)]
         bcs: bool,
     },
-    /// Obtain all objects owned by the address
+    /// Obtain all objects owned by the address. It also accepts an address by its alias.
     #[clap(name = "objects")]
     Objects {
         /// Address owning the object. If no address is provided, it will show all
         /// objects owned by `sui client active-address`.
         #[clap(name = "owner_address")]
-        address: Option<SuiAddress>,
+        address: Option<KeyIdentity>,
     },
     /// Pay coins to recipients following specified amounts, with input coins.
     /// Length of recipients must be the same as that of amounts.
@@ -283,8 +287,9 @@ pub enum SuiClientCommands {
         input_coins: Vec<ObjectID>,
 
         /// The recipient addresses, must be of same length as amounts
+        /// Aliases of addresses are also accepted as input.
         #[clap(long, num_args(1..))]
-        recipients: Vec<SuiAddress>,
+        recipients: Vec<KeyIdentity>,
 
         /// The amounts to be paid, following the order of recipients.
         #[clap(long, num_args(1..))]
@@ -317,9 +322,9 @@ pub enum SuiClientCommands {
         #[clap(long, num_args(1..))]
         input_coins: Vec<ObjectID>,
 
-        /// The recipient address.
+        /// The recipient address (or its alias if it's an address in the keystore).
         #[clap(long)]
-        recipient: SuiAddress,
+        recipient: KeyIdentity,
 
         /// Gas budget for this transaction
         #[clap(long)]
@@ -345,8 +350,9 @@ pub enum SuiClientCommands {
         input_coins: Vec<ObjectID>,
 
         /// The recipient addresses, must be of same length as amounts.
+        /// Aliases of addresses are also accepted as input.
         #[clap(long, num_args(1..))]
-        recipients: Vec<SuiAddress>,
+        recipients: Vec<KeyIdentity>,
 
         /// The amounts to be paid, following the order of recipients.
         #[clap(long, num_args(1..))]
@@ -438,13 +444,13 @@ pub enum SuiClientCommands {
         serialize_signed_transaction: bool,
     },
 
-    /// Switch active address and network(e.g., devnet, local rpc server)
+    /// Switch active address and network(e.g., devnet, local rpc server).
     #[clap(name = "switch")]
     Switch {
-        /// An Sui address to be used as the active address for subsequent
-        /// commands.
+        /// An address to be used as the active address for subsequent
+        /// commands. It accepts also the alias of the address.
         #[clap(long)]
-        address: Option<SuiAddress>,
+        address: Option<KeyIdentity>,
         /// The RPC server URL (e.g., local rpc server, devnet rpc server, etc) to be
         /// used for subsequent commands.
         #[clap(long)]
@@ -462,9 +468,9 @@ pub enum SuiClientCommands {
     /// Transfer object
     #[clap(name = "transfer")]
     Transfer {
-        /// Recipient address
+        /// Recipient address (or its alias if it's an address in the keystore)
         #[clap(long)]
-        to: SuiAddress,
+        to: KeyIdentity,
 
         /// Object to transfer, in 20 bytes Hex string
         #[clap(long)]
@@ -495,9 +501,9 @@ pub enum SuiClientCommands {
     /// is transferred.
     #[clap(name = "transfer-sui")]
     TransferSui {
-        /// Recipient address
+        /// Recipient address (or its alias if it's an address in the keystore)
         #[clap(long)]
-        to: SuiAddress,
+        to: KeyIdentity,
 
         /// Sui coin object to transfer, ID in 20 bytes Hex string. This is also the gas object.
         #[clap(long)]
@@ -961,6 +967,7 @@ impl SuiClientCommands {
                 serialize_signed_transaction,
             } => {
                 let from = context.get_object_owner(&object_id).await?;
+                let to = get_identity_address(Some(to), context)?;
                 let client = context.get_client().await?;
                 let data = client
                     .transaction_builder()
@@ -984,7 +991,7 @@ impl SuiClientCommands {
                 serialize_signed_transaction,
             } => {
                 let from = context.get_object_owner(&object_id).await?;
-
+                let to = get_identity_address(Some(to), context)?;
                 let client = context.get_client().await?;
                 let data = client
                     .transaction_builder()
@@ -1024,6 +1031,11 @@ impl SuiClientCommands {
                         amounts.len()
                     ),
                 );
+                let recipients = recipients
+                    .into_iter()
+                    .map(|x| get_identity_address(Some(x), context))
+                    .collect::<Result<Vec<SuiAddress>, anyhow::Error>>()
+                    .map_err(|e| anyhow!("{e}"))?;
                 let from = context.get_object_owner(&input_coins[0]).await?;
                 let client = context.get_client().await?;
                 let data = client
@@ -1063,6 +1075,11 @@ impl SuiClientCommands {
                         amounts.len()
                     ),
                 );
+                let recipients = recipients
+                    .into_iter()
+                    .map(|x| get_identity_address(Some(x), context))
+                    .collect::<Result<Vec<SuiAddress>, anyhow::Error>>()
+                    .map_err(|e| anyhow!("{e}"))?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
                 let client = context.get_client().await?;
                 let data = client
@@ -1089,6 +1106,7 @@ impl SuiClientCommands {
                     !input_coins.is_empty(),
                     "PayAllSui transaction requires a non-empty list of input coins"
                 );
+                let recipient = get_identity_address(Some(recipient), context)?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
                 let client = context.get_client().await?;
                 let data = client
@@ -1106,7 +1124,7 @@ impl SuiClientCommands {
             }
 
             SuiClientCommands::Objects { address } => {
-                let address = address.unwrap_or(context.active_address()?);
+                let address = get_identity_address(address, context)?;
                 let client = context.get_client().await?;
                 let mut objects: Vec<SuiObjectResponse> = Vec::new();
                 let mut cursor = None;
@@ -1159,7 +1177,7 @@ impl SuiClientCommands {
                 })
             }
             SuiClientCommands::Gas { address } => {
-                let address = address.unwrap_or(context.active_address()?);
+                let address = get_identity_address(address, context)?;
                 let coins = context
                     .gas_objects(address)
                     .await?
@@ -1240,20 +1258,28 @@ impl SuiClientCommands {
                 )
             }
             SuiClientCommands::Switch { address, env } => {
-                match (address, &env) {
-                    (None, Some(env)) => {
-                        Self::switch_env(&mut context.config, env)?;
+                let mut addr = None;
+
+                if address.is_none() && env.is_none() {
+                    return Err(anyhow!(
+                        "No address, an alias, or env specified. Please specify one."
+                    ));
+                }
+
+                if let Some(address) = address.clone() {
+                    let address = get_identity_address(Some(address), context)?;
+                    if !context.config.keystore.addresses().contains(&address) {
+                        return Err(anyhow!("Address {} not managed by wallet", address));
                     }
-                    (Some(addr), None) => {
-                        if !context.config.keystore.addresses().contains(&addr) {
-                            return Err(anyhow!("Address {} not managed by wallet", addr));
-                        }
-                        context.config.active_address = Some(addr);
-                    }
-                    _ => return Err(anyhow!("No address or env specified. Please Specify one.")),
+                    context.config.active_address = Some(address);
+                    addr = Some(address.to_string());
+                }
+
+                if let Some(ref env) = env {
+                    Self::switch_env(&mut context.config, env)?;
                 }
                 context.config.save()?;
-                SuiClientCommandResult::Switch(SwitchResponse { address, env })
+                SuiClientCommandResult::Switch(SwitchResponse { address: addr, env })
             }
             SuiClientCommands::ActiveAddress => {
                 SuiClientCommandResult::ActiveAddress(context.active_address().ok())
@@ -1574,15 +1600,19 @@ impl Display for SuiClientCommandResult {
                 Err(e) => writeln!(f, "Internal error, cannot read the object: {e}")?,
             },
             SuiClientCommandResult::Objects(object_refs) => {
-                let objects = ObjectsOutput::from_vec(object_refs.to_vec());
-                match objects {
-                    Ok(objs) => {
-                        let json_obj = json!(objs);
-                        let mut table = json_to_table(&json_obj);
-                        table.with(TableStyle::rounded().horizontals([]));
-                        writeln!(f, "{}", table)?
+                if object_refs.is_empty() {
+                    writeln!(f, "This address has no owned objects.")?
+                } else {
+                    let objects = ObjectsOutput::from_vec(object_refs.to_vec());
+                    match objects {
+                        Ok(objs) => {
+                            let json_obj = json!(objs);
+                            let mut table = json_to_table(&json_obj);
+                            table.with(TableStyle::rounded().horizontals([]));
+                            writeln!(f, "{}", table)?
+                        }
+                        Err(e) => write!(f, "Internal error: {e}")?,
                     }
-                    Err(e) => write!(f, "Internal error: {e}")?,
                 }
             }
             SuiClientCommandResult::Upgrade(response)
@@ -2011,17 +2041,18 @@ pub enum SuiClientCommandResult {
     ReplayCheckpoints,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 pub struct SwitchResponse {
     /// Active address
-    pub address: Option<SuiAddress>,
+    pub address: Option<String>,
     pub env: Option<String>,
 }
 
 impl Display for SwitchResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
-        if let Some(addr) = self.address {
+
+        if let Some(addr) = &self.address {
             writeln!(writer, "Active address switched to {addr}")?;
         }
         if let Some(env) = &self.env {

--- a/crates/sui/src/key_identity.rs
+++ b/crates/sui/src/key_identity.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt::Display, str::FromStr};
+
+use anyhow::Error;
+use serde::Serialize;
+use sui_keys::keystore::{AccountKeystore, Keystore};
+use sui_sdk::wallet_context::WalletContext;
+use sui_types::base_types::SuiAddress;
+
+/// An address or an alias associated with a key in the wallet
+/// This is used to distinguish between an address or an alias,
+/// enabling a user to use an alias for any command that requires an address.
+#[derive(Serialize, Clone)]
+pub enum KeyIdentity {
+    Address(SuiAddress),
+    Alias(String),
+}
+
+impl FromStr for KeyIdentity {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("0x") {
+            Ok(KeyIdentity::Address(SuiAddress::from_str(s)?))
+        } else {
+            Ok(KeyIdentity::Alias(s.to_string()))
+        }
+    }
+}
+
+impl Display for KeyIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let v = match self {
+            KeyIdentity::Address(x) => x.to_string(),
+            KeyIdentity::Alias(x) => x.to_string(),
+        };
+        write!(f, "{}", v)
+    }
+}
+
+/// Get the SuiAddress corresponding to this key identity.
+/// If no string is provided, then the curernt active address is returned.
+pub fn get_identity_address(
+    input: Option<KeyIdentity>,
+    ctx: &mut WalletContext,
+) -> Result<SuiAddress, Error> {
+    if let Some(addr) = input {
+        get_identity_address_from_keystore(addr, &ctx.config.keystore)
+    } else {
+        Ok(ctx.active_address()?)
+    }
+}
+
+pub fn get_identity_address_from_keystore(
+    input: KeyIdentity,
+    keystore: &Keystore,
+) -> Result<SuiAddress, Error> {
+    match input {
+        KeyIdentity::Address(x) => Ok(x),
+        KeyIdentity::Alias(x) => Ok(*keystore.get_address_by_alias(x)?),
+    }
+}

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::key_identity::{get_identity_address_from_keystore, KeyIdentity};
 use crate::zklogin_commands_util::{perform_zk_login_test_tx, read_cli_line};
 use anyhow::anyhow;
 use bip32::DerivationPath;
 use clap::*;
 use fastcrypto::ed25519::Ed25519KeyPair;
-use fastcrypto::encoding::{decode_bytes_hex, Base64, Encoding, Hex};
+use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::hash::HashFunction;
 use fastcrypto::secp256k1::recoverable::Secp256k1Sig;
 use fastcrypto::secp256k1::Secp256k1KeyPair;
@@ -165,13 +166,13 @@ pub enum KeyToolCommand {
     /// [enum SuiKeyPair] (Base64 encoded of 33-byte `flag || privkey`) or `type AuthorityKeyPair`
     /// (Base64 encoded `privkey`). It prints its Base64 encoded public key and the key scheme flag.
     Show { file: PathBuf },
-    /// Create signature using the private key for for the given address in sui keystore.
+    /// Create signature using the private key for for the given address (or its alias) in sui keystore.
     /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
     /// of the BCS serialized transaction bytes itself and its intent. If intent is absent,
     /// default will be used.
     Sign {
-        #[clap(long, value_parser = decode_bytes_hex::<SuiAddress>)]
-        address: SuiAddress,
+        #[clap(long)]
+        address: KeyIdentity,
         #[clap(long)]
         data: String,
         #[clap(long)]
@@ -720,6 +721,7 @@ impl KeyToolCommand {
                 data,
                 intent,
             } => {
+                let address = get_identity_address_from_keystore(address, keystore)?;
                 let intent = intent.unwrap_or_else(Intent::sui_transaction);
                 let intent_clone = intent.clone();
                 let msg: TransactionData =

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -5,11 +5,11 @@
 pub mod client_commands;
 pub mod console;
 pub mod fire_drill;
+pub mod genesis_ceremony;
+pub mod genesis_inspector;
+pub mod key_identity;
 pub mod keytool;
 pub mod shell;
 pub mod sui_commands;
 pub mod validator_commands;
 pub mod zklogin_commands_util;
-
-pub mod genesis_ceremony;
-pub mod genesis_inspector;

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -3,6 +3,7 @@
 
 use std::str::FromStr;
 
+use crate::key_identity::KeyIdentity;
 use crate::keytool::read_authority_keypair_from_file;
 use crate::keytool::read_keypair_from_file;
 
@@ -492,7 +493,7 @@ async fn test_sign_command() -> Result<(), anyhow::Error> {
 
     // Sign an intent message for the transaction data and a passed-in intent with scope as PersonalMessage.
     KeyToolCommand::Sign {
-        address: *sender,
+        address: KeyIdentity::Address(*sender),
         data: Base64::encode(bcs::to_bytes(&tx_data)?),
         intent: Some(Intent::sui_app(IntentScope::PersonalMessage)),
     }
@@ -501,7 +502,7 @@ async fn test_sign_command() -> Result<(), anyhow::Error> {
 
     // Sign an intent message for the transaction data without intent passed in, so default is used.
     KeyToolCommand::Sign {
-        address: *sender,
+        address: KeyIdentity::Address(*sender),
         data: Base64::encode(bcs::to_bytes(&tx_data)?),
         intent: None,
     }

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -472,6 +472,7 @@ async fn test_sign_command() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
     let binding = keystore.addresses();
     let sender = binding.first().unwrap();
+    let alias = keystore.get_alias_by_address(sender).unwrap();
 
     // Create a dummy TransactionData
     let gas = (
@@ -503,6 +504,16 @@ async fn test_sign_command() -> Result<(), anyhow::Error> {
     // Sign an intent message for the transaction data without intent passed in, so default is used.
     KeyToolCommand::Sign {
         address: KeyIdentity::Address(*sender),
+        data: Base64::encode(bcs::to_bytes(&tx_data)?),
+        intent: None,
+    }
+    .execute(&mut keystore)
+    .await?;
+
+    // Sign an intent message for the transaction data without intent passed in, so default is used.
+    // Use alias for signing instead of the address
+    KeyToolCommand::Sign {
+        address: KeyIdentity::Alias(alias),
         data: Base64::encode(bcs::to_bytes(&tx_data)?),
         intent: None,
     }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -10,6 +10,7 @@ use std::{fmt::Write, fs::read_dir, path::PathBuf, str, thread, time::Duration};
 use expect_test::expect;
 use move_package::BuildConfig as MoveBuildConfig;
 use serde_json::json;
+use sui::key_identity::{get_identity_address, KeyIdentity};
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::object::Owner;
 use sui_types::transaction::{
@@ -152,7 +153,7 @@ async fn test_objects_command() -> Result<(), anyhow::Error> {
 
     // Print objects owned by `address`
     SuiClientCommands::Objects {
-        address: Some(address),
+        address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
     .await?
@@ -184,7 +185,7 @@ async fn test_regression_6546() -> Result<(), anyhow::Error> {
     let context = &mut test_cluster.wallet;
 
     let SuiClientCommandResult::Objects(coins) = SuiClientCommands::Objects {
-        address: Some(address),
+        address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
     .await?
@@ -235,7 +236,7 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
 
     // Print objects owned by `address`
     SuiClientCommands::Objects {
-        address: Some(address),
+        address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
     .await?
@@ -317,7 +318,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     let object_to_send = object_refs.data.get(1).unwrap().object().unwrap().object_id;
 
     SuiClientCommands::Gas {
-        address: Some(address),
+        address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
     .await?
@@ -327,7 +328,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
 
     // Send an object
     SuiClientCommands::Transfer {
-        to: SuiAddress::random_for_testing_only(),
+        to: KeyIdentity::Address(SuiAddress::random_for_testing_only()),
         object_id: object_to_send,
         gas: Some(object_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
@@ -339,7 +340,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
 
     // Fetch gas again
     SuiClientCommands::Gas {
-        address: Some(address),
+        address: Some(KeyIdentity::Address(address)),
     }
     .execute(context)
     .await?
@@ -414,7 +415,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
 
     // Print objects owned by `address1`
     SuiClientCommands::Objects {
-        address: Some(address1),
+        address: Some(KeyIdentity::Address(address1)),
     }
     .execute(context)
     .await?
@@ -1597,7 +1598,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
 
     let resp = SuiClientCommands::Transfer {
         gas: Some(gas_obj_id),
-        to: recipient,
+        to: KeyIdentity::Address(recipient),
         object_id: obj_id,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         serialize_unsigned_transaction: false,
@@ -1702,7 +1703,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
 
     let resp = SuiClientCommands::Transfer {
         gas: None,
-        to: recipient,
+        to: KeyIdentity::Address(recipient),
         object_id: obj_id,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         serialize_unsigned_transaction: false,
@@ -1798,7 +1799,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
 
     // Switch the address
     let resp = SuiClientCommands::Switch {
-        address: Some(addr2),
+        address: Some(KeyIdentity::Address(addr2)),
         env: None,
     }
     .execute(context)
@@ -1810,7 +1811,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         format!(
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
-                address: Some(addr2),
+                address: Some(addr2.to_string()),
                 env: None
             })
         )
@@ -1837,7 +1838,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     // Check that we can switch to this address
     // Switch the address
     let resp = SuiClientCommands::Switch {
-        address: Some(new_addr),
+        address: Some(KeyIdentity::Address(new_addr)),
         env: None,
     }
     .execute(context)
@@ -1848,7 +1849,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         format!(
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
-                address: Some(new_addr),
+                address: Some(new_addr.to_string()),
                 env: None
             })
         )
@@ -1917,7 +1918,7 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
 
     let addr2 = context.config.keystore.addresses().get(1).cloned().unwrap();
     let resp = SuiClientCommands::Switch {
-        address: Some(addr2),
+        address: Some(KeyIdentity::Address(addr2)),
         env: None,
     }
     .execute(context)
@@ -1927,7 +1928,7 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
         format!(
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
-                address: Some(addr2),
+                address: Some(addr2.to_string()),
                 env: None
             })
         )
@@ -2356,7 +2357,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
     let coin = object_refs.get(1).unwrap().object().unwrap().object_id;
 
     SuiClientCommands::TransferSui {
-        to: address1,
+        to: KeyIdentity::Address(address1),
         sui_coin_object_id: coin,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         amount: Some(1),
@@ -2367,7 +2368,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
     .await?;
 
     SuiClientCommands::TransferSui {
-        to: address1,
+        to: KeyIdentity::Address(address1),
         sui_coin_object_id: coin,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         amount: Some(1),
@@ -2582,4 +2583,35 @@ async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
         out_str.contains("Total number of linter warnings suppressed: 5 (filtered categories: 3)")
     );
     Ok(())
+}
+
+#[tokio::test]
+async fn alias_or_address_test() {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+    let alias = context
+        .config
+        .keystore
+        .get_alias_by_address(&address)
+        .unwrap();
+
+    // by alias
+    assert_eq!(
+        address,
+        get_identity_address(Some(KeyIdentity::Alias(alias)), context).unwrap()
+    );
+    // by address
+    assert_eq!(
+        address,
+        get_identity_address(Some(KeyIdentity::Address(address)), context).unwrap()
+    );
+    // alias does not exist
+    assert!(get_identity_address(Some(KeyIdentity::Alias("alias".to_string())), context).is_err());
+
+    // get active address instead when no alias/address is given
+    assert_eq!(
+        context.active_address().unwrap(),
+        get_identity_address(None, context).unwrap()
+    );
 }


### PR DESCRIPTION
## Description 

Several commands that accept an address for a recipient can also take as input the address' alias if it is in the keystore. This PR allows those commands to accept the alias of an address, or the address as a string.

## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added support for accepting an address by its alias in several `sui client` commands: `gas, objects, pay-sui, pay-all-sui, transfer, transfer-sui, switch`, and in `sui keytool sign` 