### PR TITLE
[graphql/rpc] Make store effects optional in effects struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11853,6 +11853,7 @@ dependencies = [
  "chrono",
  "clap",
  "diesel",
+ "either",
  "expect-test",
  "fastcrypto",
  "futures",

--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
@@ -56,15 +56,3 @@
     sequenceNumber
   }
 }
-
-
-
-
-// Handle unions specially; use the max
-// For connections, recurse. Check if edge or node
-
-// Then we rework arrays
-
-// rollback explain cost & observe: mention in RPC chat to descope
-
-// add devx prog to code owners for graphql

--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
@@ -57,3 +57,14 @@
   }
 }
 
+
+
+
+// Handle unions specially; use the max
+// For connections, recurse. Check if edge or node
+
+// Then we rework arrays
+
+// rollback explain cost & observe: mention in RPC chat to descope
+
+// add devx prog to code owners for graphql

--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
@@ -56,3 +56,4 @@
     sequenceNumber
   }
 }
+

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -16,6 +16,7 @@ axum.workspace = true
 chrono.workspace = true
 clap.workspace = true
 diesel.workspace = true
+either.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 futures.workspace = true
 hex.workspace = true

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1997,7 +1997,7 @@ type TransactionBlockEffects {
 	"""
 	The transaction that ran to produce these effects.
 	"""
-	transactionBlock: TransactionBlock!
+	transactionBlock: TransactionBlock
 	"""
 	Whether the transaction executed successfully or not.
 	"""
@@ -2043,7 +2043,7 @@ type TransactionBlockEffects {
 	"""
 	Base64 encoded bcs serialization of the on-chain transaction effects.
 	"""
-	bcs: Base64
+	bcs: Base64!
 }
 
 input TransactionBlockFilter {

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -147,11 +147,10 @@ impl TransactionBlockEffects {
         let Some(stored_tx) = self.tx_data.as_ref().left() else {
             return Ok(None);
         };
-        Ok(ctx
-            .data_unchecked::<PgManager>()
+        ctx.data_unchecked::<PgManager>()
             .fetch_checkpoint(None, Some(stored_tx.checkpoint_sequence_number as u64))
             .await
-            .extend()?)
+            .extend()
     }
 
     // TODO: event_connection: EventConnection

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2001,7 +2001,7 @@ type TransactionBlockEffects {
 	"""
 	The transaction that ran to produce these effects.
 	"""
-	transactionBlock: TransactionBlock!
+	transactionBlock: TransactionBlock
 	"""
 	Whether the transaction executed successfully or not.
 	"""
@@ -2047,7 +2047,7 @@ type TransactionBlockEffects {
 	"""
 	Base64 encoded bcs serialization of the on-chain transaction effects.
 	"""
-	bcs: Base64
+	bcs: Base64!
 }
 
 input TransactionBlockFilter {


### PR DESCRIPTION
## Description 

Makes it easier to create effects struct when indexer view is not available
Needed for dry run impl as mentioned here https://github.com/MystenLabs/sui/pull/15167/files

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
