### PR TITLE
[move-ide] Fixed doc comment treatment in symbolicator

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2177,6 +2177,7 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
         col,
         request.id.clone(),
         |u| {
+            // use rust for highlighting in Markdown until there is support for Move
             let contents = HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
                 value: if let Some(s) = &u.doc_string {

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -61,8 +61,8 @@ use im::ordmap::OrdMap;
 use lsp_server::{Request, RequestId};
 use lsp_types::{
     request::GotoTypeDefinitionParams, Diagnostic, DocumentSymbol, DocumentSymbolParams,
-    GotoDefinitionParams, Hover, HoverContents, HoverParams, LanguageString, Location,
-    MarkedString, Position, Range, ReferenceParams, SymbolKind,
+    GotoDefinitionParams, Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind,
+    Position, Range, ReferenceParams, SymbolKind,
 };
 
 use std::{
@@ -2177,15 +2177,14 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
         col,
         request.id.clone(),
         |u| {
-            let lang_string = LanguageString {
-                language: "".to_string(),
+            let contents = HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
                 value: if let Some(s) = &u.doc_string {
-                    format!("{}\n\n{}", u.use_type, s)
+                    format!("```rust\n{}\n```\n{}", u.use_type, s)
                 } else {
-                    format!("{}", u.use_type)
+                    format!("```rust\n{}\n```", u.use_type)
                 },
-            };
-            let contents = HoverContents::Scalar(MarkedString::LanguageString(lang_string));
+            });
             let range = None;
             Some(serde_json::to_value(Hover { contents, range }).unwrap())
         },

--- a/external-crates/move/crates/move-analyzer/tests/symbols/sources/M6.move
+++ b/external-crates/move/crates/move-analyzer/tests/symbols/sources/M6.move
@@ -39,4 +39,10 @@ module Symbols::M6 {
     fun other_doc_struct_import(): OtherDocStruct {
         M7::create_other_struct(7)
     }
+
+    /// A documented function with type params.
+    fun type_param_doc<T: copy + drop>(param: T): T {
+        param
+    }
+
 }


### PR DESCRIPTION
## Description 

This PR fixes a problem with doc comments being incorrectly extracted for display in "type-on-hover" IDE feature. We were trying to add doc comments for identifiers that should never have them. It's more in sync with how rust-analyzer is extracting and displaying them.

## Test Plan 

Tests have been modified to reflect this and new tests have been added.