### PR TITLE
[EpochStore] release DB handle after epoch change 

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2043,7 +2043,7 @@ impl AuthorityPerEpochStore {
         'a,
         C: CheckpointServiceNotify,
     >(
-        self: &'a Arc<Self>,
+        &self,
         transactions: Vec<SequencedConsensusTransaction>,
         consensus_stats: &ExecutionIndicesWithStats,
         checkpoint_service: &Arc<C>,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1290,7 +1290,8 @@ impl CheckpointAggregator {
                 self.current.as_mut().unwrap()
             };
 
-            let iter = self.epoch_store.get_pending_checkpoint_signatures_iter(
+            let epoch_tables = self.epoch_store.tables();
+            let iter = epoch_tables.get_pending_checkpoint_signatures_iter(
                 current.summary.sequence_number,
                 current.next_index,
             )?;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1526,6 +1526,10 @@ impl SuiNode {
             };
             *self.validator_components.lock().await = new_validator_components;
 
+            // Force releasing current epoch store DB handle, because the
+            // Arc<AuthorityPerEpochStore> may linger.
+            cur_epoch_store.release_db_handles();
+
             #[cfg(msim)]
             if !matches!(
                 self.config


### PR DESCRIPTION
## Description 

Since September, validators are seeing increased memory usage over time. Upon investigations, the most of the memory growth is caused by not releasing the old per-epoch store per an epoch change. Although the symptom of lingering `AuthorityPerEpochStore` and DB handle showed up after #13819, the root cause could be elsewhere.

Instead, we apply the mitigation to release epoch DB handle after epoch change. This assumes the invariant that after epoch change, the previous epoch data is never accessed again.

## Test Plan 

Deployed to private testnet with 5min epoch interval. Memory increase and lingering DB handle no longer exists. No crash occurred on validators.

Comparing before and after the commits:

![image](https://github.com/MystenLabs/sui/assets/81660174/af28099f-9836-4d82-a4f9-41162fe3e765)

![image](https://github.com/MystenLabs/sui/assets/81660174/ce68add9-384f-4fe2-9b23-134e56a6426b)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
