### PR TITLE
[cli] Validate alias

### DIFF
--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -92,6 +92,10 @@ fn create_alias_if_not_exists_test() {
     // test expected result
     let create_alias_result = keystore.create_alias(Some("test".to_string()));
     assert_eq!("test".to_string(), create_alias_result.unwrap());
+    assert!(keystore.create_alias(Some("_test".to_string())).is_err());
+    assert!(keystore.create_alias(Some("-A".to_string())).is_err());
+    assert!(keystore.create_alias(Some("1A".to_string())).is_err());
+    assert!(keystore.create_alias(Some("&&AA".to_string())).is_err());
 }
 
 #[test]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -238,6 +238,7 @@ pub enum SuiClientCommands {
     #[clap(name = "new-address")]
     NewAddress {
         key_scheme: SignatureScheme,
+        /// The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_).
         alias: Option<String>,
         word_length: Option<String>,
         derivation_path: Option<DerivationPath>,

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::zklogin_commands_util::{perform_zk_login_test_tx, read_cli_line};
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use bip32::DerivationPath;
 use clap::*;
 use fastcrypto::ed25519::Ed25519KeyPair;

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -65,6 +65,7 @@ pub enum KeyToolCommand {
     #[clap(name = "update-alias")]
     Alias {
         old_alias: String,
+        /// The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_).
         new_alias: Option<String>,
     },
     /// Convert private key from wallet format (hex of 32 byte private key) to sui.keystore format
@@ -105,7 +106,7 @@ pub enum KeyToolCommand {
     /// Set an alias for the key with the --alias flag. If no alias is provided,
     /// the tool will automatically generate one.
     Import {
-        /// Sets an alias for this address
+        /// Sets an alias for this address. The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_).
         #[clap(long)]
         alias: Option<String>,
         input_string: String,
@@ -432,12 +433,6 @@ impl KeyToolCommand {
                 old_alias,
                 new_alias,
             } => {
-                if new_alias
-                    .as_ref()
-                    .is_some_and(|x| x.is_empty() || x.trim().is_empty())
-                {
-                    bail!("The new alias cannot be empty.");
-                }
                 let new_alias = keystore.update_alias(&old_alias, new_alias.as_deref())?;
                 CommandOutput::Alias(AliasUpdate {
                     old_alias,


### PR DESCRIPTION
## Description 

Introduce a validation step when creating or updating an alias. The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_). 

## Test Plan 

Updated existing tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added a validation step when creating or updating an alias of an address in the Sui CLI. The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_).