### PR TITLE
Place market/limit order with metadata.

### DIFF
--- a/crates/sui-framework/packages/deepbook/sources/clob_v2.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob_v2.move
@@ -1112,6 +1112,31 @@ module deepbook::clob_v2 {
         clock: &Clock,
         ctx: &mut TxContext,
     ): (Coin<BaseAsset>, Coin<QuoteAsset>) {
+        place_market_order_int(
+            pool,
+            account_cap,
+            client_order_id,
+            quantity,
+            is_bid,
+            base_coin,
+            quote_coin,
+            clock,
+            ctx
+        )
+    }
+
+    /// Place a market order to the order book.
+    fun place_market_order_int<BaseAsset, QuoteAsset>(
+        pool: &mut Pool<BaseAsset, QuoteAsset>,
+        account_cap: &AccountCap,
+        client_order_id: u64,
+        quantity: u64,
+        is_bid: bool,
+        base_coin: Coin<BaseAsset>,
+        quote_coin: Coin<QuoteAsset>,
+        clock: &Clock,
+        ctx: &mut TxContext,
+    ): (Coin<BaseAsset>, Coin<QuoteAsset>) {
         // If market bid order, match against the open ask orders. Otherwise, match against the open bid orders.
         // Take market bid order for example.
         // We first retrieve the PriceLevel with the lowest price by calling min_leaf on the asks Critbit Tree.
@@ -1245,6 +1270,39 @@ module deepbook::clob_v2 {
     /// When the limit order is successfully placed, we return true to indicate that and also the corresponding order_id.
     /// So please check that boolean value first before using the order id.
     public fun place_limit_order<BaseAsset, QuoteAsset>(
+        pool: &mut Pool<BaseAsset, QuoteAsset>,
+        client_order_id: u64,
+        price: u64,
+        quantity: u64,
+        self_matching_prevention: u8,
+        is_bid: bool,
+        expire_timestamp: u64, // Expiration timestamp in ms in absolute value inclusive.
+        restriction: u8,
+        clock: &Clock,
+        account_cap: &AccountCap,
+        ctx: &mut TxContext
+    ): (u64, u64, bool, u64) {
+        place_limit_order_int(
+            pool,
+            client_order_id,
+            price,
+            quantity,
+            self_matching_prevention,
+            is_bid,
+            expire_timestamp, // Expiration timestamp in ms in absolute value inclusive.
+            restriction,
+            clock,
+            account_cap,
+            ctx
+        )
+    }
+
+    /// Place a limit order to the order book.
+    /// Returns (base quantity filled, quote quantity filled, whether a maker order is being placed, order id of the maker order).
+    /// When the limit order is not successfully placed, we return false to indicate that and also returns a meaningless order_id 0.
+    /// When the limit order is successfully placed, we return true to indicate that and also the corresponding order_id.
+    /// So please check that boolean value first before using the order id.
+    fun place_limit_order_int<BaseAsset, QuoteAsset>(
         pool: &mut Pool<BaseAsset, QuoteAsset>,
         client_order_id: u64,
         price: u64,

--- a/crates/sui-framework/packages/deepbook/sources/clob_v2.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob_v2.move
@@ -626,8 +626,6 @@ module deepbook::clob_v2 {
         clock: &Clock,
         ctx: &mut TxContext,
     ): (Coin<BaseAsset>, Coin<QuoteAsset>, u64, vector<MatchedOrderMetadata<BaseAsset, QuoteAsset>>) {
-        assert!(quantity > 0, EInvalidQuantity);
-        assert!(coin::value(&base_coin) >= quantity, EInsufficientBaseCoin);
         let original_val = coin::value(&quote_coin);
         let (ret_base_coin, ret_quote_coin, matched_order_metadata) = place_market_order_int(
             pool,
@@ -1438,6 +1436,11 @@ module deepbook::clob_v2 {
         (base_quantity_filled, quote_quantity_filled, is_success, order_id)
     }
 
+    /// Place a limit order to the order book.
+    /// Returns (base quantity filled, quote quantity filled, whether a maker order is being placed, order id of the maker order).
+    /// When the limit order is not successfully placed, we return false to indicate that and also returns a meaningless order_id 0.
+    /// When the limit order is successfully placed, we return true to indicate that and also the corresponding order_id.
+    /// So please check that boolean value first before using the order id.
     public fun place_limit_order_with_metadata<BaseAsset, QuoteAsset>(
         pool: &mut Pool<BaseAsset, QuoteAsset>,
         client_order_id: u64,
@@ -1467,11 +1470,6 @@ module deepbook::clob_v2 {
         (base_quantity_filled, quote_quantity_filled, is_success, order_id, meta_data)
     }
 
-    /// Place a limit order to the order book.
-    /// Returns (base quantity filled, quote quantity filled, whether a maker order is being placed, order id of the maker order).
-    /// When the limit order is not successfully placed, we return false to indicate that and also returns a meaningless order_id 0.
-    /// When the limit order is successfully placed, we return true to indicate that and also the corresponding order_id.
-    /// So please check that boolean value first before using the order id.
     fun place_limit_order_int<BaseAsset, QuoteAsset>(
         pool: &mut Pool<BaseAsset, QuoteAsset>,
         client_order_id: u64,
@@ -1502,9 +1500,7 @@ module deepbook::clob_v2 {
         let original_quantity = quantity;
         let base_quantity_filled;
         let quote_quantity_filled;
-        let meta_data: vector<MatchedOrderMetadata<BaseAsset, QuoteAsset>>;
-
-        if (is_bid) {
+        let meta_data = if (is_bid) {
             let quote_quantity_original = custodian::account_available_balance<QuoteAsset>(
                 &pool.quote_custodian,
                 owner
@@ -1525,7 +1521,6 @@ module deepbook::clob_v2 {
             );
             base_quantity_filled = balance::value(&base_balance_filled);
             quote_quantity_filled = quote_quantity_original - balance::value(&quote_balance_left);
-            meta_data = matched_order_metadata;
 
             custodian::increase_user_available_balance<BaseAsset>(
                 &mut pool.base_custodian,
@@ -1537,6 +1532,8 @@ module deepbook::clob_v2 {
                 owner,
                 quote_balance_left,
             );
+
+            matched_order_metadata
         } else {
             let base_balance = custodian::decrease_user_available_balance<BaseAsset>(
                 &mut pool.base_custodian,
@@ -1554,7 +1551,6 @@ module deepbook::clob_v2 {
 
             base_quantity_filled = quantity - balance::value(&base_balance_left);
             quote_quantity_filled = balance::value(&quote_balance_filled);
-            meta_data = matched_order_metadata;
 
             custodian::increase_user_available_balance<BaseAsset>(
                 &mut pool.base_custodian,
@@ -1566,6 +1562,7 @@ module deepbook::clob_v2 {
                 owner,
                 quote_balance_filled,
             );
+            matched_order_metadata
         };
 
         let order_id;

--- a/crates/sui-framework/packages/deepbook/tests/clob_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/clob_tests.move
@@ -149,6 +149,34 @@ module deepbook::clob_test {
         );
     }
 
+    #[test]
+    fun test_swap_exact_quote_for_base_with_metadata() {
+        test_swap_exact_quote_for_base_with_metadata_(
+            scenario()
+        );
+    }
+
+    #[test]
+    fun test_swap_exact_base_for_quote_with_metadata() {
+        test_swap_exact_base_for_quote_with_metadata_(
+            scenario()
+        );
+    }
+
+    #[test]
+    fun test_place_market_order_with_metadata() {
+        test_place_market_order_with_metadata_(
+            scenario()
+        );
+    }
+
+    #[test]
+    fun test_place_limit_order_with_metadata() {
+        test_place_limit_order_with_metadata_(
+            scenario()
+        );
+    }
+
     fun get_market_price_(test: Scenario): TransactionEffects {
         let (alice, bob) = people();
         let owner = @0xF;
@@ -5655,6 +5683,262 @@ module deepbook::clob_test {
             clob::check_balance_invariants_for_account(&account_cap, quote_custodian, base_custodian, &pool);
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    fun test_swap_exact_quote_for_base_with_metadata_(test: Scenario): TransactionEffects {
+        let (alice, bob) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
+            mint_account_cap_transfer(bob, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, bob);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let clock = test::take_shared<Clock>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, bob);
+            let (base_coin, quote_coin, _, of_events) = clob::swap_exact_quote_for_base_with_metadata(
+                &mut pool,
+                CLIENT_ID_BOB,
+                &account_cap,
+                5000,
+                &clock,
+                mint_for_testing<USD>(5000, ctx(&mut test)),
+                ctx(&mut test)
+            );
+
+            let of_event = vector::borrow(&of_events, 0);
+            let (_, _, is_bid, _, _, base_asset_quantity_filled, price, _ , _) = clob::matched_order_metadata_info(of_event);
+            assert!(is_bid == false, 0);
+            assert!(base_asset_quantity_filled == 500, 0);
+            assert!(price == 5 * FLOAT_SCALING, 0);
+
+            burn_for_testing(base_coin);
+            burn_for_testing(quote_coin);
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(bob, account_cap);
+        };
+        end(test)
+    }
+
+    fun test_swap_exact_base_for_quote_with_metadata_(test: Scenario): TransactionEffects {
+        let (alice, bob) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
+            mint_account_cap_transfer(bob, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, bob);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let clock = test::take_shared<Clock>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, bob);
+            let (base_coin, quote_coin, _, of_events) = clob::swap_exact_base_for_quote_with_metadata(
+                &mut pool,
+                CLIENT_ID_BOB,
+                &account_cap,
+                500,
+                mint_for_testing<SUI>(500, ctx(&mut test)),
+                mint_for_testing<USD>(0, ctx(&mut test)),
+                &clock,
+                ctx(&mut test)
+            );
+
+            let of_event = vector::borrow(&of_events, 0);
+            let (_, _, is_bid, _, _, base_asset_quantity_filled, price, _ , _) = clob::matched_order_metadata_info(of_event);
+            assert!(is_bid == true, 0);
+            assert!(base_asset_quantity_filled == 500, 0);
+            assert!(price == 5 * FLOAT_SCALING, 0);
+
+            burn_for_testing(base_coin);
+            burn_for_testing(quote_coin);
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(bob, account_cap);
+        };
+        end(test)
+    }
+
+    fun test_place_market_order_with_metadata_(test: Scenario): TransactionEffects {
+        let (alice, bob) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
+            mint_account_cap_transfer(bob, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, bob);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let clock = test::take_shared<Clock>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, bob);
+            let (base_coin, quote_coin, of_events) = clob::place_market_order_with_metadata(
+                &mut pool,
+                &account_cap,
+                CLIENT_ID_BOB,
+                500,
+                false,
+                mint_for_testing<SUI>(500, ctx(&mut test)),
+                mint_for_testing<USD>(0, ctx(&mut test)),
+                &clock,
+                ctx(&mut test)
+            );
+
+            let of_event = vector::borrow(&of_events, 0);
+            let (_, _, is_bid, _, _, base_asset_quantity_filled, price, _ , _) = clob::matched_order_metadata_info(of_event);
+            assert!(is_bid == true, 0);
+            assert!(base_asset_quantity_filled == 500, 0);
+            assert!(price == 5 * FLOAT_SCALING, 0);
+
+            burn_for_testing(base_coin);
+            burn_for_testing(quote_coin);
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(bob, account_cap);
+        };
+        end(test)
+    }
+
+    fun test_place_limit_order_with_metadata_(test: Scenario): TransactionEffects {
+        let (alice, bob) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
+            mint_account_cap_transfer(bob, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, bob);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&test);
+            let clock = test::take_shared<Clock>(&test);
+            let account_cap = test::take_from_address<AccountCap>(&test, bob);
+            let bob_deposit_WSUI: u64 = 10000;
+            let (base_custodian, _) = clob::borrow_mut_custodian(&mut pool);
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_owner(&account_cap), bob_deposit_WSUI);
+            let (_, _, _, _, of_events) = clob::place_limit_order_with_metadata(
+                &mut pool,
+                CLIENT_ID_BOB,
+                5 * FLOAT_SCALING,
+                500,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+
+            let of_event = vector::borrow(&of_events, 0);
+            let (_, _, is_bid, _, _, base_asset_quantity_filled, price, _ , _) = clob::matched_order_metadata_info(of_event);
+            assert!(is_bid == true, 0);
+            assert!(base_asset_quantity_filled == 500, 0);
+            assert!(price == 5 * FLOAT_SCALING, 0);
+
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(bob, account_cap);
         };
         end(test)
     }


### PR DESCRIPTION
## Description 
**Proposed change:** _Add new struct MatchedOrderMetadata<BaseAsset, QuoteAsset> & return from place order functions to provide on-chain info about orders being matched & parties involved in trade._

**Use cases this change can enable:**
1. Third party protocols, using deepbook as liquidity layer, can add custom asserts & policies on matched orders in same txn(revert if matched orders doesn't fullfill custom policies & checks). This approach provides a hook for protocols to add custom functions  over matched orders in their respective packages with no changes in deepbook. 
2. Deepbook currently doesn't support slippage/min_buy amount checks. Returning matched orders from place order can allow protocols like KriyaDEX to provide slippage control in Pro-trading. (revert PTB when matched order price > allowed slippage).
3. KriyaDEX is building a perp-dex using deepbook as matching engine(in audit). For all such margining protocols dealing with leverage, it's essential to have on-chain information about matched orders(parties involved, price & size) to deterministically settle trades with protocol's clearing house. 

**Scenario(for perp-dex use case):** 
1. Attacker configures 2 wallets (w1/w2) in BTC market.
2. w1 places 10x short order at a very low price (say $100/BTC).
3. w2 places 10x long order to match with w1 in the same PTB.
4. After order matching, w2 is instantly at a high profit(mark price being $35k for BTC) while w1 is in a huge loss & banckrupt.
5. w2 waits until there is some liquidity in deepbook & closes it's position with someone else while realising the profits & withdraws.
6. w1 is instantly bankrupt with a loss to insurance fund.
7. This induces bad debt to the system & margin protocol's insurance fund can be drained.

**How returning matched orders prevents this attack?**
Third party margin protocols can enforce checks on the matched orders price. If matched order price is deviated by say x%, txns can be reverted which will prevent order matching at highly deviated price(wrt mark_price) in low liquidity environments. This scenario is analogous to slippage in spot deepbook pools. 
 
**Changes & Upgradeability:** 
1. private funcs match_ask/match_bid now also returns vector<OrderFilled> - _back compatible_
2. added new public funcs with metadata - place_market_order_with_metadata, place_limit_order_with_metadata, swap_exact_base_for_quote_with_metadata, swap_exact_quote_for_base_with_metadata. - _back compatible_

## Test Plan 

How did you test the new or updated feature?
Added unit tests for all the changes. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
