### PR TITLE
[GraphQL/TransactionBlockKind][EASY] Move `From` impl into module

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -34,11 +34,6 @@ use crate::{
         sui_system_state_summary::SuiSystemStateSummary,
         system_parameters::SystemParameters,
         transaction_block::{TransactionBlock, TransactionBlockFilter},
-        transaction_block_kind::{
-            AuthenticatorStateUpdateTransaction, ChangeEpochTransaction,
-            ConsensusCommitPrologueTransaction, EndOfEpochTransaction, GenesisTransaction,
-            ProgrammableTransactionBlock, RandomnessStateUpdateTransaction, TransactionBlockKind,
-        },
         validator::Validator,
         validator_credentials::ValidatorCredentials,
         validator_set::ValidatorSet,
@@ -83,7 +78,6 @@ use sui_types::{
     sui_system_state::sui_system_state_summary::{
         SuiSystemStateSummary as NativeSuiSystemStateSummary, SuiValidatorSummary,
     },
-    transaction::{GenesisObject, TransactionKind},
     Identifier, TypeTag,
 };
 
@@ -1654,86 +1648,6 @@ impl TryFrom<NativeSuiSystemStateSummary> for SuiSystemStateSummary {
             protocol_version: system_state.protocol_version,
             start_timestamp: Some(start_timestamp),
         })
-    }
-}
-
-impl From<&TransactionKind> for TransactionBlockKind {
-    fn from(value: &TransactionKind) -> Self {
-        match value {
-            TransactionKind::ChangeEpoch(x) => {
-                let change = ChangeEpochTransaction {
-                    epoch_id: x.epoch,
-                    timestamp: DateTime::from_ms(x.epoch_start_timestamp_ms as i64),
-                    storage_charge: Some(BigInt::from(x.storage_charge)),
-                    computation_charge: Some(BigInt::from(x.computation_charge)),
-                    storage_rebate: Some(BigInt::from(x.storage_rebate)),
-                };
-                TransactionBlockKind::ChangeEpoch(change)
-            }
-            TransactionKind::ConsensusCommitPrologue(x) => {
-                let consensus = ConsensusCommitPrologueTransaction {
-                    epoch_id: x.epoch,
-                    round: Some(x.round),
-                    timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
-                };
-                TransactionBlockKind::ConsensusCommitPrologue(consensus)
-            }
-            TransactionKind::ConsensusCommitPrologueV2(x) => {
-                let consensus = ConsensusCommitPrologueTransaction {
-                    epoch_id: x.epoch,
-                    round: Some(x.round),
-                    timestamp: DateTime::from_ms(x.commit_timestamp_ms as i64),
-                };
-                TransactionBlockKind::ConsensusCommitPrologue(consensus)
-            }
-            TransactionKind::Genesis(x) => {
-                let genesis = GenesisTransaction {
-                    objects: Some(
-                        x.objects
-                            .clone()
-                            .into_iter()
-                            .map(SuiAddress::from)
-                            .collect::<Vec<_>>(),
-                    ),
-                };
-                TransactionBlockKind::Genesis(genesis)
-            }
-            // TODO: flesh out type
-            TransactionKind::ProgrammableTransaction(pt) => {
-                TransactionBlockKind::Programmable(ProgrammableTransactionBlock {
-                    value: format!("{:?}", pt),
-                })
-            }
-            // TODO: flesh out type
-            TransactionKind::AuthenticatorStateUpdate(asu) => {
-                TransactionBlockKind::AuthenticatorState(AuthenticatorStateUpdateTransaction {
-                    value: format!("{:?}", asu),
-                })
-            }
-            // TODO: flesh out type
-            TransactionKind::RandomnessStateUpdate(rsu) => {
-                TransactionBlockKind::Randomness(RandomnessStateUpdateTransaction {
-                    value: format!("{:?}", rsu),
-                })
-            }
-            // TODO: flesh out type
-            TransactionKind::EndOfEpochTransaction(et) => {
-                TransactionBlockKind::EndOfEpoch(EndOfEpochTransaction {
-                    value: format!("{:?}", et),
-                })
-            }
-        }
-    }
-}
-
-// TODO fix this GenesisObject
-impl From<GenesisObject> for SuiAddress {
-    fn from(value: GenesisObject) -> Self {
-        match value {
-            GenesisObject::RawObject { data, owner: _ } => {
-                SuiAddress::from_bytes(data.id().to_vec()).unwrap()
-            }
-        }
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -86,7 +86,7 @@ impl TransactionBlock {
     /// transaction of this kind.
     async fn kind(&self) -> Option<TransactionBlockKind> {
         Some(TransactionBlockKind::from(
-            self.native.transaction_data().kind(),
+            self.native.transaction_data().kind().clone(),
         ))
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind.rs
@@ -4,6 +4,7 @@
 use super::{big_int::BigInt, date_time::DateTime, epoch::Epoch, sui_address::SuiAddress};
 use crate::context_data::db_data_provider::PgManager;
 use async_graphql::*;
+use sui_types::transaction::{GenesisObject, TransactionKind as NativeTransactionKind};
 
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {
@@ -94,5 +95,75 @@ impl ChangeEpochTransaction {
             .extend()?;
 
         Ok(Some(epoch))
+    }
+}
+
+impl From<NativeTransactionKind> for TransactionBlockKind {
+    fn from(kind: NativeTransactionKind) -> Self {
+        use NativeTransactionKind as K;
+        use TransactionBlockKind as T;
+
+        match kind {
+            // TODO: flesh out type
+            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock {
+                value: format!("{pt:?}"),
+            }),
+
+            K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction {
+                epoch_id: ce.epoch,
+                timestamp: DateTime::from_ms(ce.epoch_start_timestamp_ms as i64),
+                storage_charge: Some(BigInt::from(ce.storage_charge)),
+                computation_charge: Some(BigInt::from(ce.computation_charge)),
+                storage_rebate: Some(BigInt::from(ce.storage_rebate)),
+            }),
+
+            K::Genesis(g) => T::Genesis(GenesisTransaction {
+                objects: Some(g.objects.iter().cloned().map(SuiAddress::from).collect()),
+            }),
+
+            K::ConsensusCommitPrologue(ccp) => {
+                T::ConsensusCommitPrologue(ConsensusCommitPrologueTransaction {
+                    epoch_id: ccp.epoch,
+                    round: Some(ccp.round),
+                    timestamp: DateTime::from_ms(ccp.commit_timestamp_ms as i64),
+                })
+            }
+
+            K::ConsensusCommitPrologueV2(ccp) => {
+                T::ConsensusCommitPrologue(ConsensusCommitPrologueTransaction {
+                    epoch_id: ccp.epoch,
+                    round: Some(ccp.round),
+                    timestamp: DateTime::from_ms(ccp.commit_timestamp_ms as i64),
+                })
+            }
+
+            // TODO: flesh out type
+            K::AuthenticatorStateUpdate(asu) => {
+                T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
+                    value: format!("{asu:?}"),
+                })
+            }
+
+            // TODO: flesh out type
+            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction {
+                value: format!("{eoe:?}"),
+            }),
+
+            // TODO: flesh out type
+            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
+                value: format!("{rsu:?}"),
+            }),
+        }
+    }
+}
+
+// TODO fix this GenesisObject
+impl From<GenesisObject> for SuiAddress {
+    fn from(value: GenesisObject) -> Self {
+        match value {
+            GenesisObject::RawObject { data, owner: _ } => {
+                SuiAddress::from_bytes(data.id().to_vec()).unwrap()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Move `impl From<NativeTransactionKind> for TransactionBlockKind` into the `transaction_block_kind` module, from `db_data_provider`, in preparation for updating its representation.

This PR also changes the conversion to be from value.  This will become more relevant when the conversion operator works by wrapping the native type with the GraphQL type (in follow-up PRs).

## Test Plan

This change doesn't affect behaviour at all:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 