### PR TITLE
[move-ide] Added an option to turn linters on/off

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -41,6 +41,11 @@
 			"type": "object",
 			"title": "Move",
 			"properties": {
+				"move.lint": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable Move source code linting."
+                },
 				"move.server.path": {
                     "type": [
                         "null",

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -137,4 +137,9 @@ export class Configuration {
 
         return true;
     }
+
+}
+
+export function lint(): boolean {
+    return vscode.workspace.getConfiguration('move').get('lint') ?? true;
 }

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Configuration } from './configuration';
+import { lint } from './configuration';
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 import { log } from './log';
@@ -13,12 +14,26 @@ import { IndentAction } from 'vscode';
 export class Context {
     private client: lc.LanguageClient | undefined;
 
+    private lintOpt: boolean;
+
+    // The vscode-languageclient module reads a configuration option named
+    // "<extension-name>.trace.server" to determine whether to log messages. If a trace output
+    // channel is specified, these messages are printed there, otherwise they appear in the
+    // output channel that it automatically created by the `LanguageClient` (in this extension,
+    // that is 'Move Language Server'). For more information, see:
+    // https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server
+    private readonly traceOutputChannel: vscode.OutputChannel;
+
     private constructor(
         private readonly extensionContext: Readonly<vscode.ExtensionContext>,
         readonly configuration: Readonly<Configuration>,
         client: lc.LanguageClient | undefined = undefined,
     ) {
         this.client = client;
+        this.lintOpt = lint();
+        this.traceOutputChannel = vscode.window.createOutputChannel(
+            'Move Language Server Trace',
+        );
     }
 
     static create(
@@ -109,18 +124,13 @@ export class Context {
             debug: executable,
         };
 
-        // The vscode-languageclient module reads a configuration option named
-        // "<extension-name>.trace.server" to determine whether to log messages. If a trace output
-        // channel is specified, these messages are printed there, otherwise they appear in the
-        // output channel that it automatically created by the `LanguageClient` (in this extension,
-        // that is 'Move Language Server'). For more information, see:
-        // https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server
-        const traceOutputChannel = vscode.window.createOutputChannel(
-            'Move Language Server Trace',
-        );
+        this.traceOutputChannel.clear();
         const clientOptions: lc.LanguageClientOptions = {
             documentSelector: [{ scheme: 'file', language: 'move' }],
-            traceOutputChannel,
+            traceOutputChannel: this.traceOutputChannel,
+            initializationOptions: {
+                lintOpt: this.lintOpt,
+            },
         };
 
         const client = new lc.LanguageClient(
@@ -146,5 +156,38 @@ export class Context {
      */
     getClient(): lc.LanguageClient | undefined {
         return this.client;
+    }
+
+    /**
+     * Deactivates the cliend interacting with the language server.
+     */
+    async stopClient(): Promise<void> {
+        log.info('Stopping client...');
+        if (this.client) {
+            await this.client.stop();
+        }
+    }
+
+    /**
+     * Registers a handler to be executed when user/workspace configuration gets changed.
+     */
+    registerOnDidChangeConfiguration(): void {
+        vscode.workspace.onDidChangeConfiguration(async event => {
+            const changed = event.affectsConfiguration('move.lint');
+            if (changed) {
+                const newLintFlag = lint();
+                if (this.lintOpt !== newLintFlag) {
+                    this.lintOpt = newLintFlag;
+                    try {
+                        await this.stopClient();
+                        await this.startClient();
+                    } catch (err) {
+                        // Handle error
+                        log.info(String(err));
+                    }
+                }
+            }
+        });
+
     }
 } // Context

--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -121,6 +121,8 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
     context.registerCommand('textDocumentHover', commands.textDocumentHover);
     context.registerCommand('textDocumentCompletion', commands.textDocumentCompletion);
 
+    context.registerOnDidChangeConfiguration();
+
     if (updateGlobalExtVersion) {
         await extensionContext.globalState.update(globalMoveVersionKey, extension.version);
     }

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -118,7 +118,14 @@ fn main() {
             serde_json::from_value(client_response)
                 .expect("could not deserialize client capabilities");
 
-        symbolicator_runner = symbols::SymbolicatorRunner::new(symbols.clone(), diag_sender);
+        // determine if linting is on or off based on what the editor requested
+        let mut lint = false;
+        if let Some(init_options) = initialize_params.initialization_options {
+            lint = init_options.get("lintOpt").and_then(serde_json::Value::as_bool).unwrap_or(false);
+        }
+
+
+        symbolicator_runner = symbols::SymbolicatorRunner::new(symbols.clone(), diag_sender, lint);
 
         // If initialization information from the client contains a path to the directory being
         // opened, try to initialize symbols before sending response to the client. Do not bother
@@ -133,7 +140,7 @@ fn main() {
                     .stack_size(symbols::STACK_SIZE_BYTES)
                     .spawn(move || {
                         if let Ok((Some(new_symbols), _)) =
-                            symbols::Symbolicator::get_symbols(p.as_path())
+                            symbols::Symbolicator::get_symbols(p.as_path(), lint)
                         {
                             let mut old_symbols = symbols.lock().unwrap();
                             (*old_symbols).merge(new_symbols);
@@ -156,6 +163,7 @@ fn main() {
         )
         .expect("could not finish connection initialization");
 
+    let mut shutdown_req_received = false;
     loop {
         select! {
             recv(diag_receiver) -> message => {
@@ -197,7 +205,9 @@ fn main() {
             },
             recv(context.connection.receiver) -> message => {
                 match message {
-                    Ok(Message::Request(request)) => on_request(&context, &request),
+                    Ok(Message::Request(request)) => {
+                        shutdown_req_received = on_request(&context, &request, shutdown_req_received);
+                    }
                     Ok(Message::Response(response)) => on_response(&context, &response),
                     Ok(Message::Notification(notification)) => {
                         match notification.method.as_str() {
@@ -221,7 +231,22 @@ fn main() {
     eprintln!("Shut down language server '{}'.", exe);
 }
 
-fn on_request(context: &Context, request: &Request) {
+fn on_request(context: &Context, request: &Request, shutdown_request_received: bool) -> bool {
+    if shutdown_request_received {
+        let response = lsp_server::Response::new_err(
+            request.id.clone(),
+            lsp_server::ErrorCode::InvalidRequest as i32,
+            "a shutdown request already received by the server".to_string(),
+        );
+        if let Err(err) = context
+            .connection
+            .sender
+            .send(lsp_server::Message::Response(response))
+        {
+            eprintln!("could not send shutdown response: {:?}", err);
+        }
+        return true;
+    }
     match request.method.as_str() {
         lsp_types::request::Completion::METHOD => {
             on_completion_request(context, request, &context.symbols.lock().unwrap())
@@ -241,8 +266,22 @@ fn on_request(context: &Context, request: &Request) {
         lsp_types::request::DocumentSymbolRequest::METHOD => {
             symbols::on_document_symbol_request(context, request, &context.symbols.lock().unwrap());
         }
+        lsp_types::request::Shutdown::METHOD => {
+            eprintln!("Shutdown request received");
+            let response =
+                lsp_server::Response::new_ok(request.id.clone(), serde_json::Value::Null);
+            if let Err(err) = context
+                .connection
+                .sender
+                .send(lsp_server::Message::Response(response))
+            {
+                eprintln!("could not send shutdown response: {:?}", err);
+            }
+            return true;
+        }
         _ => eprintln!("handle request '{}' from client", request.method),
     }
+    false
 }
 
 fn on_response(_context: &Context, _response: &Response) {


### PR DESCRIPTION
## Description 

This PR adds an option to the VSCode extension that allows suppression of linters per user request.

## Test Plan 

Tested manually to verify that the on/off feature works (also after multiple switches back and forth)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
