### PR TITLE
[graphql/rpc] reduce limits

### DIFF
--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -90,7 +90,7 @@ impl Limits {
         self.max_query_payload_size
     }
 
-    pub fn default_for_simulator_testing()-> Self {
+    pub fn default_for_simulator_testing() -> Self {
         Self {
             max_query_nodes: 500,
             max_query_depth: 20,

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -10,9 +10,9 @@ use sui_json_rpc::name_service::NameServiceConfig;
 use crate::functional_group::FunctionalGroup;
 
 // TODO: calculate proper cost limits
-const MAX_QUERY_DEPTH: u32 = 20;
-const MAX_QUERY_NODES: u32 = 200;
-const MAX_QUERY_PAYLOAD_SIZE: u32 = 5_000;
+const MAX_QUERY_DEPTH: u32 = 15;
+const MAX_QUERY_NODES: u32 = 50;
+const MAX_QUERY_PAYLOAD_SIZE: u32 = 2_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
 const DEFAULT_PAGE_SIZE: u64 = 20; // Default number of elements allowed on a page of a connection
 const MAX_PAGE_SIZE: u64 = 50; // Maximum number of elements allowed on a page of a connection
@@ -75,6 +75,29 @@ pub struct Limits {
     pub(crate) max_page_size: u64,
     #[serde(default)]
     pub(crate) request_timeout_ms: u64,
+}
+
+impl Limits {
+    pub fn max_query_depth(&self) -> u32 {
+        self.max_query_depth
+    }
+
+    pub fn max_query_nodes(&self) -> u32 {
+        self.max_query_nodes
+    }
+
+    pub fn max_query_payload_size(&self) -> u32 {
+        self.max_query_payload_size
+    }
+
+    pub fn default_for_simulator_testing()-> Self {
+        Self {
+            max_query_nodes: 500,
+            max_query_depth: 20,
+            max_query_payload_size: 5_000,
+            ..Self::default()
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -172,12 +195,12 @@ impl ServiceConfig {
     }
 
     /// The maximum depth a GraphQL query can be to be accepted by this service.
-    async fn max_query_depth(&self) -> u32 {
+    pub async fn max_query_depth(&self) -> u32 {
         self.limits.max_query_depth
     }
 
     /// The maximum number of nodes (field names) the service will accept in a single query.
-    async fn max_query_nodes(&self) -> u32 {
+    pub async fn max_query_nodes(&self) -> u32 {
         self.limits.max_query_nodes
     }
 

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -135,10 +135,8 @@ pub async fn start_graphql_server_with_fn_rpc(
     let mut server_config = ServerConfig {
         connection: graphql_connection_config,
         service: ServiceConfig {
-            limits: Limits {
-                max_query_nodes: 500,
-                ..Limits::default()
-            },
+            // Use special limits for testing
+            limits: Limits::default_for_simulator_testing(),
             ..ServiceConfig::default()
         },
         ..ServerConfig::default()

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//#[cfg(feature = "pg_integration")]
+#[cfg(feature = "pg_integration")]
 mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
@@ -158,7 +158,7 @@ mod tests {
         let mut sim = Simulacrum::new_with_rng(rng);
         let (mut max_nodes, mut max_depth, mut max_payload) = (0, 0, 0);
 
-        sim.create_checkpoint();f
+        sim.create_checkpoint();
 
         let connection_config = ConnectionConfig::ci_integration_test_cfg();
 

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -67,29 +67,25 @@ mod tests {
                     err
                 ))
             });
-            let usage = resp
-                .usage()
-                .expect("Usage fetch should succeed")
-                .expect(&format!(
-                    "Usage should be present for query: {}",
-                    query.name
-                ));
+            if resp.errors().is_empty() {
+                let usage = resp
+                    .usage()
+                    .expect("Usage fetch should succeed")
+                    .unwrap_or_else(|| panic!("Usage should be present for query: {}", query.name));
 
-            let nodes = *usage.get("nodes").expect(&format!(
-                "Node usage should be present for query: {}",
-                query.name
-            ));
-            let depth = *usage.get("depth").expect(&format!(
-                "Depth usage should be present for query: {}",
-                query.name
-            ));
-            let payload = *usage.get("query_payload").expect(&format!(
-                "Payload usage should be present for query: {}",
-                query.name
-            ));
-            *max_nodes = max(*max_nodes, nodes);
-            *max_depth = max(*max_depth, depth);
-            *max_payload = max(*max_payload, payload);
+                let nodes = *usage.get("nodes").unwrap_or_else(|| {
+                    panic!("Node usage should be present for query: {}", query.name)
+                });
+                let depth = *usage.get("depth").unwrap_or_else(|| {
+                    panic!("Depth usage should be present for query: {}", query.name)
+                });
+                let payload = *usage.get("query_payload").unwrap_or_else(|| {
+                    panic!("Payload usage should be present for query: {}", query.name)
+                });
+                *max_nodes = max(*max_nodes, nodes);
+                *max_depth = max(*max_depth, depth);
+                *max_payload = max(*max_payload, payload);
+            }
         }
         errors
     }

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "pg_integration")]
+//#[cfg(feature = "pg_integration")]
 mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use serial_test::serial;
     use simulacrum::Simulacrum;
+    use std::cmp::max;
     use std::path::PathBuf;
     use std::sync::Arc;
-    use sui_graphql_rpc::config::ConnectionConfig;
+    use sui_graphql_rpc::config::{ConnectionConfig, Limits};
     use sui_graphql_rpc::examples::{load_examples, ExampleQuery, ExampleQueryGroup};
     use sui_graphql_rpc::test_infra::cluster::ExecutorCluster;
     use sui_graphql_rpc::test_infra::cluster::DEFAULT_INTERNAL_DATA_SOURCE_PORT;
@@ -46,23 +47,49 @@ mod tests {
     async fn validate_example_query_group(
         cluster: &ExecutorCluster,
         group: &ExampleQueryGroup,
+        max_nodes: &mut u64,
+        max_depth: &mut u64,
+        max_payload: &mut u64,
     ) -> Vec<String> {
         let mut errors = vec![];
         for query in &group.queries {
             let resp = cluster
                 .graphql_client
-                .execute(query.contents.clone(), vec![])
+                .execute_to_graphql(query.contents.clone(), true, vec![], vec![])
                 .await
                 .unwrap();
-            if let Some(err) = resp.get("errors") {
+            resp.errors().iter().for_each(|err| {
                 errors.push(format!(
                     "Query failed: {}: {} at: {}\nError: {}",
                     group.name,
                     query.name,
                     query.path.display(),
                     err
+                ))
+            });
+            let usage = resp
+                .usage()
+                .expect("Usage fetch should succeed")
+                .expect(&format!(
+                    "Usage should be present for query: {}",
+                    query.name
                 ));
-            }
+
+            let nodes = *usage.get("nodes").expect(&format!(
+                "Node usage should be present for query: {}",
+                query.name
+            ));
+            let depth = *usage.get("depth").expect(&format!(
+                "Depth usage should be present for query: {}",
+                query.name
+            ));
+            let payload = *usage.get("query_payload").expect(&format!(
+                "Payload usage should be present for query: {}",
+                query.name
+            ));
+            *max_nodes = max(*max_nodes, nodes);
+            *max_depth = max(*max_depth, depth);
+            *max_payload = max(*max_payload, payload);
         }
         errors
     }
@@ -72,6 +99,7 @@ mod tests {
     async fn test_single_all_examples_structure_valid() {
         let rng = StdRng::from_seed([12; 32]);
         let mut sim = Simulacrum::new_with_rng(rng);
+        let (mut max_nodes, mut max_depth, mut max_payload) = (0, 0, 0);
 
         sim.create_checkpoint();
 
@@ -88,8 +116,37 @@ mod tests {
 
         let mut errors = vec![];
         for group in groups {
-            errors.extend(validate_example_query_group(&cluster, &group).await);
+            let group_errors = validate_example_query_group(
+                &cluster,
+                &group,
+                &mut max_nodes,
+                &mut max_depth,
+                &mut max_payload,
+            )
+            .await;
+            errors.extend(group_errors);
         }
+
+        // Check that our examples can run with our usage limits
+        let default_config = Limits::default();
+        assert!(
+            max_nodes <= default_config.max_query_nodes() as u64,
+            "Max nodes {} exceeds default limit {}",
+            max_nodes,
+            default_config.max_query_nodes()
+        );
+        assert!(
+            max_depth <= default_config.max_query_depth() as u64,
+            "Max depth {} exceeds default limit {}",
+            max_depth,
+            default_config.max_query_depth()
+        );
+        assert!(
+            max_payload <= default_config.max_query_payload_size() as u64,
+            "Max payload {} exceeds default limit {}",
+            max_payload,
+            default_config.max_query_payload_size()
+        );
 
         assert!(errors.is_empty(), "\n{}", errors.join("\n\n"));
     }
@@ -99,8 +156,9 @@ mod tests {
     async fn test_bad_examples_fail() {
         let rng = StdRng::from_seed([12; 32]);
         let mut sim = Simulacrum::new_with_rng(rng);
+        let (mut max_nodes, mut max_depth, mut max_payload) = (0, 0, 0);
 
-        sim.create_checkpoint();
+        sim.create_checkpoint();f
 
         let connection_config = ConnectionConfig::ci_integration_test_cfg();
 
@@ -112,7 +170,14 @@ mod tests {
         .await;
 
         let bad_examples = bad_examples();
-        let errors = validate_example_query_group(&cluster, &bad_examples).await;
+        let errors = validate_example_query_group(
+            &cluster,
+            &bad_examples,
+            &mut max_nodes,
+            &mut max_depth,
+            &mut max_payload,
+        )
+        .await;
 
         assert_eq!(
             errors.len(),


### PR DESCRIPTION
## Description 

This PR makes the prod limits smaller
The values were chosen based on the limits in our examples which are:
Max nodes: 39, Max depth: 11, Max payload: 976

## Test Plan 

Existing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
