### PR TITLE
Do not always seek to first when creating SafeIterator

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1896,10 +1896,9 @@ where
             .op_metrics
             .rocksdb_iter_keys
             .with_label_values(&[&self.cf]);
-        let mut db_iter = self
+        let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        db_iter.seek_to_first();
         SafeIter::new(
             self.cf.clone(),
             db_iter,

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -17,6 +17,7 @@ pub struct SafeIter<'a, K, V> {
     db_iter: RocksDBRawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
+    is_initialized: bool,
     _timer: Option<HistogramTimer>,
     _perf_ctx: Option<RocksDBPerfContext>,
     bytes_scanned: Option<Histogram>,
@@ -41,6 +42,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
             db_iter,
             _phantom: PhantomData,
             direction: Direction::Forward,
+            is_initialized: false,
             _timer,
             _perf_ctx,
             bytes_scanned,
@@ -56,6 +58,12 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'a, K, 
     type Item = Result<(K, V), TypedStoreError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Implicitly set iterator to the first entry in the column family if it hasn't been initialized
+        // used for backward compatibility
+        if !self.is_initialized {
+            self.db_iter.seek_to_first();
+            self.is_initialized = true;
+        }
         if self.db_iter.valid() {
             let config = bincode::DefaultOptions::new()
                 .with_big_endian()
@@ -108,6 +116,7 @@ impl<'a, K: Serialize, V> SafeIter<'a, K, V> {
     /// the key.
     pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.db_iter.seek(be_fix_int_ser(key)?);
+        self.is_initialized = true;
         Ok(self)
     }
 
@@ -116,12 +125,14 @@ impl<'a, K: Serialize, V> SafeIter<'a, K, V> {
     /// no element prior to it, it returns an empty iterator.
     pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.db_iter.seek_for_prev(be_fix_int_ser(key)?);
+        self.is_initialized = true;
         Ok(self)
     }
 
     /// Seeks to the last key in the database (at this column family).
     pub fn skip_to_last(mut self) -> Self {
         self.db_iter.seek_to_last();
+        self.is_initialized = true;
         self
     }
 


### PR DESCRIPTION
## Description 

Similar change to #10756 , to SafeIterator

## Test Plan 

Existing unit tests have good coverage for SafeIterator (not for the old iterator though). I'll send out a test specific PR for the old iterator next.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
