### PR TITLE
[graphql/rpc] easy: remove `/schema` endpoint

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -107,7 +107,6 @@ impl ServerBuilder {
             let router: Router = Router::new()
                 .route("/", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
-                .route("/schema", axum::routing::get(get_schema))
                 .layer(middleware::from_fn(check_version_middleware))
                 .layer(middleware::from_fn(set_version_middleware));
             self.router = Some(router);
@@ -238,19 +237,6 @@ impl ServerBuilder {
 
         Ok(builder)
     }
-}
-
-async fn get_schema() -> impl axum::response::IntoResponse {
-    let schema = include_str!("../../schema/current_progress_schema.graphql").to_string();
-    let schema = format!(
-        r#"
-    <span style="white-space: pre;">{}
-    </span>
-    "#,
-        schema
-    );
-
-    axum::response::Html(schema)
 }
 
 async fn graphql_handler(


### PR DESCRIPTION
## Description 

Removes the `/schema` endpoint e.g https://graphql-beta.mainnet.sui.io/schema which is not really needed anymore

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
