### PR TITLE
[GraphQL/TransactionBlock] EndOfEpochTransaction

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/random.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/random.exp
@@ -6,7 +6,7 @@ Checkpoint created: 1
 task 2 'advance-epoch'. lines 8-8:
 Epoch advanced: 0
 
-task 3 'run-graphql'. lines 10-30:
+task 3 'run-graphql'. lines 10-43:
 Response: {
   "data": {
     "latestSuiSystemState": {
@@ -34,14 +34,33 @@ Response: {
           }
         }
       }
+    },
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "kind": {
+            "__typename": "EndOfEpochTransaction",
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "RandomnessStateCreateTransaction"
+                },
+                {
+                  "__typename": "ChangeEpochTransaction"
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }
 
-task 5 'create-checkpoint'. lines 36-36:
+task 5 'create-checkpoint'. lines 49-49:
 Checkpoint created: 3
 
-task 6 'run-graphql'. lines 38-54:
+task 6 'run-graphql'. lines 51-67:
 Response: {
   "data": {
     "transactionBlockConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/random.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/random.move
@@ -27,6 +27,19 @@
             }
         }
     }
+
+    transactionBlockConnection(last: 1) {
+        nodes {
+            kind {
+                __typename
+                ... on EndOfEpochTransaction {
+                    transactionConnection {
+                        nodes { __typename }
+                    }
+                }
+            }
+        }
+    }
 }
 
 

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -1069,7 +1069,7 @@ Response: {
 task 6 'advance-epoch'. lines 169-169:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 171-236:
+task 7 'run-graphql'. lines 171-249:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -1092,7 +1092,22 @@ Response: {
           },
           "kind": {
             "__typename": "EndOfEpochTransaction",
-            "value": "[ChangeEpoch(ChangeEpoch { epoch: 1, protocol_version: ProtocolVersion(32), storage_charge: 0, computation_charge: 0, storage_rebate: 0, non_refundable_storage_fee: 0, epoch_start_timestamp_ms: 85000, system_packages: [] })]"
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "ChangeEpochTransaction",
+                  "epoch": {
+                    "epochId": 1
+                  },
+                  "protocolVersion": 32,
+                  "storageCharge": "0",
+                  "computationCharge": "0",
+                  "storageRebate": "0",
+                  "nonRefundableStorageFee": "0",
+                  "startTimestamp": "1970-01-01T00:01:25Z"
+                }
+              ]
+            }
           },
           "effects": {
             "status": "SUCCESS",

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -187,7 +187,20 @@
             kind {
                 __typename
                 ... on EndOfEpochTransaction {
-                    value
+                    transactionConnection {
+                        nodes {
+                            __typename
+                            ... on ChangeEpochTransaction {
+                                epoch { epochId }
+                                protocolVersion
+                                storageCharge
+                                computationCharge
+                                storageRebate
+                                nonRefundableStorageFee
+                                startTimestamp
+                            }
+                        }
+                    }
                 }
             }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -97,6 +97,24 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+type AuthenticatorStateExpireTransaction {
+	"""
+	Expire JWKs that have a lower epoch than this.
+	"""
+	minEpoch: Epoch!
+	"""
+	The initial version that the AuthenticatorStateUpdate was shared at.
+	"""
+	authenticatorObjInitialSharedVersion: Int!
+}
+
 type AuthenticatorStateUpdateTransaction {
 	"""
 	Epoch of the authenticator state update transaction.
@@ -462,7 +480,41 @@ type EndOfEpochData {
 }
 
 type EndOfEpochTransaction {
-	value: String!
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactionConnection(first: Int, before: String, last: Int, after: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | RandomnessStateCreateTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 type Epoch {
@@ -1487,6 +1539,13 @@ type Query {
 	resolveNameServiceAddress(name: String!): Address
 	latestSuiSystemState: SuiSystemStateSummary!
 	coinMetadata(coinType: String!): CoinMetadata
+}
+
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type RandomnessStateUpdateTransaction {

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -6,8 +6,13 @@ use async_graphql::*;
 use move_binary_format::errors::PartialVMResult;
 use move_binary_format::CompiledModule;
 use sui_types::{
-    digests::TransactionDigest, object::Object as NativeObject,
-    transaction::ChangeEpoch as NativeChangeEpochTransaction,
+    digests::TransactionDigest,
+    object::Object as NativeObject,
+    transaction::{
+        AuthenticatorStateExpire as NativeAuthenticatorStateExpireTransaction,
+        ChangeEpoch as NativeChangeEpochTransaction,
+        EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind,
+    },
 };
 
 use crate::context_data::db_data_provider::validate_cursor_pagination;
@@ -22,7 +27,104 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
+pub(crate) struct EndOfEpochTransaction(pub Vec<NativeEndOfEpochTransactionKind>);
+
+#[derive(Union, Clone, PartialEq, Eq)]
+pub(crate) enum EndOfEpochTransactionKind {
+    ChangeEpoch(ChangeEpochTransaction),
+    AuthenticatorStateCreate(AuthenticatorStateCreateTransaction),
+    AuthenticatorStateExpire(AuthenticatorStateExpireTransaction),
+    RandomnessStateCreate(RandomnessStateCreateTransaction),
+}
+
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ChangeEpochTransaction(pub NativeChangeEpochTransaction);
+
+#[derive(SimpleObject, Clone, PartialEq, Eq)]
+pub(crate) struct AuthenticatorStateCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct AuthenticatorStateExpireTransaction(
+    pub NativeAuthenticatorStateExpireTransaction,
+);
+
+#[derive(SimpleObject, Clone, PartialEq, Eq)]
+pub(crate) struct RandomnessStateCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+#[Object]
+impl EndOfEpochTransaction {
+    /// The list of system transactions that are allowed to run at the end of the epoch.
+    async fn transaction_connection(
+        &self,
+        first: Option<u64>,
+        before: Option<String>,
+        last: Option<u64>,
+        after: Option<String>,
+    ) -> Result<Connection<String, EndOfEpochTransactionKind>> {
+        // TODO: make cursor opaque (currently just an offset).
+        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+
+        let total = self.0.len();
+        let mut lo = if let Some(after) = after {
+            1 + after
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
+                .extend()?
+        } else {
+            0
+        };
+
+        let mut hi = if let Some(before) = before {
+            before
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
+                .extend()?
+        } else {
+            total
+        };
+
+        let mut connection = Connection::new(false, false);
+        if hi <= lo {
+            return Ok(connection);
+        }
+
+        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
+        // lowerbound.
+        if let Some(first) = first {
+            let first = first as usize;
+            if hi - lo > first {
+                hi = lo + first;
+            }
+        }
+
+        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
+        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
+        if let Some(last) = last {
+            let last = last as usize;
+            if hi - lo > last {
+                lo = hi - last;
+            }
+        }
+
+        connection.has_previous_page = 0 < lo;
+        connection.has_next_page = hi < total;
+
+        for (idx, tx) in self.0.iter().enumerate().skip(lo).take(hi - lo) {
+            let tx = EndOfEpochTransactionKind::from(tx.clone());
+            connection.edges.push(Edge::new(idx.to_string(), tx));
+        }
+
+        Ok(connection)
+    }
+}
 
 #[Object]
 impl ChangeEpochTransaction {
@@ -156,5 +258,41 @@ impl ChangeEpochTransaction {
         }
 
         Ok(connection)
+    }
+}
+
+#[Object]
+impl AuthenticatorStateExpireTransaction {
+    /// Expire JWKs that have a lower epoch than this.
+    async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_epoch_strict(self.0.min_epoch)
+            .await
+            .extend()
+    }
+
+    /// The initial version that the AuthenticatorStateUpdate was shared at.
+    async fn authenticator_obj_initial_shared_version(&self) -> u64 {
+        self.0.authenticator_obj_initial_shared_version.value()
+    }
+}
+
+impl From<NativeEndOfEpochTransactionKind> for EndOfEpochTransactionKind {
+    fn from(eoek: NativeEndOfEpochTransactionKind) -> Self {
+        use EndOfEpochTransactionKind as K;
+        use NativeEndOfEpochTransactionKind as N;
+
+        match eoek {
+            N::ChangeEpoch(ce) => K::ChangeEpoch(ChangeEpochTransaction(ce)),
+            N::AuthenticatorStateCreate => {
+                K::AuthenticatorStateCreate(AuthenticatorStateCreateTransaction { dummy: None })
+            }
+            N::AuthenticatorStateExpire(ase) => {
+                K::AuthenticatorStateExpire(AuthenticatorStateExpireTransaction(ase))
+            }
+            N::RandomnessStateCreate => {
+                K::RandomnessStateCreate(RandomnessStateCreateTransaction { dummy: None })
+            }
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -1,19 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::transaction_block_kind::authenticator_state_update::AuthenticatorStateUpdateTransaction;
-
 use self::{
-    change_epoch::ChangeEpochTransaction,
-    consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    consensus_commit_prologue::ConsensusCommitPrologueTransaction,
+    end_of_epoch::ChangeEpochTransaction, genesis::GenesisTransaction,
     randomness_state_update::RandomnessStateUpdateTransaction,
+};
+use crate::types::transaction_block_kind::{
+    authenticator_state_update::AuthenticatorStateUpdateTransaction,
+    end_of_epoch::EndOfEpochTransaction,
 };
 use async_graphql::*;
 use sui_types::transaction::TransactionKind as NativeTransactionKind;
 
 pub(crate) mod authenticator_state_update;
-pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
+pub(crate) mod end_of_epoch;
 pub(crate) mod genesis;
 pub(crate) mod randomness_state_update;
 
@@ -31,12 +33,6 @@ pub(crate) enum TransactionBlockKind {
 // TODO: flesh out the programmable transaction block type
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 pub(crate) struct ProgrammableTransactionBlock {
-    pub value: String,
-}
-
-// TODO: flesh out the end of epoch transaction type
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct EndOfEpochTransaction {
     pub value: String,
 }
 
@@ -68,10 +64,7 @@ impl From<NativeTransactionKind> for TransactionBlockKind {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
             }
 
-            // TODO: flesh out type
-            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction {
-                value: format!("{eoe:?}"),
-            }),
+            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
 
             K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction(rsu)),
         }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -101,6 +101,24 @@ enum AddressTransactionBlockRelationship {
 	PAID
 }
 
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+type AuthenticatorStateExpireTransaction {
+	"""
+	Expire JWKs that have a lower epoch than this.
+	"""
+	minEpoch: Epoch!
+	"""
+	The initial version that the AuthenticatorStateUpdate was shared at.
+	"""
+	authenticatorObjInitialSharedVersion: Int!
+}
+
 type AuthenticatorStateUpdateTransaction {
 	"""
 	Epoch of the authenticator state update transaction.
@@ -466,7 +484,41 @@ type EndOfEpochData {
 }
 
 type EndOfEpochTransaction {
-	value: String!
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactionConnection(first: Int, before: String, last: Int, after: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | RandomnessStateCreateTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 type Epoch {
@@ -1491,6 +1543,13 @@ type Query {
 	resolveNameServiceAddress(name: String!): Address
 	latestSuiSystemState: SuiSystemStateSummary!
 	coinMetadata(coinType: String!): CoinMetadata
+}
+
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type RandomnessStateUpdateTransaction {


### PR DESCRIPTION
## Description

Add structured support for `EndOfEpochTransaction`.

## Test Plan

Adapted existing E2E tests

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- system.move random.move
```

And did a manual test to capture `AuthenticatorStateCreateTransaction` and `AuthenticatorStateExpireTransaction`:

- Create at `ERFAiYYP2pc478Te4wTMvzQbz9mhKR1KAuXmu7cpVtgQ`
- Expire at `4NtjE3jeVkysyj8Kbatg88DxBpfRguMvH47y2qo8LSF4`

![Screenshot 2023-12-04 at 4 30 53 PM](https://github.com/MystenLabs/sui/assets/332275/bff7f6ec-688e-4b09-8e34-1ddd0b467b9c)

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 
- #15182 
- #15183 
- #15184 
- #15185 
- #15186 