### PR TITLE
Introduce replay logging macro

### DIFF
--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -237,6 +237,19 @@ macro_rules! fail_point_if {
     ($tag: expr, $callback: expr) => {};
 }
 
+/// Use to write DEBUG level logs only when REPLAY_LOG
+/// environment variable is set. Useful for log lines that
+/// are only relevant to test infra which still may need to
+/// run a release build
+#[macro_export]
+macro_rules! replay_log {
+    ($($arg:tt)+) => {
+        if std::env::var("REPLAY_LOG").is_ok() {
+            tracing::debug!($($arg)+);
+        }
+    };
+}
+
 // These tests need to be run in release mode, since debug mode does overflow checks by default!
 #[cfg(test)]
 mod test {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -94,7 +94,7 @@ use sui_json_rpc::transaction_builder_api::TransactionBuilderApi;
 use sui_json_rpc::transaction_execution_api::TransactionExecutionApi;
 use sui_json_rpc::JsonRpcServerBuilder;
 use sui_kvstore::writer::setup_key_value_store_uploader;
-use sui_macros::fail_point_async;
+use sui_macros::{fail_point_async, replay_log};
 use sui_network::api::ValidatorServer;
 use sui_network::discovery;
 use sui_network::discovery::TrustedPeerChangeEvent;
@@ -466,6 +466,12 @@ impl SuiNode {
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
             ChainIdentifier::from(*genesis.checkpoint().digest()),
+        );
+
+        replay_log!(
+            "Beginning replay run. Epoch: {:?}, Protocol config: {:?}",
+            epoch_store.epoch(),
+            epoch_store.protocol_config()
         );
 
         // the database is empty at genesis time


### PR DESCRIPTION
## Description 

Introduces a macro for logging only in replay tests, which will print debug logs when `REPLAY_LOG` envvar is present

## Test Plan 

It compiles

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
