### PR TITLE
[GraphQL/TransactionBlock] AuthenticatorStateUpdate

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1,3 +1,63 @@
+type ActiveJwk {
+	"""
+	The string (Issuing Authority) that identifies the OIDC provider.
+	"""
+	iss: String!
+	"""
+	The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
+	"""
+	kid: String!
+	"""
+	The JWK key type parameter, (RFC 7517, Section 4.1).
+	"""
+	kty: String!
+	"""
+	The JWK RSA public exponent, (RFC 7517, Section 9.3).
+	"""
+	e: String!
+	"""
+	The JWK RSA modulus, (RFC 7517, Section 9.3).
+	"""
+	n: String!
+	"""
+	The JWK algorithm parameter, (RFC 7517, Section 4.4).
+	"""
+	alg: String!
+	"""
+	The most recent epoch in which the JWK was validated.
+	"""
+	epoch: Epoch!
+}
+
+type ActiveJwkConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ActiveJwkEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ActiveJwk!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ActiveJwkEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ActiveJwk!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Address implements ObjectOwner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
@@ -38,7 +98,22 @@ enum AddressTransactionBlockRelationship {
 }
 
 type AuthenticatorStateUpdateTransaction {
-	value: String!
+	"""
+	Epoch of the authenticator state update transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Consensus round of the authenticator state update.
+	"""
+	round: Int!
+	"""
+	Newly active JWKs (JSON Web Keys).
+	"""
+	newActiveJwkConnection(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
+	"""
+	The initial version of the authenticator object that it was shared at.
+	"""
+	authenticatorObjInitialSharedVersion: Int!
 }
 
 type Balance {

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    connection::{Connection, Edge},
+    *,
+};
+
+use sui_types::{
+    authenticator_state::ActiveJwk as NativeActiveJwk,
+    transaction::AuthenticatorStateUpdate as NativeAuthenticatorStateUpdateTransaction,
+};
+
+use crate::{
+    context_data::db_data_provider::{validate_cursor_pagination, PgManager},
+    error::Error,
+    types::epoch::Epoch,
+};
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct AuthenticatorStateUpdateTransaction(
+    pub NativeAuthenticatorStateUpdateTransaction,
+);
+
+struct ActiveJwk(NativeActiveJwk);
+
+#[Object]
+impl AuthenticatorStateUpdateTransaction {
+    /// Epoch of the authenticator state update transaction.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.0.epoch)
+            .await
+            .extend()
+    }
+
+    /// Consensus round of the authenticator state update.
+    async fn round(&self) -> u64 {
+        self.0.round
+    }
+
+    /// Newly active JWKs (JSON Web Keys).
+    async fn new_active_jwk_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Connection<String, ActiveJwk>> {
+        // TODO: make cursor opaque (currently just an offset).
+        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+
+        let total = self.0.new_active_jwks.len();
+
+        let mut lo = if let Some(after) = after {
+            1 + after
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
+                .extend()?
+        } else {
+            0
+        };
+
+        let mut hi = if let Some(before) = before {
+            before
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
+                .extend()?
+        } else {
+            total
+        };
+
+        let mut connection = Connection::new(false, false);
+        if hi <= lo {
+            return Ok(connection);
+        }
+
+        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
+        // lowerbound.
+        if let Some(first) = first {
+            let first = first as usize;
+            if hi - lo > first {
+                hi = lo + first;
+            }
+        }
+
+        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
+        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
+        if let Some(last) = last {
+            let last = last as usize;
+            if hi - lo > last {
+                lo = hi - last;
+            }
+        }
+
+        connection.has_previous_page = 0 < lo;
+        connection.has_next_page = hi < total;
+
+        for (idx, active_jwk) in self
+            .0
+            .new_active_jwks
+            .iter()
+            .enumerate()
+            .skip(lo)
+            .take(hi - lo)
+        {
+            connection
+                .edges
+                .push(Edge::new(idx.to_string(), ActiveJwk(active_jwk.clone())));
+        }
+
+        Ok(connection)
+    }
+
+    /// The initial version of the authenticator object that it was shared at.
+    async fn authenticator_obj_initial_shared_version(&self) -> u64 {
+        self.0.authenticator_obj_initial_shared_version.value()
+    }
+}
+
+#[Object]
+impl ActiveJwk {
+    /// The string (Issuing Authority) that identifies the OIDC provider.
+    async fn iss(&self) -> &str {
+        &self.0.jwk_id.iss
+    }
+
+    /// The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
+    async fn kid(&self) -> &str {
+        &self.0.jwk_id.kid
+    }
+
+    /// The JWK key type parameter, (RFC 7517, Section 4.1).
+    async fn kty(&self) -> &str {
+        &self.0.jwk.kty
+    }
+
+    /// The JWK RSA public exponent, (RFC 7517, Section 9.3).
+    async fn e(&self) -> &str {
+        &self.0.jwk.e
+    }
+
+    /// The JWK RSA modulus, (RFC 7517, Section 9.3).
+    async fn n(&self) -> &str {
+        &self.0.jwk.n
+    }
+
+    /// The JWK algorithm parameter, (RFC 7517, Section 4.4).
+    async fn alg(&self) -> &str {
+        &self.0.jwk.alg
+    }
+
+    /// The most recent epoch in which the JWK was validated.
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.0.epoch)
+            .await
+            .extend()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::transaction_block_kind::authenticator_state_update::AuthenticatorStateUpdateTransaction;
+
 use self::{
     change_epoch::ChangeEpochTransaction,
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
@@ -9,6 +11,7 @@ use self::{
 use async_graphql::*;
 use sui_types::transaction::TransactionKind as NativeTransactionKind;
 
+pub(crate) mod authenticator_state_update;
 pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
@@ -28,12 +31,6 @@ pub(crate) enum TransactionBlockKind {
 // TODO: flesh out the programmable transaction block type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 pub(crate) struct ProgrammableTransactionBlock {
-    pub value: String,
-}
-
-// TODO: flesh out the authenticator state update type
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct AuthenticatorStateUpdateTransaction {
     pub value: String,
 }
 
@@ -67,11 +64,8 @@ impl From<NativeTransactionKind> for TransactionBlockKind {
 
             K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(ccp.into()),
 
-            // TODO: flesh out type
             K::AuthenticatorStateUpdate(asu) => {
-                T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
-                    value: format!("{asu:?}"),
-                })
+                T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
             }
 
             // TODO: flesh out type

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2,6 +2,66 @@
 source: crates/sui-graphql-rpc/tests/snapshot_tests.rs
 expression: sdl
 ---
+type ActiveJwk {
+	"""
+	The string (Issuing Authority) that identifies the OIDC provider.
+	"""
+	iss: String!
+	"""
+	The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
+	"""
+	kid: String!
+	"""
+	The JWK key type parameter, (RFC 7517, Section 4.1).
+	"""
+	kty: String!
+	"""
+	The JWK RSA public exponent, (RFC 7517, Section 9.3).
+	"""
+	e: String!
+	"""
+	The JWK RSA modulus, (RFC 7517, Section 9.3).
+	"""
+	n: String!
+	"""
+	The JWK algorithm parameter, (RFC 7517, Section 4.4).
+	"""
+	alg: String!
+	"""
+	The most recent epoch in which the JWK was validated.
+	"""
+	epoch: Epoch!
+}
+
+type ActiveJwkConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ActiveJwkEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ActiveJwk!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ActiveJwkEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ActiveJwk!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Address implements ObjectOwner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
@@ -42,7 +102,22 @@ enum AddressTransactionBlockRelationship {
 }
 
 type AuthenticatorStateUpdateTransaction {
-	value: String!
+	"""
+	Epoch of the authenticator state update transaction.
+	"""
+	epoch: Epoch!
+	"""
+	Consensus round of the authenticator state update.
+	"""
+	round: Int!
+	"""
+	Newly active JWKs (JSON Web Keys).
+	"""
+	newActiveJwkConnection(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
+	"""
+	The initial version of the authenticator object that it was shared at.
+	"""
+	authenticatorObjInitialSharedVersion: Int!
 }
 
 type Balance {


### PR DESCRIPTION
## Description

Structured representation of `AuthenticatorStateUpdate` system transaction.

## Test Plan

Manual test (reading transaction `AwTZ7qm3BSPfDLJdut8WfF7xrqLLg6oamxCAy6UGyBbB`):

<img width="1888" alt="Screenshot 2023-12-04 at 1 18 29 AM" src="https://github.com/MystenLabs/sui/assets/332275/fbc670ff-7385-47bb-a248-29b301af0db9">

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 
- #15182 
- #15183 
- #15184 
- #15185 