### PR TITLE
[release] cherry pick fix for release v1.15.0

### DIFF
--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -37,3 +37,4 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }
+sui-json-rpc-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -35,3 +35,6 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }
+
+[features]
+test-utils = []

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -12,7 +12,6 @@ use serde_json::{json, Value};
 use serde_with::{serde_as, DisplayFromStr};
 use std::fmt;
 use std::fmt::Display;
-use std::str::FromStr;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::error::SuiResult;
 use sui_types::event::{Event, EventEnvelope, EventID};
@@ -23,6 +22,10 @@ use tabled::settings::Style as TableStyle;
 
 use crate::{type_and_fields_from_move_struct, Page};
 use sui_types::sui_serde::SuiStructTag;
+
+#[cfg(any(feature = "test-utils", test))]
+use std::str::FromStr;
+
 pub type EventPage = Page<SuiEvent, EventID>;
 
 #[serde_as]
@@ -151,6 +154,7 @@ impl Display for SuiEvent {
     }
 }
 
+#[cfg(any(feature = "test-utils", test))]
 impl SuiEvent {
     pub fn random_for_testing() -> Self {
         Self {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -489,7 +489,7 @@ impl SuiAddress {
         self.0.to_vec()
     }
 
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(feature = "test-utils", test))]
     /// Return a random SuiAddress.
     pub fn random_for_testing_only() -> Self {
         AccountAddress::random().into()


### PR DESCRIPTION
## Description 

Cherry pick the main fix for devnet/testnet release scheduled on Monday.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed the issue with compilation error pointing to `random_for_testing_only` not found for `testnet/devnet` branches.