### PR TITLE
[graphql][EASY] Renamed active_epoch and request_epoch to past tense

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1231,7 +1231,7 @@
 >        status
 >        principal
 >        estimatedReward
->        activeEpoch {
+>        activatedEpoch {
 >          epochId
 >          referenceGasPrice
 >          validatorSet {
@@ -1243,7 +1243,7 @@
 >            totalStake
 >          }
 >        }
->        requestEpoch {
+>        requestedEpoch {
 >          epochId
 >        }
 >      }

--- a/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -15,7 +15,7 @@
         status
         principal
         estimatedReward
-        activeEpoch {
+        activatedEpoch {
           epochId
           referenceGasPrice
           validatorSet {
@@ -27,7 +27,7 @@
             totalStake
           }
         }
-        requestEpoch {
+        requestedEpoch {
           epochId
         }
       }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2021,11 +2021,11 @@ type StakedSui {
 	"""
 	The epoch at which this stake became active
 	"""
-	activeEpoch: Epoch
+	activatedEpoch: Epoch
 	"""
 	The epoch at which this object was requested to join a stake pool
 	"""
-	requestEpoch: Epoch
+	requestedEpoch: Epoch
 	"""
 	The SUI that was initially staked.
 	"""

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -46,7 +46,7 @@ impl StakedSui {
     }
 
     /// The epoch at which this stake became active
-    async fn active_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
+    async fn activated_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
         Ok(Some(
             ctx.data_unchecked::<PgManager>()
                 .fetch_epoch_strict(self.native.activation_epoch())
@@ -55,7 +55,7 @@ impl StakedSui {
     }
 
     /// The epoch at which this object was requested to join a stake pool
-    async fn request_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
+    async fn requested_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>, Error> {
         Ok(Some(
             ctx.data_unchecked::<PgManager>()
                 .fetch_epoch_strict(self.native.request_epoch())

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2025,11 +2025,11 @@ type StakedSui {
 	"""
 	The epoch at which this stake became active
 	"""
-	activeEpoch: Epoch
+	activatedEpoch: Epoch
 	"""
 	The epoch at which this object was requested to join a stake pool
 	"""
-	requestEpoch: Epoch
+	requestedEpoch: Epoch
 	"""
 	The SUI that was initially staked.
 	"""


### PR DESCRIPTION
## Description 

Renames the `active_epoch` and `request_epoch` of `StakedSui` to past tense.

## Test Plan 

Updated the example.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
