### PR TITLE
[graphql][feature][breaking] compound type filter on ObjectFilter

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
@@ -1,0 +1,223 @@
+processed 13 tasks
+
+init:
+C: object(0,0)
+
+task 1 'create-checkpoint'. lines 7-7:
+Checkpoint created: 1
+
+task 2 'advance-epoch'. lines 9-9:
+Epoch advanced: 0
+
+task 3 'programmable'. lines 11-13:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4 'run'. lines 15-17:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [238, 200, 46, 64, 19, 251, 166, 48, 169, 106, 19, 152, 17, 73, 253, 13, 104, 253, 255, 233, 100, 45, 194, 20, 146, 117, 157, 165, 47, 29, 161, 135, 251, 197, 26, 138, 207, 9, 111, 134, 25, 141, 95, 164, 112, 98, 14, 214, 162, 10, 188, 9, 185, 78, 168, 145, 239, 2, 154, 93, 227, 243, 151, 19, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(4,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5 'create-checkpoint'. lines 18-18:
+Checkpoint created: 3
+
+task 6 'advance-epoch'. lines 20-20:
+Epoch advanced: 1
+
+task 7 'run-graphql'. lines 22-37:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": [
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedSui"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedSui"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedSui"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 39-54:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": [
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 56-72:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": [
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 74-90:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Invalid type provided as filter: Invalid struct type: 0x2::coin::Coin<ye>. Got error: expected token ::, got >",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "objectConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 11 'run-graphql'. lines 92-108:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Invalid type provided as filter: Invalid struct type: 0x2::coin::Coin<. Got error: unexpected end of tokens",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "objectConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 12 'run-graphql'. lines 110-126:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Invalid type provided as filter: Invalid struct type: 0x2::a%::B&. Got error: unrecognized token: %::B&",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "objectConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
@@ -1,4 +1,4 @@
-processed 13 tasks
+processed 17 tasks
 
 init:
 C: object(0,0)
@@ -80,7 +80,18 @@ Response: {
             "asMoveObject": {
               "contents": {
                 "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorState"
                 }
               }
             }
@@ -103,6 +114,94 @@ Response: {
               "contents": {
                 "type": {
                   "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::sui_system_state_inner::SuiSystemStateInnerV2>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorStateInner>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
                 }
               }
             }
@@ -113,7 +212,61 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 56-72:
+task 9 'run-graphql'. lines 56-71:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": [
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 73-88:
 Response: {
   "data": {
     "objectConnection": {
@@ -156,7 +309,50 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 74-90:
+task 11 'run-graphql'. lines 90-106:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": [
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 108-124:
 Response: {
   "data": null,
   "errors": [
@@ -178,7 +374,7 @@ Response: {
   ]
 }
 
-task 11 'run-graphql'. lines 92-108:
+task 13 'run-graphql'. lines 126-142:
 Response: {
   "data": null,
   "errors": [
@@ -200,7 +396,7 @@ Response: {
   ]
 }
 
-task 12 'run-graphql'. lines 110-126:
+task 14 'run-graphql'. lines 144-160:
 Response: {
   "data": null,
   "errors": [
@@ -220,4 +416,35 @@ Response: {
       }
     }
   ]
+}
+
+task 15 'run-graphql'. lines 162-178:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Invalid type provided as filter: Empty strings are not allowed",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "objectConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 16 'run-graphql'. lines 180-196:
+Response: {
+  "data": {
+    "objectConnection": {
+      "edges": []
+    }
+  }
 }

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
@@ -38,6 +38,40 @@
 
 //# run-graphql
 {
+  objectConnection(filter: {type: "0x2"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  objectConnection(filter: {type: "0x2::coin"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
   objectConnection(filter: {type: "0x2::coin::Coin"}) {
     edges {
       node {
@@ -111,6 +145,42 @@
 # Package, module, and name must be valid addresses and identifiers
 {
   objectConnection(filter: {type: "0x2::a%::B&"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Empty strings are invalid inputs
+{
+  objectConnection(filter: {type: "::::"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Should run successfully but return an empty result
+{
+  objectConnection(filter: {type: "u64"}) {
     edges {
       node {
         asMoveObject {

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator --accounts C
+
+// TODO: Short term hack to get around indexer epoch issue
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
+
+// TODO: Short term hack to get around indexer epoch issue
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{
+  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Fetch coins of 0x2::sui::SUI inner type
+{
+  objectConnection(filter: {type: "0x2::coin::Coin<0x2::sui::SUI>"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Inner type should be fully qualified
+{
+  objectConnection(filter: {type: "0x2::coin::Coin<ye>"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# If caller provides angle brackets, they must be balanced and wrap a valid type
+{
+  objectConnection(filter: {type: "0x2::coin::Coin<"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Package, module, and name must be valid addresses and identifiers
+{
+  objectConnection(filter: {type: "0x2::a%::B&"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -36,8 +36,10 @@
 #### &emsp;&emsp;[Object](#655350)
 ### [Object Connection](#11)
 #### &emsp;&emsp;[Filter Object Ids](#720885)
-#### &emsp;&emsp;[Filter Owner](#720886)
-#### &emsp;&emsp;[Object Connection](#720887)
+#### &emsp;&emsp;[Filter On Generic Type](#720886)
+#### &emsp;&emsp;[Filter On Type](#720887)
+#### &emsp;&emsp;[Filter Owner](#720888)
+#### &emsp;&emsp;[Object Connection](#720889)
 ### [Owner](#12)
 #### &emsp;&emsp;[Dynamic Field](#786420)
 #### &emsp;&emsp;[Dynamic Field Connection](#786421)
@@ -816,6 +818,44 @@
 >}</pre>
 
 ### <a id=720886></a>
+### Filter On Generic Type
+
+><pre>{
+>  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+>    edges {
+>      node {
+>        asMoveObject {
+>          contents {
+>            type {
+>              repr
+>            }
+>          }
+>        }
+>      }
+>    }
+>  }
+>}</pre>
+
+### <a id=720887></a>
+### Filter On Type
+
+><pre>{
+>  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+>    edges {
+>      node {
+>        asMoveObject {
+>          contents {
+>            type {
+>              repr
+>            }
+>          }
+>        }
+>      }
+>    }
+>  }
+>}</pre>
+
+### <a id=720888></a>
 ### Filter Owner
 ####  Filter on owner
 
@@ -834,7 +874,7 @@
 >  }
 >}</pre>
 
-### <a id=720887></a>
+### <a id=720889></a>
 ### Object Connection
 
 ><pre>{

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_on_generic_type.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_on_generic_type.graphql
@@ -1,0 +1,15 @@
+{
+  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_on_type.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_on_type.graphql
@@ -1,0 +1,15 @@
+{
+  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+    edges {
+      node {
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1132,9 +1132,13 @@ type ObjectEdge {
 }
 
 input ObjectFilter {
-	package: SuiAddress
-	module: String
-	ty: String
+	"""
+	This field is used to specify the type of objects that should be included
+	in the query results. Generic types can be queried by either the generic
+	type name, e.g. `0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	type: String
 	owner: SuiAddress
 	objectIds: [SuiAddress!]
 	objectKeys: [ObjectKey!]

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -123,6 +123,8 @@ pub enum DbValidationError {
     QueryCostExceeded(u64, u64),
     #[error("Page size exceeded - requested: {0}, limit: {1}")]
     PageSizeExceeded(u64, u64),
+    #[error("Invalid type provided as filter: {0}")]
+    InvalidType(String),
 }
 
 pub(crate) struct PgManager {
@@ -547,9 +549,6 @@ impl PgManager {
     }
 
     pub(crate) fn validate_obj_filter(&self, filter: &ObjectFilter) -> Result<(), Error> {
-        if filter.package.is_some() || filter.module.is_some() || filter.ty.is_some() {
-            return Err(DbValidationError::UnsupportedPMT.into());
-        }
         if filter.object_keys.is_some() {
             return Err(DbValidationError::UnsupportedObjectKeys.into());
         }
@@ -1129,9 +1128,7 @@ impl PgManager {
         before: Option<String>,
     ) -> Result<Option<Connection<String, StakedSui>>, Error> {
         let obj_filter = ObjectFilter {
-            package: None,
-            module: None,
-            ty: Some(MoveObjectType::staked_sui().to_canonical_string(/* with_prefix */ true)),
+            type_: Some(MoveObjectType::staked_sui().to_canonical_string(/* with_prefix */ true)),
             owner: Some(address),
             object_ids: None,
             object_keys: None,

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -339,23 +339,24 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
                         parts[1].clone()
                     )));
                 } else if parts.len() >= 3 {
-                    let validate_type = parse_sui_struct_tag(&object_type)
+                    let validated_type = parse_sui_struct_tag(&object_type)
                         .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
 
-                    if validate_type.type_params.is_empty() {
+                    if validated_type.type_params.is_empty() {
                         query = query.filter(
                             objects::dsl::object_type
                                 .like(format!(
                                     "{}<%",
-                                    validate_type.to_canonical_string(/* with_prefix */ true)
+                                    validated_type.to_canonical_string(/* with_prefix */ true)
                                 ))
                                 .or(objects::dsl::object_type
-                                    .eq(validate_type
+                                    .eq(validated_type
                                         .to_canonical_string(/* with_prefix */ true))),
                         );
                     } else {
                         query = query.filter(
-                            objects::dsl::object_type.eq(validate_type.to_canonical_string(true)),
+                            objects::dsl::object_type
+                                .eq(validated_type.to_canonical_string(/* with_prefix */ true)),
                         );
                     }
                 }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -320,7 +320,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
                     // We check for a leading 0x to determine if it is an address
                     // And otherwise process it as a primitive type
                     if parts[0].starts_with("0x") {
-                        let package = SuiAddress::from_str(&parts[0])
+                        let package = SuiAddress::from_str(parts[0])
                             .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
                         query =
                             query.filter(objects::dsl::object_type.like(format!("{}::%", package)));
@@ -329,13 +329,11 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
                     }
                 } else if parts.len() == 2 {
                     // Only package addresses are allowed if there are two or more parts
-                    let package = SuiAddress::from_str(&parts[0])
+                    let package = SuiAddress::from_str(parts[0])
                         .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
-                    query = query.filter(objects::dsl::object_type.like(format!(
-                        "{}::{}::%",
-                        package,
-                        parts[1].to_string()
-                    )));
+                    query = query.filter(
+                        objects::dsl::object_type.like(format!("{}::{}::%", package, parts[1])),
+                    );
                 } else if parts.len() == 3 {
                     let validated_type = parse_sui_struct_tag(&object_type)
                         .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -43,10 +43,11 @@ pub(crate) enum ObjectKind {
 
 #[derive(InputObject, Default, Clone)]
 pub(crate) struct ObjectFilter {
-    pub package: Option<SuiAddress>,
-    pub module: Option<String>,
-    pub ty: Option<String>,
-
+    /// This field is used to specify the type of objects that should be included
+    /// in the query results. Generic types can be queried by either the generic
+    /// type name, e.g. `0x2::coin::Coin`, or by the full type name, such as
+    /// `0x2::coin::Coin<0x2::sui::SUI>`.
+    pub type_: Option<String>,
     pub owner: Option<SuiAddress>,
     pub object_ids: Option<Vec<SuiAddress>>,
     pub object_keys: Option<Vec<ObjectKey>>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1136,9 +1136,13 @@ type ObjectEdge {
 }
 
 input ObjectFilter {
-	package: SuiAddress
-	module: String
-	ty: String
+	"""
+	This field is used to specify the type of objects that should be included
+	in the query results. Generic types can be queried by either the generic
+	type name, e.g. `0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	type: String
 	owner: SuiAddress
 	objectIds: [SuiAddress!]
 	objectKeys: [ObjectKey!]


### PR DESCRIPTION
## Description 

Today we have a cascading filter of package, module, and ty on the ObjectFilter. This PR combines the three fields into 1, and adds logic to handle looking up generic types. 
Now, callers can provide
1. primitive like u64
2. just the package, 0x2
3. package and module: 0x2::coin
4. package, module, type: 0x2::coin::Coin
5. fully instantiated type: 0x2::coin::Coin<0x2::sui::SUI>

## Test Plan 

New filter_by_type.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
