### PR TITLE
Remove unused dep to sui_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12502,7 +12502,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sui-core",
  "sui-json",
  "sui-json-rpc",
  "sui-json-rpc-types",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -33,7 +33,6 @@ tokio = { workspace = true, features = ["full"] }
 move-vm-runtime = { path = "../../external-crates/move/crates/move-vm-runtime" }
 sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
 
-sui-core = { workspace = true, optional = true }
 sui-move-build.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
@@ -65,6 +64,6 @@ build = []
 coverage = []
 disassemble = []
 prove = []
-unit_test = ["build", "dep:once_cell", "dep:sui-core"]
+unit_test = ["build", "dep:once_cell"]
 calibrate = []
 all = ["build", "coverage", "disassemble", "prove", "unit_test", "calibrate"]

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -20,7 +20,6 @@ clap.workspace = true
 pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["full"] }
 fastcrypto = { workspace = true }
-sui-core.workspace = true
 sui-json-rpc.workspace = true
 sui-json-rpc-types.workspace = true
 sui-json.workspace = true


### PR DESCRIPTION
## Description 

sui_core is not used in these crates, removing dep.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
