### PR TITLE
check txn size upfront and add tests for it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11593,6 +11593,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",
+ "roaring",
  "rocksdb",
  "scopeguard",
  "serde",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -29,6 +29,7 @@ once_cell.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true
 rand.workspace = true
+roaring.workspace = true
 rocksdb.workspace = true
 scopeguard.workspace = true
 serde.workspace = true

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -293,36 +293,7 @@ impl ValidatorService {
 
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
-        // Enforce overall transaction size limit.
-        let tx_size = bcs::serialized_size(&transaction).map_err(|e| {
-            SuiError::TransactionSerializationError {
-                error: e.to_string(),
-            }
-        })?;
-        let max_tx_size_bytes = epoch_store.protocol_config().max_tx_size_bytes();
-        fp_ensure!(
-            tx_size as u64 <= max_tx_size_bytes,
-            SuiError::UserInputError {
-                error: UserInputError::SizeLimitExceeded {
-                    limit: format!(
-                        "serialized transaction size exceeded maximum of {max_tx_size_bytes}"
-                    ),
-                    value: tx_size.to_string(),
-                }
-            }
-            .into()
-        );
-
-        transaction.verify_user_input()?;
-
-        // Cheap validity checks for a transaction, including input size limits.
-        let tx_data = transaction.data().transaction_data();
-        tx_data
-            .check_version_supported(epoch_store.protocol_config())
-            .map_err(Into::<SuiError>::into)?;
-        tx_data
-            .validity_check(epoch_store.protocol_config())
-            .map_err(Into::<SuiError>::into)?;
+        transaction.validity_check(epoch_store.protocol_config())?;
 
         if !epoch_store.protocol_config().zklogin_auth() && transaction.has_zklogin_sig() {
             return Err(SuiError::UnsupportedFeatureError {
@@ -404,27 +375,9 @@ impl ValidatorService {
             SuiError::InvalidSystemTransaction.into()
         );
 
-        // Enforce overall transaction size limit.
-        let tx_size = bcs::serialized_size(&certificate.data()).map_err(|e| {
-            SuiError::TransactionSerializationError {
-                error: e.to_string(),
-            }
-        })?;
-        let max_tx_size_bytes = epoch_store.protocol_config().max_tx_size_bytes();
-        fp_ensure!(
-            tx_size as u64 <= max_tx_size_bytes,
-            SuiError::UserInputError {
-                error: UserInputError::SizeLimitExceeded {
-                    limit: format!(
-                        "serialized transaction size exceeded maximum of {max_tx_size_bytes}"
-                    ),
-                    value: tx_size.to_string(),
-                }
-            }
-            .into()
-        );
-
-        certificate.verify_user_input()?;
+        certificate
+            .data()
+            .validity_check(epoch_store.protocol_config())?;
 
         let shared_object_tx = certificate.contains_shared_object();
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -290,32 +290,8 @@ impl ValidatorService {
         } = self;
 
         let transaction = request.into_inner();
-        transaction.verify_user_input()?;
 
         let epoch_store = state.load_epoch_store_one_call_per_task();
-        if !epoch_store.protocol_config().zklogin_auth() && transaction.has_zklogin_sig() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "zklogin is not enabled on this network".to_string(),
-            }
-            .into());
-        }
-        if !epoch_store.protocol_config().supports_upgraded_multisig()
-            && transaction.has_upgraded_multisig()
-        {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "upgraded multisig format not enabled on this network".to_string(),
-            }
-            .into());
-        }
-
-        // Cheap validity checks for a transaction, including input size limits.
-        let tx_data = transaction.data().transaction_data();
-        tx_data
-            .check_version_supported(epoch_store.protocol_config())
-            .map_err(Into::<SuiError>::into)?;
-        tx_data
-            .validity_check(epoch_store.protocol_config())
-            .map_err(Into::<SuiError>::into)?;
 
         // Enforce overall transaction size limit.
         let tx_size = bcs::serialized_size(&transaction).map_err(|e| {
@@ -336,6 +312,33 @@ impl ValidatorService {
             }
             .into()
         );
+
+        transaction.verify_user_input()?;
+
+        // Cheap validity checks for a transaction, including input size limits.
+        let tx_data = transaction.data().transaction_data();
+        tx_data
+            .check_version_supported(epoch_store.protocol_config())
+            .map_err(Into::<SuiError>::into)?;
+        tx_data
+            .validity_check(epoch_store.protocol_config())
+            .map_err(Into::<SuiError>::into)?;
+
+        if !epoch_store.protocol_config().zklogin_auth() && transaction.has_zklogin_sig() {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "zklogin is not enabled on this network".to_string(),
+            }
+            .into());
+        }
+
+        if !epoch_store.protocol_config().supports_upgraded_multisig()
+            && transaction.has_upgraded_multisig()
+        {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "upgraded multisig format not enabled on this network".to_string(),
+            }
+            .into());
+        }
 
         let overload_check_res =
             state.check_system_overload(&consensus_adapter, transaction.data());
@@ -399,6 +402,26 @@ impl ValidatorService {
         fp_ensure!(
             !certificate.is_system_tx(),
             SuiError::InvalidSystemTransaction.into()
+        );
+
+        // Enforce overall transaction size limit.
+        let tx_size = bcs::serialized_size(&certificate.data()).map_err(|e| {
+            SuiError::TransactionSerializationError {
+                error: e.to_string(),
+            }
+        })?;
+        let max_tx_size_bytes = epoch_store.protocol_config().max_tx_size_bytes();
+        fp_ensure!(
+            tx_size as u64 <= max_tx_size_bytes,
+            SuiError::UserInputError {
+                error: UserInputError::SizeLimitExceeded {
+                    limit: format!(
+                        "serialized transaction size exceeded maximum of {max_tx_size_bytes}"
+                    ),
+                    value: tx_size.to_string(),
+                }
+            }
+            .into()
         );
 
         certificate.verify_user_input()?;

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -889,7 +889,7 @@ async fn test_oversized_txn() {
         let mut builder = ProgrammableTransactionBuilder::new();
         // Put a lot of commands in the txn so it's large.
         for _ in 0..(1024 * 16) {
-            builder.transfer_object(recipient, obj_ref.clone()).unwrap();
+            builder.transfer_object(recipient, obj_ref).unwrap();
         }
         builder.finish()
     };

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -47,6 +47,8 @@ use crate::{
 };
 
 use super::*;
+use fastcrypto::traits::AggregateAuthenticator;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 pub use crate::authority::authority_test_utils::init_state_with_ids;
 
@@ -862,4 +864,150 @@ async fn zk_multisig_test() {
     assert!(dbg!(err).is_err());
 
     check_locks(authority_state.clone(), vec![object_id]).await;
+}
+
+#[tokio::test]
+async fn test_oversized_txn() {
+    telemetry_subscribers::init_for_testing();
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let max_txn_size = authority_state
+        .epoch_store_for_testing()
+        .protocol_config()
+        .max_tx_size_bytes() as usize;
+    let object = authority_state
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let obj_ref = object.compute_object_reference();
+
+    // Construct an oversized txn.
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Put a lot of commands in the txn so it's large.
+        for _ in 0..(1024 * 16) {
+            builder.transfer_object(recipient, obj_ref.clone()).unwrap();
+        }
+        builder.finish()
+    };
+
+    let txn_data = TransactionData::new_programmable(sender, vec![obj_ref], pt, 0, 0);
+
+    let txn = to_sender_signed_transaction(txn_data, &sender_key);
+    let tx_size = bcs::serialized_size(&txn).unwrap();
+
+    // Making sure the txn is larger than the max txn size.
+    assert!(tx_size > max_txn_size);
+
+    let consensus_address = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+
+    let server = AuthorityServer::new_for_test(
+        "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+        authority_state.clone(),
+        consensus_address,
+    );
+
+    let server_handle = server.spawn_for_test().await.unwrap();
+
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
+
+    let res = client.handle_transaction(txn).await;
+    // The txn should be rejected due to its size.
+    assert!(res
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("serialized transaction size exceeded maximum"));
+}
+
+#[tokio::test]
+async fn test_very_large_certificate() {
+    telemetry_subscribers::init_for_testing();
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let gas_object_id = ObjectID::random();
+    let authority_state =
+        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let gas_object = authority_state
+        .get_object(&gas_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let transfer_transaction = init_transfer_transaction(
+        |_| {},
+        sender,
+        &sender_key,
+        recipient,
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+
+    let consensus_address = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+
+    let server = AuthorityServer::new_for_test(
+        "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+        authority_state.clone(),
+        consensus_address,
+    );
+
+    let server_handle = server.spawn_for_test().await.unwrap();
+
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
+
+    let auth_sig = client
+        .handle_transaction(transfer_transaction.clone())
+        .await
+        .unwrap()
+        .status
+        .into_signed_for_testing();
+
+    let signatures: BTreeMap<_, _> = vec![auth_sig]
+        .into_iter()
+        .map(|a| (a.authority, a.signature))
+        .collect();
+
+    // Insert a lot into the bitmap so the cert is very large, while the txn inside is reasonably sized.
+    let mut signers_map = roaring::bitmap::RoaringBitmap::new();
+    signers_map.insert_range(0..52108864);
+    let sigs: Vec<AuthoritySignature> = signatures.into_values().collect();
+
+    let quorum_signature = sui_types::crypto::AuthorityQuorumSignInfo {
+        epoch: 0,
+        signature: sui_types::crypto::AggregateAuthoritySignature::aggregate(&sigs)
+            .map_err(|e| SuiError::InvalidSignature {
+                error: e.to_string(),
+            })
+            .expect("Validator returned invalid signature"),
+        signers_map,
+    };
+    let cert = sui_types::message_envelope::Envelope::new_from_data_and_sig(
+        transfer_transaction.into_data(),
+        quorum_signature,
+    );
+
+    let res = client.handle_certificate_v2(cert).await;
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    // The resulting error should be a RpcError with a message length too large.
+    assert!(
+        matches!(err, SuiError::RpcError(..))
+            && err.to_string().contains("message length too large")
+    );
 }


### PR DESCRIPTION
## Description 

We should check the size of the txn bytes at the beginning of handle_transaction and handle_certificate.

## Test Plan 

Added two tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
