### PR TITLE
zklogin: check multisig public key derive consistency

### DIFF
--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -676,10 +676,8 @@ async fn zk_multisig_test() {
     // Step 1. construct 2 zklogin signatures
     // read in test files that has a list of matching zklogin_inputs and its ephemeral private keys.
 
-    let file = std::fs::File::open(
-        "/Users/marklogan/dev/sui/crates/sui-types/src/unit_tests/zklogin_test_vectors.json",
-    )
-    .expect("Unable to open file");
+    let file = std::fs::File::open("../sui-types/src/unit_tests/zklogin_test_vectors.json")
+        .expect("Unable to open file");
     let test_datum: Vec<TestData> = serde_json::from_reader(file).unwrap();
     let mut pks = vec![];
     let mut kps_and_zklogin_inputs = vec![];

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -2,18 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::ed25519::Ed25519KeyPair;
-use fastcrypto::traits::KeyPair;
+use fastcrypto::traits::{EncodeDecodeBase64, KeyPair};
 use fastcrypto_zkp::bn254::zk_login::{parse_jwks, OIDCProvider, ZkLoginInputs};
 use rand::{rngs::StdRng, SeedableRng};
+use shared_crypto::intent::{Intent, IntentMessage};
 use sui_types::{
     authenticator_state::ActiveJwk,
     base_types::dbg_addr,
-    crypto::AccountKeyPair,
-    crypto::{get_key_pair, Signature},
+    crypto::{
+        get_key_pair, AccountKeyPair, PublicKey, Signature, SuiKeyPair, ZkLoginPublicIdentifier,
+    },
+    multisig::{MultiSig, MultiSigPublicKey},
     signature::GenericSignature,
     transaction::{AuthenticatorStateUpdate, TransactionDataAPI, TransactionExpiration},
-    utils::to_sender_signed_transaction,
+    utils::{to_sender_signed_transaction, TestData},
     zk_login_authenticator::ZkLoginAuthenticator,
+    zk_login_util::DEFAULT_JWK_BYTES,
 };
 
 use crate::{
@@ -606,4 +610,138 @@ async fn init_zklogin_transfer(
     ));
     tx.data_mut_for_testing().tx_signatures_mut_for_testing()[0] = authenticator;
     tx
+}
+
+#[tokio::test]
+async fn zk_multisig_test() {
+    telemetry_subscribers::init_for_testing();
+
+    // User generate a multisig account with no zklogin signer.
+    let keys = sui_types::utils::keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+    let multisig_pk = MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![1, 1, 1],
+        2,
+    )
+    .unwrap();
+    let victim_addr = SuiAddress::from(&multisig_pk);
+
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let gas_object_id = ObjectID::random();
+    let authority_state =
+        init_state_with_ids(vec![(victim_addr, object_id), (victim_addr, gas_object_id)]).await;
+
+    let jwks = parse_jwks(DEFAULT_JWK_BYTES, &OIDCProvider::Twitch).unwrap();
+    let epoch_store = authority_state.epoch_store_for_testing();
+    epoch_store.update_authenticator_state(&AuthenticatorStateUpdate {
+        epoch: 0,
+        round: 0,
+        new_active_jwks: jwks
+            .into_iter()
+            .map(|(jwk_id, jwk)| ActiveJwk {
+                jwk_id,
+                jwk,
+                epoch: 0,
+            })
+            .collect(),
+        authenticator_obj_initial_shared_version: 1.into(),
+    });
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let gas_object = authority_state
+        .get_object(&gas_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let data = TransactionData::new_transfer(
+        recipient,
+        object.compute_object_reference(),
+        victim_addr,
+        gas_object.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+
+    // Poof of concept for bypassing zklogin verification starts here.
+    // Step 1. construct 2 zklogin signatures
+    // read in test files that has a list of matching zklogin_inputs and its ephemeral private keys.
+
+    let file = std::fs::File::open(
+        "/Users/marklogan/dev/sui/crates/sui-types/src/unit_tests/zklogin_test_vectors.json",
+    )
+    .expect("Unable to open file");
+    let test_datum: Vec<TestData> = serde_json::from_reader(file).unwrap();
+    let mut pks = vec![];
+    let mut kps_and_zklogin_inputs = vec![];
+    for test in test_datum {
+        let kp = SuiKeyPair::decode_base64(&test.kp).unwrap();
+        let pk_zklogin = PublicKey::ZkLogin(
+            ZkLoginPublicIdentifier::new(
+                &OIDCProvider::Twitch.get_config().iss,
+                &test.address_seed,
+            )
+            .unwrap(),
+        );
+        pks.push(pk_zklogin);
+        kps_and_zklogin_inputs.push((
+            kp,
+            ZkLoginInputs::from_json(&test.zklogin_inputs, &test.address_seed).unwrap(),
+        ));
+    }
+
+    let mut zklogin_sigs = vec![];
+    for (kp, inputs) in kps_and_zklogin_inputs {
+        let intent_message = IntentMessage::new(Intent::sui_transaction(), data.clone());
+        let eph_sig = Signature::new_secure(&intent_message, &kp);
+        let zklogin_sig =
+            GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(inputs, 10, eph_sig));
+        zklogin_sigs.push(zklogin_sig);
+    }
+
+    // Step 2. Construct the fake multisig with the zklogin signatures.
+    let multisig = MultiSig::new(
+        vec![
+            zklogin_sigs[0].clone().to_compressed().unwrap(),
+            zklogin_sigs[1].clone().to_compressed().unwrap(),
+        ], // zklogin sigs
+        3,
+        multisig_pk,
+    );
+
+    let generic_sig = GenericSignature::MultiSig(multisig);
+
+    let transfer_transaction =
+        Transaction::from_generic_sig_data(data, Intent::sui_transaction(), vec![generic_sig]);
+
+    let consensus_address = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+
+    let server = AuthorityServer::new_for_test(
+        "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+        authority_state.clone(),
+        consensus_address,
+    );
+
+    let server_handle = server.spawn_for_test().await.unwrap();
+
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
+
+    let err = client
+        .handle_transaction(transfer_transaction.clone())
+        .await;
+
+    assert!(dbg!(err).is_err());
+
+    check_locks(authority_state.clone(), vec![object_id]).await;
 }

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -185,6 +185,13 @@ impl AuthenticatorTrait for MultiSig {
                 CompressedSignature::ZkLogin(z) => {
                     let authenticator = ZkLoginAuthenticator::from_bytes(&z.0)
                         .map_err(|_| SuiError::InvalidAuthenticator)?;
+
+                    // Check PublicKey defined in MultisigPublicKey vs the authenticator derivation is consistent.
+                    if SuiAddress::try_from(&authenticator)? != SuiAddress::from(pk) {
+                        return Err(SuiError::InvalidSignature {
+                            error: "Inconsistent pk with authenticator".to_string(),
+                        });
+                    }
                     // Author is already verified against multisig pk, do not verify author within zkLogin authenticator where self.check_author() is evaluated to false for multisig.
                     authenticator
                         .verify_claims(value, author, verify_params, self.check_author())

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -86,9 +86,6 @@ impl Hash for MultiSigLegacy {
 }
 
 impl AuthenticatorTrait for MultiSigLegacy {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> Result<(), SuiError> {
         Ok(())
     }
@@ -98,7 +95,6 @@ impl AuthenticatorTrait for MultiSigLegacy {
         _value: &IntentMessage<T>,
         _author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
@@ -111,13 +107,12 @@ impl AuthenticatorTrait for MultiSigLegacy {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
     {
         let multisig: MultiSig = self.clone().try_into()?;
-        multisig.verify_claims(value, author, aux_verify_data, check_author)
+        multisig.verify_claims(value, author, aux_verify_data)
     }
 
     fn verify_authenticator<T>(

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -56,7 +56,6 @@ impl VerifyParams {
 /// A lightweight trait that all members of [enum GenericSignature] implement.
 #[enum_dispatch]
 pub trait AuthenticatorTrait {
-    fn check_author(&self) -> bool;
     fn verify_user_authenticator_epoch(&self, epoch: EpochId) -> SuiResult;
 
     fn verify_claims<T>(
@@ -64,7 +63,6 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize;
@@ -82,8 +80,7 @@ pub trait AuthenticatorTrait {
         if let Some(epoch) = epoch {
             self.verify_user_authenticator_epoch(epoch)?;
         }
-        // when invoked from verify_authenticator, always check author.
-        self.verify_claims(value, author, aux_verify_data, true)
+        self.verify_claims(value, author, aux_verify_data)
     }
 
     fn verify_uncached_checks<T>(
@@ -91,7 +88,6 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize;
@@ -285,9 +281,6 @@ impl<'de> ::serde::Deserialize<'de> for GenericSignature {
 
 /// This ports the wrapper trait to the verify_secure defined on [enum Signature].
 impl AuthenticatorTrait for Signature {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> SuiResult {
         Ok(())
     }
@@ -296,7 +289,6 @@ impl AuthenticatorTrait for Signature {
         _value: &IntentMessage<T>,
         _author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
@@ -309,7 +301,6 @@ impl AuthenticatorTrait for Signature {
         value: &IntentMessage<T>,
         author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2235,12 +2235,7 @@ impl AuthenticatedMessage for SenderSignedData {
         for (signer, signature) in
             self.get_signer_sig_mapping(verify_params.verify_legacy_zklogin_address)?
         {
-            signature.verify_uncached_checks(
-                self.intent_message(),
-                signer,
-                verify_params,
-                signature.check_author(),
-            )?;
+            signature.verify_uncached_checks(self.intent_message(), signer, verify_params)?;
         }
         Ok(())
     }
@@ -2282,12 +2277,7 @@ impl AuthenticatedMessage for SenderSignedData {
 
         // Verify all present signatures.
         for (signer, signature) in present_sigs {
-            signature.verify_claims(
-                self.intent_message(),
-                signer,
-                verify_params,
-                signature.check_author(),
-            )?;
+            signature.verify_claims(self.intent_message(), signer, verify_params)?;
         }
         Ok(())
     }

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -1007,7 +1007,7 @@ fn multisig_zklogin_scenarios() {
         bytes: OnceCell::new(),
     };
     assert!(multisig_2
-        .verify_authenticator(&intent_msg, bad_addr, None, &aux_verify_data)
+        .verify_authenticator(intent_msg, bad_addr, None, &aux_verify_data)
         .is_err());
 
     // zkLogin sig + traditional sig combined verifies. see consistency test in /sdk/typescript/test/e2e/multisig.test.ts

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -987,6 +987,29 @@ fn multisig_zklogin_scenarios() {
         .verify_authenticator(intent_msg, zklogin_addr, Some(10), &aux_verify_data)
         .is_err());
 
+    // an inconsistent multisig public key (consists of 3 ed25519 pubkeys) fails to verify zklogin sig inside multisig. 
+    let keys = keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+    let bad_multisig_pk = MultiSigPublicKey::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![1, 1, 1],
+        1,
+    )
+    .unwrap();
+    let bad_addr = SuiAddress::from(&bad_multisig_pk);
+
+    let multisig_2 = MultiSig {
+        sigs: vec![zklogin_sig.clone().to_compressed().unwrap()],
+        bitmap: 3,
+        multisig_pk: bad_multisig_pk,
+        bytes: OnceCell::new(),
+    };
+    assert!(multisig_2
+        .verify_authenticator(&intent_msg, bad_addr, None, &aux_verify_data)
+        .is_err());
+    
     // zkLogin sig + traditional sig combined verifies. see consistency test in /sdk/typescript/test/e2e/multisig.test.ts
     let multisig_2 =
         MultiSig::combine(vec![sig1.clone(), zklogin_sig.clone()], multisig_pk.clone()).unwrap();

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -987,7 +987,7 @@ fn multisig_zklogin_scenarios() {
         .verify_authenticator(intent_msg, zklogin_addr, Some(10), &aux_verify_data)
         .is_err());
 
-    // an inconsistent multisig public key (consists of 3 ed25519 pubkeys) fails to verify zklogin sig inside multisig. 
+    // an inconsistent multisig public key (consists of 3 ed25519 pubkeys) fails to verify zklogin sig inside multisig.
     let keys = keys();
     let pk1 = keys[0].public();
     let pk2 = keys[1].public();
@@ -1009,7 +1009,7 @@ fn multisig_zklogin_scenarios() {
     assert!(multisig_2
         .verify_authenticator(&intent_msg, bad_addr, None, &aux_verify_data)
         .is_err());
-    
+
     // zkLogin sig + traditional sig combined verifies. see consistency test in /sdk/typescript/test/e2e/multisig.test.ts
     let multisig_2 =
         MultiSig::combine(vec![sig1.clone(), zklogin_sig.clone()], multisig_pk.clone()).unwrap();

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -86,9 +86,6 @@ impl Hash for ZkLoginAuthenticator {
 }
 
 impl AuthenticatorTrait for ZkLoginAuthenticator {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, epoch: EpochId) -> SuiResult {
         // Verify the max epoch in aux inputs is <= the current epoch of authority.
         if epoch > self.get_max_epoch() {
@@ -106,17 +103,15 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
         intent_msg: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
     {
-        // if check_author is true, author must be consistent with the zklogin address derived.
-        if check_author && aux_verify_data.verify_legacy_zklogin_address {
+        if aux_verify_data.verify_legacy_zklogin_address {
             if author != self.try_into()? && author != SuiAddress::legacy_try_from(self)? {
                 return Err(SuiError::InvalidAddress);
             }
-        } else if check_author && author != self.try_into()? {
+        } else if author != self.try_into()? {
             return Err(SuiError::InvalidAddress);
         }
 
@@ -153,12 +148,11 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
         intent_msg: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
     {
-        self.verify_uncached_checks(intent_msg, author, aux_verify_data, check_author)?;
+        self.verify_uncached_checks(intent_msg, author, aux_verify_data)?;
 
         // Use flag || pk_bytes.
         let mut extended_pk_bytes = vec![self.user_signature.scheme().flag()];


### PR DESCRIPTION
## Description 

check zklogin authenticator derives the same address as the public key identifier from multisig public key. 

## Test Plan 

unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
