### PR TITLE
[cert handling] Perform fullnode/system tx checks earlier

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -380,6 +380,20 @@ impl ValidatorService {
 
         let epoch_store = state.load_epoch_store_one_call_per_task();
         let certificate = request.into_inner();
+
+        // Validate if cert can be executed
+        // Fullnode does not serve handle_certificate call.
+        fp_ensure!(
+            !state.is_fullnode(&epoch_store),
+            SuiError::FullNodeCantHandleCertificate.into()
+        );
+
+        // CRITICAL! Validators should never sign an external system transaction.
+        fp_ensure!(
+            !certificate.is_system_tx(),
+            SuiError::InvalidSystemTransaction.into()
+        );
+
         certificate.verify_user_input()?;
 
         let shared_object_tx = certificate.contains_shared_object();
@@ -414,19 +428,7 @@ impl ValidatorService {
             }));
         }
 
-        // 2) Validate if cert can be executed, and verify the cert.
-        // Fullnode does not serve handle_certificate call.
-        fp_ensure!(
-            !state.is_fullnode(&epoch_store),
-            SuiError::FullNodeCantHandleCertificate.into()
-        );
-
-        // CRITICAL! Validators should never sign an external system transaction.
-        fp_ensure!(
-            !certificate.is_system_tx(),
-            SuiError::InvalidSystemTransaction.into()
-        );
-
+        // 2) Verify the cert.
         // Check system overload
         let overload_check_res =
             state.check_system_overload(&consensus_adapter, certificate.data());


### PR DESCRIPTION
## Description 

As in title

## Test Plan 

Existing tests in `crates/sui-core/src/unit_tests/authority_tests.rs`. Specifically, `test_refusal_to_sign_consensus_commit_prologue_v2` verifies we reject system transactions.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
