### PR TITLE
[gql] fix last queries for transaction connection

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.exp
@@ -1,0 +1,108 @@
+processed 15 tasks
+
+init:
+A: object(0,0)
+
+task 1 'programmable'. lines 6-8:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 10-10:
+Checkpoint created: 1
+
+task 3 'programmable'. lines 12-14:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'create-checkpoint'. lines 16-16:
+Checkpoint created: 2
+
+task 5 'programmable'. lines 18-20:
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'create-checkpoint'. lines 22-22:
+Checkpoint created: 3
+
+task 7 'programmable'. lines 24-26:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'create-checkpoint'. lines 28-28:
+Checkpoint created: 4
+
+task 9 'programmable'. lines 30-32:
+created: object(9,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10 'create-checkpoint'. lines 34-34:
+Checkpoint created: 5
+
+task 11 'run-graphql'. lines 36-43:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "cursor": "2"
+        },
+        {
+          "cursor": "3"
+        }
+      ]
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 45-52:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "cursor": "0"
+        },
+        {
+          "cursor": "1"
+        },
+        {
+          "cursor": "2"
+        }
+      ]
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 54-61:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "cursor": "2"
+        }
+      ]
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 63-74:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "cursor": "1"
+        },
+        {
+          "cursor": "2"
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.exp
@@ -1,4 +1,4 @@
-processed 15 tasks
+processed 16 tasks
 
 init:
 A: object(0,0)
@@ -43,64 +43,185 @@ gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 
 task 10 'create-checkpoint'. lines 34-34:
 Checkpoint created: 5
 
-task 11 'run-graphql'. lines 36-43:
+task 11 'run-graphql'. lines 36-53:
 Response: {
   "data": {
     "transactionBlockConnection": {
-      "edges": [
+      "nodes": [
         {
-          "cursor": "2"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AQAAAAAAAAA="
+                }
+              ]
+            }
+          }
         },
         {
-          "cursor": "3"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AgAAAAAAAAA="
+                }
+              ]
+            }
+          }
+        },
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AwAAAAAAAAA="
+                }
+              ]
+            }
+          }
+        },
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "BAAAAAAAAAA="
+                }
+              ]
+            }
+          }
+        },
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "BQAAAAAAAAA="
+                }
+              ]
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 12 'run-graphql'. lines 45-52:
+task 12 'run-graphql'. lines 55-72:
 Response: {
   "data": {
     "transactionBlockConnection": {
-      "edges": [
+      "nodes": [
         {
-          "cursor": "0"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AgAAAAAAAAA="
+                }
+              ]
+            }
+          }
         },
         {
-          "cursor": "1"
-        },
-        {
-          "cursor": "2"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AwAAAAAAAAA="
+                }
+              ]
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 13 'run-graphql'. lines 54-61:
+task 13 'run-graphql'. lines 74-91:
 Response: {
   "data": {
     "transactionBlockConnection": {
-      "edges": [
+      "nodes": [
         {
-          "cursor": "2"
+          "kind": {}
+        },
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AQAAAAAAAAA="
+                }
+              ]
+            }
+          }
+        },
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AgAAAAAAAAA="
+                }
+              ]
+            }
+          }
         }
       ]
     }
   }
 }
 
-task 14 'run-graphql'. lines 63-74:
+task 14 'run-graphql'. lines 93-110:
 Response: {
   "data": {
     "transactionBlockConnection": {
-      "edges": [
+      "nodes": [
         {
-          "cursor": "1"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AgAAAAAAAAA="
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 112-133:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AQAAAAAAAAA="
+                }
+              ]
+            }
+          }
         },
         {
-          "cursor": "2"
+          "kind": {
+            "inputConnection": {
+              "nodes": [
+                {
+                  "bytes": "AgAAAAAAAAA="
+                }
+              ]
+            }
+          }
         }
       ]
     }

--- a/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator --accounts A
+
+//# programmable --sender A --inputs 1 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlockConnection(first: 2, after: "1") {
+    edges {
+      cursor
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(last: 3, before: "3") {
+    edges {
+      cursor
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(last: 2, before: "3", filter: {atCheckpoint: 2}) {
+    edges {
+      cursor
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(
+    last: 4
+    before: "4"
+    filter: {afterCheckpoint: 0, beforeCheckpoint: 3}
+  ) {
+    edges {
+      cursor
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_connection/pagination.move
@@ -9,25 +9,25 @@
 
 //# create-checkpoint
 
-//# programmable --sender A --inputs 1 @A
+//# programmable --sender A --inputs 2 @A
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
 //# create-checkpoint
 
-//# programmable --sender A --inputs 1 @A
+//# programmable --sender A --inputs 3 @A
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
 //# create-checkpoint
 
-//# programmable --sender A --inputs 1 @A
+//# programmable --sender A --inputs 4 @A
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
 //# create-checkpoint
 
-//# programmable --sender A --inputs 1 @A
+//# programmable --sender A --inputs 5 @A
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
@@ -35,9 +35,38 @@
 
 //# run-graphql
 {
-  transactionBlockConnection(first: 2, after: "1") {
-    edges {
-      cursor
+  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+    nodes {
+      kind {
+        ... on ProgrammableTransactionBlock {
+          inputConnection(first: 1) {
+            nodes {
+              ... on Pure {
+                bytes
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(first: 2, after: "1", filter: {sentAddress: "@{A}"}) {
+    nodes {
+      kind {
+        ... on ProgrammableTransactionBlock {
+          inputConnection(first: 1) {
+            nodes {
+              ... on Pure {
+                bytes
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -45,8 +74,18 @@
 //# run-graphql
 {
   transactionBlockConnection(last: 3, before: "3") {
-    edges {
-      cursor
+    nodes {
+      kind {
+        ... on ProgrammableTransactionBlock {
+          inputConnection(first: 1) {
+            nodes {
+              ... on Pure {
+                bytes
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -54,8 +93,18 @@
 //# run-graphql
 {
   transactionBlockConnection(last: 2, before: "3", filter: {atCheckpoint: 2}) {
-    edges {
-      cursor
+    nodes {
+      kind {
+        ... on ProgrammableTransactionBlock {
+          inputConnection(first: 1) {
+            nodes {
+              ... on Pure {
+                bytes
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -67,8 +116,18 @@
     before: "4"
     filter: {afterCheckpoint: 0, beforeCheckpoint: 3}
   ) {
-    edges {
-      cursor
+    nodes {
+      kind {
+        ... on ProgrammableTransactionBlock {
+          inputConnection(first: 1) {
+            nodes {
+              ... on Pure {
+                bytes
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -43,8 +43,8 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn multi_get_txs(
-        cursor: Option<i64>,
-        descending_order: bool,
+        before: Option<i64>,
+        after: Option<i64>,
         limit: i64,
         filter: Option<TransactionBlockFilter>,
         after_tx_seq_num: Option<i64>,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -334,9 +334,10 @@ impl PgManager {
         filter: Option<TransactionBlockFilter>,
     ) -> Result<Option<(Vec<StoredTransaction>, bool)>, Error> {
         let limit = self.validate_page_limit(first, last)?;
-        let descending_order = last.is_some();
-        let cursor = after
-            .or(before)
+        let before = before
+            .map(|cursor| self.parse_tx_cursor(&cursor))
+            .transpose()?;
+        let after = after
             .map(|cursor| self.parse_tx_cursor(&cursor))
             .transpose()?;
 
@@ -381,8 +382,8 @@ impl PgManager {
 
         let query = move || {
             QueryBuilder::multi_get_txs(
-                cursor,
-                descending_order,
+                before,
+                after,
                 limit,
                 filter.clone(),
                 after_tx_seq_num,
@@ -399,6 +400,10 @@ impl PgManager {
                 let has_next_page = stored_txs.len() as i64 > limit;
                 if has_next_page {
                     stored_txs.pop();
+                }
+
+                if last.is_some() {
+                    stored_txs.reverse();
                 }
 
                 Ok((stored_txs, has_next_page))

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -95,8 +95,8 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     }
 
     fn multi_get_txs(
-        cursor: Option<i64>,
-        descending_order: bool,
+        before: Option<i64>,
+        after: Option<i64>,
         limit: i64,
         filter: Option<TransactionBlockFilter>,
         after_tx_seq_num: Option<i64>,
@@ -104,130 +104,125 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     ) -> Result<transactions::BoxedQuery<'static, Pg>, Error> {
         let mut query = transactions::dsl::transactions.into_boxed();
 
-        if let Some(cursor_val) = cursor {
-            if descending_order {
-                let filter_value =
-                    before_tx_seq_num.map_or(cursor_val, |b| std::cmp::min(b, cursor_val));
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(filter_value));
-            } else {
-                let filter_value =
-                    after_tx_seq_num.map_or(cursor_val, |a| std::cmp::max(a, cursor_val));
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(filter_value));
-            }
-        } else {
-            if let Some(av) = after_tx_seq_num {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(av));
-            }
-            if let Some(bv) = before_tx_seq_num {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(bv));
-            }
-        }
-
-        if descending_order {
-            query = query.order(transactions::dsl::tx_sequence_number.desc());
+        if let Some(after) = after {
+            query = query
+                .filter(transactions::dsl::tx_sequence_number.gt(after))
+                .order(transactions::dsl::tx_sequence_number.asc());
+        } else if let Some(before) = before {
+            query = query
+                .filter(transactions::dsl::tx_sequence_number.lt(before))
+                .order(transactions::dsl::tx_sequence_number.desc());
         } else {
             query = query.order(transactions::dsl::tx_sequence_number.asc());
         }
 
         query = query.limit(limit + 1);
 
-        if let Some(filter) = filter {
-            // Filters for transaction table
-            // at_checkpoint mutually exclusive with before_ and after_checkpoint
-            if let Some(checkpoint) = filter.at_checkpoint {
-                query = query
-                    .filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
+        if let Some(av) = after_tx_seq_num {
+            query = query.filter(transactions::dsl::tx_sequence_number.gt(av));
+        }
+        if let Some(bv) = before_tx_seq_num {
+            query = query.filter(transactions::dsl::tx_sequence_number.lt(bv));
+        }
+
+        let Some(filter) = filter else {
+            return Ok(query);
+        };
+
+        // at_checkpoint mutually exclusive with before_ and after_checkpoint
+        if let Some(checkpoint) = filter.at_checkpoint {
+            query =
+                query.filter(transactions::dsl::checkpoint_sequence_number.eq(checkpoint as i64));
+        }
+        if let Some(transaction_ids) = filter.transaction_ids {
+            let digests = transaction_ids
+                .into_iter()
+                .map(|id| Ok::<Vec<u8>, Error>(Digest::from_str(&id)?.into_vec()))
+                .collect::<Result<Vec<_>, _>>()?;
+            query = query.filter(transactions::dsl::transaction_digest.eq_any(digests));
+        }
+
+        // Queries on foreign tables
+        match (filter.package, filter.module, filter.function) {
+            (Some(p), None, None) => {
+                let subquery = tx_calls::dsl::tx_calls
+                    .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                    .select(tx_calls::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
             }
-            if let Some(transaction_ids) = filter.transaction_ids {
-                let digests = transaction_ids
-                    .into_iter()
-                    .map(|id| Ok::<Vec<u8>, Error>(Digest::from_str(&id)?.into_vec()))
-                    .collect::<Result<Vec<_>, _>>()?;
-                query = query.filter(transactions::dsl::transaction_digest.eq_any(digests));
+            (Some(p), Some(m), None) => {
+                let subquery = tx_calls::dsl::tx_calls
+                    .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                    .filter(tx_calls::dsl::module.eq(m))
+                    .select(tx_calls::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
             }
+            (Some(p), Some(m), Some(f)) => {
+                let subquery = tx_calls::dsl::tx_calls
+                    .filter(tx_calls::dsl::package.eq(p.into_vec()))
+                    .filter(tx_calls::dsl::module.eq(m))
+                    .filter(tx_calls::dsl::func.eq(f))
+                    .select(tx_calls::dsl::tx_sequence_number);
 
-            // Queries on foreign tables
-            match (filter.package, filter.module, filter.function) {
-                (Some(p), None, None) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                (Some(p), Some(m), None) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .filter(tx_calls::dsl::module.eq(m))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                (Some(p), Some(m), Some(f)) => {
-                    let subquery = tx_calls::dsl::tx_calls
-                        .filter(tx_calls::dsl::package.eq(p.into_vec()))
-                        .filter(tx_calls::dsl::module.eq(m))
-                        .filter(tx_calls::dsl::func.eq(f))
-                        .select(tx_calls::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-                _ => {}
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
             }
+            _ => {}
+        }
 
-            if let Some(signer) = filter.sign_address {
-                if let Some(sender) = filter.sent_address {
-                    let subquery = tx_senders::dsl::tx_senders
-                        .filter(
-                            tx_senders::dsl::sender
-                                .eq(signer.into_vec())
-                                .or(tx_senders::dsl::sender.eq(sender.into_vec())),
-                        )
-                        .select(tx_senders::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                } else {
-                    let subquery = tx_senders::dsl::tx_senders
-                        .filter(tx_senders::dsl::sender.eq(signer.into_vec()))
-                        .select(tx_senders::dsl::tx_sequence_number);
-
-                    query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-                }
-            } else if let Some(sender) = filter.sent_address {
+        if let Some(signer) = filter.sign_address {
+            if let Some(sender) = filter.sent_address {
                 let subquery = tx_senders::dsl::tx_senders
-                    .filter(tx_senders::dsl::sender.eq(sender.into_vec()))
+                    .filter(
+                        tx_senders::dsl::sender
+                            .eq(signer.into_vec())
+                            .or(tx_senders::dsl::sender.eq(sender.into_vec())),
+                    )
+                    .select(tx_senders::dsl::tx_sequence_number);
+
+                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+            } else {
+                let subquery = tx_senders::dsl::tx_senders
+                    .filter(tx_senders::dsl::sender.eq(signer.into_vec()))
                     .select(tx_senders::dsl::tx_sequence_number);
 
                 query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
             }
-            if let Some(recipient) = filter.recv_address {
-                let subquery = tx_recipients::dsl::tx_recipients
-                    .filter(tx_recipients::dsl::recipient.eq(recipient.into_vec()))
-                    .select(tx_recipients::dsl::tx_sequence_number);
+        } else if let Some(sender) = filter.sent_address {
+            let subquery = tx_senders::dsl::tx_senders
+                .filter(tx_senders::dsl::sender.eq(sender.into_vec()))
+                .select(tx_senders::dsl::tx_sequence_number);
 
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-            if filter.paid_address.is_some() {
-                return Err(Error::Internal(
-                    "Paid address filter not supported".to_string(),
-                ));
-            }
+            query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+        }
+        if let Some(recipient) = filter.recv_address {
+            let subquery = tx_recipients::dsl::tx_recipients
+                .filter(tx_recipients::dsl::recipient.eq(recipient.into_vec()))
+                .select(tx_recipients::dsl::tx_sequence_number);
 
-            if let Some(input_object) = filter.input_object {
-                let subquery = tx_input_objects::dsl::tx_input_objects
-                    .filter(tx_input_objects::dsl::object_id.eq(input_object.into_vec()))
-                    .select(tx_input_objects::dsl::tx_sequence_number);
+            query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+        }
+        if filter.paid_address.is_some() {
+            return Err(Error::Internal(
+                "Paid address filter not supported".to_string(),
+            ));
+        }
 
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-            if let Some(changed_object) = filter.changed_object {
-                let subquery = tx_changed_objects::dsl::tx_changed_objects
-                    .filter(tx_changed_objects::dsl::object_id.eq(changed_object.into_vec()))
-                    .select(tx_changed_objects::dsl::tx_sequence_number);
+        if let Some(input_object) = filter.input_object {
+            let subquery = tx_input_objects::dsl::tx_input_objects
+                .filter(tx_input_objects::dsl::object_id.eq(input_object.into_vec()))
+                .select(tx_input_objects::dsl::tx_sequence_number);
 
-                query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
-            }
-        };
+            query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+        }
+        if let Some(changed_object) = filter.changed_object {
+            let subquery = tx_changed_objects::dsl::tx_changed_objects
+                .filter(tx_changed_objects::dsl::object_id.eq(changed_object.into_vec()))
+                .select(tx_changed_objects::dsl::tx_sequence_number);
+
+            query = query.filter(transactions::dsl::tx_sequence_number.eq_any(subquery));
+        }
 
         Ok(query)
     }


### PR DESCRIPTION
## Description 

Currently, a graphql query for last 3 before 4 would return 3, 2, 1. This does not follow cursor specs. This PR addresses the bug to return 1, 2, 3, and adds a test to validate some scenarios.

## Test Plan 

transaction_connection/pagination.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
