### PR TITLE
[fixit] add comments in check_sponsorship

### DIFF
--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1975,11 +1975,15 @@ impl TransactionDataAPI for TransactionDataV1 {
     }
 
     /// Check if the transaction is compliant with sponsorship.
+    /// Theoretically non-programmable transactions (aka system transactions)
+    /// should not reach here. Now its mostly to ensure the function is not called
+    /// incorrectly in the future, like in a refactoring.
     fn check_sponsorship(&self) -> UserInputResult {
         // Not a sponsored transaction, nothing to check
         if self.gas_owner() == self.sender() {
             return Ok(());
         }
+        // Only programmable transactions can be sponsored
         if matches!(&self.kind, TransactionKind::ProgrammableTransaction(_)) {
             return Ok(());
         }


### PR DESCRIPTION
## Description 

When this function was originally added, we had a different transaction types system (Single, Batch, PayAllSui etc). And this function was to ensure only right transaction types could be sponsored. Today all Programmable Transactions (non-system transactions) can be sponsored. So as long as we ensure only PT can reach `fn check_sponsorship`, it is an no-op. I think it's the case today, but not sure for the future. Just leave the function as is, and add a comment. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
