### PR TITLE
[bridge 4/n] SuiSyncer

### DIFF
--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -9,9 +9,20 @@ pub mod events;
 pub mod handler;
 pub mod server;
 pub mod sui_client;
+pub mod sui_syncer;
 
 #[cfg(test)]
 pub(crate) mod eth_mock_provider;
 
 #[cfg(test)]
 pub(crate) mod sui_mock_client;
+
+#[macro_export]
+macro_rules! retry_with_max_delay {
+    ($func:expr, $max_delay:expr) => {{
+        let retry_strategy = ExponentialBackoff::from_millis(100)
+            .max_delay($max_delay)
+            .map(jitter);
+        Retry::spawn(retry_strategy, || $func).await
+    }};
+}

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -78,10 +78,10 @@ impl SuiClientInner for SuiMockClient {
                 self.past_event_query_params.lock().unwrap().push_back((
                     package,
                     module.clone(),
-                    cursor.clone(),
+                    cursor,
                 ));
                 Ok(events
-                    .get(&(package, module.clone(), cursor.clone()))
+                    .get(&(package, module.clone(), cursor))
                     .cloned()
                     .unwrap_or_else(|| {
                         panic!(

--- a/crates/sui-bridge/src/sui_syncer.rs
+++ b/crates/sui-bridge/src/sui_syncer.rs
@@ -1,14 +1,238 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The Suisyncer module is responsible for synchronizing Events emitted on Sui blockchain from
-//! concerned bridge packages. Each package is associated with a cursor, and the syncer will
-//! only query from that cursor onwards. It's likely that SuiSyncer only tracks one package.
+//! The SuiSyncer module is responsible for synchronizing Events emitted on Sui blockchain from
+//! concerned bridge packages.
 
+use crate::{
+    error::BridgeResult,
+    retry_with_max_delay,
+    sui_client::{SuiClient, SuiClientInner},
+};
+use mysten_metrics::spawn_logged_monitored_task;
+use std::{collections::HashMap, sync::Arc};
+use sui_json_rpc_types::SuiEvent;
+use sui_types::{
+    base_types::ObjectID, digests::TransactionDigest, Identifier, SUI_SYSTEM_PACKAGE_ID,
+};
+use tokio::{
+    task::JoinHandle,
+    time::{self, Duration},
+};
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio_retry::Retry;
 
+// TODO: use the right package id
+const PACKAGE_ID: ObjectID = SUI_SYSTEM_PACKAGE_ID;
+const SUI_EVENTS_CHANNEL_SIZE: usize = 1000;
 
+/// Map from contract address to their start block.
+pub type SuiTargetModules = HashMap<Identifier, TransactionDigest>;
 
-pub struct EthSyncer<P> {
-    eth_client: Arc<SuiClient>,
-    contract_addresses: EthTargetAddresses,
+pub struct SuiSyncer<C> {
+    sui_client: Arc<SuiClient<C>>,
+    // The last transaction that the syncer has fully processed.
+    // Syncer will resume post this transaction (i.e. exclusive), when it starts.
+    cursors: SuiTargetModules,
+}
+
+impl<C> SuiSyncer<C>
+where
+    C: SuiClientInner + 'static,
+{
+    pub fn new(sui_client: Arc<SuiClient<C>>, cursors: SuiTargetModules) -> Self {
+        Self {
+            sui_client,
+            cursors,
+        }
+    }
+
+    pub async fn run(
+        self,
+        query_interval: Duration,
+    ) -> BridgeResult<(
+        Vec<JoinHandle<()>>,
+        mysten_metrics::metered_channel::Receiver<Vec<SuiEvent>>,
+    )> {
+        let (events_tx, events_rx) = mysten_metrics::metered_channel::channel(
+            SUI_EVENTS_CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["sui_events_queue"]),
+        );
+
+        let mut task_handles = vec![];
+        for (module, cursor) in self.cursors {
+            let events_rx_clone = events_tx.clone();
+            let sui_client_clone = self.sui_client.clone();
+            task_handles.push(spawn_logged_monitored_task!(
+                Self::run_event_listening_task(
+                    module,
+                    cursor,
+                    events_rx_clone,
+                    sui_client_clone,
+                    query_interval
+                )
+            ));
+        }
+        Ok((task_handles, events_rx))
+    }
+
+    async fn run_event_listening_task(
+        // The module where interested events are defined.
+        // Moudle is always of bridge package 0x9.
+        module: Identifier,
+        mut next_cursor: TransactionDigest,
+        events_sender: mysten_metrics::metered_channel::Sender<Vec<SuiEvent>>,
+        sui_client: Arc<SuiClient<C>>,
+        query_interval: Duration,
+    ) {
+        tracing::info!(
+            ?module,
+            ?next_cursor,
+            "Starting sui events listening task from tx_digest {next_cursor}"
+        );
+        let mut interval = time::interval(query_interval);
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            // TODO reconsider panic, should we just log an error and continue the loop?
+            let events = retry_with_max_delay!(
+                sui_client.query_events_by_module(PACKAGE_ID, module.clone(), next_cursor),
+                Duration::from_secs(600)
+            )
+            .expect("Failed to query events from sui client after retry");
+
+            let len = events.data.len();
+            if len != 0 {
+                events_sender
+                    .send(events.data)
+                    .await
+                    .expect("All Sui event channel receivers are closed");
+                // Unwrap: `query_events_by_module` always returns Some `next_cursor`
+                // If the events list is empty, `next_cursor` will be the same as `start_tx_digest`
+                next_cursor = events.next_cursor.unwrap();
+                tracing::info!(?module, ?next_cursor, "Observed {len} new Sui events");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{sui_client::SuiClient, sui_mock_client::SuiMockClient};
+    use prometheus::Registry;
+    use sui_json_rpc_types::EventPage;
+    use sui_types::{digests::TransactionDigest, event::EventID, Identifier};
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn test_sui_syncer_basic() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+
+        let mock = SuiMockClient::default();
+        let client = Arc::new(SuiClient::new_for_testing(mock.clone()));
+        let module_foo = Identifier::new("Foo").unwrap();
+        let module_bar = Identifier::new("Bar").unwrap();
+        let empty_events = EventPage::empty();
+        let cursor = TransactionDigest::random();
+        add_event_response(&mock, module_foo.clone(), cursor, empty_events.clone());
+        add_event_response(&mock, module_bar.clone(), cursor, empty_events.clone());
+
+        let target_modules = HashMap::from_iter(vec![
+            (module_foo.clone(), cursor),
+            (module_bar.clone(), cursor),
+        ]);
+        let interval = Duration::from_millis(200);
+        let (_handles, mut events_rx) = SuiSyncer::new(client, target_modules)
+            .run(interval)
+            .await
+            .unwrap();
+
+        // Initially there are no events
+        assert_no_more_events(interval, &mut events_rx).await;
+
+        // Module Foo has new events
+        let event_1: SuiEvent = SuiEvent::random_for_testing();
+        let module_foo_events_1: sui_json_rpc_types::Page<SuiEvent, EventID> = EventPage {
+            data: vec![event_1.clone(), event_1.clone()],
+            next_cursor: None,
+            has_next_page: false,
+        };
+        add_event_response(
+            &mock,
+            module_foo.clone(),
+            event_1.id.tx_digest,
+            empty_events.clone(),
+        );
+        add_event_response(
+            &mock,
+            module_foo.clone(),
+            cursor,
+            module_foo_events_1.clone(),
+        );
+
+        let received_events = events_rx.recv().await.unwrap();
+        assert_eq!(received_events.len(), 2);
+        assert_eq!(received_events[0].id, event_1.id);
+        assert_eq!(received_events[1].id, event_1.id);
+        // No more
+        assert_no_more_events(interval, &mut events_rx).await;
+
+        // Module Bar has new events
+        let event_2: SuiEvent = SuiEvent::random_for_testing();
+        let module_bar_events_1 = EventPage {
+            data: vec![event_2.clone()],
+            next_cursor: None,
+            has_next_page: false,
+        };
+        add_event_response(
+            &mock,
+            module_bar.clone(),
+            event_2.id.tx_digest,
+            empty_events.clone(),
+        );
+
+        add_event_response(&mock, module_bar.clone(), cursor, module_bar_events_1);
+
+        let received_events = events_rx.recv().await.unwrap();
+        assert_eq!(received_events.len(), 1);
+        assert_eq!(received_events[0].id, event_2.id);
+        // No more
+        assert_no_more_events(interval, &mut events_rx).await;
+
+        Ok(())
+    }
+
+    async fn assert_no_more_events(
+        interval: Duration,
+        events_rx: &mut mysten_metrics::metered_channel::Receiver<Vec<SuiEvent>>,
+    ) {
+        match timeout(interval * 2, events_rx.recv()).await {
+            Err(_e) => (),
+            other => panic!("Should have timed out, but got: {:?}", other),
+        };
+    }
+
+    fn add_event_response(
+        mock: &SuiMockClient,
+        module: Identifier,
+        cursor: TransactionDigest,
+        events: EventPage,
+    ) {
+        mock.add_event_response(
+            PACKAGE_ID,
+            module.clone(),
+            EventID {
+                tx_digest: cursor,
+                event_seq: u16::MAX as u64,
+            },
+            events.clone(),
+        );
+    }
 }

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -190,7 +190,7 @@ impl IndexerApiServer for IndexerApiV2 {
 
         let has_next_page = results.len() > limit;
         results.truncate(limit);
-        let next_cursor = results.last().map(|o| o.id.clone());
+        let next_cursor = results.last().map(|o| o.id);
         Ok(Page {
             data: results,
             next_cursor,

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1052,7 +1052,7 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<SuiEvent>> {
-        let (tx_seq, event_seq) = if let Some(cursor) = cursor.clone() {
+        let (tx_seq, event_seq) = if let Some(cursor) = cursor {
             let EventID {
                 tx_digest,
                 event_seq,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -463,7 +463,7 @@ impl PgIndexerStore {
         page_limit -= 1;
         let has_next_page = sui_event_vec.len() > page_limit;
         sui_event_vec.truncate(page_limit);
-        let next_cursor = sui_event_vec.last().map(|e| e.id.clone());
+        let next_cursor = sui_event_vec.last().map(|e| e.id);
         Ok(EventPage {
             data: sui_event_vec,
             next_cursor,

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -257,7 +257,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .query_events(
                     &self.transaction_kv_store,
                     query,
-                    cursor.clone(),
+                    cursor,
                     limit + 1,
                     descending,
                 )
@@ -265,7 +265,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .map_err(Error::from)?;
             let has_next_page = data.len() > limit;
             data.truncate(limit);
-            let next_cursor = data.last().map_or(cursor, |e| Some(e.id.clone()));
+            let next_cursor = data.last().map_or(cursor, |e| Some(e.id));
             self.metrics
                 .query_events_result_size
                 .report(data.len() as u64);

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -41,7 +41,7 @@ pub struct EventEnvelope {
 /// Unique ID of a Sui Event, the ID is a combination of tx seq number and event seq number,
 /// the ID is local to this particular fullnode and will be different from other fullnode.
 #[serde_as]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct EventID {
     pub tx_digest: TransactionDigest,


### PR DESCRIPTION
## Description 

Implements `SuiSyncer` that periodically pulls from Sui to fetch Bridge related events. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Implements `SuiSyncer` that periodically pulls from Sui to fetch Bridge related events. 

