### PR TITLE
[bridge 10/n] storage

### DIFF
--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -8,6 +8,8 @@ use ethers::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::types::{BridgeAction, EthToSuiBridgeAction};
+
 // TODO: write a macro to handle variants
 
 // TODO: Dummy placeholder, will be replaced by actual abis
@@ -34,5 +36,23 @@ impl EthBridgeEvent {
 
         // TODO: try other variants
         None
+    }
+}
+
+impl EthBridgeEvent {
+    pub fn try_into_bridge_action(
+        self,
+        eth_tx_hash: ethers::types::H256,
+        eth_event_index: u16,
+    ) -> Option<BridgeAction> {
+        match self {
+            EthBridgeEvent::ExampleContract(event) => {
+                Some(BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
+                    eth_tx_hash,
+                    eth_event_index,
+                    eth_bridge_event: event.clone(),
+                }))
+            }
+        }
     }
 }

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -33,6 +33,8 @@ pub enum BridgeError {
     MismatchedAuthoritySigner,
     // Signature is over a mismatched action
     MismatchedAction,
+    // Storage Error
+    StorageError(String),
     // Rest API Error
     RestAPIError(String),
     // Uncategorized error

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -78,6 +78,7 @@ where
         Ok(number.as_u64())
     }
 
+    // TODO: this needs some pagination if the range is too big
     pub async fn get_events_in_range(
         &self,
         address: ethers::types::Address,

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 
 use crate::error::BridgeError;
 use crate::error::BridgeResult;
+use crate::types::BridgeAction;
 use crate::types::BridgeChainId;
+use crate::types::SuiToEthBridgeAction;
 use crate::types::TokenId;
 use ethers::types::Address as EthAddress;
 use move_core_types::language_storage::StructTag;
@@ -18,6 +20,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::SuiAddress;
+use sui_types::digests::TransactionDigest;
 
 // TODO: Placeholder, this will need to match the actual event types defined in Move
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -71,4 +74,22 @@ macro_rules! declare_events {
             }
         }
     };
+}
+
+impl SuiBridgeEvent {
+    pub fn try_into_bridge_action(
+        self,
+        sui_tx_digest: TransactionDigest,
+        sui_tx_event_index: u16,
+    ) -> Option<BridgeAction> {
+        match self {
+            SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => {
+                Some(BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
+                    sui_tx_digest,
+                    sui_tx_event_index,
+                    sui_bridge_event: event.clone(),
+                }))
+            }
+        }
+    }
 }

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -10,6 +10,7 @@ pub mod eth_syncer;
 pub mod events;
 pub mod orchestrator;
 pub mod server;
+pub mod storage;
 pub mod sui_client;
 pub mod sui_syncer;
 pub mod types;

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -1,26 +1,33 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! `BridgeOrchestrator` is the component that monitors Sui and Ethereum events
-//! with the help of `SuiSyncer` and `EthSyncer` and process them by quorum
-//! driving among bridge committee.
+//! `BridgeOrchestrator` is the component that:
+//! 1. monitors Sui and Ethereum events with the help of `SuiSyncer` and `EthSyncer`
+//! 2. updates WAL table and cursor tables
+//! 2. hands actions to `BridgeExecutor` for execution
 
 use crate::abi::EthBridgeEvent;
 use crate::error::BridgeResult;
 use crate::events::SuiBridgeEvent;
+use crate::storage::BridgeOrchestratorTables;
 use crate::sui_client::{SuiClient, SuiClientInner};
 use crate::types::BridgeCommittee;
 use arc_swap::ArcSwap;
 use mysten_metrics::spawn_logged_monitored_task;
 use std::sync::Arc;
 use sui_json_rpc_types::SuiEvent;
+use sui_types::Identifier;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 pub struct BridgeOrchestrator<C> {
     sui_client: Arc<SuiClient<C>>,
-    sui_events_rx: mysten_metrics::metered_channel::Receiver<Vec<SuiEvent>>,
-    eth_events_rx: mysten_metrics::metered_channel::Receiver<Vec<ethers::types::Log>>,
+    sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
+    eth_events_rx: mysten_metrics::metered_channel::Receiver<(
+        ethers::types::Address,
+        Vec<ethers::types::Log>,
+    )>,
+    store: Arc<BridgeOrchestratorTables>,
 }
 
 impl<C> BridgeOrchestrator<C>
@@ -29,13 +36,18 @@ where
 {
     pub async fn new(
         sui_client: Arc<SuiClient<C>>,
-        sui_events_rx: mysten_metrics::metered_channel::Receiver<Vec<SuiEvent>>,
-        eth_events_rx: mysten_metrics::metered_channel::Receiver<Vec<ethers::types::Log>>,
+        sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
+        eth_events_rx: mysten_metrics::metered_channel::Receiver<(
+            ethers::types::Address,
+            Vec<ethers::types::Log>,
+        )>,
+        store: Arc<BridgeOrchestratorTables>,
     ) -> BridgeResult<Self> {
         Ok(Self {
             sui_client,
             sui_events_rx,
             eth_events_rx,
+            store,
         })
     }
 
@@ -45,26 +57,35 @@ where
         let bridge_committee = Arc::new(ArcSwap::from_pointee(bridge_committee));
         let mut task_handles = vec![];
         let bridge_committee_clone = bridge_committee.clone();
+        let store_clone = self.store.clone();
         task_handles.push(spawn_logged_monitored_task!(Self::run_sui_watcher(
+            store_clone,
             self.sui_events_rx,
             bridge_committee_clone,
         )));
         let bridge_committee_clone = bridge_committee.clone();
+        let store_clone = self.store.clone();
         task_handles.push(spawn_logged_monitored_task!(Self::run_eth_watcher(
+            store_clone,
             self.eth_events_rx,
             bridge_committee_clone,
         )));
 
-        // TODO: spawn bridge change watcher task
+        // TODO: spawn bridge committee change watcher task
         Ok(task_handles)
     }
 
     async fn run_sui_watcher(
-        mut sui_events_rx: mysten_metrics::metered_channel::Receiver<Vec<SuiEvent>>,
-        bridge_committee: Arc<ArcSwap<BridgeCommittee>>,
+        store: Arc<BridgeOrchestratorTables>,
+        mut sui_events_rx: mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
+        _bridge_committee: Arc<ArcSwap<BridgeCommittee>>,
     ) {
         info!("Starting sui watcher task");
-        while let Some(events) = sui_events_rx.recv().await {
+        while let Some((identifier, events)) = sui_events_rx.recv().await {
+            if events.is_empty() {
+                continue;
+            }
+
             // TODO: skip events that are already processed (in DB and on chain)
 
             let bridge_events = events
@@ -73,38 +94,58 @@ where
                 .collect::<BridgeResult<Vec<_>>>()
                 .expect("Sui Event could not be deserialzed to SuiBridgeEvent");
 
-            // Load committee upfront to avoid weird edge cases where committee changes in between
-            let _committee = bridge_committee.load().clone();
-
-            // TODO: optimize handling of multiple events
+            let mut actions = vec![];
             for (sui_event, opt_bridge_event) in events.iter().zip(bridge_events) {
                 if opt_bridge_event.is_none() {
                     // TODO: we probably should not miss any events, warn for now.
                     warn!("Sui event not recognized: {:?}", sui_event);
                 }
-                let _bridge_event = opt_bridge_event.unwrap();
+                let bridge_event: SuiBridgeEvent = opt_bridge_event.unwrap();
 
-                // TODO: handle all bridge events
+                if let Some(action) = bridge_event
+                    .try_into_bridge_action(sui_event.id.tx_digest, sui_event.id.event_seq as u16)
+                {
+                    actions.push(action);
+                }
+                // TODO: handle non Action events
             }
+
+            if !actions.is_empty() {
+                // Write action to pending WAL
+                store
+                    .insert_pending_actions(&actions)
+                    .expect("Store operation should not fail");
+
+                // TODO: ask executor to execute, who calls `remove_pending_actions` after
+                // confirming the action is done.
+            }
+
+            // TODO: add tests for storage
+            // Unwrap safe: in the beginning of the loop we checked that events is not empty
+            let cursor = events.last().unwrap().id.tx_digest;
+            store
+                .update_sui_event_cursor(identifier, cursor)
+                .expect("Store operation should not fail");
         }
         panic!("Sui event channel was closed");
     }
 
     async fn run_eth_watcher(
-        mut eth_events_rx: mysten_metrics::metered_channel::Receiver<Vec<ethers::types::Log>>,
-        bridge_committee: Arc<ArcSwap<BridgeCommittee>>,
+        _store: Arc<BridgeOrchestratorTables>,
+        mut eth_events_rx: mysten_metrics::metered_channel::Receiver<(
+            ethers::types::Address,
+            Vec<ethers::types::Log>,
+        )>,
+        _bridge_committee: Arc<ArcSwap<BridgeCommittee>>,
     ) {
         info!("Starting eth watcher task");
-        while let Some(logs) = eth_events_rx.recv().await {
+        while let Some((_contract, logs)) = eth_events_rx.recv().await {
             // TODO: skip events that are not already processed (in DB and on chain)
 
             let bridge_events = logs
                 .iter()
                 .map(EthBridgeEvent::try_from_eth_log)
                 .collect::<Vec<_>>();
-
-            // Load committee upfront to avoid weird edge cases where committee changes in between
-            let _committee = bridge_committee.load().clone();
 
             for (log, opt_bridge_event) in logs.iter().zip(bridge_events) {
                 if opt_bridge_event.is_none() {

--- a/crates/sui-bridge/src/storage.rs
+++ b/crates/sui-bridge/src/storage.rs
@@ -1,0 +1,225 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use sui_types::digests::TransactionDigest;
+use sui_types::Identifier;
+
+use typed_store::rocks::{DBMap, MetricConf};
+use typed_store::traits::TableSummary;
+use typed_store::traits::TypedStoreDebug;
+use typed_store::Map;
+use typed_store_derive::DBMapUtils;
+
+use crate::error::{BridgeError, BridgeResult};
+use crate::types::{BridgeAction, BridgeActionDigest};
+
+#[derive(DBMapUtils)]
+pub struct BridgeOrchestratorTables {
+    /// pending BridgeActions that orchestrator received but not yet executed
+    pub(crate) pending_actions: DBMap<BridgeActionDigest, BridgeAction>,
+    /// module identifier to starting transaction digest
+    pub(crate) sui_syncer_cursors: DBMap<Identifier, TransactionDigest>,
+    /// contract address to starting block
+    pub(crate) eth_syncer_cursors: DBMap<ethers::types::Address, u64>,
+}
+
+// TODO remove after wireup
+#[allow(dead_code)]
+impl BridgeOrchestratorTables {
+    pub fn new(path: &Path) -> Arc<Self> {
+        Arc::new(Self::open_tables_read_write(
+            path.to_path_buf(),
+            MetricConf::new("bridge"),
+            None,
+            None,
+        ))
+    }
+
+    pub(crate) fn insert_pending_actions(&self, actions: &[BridgeAction]) -> BridgeResult<()> {
+        let mut batch = self.pending_actions.batch();
+        batch
+            .insert_batch(
+                &self.pending_actions,
+                actions.iter().map(|a| (a.digest(), a)),
+            )
+            .map_err(|e| {
+                BridgeError::StorageError(format!("Couldn't insert into pending_actions: {:?}", e))
+            })?;
+        batch
+            .write()
+            .map_err(|e| BridgeError::StorageError(format!("Couldn't write batch: {:?}", e)))
+    }
+
+    pub(crate) fn remove_pending_actions(&self, actions: &[BridgeAction]) -> BridgeResult<()> {
+        let mut batch = self.pending_actions.batch();
+        batch
+            .delete_batch(&self.pending_actions, actions.iter().map(|a| a.digest()))
+            .map_err(|e| {
+                BridgeError::StorageError(format!("Couldn't delete from pending_actions: {:?}", e))
+            })?;
+        batch
+            .write()
+            .map_err(|e| BridgeError::StorageError(format!("Couldn't write batch: {:?}", e)))
+    }
+
+    pub(crate) fn update_sui_event_cursor(
+        &self,
+        module: Identifier,
+        cursor: TransactionDigest,
+    ) -> BridgeResult<()> {
+        let mut batch = self.sui_syncer_cursors.batch();
+
+        batch
+            .insert_batch(&self.sui_syncer_cursors, [(module, cursor)])
+            .map_err(|e| {
+                BridgeError::StorageError(format!(
+                    "Coudln't insert into sui_syncer_cursors: {:?}",
+                    e
+                ))
+            })?;
+        batch
+            .write()
+            .map_err(|e| BridgeError::StorageError(format!("Couldn't write batch: {:?}", e)))
+    }
+
+    pub(crate) fn update_eth_event_cursor(
+        &self,
+        contract_address: ethers::types::Address,
+        cursor: u64,
+    ) -> BridgeResult<()> {
+        let mut batch = self.eth_syncer_cursors.batch();
+
+        batch
+            .insert_batch(&self.eth_syncer_cursors, [(contract_address, cursor)])
+            .map_err(|e| {
+                BridgeError::StorageError(format!(
+                    "Coudln't insert into eth_syncer_cursors: {:?}",
+                    e
+                ))
+            })?;
+        batch
+            .write()
+            .map_err(|e| BridgeError::StorageError(format!("Couldn't write batch: {:?}", e)))
+    }
+
+    pub(crate) fn get_all_pending_actions(
+        &self,
+    ) -> BridgeResult<HashMap<BridgeActionDigest, BridgeAction>> {
+        Ok(self.pending_actions.unbounded_iter().collect())
+    }
+
+    pub(crate) fn get_sui_event_cursor(
+        &self,
+        identifier: &Identifier,
+    ) -> BridgeResult<Option<TransactionDigest>> {
+        self.sui_syncer_cursors.get(identifier).map_err(|e| {
+            BridgeError::StorageError(format!("Couldn't get sui_syncer_cursors: {:?}", e))
+        })
+    }
+
+    pub(crate) fn get_eth_event_cursor(
+        &self,
+        contract_address: &ethers::types::Address,
+    ) -> BridgeResult<Option<u64>> {
+        self.eth_syncer_cursors.get(contract_address).map_err(|e| {
+            BridgeError::StorageError(format!("Couldn't get sui_syncer_cursors: {:?}", e))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::test_utils::get_test_sui_to_eth_bridge_action;
+
+    use super::*;
+
+    // async: existing runtime is required with typed-store
+    #[tokio::test]
+    async fn test_bridge_storage_basic() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = BridgeOrchestratorTables::new(temp_dir.path());
+
+        let action1 = get_test_sui_to_eth_bridge_action(TransactionDigest::random(), 0, 99, 10000);
+
+        let action2 = get_test_sui_to_eth_bridge_action(TransactionDigest::random(), 2, 100, 10000);
+
+        // in the beginning it's empty
+        let actions = store.get_all_pending_actions().unwrap();
+        assert!(actions.is_empty());
+
+        // remove non existing entry is ok
+        store.remove_pending_actions(&[action1.clone()]).unwrap();
+
+        store
+            .insert_pending_actions(&vec![action1.clone(), action2.clone()])
+            .unwrap();
+
+        let actions = store.get_all_pending_actions().unwrap();
+        assert_eq!(
+            actions,
+            HashMap::from_iter(vec![
+                (action1.digest(), action1.clone()),
+                (action2.digest(), action2.clone())
+            ])
+        );
+
+        // insert an existing action is ok
+        store.insert_pending_actions(&[action1.clone()]).unwrap();
+        let actions = store.get_all_pending_actions().unwrap();
+        assert_eq!(
+            actions,
+            HashMap::from_iter(vec![
+                (action1.digest(), action1.clone()),
+                (action2.digest(), action2.clone())
+            ])
+        );
+
+        // remove action 2
+        store.remove_pending_actions(&[action2.clone()]).unwrap();
+        let actions = store.get_all_pending_actions().unwrap();
+        assert_eq!(
+            actions,
+            HashMap::from_iter(vec![(action1.digest(), action1.clone())])
+        );
+
+        // remove action 1
+        store.remove_pending_actions(&[action1.clone()]).unwrap();
+        let actions = store.get_all_pending_actions().unwrap();
+        assert!(actions.is_empty());
+
+        // update eth event cursor
+        let eth_contract_address = ethers::types::Address::random();
+        let eth_block_num = 199999u64;
+        assert!(store
+            .get_eth_event_cursor(&eth_contract_address)
+            .unwrap()
+            .is_none());
+        store
+            .update_eth_event_cursor(eth_contract_address, eth_block_num)
+            .unwrap();
+        assert_eq!(
+            store
+                .get_eth_event_cursor(&eth_contract_address)
+                .unwrap()
+                .unwrap(),
+            eth_block_num
+        );
+
+        // update sui event cursor
+        let sui_module = Identifier::from_str("test").unwrap();
+        let sui_cursor = TransactionDigest::random();
+        assert!(store.get_sui_event_cursor(&sui_module).unwrap().is_none());
+        store
+            .update_sui_event_cursor(sui_module.clone(), sui_cursor)
+            .unwrap();
+        assert_eq!(
+            store.get_sui_event_cursor(&sui_module).unwrap().unwrap(),
+            sui_cursor
+        );
+    }
+}

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -8,6 +8,7 @@ use crate::error::{BridgeError, BridgeResult};
 use crate::events::EmittedSuiToEthTokenBridgeV1;
 use ethers::types::Address as EthAddress;
 pub use ethers::types::H256 as EthTransactionHash;
+use fastcrypto::hash::{HashFunction, Keccak256};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -253,6 +254,22 @@ impl BridgeAction {
             }
         }
         bytes
+    }
+
+    // Digest of BridgeAction (with Keccak256 hasher)
+    pub fn digest(&self) -> BridgeActionDigest {
+        let mut hasher = Keccak256::default();
+        hasher.update(&self.to_bytes());
+        BridgeActionDigest::new(hasher.finalize().into())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct BridgeActionDigest(Digest);
+
+impl BridgeActionDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
     }
 }
 


### PR DESCRIPTION
## Description 

Add storage stuff. The meat is in `storage.rs` and `orchestrator.rs`. Note we haven't wired it up in `fn run_eth_watcher`, because some modification are needed in the receiving channel, which will come in the next PR.

High level it works in this way:
```
#[derive(DBMapUtils)]
pub struct BridgeOrchestratorTables {
    /// pending BridgeActions that orchestrator received but not yet executed
    pub(crate) pending_actions: DBMap<BridgeActionDigest, BridgeAction>,
    /// module identifier to starting transaction digest
    pub(crate) sui_syncer_cursors: DBMap<Identifier, TransactionDigest>,
    /// contract address to starting block
    pub(crate) eth_syncer_cursors: DBMap<ethers::types::Address, u64>,
}
```

1. Orchestrator receives events from syncers. If an event is an action (e.g. token transfer), then it writes this action to `pending_actions` (WAL log), then passes it to the executor (coming in a later PR).
2. without waiting for the action to be finished, it updates the cursor in `sui_syncer_cursors` or `eth_syncer_cursors`
3. the executor will remove the action from the logs after it's confirmed to be done.

### Considerations
**Crash Recovery**
* If the program crashes after it is written to WAL and before the action getting finalized, pending actions still remain in the WAL and will be picked up during start (to be implemented), even though the cursor may have progressed further. 
* If the program crashes before the action is written into WAL, then once it starts, the syncer will get this action and send it over again.

**DB writes**
We write `pending_actions` and `xyz_syncer_cursors` in two db txes and the order is important. We want to persist changes to `pending_actions` before passing the action to Executor because if for some reason executor completes the action and remove the entry earlier than the addition, it will cause the action to remain in the pending log longer than necessarily (until next restart). It's not end of world but better to avoid.

**Cursor**
1. Sui's cursor is TransactionDigest. Today we paginate event query results with EventID (TransactionDigest + EventIdx). In `sui_syncer.rs` we implement the query such that events of a transaction never appear partially in a page. This enables downstream to track per transaction easily.
2. Eth's cursor is BlockNumber. Similarly `eth_syncer.rs` guarantees to return complete list of matched events by block level.

## Test Plan 

unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
