### PR TITLE
[gql][fix] reverse event connection result if last provided

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -147,26 +147,6 @@ Response: {
     "eventConnection": {
       "edges": [
         {
-          "cursor": "3:0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0x855f03ee5425477994bf848d764a292cdc48432e4583ddcc80cc960e637ee811::M1::EventA"
-            },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
-          }
-        },
-        {
           "cursor": "2:0",
           "node": {
             "sendingModule": {
@@ -184,6 +164,26 @@ Response: {
               "new_value": "0"
             },
             "bcs": "AAAAAAAAAAA="
+          }
+        },
+        {
+          "cursor": "3:0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0x855f03ee5425477994bf848d764a292cdc48432e4583ddcc80cc960e637ee811::M1::EventA"
+            },
+            "senders": [
+              {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            ],
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
           }
         }
       ]

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -498,6 +498,10 @@ impl PgManager {
                     stored_events.pop();
                 }
 
+                if last.is_some() {
+                    stored_events.reverse();
+                }
+
                 Ok((stored_events, has_next_page))
             })
             .transpose()


### PR DESCRIPTION
## Description 

Need to reverse the result set if the 'last' value is provided.

## Test Plan 

Update existing event_connection/pagination.exp test to correct snapshot

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
