### PR TITLE
[gql][txn-test-runner] interpolate variables in RunGraphqlCommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13223,6 +13223,7 @@ dependencies = [
  "msim",
  "once_cell",
  "rand 0.8.5",
+ "regex",
  "rocksdb",
  "serde_json",
  "simulacrum",

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.exp
@@ -1,0 +1,54 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-20:
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 22-22:
+Checkpoint created: 1
+
+task 3 'run-graphql'. lines 24-37:
+Response: {
+  "data": {
+    "coinMetadata": {
+      "decimals": 2,
+      "name": "",
+      "symbol": "FAKE",
+      "description": "",
+      "iconUrl": null,
+      "supply": "0",
+      "asMoveObject": {
+        "hasPublicTransfer": true
+      }
+    }
+  }
+}
+
+task 4 'programmable'. lines 40-42:
+created: object(4,0)
+mutated: object(0,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
+
+task 5 'create-checkpoint'. lines 44-44:
+Checkpoint created: 2
+
+task 6 'run-graphql'. lines 46-59:
+Response: {
+  "data": {
+    "coinMetadata": {
+      "decimals": 2,
+      "name": "",
+      "symbol": "FAKE",
+      "description": "",
+      "iconUrl": null,
+      "supply": "100",
+      "asMoveObject": {
+        "hasPublicTransfer": true
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A --simulator
+
+//# publish --sender A
+module test::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql --interpolations test
+{
+  coinMetadata(coinType: "@{test}::fake::FAKE") {
+    decimals
+    name
+    symbol
+    description
+    iconUrl
+    supply
+    asMoveObject {
+      hasPublicTransfer
+    }
+  }
+}
+
+
+//# programmable --sender A --inputs object(1,2) 100 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# create-checkpoint
+
+//# run-graphql --interpolations test
+{
+  coinMetadata(coinType: "@{test}::fake::FAKE") {
+    decimals
+    name
+    symbol
+    description
+    iconUrl
+    supply
+    asMoveObject {
+      hasPublicTransfer
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
@@ -21,7 +21,7 @@ module test::fake {
 
 //# create-checkpoint
 
-//# run-graphql --interpolations test
+//# run-graphql
 {
   coinMetadata(coinType: "@{test}::fake::FAKE") {
     decimals
@@ -43,7 +43,7 @@ module test::fake {
 
 //# create-checkpoint
 
-//# run-graphql --interpolations test
+//# run-graphql
 {
   coinMetadata(coinType: "@{test}::fake::FAKE") {
     decimals

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -15,6 +15,7 @@ clap.workspace = true
 eyre.workspace = true
 once_cell.workspace = true
 rand.workspace = true
+regex.workspace = true
 tempfile.workspace = true
 async-trait.workspace = true
 tokio.workspace = true

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -146,8 +146,6 @@ pub struct RunGraphqlCommand {
     pub show_service_version: bool,
     #[clap(long = "variables", num_args(1..))]
     pub variables: Vec<String>,
-    #[clap(long = "interpolations", num_args(1..))]
-    pub interpolations: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -146,6 +146,8 @@ pub struct RunGraphqlCommand {
     pub show_service_version: bool,
     #[clap(long = "variables", num_args(1..))]
     pub variables: Vec<String>,
+    #[clap(long = "interpolations", num_args(1..))]
+    pub interpolations: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1042,7 +1042,7 @@ impl<'a> SuiTestAdapter<'a> {
                 res.push(var.clone());
             } else {
                 return Err(anyhow!(
-                    "Unknown variable: {}\nAllowed variable mappings are are {:#?}",
+                    "Unknown variable: {}\nAllowed variable mappings are {:#?}",
                     decl,
                     variables
                 ));
@@ -1089,7 +1089,7 @@ impl<'a> SuiTestAdapter<'a> {
         for var_name in interpolations {
             let value = variables.get(var_name).ok_or_else(|| {
                 anyhow!(
-                    "Unknown variable: {}\nAllowed variable mappings are are {:#?}",
+                    "Unknown variable: {}\nAllowed variable mappings are {:#?}",
                     var_name,
                     variables
                 )

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1095,7 +1095,7 @@ impl<'a> SuiTestAdapter<'a> {
                 )
             })?;
             let pattern = format!("@{{{var_name}}}");
-            interpolated_query = interpolated_query.replace(&pattern, &value);
+            interpolated_query = interpolated_query.replace(&pattern, value);
         }
 
         Ok(interpolated_query)


### PR DESCRIPTION
## Description 

Interpolates variables in RunGraphqlCommand by replacing instances of "@{var}" to the value of the var named by "var". This follows the obj_x_y syntax for now. Add test for coin metadata to test new feature and test coin metadata implementation on graphql.

## Test Plan 

cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration -- coin_metadata.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
