### PR TITLE
[replay tooling] Move replay log macro to info level

### DIFF
--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -237,15 +237,17 @@ macro_rules! fail_point_if {
     ($tag: expr, $callback: expr) => {};
 }
 
-/// Use to write DEBUG level logs only when REPLAY_LOG
+/// Use to write INFO level logs only when REPLAY_LOG
 /// environment variable is set. Useful for log lines that
 /// are only relevant to test infra which still may need to
-/// run a release build
+/// run a release build. Also note that since logs of a chain
+/// replay are exceedingly verbose, this will allow one to bubble
+/// up "debug level" info while running with RUST_LOG=info.
 #[macro_export]
 macro_rules! replay_log {
     ($($arg:tt)+) => {
         if std::env::var("REPLAY_LOG").is_ok() {
-            tracing::debug!($($arg)+);
+            tracing::info!($($arg)+);
         }
     };
 }


### PR DESCRIPTION
## Description 

Because chain replay logs are exceedingly verbose, we will need to run them with `info` level. This means that this logging macro will need to run in `info` level lest they be ignored.

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
