### PR TITLE
[GraphQL/TransactionBlock] ProgrammableTransactionBlock

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -99,7 +99,7 @@ Response: {
             ],
             "objectChanges": [
               {
-                "location": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
+                "address": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -108,7 +108,7 @@ Response: {
                 }
               },
               {
-                "location": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
+                "address": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -117,7 +117,7 @@ Response: {
                 }
               },
               {
-                "location": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972",
+                "address": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -196,7 +196,7 @@ Response: {
               "nodes": [
                 {
                   "__typename": "OwnedOrImmutable",
-                  "location": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
+                  "address": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
                   "version": 2,
                   "digest": "G9mY9FYpaNat8h5inn6w9UoMzh2A1UHGrjVShdgDfXDX",
                   "object": null
@@ -329,7 +329,7 @@ Response: {
             ],
             "objectChanges": [
               {
-                "location": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
+                "address": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -338,7 +338,7 @@ Response: {
                 }
               },
               {
-                "location": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
+                "address": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -347,7 +347,7 @@ Response: {
                 }
               },
               {
-                "location": "0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3",
+                "address": "0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -637,7 +637,7 @@ Response: {
             ],
             "objectChanges": [
               {
-                "location": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
+                "address": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -659,7 +659,7 @@ Response: {
                 }
               },
               {
-                "location": "0x7348e658c081015348e0e528f860253443246c670abb4a61fbc26d4ad8205479",
+                "address": "0x7348e658c081015348e0e528f860253443246c670abb4a61fbc26d4ad8205479",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -682,7 +682,7 @@ Response: {
                 }
               },
               {
-                "location": "0xc1ee9db6c7be461ff569fe368d1dc24e6c2ad957a8bfd76e64e360d4b86febf0",
+                "address": "0xc1ee9db6c7be461ff569fe368d1dc24e6c2ad957a8bfd76e64e360d4b86febf0",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -816,7 +816,7 @@ Response: {
             ],
             "objectChanges": [
               {
-                "location": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
+                "address": "0x02150ebfe3d017c2726bd482f6d3c8a63516a398d7d98e2ee69396764e04bc76",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 6315600,  storage_rebate: 
 task 2 'create-checkpoint'. lines 21-21:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 23-88:
+task 3 'run-graphql'. lines 23-186:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -40,7 +40,42 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "value": "ProgrammableTransaction { inputs: [Pure([252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30])], commands: [Publish([[161, 28, 235, 11, 6, 0, 0, 0, 8, 1, 0, 6, 2, 6, 12, 3, 18, 10, 5, 28, 17, 7, 45, 48, 8, 93, 64, 10, 157, 1, 9, 12, 166, 1, 15, 0, 4, 1, 6, 1, 7, 0, 0, 12, 0, 1, 2, 4, 0, 2, 1, 2, 0, 0, 5, 0, 1, 0, 1, 5, 3, 4, 0, 2, 10, 3, 7, 8, 2, 1, 8, 0, 0, 1, 7, 8, 2, 1, 8, 1, 3, 70, 111, 111, 9, 84, 120, 67, 111, 110, 116, 101, 120, 116, 3, 85, 73, 68, 2, 105, 100, 1, 109, 3, 110, 101, 119, 6, 111, 98, 106, 101, 99, 116, 10, 116, 120, 95, 99, 111, 110, 116, 101, 120, 116, 2, 120, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 3, 8, 1, 8, 10, 3, 0, 1, 0, 0, 2, 5, 11, 1, 17, 1, 11, 0, 18, 0, 2, 0]], [0x0000000000000000000000000000000000000000000000000000000000000001, 0x0000000000000000000000000000000000000000000000000000000000000002]), TransferObjects([Result(0)], Input(0))] }"
+            "inputConnection": {
+              "nodes": [
+                {
+                  "__typename": "Pure",
+                  "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                }
+              ]
+            },
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "PublishTransaction",
+                  "modules": [
+                    "oRzrCwYAAAAIAQAGAgYMAxIKBRwRBy0wCF1ACp0BCQymAQ8ABAEGAQcAAAwAAQIEAAIBAgAABQABAAEFAwQAAgoDBwgCAQgAAAEHCAIBCAEDRm9vCVR4Q29udGV4dANVSUQCaWQBbQNuZXcGb2JqZWN0CnR4X2NvbnRleHQCeHMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAICAwgBCAoDAAEAAAIFCwERAQsAEgACAA=="
+                  ],
+                  "dependencies": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                  ]
+                },
+                {
+                  "__typename": "TransferObjectsTransaction",
+                  "inputs": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 0,
+                      "ix": null
+                    }
+                  ],
+                  "address": {
+                    "__typename": "Input",
+                    "ix": 0
+                  }
+                }
+              ]
+            }
           },
           "effects": {
             "status": "SUCCESS",
@@ -120,15 +155,15 @@ Response: {
   }
 }
 
-task 4 'upgrade'. lines 90-108:
+task 4 'upgrade'. lines 188-206:
 created: object(4,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 6589200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 5 'create-checkpoint'. lines 110-110:
+task 5 'create-checkpoint'. lines 208-208:
 Checkpoint created: 2
 
-task 6 'run-graphql'. lines 112-178:
+task 6 'run-graphql'. lines 210-373:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -157,7 +192,117 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "value": "ProgrammableTransaction { inputs: [Object(ImmOrOwnedObject((0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c, SequenceNumber(2), o#G9mY9FYpaNat8h5inn6w9UoMzh2A1UHGrjVShdgDfXDX))), Pure([0]), Pure([32, 171, 82, 196, 88, 52, 4, 188, 145, 159, 203, 235, 180, 132, 106, 122, 170, 108, 138, 21, 79, 188, 241, 113, 60, 80, 96, 230, 205, 10, 249, 74, 146])], commands: [MoveCall(ProgrammableMoveCall { package: 0x0000000000000000000000000000000000000000000000000000000000000002, module: Identifier(\"package\"), function: Identifier(\"authorize_upgrade\"), type_arguments: [], arguments: [Input(0), Input(1), Input(2)] }), Upgrade([[161, 28, 235, 11, 6, 0, 0, 0, 8, 1, 0, 6, 2, 6, 12, 3, 18, 20, 5, 38, 17, 7, 55, 60, 8, 115, 64, 10, 179, 1, 9, 12, 188, 1, 29, 0, 6, 1, 8, 1, 9, 0, 0, 12, 0, 1, 2, 4, 0, 2, 1, 2, 0, 0, 7, 0, 1, 0, 0, 3, 1, 2, 0, 1, 4, 4, 2, 0, 1, 7, 3, 4, 0, 2, 10, 3, 7, 8, 2, 1, 8, 0, 0, 1, 7, 8, 2, 1, 8, 1, 3, 70, 111, 111, 9, 84, 120, 67, 111, 110, 116, 101, 120, 116, 3, 85, 73, 68, 4, 98, 117, 114, 110, 6, 100, 101, 108, 101, 116, 101, 2, 105, 100, 1, 109, 3, 110, 101, 119, 6, 111, 98, 106, 101, 99, 116, 10, 116, 120, 95, 99, 111, 110, 116, 101, 120, 116, 2, 120, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 5, 8, 1, 10, 10, 3, 0, 1, 0, 0, 2, 5, 11, 1, 17, 3, 11, 0, 18, 0, 2, 1, 1, 0, 0, 2, 5, 11, 0, 19, 0, 1, 17, 2, 2, 0]], [0x0000000000000000000000000000000000000000000000000000000000000001, 0x0000000000000000000000000000000000000000000000000000000000000002], 0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972, Result(0)), MoveCall(ProgrammableMoveCall { package: 0x0000000000000000000000000000000000000000000000000000000000000002, module: Identifier(\"package\"), function: Identifier(\"commit_upgrade\"), type_arguments: [], arguments: [Input(0), Result(1)] })] }"
+            "inputConnection": {
+              "nodes": [
+                {
+                  "__typename": "OwnedOrImmutable",
+                  "location": "0x40e56eaf7b7596bb72e96051b7fc36b49006c68d32e9021a616677ac6365622c",
+                  "version": 2,
+                  "digest": "G9mY9FYpaNat8h5inn6w9UoMzh2A1UHGrjVShdgDfXDX",
+                  "object": null
+                },
+                {
+                  "__typename": "Pure",
+                  "bytes": "AA=="
+                },
+                {
+                  "__typename": "Pure",
+                  "bytes": "IKtSxFg0BLyRn8vrtIRqeqpsihVPvPFxPFBg5s0K+UqS"
+                }
+              ]
+            },
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "MoveCallTransaction",
+                  "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                  "module": "package",
+                  "functionName": "authorize_upgrade",
+                  "typeArguments": [],
+                  "arguments": [
+                    {
+                      "__typename": "Input",
+                      "ix": 0
+                    },
+                    {
+                      "__typename": "Input",
+                      "ix": 1
+                    },
+                    {
+                      "__typename": "Input",
+                      "ix": 2
+                    }
+                  ],
+                  "function": {
+                    "isEntry": false,
+                    "typeParameters": [],
+                    "parameters": [
+                      {
+                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                      },
+                      {
+                        "repr": "u8"
+                      },
+                      {
+                        "repr": "vector<u8>"
+                      }
+                    ],
+                    "return": [
+                      {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeTicket"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "__typename": "UpgradeTransaction",
+                  "modules": [
+                    "oRzrCwYAAAAIAQAGAgYMAxIUBSYRBzc8CHNACrMBCQy8AR0ABgEIAQkAAAwAAQIEAAIBAgAABwABAAADAQIAAQQEAgABBwMEAAIKAwcIAgEIAAABBwgCAQgBA0ZvbwlUeENvbnRleHQDVUlEBGJ1cm4GZGVsZXRlAmlkAW0DbmV3Bm9iamVjdAp0eF9jb250ZXh0AnhzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgACAgUIAQoKAwABAAACBQsBEQMLABIAAgEBAAACBQsAEwABEQICAA=="
+                  ],
+                  "dependencies": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                  ],
+                  "currentPackage": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972",
+                  "upgradeTicket": {
+                    "__typename": "Result",
+                    "cmd": 0,
+                    "ix": null
+                  }
+                },
+                {
+                  "__typename": "MoveCallTransaction",
+                  "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                  "module": "package",
+                  "functionName": "commit_upgrade",
+                  "typeArguments": [],
+                  "arguments": [
+                    {
+                      "__typename": "Input",
+                      "ix": 0
+                    },
+                    {
+                      "__typename": "Result",
+                      "cmd": 1,
+                      "ix": null
+                    }
+                  ],
+                  "function": {
+                    "isEntry": false,
+                    "typeParameters": [],
+                    "parameters": [
+                      {
+                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                      },
+                      {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeReceipt"
+                      }
+                    ],
+                    "return": []
+                  }
+                }
+              ]
+            }
           },
           "effects": {
             "status": "SUCCESS",
@@ -240,15 +385,15 @@ Response: {
   }
 }
 
-task 7 'programmable'. lines 180-189:
+task 7 'programmable'. lines 375-384:
 created: object(7,0), object(7,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3328800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8 'create-checkpoint'. lines 191-191:
+task 8 'create-checkpoint'. lines 386-386:
 Checkpoint created: 3
 
-task 9 'run-graphql'. lines 193-268:
+task 9 'run-graphql'. lines 388-560:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -277,7 +422,198 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "value": "ProgrammableTransaction { inputs: [Pure([42, 0, 0, 0, 0, 0, 0, 0]), Pure([43, 0, 0, 0, 0, 0, 0, 0]), Pure([232, 3, 0, 0, 0, 0, 0, 0]), Pure([252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30])], commands: [MakeMoveVec(Some(U64), [Input(0), Input(1)]), MakeMoveVec(Some(U64), []), SplitCoins(GasCoin, [Input(2), Input(2)]), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"new\"), type_arguments: [], arguments: [Result(0)] }), TransferObjects([Result(3)], Input(3)), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"new\"), type_arguments: [], arguments: [Result(1)] }), MoveCall(ProgrammableMoveCall { package: 0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3, module: Identifier(\"m\"), function: Identifier(\"burn\"), type_arguments: [], arguments: [Result(5)] }), MergeCoins(NestedResult(2, 0), [NestedResult(2, 1)]), TransferObjects([NestedResult(2, 0)], Input(3))] }"
+            "inputConnection": {
+              "nodes": [
+                {
+                  "__typename": "Pure",
+                  "bytes": "KgAAAAAAAAA="
+                },
+                {
+                  "__typename": "Pure",
+                  "bytes": "KwAAAAAAAAA="
+                },
+                {
+                  "__typename": "Pure",
+                  "bytes": "6AMAAAAAAAA="
+                },
+                {
+                  "__typename": "Pure",
+                  "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                }
+              ]
+            },
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "MakeMoveVecTransaction",
+                  "type": {
+                    "repr": "u64"
+                  },
+                  "elements": [
+                    {
+                      "__typename": "Input",
+                      "ix": 0
+                    },
+                    {
+                      "__typename": "Input",
+                      "ix": 1
+                    }
+                  ]
+                },
+                {
+                  "__typename": "MakeMoveVecTransaction",
+                  "type": {
+                    "repr": "u64"
+                  },
+                  "elements": []
+                },
+                {
+                  "__typename": "SplitCoinsTransaction",
+                  "coin": {
+                    "__typename": "GasCoin"
+                  },
+                  "amounts": [
+                    {
+                      "__typename": "Input",
+                      "ix": 2
+                    },
+                    {
+                      "__typename": "Input",
+                      "ix": 2
+                    }
+                  ]
+                },
+                {
+                  "__typename": "MoveCallTransaction",
+                  "package": "0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3",
+                  "module": "m",
+                  "functionName": "new",
+                  "typeArguments": [],
+                  "arguments": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 0,
+                      "ix": null
+                    }
+                  ],
+                  "function": {
+                    "isEntry": false,
+                    "typeParameters": [],
+                    "parameters": [
+                      {
+                        "repr": "vector<u64>"
+                      },
+                      {
+                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                      }
+                    ],
+                    "return": [
+                      {
+                        "repr": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972::m::Foo"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "__typename": "TransferObjectsTransaction",
+                  "inputs": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 3,
+                      "ix": null
+                    }
+                  ],
+                  "address": {
+                    "__typename": "Input",
+                    "ix": 3
+                  }
+                },
+                {
+                  "__typename": "MoveCallTransaction",
+                  "package": "0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3",
+                  "module": "m",
+                  "functionName": "new",
+                  "typeArguments": [],
+                  "arguments": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 1,
+                      "ix": null
+                    }
+                  ],
+                  "function": {
+                    "isEntry": false,
+                    "typeParameters": [],
+                    "parameters": [
+                      {
+                        "repr": "vector<u64>"
+                      },
+                      {
+                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                      }
+                    ],
+                    "return": [
+                      {
+                        "repr": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972::m::Foo"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "__typename": "MoveCallTransaction",
+                  "package": "0x84dbae55ee0f0fbe4cdd240a4a2b8df5e24a39837069c54e88dce7a8f6c5fab3",
+                  "module": "m",
+                  "functionName": "burn",
+                  "typeArguments": [],
+                  "arguments": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 5,
+                      "ix": null
+                    }
+                  ],
+                  "function": {
+                    "isEntry": false,
+                    "typeParameters": [],
+                    "parameters": [
+                      {
+                        "repr": "0x82ad18dd7f6e0d4e580f2f041379fb164a58e8432dc013193af5cb1b59c1b972::m::Foo"
+                      }
+                    ],
+                    "return": []
+                  }
+                },
+                {
+                  "__typename": "MergeCoinsTransaction",
+                  "coin": {
+                    "__typename": "Result",
+                    "cmd": 2,
+                    "ix": 0
+                  },
+                  "coins": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 2,
+                      "ix": 1
+                    }
+                  ]
+                },
+                {
+                  "__typename": "TransferObjectsTransaction",
+                  "inputs": [
+                    {
+                      "__typename": "Result",
+                      "cmd": 2,
+                      "ix": 0
+                    }
+                  ],
+                  "address": {
+                    "__typename": "Input",
+                    "ix": 3
+                  }
+                }
+              ]
+            }
           },
           "effects": {
             "status": "SUCCESS",
@@ -397,14 +733,14 @@ Response: {
   }
 }
 
-task 10 'programmable'. lines 270-271:
+task 10 'programmable'. lines 562-563:
 Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: None, command: None } }
 
-task 11 'create-checkpoint'. lines 273-273:
+task 11 'create-checkpoint'. lines 565-565:
 Checkpoint created: 4
 
-task 12 'run-graphql'. lines 275-341:
+task 12 'run-graphql'. lines 567-730:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -433,7 +769,30 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "value": "ProgrammableTransaction { inputs: [Pure([232, 3, 0, 0, 0, 0, 0, 0])], commands: [SplitCoins(GasCoin, [Input(0)])] }"
+            "inputConnection": {
+              "nodes": [
+                {
+                  "__typename": "Pure",
+                  "bytes": "6AMAAAAAAAA="
+                }
+              ]
+            },
+            "transactionConnection": {
+              "nodes": [
+                {
+                  "__typename": "SplitCoinsTransaction",
+                  "coin": {
+                    "__typename": "GasCoin"
+                  },
+                  "amounts": [
+                    {
+                      "__typename": "Input",
+                      "ix": 0
+                    }
+                  ]
+                }
+              ]
+            }
           },
           "effects": {
             "status": "FAILURE",

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -24,7 +24,7 @@ module P0::m {
 # Query for the publish transaction
 
 fragment ObjectContent on Object {
-    location
+    address
     version
     digest
     asMoveObject {
@@ -39,20 +39,20 @@ fragment TxInput on TransactionInput {
     __typename
 
     ... on OwnedOrImmutable {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
     }
 
     ... on SharedInput {
-        location
+        address
         initialSharedVersion
         mutable
     }
 
     ... on Receiving {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
@@ -154,7 +154,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted
@@ -211,7 +211,7 @@ module P0::m {
 # Query for the upgrade transaction
 
 fragment ObjectContent on Object {
-    location
+    address
     version
     digest
     asMoveObject {
@@ -226,20 +226,20 @@ fragment TxInput on TransactionInput {
     __typename
 
     ... on OwnedOrImmutable {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
     }
 
     ... on SharedInput {
-        location
+        address
         initialSharedVersion
         mutable
     }
 
     ... on Receiving {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
@@ -341,7 +341,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted
@@ -389,7 +389,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
 # Query for the programmable transaction
 
 fragment ObjectContent on Object {
-    location
+    address
     version
     digest
     asMoveObject {
@@ -404,20 +404,20 @@ fragment TxInput on TransactionInput {
     __typename
 
     ... on OwnedOrImmutable {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
     }
 
     ... on SharedInput {
-        location
+        address
         initialSharedVersion
         mutable
     }
 
     ... on Receiving {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
@@ -519,7 +519,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted
@@ -568,7 +568,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
 # Query for the programmable transaction, which failed.
 
 fragment ObjectContent on Object {
-    location
+    address
     version
     digest
     asMoveObject {
@@ -583,20 +583,20 @@ fragment TxInput on TransactionInput {
     __typename
 
     ... on OwnedOrImmutable {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
     }
 
     ... on SharedInput {
-        location
+        address
         initialSharedVersion
         mutable
     }
 
     ... on Receiving {
-        location
+        address
         version
         digest
         object { ...ObjectContent }
@@ -698,7 +698,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -22,6 +22,109 @@ module P0::m {
 
 //# run-graphql
 # Query for the publish transaction
+
+fragment ObjectContent on Object {
+    location
+    version
+    digest
+    asMoveObject {
+        contents {
+            type { repr }
+            json
+        }
+    }
+}
+
+fragment TxInput on TransactionInput {
+    __typename
+
+    ... on OwnedOrImmutable {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on SharedInput {
+        location
+        initialSharedVersion
+        mutable
+    }
+
+    ... on Receiving {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on Pure {
+        bytes
+    }
+}
+
+fragment TxArg on TransactionArgument {
+    __typename
+    ... on Input { ix }
+    ... on Result { cmd ix }
+}
+
+fragment Tx on ProgrammableTransaction {
+    __typename
+
+    ... on MoveCallTransaction {
+        package
+        module
+        functionName
+        typeArguments { repr }
+        arguments { ...TxArg }
+
+        function {
+            isEntry
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
+    }
+
+    ... on TransferObjectsTransaction {
+        inputs { ...TxArg }
+        address { ...TxArg }
+    }
+
+    ... on SplitCoinsTransaction {
+        coin { ...TxArg }
+        amounts { ...TxArg }
+    }
+
+    ... on MergeCoinsTransaction {
+        coin { ...TxArg }
+        coins { ...TxArg }
+    }
+
+    ... on PublishTransaction {
+        modules
+        dependencies
+    }
+
+    ... on UpgradeTransaction {
+        modules
+        dependencies
+        currentPackage
+        upgradeTicket { ...TxArg }
+    }
+
+    ... on MakeMoveVecTransaction {
+        type { repr }
+        elements { ...TxArg }
+    }
+}
+
+fragment ComprehensivePTB on ProgrammableTransactionBlock {
+    inputConnection { nodes { __typename ...TxInput } }
+    transactionConnection { nodes { __typename ...Tx } }
+}
+
 {
     transactionBlockConnection(last: 1) {
         nodes {
@@ -36,12 +139,7 @@ module P0::m {
                 gasBudget
             }
 
-            kind {
-                __typename
-                ... on ProgrammableTransactionBlock {
-                    value
-                }
-            }
+            kind { __typename ...ComprehensivePTB }
 
             effects {
                 status
@@ -110,8 +208,110 @@ module P0::m {
 //# create-checkpoint
 
 //# run-graphql
-
 # Query for the upgrade transaction
+
+fragment ObjectContent on Object {
+    location
+    version
+    digest
+    asMoveObject {
+        contents {
+            type { repr }
+            json
+        }
+    }
+}
+
+fragment TxInput on TransactionInput {
+    __typename
+
+    ... on OwnedOrImmutable {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on SharedInput {
+        location
+        initialSharedVersion
+        mutable
+    }
+
+    ... on Receiving {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on Pure {
+        bytes
+    }
+}
+
+fragment TxArg on TransactionArgument {
+    __typename
+    ... on Input { ix }
+    ... on Result { cmd ix }
+}
+
+fragment Tx on ProgrammableTransaction {
+    __typename
+
+    ... on MoveCallTransaction {
+        package
+        module
+        functionName
+        typeArguments { repr }
+        arguments { ...TxArg }
+
+        function {
+            isEntry
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
+    }
+
+    ... on TransferObjectsTransaction {
+        inputs { ...TxArg }
+        address { ...TxArg }
+    }
+
+    ... on SplitCoinsTransaction {
+        coin { ...TxArg }
+        amounts { ...TxArg }
+    }
+
+    ... on MergeCoinsTransaction {
+        coin { ...TxArg }
+        coins { ...TxArg }
+    }
+
+    ... on PublishTransaction {
+        modules
+        dependencies
+    }
+
+    ... on UpgradeTransaction {
+        modules
+        dependencies
+        currentPackage
+        upgradeTicket { ...TxArg }
+    }
+
+    ... on MakeMoveVecTransaction {
+        type { repr }
+        elements { ...TxArg }
+    }
+}
+
+fragment ComprehensivePTB on ProgrammableTransactionBlock {
+    inputConnection { nodes { __typename ...TxInput } }
+    transactionConnection { nodes { __typename ...Tx } }
+}
+
 {
     transactionBlockConnection(last: 1) {
         nodes {
@@ -126,12 +326,7 @@ module P0::m {
                 gasBudget
             }
 
-            kind {
-                __typename
-                ... on ProgrammableTransactionBlock {
-                    value
-                }
-            }
+            kind { __typename ...ComprehensivePTB }
 
             effects {
                 status
@@ -191,8 +386,110 @@ module P0::m {
 //# create-checkpoint
 
 //# run-graphql
-
 # Query for the programmable transaction
+
+fragment ObjectContent on Object {
+    location
+    version
+    digest
+    asMoveObject {
+        contents {
+            type { repr }
+            json
+        }
+    }
+}
+
+fragment TxInput on TransactionInput {
+    __typename
+
+    ... on OwnedOrImmutable {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on SharedInput {
+        location
+        initialSharedVersion
+        mutable
+    }
+
+    ... on Receiving {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on Pure {
+        bytes
+    }
+}
+
+fragment TxArg on TransactionArgument {
+    __typename
+    ... on Input { ix }
+    ... on Result { cmd ix }
+}
+
+fragment Tx on ProgrammableTransaction {
+    __typename
+
+    ... on MoveCallTransaction {
+        package
+        module
+        functionName
+        typeArguments { repr }
+        arguments { ...TxArg }
+
+        function {
+            isEntry
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
+    }
+
+    ... on TransferObjectsTransaction {
+        inputs { ...TxArg }
+        address { ...TxArg }
+    }
+
+    ... on SplitCoinsTransaction {
+        coin { ...TxArg }
+        amounts { ...TxArg }
+    }
+
+    ... on MergeCoinsTransaction {
+        coin { ...TxArg }
+        coins { ...TxArg }
+    }
+
+    ... on PublishTransaction {
+        modules
+        dependencies
+    }
+
+    ... on UpgradeTransaction {
+        modules
+        dependencies
+        currentPackage
+        upgradeTicket { ...TxArg }
+    }
+
+    ... on MakeMoveVecTransaction {
+        type { repr }
+        elements { ...TxArg }
+    }
+}
+
+fragment ComprehensivePTB on ProgrammableTransactionBlock {
+    inputConnection { nodes { __typename ...TxInput } }
+    transactionConnection { nodes { __typename ...Tx } }
+}
+
 {
     transactionBlockConnection(last: 1) {
         nodes {
@@ -207,12 +504,7 @@ module P0::m {
                 gasBudget
             }
 
-            kind {
-                __typename
-                ... on ProgrammableTransactionBlock {
-                    value
-                }
-            }
+            kind { __typename ...ComprehensivePTB }
 
             effects {
                 status
@@ -273,8 +565,110 @@ module P0::m {
 //# create-checkpoint
 
 //# run-graphql
-
 # Query for the programmable transaction, which failed.
+
+fragment ObjectContent on Object {
+    location
+    version
+    digest
+    asMoveObject {
+        contents {
+            type { repr }
+            json
+        }
+    }
+}
+
+fragment TxInput on TransactionInput {
+    __typename
+
+    ... on OwnedOrImmutable {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on SharedInput {
+        location
+        initialSharedVersion
+        mutable
+    }
+
+    ... on Receiving {
+        location
+        version
+        digest
+        object { ...ObjectContent }
+    }
+
+    ... on Pure {
+        bytes
+    }
+}
+
+fragment TxArg on TransactionArgument {
+    __typename
+    ... on Input { ix }
+    ... on Result { cmd ix }
+}
+
+fragment Tx on ProgrammableTransaction {
+    __typename
+
+    ... on MoveCallTransaction {
+        package
+        module
+        functionName
+        typeArguments { repr }
+        arguments { ...TxArg }
+
+        function {
+            isEntry
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
+    }
+
+    ... on TransferObjectsTransaction {
+        inputs { ...TxArg }
+        address { ...TxArg }
+    }
+
+    ... on SplitCoinsTransaction {
+        coin { ...TxArg }
+        amounts { ...TxArg }
+    }
+
+    ... on MergeCoinsTransaction {
+        coin { ...TxArg }
+        coins { ...TxArg }
+    }
+
+    ... on PublishTransaction {
+        modules
+        dependencies
+    }
+
+    ... on UpgradeTransaction {
+        modules
+        dependencies
+        currentPackage
+        upgradeTicket { ...TxArg }
+    }
+
+    ... on MakeMoveVecTransaction {
+        type { repr }
+        elements { ...TxArg }
+    }
+}
+
+fragment ComprehensivePTB on ProgrammableTransactionBlock {
+    inputConnection { nodes { __typename ...TxInput } }
+    transactionConnection { nodes { __typename ...Tx } }
+}
+
 {
     transactionBlockConnection(last: 1) {
         nodes {
@@ -289,12 +683,7 @@ module P0::m {
                 gasBudget
             }
 
-            kind {
-                __typename
-                ... on ProgrammableTransactionBlock {
-                    value
-                }
-            }
+            kind { __typename ...ComprehensivePTB }
 
             effects {
                 status

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -814,7 +814,7 @@ Response: {
             ],
             "objectChanges": [
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -823,7 +823,7 @@ Response: {
                 }
               },
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -832,7 +832,7 @@ Response: {
                 }
               },
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -841,7 +841,7 @@ Response: {
                 }
               },
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -850,7 +850,7 @@ Response: {
                 }
               },
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -859,7 +859,7 @@ Response: {
                 }
               },
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -868,7 +868,7 @@ Response: {
                 }
               },
               {
-                "location": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+                "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -877,7 +877,7 @@ Response: {
                 }
               },
               {
-                "location": "0x10ebc52efb0030f390024d7d46dfc340c713e0b07cbfdb0524aa2fa3a08443bf",
+                "address": "0x10ebc52efb0030f390024d7d46dfc340c713e0b07cbfdb0524aa2fa3a08443bf",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -886,7 +886,7 @@ Response: {
                 }
               },
               {
-                "location": "0x4e767a54549f18e62922823c142e344c998ed34caffb8aeba4bdee93af49b6e9",
+                "address": "0x4e767a54549f18e62922823c142e344c998ed34caffb8aeba4bdee93af49b6e9",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -895,7 +895,7 @@ Response: {
                 }
               },
               {
-                "location": "0x5060328168fd436e112c70ac65584035e5fda67373ce437baf5be1bbba2d6074",
+                "address": "0x5060328168fd436e112c70ac65584035e5fda67373ce437baf5be1bbba2d6074",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -904,7 +904,7 @@ Response: {
                 }
               },
               {
-                "location": "0x63a24458c9b9ffa14bcc4822ce364fcc8c3b6249b9d4f7e89bb6db57ffa94b17",
+                "address": "0x63a24458c9b9ffa14bcc4822ce364fcc8c3b6249b9d4f7e89bb6db57ffa94b17",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -913,7 +913,7 @@ Response: {
                 }
               },
               {
-                "location": "0x6769518afaa2e5fac47543ffaed3debb4c751d0a6dda69ec0ebb34c98bc71f98",
+                "address": "0x6769518afaa2e5fac47543ffaed3debb4c751d0a6dda69ec0ebb34c98bc71f98",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -922,7 +922,7 @@ Response: {
                 }
               },
               {
-                "location": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -931,7 +931,7 @@ Response: {
                 }
               },
               {
-                "location": "0xbe39b51af15a81f0e37a42b85187e649955a8e7774f3d35884b5aa20f604e9f9",
+                "address": "0xbe39b51af15a81f0e37a42b85187e649955a8e7774f3d35884b5aa20f604e9f9",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -940,7 +940,7 @@ Response: {
                 }
               },
               {
-                "location": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
+                "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -949,7 +949,7 @@ Response: {
                 }
               },
               {
-                "location": "0xd904de69f0dfbe023c29f1635451fe45cbec244da66292c0977e06904134830d",
+                "address": "0xd904de69f0dfbe023c29f1635451fe45cbec244da66292c0977e06904134830d",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -1030,7 +1030,7 @@ Response: {
             "balanceChanges": [],
             "objectChanges": [
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -1121,7 +1121,7 @@ Response: {
             "balanceChanges": [],
             "objectChanges": [
               {
-                "location": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
                 "idCreated": false,
                 "idDeleted": false,
                 "outputState": {
@@ -1130,7 +1130,7 @@ Response: {
                 }
               },
               {
-                "location": "0x19d32e729fa9b502bb1c9cd043465a42d341d75aa952be050355b94918530bd7",
+                "address": "0x19d32e729fa9b502bb1c9cd043465a42d341d75aa952be050355b94918530bd7",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -1139,7 +1139,7 @@ Response: {
                 }
               },
               {
-                "location": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
+                "address": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
                 "idCreated": true,
                 "idDeleted": false,
                 "outputState": {
@@ -1148,7 +1148,7 @@ Response: {
                 }
               },
               {
-                "location": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
                 "idCreated": false,
                 "idDeleted": true,
                 "outputState": null

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -58,7 +58,7 @@
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted
@@ -133,7 +133,7 @@
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted
@@ -217,7 +217,7 @@
                 }
 
                 objectChanges {
-                    location
+                    address
 
                     idCreated
                     idDeleted

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1379,7 +1379,7 @@ type ObjectChange {
 	"""
 	The address of the object that has changed.
 	"""
-	location: SuiAddress!
+	address: SuiAddress!
 	"""
 	The contents of the object immediately before the transaction.
 	"""
@@ -1505,7 +1505,7 @@ scalar OpenMoveTypeSignature
 A Move object, either immutable, or owned mutable.
 """
 type OwnedOrImmutable {
-	location: SuiAddress!
+	address: SuiAddress!
 	version: Int!
 	digest: String!
 	object: Object
@@ -1765,7 +1765,7 @@ type RandomnessStateUpdateTransaction {
 A Move object that can be received in this transaction.
 """
 type Receiving {
-	location: SuiAddress!
+	address: SuiAddress!
 	version: Int!
 	digest: String!
 	object: Object
@@ -1846,7 +1846,7 @@ type ServiceConfig {
 A Move object that's shared.
 """
 type SharedInput {
-	location: SuiAddress!
+	address: SuiAddress!
 	"""
 	The version that this this object was shared at.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1507,6 +1507,10 @@ A Move object, either immutable, or owned mutable.
 type OwnedOrImmutable {
 	address: SuiAddress!
 	version: Int!
+	"""
+	32-byte hash that identifies the object's contents at this version, encoded as a Base58
+	string.
+	"""
 	digest: String!
 	object: Object
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -705,6 +705,17 @@ enum Feature {
 }
 
 
+"""
+Access to the gas inputs, after they have been smashed into one coin. The gas coin can only be
+used by reference, except for with `TransferObjectsTransaction` that can accept it by value.
+"""
+type GasCoin {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type GasCostSummary {
 	"""
 	Gas paid for executing this transaction (in MIST).
@@ -760,6 +771,16 @@ type GenesisTransaction {
 }
 
 
+"""
+One of the input objects or primitive values to the programmable transaction block.
+"""
+type Input {
+	"""
+	Index of the programmable transaction block input (0-indexed).
+	"""
+	ix: Int!
+}
+
 
 """
 Arbitrary JSON data.
@@ -784,11 +805,69 @@ type Linkage {
 	version: Int!
 }
 
+"""
+Create a vector (possibly empty).
+"""
+type MakeMoveVecTransaction {
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]!
+}
+
+"""
+Merges `coins` into the first `coin` (produces no results).
+"""
+type MergeCoinsTransaction {
+	"""
+	The coin to merge into.
+	"""
+	coin: TransactionArgument!
+	"""
+	The coins to be merged.
+	"""
+	coins: [TransactionArgument!]!
+}
+
 enum MoveAbility {
 	COPY
 	DROP
 	KEY
 	STORE
+}
+
+"""
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	The storage ID of the package the function being called is defined in.
+	"""
+	package: SuiAddress!
+	"""
+	The name of the module the function being called is defined in.
+	"""
+	module: String!
+	"""
+	The name of the function being called.
+	"""
+	functionName: String!
+	"""
+	The function being called, resolved.
+	"""
+	function: MoveFunction
+	"""
+	The actual type parameters passed in for this move call.
+	"""
+	typeArguments: [MoveType!]!
+	"""
+	The actual function parameters passed in for this move call.
+	"""
+	arguments: [TransactionArgument!]!
 }
 
 """
@@ -1422,6 +1501,16 @@ type OpenMoveTypeSignatureBody =
 """
 scalar OpenMoveTypeSignature
 
+"""
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	location: SuiAddress!
+	version: Int!
+	digest: String!
+	object: Object
+}
+
 type Owner implements ObjectOwner {
 	asAddress: Address
 	asObject: Object
@@ -1485,8 +1574,49 @@ type PageInfo {
 	endCursor: String
 }
 
+"""
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction | TransferObjectsTransaction | SplitCoinsTransaction | MergeCoinsTransaction | PublishTransaction | UpgradeTransaction | MakeMoveVecTransaction
+
 type ProgrammableTransactionBlock {
-	value: String!
+	"""
+	Input objects or primitive values.
+	"""
+	inputConnection(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactionConnection(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """
@@ -1535,6 +1665,30 @@ type ProtocolConfigs {
 	Query for the state of the feature flag with name `key`.
 	"""
 	featureFlag(key: String!): ProtocolConfigFeatureFlag
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishTransaction {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64!
 }
 
 type Query {
@@ -1608,6 +1762,31 @@ type RandomnessStateUpdateTransaction {
 }
 
 """
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	location: SuiAddress!
+	version: Int!
+	digest: String!
+	object: Object
+}
+
+"""
+The result of another transaction command.
+"""
+type Result {
+	"""
+	The index of the previous command (0-indexed) that returned this result.
+	"""
+	cmd: Int!
+	"""
+	If the previous command returns multiple values, this is the index of the individual result
+	among the multiple results from that command (also 0-indexed).
+	"""
+	ix: Int
+}
+
+"""
 Information about whether epoch changes are using safe mode.
 """
 type SafeMode {
@@ -1661,6 +1840,37 @@ type ServiceConfig {
 	Maximum length of a query payload string.
 	"""
 	maxQueryPayloadSize: Int!
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	location: SuiAddress!
+	"""
+	The version that this this object was shared at.
+	"""
+	initialSharedVersion: Int!
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable
+	reference or by value.
+	"""
+	mutable: Boolean!
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as
+many as there are amounts.)
+"""
+type SplitCoinsTransaction {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument!
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 enum StakeStatus {
@@ -1886,6 +2096,11 @@ type SystemParameters {
 	validatorLowStakeGracePeriod: BigInt
 }
 
+"""
+An argument to a programmable transaction command.
+"""
+union TransactionArgument = GasCoin | Input | Result
+
 type TransactionBlock {
 	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
@@ -2037,6 +2252,52 @@ enum TransactionBlockKindInput {
 	PROGRAMMABLE_TX
 }
 
+union TransactionInput = OwnedOrImmutable | SharedInput | Receiving | Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public
+transfer) and must not be previously immutable or shared.
+"""
+type TransferObjectsTransaction {
+	"""
+	The objects to transfer.
+	"""
+	inputs: [TransactionArgument!]!
+	"""
+	The address to transfer to.
+	"""
+	address: TransactionArgument!
+}
+
 """
 Information about which previous versions of a package introduced its types.
 """
@@ -2053,6 +2314,28 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
+}
+
+"""
+Upgrades a Move Package.
+"""
+type UpgradeTransaction {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
+	"""
+	ID of the package being upgraded.
+	"""
+	currentPackage: SuiAddress!
+	"""
+	The `UpgradeTicket` authorizing the upgrade.
+	"""
+	upgradeTicket: TransactionArgument!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -882,7 +882,7 @@ type GasCostSummary {
 }
 
 type ObjectChange {
-  location: SuiAddress!
+  address: SuiAddress!
 
   inputState: Object
   outputState: Object

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -20,6 +20,7 @@ use crate::{
         epoch::Epoch,
         event::{Event, EventFilter},
         gas::GasCostSummary,
+        move_function::MoveFunction,
         move_module::MoveModule,
         move_object::MoveObject,
         move_package::MovePackage,
@@ -809,6 +810,19 @@ impl PgManager {
         };
 
         package.module_impl(name)
+    }
+
+    pub(crate) async fn fetch_move_function(
+        &self,
+        address: SuiAddress,
+        module: &str,
+        function: &str,
+    ) -> Result<Option<MoveFunction>, Error> {
+        let Some(module) = self.fetch_move_module(address, module).await? else {
+            return Ok(None);
+        };
+
+        module.function_impl(function.to_string())
     }
 
     pub(crate) async fn fetch_owned_objs(

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -3,7 +3,9 @@
 
 use crate::client::simple_client::SimpleClient;
 use crate::config::ConnectionConfig;
+use crate::config::Limits;
 use crate::config::ServerConfig;
+use crate::config::ServiceConfig;
 use crate::server::graphiql_server::start_graphiql_server;
 use mysten_metrics::init_metrics;
 use std::env;
@@ -139,6 +141,13 @@ pub async fn start_graphql_server_with_fn_rpc(
 ) -> JoinHandle<()> {
     let mut server_config = ServerConfig {
         connection: graphql_connection_config,
+        service: ServiceConfig {
+            limits: Limits {
+                max_query_nodes: 500,
+                ..Limits::default()
+            },
+            ..ServiceConfig::default()
+        },
         ..ServerConfig::default()
     };
     if let Some(fn_rpc_url) = fn_rpc_url {

--- a/crates/sui-graphql-rpc/src/types/base64.rs
+++ b/crates/sui-graphql-rpc/src/types/base64.rs
@@ -51,7 +51,7 @@ impl From<&[u8]> for Base64 {
 
 impl From<Vec<u8>> for Base64 {
     fn from(bytes: Vec<u8>) -> Self {
-        Base64::from(&bytes)
+        Base64(bytes)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -342,7 +342,7 @@ impl MoveModule {
         )))
     }
 
-    fn function_impl(&self, name: String) -> Result<Option<MoveFunction>, Error> {
+    pub(crate) fn function_impl(&self, name: String) -> Result<Option<MoveFunction>, Error> {
         let def = match self.parsed.function_def(&name) {
             Ok(Some(def)) => def,
             Ok(None) => return Ok(None),

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -15,7 +15,7 @@ pub(crate) struct ObjectChange {
 #[Object]
 impl ObjectChange {
     /// The address of the object that has changed.
-    async fn location(&self) -> SuiAddress {
+    async fn address(&self) -> SuiAddress {
         self.native.id.into()
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -8,7 +8,7 @@ use self::{
 };
 use crate::types::transaction_block_kind::{
     authenticator_state_update::AuthenticatorStateUpdateTransaction,
-    end_of_epoch::EndOfEpochTransaction,
+    end_of_epoch::EndOfEpochTransaction, programmable::ProgrammableTransactionBlock,
 };
 use async_graphql::*;
 use sui_types::transaction::TransactionKind as NativeTransactionKind;
@@ -17,6 +17,7 @@ pub(crate) mod authenticator_state_update;
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod end_of_epoch;
 pub(crate) mod genesis;
+pub(crate) mod programmable;
 pub(crate) mod randomness_state_update;
 
 #[derive(Union, PartialEq, Clone, Eq)]
@@ -30,42 +31,21 @@ pub(crate) enum TransactionBlockKind {
     EndOfEpoch(EndOfEpochTransaction),
 }
 
-// TODO: flesh out the programmable transaction block type
-#[derive(SimpleObject, Clone, Eq, PartialEq)]
-pub(crate) struct ProgrammableTransactionBlock {
-    pub value: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
-pub(crate) struct TxBlockKindNotImplementedYet {
-    pub(crate) text: String,
-}
-
 impl From<NativeTransactionKind> for TransactionBlockKind {
     fn from(kind: NativeTransactionKind) -> Self {
         use NativeTransactionKind as K;
         use TransactionBlockKind as T;
 
         match kind {
-            // TODO: flesh out type
-            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock {
-                value: format!("{pt:?}"),
-            }),
-
+            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock(pt)),
             K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction(ce)),
-
             K::Genesis(g) => T::Genesis(GenesisTransaction(g)),
-
             K::ConsensusCommitPrologue(ccp) => T::ConsensusCommitPrologue(ccp.into()),
-
             K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(ccp.into()),
-
             K::AuthenticatorStateUpdate(asu) => {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
             }
-
             K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
-
             K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction(rsu)),
         }
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -35,7 +35,7 @@ enum TransactionInput {
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 #[graphql(complex)]
 struct OwnedOrImmutable {
-    location: SuiAddress,
+    address: SuiAddress,
     version: u64,
     digest: String,
 }
@@ -43,7 +43,7 @@ struct OwnedOrImmutable {
 /// A Move object that's shared.
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 struct SharedInput {
-    location: SuiAddress,
+    address: SuiAddress,
     /// The version that this this object was shared at.
     initial_shared_version: u64,
     /// Controls whether the transaction block can reference the shared object as a mutable
@@ -55,7 +55,7 @@ struct SharedInput {
 #[derive(SimpleObject, Clone, Eq, PartialEq)]
 #[graphql(complex)]
 struct Receiving {
-    location: SuiAddress,
+    address: SuiAddress,
     version: u64,
     digest: String,
 }
@@ -324,7 +324,7 @@ impl ProgrammableTransactionBlock {
 impl OwnedOrImmutable {
     async fn object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.location, Some(self.version))
+            .fetch_obj(self.address, Some(self.version))
             .await
             .extend()
     }
@@ -334,7 +334,7 @@ impl OwnedOrImmutable {
 impl Receiving {
     async fn object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.location, Some(self.version))
+            .fetch_obj(self.address, Some(self.version))
             .await
             .extend()
     }
@@ -401,7 +401,7 @@ impl From<NativeCallArg> for TransactionInput {
             }),
 
             N::Object(O::ImmOrOwnedObject((id, v, d))) => I::OwnedOrImmutable(OwnedOrImmutable {
-                location: id.into(),
+                address: id.into(),
                 version: v.value(),
                 digest: d.base58_encode(),
             }),
@@ -411,13 +411,13 @@ impl From<NativeCallArg> for TransactionInput {
                 initial_shared_version,
                 mutable,
             }) => I::SharedInput(SharedInput {
-                location: id.into(),
+                address: id.into(),
                 initial_shared_version: initial_shared_version.value(),
                 mutable,
             }),
 
             N::Object(O::Receiving((id, v, d))) => I::Receiving(Receiving {
-                location: id.into(),
+                address: id.into(),
                 version: v.value(),
                 digest: d.base58_encode(),
             }),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -37,6 +37,8 @@ enum TransactionInput {
 struct OwnedOrImmutable {
     address: SuiAddress,
     version: u64,
+    /// 32-byte hash that identifies the object's contents at this version, encoded as a Base58
+    /// string.
     digest: String,
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -1,0 +1,486 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    connection::{Connection, Edge},
+    *,
+};
+use sui_types::transaction::{
+    Argument as NativeArgument, CallArg as NativeCallArg, Command as NativeProgrammableTransaction,
+    ObjectArg as NativeObjectArg, ProgrammableMoveCall as NativeMoveCallTransaction,
+    ProgrammableTransaction as NativeProgrammableTransactionBlock,
+};
+
+use crate::{
+    context_data::db_data_provider::{validate_cursor_pagination, PgManager},
+    error::Error,
+    types::{
+        base64::Base64, move_function::MoveFunction, move_type::MoveType, object::Object,
+        sui_address::SuiAddress,
+    },
+};
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct ProgrammableTransactionBlock(pub NativeProgrammableTransactionBlock);
+
+#[derive(Union, Clone, Eq, PartialEq)]
+enum TransactionInput {
+    OwnedOrImmutable(OwnedOrImmutable),
+    SharedInput(SharedInput),
+    Receiving(Receiving),
+    Pure(Pure),
+}
+
+/// A Move object, either immutable, or owned mutable.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+#[graphql(complex)]
+struct OwnedOrImmutable {
+    location: SuiAddress,
+    version: u64,
+    digest: String,
+}
+
+/// A Move object that's shared.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct SharedInput {
+    location: SuiAddress,
+    /// The version that this this object was shared at.
+    initial_shared_version: u64,
+    /// Controls whether the transaction block can reference the shared object as a mutable
+    /// reference or by value.
+    mutable: bool,
+}
+
+/// A Move object that can be received in this transaction.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+#[graphql(complex)]
+struct Receiving {
+    location: SuiAddress,
+    version: u64,
+    digest: String,
+}
+
+/// BCS encoded primitive value (not an object or Move struct).
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct Pure {
+    /// BCS serialized and Base64 encoded primitive value.
+    bytes: Base64,
+}
+
+/// A single transaction, or command, in the programmable transaction block.
+#[derive(Union, Clone, Eq, PartialEq)]
+enum ProgrammableTransaction {
+    MoveCall(MoveCallTransaction),
+    TransferObjects(TransferObjectsTransaction),
+    SplitCoins(SplitCoinsTransaction),
+    MergeCoins(MergeCoinsTransaction),
+    Publish(PublishTransaction),
+    Upgrade(UpgradeTransaction),
+    MakeMoveVec(MakeMoveVecTransaction),
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct MoveCallTransaction(NativeMoveCallTransaction);
+
+/// Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public
+/// transfer) and must not be previously immutable or shared.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct TransferObjectsTransaction {
+    /// The objects to transfer.
+    inputs: Vec<TransactionArgument>,
+
+    /// The address to transfer to.
+    address: TransactionArgument,
+}
+
+/// Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as
+/// many as there are amounts.)
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct SplitCoinsTransaction {
+    /// The coin to split.
+    coin: TransactionArgument,
+
+    /// The denominations to split off from the coin.
+    amounts: Vec<TransactionArgument>,
+}
+
+/// Merges `coins` into the first `coin` (produces no results).
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct MergeCoinsTransaction {
+    /// The coin to merge into.
+    coin: TransactionArgument,
+
+    /// The coins to be merged.
+    coins: Vec<TransactionArgument>,
+}
+
+/// Publishes a Move Package.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct PublishTransaction {
+    /// Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+    modules: Vec<Base64>,
+
+    /// IDs of the transitive dependencies of the package to be published.
+    dependencies: Vec<SuiAddress>,
+}
+
+/// Upgrades a Move Package.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct UpgradeTransaction {
+    /// Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+    modules: Vec<Base64>,
+
+    /// IDs of the transitive dependencies of the package to be published.
+    dependencies: Vec<SuiAddress>,
+
+    /// ID of the package being upgraded.
+    current_package: SuiAddress,
+
+    /// The `UpgradeTicket` authorizing the upgrade.
+    upgrade_ticket: TransactionArgument,
+}
+
+/// Create a vector (possibly empty).
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct MakeMoveVecTransaction {
+    /// If the elements are not objects, or the vector is empty, a type must be supplied.
+    #[graphql(name = "type")]
+    type_: Option<MoveType>,
+
+    /// The values to pack into the vector, all of the same type.
+    elements: Vec<TransactionArgument>,
+}
+
+/// An argument to a programmable transaction command.
+#[derive(Union, Clone, Eq, PartialEq)]
+enum TransactionArgument {
+    GasCoin(GasCoin),
+    Input(Input),
+    Result(TxResult),
+}
+
+/// Access to the gas inputs, after they have been smashed into one coin. The gas coin can only be
+/// used by reference, except for with `TransferObjectsTransaction` that can accept it by value.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct GasCoin {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+/// One of the input objects or primitive values to the programmable transaction block.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+struct Input {
+    /// Index of the programmable transaction block input (0-indexed).
+    ix: u16,
+}
+
+/// The result of another transaction command.
+#[derive(SimpleObject, Clone, Eq, PartialEq)]
+#[graphql(name = "Result")]
+struct TxResult {
+    /// The index of the previous command (0-indexed) that returned this result.
+    cmd: u16,
+
+    /// If the previous command returns multiple values, this is the index of the individual result
+    /// among the multiple results from that command (also 0-indexed).
+    ix: Option<u16>,
+}
+
+#[Object]
+impl ProgrammableTransactionBlock {
+    /// Input objects or primitive values.
+    async fn input_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Connection<String, TransactionInput>> {
+        // TODO: make cursor opaque (currently just an offset).
+        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+
+        let total = self.0.inputs.len();
+
+        let mut lo = if let Some(after) = after {
+            1 + after
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
+                .extend()?
+        } else {
+            0
+        };
+
+        let mut hi = if let Some(before) = before {
+            before
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
+                .extend()?
+        } else {
+            total
+        };
+
+        let mut connection = Connection::new(false, false);
+        if hi <= lo {
+            return Ok(connection);
+        }
+
+        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
+        // lowerbound.
+        if let Some(first) = first {
+            let first = first as usize;
+            if hi - lo > first {
+                hi = lo + first;
+            }
+        }
+
+        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
+        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
+        if let Some(last) = last {
+            let last = last as usize;
+            if hi - lo > last {
+                lo = hi - last;
+            }
+        }
+
+        connection.has_previous_page = 0 < lo;
+        connection.has_next_page = hi < total;
+
+        for (idx, input) in self.0.inputs.iter().enumerate().skip(lo).take(hi - lo) {
+            let input = TransactionInput::from(input.clone());
+            connection.edges.push(Edge::new(idx.to_string(), input));
+        }
+
+        Ok(connection)
+    }
+
+    /// The transaction commands, executed sequentially.
+    async fn transaction_connection(
+        &self,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> Result<Connection<String, ProgrammableTransaction>> {
+        // TODO: make cursor opaque (currently just an offset).
+        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+
+        let total = self.0.commands.len();
+
+        let mut lo = if let Some(after) = after {
+            1 + after
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
+                .extend()?
+        } else {
+            0
+        };
+
+        let mut hi = if let Some(before) = before {
+            before
+                .parse::<usize>()
+                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
+                .extend()?
+        } else {
+            total
+        };
+
+        let mut connection = Connection::new(false, false);
+        if hi <= lo {
+            return Ok(connection);
+        }
+
+        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
+        // lowerbound.
+        if let Some(first) = first {
+            let first = first as usize;
+            if hi - lo > first {
+                hi = lo + first;
+            }
+        }
+
+        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
+        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
+        if let Some(last) = last {
+            let last = last as usize;
+            if hi - lo > last {
+                lo = hi - last;
+            }
+        }
+
+        connection.has_previous_page = 0 < lo;
+        connection.has_next_page = hi < total;
+
+        for (idx, cmd) in self.0.commands.iter().enumerate().skip(lo).take(hi - lo) {
+            let input = ProgrammableTransaction::from(cmd.clone());
+            connection.edges.push(Edge::new(idx.to_string(), input));
+        }
+
+        Ok(connection)
+    }
+}
+
+#[ComplexObject]
+impl OwnedOrImmutable {
+    async fn object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_obj(self.location, Some(self.version))
+            .await
+            .extend()
+    }
+}
+
+#[ComplexObject]
+impl Receiving {
+    async fn object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_obj(self.location, Some(self.version))
+            .await
+            .extend()
+    }
+}
+
+/// A call to either an entry or a public Move function.
+#[Object]
+impl MoveCallTransaction {
+    /// The storage ID of the package the function being called is defined in.
+    async fn package(&self) -> SuiAddress {
+        self.0.package.into()
+    }
+
+    /// The name of the module the function being called is defined in.
+    async fn module(&self) -> &str {
+        self.0.module.as_str()
+    }
+
+    /// The name of the function being called.
+    async fn function_name(&self) -> &str {
+        self.0.function.as_str()
+    }
+
+    /// The function being called, resolved.
+    async fn function(&self, ctx: &Context<'_>) -> Result<Option<MoveFunction>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_move_function(
+                self.0.package.into(),
+                self.0.module.as_str(),
+                self.0.function.as_str(),
+            )
+            .await
+            .extend()
+    }
+
+    /// The actual type parameters passed in for this move call.
+    async fn type_arguments(&self) -> Vec<MoveType> {
+        self.0
+            .type_arguments
+            .iter()
+            .map(|tag| MoveType::new(tag.clone()))
+            .collect()
+    }
+
+    /// The actual function parameters passed in for this move call.
+    async fn arguments(&self) -> Vec<TransactionArgument> {
+        self.0
+            .arguments
+            .iter()
+            .map(|arg| TransactionArgument::from(*arg))
+            .collect()
+    }
+}
+
+impl From<NativeCallArg> for TransactionInput {
+    fn from(argument: NativeCallArg) -> Self {
+        use NativeCallArg as N;
+        use NativeObjectArg as O;
+        use TransactionInput as I;
+
+        match argument {
+            N::Pure(bytes) => I::Pure(Pure {
+                bytes: Base64::from(bytes),
+            }),
+
+            N::Object(O::ImmOrOwnedObject((id, v, d))) => I::OwnedOrImmutable(OwnedOrImmutable {
+                location: id.into(),
+                version: v.value(),
+                digest: d.base58_encode(),
+            }),
+
+            N::Object(O::SharedObject {
+                id,
+                initial_shared_version,
+                mutable,
+            }) => I::SharedInput(SharedInput {
+                location: id.into(),
+                initial_shared_version: initial_shared_version.value(),
+                mutable,
+            }),
+
+            N::Object(O::Receiving((id, v, d))) => I::Receiving(Receiving {
+                location: id.into(),
+                version: v.value(),
+                digest: d.base58_encode(),
+            }),
+        }
+    }
+}
+
+impl From<NativeProgrammableTransaction> for ProgrammableTransaction {
+    fn from(pt: NativeProgrammableTransaction) -> Self {
+        use NativeProgrammableTransaction as N;
+        use ProgrammableTransaction as P;
+        match pt {
+            N::MoveCall(call) => P::MoveCall(MoveCallTransaction(*call)),
+
+            N::TransferObjects(inputs, address) => P::TransferObjects(TransferObjectsTransaction {
+                inputs: inputs.into_iter().map(TransactionArgument::from).collect(),
+                address: address.into(),
+            }),
+
+            N::SplitCoins(coin, amounts) => P::SplitCoins(SplitCoinsTransaction {
+                coin: coin.into(),
+                amounts: amounts.into_iter().map(TransactionArgument::from).collect(),
+            }),
+
+            N::MergeCoins(coin, coins) => P::MergeCoins(MergeCoinsTransaction {
+                coin: coin.into(),
+                coins: coins.into_iter().map(TransactionArgument::from).collect(),
+            }),
+
+            N::Publish(modules, dependencies) => P::Publish(PublishTransaction {
+                modules: modules.into_iter().map(Base64::from).collect(),
+                dependencies: dependencies.into_iter().map(SuiAddress::from).collect(),
+            }),
+
+            N::MakeMoveVec(type_, elements) => P::MakeMoveVec(MakeMoveVecTransaction {
+                type_: type_.map(MoveType::new),
+                elements: elements
+                    .into_iter()
+                    .map(TransactionArgument::from)
+                    .collect(),
+            }),
+
+            N::Upgrade(modules, dependencies, current_package, upgrade_ticket) => {
+                P::Upgrade(UpgradeTransaction {
+                    modules: modules.into_iter().map(Base64::from).collect(),
+                    dependencies: dependencies.into_iter().map(SuiAddress::from).collect(),
+                    current_package: current_package.into(),
+                    upgrade_ticket: upgrade_ticket.into(),
+                })
+            }
+        }
+    }
+}
+
+impl From<NativeArgument> for TransactionArgument {
+    fn from(argument: NativeArgument) -> Self {
+        use NativeArgument as N;
+        use TransactionArgument as A;
+        match argument {
+            N::GasCoin => A::GasCoin(GasCoin { dummy: None }),
+            N::Input(ix) => A::Input(Input { ix }),
+            N::Result(cmd) => A::Result(TxResult { cmd, ix: None }),
+            N::NestedResult(cmd, ix) => A::Result(TxResult { cmd, ix: Some(ix) }),
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -709,6 +709,17 @@ enum Feature {
 }
 
 
+"""
+Access to the gas inputs, after they have been smashed into one coin. The gas coin can only be
+used by reference, except for with `TransferObjectsTransaction` that can accept it by value.
+"""
+type GasCoin {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type GasCostSummary {
 	"""
 	Gas paid for executing this transaction (in MIST).
@@ -764,6 +775,16 @@ type GenesisTransaction {
 }
 
 
+"""
+One of the input objects or primitive values to the programmable transaction block.
+"""
+type Input {
+	"""
+	Index of the programmable transaction block input (0-indexed).
+	"""
+	ix: Int!
+}
+
 
 """
 Arbitrary JSON data.
@@ -788,11 +809,69 @@ type Linkage {
 	version: Int!
 }
 
+"""
+Create a vector (possibly empty).
+"""
+type MakeMoveVecTransaction {
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]!
+}
+
+"""
+Merges `coins` into the first `coin` (produces no results).
+"""
+type MergeCoinsTransaction {
+	"""
+	The coin to merge into.
+	"""
+	coin: TransactionArgument!
+	"""
+	The coins to be merged.
+	"""
+	coins: [TransactionArgument!]!
+}
+
 enum MoveAbility {
 	COPY
 	DROP
 	KEY
 	STORE
+}
+
+"""
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	The storage ID of the package the function being called is defined in.
+	"""
+	package: SuiAddress!
+	"""
+	The name of the module the function being called is defined in.
+	"""
+	module: String!
+	"""
+	The name of the function being called.
+	"""
+	functionName: String!
+	"""
+	The function being called, resolved.
+	"""
+	function: MoveFunction
+	"""
+	The actual type parameters passed in for this move call.
+	"""
+	typeArguments: [MoveType!]!
+	"""
+	The actual function parameters passed in for this move call.
+	"""
+	arguments: [TransactionArgument!]!
 }
 
 """
@@ -1426,6 +1505,16 @@ type OpenMoveTypeSignatureBody =
 """
 scalar OpenMoveTypeSignature
 
+"""
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	location: SuiAddress!
+	version: Int!
+	digest: String!
+	object: Object
+}
+
 type Owner implements ObjectOwner {
 	asAddress: Address
 	asObject: Object
@@ -1489,8 +1578,49 @@ type PageInfo {
 	endCursor: String
 }
 
+"""
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction | TransferObjectsTransaction | SplitCoinsTransaction | MergeCoinsTransaction | PublishTransaction | UpgradeTransaction | MakeMoveVecTransaction
+
 type ProgrammableTransactionBlock {
-	value: String!
+	"""
+	Input objects or primitive values.
+	"""
+	inputConnection(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactionConnection(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 """
@@ -1539,6 +1669,30 @@ type ProtocolConfigs {
 	Query for the state of the feature flag with name `key`.
 	"""
 	featureFlag(key: String!): ProtocolConfigFeatureFlag
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishTransaction {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64!
 }
 
 type Query {
@@ -1612,6 +1766,31 @@ type RandomnessStateUpdateTransaction {
 }
 
 """
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	location: SuiAddress!
+	version: Int!
+	digest: String!
+	object: Object
+}
+
+"""
+The result of another transaction command.
+"""
+type Result {
+	"""
+	The index of the previous command (0-indexed) that returned this result.
+	"""
+	cmd: Int!
+	"""
+	If the previous command returns multiple values, this is the index of the individual result
+	among the multiple results from that command (also 0-indexed).
+	"""
+	ix: Int
+}
+
+"""
 Information about whether epoch changes are using safe mode.
 """
 type SafeMode {
@@ -1665,6 +1844,37 @@ type ServiceConfig {
 	Maximum length of a query payload string.
 	"""
 	maxQueryPayloadSize: Int!
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	location: SuiAddress!
+	"""
+	The version that this this object was shared at.
+	"""
+	initialSharedVersion: Int!
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable
+	reference or by value.
+	"""
+	mutable: Boolean!
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as
+many as there are amounts.)
+"""
+type SplitCoinsTransaction {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument!
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 enum StakeStatus {
@@ -1890,6 +2100,11 @@ type SystemParameters {
 	validatorLowStakeGracePeriod: BigInt
 }
 
+"""
+An argument to a programmable transaction command.
+"""
+union TransactionArgument = GasCoin | Input | Result
+
 type TransactionBlock {
 	"""
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
@@ -2041,6 +2256,52 @@ enum TransactionBlockKindInput {
 	PROGRAMMABLE_TX
 }
 
+union TransactionInput = OwnedOrImmutable | SharedInput | Receiving | Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public
+transfer) and must not be previously immutable or shared.
+"""
+type TransferObjectsTransaction {
+	"""
+	The objects to transfer.
+	"""
+	inputs: [TransactionArgument!]!
+	"""
+	The address to transfer to.
+	"""
+	address: TransactionArgument!
+}
+
 """
 Information about which previous versions of a package introduced its types.
 """
@@ -2057,6 +2318,28 @@ type TypeOrigin {
 	The storage ID of the package that first defined this type.
 	"""
 	definingId: SuiAddress!
+}
+
+"""
+Upgrades a Move Package.
+"""
+type UpgradeTransaction {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
+	"""
+	ID of the package being upgraded.
+	"""
+	currentPackage: SuiAddress!
+	"""
+	The `UpgradeTicket` authorizing the upgrade.
+	"""
+	upgradeTicket: TransactionArgument!
 }
 
 type Validator {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1383,7 +1383,7 @@ type ObjectChange {
 	"""
 	The address of the object that has changed.
 	"""
-	location: SuiAddress!
+	address: SuiAddress!
 	"""
 	The contents of the object immediately before the transaction.
 	"""
@@ -1509,7 +1509,7 @@ scalar OpenMoveTypeSignature
 A Move object, either immutable, or owned mutable.
 """
 type OwnedOrImmutable {
-	location: SuiAddress!
+	address: SuiAddress!
 	version: Int!
 	digest: String!
 	object: Object
@@ -1769,7 +1769,7 @@ type RandomnessStateUpdateTransaction {
 A Move object that can be received in this transaction.
 """
 type Receiving {
-	location: SuiAddress!
+	address: SuiAddress!
 	version: Int!
 	digest: String!
 	object: Object
@@ -1850,7 +1850,7 @@ type ServiceConfig {
 A Move object that's shared.
 """
 type SharedInput {
-	location: SuiAddress!
+	address: SuiAddress!
 	"""
 	The version that this this object was shared at.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1511,6 +1511,10 @@ A Move object, either immutable, or owned mutable.
 type OwnedOrImmutable {
 	address: SuiAddress!
 	version: Int!
+	"""
+	32-byte hash that identifies the object's contents at this version, encoded as a Base58
+	string.
+	"""
 	digest: String!
 	object: Object
 }


### PR DESCRIPTION
## Description

Structured representation of ProgrammableTransactionBlock.  The implementation diverges from the originally written schema in some important ways:

- `TransactionInput` has changed drastically. Previously it was a union between `MoveObject`, `MovePackage` and `SharedInput`. Now it is a union between `ImmutableOrOwned` (object), `SharedInput`, `Receiving`, and `Pure`. This is because it's not possible to know from the transaction kind alone whether a given input is a package or an object, so they have been combined into `ImmutableOrOwned`, the absence of `Pure` arguments was a previous oversight, and `Receiving` is a new feature.

- Types that were empty in the schema now need a dummy field.

- The `inputs` and `transactions` fields are now connections, because they can contain complex sub-queries that will need to be limited.

- `ImmutableOrOwned` transaction inputs expose the object being referenced, but also its object reference.  This is so the object being referenced can be identified even if the indexer does not have its contents (e.g. it's pruned).

- `MoveCallTransaction` similarly exposes the details of the function being called (package, module, name) as well as the resolved function, so that even for transactions that failed to run because the function could not be found, we can display which function it was.

These changes will be reflected back into the draft schema at a later date, along with other smaller discrepencies that have crept in during development.

## Test Plan

Updated the PTB E2E test:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- programmable.move
```

This updated test required increasing the query node limit in test settings.  Something to consider when revisiting the limits.

## Stack

- #15095 
- #15145 
- #15146 
- #15147
- #15179
- #15180 
- #15181 
- #15182 
- #15183 
- #15184 
- #15185 
- #15186 
- #15188 