### PR TITLE
[gql] update cursor logic for coins and objects

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -1,0 +1,133 @@
+processed 13 tasks
+
+task 1 'publish'. lines 6-23:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 25-25:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 27-27:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'run'. lines 29-29:
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'run'. lines 31-31:
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'run'. lines 33-33:
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'create-checkpoint'. lines 35-35:
+Checkpoint created: 1
+
+task 8 'run-graphql'. lines 37-47:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x1a7608bbb2287049af7277beb03675da855f91f1e576bf85955be7bcf1a00dee"
+          },
+          {
+            "cursor": "0x2d5bd25ebb5bd55a8f3cdcf3e9a2840e4ecd21cf783f3af27241bbc7484a4f67"
+          },
+          {
+            "cursor": "0x767a20e24e00708b5134771a7897f5278107ce8544f03cab44628d84be11164f"
+          },
+          {
+            "cursor": "0x925fbd4db2688a5f5cdf953f8c3522668922305d6f5510b6e0ccf9d3bb92d8fa"
+          },
+          {
+            "cursor": "0x9cc539daaa3fc1684ab3cb0cf7f74a4a8339982d2f30458c05469189eece758b"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 49-59:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x1a7608bbb2287049af7277beb03675da855f91f1e576bf85955be7bcf1a00dee"
+          },
+          {
+            "cursor": "0x2d5bd25ebb5bd55a8f3cdcf3e9a2840e4ecd21cf783f3af27241bbc7484a4f67"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 61-73:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x2d5bd25ebb5bd55a8f3cdcf3e9a2840e4ecd21cf783f3af27241bbc7484a4f67"
+          },
+          {
+            "cursor": "0x767a20e24e00708b5134771a7897f5278107ce8544f03cab44628d84be11164f"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 75-85:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x925fbd4db2688a5f5cdf953f8c3522668922305d6f5510b6e0ccf9d3bb92d8fa"
+          },
+          {
+            "cursor": "0x9cc539daaa3fc1684ab3cb0cf7f74a4a8339982d2f30458c05469189eece758b"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 87-97:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x2d5bd25ebb5bd55a8f3cdcf3e9a2840e4ecd21cf783f3af27241bbc7484a4f67"
+          },
+          {
+            "cursor": "0x767a20e24e00708b5134771a7897f5278107ce8544f03cab44628d84be11164f"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 A=0x42 --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::create --args 1 @A
+
+//# run Test::M1::create --args 2 @A
+
+//# run Test::M1::create --args 3 @A
+
+//# run Test::M1::create --args 4 @A
+
+//# create-checkpoint
+
+//# run-graphql --variables A
+{
+  # select all objects owned by A
+  address(address: $A) {
+    objectConnection {
+      edges {
+        cursor
+      }
+    }
+  }
+}
+
+//# run-graphql --variables A
+{
+  # select the first 2 objects owned by A
+  address(address: $A) {
+    objectConnection(first: 2) {
+      edges {
+        cursor
+      }
+    }
+  }
+}
+
+//# run-graphql --variables A obj_5_0
+{
+  address(address: $A) {
+    # select the 2nd and 3rd objects
+    # note that order does not correspond
+    # to order in which objects were created
+    objectConnection(first: 2 after: $obj_5_0) {
+      edges {
+        cursor
+      }
+    }
+  }
+}
+
+//# run-graphql --variables A obj_4_0
+{
+  address(address: $A) {
+    # select 4th and last object
+    objectConnection(first: 2 after: $obj_4_0) {
+      edges {
+        cursor
+      }
+    }
+  }
+}
+
+//# run-graphql --variables A obj_3_0
+{
+  address(address: $A) {
+    # select 3rd and 4th object
+    objectConnection(last: 2 before: $obj_3_0) {
+      edges {
+        cursor
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -51,15 +51,15 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
         before_tx_seq_num: Option<i64>,
     ) -> Result<transactions::BoxedQuery<'static, DB>, Error>;
     fn multi_get_coins(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
+        before: Option<Vec<u8>>,
+        after: Option<Vec<u8>>,
         limit: i64,
         address: Option<Vec<u8>>,
         coin_type: String,
     ) -> objects::BoxedQuery<'static, DB>;
     fn multi_get_objs(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
+        before: Option<Vec<u8>>,
+        after: Option<Vec<u8>>,
         limit: i64,
         filter: Option<ObjectFilter>,
         owner_type: Option<OwnerType>,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -268,6 +268,10 @@ impl PgManager {
                     stored_objs.pop();
                 }
 
+                if last.is_some() {
+                    stored_objs.reverse();
+                }
+
                 Ok((stored_objs, has_next_page))
             })
             .transpose()
@@ -537,11 +541,16 @@ impl PgManager {
         let result: Option<Vec<StoredObject>> = self
             .run_query_async_with_cost(query, |query| move |conn| query.load(conn).optional())
             .await?;
+
         result
             .map(|mut stored_objs| {
                 let has_next_page = stored_objs.len() as i64 > limit;
                 if has_next_page {
                     stored_objs.pop();
+                }
+
+                if last.is_some() {
+                    stored_objs.reverse();
                 }
 
                 Ok((stored_objs, has_next_page))

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -228,25 +228,13 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         Ok(query)
     }
     fn multi_get_coins(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
+        before: Option<Vec<u8>>,
+        after: Option<Vec<u8>>,
         limit: i64,
         address: Option<Vec<u8>>,
         coin_type: String,
     ) -> objects::BoxedQuery<'static, Pg> {
-        let mut query = objects::dsl::objects.into_boxed();
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(objects::dsl::object_id.lt(cursor));
-            } else {
-                query = query.filter(objects::dsl::object_id.gt(cursor));
-            }
-        }
-        if descending_order {
-            query = query.order(objects::dsl::object_id.desc());
-        } else {
-            query = query.order(objects::dsl::object_id.asc());
-        }
+        let mut query = order_objs(before, after);
         query = query.limit(limit + 1);
 
         if let Some(address) = address {
@@ -260,117 +248,101 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         query
     }
     fn multi_get_objs(
-        cursor: Option<Vec<u8>>,
-        descending_order: bool,
+        before: Option<Vec<u8>>,
+        after: Option<Vec<u8>>,
         limit: i64,
         filter: Option<ObjectFilter>,
         owner_type: Option<OwnerType>,
     ) -> Result<objects::BoxedQuery<'static, Pg>, Error> {
-        let mut query = objects::dsl::objects.into_boxed();
-
-        if let Some(cursor) = cursor {
-            if descending_order {
-                query = query.filter(objects::dsl::object_id.lt(cursor));
-            } else {
-                query = query.filter(objects::dsl::object_id.gt(cursor));
-            }
-        }
-
-        if descending_order {
-            query = query.order(objects::dsl::object_id.desc());
-        } else {
-            query = query.order(objects::dsl::object_id.asc());
-        }
-
+        let mut query = order_objs(before, after);
         query = query.limit(limit + 1);
 
-        if let Some(filter) = filter {
-            if let Some(object_ids) = filter.object_ids {
-                query = query.filter(
-                    objects::dsl::object_id.eq_any(
-                        object_ids
-                            .into_iter()
-                            .map(|id| id.into_vec())
-                            .collect::<Vec<_>>(),
-                    ),
-                );
+        let Some(filter) = filter else {
+            return Ok(query);
+        };
+
+        if let Some(object_ids) = filter.object_ids {
+            query = query.filter(
+                objects::dsl::object_id.eq_any(
+                    object_ids
+                        .into_iter()
+                        .map(|id| id.into_vec())
+                        .collect::<Vec<_>>(),
+                ),
+            );
+        }
+
+        if let Some(owner) = filter.owner {
+            query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
+
+            match owner_type {
+                Some(OwnerType::Address) => {
+                    query = query.filter(objects::dsl::owner_type.eq(OwnerType::Address as i16));
+                }
+                Some(OwnerType::Object) => {
+                    query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
+                }
+                None => {
+                    query = query.filter(
+                        objects::dsl::owner_type
+                            .eq(OwnerType::Address as i16)
+                            .or(objects::dsl::owner_type.eq(OwnerType::Object as i16)),
+                    );
+                }
+                _ => Err(DbValidationError::InvalidOwnerType)?,
+            }
+        }
+
+        if let Some(object_type) = filter.type_ {
+            let parts: Vec<_> = object_type.splitn(3, "::").collect();
+
+            if parts.iter().any(|&part| part.is_empty()) {
+                return Err(DbValidationError::InvalidType(
+                    "Empty strings are not allowed".to_string(),
+                ))?;
             }
 
-            if let Some(owner) = filter.owner {
-                query = query.filter(objects::dsl::owner_id.eq(owner.into_vec()));
-
-                match owner_type {
-                    Some(OwnerType::Address) => {
-                        query =
-                            query.filter(objects::dsl::owner_type.eq(OwnerType::Address as i16));
-                    }
-                    Some(OwnerType::Object) => {
-                        query = query.filter(objects::dsl::owner_type.eq(OwnerType::Object as i16));
-                    }
-                    None => {
-                        query = query.filter(
-                            objects::dsl::owner_type
-                                .eq(OwnerType::Address as i16)
-                                .or(objects::dsl::owner_type.eq(OwnerType::Object as i16)),
-                        );
-                    }
-                    _ => Err(DbValidationError::InvalidOwnerType)?,
-                }
-            }
-
-            if let Some(object_type) = filter.type_ {
-                let parts: Vec<_> = object_type.splitn(3, "::").collect();
-
-                if parts.iter().any(|&part| part.is_empty()) {
-                    return Err(DbValidationError::InvalidType(
-                        "Empty strings are not allowed".to_string(),
-                    ))?;
-                }
-
-                if parts.len() == 1 {
-                    // We check for a leading 0x to determine if it is an address
-                    // And otherwise process it as a primitive type
-                    if parts[0].starts_with("0x") {
-                        let package = SuiAddress::from_str(parts[0])
-                            .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
-                        query =
-                            query.filter(objects::dsl::object_type.like(format!("{}::%", package)));
-                    } else {
-                        query = query.filter(objects::dsl::object_type.eq(parts[0].to_string()));
-                    }
-                } else if parts.len() == 2 {
-                    // Only package addresses are allowed if there are two or more parts
+            if parts.len() == 1 {
+                // We check for a leading 0x to determine if it is an address
+                // And otherwise process it as a primitive type
+                if parts[0].starts_with("0x") {
                     let package = SuiAddress::from_str(parts[0])
                         .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
-                    query = query.filter(
-                        objects::dsl::object_type.like(format!("{}::{}::%", package, parts[1])),
-                    );
-                } else if parts.len() == 3 {
-                    let validated_type = parse_sui_struct_tag(&object_type)
-                        .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
-
-                    if validated_type.type_params.is_empty() {
-                        query = query.filter(
-                            objects::dsl::object_type
-                                .like(format!(
-                                    "{}<%",
-                                    validated_type.to_canonical_string(/* with_prefix */ true)
-                                ))
-                                .or(objects::dsl::object_type
-                                    .eq(validated_type
-                                        .to_canonical_string(/* with_prefix */ true))),
-                        );
-                    } else {
-                        query = query.filter(
-                            objects::dsl::object_type
-                                .eq(validated_type.to_canonical_string(/* with_prefix */ true)),
-                        );
-                    }
+                    query = query.filter(objects::dsl::object_type.like(format!("{}::%", package)));
                 } else {
-                    return Err(Error::Internal(
-                        "Invalid type. Type must have 3 or less parts".to_string(),
-                    ));
+                    query = query.filter(objects::dsl::object_type.eq(parts[0].to_string()));
                 }
+            } else if parts.len() == 2 {
+                // Only package addresses are allowed if there are two or more parts
+                let package = SuiAddress::from_str(parts[0])
+                    .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
+                query = query.filter(
+                    objects::dsl::object_type.like(format!("{}::{}::%", package, parts[1])),
+                );
+            } else if parts.len() == 3 {
+                let validated_type = parse_sui_struct_tag(&object_type)
+                    .map_err(|e| DbValidationError::InvalidType(e.to_string()))?;
+
+                if validated_type.type_params.is_empty() {
+                    query = query.filter(
+                        objects::dsl::object_type
+                            .like(format!(
+                                "{}<%",
+                                validated_type.to_canonical_string(/* with_prefix */ true)
+                            ))
+                            .or(objects::dsl::object_type
+                                .eq(validated_type.to_canonical_string(/* with_prefix */ true))),
+                    );
+                } else {
+                    query = query.filter(
+                        objects::dsl::object_type
+                            .eq(validated_type.to_canonical_string(/* with_prefix */ true)),
+                    );
+                }
+            } else {
+                return Err(Error::Internal(
+                    "Invalid type. Type must have 3 or less parts".to_string(),
+                ));
             }
         }
 
@@ -643,6 +615,22 @@ pub fn extract_cost(explain_result: &str) -> Result<f64, Error> {
             "Failed to get cost from query plan".to_string(),
         ))
     }
+}
+
+fn order_objs(before: Option<Vec<u8>>, after: Option<Vec<u8>>) -> objects::BoxedQuery<'static, Pg> {
+    let mut query = objects::dsl::objects.into_boxed();
+    if let Some(after) = after {
+        query = query
+            .filter(objects::dsl::object_id.gt(after))
+            .order(objects::dsl::object_id.asc());
+    } else if let Some(before) = before {
+        query = query
+            .filter(objects::dsl::object_id.lt(before))
+            .order(objects::dsl::object_id.desc());
+    } else {
+        query = query.order(objects::dsl::object_id.asc());
+    }
+    query
 }
 
 pub(crate) type QueryBuilder = PgQueryBuilder;


### PR DESCRIPTION
## Description 

Last of the multi get queries backing connections. Fix results returned for last + before queries to return results in ascending order.

## Test Plan 

objects/pagination.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
