### PR TITLE
[graphql][fix][breaking] cursor logic for checkpoint connection

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,15 @@
-processed 8 tasks
+processed 10 tasks
 
-task 1 'create-checkpoint'. lines 16-16:
-Checkpoint created: 11
+task 1 'create-checkpoint'. lines 18-18:
+Checkpoint created: 4
 
-task 2 'run-graphql'. lines 18-25:
+task 2 'create-checkpoint'. lines 20-20:
+Checkpoint created: 8
+
+task 3 'create-checkpoint'. lines 22-22:
+Checkpoint created: 12
+
+task 4 'run-graphql'. lines 24-31:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -25,7 +31,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 27-34:
+task 5 'run-graphql'. lines 33-40:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -38,7 +44,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 36-43:
+task 6 'run-graphql'. lines 42-49:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -60,14 +66,11 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 45-52:
+task 7 'run-graphql'. lines 51-58:
 Response: {
   "data": {
     "checkpointConnection": {
       "nodes": [
-        {
-          "sequenceNumber": 8
-        },
         {
           "sequenceNumber": 9
         },
@@ -76,13 +79,16 @@ Response: {
         },
         {
           "sequenceNumber": 11
+        },
+        {
+          "sequenceNumber": 12
         }
       ]
     }
   }
 }
 
-task 6 'run-graphql'. lines 54-61:
+task 8 'run-graphql'. lines 60-67:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -104,7 +110,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 63-70:
+task 9 'run-graphql'. lines 69-76:
 Response: {
   "data": {
     "checkpointConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,0 +1,105 @@
+processed 7 tasks
+
+task 1 'create-checkpoint'. lines 15-15:
+Checkpoint created: 20
+
+task 2 'run-graphql'. lines 17-24:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        },
+        {
+          "sequenceNumber": 10
+        }
+      ]
+    }
+  }
+}
+
+task 3 'run-graphql'. lines 26-33:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        }
+      ]
+    }
+  }
+}
+
+task 4 'run-graphql'. lines 35-42:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 0
+        },
+        {
+          "sequenceNumber": 1
+        },
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        }
+      ]
+    }
+  }
+}
+
+task 5 'run-graphql'. lines 44-51:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 17
+        },
+        {
+          "sequenceNumber": 18
+        },
+        {
+          "sequenceNumber": 19
+        },
+        {
+          "sequenceNumber": 20
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 53-60:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        },
+        {
+          "sequenceNumber": 4
+        },
+        {
+          "sequenceNumber": 5
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 task 1 'create-checkpoint'. lines 16-16:
-Checkpoint created: 20
+Checkpoint created: 11
 
 task 2 'run-graphql'. lines 18-25:
 Response: {
@@ -66,16 +66,16 @@ Response: {
     "checkpointConnection": {
       "nodes": [
         {
-          "sequenceNumber": 17
+          "sequenceNumber": 8
         },
         {
-          "sequenceNumber": 18
+          "sequenceNumber": 9
         },
         {
-          "sequenceNumber": 19
+          "sequenceNumber": 10
         },
         {
-          "sequenceNumber": 20
+          "sequenceNumber": 11
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,9 @@
-processed 7 tasks
+processed 8 tasks
 
-task 1 'create-checkpoint'. lines 15-15:
+task 1 'create-checkpoint'. lines 16-16:
 Checkpoint created: 20
 
-task 2 'run-graphql'. lines 17-24:
+task 2 'run-graphql'. lines 18-25:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -25,7 +25,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 26-33:
+task 3 'run-graphql'. lines 27-34:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -38,7 +38,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 35-42:
+task 4 'run-graphql'. lines 36-43:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -60,7 +60,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 44-51:
+task 5 'run-graphql'. lines 45-52:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -82,7 +82,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 53-60:
+task 6 'run-graphql'. lines 54-61:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -93,6 +93,22 @@ Response: {
         {
           "sequenceNumber": 3
         },
+        {
+          "sequenceNumber": 4
+        },
+        {
+          "sequenceNumber": 5
+        }
+      ]
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 63-70:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
         {
           "sequenceNumber": 4
         },

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,15 +1,9 @@
-processed 10 tasks
+processed 8 tasks
 
 task 1 'create-checkpoint'. lines 18-18:
-Checkpoint created: 4
-
-task 2 'create-checkpoint'. lines 20-20:
-Checkpoint created: 8
-
-task 3 'create-checkpoint'. lines 22-22:
 Checkpoint created: 12
 
-task 4 'run-graphql'. lines 24-31:
+task 2 'run-graphql'. lines 20-27:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -31,7 +25,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 33-40:
+task 3 'run-graphql'. lines 29-36:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -44,7 +38,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 42-49:
+task 4 'run-graphql'. lines 38-45:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -66,7 +60,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 51-58:
+task 5 'run-graphql'. lines 47-54:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -88,7 +82,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 60-67:
+task 6 'run-graphql'. lines 56-63:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -110,7 +104,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 69-76:
+task 7 'run-graphql'. lines 65-72:
 Response: {
   "data": {
     "checkpointConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -27,59 +27,68 @@ Response: {
 
 task 3 'run-graphql'. lines 29-36:
 Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
+  "data": null,
+  "errors": [
+    {
+      "message": "'first' can only be used with 'after",
+      "locations": [
         {
-          "sequenceNumber": 7
+          "line": 2,
+          "column": 3
         }
-      ]
+      ],
+      "path": [
+        "checkpointConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
-  }
+  ]
 }
 
 task 4 'run-graphql'. lines 38-45:
 Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
+  "data": null,
+  "errors": [
+    {
+      "message": "'first' can only be used with 'after",
+      "locations": [
         {
-          "sequenceNumber": 0
-        },
-        {
-          "sequenceNumber": 1
-        },
-        {
-          "sequenceNumber": 2
-        },
-        {
-          "sequenceNumber": 3
+          "line": 2,
+          "column": 3
         }
-      ]
+      ],
+      "path": [
+        "checkpointConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
-  }
+  ]
 }
 
 task 5 'run-graphql'. lines 47-54:
 Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
+  "data": null,
+  "errors": [
+    {
+      "message": "'last' can only be used with 'before'",
+      "locations": [
         {
-          "sequenceNumber": 9
-        },
-        {
-          "sequenceNumber": 10
-        },
-        {
-          "sequenceNumber": 11
-        },
-        {
-          "sequenceNumber": 12
+          "line": 2,
+          "column": 3
         }
-      ]
+      ],
+      "path": [
+        "checkpointConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
-  }
+  ]
 }
 
 task 6 'run-graphql'. lines 56-63:
@@ -106,16 +115,22 @@ Response: {
 
 task 7 'run-graphql'. lines 65-72:
 Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
+  "data": null,
+  "errors": [
+    {
+      "message": "'last' can only be used with 'before'",
+      "locations": [
         {
-          "sequenceNumber": 4
-        },
-        {
-          "sequenceNumber": 5
+          "line": 2,
+          "column": 3
         }
-      ]
+      ],
+      "path": [
+        "checkpointConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
-  }
+  ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -4,16 +4,22 @@
 // Test cursor connection pagination logic
 // The implementation privileges `after`, `before`, `first`, and `last` in that order.
 // Currently implemented only for items ordered in ascending order by `sequenceNumber`.
+
+// Assuming checkpoints 0 through 12
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints 8, 9, 10, 11
+// last: 4, after: "6" -> checkpoints 9, 10, 11, 12
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 11
+//# create-checkpoint 4
+
+//# create-checkpoint 4
+
+//# create-checkpoint 4
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -15,11 +15,7 @@
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 4
-
-//# create-checkpoint 4
-
-//# create-checkpoint 4
+//# create-checkpoint 12
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -9,6 +9,7 @@
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
 // last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
+// last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
@@ -53,6 +54,15 @@
 //# run-graphql
 {
   checkpointConnection(last: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, before: "6", after: "3") {
     nodes {
       sequenceNumber
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -7,13 +7,13 @@
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
+// last: 4, after: "6" -> checkpoints 11, 10, 9, 8
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 
 //# init --addresses Test=0x0 --simulator
 
-//# create-checkpoint 20
+//# create-checkpoint 11
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -8,10 +8,10 @@
 // Assuming checkpoints 0 through 12
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
-// first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints 9, 10, 11, 12
+// first: 4, before: "6" -> error
+// last: 4, after: "6" -> error
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
-// last: 4, before: "6", after: "3" -> checkpoints 4, 5
+// last: 4, before: "6", after: "3" -> error
 
 //# init --addresses Test=0x0 --simulator
 

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test cursor connection pagination logic
+// The implementation privileges `after`, `before`, `first`, and `last` in that order.
+// Currently implemented only for items ordered in ascending order by `sequenceNumber`.
+// first: 4, after: "6" -> checkpoints 7, 8, 9, 10
+// first: 4, after: "6", before: "8" -> checkpoints 7
+// first: 4, before: "6" -> checkpoints 0, 1, 2, 3
+// last: 4, after: "6" -> checkpoints n-3, n-2, n-1, n
+// last: 4, before: "6" -> checkpoints 2, 3, 4, 5
+
+//# init --addresses Test=0x0 --simulator
+
+//# create-checkpoint 20
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, after: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, after: "6", before: "8") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(first: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, after: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection(last: 4, before: "6") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -7,7 +7,7 @@
 // first: 4, after: "6" -> checkpoints 7, 8, 9, 10
 // first: 4, after: "6", before: "8" -> checkpoints 7
 // first: 4, before: "6" -> checkpoints 0, 1, 2, 3
-// last: 4, after: "6" -> checkpoints 11, 10, 9, 8
+// last: 4, after: "6" -> checkpoints 8, 9, 10, 11
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> checkpoints 4, 5
 

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -27,6 +27,7 @@ pub(crate) enum QueryDirection {
 }
 
 /// Controls the final ordering of the result set
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum SortOrder {
     /// Preserves the original order of the result set.

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -26,15 +26,14 @@ pub(crate) enum QueryDirection {
     Last,
 }
 
-/// Controls the final ordering of the result set
+/// Controls the final ordering of the result set.
+/// Does not directly correspond to whether the query is ordered by ascending or descending.
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum SortOrder {
-    /// Preserves the original order of the result set.
-    /// This is typically a query ordered by some key in ascending order.
+    /// Preserves the original ordering of the set before applying cursor and limit.
     Asc,
-    /// Reverses the order of the result set.
-    /// This is typically a query ordered by some key in descending order.
+    /// Reverses the ordering of the set before applying cursor and limit.
     Desc,
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::{backend::Backend, query_builder::AsQuery, query_dsl::methods::BoxedDsl};
+use diesel::backend::Backend;
 use sui_indexer::{
     schema_v2::{checkpoints, epochs, objects, transactions},
     types_v2::OwnerType,
@@ -16,21 +16,14 @@ use diesel::{
     sql_types::Text,
 };
 
-#[derive(Clone, Copy)]
-pub(crate) enum Cursor {
-    After,
-    Before,
-}
-
-/// Controls how many records the query fetches before or after some cursor
-#[derive(Clone, Copy)]
+/// An enum representing whether first and/ or last was provided in the graphql request.
+#[derive(Clone, Copy, PartialEq)]
 pub(crate) enum QueryDirection {
-    /// Fetch first n records after some cursor (exclusive) or from the beginning.
-    /// The edge closest to the cursor or beginning comes first in the result set.
-    First(i64),
-    /// Fetch last n records before some cursor (exclusive) or from the end.
-    /// The edge closest to the cursor or end comes last in the result set.
-    Last(i64),
+    /// If first is provided, the result set fetched from the db does not need to be reversed.
+    /// Queries default to this direction.
+    First,
+    /// The direction is last iff first is not provided and last is provided.
+    Last,
 }
 
 /// Controls the final ordering of the result set
@@ -95,8 +88,8 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
-        cursor: Option<i64>,
-        cursor_type: Option<Cursor>,
+        before: Option<i64>,
+        after: Option<i64>,
         limit: i64,
         edge_order: SortOrder,
         query_direction: QueryDirection,
@@ -129,31 +122,4 @@ impl<T: QueryId> QueryId for Explained<T> {
 /// Explained<T> is a fully structured query with return of type Text
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
-}
-
-/// The struct returned for query.subquery()
-#[derive(Debug, Clone, Copy)]
-pub struct Subqueried<T> {
-    pub query: T,
-}
-
-/// Allows .subquery() method on any Diesel query
-pub trait Subquery: AsQuery + Sized {
-    fn subquery(self) -> Subqueried<Self>;
-}
-impl<T: AsQuery> Subquery for T {
-    fn subquery(self) -> Subqueried<Self> {
-        Subqueried { query: self }
-    }
-}
-
-/// All queries need to implement QueryId
-impl<T: QueryId> QueryId for Subqueried<T> {
-    type QueryId = (T::QueryId, std::marker::PhantomData<&'static str>);
-    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
-}
-
-/// Subqueried<T> wraps the query in a SELECT * FROM (query) AS SUB
-impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Subqueried<T> {
-    type SqlType = T::SqlType;
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -26,16 +26,16 @@ pub(crate) enum CursorBound<T> {
 /// Controls whether the query is in ascending or descending order.
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq)]
-pub(crate) enum SortOrder {
+pub(crate) enum OrderBy {
     Asc,
     Desc,
 }
 
-impl SortOrder {
+impl OrderBy {
     pub fn invert(&self) -> Self {
         match self {
-            SortOrder::Asc => SortOrder::Desc,
-            SortOrder::Desc => SortOrder::Asc,
+            OrderBy::Asc => OrderBy::Desc,
+            OrderBy::Desc => OrderBy::Asc,
         }
     }
 }
@@ -91,7 +91,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
-        sort_order: SortOrder,
+        order_by: OrderBy,
         before: Option<CursorBound<i64>>,
         after: Option<CursorBound<i64>>,
         limit: i64,

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -16,30 +16,6 @@ use diesel::{
     sql_types::Text,
 };
 
-/// An enum that determines whether to select rows that are greater than or less than the cursor.
-#[derive(Clone, Copy, PartialEq)]
-pub(crate) enum CursorBound<T> {
-    Gt(T),
-    Lt(T),
-}
-
-/// Controls whether the query is in ascending or descending order.
-#[allow(dead_code)]
-#[derive(Clone, Copy, PartialEq)]
-pub(crate) enum OrderBy {
-    Asc,
-    Desc,
-}
-
-impl OrderBy {
-    pub fn invert(&self) -> Self {
-        match self {
-            OrderBy::Asc => OrderBy::Desc,
-            OrderBy::Desc => OrderBy::Asc,
-        }
-    }
-}
-
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     'a,
     (
@@ -91,9 +67,8 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
-        order_by: OrderBy,
-        before: Option<CursorBound<i64>>,
-        after: Option<CursorBound<i64>>,
+        before: Option<i64>,
+        after: Option<i64>,
         limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::backend::Backend;
+use diesel::{backend::Backend, query_builder::AsQuery, query_dsl::methods::BoxedDsl};
 use sui_indexer::{
     schema_v2::{checkpoints, epochs, objects, transactions},
     types_v2::OwnerType,
@@ -15,6 +15,34 @@ use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
     sql_types::Text,
 };
+
+#[derive(Clone, Copy)]
+pub(crate) enum Cursor {
+    After,
+    Before,
+}
+
+/// Controls how many records the query fetches before or after some cursor
+#[derive(Clone, Copy)]
+pub(crate) enum QueryDirection {
+    /// Fetch first n records after some cursor (exclusive) or from the beginning.
+    /// The edge closest to the cursor or beginning comes first in the result set.
+    First(i64),
+    /// Fetch last n records before some cursor (exclusive) or from the end.
+    /// The edge closest to the cursor or end comes last in the result set.
+    Last(i64),
+}
+
+/// Controls the final ordering of the result set
+#[derive(Clone, Copy)]
+pub(crate) enum SortOrder {
+    /// Preserves the original order of the result set.
+    /// This is typically a query ordered by some key in ascending order.
+    Asc,
+    /// Reverses the order of the result set.
+    /// This is typically a query ordered by some key in descending order.
+    Desc,
+}
 
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     'a,
@@ -68,13 +96,15 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
         cursor: Option<i64>,
-        descending_order: bool,
+        cursor_type: Option<Cursor>,
         limit: i64,
+        edge_order: SortOrder,
+        query_direction: QueryDirection,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;
 }
 
-/// Struct for custom diesel function
+/// The struct returned for query.explain()
 #[derive(Debug, Clone, Copy)]
 pub struct Explained<T> {
     pub query: T,
@@ -99,4 +129,31 @@ impl<T: QueryId> QueryId for Explained<T> {
 /// Explained<T> is a fully structured query with return of type Text
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
+}
+
+/// The struct returned for query.subquery()
+#[derive(Debug, Clone, Copy)]
+pub struct Subqueried<T> {
+    pub query: T,
+}
+
+/// Allows .subquery() method on any Diesel query
+pub trait Subquery: AsQuery + Sized {
+    fn subquery(self) -> Subqueried<Self>;
+}
+impl<T: AsQuery> Subquery for T {
+    fn subquery(self) -> Subqueried<Self> {
+        Subqueried { query: self }
+    }
+}
+
+/// All queries need to implement QueryId
+impl<T: QueryId> QueryId for Subqueried<T> {
+    type QueryId = (T::QueryId, std::marker::PhantomData<&'static str>);
+    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
+}
+
+/// Subqueried<T> wraps the query in a SELECT * FROM (query) AS SUB
+impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Subqueried<T> {
+    type SqlType = T::SqlType;
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -16,30 +16,18 @@ use diesel::{
     sql_types::Text,
 };
 
+/// An enum that determines whether to select rows that are greater than or less than the cursor.
 #[derive(Clone, Copy, PartialEq)]
-pub(crate) enum PaginationBound<T> {
+pub(crate) enum CursorBound<T> {
     Gt(T),
     Lt(T),
 }
 
-/// An enum representing whether first and/ or last was provided in the graphql request.
-#[derive(Clone, Copy, PartialEq)]
-pub(crate) enum QueryDirection {
-    /// If first is provided, the result set fetched from the db does not need to be reversed.
-    /// Queries default to this direction.
-    First,
-    /// The direction is last iff first is not provided and last is provided.
-    Last,
-}
-
-/// Controls the final ordering of the result set.
-/// Does not directly correspond to whether the query is ordered by ascending or descending.
+/// Controls whether the query is in ascending or descending order.
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum SortOrder {
-    /// Preserves the original ordering of the set before applying cursor and limit.
     Asc,
-    /// Reverses the ordering of the set before applying cursor and limit.
     Desc,
 }
 
@@ -104,8 +92,8 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
         sort_order: SortOrder,
-        before: Option<PaginationBound<i64>>,
-        after: Option<PaginationBound<i64>>,
+        before: Option<CursorBound<i64>>,
+        after: Option<CursorBound<i64>>,
         limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -16,6 +16,12 @@ use diesel::{
     sql_types::Text,
 };
 
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum PaginationBound<T> {
+    Gt(T),
+    Lt(T),
+}
+
 /// An enum representing whether first and/ or last was provided in the graphql request.
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum QueryDirection {
@@ -29,12 +35,21 @@ pub(crate) enum QueryDirection {
 /// Controls the final ordering of the result set.
 /// Does not directly correspond to whether the query is ordered by ascending or descending.
 #[allow(dead_code)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub(crate) enum SortOrder {
     /// Preserves the original ordering of the set before applying cursor and limit.
     Asc,
     /// Reverses the ordering of the set before applying cursor and limit.
     Desc,
+}
+
+impl SortOrder {
+    pub fn invert(&self) -> Self {
+        match self {
+            SortOrder::Asc => SortOrder::Desc,
+            SortOrder::Desc => SortOrder::Asc,
+        }
+    }
 }
 
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
@@ -88,11 +103,10 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
     fn multi_get_checkpoints(
-        before: Option<i64>,
-        after: Option<i64>,
+        sort_order: SortOrder,
+        before: Option<PaginationBound<i64>>,
+        after: Option<PaginationBound<i64>>,
         limit: i64,
-        edge_order: SortOrder,
-        query_direction: QueryDirection,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::db_backend::{Cursor, GenericQueryBuilder, QueryDirection, SortOrder};
 use crate::{
     config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
@@ -80,8 +81,6 @@ use sui_types::{
     },
     Identifier, TypeTag,
 };
-
-use super::db_backend::GenericQueryBuilder;
 
 #[cfg(feature = "pg_backend")]
 use super::pg_backend::{PgQueryExecutor, QueryBuilder};
@@ -406,6 +405,21 @@ impl PgManager {
     ) -> Result<Option<(Vec<StoredCheckpoint>, bool)>, Error> {
         let limit = self.validate_page_limit(first, last)?;
         let descending_order = last.is_some();
+        let cursor_type = if after.is_some() {
+            Some(Cursor::After)
+        } else if before.is_some() {
+            Some(Cursor::Before)
+        } else {
+            None
+        };
+        let direction = if last.is_some() {
+            QueryDirection::Last(last.unwrap() as i64)
+        } else if first.is_some() {
+            QueryDirection::First(first.unwrap() as i64)
+        } else {
+            QueryDirection::First(limit)
+        };
+
         let cursor = after
             .or(before)
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
@@ -416,8 +430,10 @@ impl PgManager {
                 move || {
                     Ok(QueryBuilder::multi_get_checkpoints(
                         cursor,
-                        descending_order,
+                        cursor_type,
                         limit,
+                        SortOrder::Asc,
+                        direction,
                         epoch.map(|e| e as i64),
                     ))
                 },
@@ -1675,17 +1691,17 @@ pub(crate) fn validate_cursor_pagination(
     last: &Option<u64>,
     before: &Option<String>,
 ) -> Result<(), Error> {
-    if first.is_some() && before.is_some() {
-        return Err(DbValidationError::FirstAfter.into());
-    }
+    // if first.is_some() && before.is_some() {
+    //     return Err(DbValidationError::FirstAfter.into());
+    // }
 
-    if last.is_some() && after.is_some() {
-        return Err(DbValidationError::LastBefore.into());
-    }
+    // if last.is_some() && after.is_some() {
+    //     return Err(DbValidationError::LastBefore.into());
+    // }
 
-    if before.is_some() && after.is_some() {
-        return Err(Error::CursorNoBeforeAfter);
-    }
+    // if before.is_some() && after.is_some() {
+    //     return Err(Error::CursorNoBeforeAfter);
+    // }
 
     if first.is_some() && last.is_some() {
         return Err(Error::CursorNoFirstLast);

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1753,6 +1753,10 @@ pub(crate) fn validate_cursor_pagination(
         return Err(Error::CursorNoBeforeAfter);
     }
 
+    if first.is_some() && last.is_some() {
+        return Err(Error::CursorNoFirstLast);
+    }
+
     Ok(())
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::db_backend::{GenericQueryBuilder, QueryDirection, SortOrder};
+use super::db_backend::{GenericQueryBuilder, PaginationBound, QueryDirection, SortOrder};
 use crate::{
     config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
@@ -141,13 +141,6 @@ impl PgManager {
 
 /// Implement methods to query db and return StoredData
 impl PgManager {
-    /// handle pagination logic
-    // fn handle_checkpoint_pagination(
-    // before: Option<String>,
-    // after: Option<String>,
-    // sort_order: SortOrder
-    // ) -> Result<(), Error> {}
-
     async fn get_tx(&self, digest: Vec<u8>) -> Result<Option<StoredTransaction>, Error> {
         self.run_query_async_with_cost(
             move || Ok(QueryBuilder::get_tx_by_digest(digest.clone())),
@@ -412,10 +405,6 @@ impl PgManager {
     ) -> Result<Option<(Vec<StoredCheckpoint>, bool)>, Error> {
         validate_cursor_pagination_post_fix(&first, &last)?;
         let limit = self.validate_page_limit(first, last)?;
-        let direction = match (first, last) {
-            (None, Some(_)) => QueryDirection::Last,
-            _ => QueryDirection::First,
-        };
         let before = before
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
             .transpose()?;
@@ -423,15 +412,17 @@ impl PgManager {
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
             .transpose()?;
 
+        let (sort_order, requires_invert, before, after) =
+            self.handle_cursor_pagination(SortOrder::Asc, first, after, last, before)?;
+
         let result: Option<Vec<StoredCheckpoint>> = self
             .run_query_async_with_cost(
                 move || {
                     Ok(QueryBuilder::multi_get_checkpoints(
+                        sort_order,
                         before,
                         after,
                         limit,
-                        SortOrder::Asc,
-                        direction,
                         epoch.map(|e| e as i64),
                     ))
                 },
@@ -446,7 +437,7 @@ impl PgManager {
                     stored_checkpoints.pop();
                 }
 
-                if direction == QueryDirection::Last {
+                if requires_invert {
                     stored_checkpoints.reverse();
                 }
 
@@ -499,6 +490,62 @@ impl PgManager {
 
 /// Implement methods to be used by graphql resolvers
 impl PgManager {
+    pub(crate) fn handle_cursor_pagination<T>(
+        &self,
+        sort_order: SortOrder,
+        first: Option<u64>,
+        after: Option<T>,
+        last: Option<u64>,
+        before: Option<T>,
+    ) -> Result<
+        (
+            SortOrder,
+            bool,
+            Option<PaginationBound<T>>,
+            Option<PaginationBound<T>>,
+        ),
+        Error,
+    > {
+        let selection = match (first, last) {
+            (None, Some(_)) => QueryDirection::Last,
+            _ => QueryDirection::First,
+        };
+
+        let (new_sort_order, requires_invert) = match selection {
+            QueryDirection::First => (sort_order, false),
+            QueryDirection::Last => (sort_order.invert(), true),
+        };
+
+        // Note that we use the original sort_order always
+        // This is because last only impacts asc or desc - the cursor logic is consistent with 'first' queries
+        let (new_after, new_before) = self.determine_cursor_bounds(sort_order, before, after)?;
+        Ok((new_sort_order, requires_invert, new_before, new_after))
+    }
+
+    pub(crate) fn determine_cursor_bounds<T>(
+        &self,
+        sort_order: SortOrder,
+        before: Option<T>,
+        after: Option<T>,
+    ) -> Result<(Option<PaginationBound<T>>, Option<PaginationBound<T>>), Error> {
+        let new_after = after.map(|a| {
+            if sort_order == SortOrder::Asc {
+                PaginationBound::Gt(a)
+            } else {
+                PaginationBound::Lt(a)
+            }
+        });
+        let new_before = before.map(|b| {
+            if sort_order == SortOrder::Asc {
+                PaginationBound::Lt(b)
+            } else {
+                PaginationBound::Gt(b)
+            }
+        });
+
+        Ok((new_after, new_before))
+    }
+
     pub(crate) fn parse_tx_cursor(&self, cursor: &str) -> Result<i64, Error> {
         let tx_sequence_number = cursor
             .parse::<i64>()

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::db_backend::{CursorBound, GenericQueryBuilder, SortOrder};
+use super::db_backend::{CursorBound, GenericQueryBuilder, OrderBy};
 use crate::{
     config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
@@ -119,22 +119,22 @@ pub(crate) struct CursorBounds<T> {
 }
 
 impl<T> CursorBounds<T> {
-    pub(crate) fn new(sort_order: SortOrder, before: Option<T>, after: Option<T>) -> Self {
+    pub(crate) fn new(order_by: OrderBy, before: Option<T>, after: Option<T>) -> Self {
         Self {
-            after: after.map(|a| match sort_order {
-                SortOrder::Asc => CursorBound::Gt(a),
-                SortOrder::Desc => CursorBound::Lt(a),
+            after: after.map(|a| match order_by {
+                OrderBy::Asc => CursorBound::Gt(a),
+                OrderBy::Desc => CursorBound::Lt(a),
             }),
-            before: before.map(|b| match sort_order {
-                SortOrder::Asc => CursorBound::Lt(b),
-                SortOrder::Desc => CursorBound::Gt(b),
+            before: before.map(|b| match order_by {
+                OrderBy::Asc => CursorBound::Lt(b),
+                OrderBy::Desc => CursorBound::Gt(b),
             }),
         }
     }
 }
 
 pub(crate) struct PaginationParams<T> {
-    pub sort_order: SortOrder,
+    pub order_by: OrderBy,
     pub before: Option<CursorBound<T>>,
     pub after: Option<CursorBound<T>>,
     pub requires_invert: bool,
@@ -148,23 +148,23 @@ impl<T> PaginationParams<T> {
     /// and the pagination logic for 'before' and 'after' cursors.
     /// A query defaults to 'first' if neither 'first' nor 'last' is provided.
     pub(crate) fn new(
-        sort_order: Option<SortOrder>,
+        order_by: Option<OrderBy>,
         first: Option<u64>,
         after: Option<T>,
         last: Option<u64>,
         before: Option<T>,
     ) -> Self {
-        let sort_order = sort_order.unwrap_or(SortOrder::Asc);
-        let (new_sort_order, requires_invert) = match (first, last) {
-            (None, Some(_)) => (sort_order.invert(), true),
-            _ => (sort_order, false),
+        let order_by = order_by.unwrap_or(OrderBy::Asc);
+        let (new_order_by, requires_invert) = match (first, last) {
+            (None, Some(_)) => (order_by.invert(), true),
+            _ => (order_by, false),
         };
 
-        // Note that we use the original sort_order - the cursor bounding logic is consistent with 'first' queries
-        let cursors = CursorBounds::new(sort_order, before, after);
+        // Note that we use the original order_by - the cursor bounding logic is consistent with 'first' queries
+        let cursors = CursorBounds::new(order_by, before, after);
 
         PaginationParams {
-            sort_order: new_sort_order,
+            order_by: new_order_by,
             requires_invert,
             before: cursors.before,
             after: cursors.after,
@@ -484,7 +484,7 @@ impl PgManager {
             .run_query_async_with_cost(
                 move || {
                     Ok(QueryBuilder::multi_get_checkpoints(
-                        pagination_params.sort_order,
+                        pagination_params.order_by,
                         pagination_params.before,
                         pagination_params.after,
                         limit,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::db_backend::{GenericQueryBuilder, PaginationBound, QueryDirection, SortOrder};
+use super::db_backend::{CursorBound, GenericQueryBuilder, SortOrder};
 use crate::{
     config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
@@ -111,6 +111,65 @@ pub enum DbValidationError {
     QueryCostExceeded(u64, u64),
     #[error("Page size exceeded - requested: {0}, limit: {1}")]
     PageSizeExceeded(u64, u64),
+}
+
+pub(crate) struct CursorBounds<T> {
+    pub before: Option<CursorBound<T>>,
+    pub after: Option<CursorBound<T>>,
+}
+
+impl<T> CursorBounds<T> {
+    pub(crate) fn new(sort_order: SortOrder, before: Option<T>, after: Option<T>) -> Self {
+        Self {
+            after: after.map(|a| match sort_order {
+                SortOrder::Asc => CursorBound::Gt(a),
+                SortOrder::Desc => CursorBound::Lt(a),
+            }),
+            before: before.map(|b| match sort_order {
+                SortOrder::Asc => CursorBound::Lt(b),
+                SortOrder::Desc => CursorBound::Gt(b),
+            }),
+        }
+    }
+}
+
+pub(crate) struct PaginationParams<T> {
+    pub sort_order: SortOrder,
+    pub before: Option<CursorBound<T>>,
+    pub after: Option<CursorBound<T>>,
+    pub requires_invert: bool,
+}
+
+impl<T> PaginationParams<T> {
+    /// Translates graphql cursor arguments to db pagination logic.
+    /// There are two types of pagination, queries with 'first', and queries with 'last'.
+    /// 'First' queries do not require inverting the result set, while 'last' queries do.
+    /// This method returns the sort order, whether the result set needs to be inverted,
+    /// and the pagination logic for 'before' and 'after' cursors.
+    /// A query defaults to 'first' if neither 'first' nor 'last' is provided.
+    pub(crate) fn new(
+        sort_order: Option<SortOrder>,
+        first: Option<u64>,
+        after: Option<T>,
+        last: Option<u64>,
+        before: Option<T>,
+    ) -> Self {
+        let sort_order = sort_order.unwrap_or(SortOrder::Asc);
+        let (new_sort_order, requires_invert) = match (first, last) {
+            (None, Some(_)) => (sort_order.invert(), true),
+            _ => (sort_order, false),
+        };
+
+        // Note that we use the original sort_order - the cursor bounding logic is consistent with 'first' queries
+        let cursors = CursorBounds::new(sort_order, before, after);
+
+        PaginationParams {
+            sort_order: new_sort_order,
+            requires_invert,
+            before: cursors.before,
+            after: cursors.after,
+        }
+    }
 }
 
 pub(crate) struct PgManager {
@@ -395,6 +454,13 @@ impl PgManager {
             .transpose()
     }
 
+    pub(crate) fn parse_checkpoint_cursor(&self, cursor: &str) -> Result<i64, Error> {
+        let sequence_number = cursor.parse::<i64>().map_err(|e| {
+            Error::InvalidCursor(format!("Failed to parse checkpoint cursor: {}", e))
+        })?;
+        Ok(sequence_number)
+    }
+
     async fn multi_get_checkpoints(
         &self,
         first: Option<u64>,
@@ -412,16 +478,15 @@ impl PgManager {
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
             .transpose()?;
 
-        let (sort_order, requires_invert, before, after) =
-            self.handle_cursor_pagination(SortOrder::Asc, first, after, last, before)?;
+        let pagination_params = PaginationParams::new(None, first, after, last, before);
 
         let result: Option<Vec<StoredCheckpoint>> = self
             .run_query_async_with_cost(
                 move || {
                     Ok(QueryBuilder::multi_get_checkpoints(
-                        sort_order,
-                        before,
-                        after,
+                        pagination_params.sort_order,
+                        pagination_params.before,
+                        pagination_params.after,
                         limit,
                         epoch.map(|e| e as i64),
                     ))
@@ -437,7 +502,7 @@ impl PgManager {
                     stored_checkpoints.pop();
                 }
 
-                if requires_invert {
+                if pagination_params.requires_invert {
                     stored_checkpoints.reverse();
                 }
 
@@ -490,62 +555,6 @@ impl PgManager {
 
 /// Implement methods to be used by graphql resolvers
 impl PgManager {
-    pub(crate) fn handle_cursor_pagination<T>(
-        &self,
-        sort_order: SortOrder,
-        first: Option<u64>,
-        after: Option<T>,
-        last: Option<u64>,
-        before: Option<T>,
-    ) -> Result<
-        (
-            SortOrder,
-            bool,
-            Option<PaginationBound<T>>,
-            Option<PaginationBound<T>>,
-        ),
-        Error,
-    > {
-        let selection = match (first, last) {
-            (None, Some(_)) => QueryDirection::Last,
-            _ => QueryDirection::First,
-        };
-
-        let (new_sort_order, requires_invert) = match selection {
-            QueryDirection::First => (sort_order, false),
-            QueryDirection::Last => (sort_order.invert(), true),
-        };
-
-        // Note that we use the original sort_order always
-        // This is because last only impacts asc or desc - the cursor logic is consistent with 'first' queries
-        let (new_after, new_before) = self.determine_cursor_bounds(sort_order, before, after)?;
-        Ok((new_sort_order, requires_invert, new_before, new_after))
-    }
-
-    pub(crate) fn determine_cursor_bounds<T>(
-        &self,
-        sort_order: SortOrder,
-        before: Option<T>,
-        after: Option<T>,
-    ) -> Result<(Option<PaginationBound<T>>, Option<PaginationBound<T>>), Error> {
-        let new_after = after.map(|a| {
-            if sort_order == SortOrder::Asc {
-                PaginationBound::Gt(a)
-            } else {
-                PaginationBound::Lt(a)
-            }
-        });
-        let new_before = before.map(|b| {
-            if sort_order == SortOrder::Asc {
-                PaginationBound::Lt(b)
-            } else {
-                PaginationBound::Gt(b)
-            }
-        });
-
-        Ok((new_after, new_before))
-    }
-
     pub(crate) fn parse_tx_cursor(&self, cursor: &str) -> Result<i64, Error> {
         let tx_sequence_number = cursor
             .parse::<i64>()
@@ -557,13 +566,6 @@ impl PgManager {
         Ok(SuiAddress::from_str(cursor)
             .map_err(|e| Error::InvalidCursor(e.to_string()))?
             .into_vec())
-    }
-
-    pub(crate) fn parse_checkpoint_cursor(&self, cursor: &str) -> Result<i64, Error> {
-        let sequence_number = cursor
-            .parse::<i64>()
-            .map_err(|_| Error::InvalidCursor("checkpoint".to_string()))?;
-        Ok(sequence_number)
     }
 
     pub(crate) fn parse_event_cursor(&self, cursor: String) -> Result<EventID, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::db_backend::{Cursor, GenericQueryBuilder, QueryDirection, SortOrder};
+use super::db_backend::{GenericQueryBuilder, QueryDirection, SortOrder};
 use crate::{
     config::{Limits, DEFAULT_SERVER_DB_POOL_SIZE},
     error::Error,
@@ -403,25 +403,16 @@ impl PgManager {
         before: Option<String>,
         epoch: Option<u64>,
     ) -> Result<Option<(Vec<StoredCheckpoint>, bool)>, Error> {
+        validate_cursor_pagination_post_fix(&first, &last)?;
         let limit = self.validate_page_limit(first, last)?;
-        let descending_order = last.is_some();
-        let cursor_type = if after.is_some() {
-            Some(Cursor::After)
-        } else if before.is_some() {
-            Some(Cursor::Before)
-        } else {
-            None
+        let direction = match (first, last) {
+            (None, Some(_)) => QueryDirection::Last,
+            _ => QueryDirection::First,
         };
-        let direction = if last.is_some() {
-            QueryDirection::Last(last.unwrap() as i64)
-        } else if first.is_some() {
-            QueryDirection::First(first.unwrap() as i64)
-        } else {
-            QueryDirection::First(limit)
-        };
-
-        let cursor = after
-            .or(before)
+        let before = before
+            .map(|cursor| self.parse_checkpoint_cursor(&cursor))
+            .transpose()?;
+        let after = after
             .map(|cursor| self.parse_checkpoint_cursor(&cursor))
             .transpose()?;
 
@@ -429,8 +420,8 @@ impl PgManager {
             .run_query_async_with_cost(
                 move || {
                     Ok(QueryBuilder::multi_get_checkpoints(
-                        cursor,
-                        cursor_type,
+                        before,
+                        after,
                         limit,
                         SortOrder::Asc,
                         direction,
@@ -446,6 +437,10 @@ impl PgManager {
                 let has_next_page = stored_checkpoints.len() as i64 > limit;
                 if has_next_page {
                     stored_checkpoints.pop();
+                }
+
+                if direction == QueryDirection::Last {
+                    stored_checkpoints.reverse();
                 }
 
                 Ok((stored_checkpoints, has_next_page))
@@ -889,7 +884,6 @@ impl PgManager {
         before: Option<String>,
         epoch: Option<u64>,
     ) -> Result<Option<Connection<String, Checkpoint>>, Error> {
-        validate_cursor_pagination(&first, &after, &last, &before)?;
         let checkpoints = self
             .multi_get_checkpoints(first, after, last, before, epoch)
             .await?;
@@ -1691,18 +1685,25 @@ pub(crate) fn validate_cursor_pagination(
     last: &Option<u64>,
     before: &Option<String>,
 ) -> Result<(), Error> {
-    // if first.is_some() && before.is_some() {
-    //     return Err(DbValidationError::FirstAfter.into());
-    // }
+    if first.is_some() && before.is_some() {
+        return Err(DbValidationError::FirstAfter.into());
+    }
 
-    // if last.is_some() && after.is_some() {
-    //     return Err(DbValidationError::LastBefore.into());
-    // }
+    if last.is_some() && after.is_some() {
+        return Err(DbValidationError::LastBefore.into());
+    }
 
-    // if before.is_some() && after.is_some() {
-    //     return Err(Error::CursorNoBeforeAfter);
-    // }
+    if before.is_some() && after.is_some() {
+        return Err(Error::CursorNoBeforeAfter);
+    }
 
+    Ok(())
+}
+
+pub(crate) fn validate_cursor_pagination_post_fix(
+    first: &Option<u64>,
+    last: &Option<u64>,
+) -> Result<(), Error> {
     if first.is_some() && last.is_some() {
         return Err(Error::CursorNoFirstLast);
     }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -141,6 +141,13 @@ impl PgManager {
 
 /// Implement methods to query db and return StoredData
 impl PgManager {
+    /// handle pagination logic
+    // fn handle_checkpoint_pagination(
+    // before: Option<String>,
+    // after: Option<String>,
+    // sort_order: SortOrder
+    // ) -> Result<(), Error> {}
+
     async fn get_tx(&self, digest: Vec<u8>) -> Result<Option<StoredTransaction>, Error> {
         self.run_query_async_with_cost(
             move || Ok(QueryBuilder::get_tx_by_digest(digest.clone())),

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -30,6 +30,7 @@ use sui_indexer::{
 pub(crate) struct PgQueryBuilder;
 
 impl PgQueryBuilder {
+    /// Handles pagination logic when the query selects for the first n
     fn handle_checkpoint_pagination_first(
         before: Option<i64>,
         after: Option<i64>,
@@ -61,7 +62,8 @@ impl PgQueryBuilder {
         query
     }
 
-    // 'last' queries require a final reverse ordering
+    /// Handles pagination logic when the query selects for the last n
+    /// These queries require a reverse ordering of the result set
     fn handle_checkpoint_pagination_last(
         before: Option<i64>,
         after: Option<i64>,

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -3,7 +3,7 @@
 
 use super::{
     db_backend::{
-        BalanceQuery, Explain, Explained, GenericQueryBuilder, QueryDirection, SortOrder,
+        BalanceQuery, Explain, Explained, GenericQueryBuilder, PaginationBound, SortOrder,
     },
     db_data_provider::DbValidationError,
 };
@@ -28,73 +28,6 @@ use sui_indexer::{
 };
 
 pub(crate) struct PgQueryBuilder;
-
-impl PgQueryBuilder {
-    /// Handles pagination logic when the query selects for the first n
-    fn handle_checkpoint_pagination_first(
-        before: Option<i64>,
-        after: Option<i64>,
-        sort_order: SortOrder,
-    ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
-
-        match sort_order {
-            SortOrder::Asc => {
-                query = query.order(checkpoints::dsl::sequence_number.asc());
-                if let Some(after) = after {
-                    query = query.filter(checkpoints::dsl::sequence_number.gt(after));
-                }
-                if let Some(before) = before {
-                    query = query.filter(checkpoints::dsl::sequence_number.lt(before));
-                }
-            }
-            SortOrder::Desc => {
-                query = query.order(checkpoints::dsl::sequence_number.desc());
-                if let Some(after) = after {
-                    query = query.filter(checkpoints::dsl::sequence_number.lt(after));
-                }
-                if let Some(before) = before {
-                    query = query.filter(checkpoints::dsl::sequence_number.gt(before));
-                }
-            }
-        }
-
-        query
-    }
-
-    /// Handles pagination logic when the query selects for the last n
-    /// These queries require a reverse ordering of the result set
-    fn handle_checkpoint_pagination_last(
-        before: Option<i64>,
-        after: Option<i64>,
-        sort_order: SortOrder,
-    ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
-
-        match sort_order {
-            SortOrder::Asc => {
-                query = query.order(checkpoints::dsl::sequence_number.desc());
-                if let Some(after) = after {
-                    query = query.filter(checkpoints::dsl::sequence_number.gt(after));
-                }
-                if let Some(before) = before {
-                    query = query.filter(checkpoints::dsl::sequence_number.lt(before));
-                }
-            }
-            SortOrder::Desc => {
-                query = query.order(checkpoints::dsl::sequence_number.asc());
-                if let Some(after) = after {
-                    query = query.filter(checkpoints::dsl::sequence_number.lt(after));
-                }
-                if let Some(before) = before {
-                    query = query.filter(checkpoints::dsl::sequence_number.gt(before));
-                }
-            }
-        }
-
-        query
-    }
-}
 
 impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, Pg> {
@@ -413,21 +346,44 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         query.filter(objects::dsl::coin_type.eq(coin_type))
     }
     fn multi_get_checkpoints(
-        before: Option<i64>,
-        after: Option<i64>,
-        limit: i64,
         sort_order: SortOrder,
-        query_direction: QueryDirection,
+        before: Option<PaginationBound<i64>>,
+        after: Option<PaginationBound<i64>>,
+        limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let mut query = match query_direction {
-            QueryDirection::First => {
-                PgQueryBuilder::handle_checkpoint_pagination_first(before, after, sort_order)
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+
+        match sort_order {
+            SortOrder::Asc => {
+                query = query.order(checkpoints::dsl::sequence_number.asc());
             }
-            QueryDirection::Last => {
-                PgQueryBuilder::handle_checkpoint_pagination_last(before, after, sort_order)
+            SortOrder::Desc => {
+                query = query.order(checkpoints::dsl::sequence_number.desc());
             }
-        };
+        }
+
+        if let Some(after) = after {
+            match after {
+                PaginationBound::Gt(after) => {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(after));
+                }
+                PaginationBound::Lt(after) => {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(after));
+                }
+            }
+        }
+
+        if let Some(before) = before {
+            match before {
+                PaginationBound::Gt(before) => {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(before));
+                }
+                PaginationBound::Lt(before) => {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(before));
+                }
+            }
+        }
 
         if let Some(epoch) = epoch {
             query = query.filter(checkpoints::dsl::epoch.eq(epoch));

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{
-        BalanceQuery, Explain, Explained, GenericQueryBuilder, PaginationBound, SortOrder,
-    },
+    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, SortOrder},
     db_data_provider::DbValidationError,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -347,8 +345,8 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     }
     fn multi_get_checkpoints(
         sort_order: SortOrder,
-        before: Option<PaginationBound<i64>>,
-        after: Option<PaginationBound<i64>>,
+        before: Option<CursorBound<i64>>,
+        after: Option<CursorBound<i64>>,
         limit: i64,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
@@ -365,10 +363,10 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
 
         if let Some(after) = after {
             match after {
-                PaginationBound::Gt(after) => {
+                CursorBound::Gt(after) => {
                     query = query.filter(checkpoints::dsl::sequence_number.gt(after));
                 }
-                PaginationBound::Lt(after) => {
+                CursorBound::Lt(after) => {
                     query = query.filter(checkpoints::dsl::sequence_number.lt(after));
                 }
             }
@@ -376,10 +374,10 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
 
         if let Some(before) = before {
             match before {
-                PaginationBound::Gt(before) => {
+                CursorBound::Gt(before) => {
                     query = query.filter(checkpoints::dsl::sequence_number.gt(before));
                 }
-                PaginationBound::Lt(before) => {
+                CursorBound::Lt(before) => {
                     query = query.filter(checkpoints::dsl::sequence_number.lt(before));
                 }
             }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder},
+    db_backend::{
+        BalanceQuery, Cursor, Explain, Explained, GenericQueryBuilder, QueryDirection, SortOrder,
+        Subqueried, Subquery,
+    },
     db_data_provider::DbValidationError,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -12,9 +15,15 @@ use crate::{
 };
 use async_trait::async_trait;
 use diesel::{
+    associations::HasTable,
+    helper_types::IntoBoxed,
     pg::Pg,
-    query_builder::{AstPass, QueryFragment},
-    BoolExpressionMethods, ExpressionMethods, PgConnection, QueryDsl, QueryResult, RunQueryDsl,
+    query_builder::{
+        AsQuery, AstPass, BoxedSelectStatement, FromClause, Query, QueryFragment, SelectStatement,
+    },
+    query_dsl::methods::BoxedDsl,
+    BoolExpressionMethods, Expression, ExpressionMethods, PgConnection, QueryDsl, QueryResult,
+    QuerySource, RunQueryDsl, Table,
 };
 use std::str::FromStr;
 use sui_indexer::{
@@ -26,6 +35,80 @@ use sui_indexer::{
 };
 
 pub(crate) struct PgQueryBuilder;
+
+impl PgQueryBuilder {
+    fn handle_checkpoint_pagination_first(
+        cursor: i64,
+        cursor_type: Cursor,
+        sort_order: SortOrder,
+    ) -> checkpoints::BoxedQuery<'static, Pg> {
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+
+        match (cursor_type, sort_order) {
+            (Cursor::After, SortOrder::Asc) => {
+                query = query
+                    .filter(checkpoints::dsl::sequence_number.gt(cursor))
+                    .order(checkpoints::dsl::sequence_number.asc());
+            }
+            (Cursor::Before, SortOrder::Asc) => {
+                query = query
+                    .filter(checkpoints::dsl::sequence_number.lt(cursor))
+                    .order(checkpoints::dsl::sequence_number.asc());
+            }
+            (Cursor::After, SortOrder::Desc) => {
+                query = query
+                    .filter(checkpoints::dsl::sequence_number.lt(cursor))
+                    .order(checkpoints::dsl::sequence_number.desc());
+            }
+            (Cursor::Before, SortOrder::Desc) => {
+                query = query
+                    .filter(checkpoints::dsl::sequence_number.gt(cursor))
+                    .order(checkpoints::dsl::sequence_number.desc());
+            }
+        }
+        query
+    }
+
+    fn handle_checkpoint_pagination_last(
+        cursor: i64,
+        cursor_type: Cursor,
+        sort_order: SortOrder,
+    ) -> checkpoints::BoxedQuery<'static, Pg> {
+        let subquery = match (cursor_type, sort_order) {
+            (Cursor::After, SortOrder::Asc) => PgQueryBuilder::handle_checkpoint_pagination_first(
+                cursor,
+                Cursor::Before,
+                SortOrder::Desc,
+            ), // outer asc
+            (Cursor::Before, SortOrder::Asc) => PgQueryBuilder::handle_checkpoint_pagination_first(
+                cursor,
+                Cursor::After,
+                SortOrder::Desc,
+            ), // outer asc
+            (Cursor::After, SortOrder::Desc) => PgQueryBuilder::handle_checkpoint_pagination_first(
+                cursor,
+                Cursor::Before,
+                SortOrder::Asc,
+            ), // outer desc
+            (Cursor::Before, SortOrder::Desc) => {
+                PgQueryBuilder::handle_checkpoint_pagination_first(
+                    cursor,
+                    Cursor::After,
+                    SortOrder::Asc,
+                )
+            } // outer desc
+        };
+
+        match sort_order {
+            SortOrder::Asc => subquery
+                .subquery()
+                .order(checkpoints::dsl::sequence_number.asc()),
+            SortOrder::Desc => subquery
+                .subquery()
+                .order(checkpoints::dsl::sequence_number.desc()),
+        }
+    }
+}
 
 impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, Pg> {
@@ -345,27 +428,34 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     }
     fn multi_get_checkpoints(
         cursor: Option<i64>,
-        descending_order: bool,
+        cursor_type: Option<Cursor>,
         limit: i64,
+        sort_order: SortOrder,
+        query_direction: QueryDirection,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(checkpoints::dsl::sequence_number.lt(cursor));
-            } else {
-                query = query.filter(checkpoints::dsl::sequence_number.gt(cursor));
-            }
-        }
-        if descending_order {
-            query = query.order(checkpoints::dsl::sequence_number.desc());
+        if let (Some(cursor), Some(cursor_type)) = (cursor, cursor_type) {
+            query = match query_direction {
+                QueryDirection::First(_) => PgQueryBuilder::handle_checkpoint_pagination_first(
+                    cursor,
+                    cursor_type,
+                    sort_order,
+                ),
+                QueryDirection::Last(_) => PgQueryBuilder::handle_checkpoint_pagination_last(
+                    cursor,
+                    cursor_type,
+                    sort_order,
+                ),
+            };
         } else {
-            query = query.order(checkpoints::dsl::sequence_number.asc());
+            query = match sort_order {
+                SortOrder::Asc => query.order(checkpoints::dsl::sequence_number.asc()),
+                SortOrder::Desc => query.order(checkpoints::dsl::sequence_number.desc()),
+            };
         }
-        if let Some(epoch) = epoch {
-            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
-        }
+
         query = query.limit(limit + 1);
 
         query
@@ -384,6 +474,42 @@ where
         out.push_sql("EXPLAIN (FORMAT JSON) ");
         self.query.walk_ast(out.reborrow())?;
         Ok(())
+    }
+}
+
+/// Allows methods like load(), get_result(), etc. on a Subqueried query
+impl<T> RunQueryDsl<PgConnection> for Subqueried<T> {}
+
+/// Implement logic wrapping queries in a SELECT * FROM (query) AS SUB
+impl<T> QueryFragment<Pg> for Subqueried<T>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.push_sql("SELECT * FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") AS sub");
+        Ok(())
+    }
+}
+
+// impl<T: Query> AsQuery for Subqueried<T> {
+//     type SqlType = <T as Query>::SqlType;
+//     type Query = T;
+
+//     fn as_query(self) -> <T as AsQuery>::Query {
+//         self
+//     }
+// }
+
+impl<T> BoxedDsl<'_, Pg> for Subqueried<T>
+where
+    T: Table + HasTable<Table = T> + AsQuery + QueryFragment<Pg> + 'static,
+{
+    type Output = BoxedSelectStatement<'static, T::SqlType, Self, Pg>;
+
+    fn internal_into_boxed(self) -> Self::Output {
+        self.as_query().internal_into_boxed()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -352,6 +352,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     ) -> checkpoints::BoxedQuery<'static, Pg> {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
+        // TODO (wlmyng): Reduce redundancy when other multi-gets are refactored
         match sort_order {
             SortOrder::Asc => {
                 query = query.order(checkpoints::dsl::sequence_number.asc());

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, SortOrder},
+    db_backend::{BalanceQuery, CursorBound, Explain, Explained, GenericQueryBuilder, OrderBy},
     db_data_provider::DbValidationError,
 };
 use crate::context_data::db_data_provider::PgManager;
@@ -344,7 +344,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         query.filter(objects::dsl::coin_type.eq(coin_type))
     }
     fn multi_get_checkpoints(
-        sort_order: SortOrder,
+        order_by: OrderBy,
         before: Option<CursorBound<i64>>,
         after: Option<CursorBound<i64>>,
         limit: i64,
@@ -353,11 +353,11 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
         // TODO (wlmyng): Reduce redundancy when other multi-gets are refactored
-        match sort_order {
-            SortOrder::Asc => {
+        match order_by {
+            OrderBy::Asc => {
                 query = query.order(checkpoints::dsl::sequence_number.asc());
             }
-            SortOrder::Desc => {
+            OrderBy::Desc => {
                 query = query.order(checkpoints::dsl::sequence_number.desc());
             }
         }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -3,8 +3,7 @@
 
 use super::{
     db_backend::{
-        BalanceQuery, Cursor, Explain, Explained, GenericQueryBuilder, QueryDirection, SortOrder,
-        Subqueried, Subquery,
+        BalanceQuery, Explain, Explained, GenericQueryBuilder, QueryDirection, SortOrder,
     },
     db_data_provider::DbValidationError,
 };
@@ -15,15 +14,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use diesel::{
-    associations::HasTable,
-    helper_types::IntoBoxed,
     pg::Pg,
-    query_builder::{
-        AsQuery, AstPass, BoxedSelectStatement, FromClause, Query, QueryFragment, SelectStatement,
-    },
-    query_dsl::methods::BoxedDsl,
-    BoolExpressionMethods, Expression, ExpressionMethods, PgConnection, QueryDsl, QueryResult,
-    QuerySource, RunQueryDsl, Table,
+    query_builder::{AstPass, QueryFragment},
+    BoolExpressionMethods, ExpressionMethods, PgConnection, QueryDsl, QueryResult, RunQueryDsl,
 };
 use std::str::FromStr;
 use sui_indexer::{
@@ -38,75 +31,66 @@ pub(crate) struct PgQueryBuilder;
 
 impl PgQueryBuilder {
     fn handle_checkpoint_pagination_first(
-        cursor: i64,
-        cursor_type: Cursor,
+        before: Option<i64>,
+        after: Option<i64>,
         sort_order: SortOrder,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
         let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
-        match (cursor_type, sort_order) {
-            (Cursor::After, SortOrder::Asc) => {
-                query = query
-                    .filter(checkpoints::dsl::sequence_number.gt(cursor))
-                    .order(checkpoints::dsl::sequence_number.asc());
+        match sort_order {
+            SortOrder::Asc => {
+                query = query.order(checkpoints::dsl::sequence_number.asc());
+                if let Some(after) = after {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(after));
+                }
+                if let Some(before) = before {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(before));
+                }
             }
-            (Cursor::Before, SortOrder::Asc) => {
-                query = query
-                    .filter(checkpoints::dsl::sequence_number.lt(cursor))
-                    .order(checkpoints::dsl::sequence_number.asc());
-            }
-            (Cursor::After, SortOrder::Desc) => {
-                query = query
-                    .filter(checkpoints::dsl::sequence_number.lt(cursor))
-                    .order(checkpoints::dsl::sequence_number.desc());
-            }
-            (Cursor::Before, SortOrder::Desc) => {
-                query = query
-                    .filter(checkpoints::dsl::sequence_number.gt(cursor))
-                    .order(checkpoints::dsl::sequence_number.desc());
+            SortOrder::Desc => {
+                query = query.order(checkpoints::dsl::sequence_number.desc());
+                if let Some(after) = after {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(after));
+                }
+                if let Some(before) = before {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(before));
+                }
             }
         }
+
         query
     }
 
+    // 'last' queries require a final reverse ordering
     fn handle_checkpoint_pagination_last(
-        cursor: i64,
-        cursor_type: Cursor,
+        before: Option<i64>,
+        after: Option<i64>,
         sort_order: SortOrder,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let subquery = match (cursor_type, sort_order) {
-            (Cursor::After, SortOrder::Asc) => PgQueryBuilder::handle_checkpoint_pagination_first(
-                cursor,
-                Cursor::Before,
-                SortOrder::Desc,
-            ), // outer asc
-            (Cursor::Before, SortOrder::Asc) => PgQueryBuilder::handle_checkpoint_pagination_first(
-                cursor,
-                Cursor::After,
-                SortOrder::Desc,
-            ), // outer asc
-            (Cursor::After, SortOrder::Desc) => PgQueryBuilder::handle_checkpoint_pagination_first(
-                cursor,
-                Cursor::Before,
-                SortOrder::Asc,
-            ), // outer desc
-            (Cursor::Before, SortOrder::Desc) => {
-                PgQueryBuilder::handle_checkpoint_pagination_first(
-                    cursor,
-                    Cursor::After,
-                    SortOrder::Asc,
-                )
-            } // outer desc
-        };
+        let mut query = checkpoints::dsl::checkpoints.into_boxed();
 
         match sort_order {
-            SortOrder::Asc => subquery
-                .subquery()
-                .order(checkpoints::dsl::sequence_number.asc()),
-            SortOrder::Desc => subquery
-                .subquery()
-                .order(checkpoints::dsl::sequence_number.desc()),
+            SortOrder::Asc => {
+                query = query.order(checkpoints::dsl::sequence_number.desc());
+                if let Some(after) = after {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(after));
+                }
+                if let Some(before) = before {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(before));
+                }
+            }
+            SortOrder::Desc => {
+                query = query.order(checkpoints::dsl::sequence_number.asc());
+                if let Some(after) = after {
+                    query = query.filter(checkpoints::dsl::sequence_number.lt(after));
+                }
+                if let Some(before) = before {
+                    query = query.filter(checkpoints::dsl::sequence_number.gt(before));
+                }
+            }
         }
+
+        query
     }
 }
 
@@ -427,33 +411,24 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         query.filter(objects::dsl::coin_type.eq(coin_type))
     }
     fn multi_get_checkpoints(
-        cursor: Option<i64>,
-        cursor_type: Option<Cursor>,
+        before: Option<i64>,
+        after: Option<i64>,
         limit: i64,
         sort_order: SortOrder,
         query_direction: QueryDirection,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let mut query = checkpoints::dsl::checkpoints.into_boxed();
+        let mut query = match query_direction {
+            QueryDirection::First => {
+                PgQueryBuilder::handle_checkpoint_pagination_first(before, after, sort_order)
+            }
+            QueryDirection::Last => {
+                PgQueryBuilder::handle_checkpoint_pagination_last(before, after, sort_order)
+            }
+        };
 
-        if let (Some(cursor), Some(cursor_type)) = (cursor, cursor_type) {
-            query = match query_direction {
-                QueryDirection::First(_) => PgQueryBuilder::handle_checkpoint_pagination_first(
-                    cursor,
-                    cursor_type,
-                    sort_order,
-                ),
-                QueryDirection::Last(_) => PgQueryBuilder::handle_checkpoint_pagination_last(
-                    cursor,
-                    cursor_type,
-                    sort_order,
-                ),
-            };
-        } else {
-            query = match sort_order {
-                SortOrder::Asc => query.order(checkpoints::dsl::sequence_number.asc()),
-                SortOrder::Desc => query.order(checkpoints::dsl::sequence_number.desc()),
-            };
+        if let Some(epoch) = epoch {
+            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
         }
 
         query = query.limit(limit + 1);
@@ -474,42 +449,6 @@ where
         out.push_sql("EXPLAIN (FORMAT JSON) ");
         self.query.walk_ast(out.reborrow())?;
         Ok(())
-    }
-}
-
-/// Allows methods like load(), get_result(), etc. on a Subqueried query
-impl<T> RunQueryDsl<PgConnection> for Subqueried<T> {}
-
-/// Implement logic wrapping queries in a SELECT * FROM (query) AS SUB
-impl<T> QueryFragment<Pg> for Subqueried<T>
-where
-    T: QueryFragment<Pg>,
-{
-    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
-        out.push_sql("SELECT * FROM (");
-        self.query.walk_ast(out.reborrow())?;
-        out.push_sql(") AS sub");
-        Ok(())
-    }
-}
-
-// impl<T: Query> AsQuery for Subqueried<T> {
-//     type SqlType = <T as Query>::SqlType;
-//     type Query = T;
-
-//     fn as_query(self) -> <T as AsQuery>::Query {
-//         self
-//     }
-// }
-
-impl<T> BoxedDsl<'_, Pg> for Subqueried<T>
-where
-    T: Table + HasTable<Table = T> + AsQuery + QueryFragment<Pg> + 'static,
-{
-    type Output = BoxedSelectStatement<'static, T::SqlType, Self, Pg>;
-
-    fn internal_into_boxed(self) -> Self::Output {
-        self.as_query().internal_into_boxed()
     }
 }
 


### PR DESCRIPTION
## Description 

Simplify cursor logic for checkpoints to just the first+after and last+before cases, and return an error for all other combinations.

## Test Plan 

New test checkpoint_connection_pagination.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
