### PR TITLE
[test] adding test to prove acquire locks dedup functionality.

### DIFF
--- a/crates/sui-storage/src/mutex_table.rs
+++ b/crates/sui-storage/src/mutex_table.rs
@@ -345,6 +345,36 @@ async fn test_mutex_table() {
 }
 
 #[tokio::test]
+async fn test_acquire_locks() {
+    let mutex_table =
+        RwLockTable::<String>::new_with_cleanup(1, Duration::from_secs(10), Duration::MAX, 1000);
+    let object_1 = "object 1".to_string();
+    let object_2 = "object 2".to_string();
+    let object_3 = "object 3".to_string();
+
+    // ensure even with duplicate objects we succeed acquiring their locks
+    let objects = vec![
+        object_1.clone(),
+        object_2.clone(),
+        object_2,
+        object_1.clone(),
+        object_3,
+        object_1,
+    ];
+
+    let locks = mutex_table.acquire_locks(objects.clone().into_iter()).await;
+    assert_eq!(locks.len(), 3);
+
+    for object in objects.clone() {
+        assert!(mutex_table.try_acquire_lock(object).is_err());
+    }
+
+    drop(locks);
+    let locks = mutex_table.acquire_locks(objects.into_iter()).await;
+    assert_eq!(locks.len(), 3);
+}
+
+#[tokio::test]
 async fn test_read_locks() {
     let mutex_table =
         RwLockTable::<String>::new_with_cleanup(1, Duration::from_secs(10), Duration::MAX, 1000);


### PR DESCRIPTION
## Description 

Adding a test to prove that acquire locks method can properly handle duplicate objects and avoid getting into a deadlock situation.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
