### PR TITLE
Make the ownership invariant checks easier to understand. Improved precision.  

### DIFF
--- a/crates/sui-types/src/execution_mode.rs
+++ b/crates/sui-types/src/execution_mode.rs
@@ -155,6 +155,7 @@ impl ExecutionMode for System {
     type ExecutionResults = ();
 
     fn allow_arbitrary_function_calls() -> bool {
+        // allows bypassing visibility for system calls
         true
     }
 

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -188,6 +188,11 @@ pub trait Storage {
         &mut self,
         loaded_runtime_objects: BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata>,
     );
+
+    fn save_wrapped_object_containers(
+        &mut self,
+        wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
+    );
 }
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -138,6 +138,7 @@ impl<'a> ObjectRuntime<'a> {
     ) -> Self {
         let mut input_object_owners = BTreeMap::new();
         let mut root_version = BTreeMap::new();
+        let mut wrapped_object_containers = BTreeMap::new();
         for (id, input_object) in input_objects {
             let InputObject {
                 contained_uids,
@@ -148,12 +149,17 @@ impl<'a> ObjectRuntime<'a> {
             debug_assert!(contained_uids.contains(&id));
             for contained_uid in contained_uids {
                 root_version.insert(contained_uid, version);
+                if contained_uid != id {
+                    let prev = wrapped_object_containers.insert(contained_uid, id);
+                    debug_assert!(prev.is_none());
+                }
             }
         }
         Self {
             child_object_store: ChildObjectStore::new(
                 object_resolver,
                 root_version,
+                wrapped_object_containers,
                 is_metered,
                 protocol_config,
                 metrics.clone(),
@@ -441,6 +447,12 @@ impl<'a> ObjectRuntime<'a> {
                     .map(|(id, meta)| (*id, meta.clone())),
             )
             .collect()
+    }
+
+    /// A map from wrapped objects to the object that wraps them at the beginning of the
+    /// transaction.
+    pub fn wrapped_object_containers(&self) -> BTreeMap<ObjectID, ObjectID> {
+        self.child_object_store.wrapped_object_containers().clone()
     }
 }
 

--- a/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
@@ -1095,6 +1095,13 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     ) {
         TemporaryStore::save_loaded_runtime_objects(self, loaded_runtime_objects)
     }
+
+    fn save_wrapped_object_containers(
+        &mut self,
+        _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
+    ) {
+        panic!("Unused in v1")
+    }
 }
 
 impl<'backing> BackingPackageStore for TemporaryStore<'backing> {

--- a/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
@@ -1100,7 +1100,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
         &mut self,
         _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
     ) {
-        panic!("Unused in v1")
+        unreachable!("Unused in next-vm")
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -991,6 +991,13 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     ) {
         TemporaryStore::save_loaded_runtime_objects(self, loaded_runtime_objects)
     }
+
+    fn save_wrapped_object_containers(
+        &mut self,
+        _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
+    ) {
+        panic!("Unused in v0")
+    }
 }
 
 impl<'backing> BackingPackageStore for TemporaryStore<'backing> {

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -996,7 +996,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
         &mut self,
         _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
     ) {
-        panic!("Unused in v0")
+        unreachable!("Unused in v0")
     }
 }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -1100,6 +1100,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
         &mut self,
         _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
     ) {
+        unreachable!("Unused in v1")
     }
 }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -1095,6 +1095,12 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     ) {
         TemporaryStore::save_loaded_runtime_objects(self, loaded_runtime_objects)
     }
+
+    fn save_wrapped_object_containers(
+        &mut self,
+        _wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
+    ) {
+    }
 }
 
 impl<'backing> BackingPackageStore for TemporaryStore<'backing> {


### PR DESCRIPTION
## Description 

- Rewrote the ownership invariant check to hopefully make it a bit easier to follow 
- Threaded in wrapped object data and the mutable input information for more precise ownership checks. Previously we would have missed mutations on readonly/deleted shared objects. Additionally, we assumed any writes to wrapped object children were properly authenticated. 

## Test Plan 

- Do we have tests for this?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
