### PR TITLE
[GraphQL/TransactionBlock] RandomnessStateUpdate

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -27,6 +27,7 @@ use sui_types::error::SuiError;
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
+use sui_types::transaction::EndOfEpochTransactionKind;
 use sui_types::{
     base_types::SuiAddress,
     committee::Committee,
@@ -221,19 +222,30 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
     /// Advances the epoch.
     ///
-    /// This creates and executes an EpochChange transaction which advances the chain into the next
-    /// epoch. Since the EpochChange transaction is required to be the final transaction in an
-    /// epoch, the final checkpoint in the epoch is also created.
+    /// This creates and executes an EndOfEpoch transaction which advances the chain into the next
+    /// epoch. Since it is required to be the final transaction in an epoch, the final checkpoint in
+    /// the epoch is also created.
+    ///
+    /// create_random_state controls whether a `RandomStateCreate` end of epoch transaction is
+    /// included as part of this epoch change (to initialise on-chain randomness for the first
+    /// time).
     ///
     /// NOTE: This function does not currently support updating the protocol version or the system
     /// packages
-    pub fn advance_epoch(&mut self) {
+    pub fn advance_epoch(&mut self, create_random_state: bool) {
         let next_epoch = self.epoch_state.epoch() + 1;
         let next_epoch_protocol_version = self.epoch_state.protocol_version();
         let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
         let epoch_start_timestamp_ms = self.store.get_clock().timestamp_ms();
         let next_epoch_system_package_bytes = vec![];
-        let tx = VerifiedTransaction::new_change_epoch(
+
+        let mut kinds = vec![];
+
+        if create_random_state {
+            kinds.push(EndOfEpochTransactionKind::new_randomness_state_create());
+        }
+
+        kinds.push(EndOfEpochTransactionKind::new_change_epoch(
             next_epoch,
             next_epoch_protocol_version,
             gas_cost_summary.storage_cost,
@@ -242,8 +254,9 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             gas_cost_summary.non_refundable_storage_fee,
             epoch_start_timestamp_ms,
             next_epoch_system_package_bytes,
-        );
+        ));
 
+        let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
         self.execute_transaction(tx.into())
             .expect("advancing the epoch cannot fail");
 
@@ -463,7 +476,7 @@ mod tests {
 
         let start_epoch = chain.store.get_highest_checkpint().unwrap().epoch;
         for i in 0..steps {
-            chain.advance_epoch();
+            chain.advance_epoch(/* create_random_state */ false);
             chain.advance_clock(Duration::from_millis(1));
             chain.create_checkpoint();
             println!("{i}");

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -26,7 +26,7 @@ task 6 'advance-epoch'. lines 39-39:
 Epoch advanced: 5
 
 task 7 'view-checkpoint'. lines 41-41:
-CheckpointSummary { epoch: 5, seq: 10, content_digest: 61bEMkkiRg8f9wrnsiJr41Q5wBH1jmNZHQDkNmPYw5NM,
+CheckpointSummary { epoch: 5, seq: 10, content_digest: E8F7PJ9CSU8i8pSr6d3HXKdMxdyTb6NLdnc32dQAg9P3,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
 task 8 'run-graphql'. lines 43-49:

--- a/crates/sui-graphql-e2e-tests/tests/transactions/random.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/random.exp
@@ -1,0 +1,63 @@
+processed 7 tasks
+
+task 1 'create-checkpoint'. lines 6-6:
+Checkpoint created: 1
+
+task 2 'advance-epoch'. lines 8-8:
+Epoch advanced: 0
+
+task 3 'run-graphql'. lines 10-30:
+Response: {
+  "data": {
+    "latestSuiSystemState": {
+      "protocolConfigs": {
+        "protocolVersion": 32,
+        "randomBeacon": {
+          "value": true
+        }
+      }
+    },
+    "object": {
+      "location": "0x0000000000000000000000000000000000000000000000000000000000000008",
+      "version": 2,
+      "asMoveObject": {
+        "contents": {
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::random::Random"
+          },
+          "json": {
+            "id": "0x0000000000000000000000000000000000000000000000000000000000000008",
+            "inner": {
+              "id": "0x25629a1397e4822d51639dd612de1377cdb8d09fb30263af5a1632b38427f554",
+              "version": "1"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+task 5 'create-checkpoint'. lines 36-36:
+Checkpoint created: 3
+
+task 6 'run-graphql'. lines 38-53:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "kind": {
+            "__typename": "RandomnessStateUpdateTransaction",
+            "epoch": {
+              "epochId": 0
+            },
+            "randomnessRound": 1,
+            "randomBytes": "SGVsbG8gU3Vp",
+            "randomnessObjInitialSharedVersion": 2
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/random.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/random.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator
+
+//# create-checkpoint
+
+//# advance-epoch --create-random-state
+
+//# run-graphql
+# Make sure the randomness state was created on the epoch boundary
+{
+    latestSuiSystemState {
+        protocolConfigs {
+            protocolVersion
+            randomBeacon: featureFlag(key: "random_beacon") { value }
+        }
+    }
+
+    object(address: "0x8") {
+        location
+        version
+        asMoveObject {
+            contents {
+                type { repr }
+                json
+            }
+        }
+    }
+}
+
+
+//# set-random-state --randomness-round 1 --random-bytes SGVsbG8gU3Vp --randomness-initial-version 2
+# Set the contents of the randomness object
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            kind {
+                __typename
+                ... on RandomnessStateUpdateTransaction {
+                    epoch { epochId }
+                    randomnessRound
+                    randomBytes
+                    randomnessObjInitialSharedVersion
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -1069,13 +1069,13 @@ Response: {
 task 6 'advance-epoch'. lines 169-169:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 171-240:
+task 7 'run-graphql'. lines 171-236:
 Response: {
   "data": {
     "transactionBlockConnection": {
       "nodes": [
         {
-          "digest": "fvUnamxVj1m1M4DZ8dryuzqrjYRvLDHNjexNwxc6HA7",
+          "digest": "GKoYFakg3kNVzzFVWyLUTTYw4h29b2g4Mw2qMWCRsPZe",
           "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
@@ -1091,14 +1091,8 @@ Response: {
             "gasBudget": "0"
           },
           "kind": {
-            "__typename": "ChangeEpochTransaction",
-            "epoch": {
-              "epochId": 1
-            },
-            "startTimestamp": "1970-01-01T00:01:25Z",
-            "storageCharge": "0",
-            "computationCharge": "0",
-            "storageRebate": "0"
+            "__typename": "EndOfEpochTransaction",
+            "value": "[ChangeEpoch(ChangeEpoch { epoch: 1, protocol_version: ProtocolVersion(32), storage_charge: 0, computation_charge: 0, storage_rebate: 0, non_refundable_storage_fee: 0, epoch_start_timestamp_ms: 85000, system_packages: [] })]"
           },
           "effects": {
             "status": "SUCCESS",
@@ -1117,7 +1111,7 @@ Response: {
                 "idDeleted": false,
                 "outputState": {
                   "location": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                  "digest": "5jzahJer9cg4yJaBZhjpEAbLtzHcKguzMtFBc1poL5fS"
+                  "digest": "J1C81xskJaop96EsuSZXSxgvodwmMnD9tdDfocXxzrFg"
                 }
               },
               {
@@ -1126,7 +1120,7 @@ Response: {
                 "idDeleted": false,
                 "outputState": {
                   "location": "0x19d32e729fa9b502bb1c9cd043465a42d341d75aa952be050355b94918530bd7",
-                  "digest": "8mEa8WX4KAN54tQ8QeTeiKeDE9YWKtxV5wD9ArYyif3q"
+                  "digest": "Gx3QAxbL3mhy8iMs7eeoak3sexsofThp5vQ2nXQKA7Hz"
                 }
               },
               {
@@ -1135,7 +1129,7 @@ Response: {
                 "idDeleted": false,
                 "outputState": {
                   "location": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
-                  "digest": "4t3qXxnURzPoMNEYZVeCtdGnj7jKbSLRa6aDRuVeUgiW"
+                  "digest": "31jjBqQsbj1ngB5DHiUa2m3TQmZf1pDSVfd1BXWAPovo"
                 }
               },
               {
@@ -1162,7 +1156,7 @@ Response: {
               "sequenceNumber": 2
             },
             "transactionBlock": {
-              "digest": "fvUnamxVj1m1M4DZ8dryuzqrjYRvLDHNjexNwxc6HA7"
+              "digest": "GKoYFakg3kNVzzFVWyLUTTYw4h29b2g4Mw2qMWCRsPZe"
             }
           },
           "expiration": null

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -186,12 +186,8 @@
 
             kind {
                 __typename
-                ... on ChangeEpochTransaction {
-                    epoch { epochId }
-                    startTimestamp
-                    storageCharge
-                    computationCharge
-                    storageRebate
+                ... on EndOfEpochTransaction {
+                    value
                 }
             }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1441,8 +1441,26 @@ type Query {
 	coinMetadata(coinType: String!): CoinMetadata
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
 type RandomnessStateUpdateTransaction {
-	value: String!
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int!
+	"""
+	Updated random bytes, encoded as Base64.
+	"""
+	randomBytes: Base64!
+	"""
+	The initial version the randomness object was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int!
 }
 
 """

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -4,6 +4,7 @@
 use self::{
     change_epoch::ChangeEpochTransaction,
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    randomness_state_update::RandomnessStateUpdateTransaction,
 };
 use async_graphql::*;
 use sui_types::transaction::TransactionKind as NativeTransactionKind;
@@ -11,6 +12,7 @@ use sui_types::transaction::TransactionKind as NativeTransactionKind;
 pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
+pub(crate) mod randomness_state_update;
 
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {
@@ -32,12 +34,6 @@ pub(crate) struct ProgrammableTransactionBlock {
 // TODO: flesh out the authenticator state update type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 pub(crate) struct AuthenticatorStateUpdateTransaction {
-    pub value: String,
-}
-
-// TODO: flesh out the randomness state update type
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct RandomnessStateUpdateTransaction {
     pub value: String,
 }
 
@@ -83,10 +79,7 @@ impl From<NativeTransactionKind> for TransactionBlockKind {
                 value: format!("{eoe:?}"),
             }),
 
-            // TODO: flesh out type
-            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
-                value: format!("{rsu:?}"),
-            }),
+            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction(rsu)),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    context_data::db_data_provider::PgManager,
+    types::{base64::Base64, epoch::Epoch},
+};
+use async_graphql::*;
+use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct RandomnessStateUpdateTransaction(pub NativeRandomnessStateUpdate);
+
+/// System transaction to update the source of on-chain randomness.
+#[Object]
+impl RandomnessStateUpdateTransaction {
+    /// Epoch of the randomness state update transaction.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.0.epoch)
+            .await
+            .extend()
+    }
+
+    /// Randomness round of the update.
+    async fn randomness_round(&self) -> u64 {
+        self.0.randomness_round
+    }
+
+    /// Updated random bytes, encoded as Base64.
+    async fn random_bytes(&self) -> Base64 {
+        Base64::from(&self.0.random_bytes)
+    }
+
+    /// The initial version the randomness object was shared at.
+    async fn randomness_obj_initial_shared_version(&self) -> u64 {
+        self.0.randomness_obj_initial_shared_version.value()
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1445,8 +1445,26 @@ type Query {
 	coinMetadata(coinType: String!): CoinMetadata
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
 type RandomnessStateUpdateTransaction {
-	value: String!
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int!
+	"""
+	Updated random bytes, encoded as Base64.
+	"""
+	randomBytes: Base64!
+	"""
+	The initial version the randomness object was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int!
 }
 
 """

--- a/crates/sui-rest-api/src/node_state_getter.rs
+++ b/crates/sui-rest-api/src/node_state_getter.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_core::authority::AuthorityState;
+use sui_types::committee::EpochId;
 use sui_types::error::UserInputError;
 use sui_types::{
     base_types::{ObjectID, VersionNumber},
@@ -19,6 +20,13 @@ use sui_types::{
 /// Trait for getting data from the node state.
 /// TODO: need a better name for this?
 pub trait NodeStateGetter: Sync + Send {
+    fn get_latest_epoch_id(&self) -> SuiResult<EpochId> {
+        let latest_checkpoint_id = self.get_latest_checkpoint_sequence_number()?;
+        let latest_checkpoint =
+            self.get_verified_checkpoint_by_sequence_number(latest_checkpoint_id)?;
+        Ok(latest_checkpoint.epoch())
+    }
+
     fn get_verified_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -156,6 +156,18 @@ pub struct CreateCheckpointCommand {
 #[derive(Debug, clap::Parser)]
 pub struct AdvanceEpochCommand {
     pub count: Option<u64>,
+    #[clap(long = "create-random-state")]
+    pub create_random_state: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct SetRandomStateCommand {
+    #[clap(long = "randomness-round")]
+    pub randomness_round: u64,
+    #[clap(long = "random-bytes")]
+    pub random_bytes: String,
+    #[clap(long = "randomness-initial-version")]
+    pub randomness_initial_version: u64,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -180,6 +192,8 @@ pub enum SuiSubcommand {
     AdvanceEpoch(AdvanceEpochCommand),
     #[clap(name = "advance-clock")]
     AdvanceClock(AdvanceClockCommand),
+    #[clap(name = "set-random-state")]
+    SetRandomState(SetRandomStateCommand),
     #[clap(name = "view-checkpoint")]
     ViewCheckpoint,
     #[clap(name = "run-graphql")]

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -75,7 +75,7 @@ pub trait TransactionalAdapter: Send + Sync + ObjectStore + NodeStateGetter {
         duration: std::time::Duration,
     ) -> anyhow::Result<TransactionEffects>;
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()>;
+    async fn advance_epoch(&mut self, create_random_state: bool) -> anyhow::Result<()>;
 
     async fn request_gas(
         &mut self,
@@ -163,7 +163,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         unimplemented!("advance_clock not supported")
     }
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
+    async fn advance_epoch(&mut self, _create_random_state: bool) -> anyhow::Result<()> {
         unimplemented!("advance_epoch not supported")
     }
 
@@ -312,8 +312,8 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         Ok(self.advance_clock(duration))
     }
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
-        self.advance_epoch();
+    async fn advance_epoch(&mut self, create_random_state: bool) -> anyhow::Result<()> {
+        self.advance_epoch(create_random_state);
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Add structured support for the `RandomnessStateUpdate` transaction.

## Test Plan

Added a new E2E test that sets up the randomness object, and updates it:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- random.move
```

This required making some changes and additions to the transactional test runner:

- Epoch changes using `EndOfEpochTransaction` (the newer form) instead of `ChangeEpoch`.
- A `--create-random-state` option for `advance-epoch`.
- A `set-random-state` command for running the associated system transaction.
- An API for extracting the latest Epoch ID.

This has knock-on effects to other tests:

- Digests change because the epoch change transaction kind has changed.
- The test for `ChangeEpochTransaction` no longer works (but this will be fixed once `EndOfEpochTransaction` gains full support in an upcoming PR).
- (I replaced some fully-qualified types/functions with a `use`).


## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 
- #15182 
- #15183 
- #15184 