### PR TITLE
[GraphQL/MoveObject] Remove `hasPublicTransfer`

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -493,9 +493,6 @@
 >    description
 >    iconUrl
 >    supply
->    asMoveObject {
->      hasPublicTransfer
->    }
 >  }
 >}</pre>
 
@@ -531,7 +528,6 @@
 >            bcs
 >            kind
 >          }
->          hasPublicTransfer
 >        }
 >        exchangeRatesSize
 >        stakingPoolActivationEpoch
@@ -583,7 +579,6 @@
 >            bcs
 >            kind
 >          }
->          hasPublicTransfer
 >        }
 >        exchangeRatesSize
 >        stakingPoolActivationEpoch
@@ -928,7 +923,6 @@
 >    data
 >  }
 >  ... on MoveObject {
->    hasPublicTransfer
 >    contents {
 >      type {
 >        repr
@@ -986,7 +980,6 @@
 >    __typename
 >  }
 >  ... on MoveObject {
->    hasPublicTransfer
 >    contents {
 >      type {
 >        repr
@@ -1179,7 +1172,6 @@
 >            bcs
 >            kind
 >          }
->          hasPublicTransfer
 >        }
 >        exchangeRatesSize
 >        stakingPoolActivationEpoch

--- a/crates/sui-graphql-rpc/examples/coin_metadata/coin_metadata.graphql
+++ b/crates/sui-graphql-rpc/examples/coin_metadata/coin_metadata.graphql
@@ -6,8 +6,5 @@ query CoinMetadata {
     description
     iconUrl
     supply
-    asMoveObject {
-      hasPublicTransfer
-    }
   }
 }

--- a/crates/sui-graphql-rpc/examples/epoch/latest_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/latest_epoch.graphql
@@ -25,7 +25,6 @@
             bcs
             kind
           }
-          hasPublicTransfer
         }
         exchangeRatesSize
         stakingPoolActivationEpoch

--- a/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
@@ -25,7 +25,6 @@
             bcs
             kind
           }
-          hasPublicTransfer
         }
         exchangeRatesSize
         stakingPoolActivationEpoch

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field.graphql
@@ -7,7 +7,6 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
     __typename
   }
   ... on MoveObject {
-    hasPublicTransfer
     contents {
       type {
         repr

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_field_connection.graphql
@@ -6,7 +6,6 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
     data
   }
   ... on MoveObject {
-    hasPublicTransfer
     contents {
       type {
         repr

--- a/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
+++ b/crates/sui-graphql-rpc/examples/owner/dynamic_object_field.graphql
@@ -7,7 +7,6 @@ fragment DynamicFieldValueSelection on DynamicFieldValue {
     __typename
   }
   ... on MoveObject {
-    hasPublicTransfer
     contents {
       type {
         repr

--- a/crates/sui-graphql-rpc/examples/sui_system_state_summary/sui_system_state_summary.graphql
+++ b/crates/sui-graphql-rpc/examples/sui_system_state_summary/sui_system_state_summary.graphql
@@ -20,7 +20,6 @@
             bcs
             kind
           }
-          hasPublicTransfer
         }
         exchangeRatesSize
         stakingPoolActivationEpoch

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -788,10 +788,6 @@ type MoveObject {
 	"""
 	contents: MoveValue
 	"""
-	Determines whether a tx can transfer this object
-	"""
-	hasPublicTransfer: Boolean
-	"""
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
 	"""

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -467,7 +467,6 @@ interface IObject {
 
 interface IMoveObject {
   contents: MoveValue
-  hasPublicTransfer: Boolean
 }
 
 # Returned by Object.owner, where we can't disambiguate between
@@ -530,7 +529,7 @@ type Epoch {
   netInflow: BigInt
   fundInflow: BigInt
   fundOutflow: BigInt
-  
+
   # TODO: Identify non-duplicate fields in `EndOfEpochInfo`
 
   checkpointConnection(

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -34,11 +34,6 @@ impl MoveObject {
         Some(MoveValue::new(type_, self.native.contents().into()))
     }
 
-    /// Determines whether a tx can transfer this object
-    async fn has_public_transfer(&self) -> Option<bool> {
-        Some(self.native.has_public_transfer())
-    }
-
     /// Attempts to convert the Move object into an Object
     /// This provides additional information such as version and digest on the top-level
     async fn as_object(&self) -> &Object {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -792,10 +792,6 @@ type MoveObject {
 	"""
 	contents: MoveValue
 	"""
-	Determines whether a tx can transfer this object
-	"""
-	hasPublicTransfer: Boolean
-	"""
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
 	"""


### PR DESCRIPTION
## Description

Since we made it possible to add abilities to existing system types through protocol upgrades, this field is no longer accurate: Previously, when an object was created, this value was cached based on whether its type had `store` at the time that version of the object was created.

This can cause problems when it's a system type, and `store` was added to it in a protocol upgrade, as the field will incorrectly state that the object does not have public transfer when in fact it does.

This was fixed at the protocol level by recomputing the field every time the object is loaded for execution, but it still means the field exists and could be stale.

This PR removes the field from GraphQL to avoid confusion due to staleness.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```