### PR TITLE
Create safe_range_iter and replace range_iter

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2509,24 +2509,29 @@ impl AuthorityState {
                     );
                     let mut object_scanned: u64 = 0;
                     let mut wrapped_objects_to_remove = vec![];
-                    for (object_key, object) in self.database.perpetual_tables.objects.range_iter(
+                    for db_result in self.database.perpetual_tables.objects.safe_range_iter(
                         ObjectKey::min_for_id(&start_id)..=ObjectKey::max_for_id(&end_id),
                     ) {
-                        object_scanned += 1;
-                        if object_scanned % 100000 == 0 {
-                            info!(
-                                "[Re-accumulate] Task {}: object scanned: {}",
-                                index, object_scanned,
-                            );
-                        }
-                        if matches!(prev.1.inner(), StoreObject::Wrapped)
-                            && object_key.0 != prev.0 .0
-                        {
-                            wrapped_objects_to_remove
-                                .push(WrappedObject::new(prev.0 .0, prev.0 .1));
-                        }
+                        match db_result {
+                            Ok((object_key, object)) => {
+                                object_scanned += 1;
+                                if object_scanned % 100000 == 0 {
+                                    info!(
+                                        "[Re-accumulate] Task {}: object scanned: {}",
+                                        index, object_scanned,
+                                    );
+                                }
+                                if matches!(prev.1.inner(), StoreObject::Wrapped)
+                                    && object_key.0 != prev.0 .0
+                                {
+                                    wrapped_objects_to_remove
+                                        .push(WrappedObject::new(prev.0 .0, prev.0 .1));
+                                }
 
-                        prev = (object_key, object);
+                                prev = (object_key, object);
+                            }
+                            Err(err) => return Err(err),
+                        }
                     }
                     if matches!(prev.1.inner(), StoreObject::Wrapped) {
                         wrapped_objects_to_remove.push(WrappedObject::new(prev.0 .0, prev.0 .1));
@@ -2537,7 +2542,7 @@ impl AuthorityState {
                         object_scanned,
                         wrapped_objects_to_remove.len(),
                     );
-                    (wrapped_objects_to_remove, object_scanned)
+                    Ok((wrapped_objects_to_remove, object_scanned))
                 }));
             }
             let (last_checkpoint_of_epoch, cur_accumulator) = self
@@ -2547,7 +2552,8 @@ impl AuthorityState {
                 pending_tasks.into_iter().fold(
                     (cur_accumulator, 0u64, 0usize),
                     |(mut accumulator, total_objects_scanned, total_wrapped_objects), task| {
-                        let (wrapped_objects_to_remove, object_scanned) = task.join().unwrap();
+                        let (wrapped_objects_to_remove, object_scanned) =
+                            task.join().unwrap().unwrap();
                         accumulator.remove_all(
                             wrapped_objects_to_remove
                                 .iter()

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2530,7 +2530,10 @@ impl AuthorityState {
 
                                 prev = (object_key, object);
                             }
-                            Err(err) => return Err(err),
+                            Err(err) => {
+                                warn!("Object iterator encounter RocksDB error {:?}", err);
+                                return Err(err);
+                            }
                         }
                     }
                     if matches!(prev.1.inner(), StoreObject::Wrapped) {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1070,11 +1070,11 @@ impl AuthorityPerEpochStore {
         from_checkpoint: CheckpointSequenceNumber,
         to_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult<Vec<(CheckpointSequenceNumber, Accumulator)>> {
-        Ok(self
-            .tables()?
+        self.tables()?
             .state_hash_by_checkpoint
-            .range_iter(from_checkpoint..=to_checkpoint)
-            .collect())
+            .safe_range_iter(from_checkpoint..=to_checkpoint)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(SuiError::StorageError)
     }
 
     /// Returns future containing the state digest for the given epoch

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -346,9 +346,12 @@ impl AuthorityStore {
         let data = self
             .perpetual_tables
             .events
-            .range_iter((*event_digest, 0)..=(*event_digest, usize::MAX))
-            .map(|(_, e)| e)
-            .collect::<Vec<_>>();
+            .safe_range_iter((*event_digest, 0)..=(*event_digest, usize::MAX))
+            .map(|r| match r {
+                Ok((_, event)) => Ok(event),
+                Err(err) => Err(err),
+            })
+            .collect::<Result<Vec<_>, TypedStoreError>>()?;
         Ok(data.is_empty().not().then_some(TransactionEvents { data }))
     }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -347,10 +347,7 @@ impl AuthorityStore {
             .perpetual_tables
             .events
             .safe_range_iter((*event_digest, 0)..=(*event_digest, usize::MAX))
-            .map(|r| match r {
-                Ok((_, event)) => Ok(event),
-                Err(err) => Err(err),
-            })
+            .map_ok(|(_, event)| event)
             .collect::<Result<Vec<_>, TypedStoreError>>()?;
         Ok(data.is_empty().not().then_some(TransactionEvents { data }))
     }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -167,11 +167,12 @@ impl AuthorityPerpetualTables {
         else {
             return None;
         };
-        iter.reverse().next().and_then(|db_result| {
-            db_result
-                .map(|(key, o)| self.object(&key, o).ok().flatten())
-                .ok()
-                .flatten()
+        iter.reverse().next().and_then(|db_result| match db_result {
+            Ok((key, o)) => self.object(&key, o).ok().flatten(),
+            Err(err) => {
+                warn!("Object iterator encountered RocksDB error {:?}", err);
+                None
+            }
         })
     }
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1182,6 +1182,55 @@ impl<K, V> DBMap<K, V> {
             perf_ctx,
         )
     }
+
+    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+
+        let lower_bound = range.start_bound();
+        let upper_bound = range.end_bound();
+
+        match lower_bound {
+            Bound::Included(lower_bound) => {
+                // Rocksdb lower bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Excluded(lower_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        match upper_bound {
+            Bound::Included(upper_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+
+                // If the key is already at the limit, there's nowhere else to go, so no upper bound
+                if !is_max(&key_buf) {
+                    // Since we want exclusive, we need to increment the key to get the upper bound
+                    big_endian_saturating_add_one(&mut key_buf);
+                    readopts.set_iterate_upper_bound(key_buf);
+                }
+            }
+            Bound::Excluded(upper_bound) => {
+                // Rocksdb upper bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+                readopts.set_iterate_upper_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        readopts
+    }
 }
 
 /// Provides a mutable struct to form a collection of database write operations, and execute them.
@@ -1927,48 +1976,7 @@ where
     /// Similar to `iter_with_bounds` but allows specifying inclusivity/exclusivity of ranges explicitly.
     /// TODO: find better name
     fn range_iter(&'a self, range: impl RangeBounds<K>) -> Self::Iterator {
-        let mut readopts = self.opts.readopts();
-
-        let lower_bound = range.start_bound();
-        let upper_bound = range.end_bound();
-
-        match lower_bound {
-            Bound::Included(lower_bound) => {
-                // Rocksdb lower bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Excluded(lower_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-
-                // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        match upper_bound {
-            Bound::Included(upper_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-
-                // If the key is already at the limit, there's nowhere else to go, so no upper bound
-                if !is_max(&key_buf) {
-                    // Since we want exclusive, we need to increment the key to get the upper bound
-                    big_endian_saturating_add_one(&mut key_buf);
-                    readopts.set_iterate_upper_bound(key_buf);
-                }
-            }
-            Bound::Excluded(upper_bound) => {
-                // Rocksdb upper bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-                readopts.set_iterate_upper_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
+        let readopts = self.create_read_options_with_range(range);
         let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         Iter::new(
@@ -1986,6 +1994,21 @@ where
         let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_range(range);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         SafeIter::new(
             self.cf.clone(),

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1183,6 +1183,7 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
+    // Creates an RocksDB read option with lower and upper bounds set corresponding to `range`.
     fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
     where
         K: Serialize,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -40,6 +40,21 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrap
 }
 
 // Creates an Iterator based on `use_safe_iter` on `db`.
+fn get_range_iter<K, V>(
+    db: &DBMap<K, V>,
+    range: impl RangeBounds<K>,
+    use_safe_iter: bool,
+) -> TestIteratorWrapper<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    match use_safe_iter {
+        true => TestIteratorWrapper::SafeIter(db.safe_range_iter(range)),
+        false => TestIteratorWrapper::Iter(db.range_iter(range)),
+    }
+}
+
 fn get_iter<K, V>(db: &DBMap<K, V>, use_safe_iter: bool) -> TestIteratorWrapper<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
@@ -740,7 +755,10 @@ async fn test_iter_with_bounds(#[values(true, false)] is_transactional: bool) {
 
 #[rstest]
 #[tokio::test]
-async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
+async fn test_range_iter(
+    #[values(true, false)] is_transactional: bool,
+    #[values(true, false)] use_safe_iter: bool,
+) {
     let db = open_map(temp_dir(), None, is_transactional);
     let min = u64::MAX - 100;
     let max = u64::MAX;
@@ -749,7 +767,9 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
             db.insert(&i, &i.to_string()).unwrap();
         }
     }
-    let db_iter = db.range_iter(min..=max).skip_prior_to(&(min + 50)).unwrap();
+    let db_iter = get_range_iter(&db, min..=max, use_safe_iter)
+        .skip_prior_to(&(min + 50))
+        .unwrap();
 
     assert_eq!(
         (min + 49..min + 50)
@@ -768,8 +788,40 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
         }
     }
 
+    let db_iter = get_range_iter(&db, 10..=20, use_safe_iter);
+
+    assert_eq!(
+        (10..21).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = get_range_iter(&db, ..20, use_safe_iter);
+
+    assert_eq!(
+        (1..20).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = get_range_iter(&db, 60.., use_safe_iter);
+
+    assert_eq!(
+        (60..100).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = get_range_iter(&db, 60..70, use_safe_iter)
+        .skip_prior_to(&200)
+        .unwrap();
+
+    assert_eq!(
+        (69..70).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
     // Skip prior to will return an iterator starting with an "unexpected" key if the sought one is not in the table
-    let db_iter = db.range_iter(1..=99).skip_prior_to(&50).unwrap();
+    let db_iter = get_range_iter(&db, 1..=99, use_safe_iter)
+        .skip_prior_to(&50)
+        .unwrap();
 
     assert_eq!(
         (49..50)
@@ -779,7 +831,9 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db.range_iter(1..=99).skip_prior_to(&1).unwrap();
+    let db_iter = get_range_iter(&db, 1..=99, use_safe_iter)
+        .skip_prior_to(&1)
+        .unwrap();
 
     assert_eq!(
         (1..50)
@@ -789,7 +843,9 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db.range_iter(2..=99).skip_prior_to(&2).unwrap();
+    let db_iter = get_range_iter(&db, 2..=99, use_safe_iter)
+        .skip_prior_to(&2)
+        .unwrap();
 
     assert_eq!(
         (2..50)
@@ -799,7 +855,9 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db.range_iter(2..99).skip_prior_to(&2).unwrap();
+    let db_iter = get_range_iter(&db, 2..99, use_safe_iter)
+        .skip_prior_to(&2)
+        .unwrap();
 
     assert_eq!(
         (2..50)
@@ -818,18 +876,24 @@ async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
     );
 
     // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = db.range_iter(1..=50).skip_to(&50).unwrap();
+    let db_iter = get_range_iter(&db, 1..=50, use_safe_iter)
+        .skip_to(&50)
+        .unwrap();
     assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
 
     // Skip to first key in the bound (bound is [1, 49))
-    let db_iter = db.range_iter(1..49).skip_to(&1).unwrap();
+    let db_iter = get_range_iter(&db, 1..49, use_safe_iter)
+        .skip_to(&1)
+        .unwrap();
     assert_eq!(
         (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
 
     // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = db.range_iter(1..=50).skip_prior_to(&50).unwrap();
+    let db_iter = get_range_iter(&db, 1..=50, use_safe_iter)
+        .skip_prior_to(&50)
+        .unwrap();
     assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
 }
 

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -302,6 +302,10 @@ where
         .build()
     }
 
+    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
+        unimplemented!("umplemented API");
+    }
+
     fn keys(&'a self) -> Self::Keys {
         TestDBKeysBuilder {
             rows: self.rows.read().unwrap(),

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -277,7 +277,7 @@ where
     }
 
     fn unbounded_iter(&'a self) -> Self::Iterator {
-        unimplemented!("umplemented API");
+        unimplemented!("unimplemented API");
     }
 
     fn iter_with_bounds(
@@ -285,11 +285,11 @@ where
         _lower_bound: Option<K>,
         _upper_bound: Option<K>,
     ) -> Self::Iterator {
-        unimplemented!("umplemented API");
+        unimplemented!("unimplemented API");
     }
 
     fn range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::Iterator {
-        unimplemented!("umplemented API");
+        unimplemented!("unimplemented API");
     }
 
     fn safe_iter(&'a self) -> Self::SafeIterator {
@@ -303,7 +303,7 @@ where
     }
 
     fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
-        unimplemented!("umplemented API");
+        unimplemented!("unimplemented API");
     }
 
     fn keys(&'a self) -> Self::Keys {

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -66,8 +66,11 @@ where
     /// TODO: find better name
     fn range_iter(&'a self, range: impl RangeBounds<K>) -> Self::Iterator;
 
-    /// Same as `iter` but performs status check
+    /// Same as `iter` but performs status check.
     fn safe_iter(&'a self) -> Self::SafeIterator;
+
+    // Same as `range_iter` but performs status check.
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
 
     /// Returns an iterator over each key in the map.
     fn keys(&'a self) -> Self::Keys;


### PR DESCRIPTION
## Description 

Create a `safe_range_iter` and replace existing `range_iter` with it. With `safe_range_iter`, it returns RocksDB erros encountered while iterating through specified key ranges.

## Test Plan 

Added more unit test to test range iterator.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
