### PR TITLE
[graphql/rpc] available range support

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.exp
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.exp
@@ -1,0 +1,55 @@
+processed 5 tasks
+
+task 1 'run-graphql'. lines 6-28:
+Response: {
+  "data": {
+    "availableRange": {
+      "first": {
+        "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+        "sequenceNumber": 0
+      },
+      "last": {
+        "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+        "sequenceNumber": 0
+      }
+    },
+    "first": {
+      "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+      "sequenceNumber": 0
+    },
+    "last": {
+      "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+      "sequenceNumber": 0
+    }
+  }
+}
+
+task 2 'create-checkpoint'. lines 30-30:
+Checkpoint created: 1
+
+task 3 'create-checkpoint'. lines 33-33:
+Checkpoint created: 2
+
+task 4 'run-graphql'. lines 36-58:
+Response: {
+  "data": {
+    "availableRange": {
+      "first": {
+        "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+        "sequenceNumber": 0
+      },
+      "last": {
+        "digest": "28UZTEQrSWFHRb6PLqHTHvA7Hnqy5o74b8cCnVfX7RyL",
+        "sequenceNumber": 2
+      }
+    },
+    "first": {
+      "digest": "HMj747PtU5izxzaxMTYKz2xvQB3Mh2zn4v94ZCRanMd2",
+      "sequenceNumber": 0
+    },
+    "last": {
+      "digest": "28UZTEQrSWFHRb6PLqHTHvA7Hnqy5o74b8cCnVfX7RyL",
+      "sequenceNumber": 2
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator
+
+//# run-graphql
+{
+  availableRange {
+    first {
+      digest
+      sequenceNumber
+    }
+    last {
+      digest
+      sequenceNumber
+    }
+  }
+
+  first: checkpoint(id: { sequenceNumber: 0 } ) {
+    digest
+    sequenceNumber
+  }
+  
+  last: checkpoint {
+    digest
+    sequenceNumber
+  }
+}
+
+//# create-checkpoint
+
+
+//# create-checkpoint
+
+
+//# run-graphql
+{
+  availableRange {
+    first {
+      digest
+      sequenceNumber
+    }
+    last {
+      digest
+      sequenceNumber
+    }
+  }
+
+  first: checkpoint(id: { sequenceNumber: 0 } ) {
+    digest
+    sequenceNumber
+  }
+  
+  last: checkpoint {
+    digest
+    sequenceNumber
+  }
+}
+

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -41,6 +41,11 @@ type AuthenticatorStateUpdate {
 	value: String!
 }
 
+type AvailableRange {
+	first: Checkpoint
+	last: Checkpoint
+}
+
 type Balance {
 	"""
 	Coin type for the balance, such as 0x2::sui::SUI
@@ -1326,6 +1331,11 @@ type Query {
 	network).
 	"""
 	chainIdentifier: String!
+	"""
+	Range of checkpoints that the RPC has data available for (for data
+	that can be tied to a particular checkpoint).
+	"""
+	availableRange: AvailableRange!
 	"""
 	Configuration for this RPC service
 	"""

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -38,6 +38,9 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_checkpoint_by_sequence_number(
         sequence_number: i64,
     ) -> checkpoints::BoxedQuery<'static, DB>;
+    /// This gets the earliest checkpoint for which we can satisfy all queries
+    /// related to that checkpoint.
+    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn multi_get_txs(
         cursor: Option<i64>,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -219,6 +219,14 @@ impl PgManager {
         .await
     }
 
+    async fn get_earliest_complete_checkpoint(&self) -> Result<Option<StoredCheckpoint>, Error> {
+        let query = move || Ok(QueryBuilder::get_earliest_complete_checkpoint());
+        self.run_query_async_with_cost(query, |query| {
+            move |conn| query.get_result::<StoredCheckpoint>(conn).optional()
+        })
+        .await
+    }
+
     async fn get_chain_identifier(&self) -> Result<ChainIdentifier, Error> {
         let result = self
             .get_checkpoint(None, Some(0))
@@ -644,6 +652,15 @@ impl PgManager {
             )
             .await?;
         stored_checkpoint.map(Checkpoint::try_from).transpose()
+    }
+
+    pub(crate) async fn fetch_earliest_complete_checkpoint(
+        &self,
+    ) -> Result<Option<Checkpoint>, Error> {
+        self.get_earliest_complete_checkpoint()
+            .await?
+            .map(Checkpoint::try_from)
+            .transpose()
     }
 
     pub(crate) async fn fetch_chain_identifier(&self) -> Result<String, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -77,6 +77,14 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
             .limit(1)
             .into_boxed()
     }
+
+    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
+        checkpoints::dsl::checkpoints
+            .order_by(checkpoints::dsl::sequence_number.asc())
+            .limit(1)
+            .into_boxed()
+    }
+
     fn multi_get_txs(
         cursor: Option<i64>,
         descending_order: bool,

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::checkpoint::Checkpoint;
+use crate::context_data::db_data_provider::PgManager;
+use async_graphql::*;
+
+/// Information about whether epoch changes are using safe mode.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AvailableRange;
+
+// TODO: do both in one query?
+#[Object]
+impl AvailableRange {
+    async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_earliest_complete_checkpoint()
+            .await
+            .extend()
+    }
+
+    async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
+        ctx.data_unchecked::<PgManager>()
+            .fetch_checkpoint(None, None)
+            .await
+            .extend()
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod address;
+pub(crate) mod available_range;
 pub(crate) mod balance;
 pub(crate) mod balance_change;
 pub(crate) mod base64;

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -6,6 +6,7 @@ use sui_json_rpc::name_service::NameServiceConfig;
 
 use super::{
     address::Address,
+    available_range::AvailableRange,
     checkpoint::{Checkpoint, CheckpointId},
     coin::Coin,
     coin_metadata::CoinMetadata,
@@ -35,6 +36,12 @@ impl Query {
             .fetch_chain_identifier()
             .await
             .extend()
+    }
+
+    /// Range of checkpoints that the RPC has data available for (for data
+    /// that can be tied to a particular checkpoint).
+    async fn available_range(&self) -> Result<AvailableRange> {
+        Ok(AvailableRange)
     }
 
     /// Configuration for this RPC service

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -45,6 +45,11 @@ type AuthenticatorStateUpdate {
 	value: String!
 }
 
+type AvailableRange {
+	first: Checkpoint
+	last: Checkpoint
+}
+
 type Balance {
 	"""
 	Coin type for the balance, such as 0x2::sui::SUI
@@ -1330,6 +1335,11 @@ type Query {
 	network).
 	"""
 	chainIdentifier: String!
+	"""
+	Range of checkpoints that the RPC has data available for (for data
+	that can be tied to a particular checkpoint).
+	"""
+	availableRange: AvailableRange!
 	"""
 	Configuration for this RPC service
 	"""


### PR DESCRIPTION
## Description 

According to data platform, the min and max checkpoints in checkpoint table correspond to the avail range, and the table is ordered.

## Test Plan 

e2e test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
