### PR TITLE
[Sui] extract common checks for transaction into a separate function

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1358,7 +1358,7 @@ impl AuthorityState {
         tx_data.check_version_supported(epoch_store.protocol_config())?;
         tx_data.validity_check(epoch_store.protocol_config())?;
 
-        // The cost of re-auditing a transaction before execution is tolerated.
+        // The cost of partially re-auditing a transaction before execution is tolerated.
         let (gas_status, input_objects) = sui_transaction_checks::check_certificate_input(
             certificate,
             input_objects,
@@ -1599,9 +1599,7 @@ impl AuthorityState {
 
         let protocol_config = epoch_store.protocol_config();
         transaction_kind.check_version_supported(protocol_config)?;
-
-        // No validity check of the transaction is performed per comment above
-        // `dev_inspect_transaction_block()` in sui-sdk.
+        transaction_kind.validity_check(protocol_config)?;
 
         let max_tx_gas = protocol_config.max_tx_gas();
         let reference_gas_price = epoch_store.reference_gas_price();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -738,7 +738,6 @@ impl AuthorityState {
                 tx_digest,
                 &input_object_kinds,
                 &receiving_objects_refs,
-                epoch_store.protocol_config(),
                 epoch_store.epoch(),
             )
             .await?;

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -40,7 +40,6 @@ impl TransactionInputLoader {
         _tx_digest: &TransactionDigest,
         input_object_kinds: &[InputObjectKind],
         receiving_objects: &[ObjectRef],
-        _protocol_config: &ProtocolConfig,
         epoch_id: EpochId,
     ) -> SuiResult<(InputObjects, ReceivingObjects)> {
         // Length of input_object_kinds have beeen checked via validity_check() for ProgrammableTransaction.

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -10,7 +10,6 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, TransactionDigest},
     error::{SuiError, SuiResult, UserInputError},
-    fp_ensure,
     storage::{BackingPackageStore, GetSharedLocks, ObjectKey, ObjectStore},
     transaction::{
         InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
@@ -41,19 +40,10 @@ impl TransactionInputLoader {
         _tx_digest: &TransactionDigest,
         input_object_kinds: &[InputObjectKind],
         receiving_objects: &[ObjectRef],
-        protocol_config: &ProtocolConfig,
+        _protocol_config: &ProtocolConfig,
         epoch_id: EpochId,
     ) -> SuiResult<(InputObjects, ReceivingObjects)> {
-        fp_ensure!(
-            receiving_objects.len() + input_object_kinds.len()
-                <= protocol_config.max_input_objects() as usize,
-            UserInputError::SizeLimitExceeded {
-                limit: "maximum input and receiving objects in a transaction".to_string(),
-                value: protocol_config.max_input_objects().to_string()
-            }
-            .into()
-        );
-
+        // Length of input_object_kinds have beeen checked via validity_check() for ProgrammableTransaction.
         let mut input_results = vec![None; input_object_kinds.len()];
         let mut object_refs = Vec::with_capacity(input_object_kinds.len());
         let mut fetch_indices = Vec::with_capacity(input_object_kinds.len());
@@ -290,19 +280,10 @@ impl TransactionInputLoader {
         _tx_digest: Option<&TransactionDigest>,
         input_object_kinds: &[InputObjectKind],
         receiving_objects: &[ObjectRef],
-        protocol_config: &ProtocolConfig,
+        _protocol_config: &ProtocolConfig,
     ) -> SuiResult<(InputObjects, ReceivingObjects)> {
-        fp_ensure!(
-            receiving_objects.len() + input_object_kinds.len()
-                <= protocol_config.max_input_objects() as usize,
-            UserInputError::SizeLimitExceeded {
-                limit: "maximum input and receiving objects in a transaction".to_string(),
-                value: protocol_config.max_input_objects().to_string()
-            }
-            .into()
-        );
-
         let mut results = Vec::with_capacity(input_object_kinds.len());
+        // Length of input_object_kinds have beeen checked via validity_check() for ProgrammableTransaction.
         for kind in input_object_kinds {
             let obj = match kind {
                 InputObjectKind::MovePackage(id) => self

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -74,22 +74,17 @@ mod checked {
         receiving_objects: ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
     ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
-        // Cheap validity checks that is ok to run multiple times during processing.
-        transaction.check_version_supported(protocol_config)?;
-        transaction.validity_check(protocol_config)?;
-
-        // Runs verifier, which could be expensive.
-        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
-
-        let gas_status = get_gas_status(
-            &input_objects,
-            transaction.gas(),
+        let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
             transaction,
+            &input_objects,
+            transaction.gas(),
         )?;
-        check_objects(transaction, &input_objects)?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
+        // Runs verifier, which could be expensive.
+        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
+
         Ok((gas_status, input_objects.into_checked()))
     }
 
@@ -102,28 +97,27 @@ mod checked {
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
     ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
-        // Cheap validity checks that is ok to run multiple times during processing.
-        transaction.check_version_supported(protocol_config)?;
-        transaction.validity_check_no_gas_check(protocol_config)?;
-
-        // Runs verifier, which could be expensive.
-        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
-
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
 
-        let gas_status = get_gas_status(
-            &input_objects,
-            &[gas_object_ref],
+        let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
             transaction,
+            &input_objects,
+            &[gas_object_ref],
         )?;
-        check_objects(transaction, &input_objects)?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
+        // Runs verifier, which could be expensive.
+        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
+
         Ok((gas_status, input_objects.into_checked()))
     }
 
+    // Since the purpose of this function is to audit certified transactions,
+    // the checks here should be a strict subset of the checks in check_transaction_input().
+    // For checks not performed in this function but in check_transaction_input(),
+    // we should add a comment calling out the difference.
     #[instrument(level = "trace", skip_all)]
     pub fn check_certificate_input(
         cert: &VerifiedExecutableTransaction,
@@ -131,25 +125,17 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
-        // Cheap validity checks that is ok to run multiple times during processing.
         let tx_data = cert.data().transaction_data();
-        tx_data
-            .check_version_supported(protocol_config)
-            .expect("Certified transaction should be valid");
-        tx_data
-            .validity_check(protocol_config)
-            .expect("Certified transaction should be valid");
-
-        let tx_data = &cert.data().intent_message().value;
-        let gas_status = get_gas_status(
-            &input_objects,
-            tx_data.gas(),
+        let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
             tx_data,
+            &input_objects,
+            tx_data.gas(),
         )?;
-        check_objects(tx_data, &input_objects)?;
         // NB: We do not check receiving objects when executing. Only at signing time do we check.
+        // NB: move verifier is only checked at signing time, not at execution.
+
         Ok((gas_status, input_objects.into_checked()))
     }
 
@@ -196,6 +182,30 @@ mod checked {
         ));
 
         Ok((gas_object_ref, input_objects.into_checked()))
+    }
+
+    // Common checks performed for transactions and certificates.
+    fn check_transaction_input_inner(
+        protocol_config: &ProtocolConfig,
+        reference_gas_price: u64,
+        transaction: &TransactionData,
+        input_objects: &InputObjects,
+        gas: &[ObjectRef],
+    ) -> SuiResult<SuiGasStatus> {
+        // Cheap validity checks that is ok to run multiple times during processing.
+        transaction.check_version_supported(protocol_config)?;
+        transaction.validity_check(protocol_config)?;
+
+        let gas_status = get_gas_status(
+            input_objects,
+            gas,
+            protocol_config,
+            reference_gas_price,
+            transaction,
+        )?;
+        check_objects(transaction, input_objects)?;
+
+        Ok(gas_status)
     }
 
     fn check_receiving_objects(


### PR DESCRIPTION
## Description 

Currently there are both duplications and differences between transaction and certificate input checks. Extracting them into a separate function so it will be easier to update all check logic in future.

Also, remove unnecessary input length checks that should not run during epoch change.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
