### PR TITLE
[GraphQL/Query] Standalone type query

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -1,0 +1,177 @@
+processed 7 tasks
+
+task 1 'run-graphql'. lines 6-14:
+Response: {
+  "data": {
+    "type": {
+      "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::priority_queue::PriorityQueue<0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>>",
+      "signature": {
+        "struct": {
+          "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "module": "priority_queue",
+          "type": "PriorityQueue",
+          "type_parameters": [
+            {
+              "struct": {
+                "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "module": "coin",
+                "type": "Coin",
+                "type_parameters": [
+                  {
+                    "struct": {
+                      "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                      "module": "sui",
+                      "type": "SUI",
+                      "type_parameters": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "layout": {
+        "struct": [
+          {
+            "name": "entries",
+            "layout": {
+              "vector": {
+                "struct": [
+                  {
+                    "name": "priority",
+                    "layout": "u64"
+                  },
+                  {
+                    "name": "value",
+                    "layout": {
+                      "struct": [
+                        {
+                          "name": "id",
+                          "layout": {
+                            "struct": [
+                              {
+                                "name": "id",
+                                "layout": {
+                                  "struct": [
+                                    {
+                                      "name": "bytes",
+                                      "layout": "address"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "balance",
+                          "layout": {
+                            "struct": [
+                              {
+                                "name": "value",
+                                "layout": "u64"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 2 'run-graphql'. lines 16-24:
+Response: {
+  "data": {
+    "type": {
+      "repr": "u64",
+      "signature": "u64",
+      "layout": "u64"
+    }
+  }
+}
+
+task 3 'run-graphql'. lines 26-34:
+Response: {
+  "data": {
+    "type": {
+      "repr": "vector<u64>",
+      "signature": {
+        "vector": "u64"
+      },
+      "layout": {
+        "vector": "u64"
+      }
+    }
+  }
+}
+
+task 4 'run-graphql'. lines 36-44:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Bad type: unexpected token Name(\"not_a_type\"), expected type tag",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "type"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 5 'run-graphql'. lines 46-57:
+Response: {
+  "data": {
+    "type": {
+      "repr": "0x0000000000000000000000000000000000000000000000000000000000000042::not::Here",
+      "signature": {
+        "struct": {
+          "package": "0x0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "not",
+          "type": "Here",
+          "type_parameters": []
+        }
+      }
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 59-67:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Internal error occurred while processing request: Error calculating layout for 0x0000000000000000000000000000000000000000000000000000000000000042::not::Here: Package not found: 0000000000000000000000000000000000000000000000000000000000000042",
+      "locations": [
+        {
+          "line": 5,
+          "column": 9
+        }
+      ],
+      "path": [
+        "type",
+        "layout"
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
+}

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -153,7 +153,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 59-67:
+task 6 'run-graphql'. lines 59-74:
 Response: {
   "data": null,
   "errors": [
@@ -161,7 +161,7 @@ Response: {
       "message": "Internal error occurred while processing request: Error calculating layout for 0x0000000000000000000000000000000000000000000000000000000000000042::not::Here: Package not found: 0000000000000000000000000000000000000000000000000000000000000042",
       "locations": [
         {
-          "line": 5,
+          "line": 12,
           "column": 9
         }
       ],

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator
+
+//# run-graphql
+# Happy path -- valid type, get everything
+{
+    type(type: "0x2::priority_queue::PriorityQueue<0x2::coin::Coin<0x2::sui::SUI>>") {
+        repr
+        signature
+        layout
+    }
+}
+
+//# run-graphql
+# Happy path -- primitive type
+{
+    type(type: "u64") {
+        repr
+        signature
+        layout
+    }
+}
+
+//# run-graphql
+# Happy path -- primitive type with generic parameter
+{
+    type(type: "vector<u64>") {
+        repr
+        signature
+        layout
+    }
+}
+
+//# run-graphql
+# Unhappy path -- bad type tag (failed to parse)
+{
+    type(type: "not_a_type") {
+        repr
+        signature
+        layout
+    }
+}
+
+//# run-graphql
+
+# Semi-happy path -- the input looks like a type, but that type
+# doesn't exist. Depending on which fields you ask for, this request
+# may still succeed.
+
+{
+    type(type: "0x42::not::Here") {
+        repr
+        signature
+    }
+}
+
+//# run-graphql
+
+# Unhappy side of semi-happy path -- asking for a layout for a type
+# that doesn't exist won't work.
+#
+# TODO: This currently produces an INTERNAL_SERVER_ERROR, but should
+# produce a user error. This because, like other parts of our
+# codebase, we don't have enough differentiation in error types for
+# MoveType to signal an error in layout calculation and the GraphQL
+# field implementations to know that it is a user error or an internal
+# error.
+{
+    type(type: "0x42::not::Here") {
+        layout
+    }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1791,6 +1791,11 @@ type Query {
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
 	"""
+	Fetch a structured representation of a concrete type, including its layout information.
+	Fails if the type is malformed.
+	"""
+	type(type: String!): MoveType!
+	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
 	epoch(id: Int): Epoch

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -59,6 +59,7 @@ type Query {
   owner(address: SuiAddress!): Owner
   object(address: SuiAddress!, version: Int): Object
   address(address: SuiAddress!): Address
+  type(type: String!): MoveType!
 
   # Fetch epoch information by ID (defaults to the latest epoch).
   epoch(id: Int): Epoch

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use async_graphql::{connection::Connection, *};
 use sui_json_rpc::name_service::NameServiceConfig;
+use sui_types::TypeTag;
 
 use super::{
     address::Address,
@@ -12,6 +15,7 @@ use super::{
     coin_metadata::CoinMetadata,
     epoch::Epoch,
     event::{Event, EventFilter},
+    move_type::MoveType,
     object::{Object, ObjectFilter},
     owner::{ObjectOwner, Owner},
     protocol_config::ProtocolConfigs,
@@ -74,6 +78,16 @@ impl Query {
 
     async fn address(&self, address: SuiAddress) -> Option<Address> {
         Some(Address { address })
+    }
+
+    /// Fetch a structured representation of a concrete type, including its layout information.
+    /// Fails if the type is malformed.
+    async fn type_(&self, type_: String) -> Result<MoveType> {
+        Ok(MoveType::new(
+            TypeTag::from_str(&type_)
+                .map_err(|e| Error::Client(format!("Bad type: {e}")))
+                .extend()?,
+        ))
     }
 
     /// Fetch epoch information by ID (defaults to the latest epoch).

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1795,6 +1795,11 @@ type Query {
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
 	"""
+	Fetch a structured representation of a concrete type, including its layout information.
+	Fails if the type is malformed.
+	"""
+	type(type: String!): MoveType!
+	"""
 	Fetch epoch information by ID (defaults to the latest epoch).
 	"""
 	epoch(id: Int): Epoch


### PR DESCRIPTION
## Description

Makes it possible to get layout information for a type without it being associated to an existing object, as requested by @hayes-mysten.

Note that currently this implementation will report an internal error if you try and fetch the layout of a type that doesn't exist. This should really be a user error (bad user input), for supplying a type that doesn't exist.

This will be fixed in a follow-up when we overhaul the error story for GraphQL (Similar fixes are also required for the database and execution layers as well).

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- types.move
```