### PR TITLE
[transactional-test-runner] read-only shared inputs

### DIFF
--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -207,7 +207,7 @@ pub enum SuiExtraValueArgs {
     Object(FakeID, Option<SequenceNumber>),
     Digest(String),
     Receiving(FakeID, Option<SequenceNumber>),
-    ReadShared(FakeID, Option<SequenceNumber>),
+    ImmShared(FakeID, Option<SequenceNumber>),
 }
 
 pub enum SuiValue {
@@ -216,7 +216,7 @@ pub enum SuiValue {
     ObjVec(Vec<(FakeID, Option<SequenceNumber>)>),
     Digest(String),
     Receiving(FakeID, Option<SequenceNumber>),
-    ReadShared(FakeID, Option<SequenceNumber>),
+    ImmShared(FakeID, Option<SequenceNumber>),
 }
 
 impl SuiExtraValueArgs {
@@ -237,8 +237,8 @@ impl SuiExtraValueArgs {
     fn parse_read_shared_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
         parser: &mut MoveCLParser<'a, ValueToken, I>,
     ) -> anyhow::Result<Self> {
-        let (fake_id, version) = Self::parse_receiving_or_object_value(parser, "readshared")?;
-        Ok(SuiExtraValueArgs::ReadShared(fake_id, version))
+        let (fake_id, version) = Self::parse_receiving_or_object_value(parser, "immshared")?;
+        Ok(SuiExtraValueArgs::ImmShared(fake_id, version))
     }
 
     fn parse_digest_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
@@ -296,7 +296,7 @@ impl SuiValue {
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
             SuiValue::Receiving(_, _) => panic!("unexpected nested Sui receiving object in args"),
-            SuiValue::ReadShared(_, _) => panic!("unexpected nested Sui shared object in args"),
+            SuiValue::ImmShared(_, _) => panic!("unexpected nested Sui shared object in args"),
         }
     }
 
@@ -307,7 +307,7 @@ impl SuiValue {
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
             SuiValue::Receiving(_, _) => panic!("unexpected nested Sui receiving object in args"),
-            SuiValue::ReadShared(_, _) => panic!("unexpected nested Sui shared object in args"),
+            SuiValue::ImmShared(_, _) => panic!("unexpected nested Sui shared object in args"),
         }
     }
 
@@ -393,7 +393,7 @@ impl SuiValue {
             SuiValue::Receiving(fake_id, version) => {
                 CallArg::Object(Self::receiving_arg(fake_id, version, test_adapter)?)
             }
-            SuiValue::ReadShared(fake_id, version) => {
+            SuiValue::ImmShared(fake_id, version) => {
                 CallArg::Object(Self::read_shared_arg(fake_id, version, test_adapter)?)
             }
             SuiValue::ObjVec(_) => bail!("obj vec is not supported as an input"),
@@ -436,7 +436,7 @@ impl ParsableValue for SuiExtraValueArgs {
             (ValueToken::Ident, "object") => Some(Self::parse_object_value(parser)),
             (ValueToken::Ident, "digest") => Some(Self::parse_digest_value(parser)),
             (ValueToken::Ident, "receiving") => Some(Self::parse_receiving_value(parser)),
-            (ValueToken::Ident, "readshared") => Some(Self::parse_read_shared_value(parser)),
+            (ValueToken::Ident, "immshared") => Some(Self::parse_read_shared_value(parser)),
             _ => None,
         }
     }
@@ -471,7 +471,7 @@ impl ParsableValue for SuiExtraValueArgs {
             SuiExtraValueArgs::Object(id, version) => Ok(SuiValue::Object(id, version)),
             SuiExtraValueArgs::Digest(pkg) => Ok(SuiValue::Digest(pkg)),
             SuiExtraValueArgs::Receiving(id, version) => Ok(SuiValue::Receiving(id, version)),
-            SuiExtraValueArgs::ReadShared(id, version) => Ok(SuiValue::ReadShared(id, version)),
+            SuiExtraValueArgs::ImmShared(id, version) => Ok(SuiValue::ImmShared(id, version)),
         }
     }
 }

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -207,6 +207,7 @@ pub enum SuiExtraValueArgs {
     Object(FakeID, Option<SequenceNumber>),
     Digest(String),
     Receiving(FakeID, Option<SequenceNumber>),
+    ReadShared(FakeID, Option<SequenceNumber>),
 }
 
 pub enum SuiValue {
@@ -215,6 +216,7 @@ pub enum SuiValue {
     ObjVec(Vec<(FakeID, Option<SequenceNumber>)>),
     Digest(String),
     Receiving(FakeID, Option<SequenceNumber>),
+    ReadShared(FakeID, Option<SequenceNumber>),
 }
 
 impl SuiExtraValueArgs {
@@ -230,6 +232,13 @@ impl SuiExtraValueArgs {
     ) -> anyhow::Result<Self> {
         let (fake_id, version) = Self::parse_receiving_or_object_value(parser, "receiving")?;
         Ok(SuiExtraValueArgs::Receiving(fake_id, version))
+    }
+
+    fn parse_read_shared_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
+        parser: &mut MoveCLParser<'a, ValueToken, I>,
+    ) -> anyhow::Result<Self> {
+        let (fake_id, version) = Self::parse_receiving_or_object_value(parser, "readshared")?;
+        Ok(SuiExtraValueArgs::ReadShared(fake_id, version))
     }
 
     fn parse_digest_value<'a, I: Iterator<Item = (ValueToken, &'a str)>>(
@@ -287,6 +296,7 @@ impl SuiValue {
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
             SuiValue::Receiving(_, _) => panic!("unexpected nested Sui receiving object in args"),
+            SuiValue::ReadShared(_, _) => panic!("unexpected nested Sui shared object in args"),
         }
     }
 
@@ -297,6 +307,7 @@ impl SuiValue {
             SuiValue::ObjVec(_) => panic!("unexpected nested Sui object vector in args"),
             SuiValue::Digest(_) => panic!("unexpected nested Sui package digest in args"),
             SuiValue::Receiving(_, _) => panic!("unexpected nested Sui receiving object in args"),
+            SuiValue::ReadShared(_, _) => panic!("unexpected nested Sui shared object in args"),
         }
     }
 
@@ -330,6 +341,27 @@ impl SuiValue {
         Ok(ObjectArg::Receiving(obj.compute_object_reference()))
     }
 
+    fn read_shared_arg(
+        fake_id: FakeID,
+        version: Option<SequenceNumber>,
+        test_adapter: &SuiTestAdapter,
+    ) -> anyhow::Result<ObjectArg> {
+        let obj = Self::resolve_object(fake_id, version, test_adapter)?;
+        let id = obj.id();
+        if let Owner::Shared {
+            initial_shared_version,
+        } = obj.owner
+        {
+            Ok(ObjectArg::SharedObject {
+                id,
+                initial_shared_version,
+                mutable: false,
+            })
+        } else {
+            bail!("{fake_id} is not a shared object.")
+        }
+    }
+
     fn object_arg(
         fake_id: FakeID,
         version: Option<SequenceNumber>,
@@ -360,6 +392,9 @@ impl SuiValue {
             SuiValue::MoveValue(v) => CallArg::Pure(v.simple_serialize().unwrap()),
             SuiValue::Receiving(fake_id, version) => {
                 CallArg::Object(Self::receiving_arg(fake_id, version, test_adapter)?)
+            }
+            SuiValue::ReadShared(fake_id, version) => {
+                CallArg::Object(Self::read_shared_arg(fake_id, version, test_adapter)?)
             }
             SuiValue::ObjVec(_) => bail!("obj vec is not supported as an input"),
             SuiValue::Digest(pkg) => {
@@ -401,6 +436,7 @@ impl ParsableValue for SuiExtraValueArgs {
             (ValueToken::Ident, "object") => Some(Self::parse_object_value(parser)),
             (ValueToken::Ident, "digest") => Some(Self::parse_digest_value(parser)),
             (ValueToken::Ident, "receiving") => Some(Self::parse_receiving_value(parser)),
+            (ValueToken::Ident, "readshared") => Some(Self::parse_read_shared_value(parser)),
             _ => None,
         }
     }
@@ -435,6 +471,7 @@ impl ParsableValue for SuiExtraValueArgs {
             SuiExtraValueArgs::Object(id, version) => Ok(SuiValue::Object(id, version)),
             SuiExtraValueArgs::Digest(pkg) => Ok(SuiValue::Digest(pkg)),
             SuiExtraValueArgs::Receiving(id, version) => Ok(SuiValue::Receiving(id, version)),
+            SuiExtraValueArgs::ReadShared(id, version) => Ok(SuiValue::ReadShared(id, version)),
         }
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -937,6 +937,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     SuiValue::Digest(_) => bail!("digest is not supported as an input"),
                     SuiValue::ObjVec(_) => bail!("obj vec is not supported as an input"),
                     SuiValue::Receiving(_, _) => bail!("receiving is not supported as an input"),
+                    SuiValue::ReadShared(_, _) => {
+                        bail!("read-only shared object is not supported as an input")
+                    }
                 };
                 let value = NumericalAddress::new(value.into_bytes(), NumberFormat::Hex);
                 self.compiled_state

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -937,7 +937,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     SuiValue::Digest(_) => bail!("digest is not supported as an input"),
                     SuiValue::ObjVec(_) => bail!("obj vec is not supported as an input"),
                     SuiValue::Receiving(_, _) => bail!("receiving is not supported as an input"),
-                    SuiValue::ReadShared(_, _) => {
+                    SuiValue::ImmShared(_, _) => {
                         bail!("read-only shared object is not supported as an input")
                     }
                 };


### PR DESCRIPTION
## Description

Add the ability to specify a transction input that is a read-only shared object (So I can test what transaction effects look like when a transaction includes one of these).

## Test Plan

Tested in a follow-up PR that uses this in one of its tests.