### PR TITLE
Hardcode intent for transaction messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12590,6 +12590,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml 0.8.26",
+ "shared-crypto",
  "shellexpand",
  "similar",
  "sui-config",

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -45,8 +45,6 @@ pub use self::store::in_mem_store::InMemoryStore;
 use self::store::in_mem_store::KeyStore;
 pub use self::store::SimulatorStore;
 use sui_types::mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider};
-
-use shared_crypto::intent::Intent;
 use sui_types::{
     gas_coin::GasCoin,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -358,11 +356,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let kind = sui_types::transaction::TransactionKind::ProgrammableTransaction(pt);
         let tx_data =
             sui_types::transaction::TransactionData::new_with_gas_data(kind, *sender, gas_data);
-        let tx = Transaction::from_data_and_signer(
-            tx_data,
-            shared_crypto::intent::Intent::sui_transaction(),
-            vec![key],
-        );
+        let tx = Transaction::from_data_and_signer(tx_data, vec![key]);
 
         self.execute_transaction(tx).map(|x| x.0)
     }
@@ -441,7 +435,7 @@ impl Simulacrum {
             budget: 1_000_000_000,
         };
         let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data);
-        let tx = Transaction::from_data_and_signer(tx_data, Intent::sui_transaction(), vec![key]);
+        let tx = Transaction::from_data_and_signer(tx_data, vec![key]);
         (tx, transfer_amount)
     }
 }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -21,7 +21,6 @@ use sui_types::object::Owner;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
-use shared_crypto::intent::Intent;
 use sui_sdk::SuiClient;
 use sui_types::gas_coin::GasCoin;
 use sui_types::{
@@ -153,7 +152,7 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver_api()
             .execute_transaction_block(
-                Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature]),
+                Transaction::from_data(txn_data, vec![signature]),
                 SuiTransactionBlockResponseOptions::new()
                     .with_object_changes()
                     .with_balance_changes()

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -433,7 +433,6 @@ pub fn make_dummy_tx(
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * 10,
             10,
         ),
-        Intent::sui_transaction(),
         vec![sender_sec],
     )
 }

--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -56,7 +56,7 @@ async fn _split_coins_equally(
         .keystore
         .sign_secure(&active_address, &tx_data, Intent::sui_transaction())
         .unwrap();
-    let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
+    let tx = Transaction::from_data(tx_data, vec![signature]);
     let resp = client
         .quorum_driver_api()
         .execute_transaction_block(
@@ -110,7 +110,7 @@ async fn _merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), a
             .keystore
             .sign_secure(&active_address, &tx_data, Intent::sui_transaction())
             .unwrap();
-        let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
+        let tx = Transaction::from_data(tx_data, vec![signature]);
         client
             .quorum_driver_api()
             .execute_transaction_block(

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -420,7 +420,7 @@ impl SimpleFaucet {
             .keystore
             .sign_secure(&self.active_address, &tx_data, Intent::sui_transaction())
             .map_err(FaucetError::internal)?;
-        let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
+        let tx = Transaction::from_data(tx_data, vec![signature]);
         let tx_digest = *tx.digest();
         info!(
             ?tx_digest,

--- a/crates/sui-graphql-rpc/src/mutation.rs
+++ b/crates/sui-graphql-rpc/src/mutation.rs
@@ -5,7 +5,6 @@ use crate::{error::Error, types::execution_result::ExecutionResult};
 use async_graphql::*;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::{encoding::Base64, traits::ToFromBytes};
-use shared_crypto::intent::Intent;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_sdk::SuiClient;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
@@ -71,8 +70,7 @@ impl Mutation {
                 .extend()?,
             );
         }
-        let transaction =
-            Transaction::from_generic_sig_data(tx_data, Intent::sui_transaction(), sigs);
+        let transaction = Transaction::from_generic_sig_data(tx_data, sigs);
 
         let result = sui_sdk_client
             .quorum_driver_api()

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -104,7 +104,7 @@ impl TransactionExecutionApi {
         for sig in signatures {
             sigs.push(GenericSignature::from_bytes(&sig.to_vec()?)?);
         }
-        let txn = Transaction::from_generic_sig_data(tx_data, Intent::sui_transaction(), sigs);
+        let txn = Transaction::from_generic_sig_data(tx_data, sigs);
         let raw_transaction = if opts.show_raw_input {
             bcs::to_bytes(txn.data())?
         } else {

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -34,6 +34,7 @@ move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 tokio.workspace = true
 
+shared-crypto.workspace = true
 sui-config.workspace = true
 sui-core.workspace = true
 sui-execution.workspace = true

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -19,6 +19,7 @@ use move_core_types::{
 };
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
+use shared_crypto::intent::Intent;
 use similar::{ChangeTag, TextDiff};
 use std::{
     collections::{BTreeMap, HashSet},
@@ -828,12 +829,14 @@ impl LocalExec {
         let required_objects = pre_run_sandbox.required_objects.clone();
         let shared_object_refs = pre_run_sandbox.transaction_info.shared_object_refs.clone();
 
-        let transaction_intent = pre_run_sandbox
-            .transaction_info
-            .sender_signed_data
-            .intent_message()
-            .intent
-            .clone();
+        assert_eq!(
+            pre_run_sandbox
+                .transaction_info
+                .sender_signed_data
+                .intent_message()
+                .intent,
+            Intent::sui_transaction()
+        );
         let transaction_signatures = pre_run_sandbox
             .transaction_info
             .sender_signed_data
@@ -859,11 +862,8 @@ impl LocalExec {
         )
         .await;
 
-        let sender_signed_tx = Transaction::from_generic_sig_data(
-            transaction_data,
-            transaction_intent,
-            transaction_signatures,
-        );
+        let sender_signed_tx =
+            Transaction::from_generic_sig_data(transaction_data, transaction_signatures);
         let sender_signed_tx = VerifiedTransaction::new_unchecked(
             VerifiedTransaction::new_unchecked(sender_signed_tx).into(),
         );

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -107,7 +107,6 @@ pub async fn combine(
 
     let signed_tx = Transaction::from_generic_sig_data(
         intent_msg.value,
-        Intent::sui_transaction(),
         vec![GenericSignature::from_bytes(
             &[&*flag, &*sig_bytes, &*pub_key].concat(),
         )?],

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -716,7 +716,7 @@ async fn test_transaction(
     let response = client
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(data.clone(), Intent::sui_transaction(), vec![signature]),
+            Transaction::from_data(data.clone(), vec![signature]),
             SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -778,7 +778,7 @@ pub(crate) async fn sign_and_execute(
     let transaction_response = match client
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(txn_data, Intent::sui_transaction(), vec![signature]),
+            Transaction::from_data(txn_data, vec![signature]),
             SuiTransactionBlockResponseOptions::new().with_effects(),
             Some(request_type),
         )

--- a/crates/sui-sdk/examples/programmable_transactions_api.rs
+++ b/crates/sui-sdk/examples/programmable_transactions_api.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let transaction_response = sui
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]),
+            Transaction::from_data(tx_data, vec![signature]),
             SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/sui-sdk/examples/sign_tx_guide.rs
+++ b/crates/sui-sdk/examples/sign_tx_guide.rs
@@ -140,7 +140,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             sui_types::transaction::Transaction::from_generic_sig_data(
                 intent_msg.value,
-                Intent::sui_transaction(),
                 vec![GenericSignature::Signature(sui_sig)],
             ),
             SuiTransactionBlockResponseOptions::default(),

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -103,11 +103,7 @@ impl TicTacToe {
             .client
             .quorum_driver_api()
             .execute_transaction_block(
-                Transaction::from_data(
-                    create_game_call,
-                    Intent::sui_transaction(),
-                    vec![signature],
-                ),
+                Transaction::from_data(create_game_call, vec![signature]),
                 SuiTransactionBlockResponseOptions::full_content(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
@@ -207,11 +203,7 @@ impl TicTacToe {
                 .client
                 .quorum_driver_api()
                 .execute_transaction_block(
-                    Transaction::from_data(
-                        place_mark_call,
-                        Intent::sui_transaction(),
-                        vec![signature],
-                    ),
+                    Transaction::from_data(place_mark_call, vec![signature]),
                     SuiTransactionBlockResponseOptions::new().with_effects(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -48,7 +48,7 @@ pub const SUI_FAUCET: &str = "https://faucet.testnet.sui.io/v1/gas"; // testnet 
 ///
 /// By default, this function will set up a wallet locally if there isn't any, or reuse the
 /// existing one and its active address. This function should be used when two addresses are needed,
-/// e.g., transfering objects from one address to another.
+/// e.g., transferring objects from one address to another.
 pub async fn setup_for_write() -> Result<(SuiClient, SuiAddress, SuiAddress), anyhow::Error> {
     let (client, active_address) = setup_for_read().await?;
     // make sure we have some SUI (5_000_000 MIST) on this address
@@ -130,7 +130,7 @@ pub async fn request_tokens_from_faucet(
 
     let mut coin_id = "".to_string();
 
-    // wait for the faucet to finsh the batch of token requests
+    // wait for the faucet to finish the batch of token requests
     loop {
         let resp = client
             .get("https://faucet.testnet.sui.io/v1/status")
@@ -222,7 +222,7 @@ pub async fn split_coin_digest(
     // get the reference gas price from the network
     let gas_price = sui.read_api().get_reference_gas_price().await?;
 
-    // now we programatically build the transaction through several commands
+    // now we programmatically build the transaction through several commands
     let mut ptb = ProgrammableTransactionBuilder::new();
     // first, we want to split the coin, and we specify how much SUI (in MIST) we want
     // for the new coin
@@ -259,7 +259,7 @@ pub async fn split_coin_digest(
     let transaction_response = sui
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]),
+            Transaction::from_data(tx_data, vec![signature]),
             SuiTransactionBlockResponseOptions::new(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -286,7 +286,7 @@ impl WalletContext {
             .sign_secure(&data.sender(), data, Intent::sui_transaction())
             .unwrap();
         // TODO: To support sponsored transaction, we should also look at the gas owner.
-        Transaction::from_data(data.clone(), Intent::sui_transaction(), vec![sig])
+        Transaction::from_data(data.clone(), vec![sig])
     }
 
     /// Execute a transaction and wait for it to be locally executed on the fullnode.

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -324,7 +324,7 @@ impl TestTransactionBuilder {
     }
 
     pub fn build_and_sign(self, signer: &dyn Signer<Signature>) -> Transaction {
-        Transaction::from_data_and_signer(self.build(), Intent::sui_transaction(), vec![signer])
+        Transaction::from_data_and_signer(self.build(), vec![signer])
     }
 
     pub fn build_and_sign_multisig(
@@ -333,8 +333,7 @@ impl TestTransactionBuilder {
         signers: &[&dyn Signer<Signature>],
     ) -> Transaction {
         let data = self.build();
-        let intent = Intent::sui_transaction();
-        let intent_msg = IntentMessage::new(intent.clone(), data.clone());
+        let intent_msg = IntentMessage::new(Intent::sui_transaction(), data.clone());
 
         let mut signatures = Vec::with_capacity(signers.len());
         for signer in signers {
@@ -344,7 +343,7 @@ impl TestTransactionBuilder {
         let multisig =
             GenericSignature::MultiSig(MultiSig::combine(signatures, multisig_pk).unwrap());
 
-        Transaction::from_generic_sig_data(data, intent, vec![multisig])
+        Transaction::from_generic_sig_data(data, vec![multisig])
     }
 
     pub fn build_and_sign_multisig_legacy(
@@ -365,7 +364,7 @@ impl TestTransactionBuilder {
             MultiSigLegacy::combine(signatures, multisig_pk).unwrap(),
         );
 
-        Transaction::from_generic_sig_data(data, intent, vec![multisig])
+        Transaction::from_generic_sig_data(data, vec![multisig])
     }
 }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -30,7 +30,7 @@ use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use shared_crypto::intent::{Intent, IntentScope};
+use shared_crypto::intent::IntentScope;
 use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -571,7 +571,6 @@ impl FullCheckpointContents {
                 100000000000,
                 100,
             ),
-            Intent::sui_transaction(),
             vec![&key],
         );
         let effects = TransactionEffects::new_with_tx(&transaction);
@@ -801,8 +800,8 @@ mod tests {
 
     // Tests that ConsensusCommitPrologue with different consensus commit digest will result in different checkpoint content.
     #[test]
-    fn test_checkpoing_summary_with_different_consensus_digest() {
-        // First, tests that same consensus commit digest will procude the same checkpoint content.
+    fn test_checkpoint_summary_with_different_consensus_digest() {
+        // First, tests that same consensus commit digest will produce the same checkpoint content.
         {
             let t1 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,
@@ -821,7 +820,7 @@ mod tests {
             assert_eq!(c1.digest(), c2.digest());
         }
 
-        // Next, tests that different consensus commit digests will procude the different checkpoint contents.
+        // Next, tests that different consensus commit digests will produce the different checkpoint contents.
         {
             let t1 = VerifiedTransaction::new_consensus_commit_prologue_v2(
                 1,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2327,24 +2327,20 @@ impl<S> Envelope<SenderSignedData, S> {
 impl Transaction {
     pub fn from_data_and_signer(
         data: TransactionData,
-        intent: Intent,
         signers: Vec<&dyn Signer<Signature>>,
     ) -> Self {
-        let intent_msg = IntentMessage::new(intent.clone(), data.clone());
+        // TODO: Avoid clone of data. This can be done by adjusting the API around tx construction.
+        let intent_msg = IntentMessage::new(Intent::sui_transaction(), data.clone());
         let mut signatures = Vec::with_capacity(signers.len());
         for signer in signers {
             signatures.push(Signature::new_secure(&intent_msg, signer));
         }
-        Self::from_data(data, intent, signatures)
+        Self::from_data(data, signatures)
     }
 
     // TODO: Rename this function and above to make it clearer.
-    pub fn from_data(data: TransactionData, intent: Intent, signatures: Vec<Signature>) -> Self {
-        Self::from_generic_sig_data(
-            data,
-            intent,
-            signatures.into_iter().map(|s| s.into()).collect(),
-        )
+    pub fn from_data(data: TransactionData, signatures: Vec<Signature>) -> Self {
+        Self::from_generic_sig_data(data, signatures.into_iter().map(|s| s.into()).collect())
     }
 
     pub fn signature_from_signer(
@@ -2356,12 +2352,12 @@ impl Transaction {
         Signature::new_secure(&intent_msg, signer)
     }
 
-    pub fn from_generic_sig_data(
-        data: TransactionData,
-        intent: Intent,
-        signatures: Vec<GenericSignature>,
-    ) -> Self {
-        Self::new(SenderSignedData::new(data, intent, signatures))
+    pub fn from_generic_sig_data(data: TransactionData, signatures: Vec<GenericSignature>) -> Self {
+        Self::new(SenderSignedData::new(
+            data,
+            Intent::sui_transaction(),
+            signatures,
+        ))
     }
 
     /// Returns the Base64 encoded tx_bytes

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -78,7 +78,7 @@ fn test_authority_signature_intent() {
         &IntentMessage::new(Intent::sui_transaction(), data.clone()),
         &sender_key,
     );
-    let tx = Transaction::from_data(data, Intent::sui_transaction(), vec![signature]);
+    let tx = Transaction::from_data(data, vec![signature]);
     let tx1 = tx.clone();
     assert!(tx.verify(&Default::default()).is_ok());
 

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -109,9 +109,9 @@ pub fn make_transaction_data(sender: SuiAddress) -> TransactionData {
 
 /// Make a user signed transaction with the given sender and its keypair. This
 /// is not verified or signed by authority.
-pub fn make_transaction(sender: SuiAddress, kp: &SuiKeyPair, intent: Intent) -> Transaction {
+pub fn make_transaction(sender: SuiAddress, kp: &SuiKeyPair) -> Transaction {
     let data = make_transaction_data(sender);
-    Transaction::from_data_and_signer(data, intent, vec![kp])
+    Transaction::from_data_and_signer(data, vec![kp])
 }
 
 // This is used to sign transaction with signer using default Intent.
@@ -126,7 +126,7 @@ pub fn to_sender_signed_transaction_with_multi_signers(
     data: TransactionData,
     signers: Vec<&dyn Signer<Signature>>,
 ) -> Transaction {
-    Transaction::from_data_and_signer(data, Intent::sui_transaction(), signers)
+    Transaction::from_data_and_signer(data, signers)
 }
 
 pub fn mock_certified_checkpoint<'a>(
@@ -248,11 +248,7 @@ mod zk_login {
         proof: ZkLoginInputs,
         data: TransactionData,
     ) -> (SuiAddress, Transaction, GenericSignature) {
-        let tx = Transaction::from_data_and_signer(
-            data.clone(),
-            Intent::sui_transaction(),
-            vec![user_key],
-        );
+        let tx = Transaction::from_data_and_signer(data.clone(), vec![user_key]);
 
         let s = match tx.inner().tx_signatures.first().unwrap() {
             GenericSignature::Signature(s) => s,
@@ -300,7 +296,7 @@ mod zk_login {
         )
         .unwrap();
         let addr = SuiAddress::from(&multisig_pk);
-        let tx = make_transaction(addr, &keys[0], Intent::sui_transaction());
+        let tx = make_transaction(addr, &keys[0]);
 
         let msg = IntentMessage::new(Intent::sui_transaction(), tx.transaction_data().clone());
         let sig1 = Signature::new_secure(&msg, &keys[0]).into();

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1281,8 +1281,7 @@ impl SuiClientCommands {
                         .map_err(|e| anyhow!(e))?,
                     );
                 }
-                let transaction =
-                    Transaction::from_generic_sig_data(data, Intent::sui_transaction(), sigs);
+                let transaction = Transaction::from_generic_sig_data(data, sigs);
 
                 let response = context.execute_transaction_may_fail(transaction).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -16,7 +16,6 @@ use clap::*;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::traits::{KeyPair, ToFromBytes};
 use move_core_types::ident_str;
-use shared_crypto::intent::Intent;
 use std::path::{Path, PathBuf};
 use sui_config::node::{AuthorityKeyPairWithPath, KeyPairWithPath};
 use sui_config::{local_ip_utils, Config, NodeConfig, PersistedConfig};
@@ -337,8 +336,7 @@ async fn execute_tx(
     tx_data: TransactionData,
     action: &str,
 ) -> anyhow::Result<()> {
-    let tx =
-        Transaction::from_data_and_signer(tx_data, Intent::sui_transaction(), vec![account_key]);
+    let tx = Transaction::from_data_and_signer(tx_data, vec![account_key]);
     info!("Executing {:?}", tx.digest());
     let tx_digest = *tx.digest();
     let resp = sui_client

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -55,7 +55,7 @@ async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
         &IntentMessage::new(Intent::sui_transaction(), deserialized_data),
         keypair,
     );
-    let txn = Transaction::from_data(data, Intent::sui_transaction(), vec![signature]);
+    let txn = Transaction::from_data(data, vec![signature]);
     context.execute_transaction_must_succeed(txn).await;
     let (_, summary) = get_validator_summary(&sui_client, validator_address)
         .await?

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -637,7 +637,7 @@ async fn call_0x5(
             .config
             .keystore
             .sign_secure(&sender, &tx_data, Intent::sui_transaction())?;
-    let transaction = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature]);
+    let transaction = Transaction::from_data(tx_data, vec![signature]);
     let sui_client = context.get_client().await?;
     sui_client
         .quorum_driver_api()

--- a/crates/sui/src/zklogin_commands_util.rs
+++ b/crates/sui/src/zklogin_commands_util.rs
@@ -183,7 +183,7 @@ pub async fn perform_zk_login_test_tx(
     let transaction_response = sui
         .quorum_driver_api()
         .execute_transaction_block(
-            Transaction::from_generic_sig_data(txb_res, Intent::sui_transaction(), vec![multisig]),
+            Transaction::from_generic_sig_data(txb_res, vec![multisig]),
             SuiTransactionBlockResponseOptions::full_content(),
             None,
         )


### PR DESCRIPTION
## Description 

All transaction messages should have the same intent, which can be hard coded instead of always passing in, which adds possibility for introducing errors and bugs.

## Test Plan 

CI. All changes are trivial and straightforward.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
