### PR TITLE
[GraphQL/TransactionBlock] ConsensusCommitPrologueTransaction

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -988,7 +988,7 @@ Response: {
 task 3 'create-checkpoint'. lines 94-94:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 96-164:
+task 4 'run-graphql'. lines 96-165:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -1015,7 +1015,8 @@ Response: {
               "epochId": 0
             },
             "round": 0,
-            "timestamp": "1970-01-01T00:00:42Z"
+            "commitTimestamp": "1970-01-01T00:00:42Z",
+            "consensusCommitDigest": "11111111111111111111111111111111"
           },
           "effects": {
             "status": "SUCCESS",
@@ -1065,10 +1066,10 @@ Response: {
   }
 }
 
-task 6 'advance-epoch'. lines 168-168:
+task 6 'advance-epoch'. lines 169-169:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 170-239:
+task 7 'run-graphql'. lines 171-240:
 Response: {
   "data": {
     "transactionBlockConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -115,7 +115,8 @@
                 ... on ConsensusCommitPrologueTransaction {
                     epoch { epochId }
                     round
-                    timestamp
+                    commitTimestamp
+                    consensusCommitDigest
                 }
             }
 

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1252,12 +1252,13 @@
 >      kind {
 >        __typename
 >        ... on ConsensusCommitPrologueTransaction {
->          timestamp
->          round
 >          epoch {
 >            epochId
 >            referenceGasPrice
 >          }
+>          round
+>          commitTimestamp
+>          consensusCommitDigest
 >        }
 >        ... on ChangeEpochTransaction {
 >          computationCharge

--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
@@ -9,12 +9,13 @@
       kind {
         __typename
         ... on ConsensusCommitPrologueTransaction {
-          timestamp
-          round
           epoch {
             epochId
             referenceGasPrice
           }
+          round
+          commitTimestamp
+          consensusCommitDigest
         }
         ... on ChangeEpochTransaction {
           computationCharge

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -303,9 +303,23 @@ type CommitteeMember {
 }
 
 type ConsensusCommitPrologueTransaction {
-	round: Int
-	timestamp: DateTime
-	epoch: Epoch
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Consensus round of the commit.
+	"""
+	round: Int!
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2 of the
+	transaction).
+	"""
+	consensusCommitDigest: String
 }
 
 scalar DateTime

--- a/crates/sui-graphql-rpc/src/types/date_time.rs
+++ b/crates/sui-graphql-rpc/src/types/date_time.rs
@@ -32,6 +32,9 @@ impl ScalarType for DateTime {
 
 impl DateTime {
     pub fn from_ms(timestamp_ms: i64) -> Option<Self> {
+        // TODO: `timestamp_millis_opt` returns an optional to handle ambiguous time conversions
+        // which UTC does not have, so this should be converted to return a Result, with an
+        // `InternalError`.
         ChronoUtc
             .timestamp_millis_opt(timestamp_ms)
             .single()

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    context_data::db_data_provider::PgManager,
+    types::{date_time::DateTime, epoch::Epoch},
+};
+use async_graphql::*;
+use fastcrypto::encoding::{Base58, Encoding};
+use sui_types::{
+    digests::ConsensusCommitDigest,
+    messages_checkpoint::CheckpointTimestamp,
+    messages_consensus::{
+        ConsensusCommitPrologue as NativeConsensusCommitPrologueTransactionV1,
+        ConsensusCommitPrologueV2 as NativeConsensusCommitPrologueTransactionV2,
+    },
+};
+
+/// Other transaction kinds are usually represented by directly wrapping their native
+/// representation. This kind has two native versions in the protocol, so the same cannot be done.
+/// V2 has all the fields of V1 and one extra (consensus commit digest). The GraphQL representation
+/// of this type is a struct containing all the common fields, as they are in the native type, and
+/// an optional `consensus_commit_digest`.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ConsensusCommitPrologueTransaction {
+    epoch: u64,
+    round: u64,
+    commit_timestamp_ms: CheckpointTimestamp,
+    consensus_commit_digest: Option<ConsensusCommitDigest>,
+}
+
+#[Object]
+impl ConsensusCommitPrologueTransaction {
+    /// Epoch of the commit prologue transaction.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.epoch)
+            .await
+            .extend()
+    }
+
+    /// Consensus round of the commit.
+    async fn round(&self) -> u64 {
+        self.round
+    }
+
+    /// Unix timestamp from consensus.
+    async fn commit_timestamp(&self) -> Option<DateTime> {
+        DateTime::from_ms(self.commit_timestamp_ms as i64)
+    }
+
+    /// Digest of consensus output, encoded as a Base58 string (only available from V2 of the
+    /// transaction).
+    async fn consensus_commit_digest(&self) -> Option<String> {
+        self.consensus_commit_digest
+            .map(|digest| Base58::encode(digest.inner()))
+    }
+}
+
+impl From<NativeConsensusCommitPrologueTransactionV1> for ConsensusCommitPrologueTransaction {
+    fn from(ccp: NativeConsensusCommitPrologueTransactionV1) -> Self {
+        Self {
+            epoch: ccp.epoch,
+            round: ccp.round,
+            commit_timestamp_ms: ccp.commit_timestamp_ms,
+            consensus_commit_digest: None,
+        }
+    }
+}
+
+impl From<NativeConsensusCommitPrologueTransactionV2> for ConsensusCommitPrologueTransaction {
+    fn from(ccp: NativeConsensusCommitPrologueTransactionV2) -> Self {
+        Self {
+            epoch: ccp.epoch,
+            round: ccp.round,
+            commit_timestamp_ms: ccp.commit_timestamp_ms,
+            consensus_commit_digest: Some(ccp.consensus_commit_digest),
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -307,9 +307,23 @@ type CommitteeMember {
 }
 
 type ConsensusCommitPrologueTransaction {
-	round: Int
-	timestamp: DateTime
-	epoch: Epoch
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Consensus round of the commit.
+	"""
+	round: Int!
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2 of the
+	transaction).
+	"""
+	consensusCommitDigest: String
 }
 
 scalar DateTime


### PR DESCRIPTION
## Description

- Move implementation to its own module.
- Align with pattern used for other kind types (relying on the native representation), but with a twist.
- Adds `consensusCommitDigest` from the V2 version.
- Rename `timestamp` to `commitTimestamp` to match core protocol type.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --feature pg_integration          \
  -- system.move
```

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 
- #15182 
- #15183 