### PR TITLE
[refactor] allow setting validator name during genesis

### DIFF
--- a/crates/sui-swarm-config/src/genesis_config.rs
+++ b/crates/sui-swarm-config/src/genesis_config.rs
@@ -52,6 +52,7 @@ pub struct ValidatorGenesisConfig {
     pub consensus_internal_worker_address: Option<Multiaddr>,
     #[serde(default = "default_stake")]
     pub stake: u64,
+    pub name: Option<String>,
 }
 
 impl ValidatorGenesisConfig {
@@ -208,6 +209,7 @@ impl ValidatorGenesisConfigBuilder {
             consensus_address,
             consensus_internal_worker_address: None,
             stake: sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST,
+            name: None,
         }
     }
 }

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -327,7 +327,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 .add_objects(self.additional_objects);
 
             for (i, validator) in validators.iter().enumerate() {
-                let name = format!("validator-{i}");
+                let name = validator
+                    .name
+                    .clone()
+                    .unwrap_or(format!("validator-{i}").to_string());
                 let validator_info = validator.to_validator_info(name);
                 builder =
                     builder.add_validator(validator_info.info, validator_info.proof_of_possession);


### PR DESCRIPTION
## Description 

Follow up of https://github.com/MystenLabs/sui-operations/pull/2943

Currently validators in our dev environments expose hostnames as "Validator-1,2,3...". We need better insight in our environments when debugging and that labelling doesn't help . Instead exposing the actual hostname (dns url) will help here. Not aware if there is a specific reason of not allowing this.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
