### PR TITLE
[snapshots] Upload formal snapshots before db snapshots

### DIFF
--- a/crates/sui-snapshot/src/uploader.rs
+++ b/crates/sui-snapshot/src/uploader.rs
@@ -12,9 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
-use sui_core::db_checkpoint_handler::{
-    STATE_SNAPSHOT_COMPLETED_MARKER, SUCCESS_MARKER, UPLOAD_COMPLETED_MARKER,
-};
+use sui_core::db_checkpoint_handler::{STATE_SNAPSHOT_COMPLETED_MARKER, SUCCESS_MARKER};
 use sui_storage::object_store::util::{
     find_all_dirs_with_epoch_prefix, find_missing_epochs_dirs, path_to_filesystem, put,
 };
@@ -123,12 +121,6 @@ impl StateSnapshotUploader {
         dirs.sort_by_key(|(epoch_num, _path)| *epoch_num);
         for (epoch, db_path) in dirs {
             if missing_epochs.contains(epoch) || *epoch >= last_missing_epoch {
-                let dir_path = path_to_filesystem(self.db_checkpoint_path.clone(), db_path)?;
-                let upload_completed_path = dir_path.join(UPLOAD_COMPLETED_MARKER);
-                if !upload_completed_path.exists() {
-                    info!("State snapshot creation for epoch: {} to wait until db checkpoint uploaded", *epoch);
-                    continue;
-                }
                 info!("Starting state snapshot creation for epoch: {}", *epoch);
                 let state_snapshot_writer = StateSnapshotWriterV1::new_from_store(
                     &self.staging_path,


### PR DESCRIPTION
## Description 

Formal snapshots are much smaller than db snapshots, hence they take much less time to upload. Additionally, validators are the greatest beneficiaries of formal snapshots, and are more sensitive to the effects of lagging the network, therefore there is a strong need for formal snapshots of the current epoch to be available as quickly as possible after epoch change (6 hour lag out of a 24 hour epoch is too long).

To address this, for a node that is configured to upload both snapshot types, formal snapshots will be the first to start, and db snapshot upload will block on its completion (note that we cannot do them concurrently as they both need to open the db checkpoint as a perpetual DB - formal snapshots in order to scan the live object set, and db checkpoint uploader to prune and compact. 

## Test Plan 

Ran locally and verified snapshot and db checkpoints are being generated successfully

```
# db checkpoints and snapshots garbage collected
williamsmith in /opt/sui/db/authorities_db/full_node_db λ du -sh ./*
  0B	./db_checkpoints
 51G	./live
  0B	./snapshot
# local db checkpoints and snapshots created
williamsmith in /opt/sui/db λ du -sh ./local_*
 76G	./local_db_snapshots
 26G	./local_formal_snapshots
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
