### PR TITLE
[authority] Remove spawn from handle_certificate_v2

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -548,21 +548,17 @@ impl Validator for ValidatorService {
         request.get_ref().verify_user_input()?;
         let validator_service = self.clone();
 
-        // Spawns a task which handles the certificate. The task will unconditionally continue
-        // processing in the event that the client connection is dropped.
-        spawn_monitored_task!(async move {
-            let span = error_span!("handle_certificate", tx_digest = ?request.get_ref().digest());
-            Self::handle_certificate(validator_service, request, true)
-                .instrument(span)
-                .await
-        })
-        .await
-        .unwrap()
-        .map(|v| {
-            tonic::Response::new(
-                v.expect("handle_certificate should not return none with wait_for_effects=true"),
-            )
-        })
+        let span = error_span!("handle_certificate", tx_digest = ?request.get_ref().digest());
+        Self::handle_certificate(validator_service, request, true)
+            .instrument(span)
+            .await
+            .map(|v| {
+                tonic::Response::new(
+                    v.expect(
+                        "handle_certificate should not return none with wait_for_effects=true",
+                    ),
+                )
+            })
     }
 
     async fn handle_certificate(


### PR DESCRIPTION
It used to be there because execution was done in the handle_certificate task. Right now we do execution in a separate task, handle_certificate should not be cancellation safe.

List of `await`s in the `handle_certificate` path:

* `signature_verifier.verify_cert` - safe to drop (`verify_cert_inner` seem to have comments about cancellation safety)
* `execute_certificate` - only `await` inside this call is `notify_read_effects` which is cancellation safe

