### PR TITLE
Remove redundant system tx check

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -388,11 +388,6 @@ impl ValidatorService {
         );
 
         // CRITICAL! Validators should never sign an external system transaction.
-        fp_ensure!(
-            !certificate.is_system_tx(),
-            SuiError::InvalidSystemTransaction.into()
-        );
-
         certificate.verify_user_input()?;
 
         let shared_object_tx = certificate.contains_shared_object();


### PR DESCRIPTION
This system tx check happens in `verify_user_input()`