### PR TITLE
Don't end epoch until all deferred tx have been sequenced

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -13,7 +13,6 @@ use parking_lot::RwLock;
 use parking_lot::{Mutex, RwLockReadGuard, RwLockWriteGuard};
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::iter;
@@ -98,7 +97,6 @@ use typed_store_derive::DBMapUtils;
 // TODO: Make a single table (e.g., called `variables`) storing all our lonely variables in one place.
 const LAST_CONSENSUS_STATS_ADDR: u64 = 0;
 const RECONFIG_STATE_INDEX: u64 = 0;
-const FINAL_EPOCH_CHECKPOINT_INDEX: u64 = 0;
 const OVERRIDE_PROTOCOL_UPGRADE_BUFFER_STAKE_INDEX: u64 = 0;
 pub const EPOCH_DB_PREFIX: &str = "epoch_";
 
@@ -364,10 +362,8 @@ pub struct AuthorityEpochTables {
     /// Validators that have sent EndOfPublish message in this epoch
     end_of_publish: DBMap<AuthorityName, ()>,
 
-    // todo - if we move processing of entire nw commit into single DB batch,
-    // we can potentially get rid of this table
-    /// Records narwhal consensus output index of the final checkpoint in epoch
-    /// This is a single entry table with key FINAL_EPOCH_CHECKPOINT_INDEX
+    // TODO: Unused. Remove when removal of DBMap tables is supported.
+    #[allow(dead_code)]
     final_epoch_checkpoint: DBMap<u64, u64>,
 
     /// This table has information for the checkpoints for which we constructed all the data
@@ -1931,13 +1927,6 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn final_epoch_checkpoint(&self) -> SuiResult<Option<u64>> {
-        Ok(self
-            .tables()?
-            .final_epoch_checkpoint
-            .get(&FINAL_EPOCH_CHECKPOINT_INDEX)?)
-    }
-
     pub fn get_reconfig_state_read_lock_guard(&self) -> RwLockReadGuard<ReconfigState> {
         self.reconfig_state_mem.read()
     }
@@ -2202,7 +2191,7 @@ impl AuthorityPerEpochStore {
             .chain(sequenced_transactions)
             .collect();
 
-        let (transactions_to_schedule, notifications, lock_and_final_round) = self
+        let (transactions_to_schedule, notifications, lock, final_round) = self
             .process_consensus_transactions(
                 &mut batch,
                 &consensus_transactions,
@@ -2216,45 +2205,38 @@ impl AuthorityPerEpochStore {
             .await?;
         self.record_consensus_commit_stats(&mut batch, consensus_stats)?;
 
-        // The last block in this function notifies about new checkpoint if needed
-        // It's important that we use as_ref() here to make sure we are not dropping the lock.
-        // The lock needs to be held until the end of this function.
-        let final_checkpoint_round = lock_and_final_round.as_ref().map(|(_, r)| *r);
-        let final_checkpoint = match final_checkpoint_round.map(|r| r.cmp(&commit_round)) {
-            Some(Ordering::Less) => {
-                debug!(
-                    "Not forming checkpoint for round {} above final checkpoint round {:?}",
-                    commit_round, final_checkpoint_round
-                );
-                return Ok(vec![]);
-            }
-            Some(Ordering::Equal) => true,
-            Some(Ordering::Greater) => false,
-            None => false,
+        // Create a pending checkpoint if we are still accepting tx.
+        let should_accept_tx = if let Some(lock) = &lock {
+            lock.should_accept_tx()
+        } else {
+            self.get_reconfig_state_read_lock_guard().should_accept_tx()
         };
-        let pending_checkpoint = PendingCheckpoint {
-            roots: roots.into_iter().collect(),
-            details: PendingCheckpointInfo {
-                timestamp_ms: commit_timestamp,
-                last_of_epoch: final_checkpoint,
-                commit_height: commit_round,
-            },
-        };
+        let make_checkpoint = should_accept_tx || final_round;
+        if make_checkpoint {
+            let pending_checkpoint = PendingCheckpoint {
+                roots: roots.into_iter().collect(),
+                details: PendingCheckpointInfo {
+                    timestamp_ms: commit_timestamp,
+                    last_of_epoch: final_round,
+                    commit_height: commit_round,
+                },
+            };
 
-        self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
+            self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
+            checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
+        }
 
         batch.write()?;
 
         self.process_notifications(&notifications, &end_of_publish_transactions);
 
-        checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
-
-        if final_checkpoint {
+        if final_round {
             info!(
                 epoch=?self.epoch(),
-                // Accessing lock_and_final_round on purpose so that the compiler ensures
+                // Accessing lock on purpose so that the compiler ensures
                 // the lock is not yet dropped.
-                last_checkpoint_round=?lock_and_final_round.as_ref().map(|(_, r)| *r),
+                lock=?lock.as_ref(),
+                final_round=?final_round,
                 "Received 2f+1 EndOfPublish messages, notifying last checkpoint"
             );
             self.record_end_of_message_quorum_time_metric();
@@ -2332,7 +2314,8 @@ impl AuthorityPerEpochStore {
     ) -> SuiResult<(
         Vec<VerifiedExecutableTransaction>,
         Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
-        Option<(RwLockWriteGuard<ReconfigState>, u64)>,
+        Option<parking_lot::RwLockWriteGuard<ReconfigState>>,
+        bool, // final round
     )> {
         let mut verified_certificates = Vec::with_capacity(transactions.len());
         let mut notifications = Vec::with_capacity(transactions.len());
@@ -2413,27 +2396,21 @@ impl AuthorityPerEpochStore {
             shared_input_next_versions.into_iter(),
         )?;
 
-        let lock_and_final_round =
-            self.process_end_of_publish_transactions(batch, end_of_publish_transactions)?;
+        let lock = self.process_end_of_publish_transactions(batch, end_of_publish_transactions)?;
+        let (lock, final_round) = self.process_end_of_all_transactions(batch, lock)?;
 
-        Ok((verified_certificates, notifications, lock_and_final_round))
+        Ok((verified_certificates, notifications, lock, final_round))
     }
 
     fn process_end_of_publish_transactions(
         &self,
         write_batch: &mut DBBatch,
         transactions: &[VerifiedSequencedConsensusTransaction],
-    ) -> SuiResult<
-        Option<(
-            RwLockWriteGuard<ReconfigState>,
-            u64, /* final checkpoint round */
-        )>,
-    > {
+    ) -> SuiResult<Option<parking_lot::RwLockWriteGuard<ReconfigState>>> {
         let mut ret = None;
 
         for transaction in transactions {
             let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
-                consensus_index,
                 transaction,
                 ..
             }) = transaction;
@@ -2471,30 +2448,55 @@ impl AuthorityPerEpochStore {
                     );
                     let mut lock = self.get_reconfig_state_write_lock_guard();
                     lock.close_all_certs();
-                    // We store reconfig_state and end_of_publish in same batch to avoid dealing with inconsistency here on restart
                     self.store_reconfig_state_batch(&lock, write_batch)?;
-                    write_batch.insert_batch(
-                        &self.tables()?.final_epoch_checkpoint,
-                        [(
-                            &FINAL_EPOCH_CHECKPOINT_INDEX,
-                            &consensus_index.last_committed_round,
-                        )],
-                    )?;
                     // Holding this lock until end of process_consensus_transactions_and_commit_boundary() where we write batch to DB
-                    ret = Some((lock, consensus_index.last_committed_round));
+                    ret = Some(lock);
                 };
-                // Important: we actually rely here on fact that ConsensusHandler panics if it's
+                // Important: we actually rely here on fact that ConsensusHandler panics if its
                 // operation returns error. If some day we won't panic in ConsensusHandler on error
                 // we need to figure out here how to revert in-memory state of .end_of_publish
                 // and .reconfig_state when write fails.
                 self.record_consensus_message_processed(write_batch, transaction.key())?;
             } else {
                 panic!(
-                    "process_end_of_publish_transaction called with non-end-of-publish transaction"
+                    "process_end_of_publish_transactions called with non-end-of-publish transaction"
                 );
             }
         }
         Ok(ret)
+    }
+
+    fn process_end_of_all_transactions<'a>(
+        &'a self,
+        write_batch: &mut DBBatch,
+        lock: Option<parking_lot::RwLockWriteGuard<'a, ReconfigState>>,
+    ) -> SuiResult<(
+        Option<parking_lot::RwLockWriteGuard<'a, ReconfigState>>,
+        bool,
+    )> {
+        let is_reject_all_certs = if let Some(lock) = &lock {
+            lock.is_reject_all_certs()
+        } else {
+            // It is ok to just release lock here as this function is the only place that
+            // transitions into RejectAllTx state, and this function itself is always
+            // executed from consensus task.
+            self.get_reconfig_state_read_lock_guard()
+                .is_reject_all_certs()
+        };
+
+        if !is_reject_all_certs || !self.deferred_transactions_empty() {
+            // Don't end epoch until all deferred transactions are processed.
+            return Ok((lock, false));
+        }
+
+        let mut lock = if let Some(lock) = lock {
+            lock
+        } else {
+            self.get_reconfig_state_write_lock_guard()
+        };
+        lock.close_all_tx();
+        self.store_reconfig_state_batch(&lock, write_batch)?;
+        Ok((Some(lock), true))
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -2553,6 +2555,7 @@ impl AuthorityPerEpochStore {
                 if !self
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()
+                    && !previously_deferred_tx_digests.contains(certificate.digest())
                 {
                     debug!("Ignoring consensus certificate for transaction {:?} because of end of epoch",
                     certificate.digest());
@@ -2656,10 +2659,7 @@ impl AuthorityPerEpochStore {
                 panic!("process_consensus_transaction called with external RandomnessStateUpdate");
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
-                if !self
-                    .get_reconfig_state_read_lock_guard()
-                    .should_accept_consensus_certs()
-                {
+                if !self.get_reconfig_state_read_lock_guard().should_accept_tx() {
                     debug!(
                         "Ignoring system transaction {:?} because of end of epoch",
                         system_transaction.digest()

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -832,19 +832,7 @@ impl ConsensusAdapter {
             {
                 let pending_count = epoch_store.pending_consensus_certificates_count();
                 debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
-                // Send end of epoch if empty and all deferred tx are procesed.
-                if pending_count > 0 {
-                    false
-                } else {
-                    // Don't check deferred table until pending_count is already 0, since it may
-                    // require scanning through a bunch of deletion markers.
-                    let deferred_is_empty = epoch_store.deferred_transactions_empty();
-                    debug!(
-                        ?deferred_is_empty,
-                        "Deciding whether to block EndOfPublish on deferred tx"
-                    );
-                    deferred_is_empty
-                }
+                pending_count == 0 // send end of epoch if empty
             } else {
                 false
             }

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -10,6 +10,7 @@ pub enum ReconfigCertStatus {
     AcceptAllCerts,
     RejectUserCerts,
     RejectAllCerts,
+    RejectAllTx,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -45,7 +46,22 @@ impl ReconfigState {
     }
 
     pub fn should_accept_consensus_certs(&self) -> bool {
-        !matches!(self.status, ReconfigCertStatus::RejectAllCerts)
+        matches!(
+            self.status,
+            ReconfigCertStatus::AcceptAllCerts | ReconfigCertStatus::RejectUserCerts
+        )
+    }
+
+    pub fn is_reject_all_certs(&self) -> bool {
+        matches!(self.status, ReconfigCertStatus::RejectAllCerts)
+    }
+
+    pub fn close_all_tx(&mut self) {
+        self.status = ReconfigCertStatus::RejectAllTx;
+    }
+
+    pub fn should_accept_tx(&self) -> bool {
+        !matches!(self.status, ReconfigCertStatus::RejectAllTx)
     }
 }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -8,8 +8,15 @@ use std::sync::Arc;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReconfigCertStatus {
     AcceptAllCerts,
+
+    // User certs rejected, but we still accept certs received through consensus.
     RejectUserCerts,
+
+    // All certs rejected, including ones received through consensus.
+    // But we still accept other transactions from consensus (e.g. RandomnessStateUpdate).
     RejectAllCerts,
+
+    // All tx rejected, including system tx.
     RejectAllTx,
 }
 


### PR DESCRIPTION
Adds a new config state for end-of-epoch in which we reject all certs, but continue to accept system tx (including randomness updates) until all deferred tx have been sequenced.

Also cleans up and fixes issues with final checkpoint generation.