### PR TITLE
Move verify_transaction to AuthorityPerEpochStore to discourage calling it with an out-of-date epoch store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4356,16 +4356,6 @@ impl AuthorityState {
         Ok(new_epoch_store)
     }
 
-    // TODO: when we add stateful authenticators, we may need to take care that this function is
-    // reconfig safe (i.e. cannot be called concurrently with reconfiguration).
-    #[instrument(level = "trace", skip_all)]
-    pub fn verify_transaction(&self, tx: Transaction) -> SuiResult<VerifiedTransaction> {
-        self.load_epoch_store_one_call_per_task()
-            .signature_verifier
-            .verify_tx(tx.data())
-            .map(|_| VerifiedTransaction::new_from_verified(tx))
-    }
-
     #[cfg(test)]
     pub(crate) fn iter_live_object_set_for_testing(
         &self,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -32,7 +32,8 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::{
     AuthenticatorStateUpdate, CertifiedTransaction, SenderSignedData, SharedInputObject,
-    TransactionDataAPI, TransactionKind, VerifiedCertificate, VerifiedSignedTransaction,
+    Transaction, TransactionDataAPI, TransactionKind, VerifiedCertificate,
+    VerifiedSignedTransaction, VerifiedTransaction,
 };
 use sui_types::SUI_RANDOMNESS_STATE_OBJECT_ID;
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -2005,6 +2006,13 @@ impl AuthorityPerEpochStore {
             Either::Left((_, _f)) => Err(()),
             Either::Right((result, _)) => Ok(result),
         }
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub fn verify_transaction(&self, tx: Transaction) -> SuiResult<VerifiedTransaction> {
+        self.signature_verifier
+            .verify_tx(tx.data())
+            .map(|_| VerifiedTransaction::new_from_verified(tx))
     }
 
     /// Verifies transaction signatures and other data

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -54,7 +54,7 @@ pub async fn certify_transaction(
 ) -> Result<VerifiedCertificate, SuiError> {
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
-    let transaction = authority.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let response = authority
         .handle_transaction(&epoch_store, transaction.clone())
@@ -256,7 +256,10 @@ pub fn init_transfer_transaction(
         gas_price,
     );
     let tx = to_sender_signed_transaction(data, secret);
-    authority_state.verify_transaction(tx).unwrap()
+    authority_state
+        .epoch_store_for_testing()
+        .verify_transaction(tx)
+        .unwrap()
 }
 
 pub fn init_certified_transfer_transaction(
@@ -286,7 +289,7 @@ pub fn init_certified_transaction(
     authority_state: &AuthorityState,
 ) -> VerifiedCertificate {
     let epoch_store = authority_state.epoch_store_for_testing();
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let vote = VerifiedSignedTransaction::new(
         0,
@@ -309,7 +312,7 @@ pub async fn certify_shared_obj_transaction_no_execution(
     transaction: Transaction,
 ) -> Result<VerifiedCertificate, SuiError> {
     let epoch_store = authority.load_epoch_store_one_call_per_task();
-    let transaction = authority.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     let response = authority
         .handle_transaction(&epoch_store, transaction.clone())
         .await?;

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -350,7 +350,7 @@ impl ValidatorService {
         let _handle_tx_metrics_guard = metrics.handle_transaction_latency.start_timer();
 
         let tx_verif_metrics_guard = metrics.tx_verification_latency.start_timer();
-        let transaction = state.verify_transaction(transaction).tap_err(|_| {
+        let transaction = epoch_store.verify_transaction(transaction).tap_err(|_| {
             metrics.signature_errors.inc();
         })?;
         drop(tx_verif_metrics_guard);

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -60,7 +60,7 @@ pub async fn send_and_confirm_transaction(
 ) -> Result<(CertifiedTransaction, SignedTransactionEffects), SuiError> {
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
-    let transaction = authority.verify_transaction(transaction)?;
+    let transaction = epoch_store.verify_transaction(transaction)?;
     let response = authority
         .handle_transaction(&epoch_store, transaction.clone())
         .await?;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3098,7 +3098,7 @@ async fn test_invalid_authenticator_state_parameter() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let Err(e) = authority_state
         .handle_transaction(&epoch_store, transaction)
@@ -3153,7 +3153,7 @@ async fn test_invalid_randomness_parameter() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let Err(e) = authority_state
         .handle_transaction(&epoch_store, transaction)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1485,7 +1485,7 @@ async fn test_handle_sponsored_transaction() {
     );
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &sponsor_key]);
-    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
+    let dual_signed_tx = epoch_store.verify_transaction(dual_signed_tx).unwrap();
 
     authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
@@ -1534,7 +1534,7 @@ async fn test_handle_sponsored_transaction() {
     );
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &wrong_owner_key]);
-    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
+    let dual_signed_tx = epoch_store.verify_transaction(dual_signed_tx).unwrap();
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
@@ -1563,7 +1563,7 @@ async fn test_handle_sponsored_transaction() {
     );
     let dual_signed_tx =
         to_sender_signed_transaction_with_multi_signers(data, vec![&sender_key, &third_party_key]);
-    let dual_signed_tx = authority_state.verify_transaction(dual_signed_tx).unwrap();
+    let dual_signed_tx = epoch_store.verify_transaction(dual_signed_tx).unwrap();
     let error = authority_state
         .handle_transaction(&epoch_store, dual_signed_tx.clone())
         .await
@@ -1678,7 +1678,7 @@ async fn test_objected_owned_gas() {
     );
 
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -1852,7 +1852,7 @@ async fn test_publish_non_existing_dependent_module() {
         rgp,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let transaction = authority.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     let response = authority
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -2173,7 +2173,7 @@ async fn test_missing_package() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -2221,7 +2221,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s1_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -2247,7 +2247,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s2_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -2273,7 +2273,7 @@ async fn test_type_argument_dependencies() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(data, &s3_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     let result = authority_state
         .handle_transaction(&epoch_store, transaction)
         .await;
@@ -2980,7 +2980,7 @@ async fn test_refusal_to_sign_consensus_commit_prologue() {
 
     // Sender is able to sign it.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     // But the authority should refuse to handle it.
     assert!(matches!(
@@ -3017,7 +3017,7 @@ async fn test_refusal_to_sign_consensus_commit_prologue_v2() {
 
     // Sender is able to sign it.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     // But the authority should refuse to handle it.
     assert!(matches!(
@@ -3055,7 +3055,7 @@ async fn test_invalid_mutable_clock_parameter() {
     .unwrap();
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let Err(e) = authority_state
         .handle_transaction(&epoch_store, transaction)
@@ -3240,7 +3240,7 @@ async fn test_valid_immutable_clock_parameter() {
     .unwrap();
 
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction)
         .await
@@ -3299,7 +3299,7 @@ async fn test_transfer_sui_no_amount() {
 
     // Make sure transaction handling works as usual.
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    let transaction = authority_state.verify_transaction(transaction).unwrap();
+    let transaction = epoch_store.verify_transaction(transaction).unwrap();
     authority_state
         .handle_transaction(&epoch_store, transaction.clone())
         .await
@@ -4645,7 +4645,7 @@ async fn make_test_transaction(
     for authority in authorities {
         let epoch_store = authority.load_epoch_store_one_call_per_task();
         let transaction = transaction.clone();
-        let transaction = authority.verify_transaction(transaction).unwrap();
+        let transaction = epoch_store.verify_transaction(transaction).unwrap();
         let response = authority
             .handle_transaction(&epoch_store, transaction.clone())
             .await

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -80,7 +80,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         )
         .unwrap();
 
-        let transaction = authority
+        let transaction = epoch_store
             .verify_transaction(to_sender_signed_transaction(data, &keypair))
             .unwrap();
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -979,7 +979,7 @@ async fn execute_transfer_with_price(
                 )
             })
     } else {
-        let tx = authority_state.verify_transaction(tx).unwrap();
+        let tx = epoch_store.verify_transaction(tx).unwrap();
 
         authority_state
             .handle_transaction(&epoch_store, tx)

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -125,10 +125,9 @@ async fn transfer_with_account(
             vec![&sender_account.1, &sponsor_account.1],
         )
     };
-    let tx = state.verify_transaction(tx).unwrap();
-    state
-        .handle_transaction(&state.epoch_store_for_testing(), tx)
-        .await
+    let epoch_store = state.epoch_store_for_testing();
+    let tx = epoch_store.verify_transaction(tx).unwrap();
+    state.handle_transaction(&epoch_store, tx).await
 }
 
 async fn handle_move_call_transaction(
@@ -153,11 +152,10 @@ async fn handle_move_call_transaction(
         rgp,
     )
     .unwrap();
+    let epoch_store = state.epoch_store_for_testing();
     let tx = to_sender_signed_transaction(data, &account.1);
-    let tx = state.verify_transaction(tx).unwrap();
-    state
-        .handle_transaction(&state.epoch_store_for_testing(), tx)
-        .await
+    let tx = epoch_store.verify_transaction(tx).unwrap();
+    state.handle_transaction(&epoch_store, tx).await
 }
 
 fn assert_denied<T: std::fmt::Debug>(result: &SuiResult<T>) {
@@ -256,10 +254,9 @@ async fn test_shared_object_transaction_disabled() {
     let tx = TestTransactionBuilder::new(account.0, account.2[0], gas_price)
         .call_staking(account.2[1], SuiAddress::default())
         .build_and_sign(&account.1);
-    let tx = state.verify_transaction(tx).unwrap();
-    let result = state
-        .handle_transaction(&state.epoch_store_for_testing(), tx)
-        .await;
+    let epoch_store = state.epoch_store_for_testing();
+    let tx = epoch_store.verify_transaction(tx).unwrap();
+    let result = state.handle_transaction(&epoch_store, tx).await;
     assert_denied(&result);
 }
 
@@ -279,10 +276,9 @@ async fn test_package_publish_disabled() {
     let tx = TestTransactionBuilder::new(sender, gas_object, rgp)
         .publish(path)
         .build_and_sign(keypair);
-    let tx = state.verify_transaction(tx).unwrap();
-    let result = state
-        .handle_transaction(&state.epoch_store_for_testing(), tx)
-        .await;
+    let epoch_store = state.epoch_store_for_testing();
+    let tx = epoch_store.verify_transaction(tx).unwrap();
+    let result = state.handle_transaction(&epoch_store, tx).await;
     assert_denied(&result);
 }
 
@@ -459,7 +455,7 @@ async fn test_certificate_deny() {
         .build()
         .await;
     let epoch_store = state.epoch_store_for_testing();
-    let tx = state.verify_transaction(tx).unwrap();
+    let tx = epoch_store.verify_transaction(tx).unwrap();
     let signature = state
         .handle_transaction(&epoch_store, tx.clone())
         .await

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -1317,7 +1317,10 @@ async fn test_access_old_object_pruned() {
         let epoch_store = state.epoch_store_for_testing();
         assert_eq!(
             state
-                .handle_transaction(&epoch_store, state.verify_transaction(tx.clone()).unwrap())
+                .handle_transaction(
+                    &epoch_store,
+                    epoch_store.verify_transaction(tx.clone()).unwrap()
+                )
                 .await
                 .unwrap_err(),
             SuiError::UserInputError {

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -100,7 +100,7 @@ async fn test_transaction_expiration() {
         .with_async(|node| async {
             let epoch_store = node.state().epoch_store_for_testing();
             let state = node.state();
-            let expired_transaction = state.verify_transaction(expired_transaction).unwrap();
+            let expired_transaction = epoch_store.verify_transaction(expired_transaction).unwrap();
             state
                 .handle_transaction(&epoch_store, expired_transaction)
                 .await
@@ -115,7 +115,7 @@ async fn test_transaction_expiration() {
         .with_async(|node| async {
             let epoch_store = node.state().epoch_store_for_testing();
             let state = node.state();
-            let transaction = state.verify_transaction(transaction).unwrap();
+            let transaction = epoch_store.verify_transaction(transaction).unwrap();
             state.handle_transaction(&epoch_store, transaction).await
         })
         .await


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
