### PR TITLE
[bridge 11/n] handle eth actions in orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11435,6 +11435,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
+ "hex-literal 0.3.4",
  "move-core-types",
  "mysten-metrics",
  "once_cell",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -45,3 +45,4 @@ shared-crypto.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
 sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
 sui-config.workspace = true
+hex-literal = "0.3.4"

--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::EthLog;
 use ethers::{
     abi::RawLog,
     contract::{abigen, EthLogDecode},
-    types::Log,
 };
 use serde::{Deserialize, Serialize};
 
@@ -25,10 +25,10 @@ abigen!(
 );
 
 impl EthBridgeEvent {
-    pub fn try_from_eth_log(log: &Log) -> Option<EthBridgeEvent> {
+    pub fn try_from_eth_log(log: &EthLog) -> Option<EthBridgeEvent> {
         let raw_log = RawLog {
-            topics: log.topics.clone(),
-            data: log.data.to_vec(),
+            topics: log.log.topics.clone(),
+            data: log.log.data.to_vec(),
         };
         if let Ok(decoded) = ExampleContractEvents::decode_log(&raw_log) {
             return Some(EthBridgeEvent::ExampleContract(decoded));
@@ -54,5 +54,56 @@ impl EthBridgeEvent {
                 }))
             }
         }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use ethers::types::Address as EthAddress;
+    use ethers::{
+        abi::{long_signature, ParamType},
+        types::{Log, H256},
+    };
+    use hex_literal::hex;
+
+    use crate::types::{BridgeAction, EthToSuiBridgeAction};
+
+    use super::{ExampleContractEvents, TransferFilter};
+
+    /// Returns a test Log and corresponding BridgeAction
+    // Refernece: https://github.com/rust-ethereum/ethabi/blob/master/ethabi/src/event.rs#L192
+    pub fn get_test_log_and_action(contract_address: EthAddress) -> (Log, BridgeAction) {
+        let log = Log {
+            address: contract_address,
+            topics: vec![
+                long_signature(
+                    "Transfer",
+                    &[ParamType::Address, ParamType::Address, ParamType::Uint(256)],
+                ),
+                hex!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").into(),
+                hex!("000000000000000000000000dbf5e9c5206d0db70a90108bf936da60221dc080").into(),
+            ],
+            data: hex!(
+                "
+                0000000000000000000000000000000000000000000000000000000000000003
+                "
+            )
+            .into(),
+            block_hash: Some(H256::random()),
+            block_number: Some(1.into()),
+            transaction_hash: Some(H256::random()),
+            log_index: Some(0.into()),
+            ..Default::default()
+        };
+        let bridge_action = BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
+            eth_tx_hash: log.transaction_hash.unwrap(),
+            eth_event_index: 10,
+            eth_bridge_event: ExampleContractEvents::TransferFilter(TransferFilter {
+                from: log.topics[1].into(),
+                to: log.topics[2].into(),
+                amount: 3.into(), // matches `data` in log
+            }),
+        });
+        (log, bridge_action)
     }
 }

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -21,6 +21,8 @@ pub enum BridgeError {
     AuthoritySignatureAggregationTooManyError(String),
     // Transient Ethereum provider error
     TransientProviderError(String),
+    // Ethereum provider error
+    ProviderError(String),
     // Invalid BridgeCommittee
     InvalidBridgeCommittee(String),
     // Invalid Bridge authority signature

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -34,9 +34,12 @@ pub struct EmittedSuiToEthTokenBridgeV1 {
     pub amount: u128,
 }
 
+const EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG: &str =
+    "0x01::SuiToEthTokenBridge::SuiToEthTokenBridge";
+
 crate::declare_events!(
     // TODO: Placeholder, use right struct tag
-    SuiToEthTokenBridgeV1(EmittedSuiToEthTokenBridgeV1) => "0x01::SuiToEthTokenBridge::SuiToEthTokenBridge",
+    SuiToEthTokenBridgeV1(EmittedSuiToEthTokenBridgeV1) => EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG,
     // Add new event types here. Format: EnumVariantName(Struct) => "StructTagString",
 );
 
@@ -91,5 +94,61 @@ impl SuiBridgeEvent {
                 }))
             }
         }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::{EmittedSuiToEthTokenBridgeV1, EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG};
+    use crate::types::BridgeAction;
+    use crate::types::BridgeChainId;
+    use crate::types::SuiToEthBridgeAction;
+    use crate::types::TokenId;
+    use ethers::types::Address as EthAddress;
+    use move_core_types::language_storage::StructTag;
+    use std::str::FromStr;
+    use sui_json_rpc_types::SuiEvent;
+    use sui_types::base_types::ObjectID;
+    use sui_types::base_types::SuiAddress;
+    use sui_types::digests::TransactionDigest;
+    use sui_types::event::EventID;
+    use sui_types::Identifier;
+
+    /// Returns a test SuiEvent and corresponding BridgeAction
+    pub fn get_test_sui_event_and_action(identifier: Identifier) -> (SuiEvent, BridgeAction) {
+        let emitted_event = EmittedSuiToEthTokenBridgeV1 {
+            nonce: 1,
+            sui_chain_id: BridgeChainId::SuiTestnet,
+            eth_chain_id: BridgeChainId::EthSepolia,
+            sui_address: SuiAddress::random_for_testing_only(),
+            eth_address: EthAddress::random(),
+            token_id: TokenId::Sui,
+            amount: 100,
+        };
+        let tx_digest = TransactionDigest::random();
+        let event_idx = 10u16;
+        let bridge_action = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
+            sui_tx_digest: tx_digest,
+            sui_tx_event_index: event_idx,
+            sui_bridge_event: emitted_event.clone(),
+        });
+        let event = SuiEvent {
+            // For this test to pass, match what is in events.rs
+            type_: StructTag::from_str(EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG).unwrap(),
+            bcs: bcs::to_bytes(&emitted_event).unwrap(),
+            id: EventID {
+                tx_digest,
+                event_seq: event_idx as u64,
+            },
+
+            // The following fields do not matter as of writing,
+            // but if tests start to fail, it's worth checking these fields.
+            package_id: ObjectID::ZERO,
+            transaction_module: identifier.clone(),
+            sender: SuiAddress::random_for_testing_only(),
+            parsed_json: serde_json::json!({"test": "test"}),
+            timestamp_ms: None,
+        };
+        (event, bridge_action)
     }
 }


### PR DESCRIPTION
## Description 

1. For Orchestrator's eth watcher channel, change eth logs from `Log` to `EthLog`. The latter contains essential attribute of the log, which are Optional in the former. See `fn get_log_tx_details` for the conversion from `Log` to `EthLog`
2. add handling for eth actions (handling for sui actions is done in previous PR)
3. add storage focused tests for orchestrator


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
