### PR TITLE
[GraphQL/TransactionBlock] Consistent naming for kind types

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -39,7 +39,7 @@ Response: {
             "gasBudget": "5000000000"
           },
           "kind": {
-            "__typename": "ProgrammableTransaction",
+            "__typename": "ProgrammableTransactionBlock",
             "value": "ProgrammableTransaction { inputs: [Pure([252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30])], commands: [Publish([[161, 28, 235, 11, 6, 0, 0, 0, 8, 1, 0, 6, 2, 6, 12, 3, 18, 10, 5, 28, 17, 7, 45, 48, 8, 93, 64, 10, 157, 1, 9, 12, 166, 1, 15, 0, 4, 1, 6, 1, 7, 0, 0, 12, 0, 1, 2, 4, 0, 2, 1, 2, 0, 0, 5, 0, 1, 0, 1, 5, 3, 4, 0, 2, 10, 3, 7, 8, 2, 1, 8, 0, 0, 1, 7, 8, 2, 1, 8, 1, 3, 70, 111, 111, 9, 84, 120, 67, 111, 110, 116, 101, 120, 116, 3, 85, 73, 68, 2, 105, 100, 1, 109, 3, 110, 101, 119, 6, 111, 98, 106, 101, 99, 116, 10, 116, 120, 95, 99, 111, 110, 116, 101, 120, 116, 2, 120, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 3, 8, 1, 8, 10, 3, 0, 1, 0, 0, 2, 5, 11, 1, 17, 1, 11, 0, 18, 0, 2, 0]], [0x0000000000000000000000000000000000000000000000000000000000000001, 0x0000000000000000000000000000000000000000000000000000000000000002]), TransferObjects([Result(0)], Input(0))] }"
           },
           "effects": {
@@ -156,7 +156,7 @@ Response: {
             "gasBudget": "5000000000"
           },
           "kind": {
-            "__typename": "ProgrammableTransaction",
+            "__typename": "ProgrammableTransactionBlock",
             "value": "ProgrammableTransaction { inputs: [Object(ImmOrOwnedObject((0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c, SequenceNumber(2), o#G9mY9FYpaNat8h5inn6w9UoMzh2A1UHGrjVShdgDfXDX))), Pure([0]), Pure([32, 171, 82, 196, 88, 52, 4, 188, 145, 159, 203, 235, 180, 132, 106, 122, 170, 108, 138, 21, 79, 188, 241, 113, 60, 80, 96, 230, 205, 10, 249, 74, 146])], commands: [MoveCall(ProgrammableMoveCall { package: 0x0000000000000000000000000000000000000000000000000000000000000002, module: Identifier(\"package\"), function: Identifier(\"authorize_upgrade\"), type_arguments: [], arguments: [Input(0), Input(1), Input(2)] }), Upgrade([[161, 28, 235, 11, 6, 0, 0, 0, 8, 1, 0, 6, 2, 6, 12, 3, 18, 20, 5, 38, 17, 7, 55, 60, 8, 115, 64, 10, 179, 1, 9, 12, 188, 1, 29, 0, 6, 1, 8, 1, 9, 0, 0, 12, 0, 1, 2, 4, 0, 2, 1, 2, 0, 0, 7, 0, 1, 0, 0, 3, 1, 2, 0, 1, 4, 4, 2, 0, 1, 7, 3, 4, 0, 2, 10, 3, 7, 8, 2, 1, 8, 0, 0, 1, 7, 8, 2, 1, 8, 1, 3, 70, 111, 111, 9, 84, 120, 67, 111, 110, 116, 101, 120, 116, 3, 85, 73, 68, 4, 98, 117, 114, 110, 6, 100, 101, 108, 101, 116, 101, 2, 105, 100, 1, 109, 3, 110, 101, 119, 6, 111, 98, 106, 101, 99, 116, 10, 116, 120, 95, 99, 111, 110, 116, 101, 120, 116, 2, 120, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 5, 8, 1, 10, 10, 3, 0, 1, 0, 0, 2, 5, 11, 1, 17, 3, 11, 0, 18, 0, 2, 1, 1, 0, 0, 2, 5, 11, 0, 19, 0, 1, 17, 2, 2, 0]], [0x0000000000000000000000000000000000000000000000000000000000000001, 0x0000000000000000000000000000000000000000000000000000000000000002], 0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972, Result(0)), MoveCall(ProgrammableMoveCall { package: 0x0000000000000000000000000000000000000000000000000000000000000002, module: Identifier(\"package\"), function: Identifier(\"commit_upgrade\"), type_arguments: [], arguments: [Input(0), Result(1)] })] }"
           },
           "effects": {
@@ -276,7 +276,7 @@ Response: {
             "gasBudget": "5000000000"
           },
           "kind": {
-            "__typename": "ProgrammableTransaction",
+            "__typename": "ProgrammableTransactionBlock",
             "value": "ProgrammableTransaction { inputs: [Pure([42, 0, 0, 0, 0, 0, 0, 0]), Pure([43, 0, 0, 0, 0, 0, 0, 0]), Pure([232, 3, 0, 0, 0, 0, 0, 0]), Pure([252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30])], commands: [MakeMoveVec(Some(U64), [Input(0), Input(1)]), MakeMoveVec(Some(U64), []), SplitCoins(GasCoin, [Input(2), Input(2)]), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"new\"), type_arguments: [], arguments: [Result(0)] }), TransferObjects([Result(3)], Input(3)), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"new\"), type_arguments: [], arguments: [Result(1)] }), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"burn\"), type_arguments: [], arguments: [Result(5)] }), MergeCoins(NestedResult(2, 0), [NestedResult(2, 1)]), TransferObjects([NestedResult(2, 0)], Input(3))] }"
           },
           "effects": {
@@ -432,7 +432,7 @@ Response: {
             "gasBudget": "5000000000"
           },
           "kind": {
-            "__typename": "ProgrammableTransaction",
+            "__typename": "ProgrammableTransactionBlock",
             "value": "ProgrammableTransaction { inputs: [Pure([232, 3, 0, 0, 0, 0, 0, 0])], commands: [SplitCoins(GasCoin, [Input(0)])] }"
           },
           "effects": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -38,7 +38,7 @@ module P0::m {
 
             kind {
                 __typename
-                ... on ProgrammableTransaction {
+                ... on ProgrammableTransactionBlock {
                     value
                 }
             }
@@ -128,7 +128,7 @@ module P0::m {
 
             kind {
                 __typename
-                ... on ProgrammableTransaction {
+                ... on ProgrammableTransactionBlock {
                     value
                 }
             }
@@ -209,7 +209,7 @@ module P0::m {
 
             kind {
                 __typename
-                ... on ProgrammableTransaction {
+                ... on ProgrammableTransactionBlock {
                     value
                 }
             }
@@ -291,7 +291,7 @@ module P0::m {
 
             kind {
                 __typename
-                ... on ProgrammableTransaction {
+                ... on ProgrammableTransactionBlock {
                     value
                 }
             }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -37,7 +37,7 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
-type AuthenticatorStateUpdate {
+type AuthenticatorStateUpdateTransaction {
 	value: String!
 }
 
@@ -1276,7 +1276,7 @@ type PageInfo {
 	endCursor: String
 }
 
-type ProgrammableTransaction {
+type ProgrammableTransactionBlock {
 	value: String!
 }
 
@@ -1364,7 +1364,7 @@ type Query {
 	coinMetadata(coinType: String!): CoinMetadata
 }
 
-type RandomnessStateUpdate {
+type RandomnessStateUpdateTransaction {
 	value: String!
 }
 
@@ -1791,7 +1791,7 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
-union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction | AuthenticatorStateUpdate | RandomnessStateUpdate | EndOfEpochTransaction
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -754,6 +754,9 @@ union TransactionBlockKind =
   | GenesisTransaction
   | ChangeEpochTransaction
   | ProgrammableTransactionBlock
+  | AuthenticatorStateUpdateTransaction
+  | RandomnessStateUpdateTransaction
+  | EndOfEpochTransaction
 
 type ConsensusCommitPrologueTransaction {
   epoch: Epoch

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -35,9 +35,9 @@ use crate::{
         system_parameters::SystemParameters,
         transaction_block::{TransactionBlock, TransactionBlockFilter},
         transaction_block_kind::{
-            AuthenticatorStateUpdate, ChangeEpochTransaction, ConsensusCommitPrologueTransaction,
-            EndOfEpochTransaction, GenesisTransaction, ProgrammableTransaction,
-            RandomnessStateUpdate, TransactionBlockKind,
+            AuthenticatorStateUpdateTransaction, ChangeEpochTransaction,
+            ConsensusCommitPrologueTransaction, EndOfEpochTransaction, GenesisTransaction,
+            ProgrammableTransactionBlock, RandomnessStateUpdateTransaction, TransactionBlockKind,
         },
         validator::Validator,
         validator_credentials::ValidatorCredentials,
@@ -1668,7 +1668,7 @@ impl From<&TransactionKind> for TransactionBlockKind {
                     computation_charge: Some(BigInt::from(x.computation_charge)),
                     storage_rebate: Some(BigInt::from(x.storage_rebate)),
                 };
-                TransactionBlockKind::ChangeEpochTransaction(change)
+                TransactionBlockKind::ChangeEpoch(change)
             }
             TransactionKind::ConsensusCommitPrologue(x) => {
                 let consensus = ConsensusCommitPrologueTransaction {
@@ -1676,7 +1676,7 @@ impl From<&TransactionKind> for TransactionBlockKind {
                     round: Some(x.round),
                     timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
                 };
-                TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
+                TransactionBlockKind::ConsensusCommitPrologue(consensus)
             }
             TransactionKind::ConsensusCommitPrologueV2(x) => {
                 let consensus = ConsensusCommitPrologueTransaction {
@@ -1684,7 +1684,7 @@ impl From<&TransactionKind> for TransactionBlockKind {
                     round: Some(x.round),
                     timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
                 };
-                TransactionBlockKind::ConsensusCommitPrologueTransaction(consensus)
+                TransactionBlockKind::ConsensusCommitPrologue(consensus)
             }
             TransactionKind::Genesis(x) => {
                 let genesis = GenesisTransaction {
@@ -1696,31 +1696,29 @@ impl From<&TransactionKind> for TransactionBlockKind {
                             .collect::<Vec<_>>(),
                     ),
                 };
-                TransactionBlockKind::GenesisTransaction(genesis)
+                TransactionBlockKind::Genesis(genesis)
             }
             // TODO: flesh out type
             TransactionKind::ProgrammableTransaction(pt) => {
-                TransactionBlockKind::ProgrammableTransactionBlock(ProgrammableTransaction {
+                TransactionBlockKind::Programmable(ProgrammableTransactionBlock {
                     value: format!("{:?}", pt),
                 })
             }
             // TODO: flesh out type
             TransactionKind::AuthenticatorStateUpdate(asu) => {
-                TransactionBlockKind::AuthenticatorStateUpdateTransaction(
-                    AuthenticatorStateUpdate {
-                        value: format!("{:?}", asu),
-                    },
-                )
+                TransactionBlockKind::AuthenticatorState(AuthenticatorStateUpdateTransaction {
+                    value: format!("{:?}", asu),
+                })
             }
             // TODO: flesh out type
             TransactionKind::RandomnessStateUpdate(rsu) => {
-                TransactionBlockKind::RandomnessStateUpdateTransaction(RandomnessStateUpdate {
+                TransactionBlockKind::Randomness(RandomnessStateUpdateTransaction {
                     value: format!("{:?}", rsu),
                 })
             }
             // TODO: flesh out type
             TransactionKind::EndOfEpochTransaction(et) => {
-                TransactionBlockKind::EndOfEpochTransaction(EndOfEpochTransaction {
+                TransactionBlockKind::EndOfEpoch(EndOfEpochTransaction {
                     value: format!("{:?}", et),
                 })
             }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -7,30 +7,30 @@ use async_graphql::*;
 
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {
-    ConsensusCommitPrologueTransaction(ConsensusCommitPrologueTransaction),
-    GenesisTransaction(GenesisTransaction),
-    ChangeEpochTransaction(ChangeEpochTransaction),
-    ProgrammableTransactionBlock(ProgrammableTransaction),
-    AuthenticatorStateUpdateTransaction(AuthenticatorStateUpdate),
-    RandomnessStateUpdateTransaction(RandomnessStateUpdate),
-    EndOfEpochTransaction(EndOfEpochTransaction),
+    ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),
+    Genesis(GenesisTransaction),
+    ChangeEpoch(ChangeEpochTransaction),
+    Programmable(ProgrammableTransactionBlock),
+    AuthenticatorState(AuthenticatorStateUpdateTransaction),
+    Randomness(RandomnessStateUpdateTransaction),
+    EndOfEpoch(EndOfEpochTransaction),
 }
 
 // TODO: flesh out the programmable transaction block type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct ProgrammableTransaction {
+pub(crate) struct ProgrammableTransactionBlock {
     pub value: String,
 }
 
 // TODO: flesh out the authenticator state update type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct AuthenticatorStateUpdate {
+pub(crate) struct AuthenticatorStateUpdateTransaction {
     pub value: String,
 }
 
 // TODO: flesh out the randomness state update type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct RandomnessStateUpdate {
+pub(crate) struct RandomnessStateUpdateTransaction {
     pub value: String,
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -41,7 +41,7 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
-type AuthenticatorStateUpdate {
+type AuthenticatorStateUpdateTransaction {
 	value: String!
 }
 
@@ -1280,7 +1280,7 @@ type PageInfo {
 	endCursor: String
 }
 
-type ProgrammableTransaction {
+type ProgrammableTransactionBlock {
 	value: String!
 }
 
@@ -1368,7 +1368,7 @@ type Query {
 	coinMetadata(coinType: String!): CoinMetadata
 }
 
-type RandomnessStateUpdate {
+type RandomnessStateUpdateTransaction {
 	value: String!
 }
 
@@ -1795,7 +1795,7 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
-union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransaction | AuthenticatorStateUpdate | RandomnessStateUpdate | EndOfEpochTransaction
+union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
 enum TransactionBlockKindInput {
 	SYSTEM_TX


### PR DESCRIPTION
## Description

Make sure all the transaction kind types end in `Transaction`, except `ProgrammableTransactionBlock` which is a compound transaction, so ends in `Block`.  Make sure the types match what is in the drafts.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --feaures pg_integration
```

## Stack

- #15095 
- #15145 
- #15146 
- #15147