### PR TITLE
fix: Fixed the path generation method in the code to support Windows …

### DIFF
--- a/sdk/create-dapp/src/index.ts
+++ b/sdk/create-dapp/src/index.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, statSync } from 'fs';
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
-import { relative, resolve } from 'path';
+import { relative, resolve, join, sep } from 'path';
 import { parseArgs } from 'util';
 import { prompt } from 'enquirer';
 
@@ -111,8 +111,7 @@ async function collectFiles(template: string, dAppName: string) {
 async function writeFiles(files: Array<{ path: string; content: Buffer }>, outDir: string) {
 	for (const file of files) {
 		const filePath = resolve(outDir, file.path);
-		const dirPath = filePath.split('/').slice(0, -1).join('/');
-
+		const dirPath = join(...filePath.split(sep).slice(0, -1));
 		if (!existsSync(dirPath)) {
 			await mkdir(dirPath, { recursive: true });
 		}


### PR DESCRIPTION
The use of @mysten/create-dapp will report an error in windows, because the code only supports the Linux path format. I tried to modify this bug so that it can support the windows system.

## Description 

I use the path module of Node.js for cross-platform path splicing. This module automatically handles path separator differences in different operating systems so that the code can run correctly on both Windows and Unix-like systems.
```const dirPath = join(...filePath.split(sep).slice(0, -1));```

## Test Plan 

I tested using Windows Powershell and WSL respectively and found no problems.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
