### PR TITLE
[GraphQL/TransactionBlock] ChangeEpochTransaction

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -349,7 +349,7 @@ Response: {
             "epoch": {
               "epochId": 1
             },
-            "timestamp": "1970-01-01T00:01:25Z",
+            "startTimestamp": "1970-01-01T00:01:25Z",
             "storageCharge": "0",
             "computationCharge": "0",
             "storageRebate": "0"

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -170,7 +170,7 @@
                 __typename
                 ... on ChangeEpochTransaction {
                     epoch { epochId }
-                    timestamp
+                    startTimestamp
                     storageCharge
                     computationCharge
                     storageRebate

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1262,7 +1262,7 @@
 >        ... on ChangeEpochTransaction {
 >          computationCharge
 >          storageCharge
->          timestamp
+>          startTimestamp
 >          storageRebate
 >        }
 >        ... on GenesisTransaction {

--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
@@ -19,7 +19,7 @@
         ... on ChangeEpochTransaction {
           computationCharge
           storageCharge
-          timestamp
+          startTimestamp
           storageRebate
         }
         ... on GenesisTransaction {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -109,11 +109,41 @@ scalar BigInt
 
 
 type ChangeEpochTransaction {
-	timestamp: DateTime
-	storageCharge: BigInt
-	computationCharge: BigInt
-	storageRebate: BigInt
-	epoch: Epoch
+	"""
+	The next (to become) epoch.
+	"""
+	epoch: Epoch!
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int!
+	"""
+	The total amount of gas charged for storage during the previous epoch (in MIST).
+	"""
+	storageCharge: BigInt!
+	"""
+	The total amount of gas charged for computation during the previous epoch (in MIST).
+	"""
+	computationCharge: BigInt!
+	"""
+	The SUI returned to transaction senders for cleaning up objects (in MIST).
+	"""
+	storageRebate: BigInt!
+	"""
+	The total gas retained from storage fees, that will not be returned by storage rebates when
+	the relevant objects are cleaned up (in MIST).
+	"""
+	nonRefundableStorageFee: BigInt!
+	"""
+	Time at which the next epoch will start.
+	"""
+	startTimestamp: DateTime
+	"""
+	System packages (specifically framework and move stdlib) that are written before the new
+	epoch starts, to upgrade them on-chain. Validators write these packages out when running the
+	transaction.
+	"""
+	systemPackageConnection(first: Int, after: String, last: Int, before: String): MovePackageConnection!
 }
 
 type Checkpoint {
@@ -531,22 +561,22 @@ enum Feature {
 
 type GasCostSummary {
 	"""
-	Gas paid for executing this transaction.
+	Gas paid for executing this transaction (in MIST).
 	"""
 	computationCost: BigInt
 	"""
-	Gas paid for the data stored on-chain by this transaction.
+	Gas paid for the data stored on-chain by this transaction (in MIST).
 	"""
 	storageCost: BigInt
 	"""
 	Part of storage cost that can be reclaimed by cleaning up data created by this transaction
-	(when objects are deleted or an object is modified, whch is treated as a deletion followed
-	by a creation).
+	(when objects are deleted or an object is modified, which is treated as a deletion followed
+	by a creation) (in MIST).
 	"""
 	storageRebate: BigInt
 	"""
 	Part of storage cost that is not reclaimed when data created by this transaction is cleaned
-	up.
+	up (in MIST).
 	"""
 	nonRefundableStorageFee: BigInt
 }
@@ -566,7 +596,8 @@ type GasInput {
 	"""
 	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
 	"""
-	An unsigned integer specifying the number of native tokens per gas unit this transaction will pay
+	An unsigned integer specifying the number of native tokens per gas unit this transaction
+	will pay (in MIST).
 	"""
 	gasPrice: BigInt
 	"""
@@ -834,6 +865,35 @@ type MovePackage {
 	"""
 	bcs: Base64
 	asObject: Object!
+}
+
+type MovePackageConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [MovePackageEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MovePackage!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MovePackageEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: MovePackage!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -71,7 +71,8 @@ impl GasInput {
             .extend()
     }
 
-    /// An unsigned integer specifying the number of native tokens per gas unit this transaction will pay
+    /// An unsigned integer specifying the number of native tokens per gas unit this transaction
+    /// will pay (in MIST).
     async fn gas_price(&self) -> Option<BigInt> {
         Some(BigInt::from(self.price))
     }
@@ -84,25 +85,25 @@ impl GasInput {
 
 #[Object]
 impl GasCostSummary {
-    /// Gas paid for executing this transaction.
+    /// Gas paid for executing this transaction (in MIST).
     async fn computation_cost(&self) -> Option<BigInt> {
         Some(BigInt::from(self.computation_cost))
     }
 
-    /// Gas paid for the data stored on-chain by this transaction.
+    /// Gas paid for the data stored on-chain by this transaction (in MIST).
     async fn storage_cost(&self) -> Option<BigInt> {
         Some(BigInt::from(self.storage_cost))
     }
 
     /// Part of storage cost that can be reclaimed by cleaning up data created by this transaction
-    /// (when objects are deleted or an object is modified, whch is treated as a deletion followed
-    /// by a creation).
+    /// (when objects are deleted or an object is modified, which is treated as a deletion followed
+    /// by a creation) (in MIST).
     async fn storage_rebate(&self) -> Option<BigInt> {
         Some(BigInt::from(self.storage_rebate))
     }
 
     /// Part of storage cost that is not reclaimed when data created by this transaction is cleaned
-    /// up.
+    /// up (in MIST).
     async fn non_refundable_storage_fee(&self) -> Option<BigInt> {
         Some(BigInt::from(self.non_refundable_storage_fee))
     }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -294,6 +294,17 @@ impl Object {
     }
 }
 
+impl Object {
+    /// Construct a GraphQL object from a native object, without its stored (indexed) counterpart.
+    pub(crate) fn from_native(address: SuiAddress, native: NativeObject) -> Object {
+        Object {
+            address,
+            stored: None,
+            native,
+        }
+    }
+}
+
 impl TryFrom<StoredObject> for Object {
     type Error = Error;
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/change_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/change_epoch.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::connection::{Connection, Edge};
+use async_graphql::*;
+use move_binary_format::errors::PartialVMResult;
+use move_binary_format::CompiledModule;
+use sui_types::{
+    digests::TransactionDigest, object::Object as NativeObject,
+    transaction::ChangeEpoch as NativeChangeEpochTransaction,
+};
+
+use crate::context_data::db_data_provider::validate_cursor_pagination;
+use crate::types::sui_address::SuiAddress;
+use crate::{
+    context_data::db_data_provider::PgManager,
+    error::Error,
+    types::{
+        big_int::BigInt, date_time::DateTime, epoch::Epoch, move_package::MovePackage,
+        object::Object,
+    },
+};
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ChangeEpochTransaction(pub NativeChangeEpochTransaction);
+
+#[Object]
+impl ChangeEpochTransaction {
+    /// The next (to become) epoch.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.0.epoch)
+            .await
+            .extend()
+    }
+
+    /// The protocol version in effect in the new epoch.
+    async fn protocol_version(&self) -> u64 {
+        self.0.protocol_version.as_u64()
+    }
+
+    /// The total amount of gas charged for storage during the previous epoch (in MIST).
+    async fn storage_charge(&self) -> BigInt {
+        BigInt::from(self.0.storage_charge)
+    }
+
+    /// The total amount of gas charged for computation during the previous epoch (in MIST).
+    async fn computation_charge(&self) -> BigInt {
+        BigInt::from(self.0.computation_charge)
+    }
+
+    /// The SUI returned to transaction senders for cleaning up objects (in MIST).
+    async fn storage_rebate(&self) -> BigInt {
+        BigInt::from(self.0.storage_rebate)
+    }
+
+    /// The total gas retained from storage fees, that will not be returned by storage rebates when
+    /// the relevant objects are cleaned up (in MIST).
+    async fn non_refundable_storage_fee(&self) -> BigInt {
+        BigInt::from(self.0.non_refundable_storage_fee)
+    }
+
+    /// Time at which the next epoch will start.
+    async fn start_timestamp(&self) -> Option<DateTime> {
+        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)
+    }
+
+    /// System packages (specifically framework and move stdlib) that are written before the new
+    /// epoch starts, to upgrade them on-chain. Validators write these packages out when running the
+    /// transaction.
+    async fn system_package_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Connection<String, MovePackage>> {
+        // TODO: make cursor opaque (currently just an offset).
+        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+
+        let total = self.0.system_packages.len();
+
+        let mut lo = if let Some(after) = after {
+            1 + after
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
+                .extend()?
+        } else {
+            0
+        };
+
+        let mut hi = if let Some(before) = before {
+            before
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
+                .extend()?
+        } else {
+            total
+        };
+
+        let mut connection = Connection::new(false, false);
+        if hi <= lo {
+            return Ok(connection);
+        }
+
+        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
+        // lowerbound.
+        if let Some(first) = first {
+            let first = first as usize;
+            if hi - lo > first {
+                hi = lo + first;
+            }
+        }
+
+        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
+        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
+        if let Some(last) = last {
+            let last = last as usize;
+            if hi - lo > last {
+                lo = hi - last;
+            }
+        }
+
+        connection.has_previous_page = 0 < lo;
+        connection.has_next_page = hi < total;
+
+        for (idx, (version, modules, deps)) in self
+            .0
+            .system_packages
+            .iter()
+            .enumerate()
+            .skip(lo)
+            .take(hi - lo)
+        {
+            let compiled_modules = modules
+                .iter()
+                .map(|bytes| CompiledModule::deserialize_with_defaults(bytes))
+                .collect::<PartialVMResult<Vec<_>>>()
+                .map_err(|e| Error::Internal(format!("Failed to deserialize system modules: {e}")))
+                .extend()?;
+
+            let native = NativeObject::new_system_package(
+                &compiled_modules,
+                *version,
+                deps.clone(),
+                TransactionDigest::ZERO,
+            );
+
+            let runtime_id = native.id();
+            let object = Object::from_native(SuiAddress::from(runtime_id), native);
+            let package = MovePackage::try_from(&object)
+                .map_err(|_| Error::Internal("Failed to create system package".to_string()))
+                .extend()?;
+
+            connection.edges.push(Edge::new(idx.to_string(), package));
+        }
+
+        Ok(connection)
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -113,11 +113,41 @@ scalar BigInt
 
 
 type ChangeEpochTransaction {
-	timestamp: DateTime
-	storageCharge: BigInt
-	computationCharge: BigInt
-	storageRebate: BigInt
-	epoch: Epoch
+	"""
+	The next (to become) epoch.
+	"""
+	epoch: Epoch!
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int!
+	"""
+	The total amount of gas charged for storage during the previous epoch (in MIST).
+	"""
+	storageCharge: BigInt!
+	"""
+	The total amount of gas charged for computation during the previous epoch (in MIST).
+	"""
+	computationCharge: BigInt!
+	"""
+	The SUI returned to transaction senders for cleaning up objects (in MIST).
+	"""
+	storageRebate: BigInt!
+	"""
+	The total gas retained from storage fees, that will not be returned by storage rebates when
+	the relevant objects are cleaned up (in MIST).
+	"""
+	nonRefundableStorageFee: BigInt!
+	"""
+	Time at which the next epoch will start.
+	"""
+	startTimestamp: DateTime
+	"""
+	System packages (specifically framework and move stdlib) that are written before the new
+	epoch starts, to upgrade them on-chain. Validators write these packages out when running the
+	transaction.
+	"""
+	systemPackageConnection(first: Int, after: String, last: Int, before: String): MovePackageConnection!
 }
 
 type Checkpoint {
@@ -535,22 +565,22 @@ enum Feature {
 
 type GasCostSummary {
 	"""
-	Gas paid for executing this transaction.
+	Gas paid for executing this transaction (in MIST).
 	"""
 	computationCost: BigInt
 	"""
-	Gas paid for the data stored on-chain by this transaction.
+	Gas paid for the data stored on-chain by this transaction (in MIST).
 	"""
 	storageCost: BigInt
 	"""
 	Part of storage cost that can be reclaimed by cleaning up data created by this transaction
-	(when objects are deleted or an object is modified, whch is treated as a deletion followed
-	by a creation).
+	(when objects are deleted or an object is modified, which is treated as a deletion followed
+	by a creation) (in MIST).
 	"""
 	storageRebate: BigInt
 	"""
 	Part of storage cost that is not reclaimed when data created by this transaction is cleaned
-	up.
+	up (in MIST).
 	"""
 	nonRefundableStorageFee: BigInt
 }
@@ -570,7 +600,8 @@ type GasInput {
 	"""
 	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
 	"""
-	An unsigned integer specifying the number of native tokens per gas unit this transaction will pay
+	An unsigned integer specifying the number of native tokens per gas unit this transaction
+	will pay (in MIST).
 	"""
 	gasPrice: BigInt
 	"""
@@ -838,6 +869,35 @@ type MovePackage {
 	"""
 	bcs: Base64
 	asObject: Object!
+}
+
+type MovePackageConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [MovePackageEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MovePackage!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MovePackageEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: MovePackage!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """


### PR DESCRIPTION
## Description

Complete support for the ChangeEpoch transaction kind, leveraging the support for representing `Object`s that have not been indexed to represent the contents of system package upgrades.

This PR adds the following fields:

- `ChangeEpochTransaction.protocolVersion`.
- `ChangeEpochTransaction.systemPackageConnection`.

And renames `ChangeEpochTransaction.timestamp` to `ChangeEpochTransaction.startTimestamp` to match its representation in `sui-types`.

It also uses the native representation of `ChangeEpochTransaction` as the underlying representation of the GraphQL type, moving it into its own module.

## Test Plan

It's not easy to simulate a system package upgrade using transactional tests, so instead, tested manually, by viewing the following transaction: `F8GGcAVhtPumDoXzc6z9N8Hf9zoTNFx1BPiCy7FJNZsQ` (which is a change epoch transaction involving a system package):

<img width="1888" alt="Screenshot 2023-12-02 at 8 45 29 PM" src="https://github.com/MystenLabs/sui/assets/332275/8dedd79a-5d69-4fa7-8b22-274ecb886e13">

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 