### PR TITLE
zklogin: check multisig public key derive consistency (#15208)

### DIFF
--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -76,9 +76,6 @@ impl Hash for MultiSig {
 }
 
 impl AuthenticatorTrait for MultiSig {
-    fn check_author(&self) -> bool {
-        false
-    }
     fn verify_user_authenticator_epoch(&self, epoch_id: EpochId) -> Result<(), SuiError> {
         // If there is any zkLogin signatures, filter and check epoch for each.
         self.get_zklogin_sigs()?
@@ -91,7 +88,6 @@ impl AuthenticatorTrait for MultiSig {
         _value: &IntentMessage<T>,
         _author: SuiAddress,
         _verify_params: &VerifyParams,
-        _check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
@@ -102,9 +98,8 @@ impl AuthenticatorTrait for MultiSig {
     fn verify_claims<T>(
         &self,
         value: &IntentMessage<T>,
-        author: SuiAddress,
+        multisig_address: SuiAddress,
         verify_params: &VerifyParams,
-        _check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
@@ -115,7 +110,7 @@ impl AuthenticatorTrait for MultiSig {
                 error: "Invalid multisig".to_string(),
             })?;
 
-        if SuiAddress::from(&self.multisig_pk) != author {
+        if SuiAddress::from(&self.multisig_pk) != multisig_address {
             return Err(SuiError::InvalidSignature {
                 error: "Invalid address".to_string(),
             });
@@ -135,67 +130,68 @@ impl AuthenticatorTrait for MultiSig {
         // Verify each signature against its corresponding signature scheme and public key.
         // TODO: further optimization can be done because multiple Ed25519 signatures can be batch verified.
         for (sig, i) in self.sigs.iter().zip(as_indices(self.bitmap)?) {
-            let (pk, weight) =
+            let (subsig_pubkey, weight) =
                 self.multisig_pk
                     .pk_map
                     .get(i as usize)
                     .ok_or(SuiError::InvalidSignature {
                         error: "Invalid public keys index".to_string(),
                     })?;
-            let res = match sig {
-                CompressedSignature::Ed25519(s) => {
-                    let pk = Ed25519PublicKey::from_bytes(pk.as_ref()).map_err(|_| {
-                        SuiError::InvalidSignature {
-                            error: "Invalid public key".to_string(),
-                        }
-                    })?;
-                    pk.verify(
-                        &digest,
-                        &s.try_into().map_err(|_| SuiError::InvalidSignature {
-                            error: "Fail to verify single sig".to_string(),
-                        })?,
-                    )
-                }
-                CompressedSignature::Secp256k1(s) => {
-                    let pk = Secp256k1PublicKey::from_bytes(pk.as_ref()).map_err(|_| {
-                        SuiError::InvalidSignature {
-                            error: "Invalid public key".to_string(),
-                        }
-                    })?;
-                    pk.verify(
-                        &digest,
-                        &s.try_into().map_err(|_| SuiError::InvalidSignature {
-                            error: "Fail to verify single sig".to_string(),
-                        })?,
-                    )
-                }
-                CompressedSignature::Secp256r1(s) => {
-                    let pk = Secp256r1PublicKey::from_bytes(pk.as_ref()).map_err(|_| {
-                        SuiError::InvalidSignature {
-                            error: "Invalid public key".to_string(),
-                        }
-                    })?;
-                    pk.verify(
-                        &digest,
-                        &s.try_into().map_err(|_| SuiError::InvalidSignature {
-                            error: "Fail to verify single sig".to_string(),
-                        })?,
-                    )
-                }
-                CompressedSignature::ZkLogin(z) => {
-                    let authenticator = ZkLoginAuthenticator::from_bytes(&z.0)
-                        .map_err(|_| SuiError::InvalidAuthenticator)?;
-                    // Author is already verified against multisig pk, do not verify author within zkLogin authenticator where self.check_author() is evaluated to false for multisig.
-                    authenticator
-                        .verify_claims(value, author, verify_params, self.check_author())
-                        .map_err(|_| FastCryptoError::InvalidSignature)
-                }
-            };
+            let res =
+                match sig {
+                    CompressedSignature::Ed25519(s) => {
+                        let pk =
+                            Ed25519PublicKey::from_bytes(subsig_pubkey.as_ref()).map_err(|_| {
+                                SuiError::InvalidSignature {
+                                    error: "Invalid public key".to_string(),
+                                }
+                            })?;
+                        pk.verify(
+                            &digest,
+                            &s.try_into().map_err(|_| SuiError::InvalidSignature {
+                                error: "Fail to verify single sig".to_string(),
+                            })?,
+                        )
+                    }
+                    CompressedSignature::Secp256k1(s) => {
+                        let pk = Secp256k1PublicKey::from_bytes(subsig_pubkey.as_ref()).map_err(
+                            |_| SuiError::InvalidSignature {
+                                error: "Invalid public key".to_string(),
+                            },
+                        )?;
+                        pk.verify(
+                            &digest,
+                            &s.try_into().map_err(|_| SuiError::InvalidSignature {
+                                error: "Fail to verify single sig".to_string(),
+                            })?,
+                        )
+                    }
+                    CompressedSignature::Secp256r1(s) => {
+                        let pk = Secp256r1PublicKey::from_bytes(subsig_pubkey.as_ref()).map_err(
+                            |_| SuiError::InvalidSignature {
+                                error: "Invalid public key".to_string(),
+                            },
+                        )?;
+                        pk.verify(
+                            &digest,
+                            &s.try_into().map_err(|_| SuiError::InvalidSignature {
+                                error: "Fail to verify single sig".to_string(),
+                            })?,
+                        )
+                    }
+                    CompressedSignature::ZkLogin(z) => {
+                        let authenticator = ZkLoginAuthenticator::from_bytes(&z.0)
+                            .map_err(|_| SuiError::InvalidAuthenticator)?;
+                        authenticator
+                            .verify_claims(value, SuiAddress::from(subsig_pubkey), verify_params)
+                            .map_err(|_| FastCryptoError::InvalidSignature)
+                    }
+                };
             if res.is_ok() {
                 weight_sum += *weight as u16;
             } else {
                 return Err(SuiError::InvalidSignature {
-                    error: format!("Invalid signature for pk={:?}", pk),
+                    error: format!("Invalid signature for pk={:?}", subsig_pubkey),
                 });
             }
         }

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -86,9 +86,6 @@ impl Hash for MultiSigLegacy {
 }
 
 impl AuthenticatorTrait for MultiSigLegacy {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> Result<(), SuiError> {
         Ok(())
     }
@@ -98,7 +95,6 @@ impl AuthenticatorTrait for MultiSigLegacy {
         _value: &IntentMessage<T>,
         _author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
@@ -111,13 +107,12 @@ impl AuthenticatorTrait for MultiSigLegacy {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
     {
         let multisig: MultiSig = self.clone().try_into()?;
-        multisig.verify_claims(value, author, aux_verify_data, check_author)
+        multisig.verify_claims(value, author, aux_verify_data)
     }
 
     fn verify_authenticator<T>(

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -56,7 +56,6 @@ impl VerifyParams {
 /// A lightweight trait that all members of [enum GenericSignature] implement.
 #[enum_dispatch]
 pub trait AuthenticatorTrait {
-    fn check_author(&self) -> bool;
     fn verify_user_authenticator_epoch(&self, epoch: EpochId) -> SuiResult;
 
     fn verify_claims<T>(
@@ -64,7 +63,6 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize;
@@ -82,8 +80,7 @@ pub trait AuthenticatorTrait {
         if let Some(epoch) = epoch {
             self.verify_user_authenticator_epoch(epoch)?;
         }
-        // when invoked from verify_authenticator, always check author.
-        self.verify_claims(value, author, aux_verify_data, true)
+        self.verify_claims(value, author, aux_verify_data)
     }
 
     fn verify_uncached_checks<T>(
@@ -91,7 +88,6 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize;
@@ -285,9 +281,6 @@ impl<'de> ::serde::Deserialize<'de> for GenericSignature {
 
 /// This ports the wrapper trait to the verify_secure defined on [enum Signature].
 impl AuthenticatorTrait for Signature {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, _: EpochId) -> SuiResult {
         Ok(())
     }
@@ -296,7 +289,6 @@ impl AuthenticatorTrait for Signature {
         _value: &IntentMessage<T>,
         _author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
@@ -309,7 +301,6 @@ impl AuthenticatorTrait for Signature {
         value: &IntentMessage<T>,
         author: SuiAddress,
         _aux_verify_data: &VerifyParams,
-        _check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2237,12 +2237,7 @@ impl AuthenticatedMessage for SenderSignedData {
         for (signer, signature) in
             self.get_signer_sig_mapping(verify_params.verify_legacy_zklogin_address)?
         {
-            signature.verify_uncached_checks(
-                self.intent_message(),
-                signer,
-                verify_params,
-                signature.check_author(),
-            )?;
+            signature.verify_uncached_checks(self.intent_message(), signer, verify_params)?;
         }
         Ok(())
     }
@@ -2284,12 +2279,7 @@ impl AuthenticatedMessage for SenderSignedData {
 
         // Verify all present signatures.
         for (signer, signature) in present_sigs {
-            signature.verify_claims(
-                self.intent_message(),
-                signer,
-                verify_params,
-                signature.check_author(),
-            )?;
+            signature.verify_claims(self.intent_message(), signer, verify_params)?;
         }
         Ok(())
     }

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -86,9 +86,6 @@ impl Hash for ZkLoginAuthenticator {
 }
 
 impl AuthenticatorTrait for ZkLoginAuthenticator {
-    fn check_author(&self) -> bool {
-        true
-    }
     fn verify_user_authenticator_epoch(&self, epoch: EpochId) -> SuiResult {
         // Verify the max epoch in aux inputs is <= the current epoch of authority.
         if epoch > self.get_max_epoch() {
@@ -106,17 +103,15 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
         intent_msg: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
     {
-        // if check_author is true, author must be consistent with the zklogin address derived.
-        if check_author && aux_verify_data.verify_legacy_zklogin_address {
+        if aux_verify_data.verify_legacy_zklogin_address {
             if author != self.try_into()? && author != SuiAddress::legacy_try_from(self)? {
                 return Err(SuiError::InvalidAddress);
             }
-        } else if check_author && author != self.try_into()? {
+        } else if author != self.try_into()? {
             return Err(SuiError::InvalidAddress);
         }
 
@@ -153,12 +148,11 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
         intent_msg: &IntentMessage<T>,
         author: SuiAddress,
         aux_verify_data: &VerifyParams,
-        check_author: bool,
     ) -> SuiResult
     where
         T: Serialize,
     {
-        self.verify_uncached_checks(intent_msg, author, aux_verify_data, check_author)?;
+        self.verify_uncached_checks(intent_msg, author, aux_verify_data)?;
 
         // Use flag || pk_bytes.
         let mut extended_pk_bytes = vec![self.user_signature.scheme().flag()];


### PR DESCRIPTION
## Description 

check zklogin authenticator derives the same address as the public key identifier from multisig public key.

## Test Plan 

unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

---------

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
