### PR TITLE
indexer: quick object snapshot and fix object history

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
@@ -60,8 +60,8 @@ CREATE TABLE objects_history (
 CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 -- TODO(gegaowp): add corresponding indices for consistent reads of objects_history table
 
--- snapshot table by folding objects_history table until certain epoch,
--- effectively the snapshot of objects at the same epoch,
+-- snapshot table by folding objects_history table until certain checkpoint,
+-- effectively the snapshot of objects at the same checkpoint,
 -- except that it also includes deleted or wrapped objects with the corresponding object_status.
 CREATE TABLE objects_snapshot (
     object_id                   bytea         PRIMARY KEY,
@@ -80,3 +80,7 @@ CREATE TABLE objects_snapshot (
     df_object_type              text,
     df_object_id                bytea
 );
+CREATE INDEX objects_snapshot_checkpoint_sequence_number ON objects_snapshot (checkpoint_sequence_number);
+CREATE INDEX objects_snapshot_owner ON objects_snapshot (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX objects_snapshot_coin ON objects_snapshot (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
+CREATE INDEX objects_snapshot_type ON objects_snapshot (object_type);

--- a/crates/sui-indexer/migrations_v2/2023-10-07-160139_display/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-10-07-160139_display/up.sql
@@ -4,5 +4,5 @@ CREATE TABLE display
     object_type     text        PRIMARY KEY,
     id              BYTEA       NOT NULL,
     version         SMALLINT    NOT NULL,
-    bcs          BYTEA       NOT NULL
+    bcs             BYTEA       NOT NULL
 );

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -308,6 +308,8 @@ where
         // Index Objects
         let object_changes: TransactionObjectChangesToCommit =
             Self::index_objects(data.clone(), &metrics, &module_resolver);
+        let object_history_changes: TransactionObjectChangesToCommit =
+            Self::index_objects_history(data.clone(), &module_resolver);
 
         let (checkpoint, db_transactions, db_events, db_indices, db_displays) = {
             let CheckpointData {
@@ -345,6 +347,7 @@ where
             tx_indices: db_indices,
             display_updates: db_displays,
             object_changes,
+            object_history_changes,
             packages,
             epoch,
         })
@@ -579,6 +582,73 @@ where
                             object.clone(),
                             df_info,
                         ))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        TransactionObjectChangesToCommit {
+            changed_objects,
+            deleted_objects: indexed_deleted_objects,
+        }
+    }
+
+    // similar to index_objects, but objects_history keeps all versions of objects
+    fn index_objects_history(
+        data: CheckpointData,
+        module_resolver: &impl GetModule,
+    ) -> TransactionObjectChangesToCommit {
+        let checkpoint_seq = data.checkpoint_summary.sequence_number;
+        let deleted_objects = data
+            .transactions
+            .iter()
+            .flat_map(|tx| get_deleted_objects(&tx.effects))
+            .collect::<Vec<_>>();
+        let indexed_deleted_objects: Vec<IndexedDeletedObject> = deleted_objects
+            .into_iter()
+            .map(|o| IndexedDeletedObject {
+                object_id: o.0,
+                object_version: o.1.value(),
+                checkpoint_sequence_number: checkpoint_seq,
+            })
+            .collect();
+
+        let history_object_map = data
+            .output_objects()
+            .into_iter()
+            .map(|o| (o.id(), o.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let changed_objects: Vec<IndexedObject> = data
+            .transactions
+            .iter()
+            .flat_map(|tx| {
+                let CheckpointTransaction {
+                    transaction: tx,
+                    effects: fx,
+                    ..
+                } = tx;
+                fx.all_changed_objects()
+                    .into_iter()
+                    .map(|(oref, _owner, _kind)| {
+                        let history_object = history_object_map.get(&(oref.0)).unwrap_or_else(|| {
+                            panic!(
+                                "object {:?} not found in CheckpointData (tx_digest: {})",
+                                oref.0,
+                                tx.digest()
+                            )
+                        });
+                        assert_eq!(oref.1, history_object.version());
+                        let df_info =
+                            try_create_dynamic_field_info(history_object, &history_object_map, module_resolver)
+                                .unwrap_or_else(|e| {
+                                    panic!(
+                                "failed to create dynamic field info for history obj: {:?}:{:?}. Err: {e}",
+                                history_object.id(),
+                                history_object.version()
+                            )
+                                });
+
+                        IndexedObject::from_object(checkpoint_seq, history_object.clone(), df_info)
                     })
                     .collect::<Vec<_>>()
             })

--- a/crates/sui-indexer/src/handlers/mod.rs
+++ b/crates/sui-indexer/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub struct CheckpointDataToCommit {
     pub tx_indices: Vec<TxIndex>,
     pub display_updates: BTreeMap<String, StoredDisplay>,
     pub object_changes: TransactionObjectChangesToCommit,
+    pub object_history_changes: TransactionObjectChangesToCommit,
     pub packages: Vec<IndexedPackage>,
     pub epoch: Option<EpochToCommit>,
 }

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -65,6 +65,8 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_tx_indices_chunks: Histogram,
     pub checkpoint_db_commit_latency_checkpoints: Histogram,
     pub checkpoint_db_commit_latency_epoch: Histogram,
+    pub advance_epoch_latency: Histogram,
+    pub update_object_snapshot_latency: Histogram,
     // average latency of committing 1000 transactions.
     // 1000 is not necessarily the batch size, it's to roughly map average tx commit latency to [0.1, 1] seconds,
     // which is well covered by DB_COMMIT_LATENCY_SEC_BUCKETS.
@@ -383,6 +385,18 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            advance_epoch_latency: register_histogram_with_registry!(
+                "advance_epoch_latency",
+                "Time spent in advancing epoch",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            update_object_snapshot_latency: register_histogram_with_registry!(
+                "update_object_snapshot_latency",
+                "Time spent in updating object snapshot",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
             thousand_transaction_avg_db_commit_latency: register_histogram_with_registry!(
                 "transaction_db_commit_latency",
                 "Average time spent commiting 1000 transactions to the db",

--- a/crates/sui-indexer/src/store/indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/indexer_store_v2.rs
@@ -27,6 +27,10 @@ pub trait IndexerStoreV2 {
 
     async fn get_latest_tx_checkpoint_sequence_number(&self) -> Result<Option<u64>, IndexerError>;
 
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError>;
+
     async fn get_object_read(
         &self,
         object_id: ObjectID,
@@ -42,6 +46,8 @@ pub trait IndexerStoreV2 {
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
+
+    async fn persist_object_snapshot(&self) -> Result<(), IndexerError>;
 
     async fn persist_checkpoints(
         &self,

--- a/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
@@ -38,8 +38,8 @@ use crate::models_v2::objects::{
 use crate::models_v2::packages::StoredPackage;
 use crate::models_v2::transactions::StoredTransaction;
 use crate::schema_v2::{
-    checkpoints, display, epochs, events, objects, objects_history, packages, transactions,
-    tx_calls, tx_changed_objects, tx_input_objects, tx_recipients, tx_senders,
+    checkpoints, display, epochs, events, objects, objects_history, objects_snapshot, packages,
+    transactions, tx_calls, tx_changed_objects, tx_input_objects, tx_recipients, tx_senders,
 };
 use crate::store::diesel_macro::{read_only_blocking, transactional_blocking_with_retry};
 use crate::store::module_resolver_v2::IndexerStoreModuleResolver;
@@ -73,7 +73,36 @@ const PG_COMMIT_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
 // The amount of rows to update in one DB transcation, for objects particularly
 // Having this number too high may cause many db deadlocks because of
 // optimistic locking.
-const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
+const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 100;
+const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: usize = 900;
+const OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG: usize = 300;
+
+const UPDATE_OBJECTS_SNAPSHOT_QUERY: &str = r"
+INSERT INTO objects_snapshot (object_id, object_version, object_status, object_digest, checkpoint_sequence_number, owner_type, owner_id, object_type, serialized_object, coin_type, coin_balance, df_kind, df_name, df_object_type, df_object_id)
+SELECT object_id, object_version, object_status, object_digest, checkpoint_sequence_number, owner_type, owner_id, object_type, serialized_object, coin_type, coin_balance, df_kind, df_name, df_object_type, df_object_id
+FROM (
+    SELECT *,
+           ROW_NUMBER() OVER (PARTITION BY object_id ORDER BY object_version DESC) as rn
+    FROM objects_history
+    WHERE checkpoint_sequence_number >= $1 AND checkpoint_sequence_number < $2
+) as subquery
+WHERE rn = 1
+ON CONFLICT (object_id) DO UPDATE
+SET object_version = EXCLUDED.object_version,
+    object_status = EXCLUDED.object_status,
+    object_digest = EXCLUDED.object_digest,
+    checkpoint_sequence_number = EXCLUDED.checkpoint_sequence_number,
+    owner_type = EXCLUDED.owner_type,
+    owner_id = EXCLUDED.owner_id,
+    object_type = EXCLUDED.object_type,
+    serialized_object = EXCLUDED.serialized_object,
+    coin_type = EXCLUDED.coin_type,
+    coin_balance = EXCLUDED.coin_balance,
+    df_kind = EXCLUDED.df_kind,
+    df_name = EXCLUDED.df_name,
+    df_object_type = EXCLUDED.df_object_type,
+    df_object_id = EXCLUDED.df_object_id;
+";
 
 #[derive(Clone)]
 pub struct PgIndexerStoreV2 {
@@ -82,6 +111,8 @@ pub struct PgIndexerStoreV2 {
     metrics: IndexerMetrics,
     parallel_chunk_size: usize,
     parallel_objects_chunk_size: usize,
+    object_snapshot_min_checkpoint_lag: usize,
+    object_snapshot_max_checkpoint_lag: usize,
     partition_manager: PgPartitionManager,
 }
 
@@ -98,6 +129,16 @@ impl PgIndexerStoreV2 {
             .unwrap_or_else(|_e| PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX.to_string())
             .parse::<usize>()
             .unwrap();
+        let object_snapshot_min_checkpoint_lag =
+            std::env::var("OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG")
+                .unwrap_or_else(|_e| OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG.to_string())
+                .parse::<usize>()
+                .unwrap();
+        let object_snapshot_max_checkpoint_lag =
+            std::env::var("OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG")
+                .unwrap_or_else(|_e| OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG.to_string())
+                .parse::<usize>()
+                .unwrap();
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())
             .expect("Failed to initialize partition manager");
 
@@ -107,6 +148,8 @@ impl PgIndexerStoreV2 {
             metrics,
             parallel_chunk_size,
             parallel_objects_chunk_size,
+            object_snapshot_min_checkpoint_lag,
+            object_snapshot_max_checkpoint_lag,
             partition_manager,
         }
     }
@@ -123,6 +166,18 @@ impl PgIndexerStoreV2 {
                 .map(|v| v.map(|v| v as u64))
         })
         .context("Failed reading latest checkpoint sequence number from PostgresDB")
+    }
+
+    fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            objects_snapshot::dsl::objects_snapshot
+                .select(max(objects_snapshot::checkpoint_sequence_number))
+                .first::<Option<i64>>(conn)
+                .map(|v| v.map(|v| v as u64))
+        })
+        .context("Failed reading latest object snapshot checkpoint sequence number from PostgresDB")
     }
 
     // Note: here we treat Deleted as NotExists too
@@ -317,6 +372,22 @@ impl PgIndexerStoreV2 {
                 mutated_objects.len() + deleted_object_ids.len(),
             )
         })
+    }
+
+    fn persist_object_snapshot(&self, start_cp: u64, end_cp: u64) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                RunQueryDsl::execute(
+                    diesel::sql_query(UPDATE_OBJECTS_SNAPSHOT_QUERY)
+                        .bind::<diesel::sql_types::BigInt, _>(start_cp as i64)
+                        .bind::<diesel::sql_types::BigInt, _>(end_cp as i64),
+                    conn,
+                )
+            },
+            Duration::from_secs(10)
+        )?;
+        Ok(())
     }
 
     fn persist_checkpoints(&self, checkpoints: Vec<IndexedCheckpoint>) -> Result<(), IndexerError> {
@@ -701,16 +772,19 @@ impl PgIndexerStoreV2 {
                     EpochPartitionData::compose_data(epoch_to_commit, last_epoch);
                 let table_partitions = self.partition_manager.get_table_partitions()?;
                 for (table, last_partition) in table_partitions {
+                    let guard = self.metrics.advance_epoch_latency.start_timer();
                     self.partition_manager.advance_table_epoch_partition(
                         table.clone(),
                         last_partition,
                         &epoch_partition_data,
                     )?;
-                    // update objects_snapshot with objects_history of last epoch
-                    if table == *"objects_history" {
-                        self.partition_manager
-                            .update_objects_snapshot(&epoch_partition_data)?;
-                    }
+                    let elapsed = guard.stop_and_record();
+                    info!(
+                        elapsed,
+                        "Advanced epoch partition {} for table {}",
+                        last_partition,
+                        table.clone()
+                    );
                 }
             } else {
                 tracing::error!("Last epoch: {} from PostgresDB is None.", last_epoch_id);
@@ -787,6 +861,15 @@ impl IndexerStoreV2 for PgIndexerStoreV2 {
             .await
     }
 
+    async fn get_latest_object_snapshot_checkpoint_sequence_number(
+        &self,
+    ) -> Result<Option<u64>, IndexerError> {
+        self.execute_in_blocking_worker(|this| {
+            this.get_latest_object_snapshot_checkpoint_sequence_number()
+        })
+        .await
+    }
+
     async fn get_object_read(
         &self,
         object_id: ObjectID,
@@ -837,7 +920,7 @@ impl IndexerStoreV2 for PgIndexerStoreV2 {
         if object_changes.is_empty() {
             return Ok(());
         }
-        let objects = make_final_list_of_objects_to_commit(object_changes);
+        let objects = make_objects_history_to_commit(object_changes);
         let guard = self
             .metrics
             .checkpoint_db_commit_latency_objects_history
@@ -862,6 +945,38 @@ impl IndexerStoreV2 for PgIndexerStoreV2 {
             })?;
         let elapsed = guard.stop_and_record();
         info!(elapsed, "Persisted {} objects history", len);
+        Ok(())
+    }
+
+    async fn persist_object_snapshot(&self) -> Result<(), IndexerError> {
+        let latest_cp = self
+            .get_latest_tx_checkpoint_sequence_number()?
+            .unwrap_or_default();
+        let latest_snapshot_cp = self
+            .get_latest_object_snapshot_checkpoint_sequence_number()?
+            .unwrap_or_default();
+
+        if latest_cp <= latest_snapshot_cp + self.object_snapshot_max_checkpoint_lag as u64 {
+            return Ok(());
+        }
+        // make sure cp 0 is handled
+        let start_cp = if latest_snapshot_cp == 0 {
+            0
+        } else {
+            latest_snapshot_cp + 1
+        };
+        // with MAX and MIN, the CSR range will vary from MIN cps to MAX cps
+        let snapshot_window = self.object_snapshot_max_checkpoint_lag as u64
+            - self.object_snapshot_min_checkpoint_lag as u64;
+        let guard = self.metrics.update_object_snapshot_latency.start_timer();
+        self.persist_object_snapshot(start_cp, start_cp + snapshot_window)?;
+        let elapsed = guard.stop_and_record();
+        info!(
+            elapsed,
+            "Persisted snapshot for checkpoints from {} to {}",
+            start_cp,
+            start_cp + snapshot_window,
+        );
         Ok(())
     }
 
@@ -1052,6 +1167,31 @@ fn make_final_list_of_objects_to_commit(
             latest_objects
                 .into_values()
                 .map(StoredObject::from)
+                .map(ObjectChangeToCommit::MutatedObject),
+        )
+        .collect()
+}
+
+fn make_objects_history_to_commit(
+    tx_object_changes: Vec<TransactionObjectChangesToCommit>,
+) -> Vec<ObjectChangeToCommit> {
+    let deleted_objects: Vec<StoredDeletedObject> = tx_object_changes
+        .clone()
+        .into_iter()
+        .flat_map(|changes| changes.deleted_objects)
+        .map(|o| o.into())
+        .collect();
+    let mutated_objects: Vec<StoredObject> = tx_object_changes
+        .into_iter()
+        .flat_map(|changes| changes.changed_objects)
+        .map(|o| o.into())
+        .collect();
+    deleted_objects
+        .into_iter()
+        .map(ObjectChangeToCommit::DeletedObject)
+        .chain(
+            mutated_objects
+                .into_iter()
                 .map(ObjectChangeToCommit::MutatedObject),
         )
         .collect()

--- a/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
@@ -73,10 +73,12 @@ const PG_COMMIT_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
 // The amount of rows to update in one DB transcation, for objects particularly
 // Having this number too high may cause many db deadlocks because of
 // optimistic locking.
-const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 100;
+const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
 const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: usize = 900;
 const OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG: usize = 300;
 
+// with rn = 1, we only select the latest version of each object,
+// so that we don't have to update the same object multiple times.
 const UPDATE_OBJECTS_SNAPSHOT_QUERY: &str = r"
 INSERT INTO objects_snapshot (object_id, object_version, object_status, object_digest, checkpoint_sequence_number, owner_type, owner_id, object_type, serialized_object, coin_type, coin_balance, df_kind, df_name, df_object_type, df_object_id)
 SELECT object_id, object_version, object_status, object_digest, checkpoint_sequence_number, owner_type, owner_id, object_type, serialized_object, coin_type, coin_balance, df_kind, df_name, df_object_type, df_object_id


### PR DESCRIPTION
## Description 

main changes are:
- instead of updating object snapshot at epoch boundary, now we update object snapshot following a sliding window of checkpoints, so that each update will not take too long
- fix object history, prev it skipped intermediate object versions, which is correct for `objects` which only tracks latest versions, but not the case for `objects_history`, which is supposed to track all versions
- move advance epoch before checkpoint persisting, so that checkpoint can always be the watermark, in case of pod crashing and resuming, the advance epoch process will be resumed properly too

## Test Plan 

local run and verify that
- objects_history table has all intermediate versions & checkpoints
- object snapshot can be update properly per the objects_history

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
