### PR TITLE
[gql][feature] display field on object

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/display.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.exp
@@ -1,10 +1,10 @@
-processed 18 tasks
+processed 17 tasks
 
 init:
 A: object(0,0)
 
 task 1 'publish'. lines 6-134:
-events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("DisplayCreated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221] }
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("DisplayCreated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [86, 80, 125, 123, 92, 155, 62, 8, 231, 207, 97, 141, 216, 9, 96, 164, 199, 173, 224, 175, 11, 236, 115, 185, 217, 23, 118, 142, 230, 69, 174, 235] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 21470000,  storage_rebate: 0, non_refundable_storage_fee: 0
@@ -13,95 +13,32 @@ task 2 'create-checkpoint'. lines 136-136:
 Checkpoint created: 1
 
 task 3 'view-checkpoint'. lines 138-138:
-CheckpointSummary { epoch: 0, seq: 1, content_digest: 6vMWtQTTwdGtLq6HYiriR1KwkQ8jX6RWQcuFB5YrdAyE,
+CheckpointSummary { epoch: 0, seq: 1, content_digest: HBrKUuYgbe9vaZL9EsQvuhRPM1WawQZ4ZDCydDPQF3He,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, storage_cost: 21470000, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 4 'run-graphql'. lines 140-156:
-Response: {
-  "data": {
-    "address": {
-      "objectConnection": {
-        "nodes": [
-          {
-            "asMoveObject": {
-              "contents": {
-                "json": {
-                  "id": "0x7042dc00f72a7fac0b1da2c97be60f7a6d505e998fb275f837002effe5e8858a",
-                  "package": "26d80a9760adae85faacbc2ecd6f334b71294902f914654c5ef73c0eb1889de6",
-                  "module_name": "boars"
-                },
-                "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::Publisher"
-                }
-              }
-            }
-          },
-          {
-            "asMoveObject": {
-              "contents": {
-                "json": {
-                  "id": "0xa0c97e7c6cb6d76d95e12a964b00e087002356442e4d0e0c442e55bc01fca2dd",
-                  "fields": {
-                    "contents": []
-                  },
-                  "version": 0
-                },
-                "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::display::Display<0x26d80a9760adae85faacbc2ecd6f334b71294902f914654c5ef73c0eb1889de6::boars::Boar>"
-                }
-              }
-            }
-          },
-          {
-            "asMoveObject": {
-              "contents": {
-                "json": {
-                  "id": "0xeedca0abcb8cdef01a0431d8a82547589310bbc94907768ffe81ce7ab4c8d9d8",
-                  "balance": {
-                    "value": "299999977530000"
-                  }
-                },
-                "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                }
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-
-task 5 'run'. lines 158-158:
-created: object(5,0)
+task 4 'run'. lines 140-140:
+created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3556800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 6 'run'. lines 160-160:
-events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 1, 0, 3, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125] }
+task 5 'run'. lines 142-142:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [86, 80, 125, 123, 92, 155, 62, 8, 231, 207, 97, 141, 216, 9, 96, 164, 199, 173, 224, 175, 11, 236, 115, 185, 217, 23, 118, 142, 230, 69, 174, 235, 1, 0, 3, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 2941200,  storage_rebate: 2625876, non_refundable_storage_fee: 26524
 
-task 7 'create-checkpoint'. lines 162-162:
+task 6 'create-checkpoint'. lines 144-144:
 Checkpoint created: 2
 
-task 8 'view-checkpoint'. lines 164-164:
-CheckpointSummary { epoch: 0, seq: 2, content_digest: AbG11UqD4A6i5UiTS5imR5G9VBAu2RjNUsofMBHTEVkQ,
+task 7 'view-checkpoint'. lines 146-146:
+CheckpointSummary { epoch: 0, seq: 2, content_digest: Cb1sLgAjTd7abqbWRD56UyT77NpzjvEeqHBuidMmW25S,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, storage_cost: 27968000, storage_rebate: 3603996, non_refundable_storage_fee: 36404 }}
 
-task 9 'run-graphql'. lines 166-179:
+task 8 'run-graphql'. lines 148-161:
 Response: {
   "data": {
     "address": {
       "objectConnection": {
         "nodes": [
-          {
-            "display": null
-          },
-          {
-            "display": null
-          },
           {
             "display": [
               {
@@ -120,9 +57,6 @@ Response: {
                 "error": "Field 'namee' not found"
               }
             ]
-          },
-          {
-            "display": null
           }
         ]
       }
@@ -130,30 +64,24 @@ Response: {
   }
 }
 
-task 10 'run'. lines 181-181:
-events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 2, 0, 4, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125] }
+task 9 'run'. lines 163-163:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [86, 80, 125, 123, 92, 155, 62, 8, 231, 207, 97, 141, 216, 9, 96, 164, 199, 173, 224, 175, 11, 236, 115, 185, 217, 23, 118, 142, 230, 69, 174, 235, 2, 0, 4, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 3032400,  storage_rebate: 2911788, non_refundable_storage_fee: 29412
 
-task 11 'create-checkpoint'. lines 183-183:
+task 10 'create-checkpoint'. lines 165-165:
 Checkpoint created: 3
 
-task 12 'view-checkpoint'. lines 185-185:
-CheckpointSummary { epoch: 0, seq: 3, content_digest: EomheWWiHFVb1p2NTJPWCDeLheSBLa8Y5VoDvKGmNS82,
+task 11 'view-checkpoint'. lines 167-167:
+CheckpointSummary { epoch: 0, seq: 3, content_digest: 2bY7T5iAu6ruVCgaM4ETqHS6abE8sVnLWXwUa8r6pxAH,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, storage_cost: 31000400, storage_rebate: 6515784, non_refundable_storage_fee: 65816 }}
 
-task 13 'run-graphql'. lines 187-200:
+task 12 'run-graphql'. lines 169-182:
 Response: {
   "data": {
     "address": {
       "objectConnection": {
         "nodes": [
-          {
-            "display": null
-          },
-          {
-            "display": null
-          },
           {
             "display": [
               {
@@ -177,9 +105,6 @@ Response: {
                 "error": null
               }
             ]
-          },
-          {
-            "display": null
           }
         ]
       }
@@ -187,30 +112,24 @@ Response: {
   }
 }
 
-task 14 'run'. lines 202-202:
-events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 3, 0, 15, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125, 5, 98, 111, 111, 108, 115, 7, 123, 98, 111, 111, 108, 115, 125, 5, 98, 117, 121, 101, 114, 7, 123, 98, 117, 121, 101, 114, 125, 4, 110, 97, 109, 101, 6, 123, 110, 97, 109, 101, 125, 7, 99, 114, 101, 97, 116, 111, 114, 9, 123, 99, 114, 101, 97, 116, 111, 114, 125, 5, 112, 114, 105, 99, 101, 7, 123, 112, 114, 105, 99, 101, 125, 11, 112, 114, 111, 106, 101, 99, 116, 95, 117, 114, 108, 58, 85, 110, 105, 113, 117, 101, 32, 66, 111, 97, 114, 32, 102, 114, 111, 109, 32, 116, 104, 101, 32, 66, 111, 97, 114, 115, 32, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 32, 119, 105, 116, 104, 32, 123, 110, 97, 109, 101, 125, 32, 97, 110, 100, 32, 123, 105, 100, 125, 8, 98, 97, 115, 101, 95, 117, 114, 108, 32, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 123, 105, 109, 103, 95, 117, 114, 108, 125, 11, 110, 111, 95, 116, 101, 109, 112, 108, 97, 116, 101, 23, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 3, 97, 103, 101, 21, 123, 109, 101, 116, 97, 100, 97, 116, 97, 46, 110, 101, 115, 116, 101, 100, 46, 97, 103, 101, 125, 8, 102, 117, 108, 108, 95, 117, 114, 108, 10, 123, 102, 117, 108, 108, 95, 117, 114, 108, 125, 13, 101, 115, 99, 97, 112, 101, 95, 115, 121, 110, 116, 97, 120, 8, 92, 123, 110, 97, 109, 101, 92, 125] }
+task 13 'run'. lines 184-184:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [86, 80, 125, 123, 92, 155, 62, 8, 231, 207, 97, 141, 216, 9, 96, 164, 199, 173, 224, 175, 11, 236, 115, 185, 217, 23, 118, 142, 230, 69, 174, 235, 3, 0, 15, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125, 5, 98, 111, 111, 108, 115, 7, 123, 98, 111, 111, 108, 115, 125, 5, 98, 117, 121, 101, 114, 7, 123, 98, 117, 121, 101, 114, 125, 4, 110, 97, 109, 101, 6, 123, 110, 97, 109, 101, 125, 7, 99, 114, 101, 97, 116, 111, 114, 9, 123, 99, 114, 101, 97, 116, 111, 114, 125, 5, 112, 114, 105, 99, 101, 7, 123, 112, 114, 105, 99, 101, 125, 11, 112, 114, 111, 106, 101, 99, 116, 95, 117, 114, 108, 58, 85, 110, 105, 113, 117, 101, 32, 66, 111, 97, 114, 32, 102, 114, 111, 109, 32, 116, 104, 101, 32, 66, 111, 97, 114, 115, 32, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 32, 119, 105, 116, 104, 32, 123, 110, 97, 109, 101, 125, 32, 97, 110, 100, 32, 123, 105, 100, 125, 8, 98, 97, 115, 101, 95, 117, 114, 108, 32, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 123, 105, 109, 103, 95, 117, 114, 108, 125, 11, 110, 111, 95, 116, 101, 109, 112, 108, 97, 116, 101, 23, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 3, 97, 103, 101, 21, 123, 109, 101, 116, 97, 100, 97, 116, 97, 46, 110, 101, 115, 116, 101, 100, 46, 97, 103, 101, 125, 8, 102, 117, 108, 108, 95, 117, 114, 108, 10, 123, 102, 117, 108, 108, 95, 117, 114, 108, 125, 13, 101, 115, 99, 97, 112, 101, 95, 115, 121, 110, 116, 97, 120, 8, 92, 123, 110, 97, 109, 101, 92, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5236400,  storage_rebate: 3002076, non_refundable_storage_fee: 30324
 
-task 15 'create-checkpoint'. lines 204-204:
+task 14 'create-checkpoint'. lines 186-186:
 Checkpoint created: 4
 
-task 16 'view-checkpoint'. lines 206-206:
-CheckpointSummary { epoch: 0, seq: 4, content_digest: DAoCKrW4f9Sdi89up81V6cL1R3ijYQJqvwNmDQGqaV3c,
+task 15 'view-checkpoint'. lines 188-188:
+CheckpointSummary { epoch: 0, seq: 4, content_digest: 7XfCMPheHiDPqAyuB4eHHjkyVtq8ZiciFDMkY4bMw27b,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, storage_cost: 36236800, storage_rebate: 9517860, non_refundable_storage_fee: 96140 }}
 
-task 17 'run-graphql'. lines 208-221:
+task 16 'run-graphql'. lines 190-203:
 Response: {
   "data": {
     "address": {
       "objectConnection": {
         "nodes": [
-          {
-            "display": null
-          },
-          {
-            "display": null
-          },
           {
             "display": [
               {
@@ -260,7 +179,7 @@ Response: {
               },
               {
                 "key": "project_url",
-                "value": "Unique Boar from the Boars collection with First Boar and 0xc21157aecc76c14394e0d1eaa2d4cceb01c377b1905e84935894f76359282653",
+                "value": "Unique Boar from the Boars collection with First Boar and 0xdfdc75c5a00e976f06fb7f9d23aab51251beae6dc7e3b0f41a815d0c3a948027",
                 "error": null
               },
               {
@@ -289,9 +208,6 @@ Response: {
                 "error": null
               }
             ]
-          },
-          {
-            "display": null
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.exp
@@ -1,0 +1,300 @@
+processed 18 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-134:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("DisplayCreated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221] }
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 21470000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 136-136:
+Checkpoint created: 1
+
+task 3 'view-checkpoint'. lines 138-138:
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 6vMWtQTTwdGtLq6HYiriR1KwkQ8jX6RWQcuFB5YrdAyE,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, storage_cost: 21470000, storage_rebate: 0, non_refundable_storage_fee: 0 }}
+
+task 4 'run-graphql'. lines 140-156:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "nodes": [
+          {
+            "asMoveObject": {
+              "contents": {
+                "json": {
+                  "id": "0x7042dc00f72a7fac0b1da2c97be60f7a6d505e998fb275f837002effe5e8858a",
+                  "package": "26d80a9760adae85faacbc2ecd6f334b71294902f914654c5ef73c0eb1889de6",
+                  "module_name": "boars"
+                },
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::Publisher"
+                }
+              }
+            }
+          },
+          {
+            "asMoveObject": {
+              "contents": {
+                "json": {
+                  "id": "0xa0c97e7c6cb6d76d95e12a964b00e087002356442e4d0e0c442e55bc01fca2dd",
+                  "fields": {
+                    "contents": []
+                  },
+                  "version": 0
+                },
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::display::Display<0x26d80a9760adae85faacbc2ecd6f334b71294902f914654c5ef73c0eb1889de6::boars::Boar>"
+                }
+              }
+            }
+          },
+          {
+            "asMoveObject": {
+              "contents": {
+                "json": {
+                  "id": "0xeedca0abcb8cdef01a0431d8a82547589310bbc94907768ffe81ce7ab4c8d9d8",
+                  "balance": {
+                    "value": "299999977530000"
+                  }
+                },
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 5 'run'. lines 158-158:
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3556800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'run'. lines 160-160:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 1, 0, 3, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125] }
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 2941200,  storage_rebate: 2625876, non_refundable_storage_fee: 26524
+
+task 7 'create-checkpoint'. lines 162-162:
+Checkpoint created: 2
+
+task 8 'view-checkpoint'. lines 164-164:
+CheckpointSummary { epoch: 0, seq: 2, content_digest: AbG11UqD4A6i5UiTS5imR5G9VBAu2RjNUsofMBHTEVkQ,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, storage_cost: 27968000, storage_rebate: 3603996, non_refundable_storage_fee: 36404 }}
+
+task 9 'run-graphql'. lines 166-179:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "nodes": [
+          {
+            "display": null
+          },
+          {
+            "display": null
+          },
+          {
+            "display": [
+              {
+                "key": "vectors",
+                "value": null,
+                "error": "Vector of name vec is not supported as a Display value"
+              },
+              {
+                "key": "idd",
+                "value": null,
+                "error": "Field 'idd' not found"
+              },
+              {
+                "key": "namee",
+                "value": null,
+                "error": "Field 'namee' not found"
+              }
+            ]
+          },
+          {
+            "display": null
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run'. lines 181-181:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 2, 0, 4, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125] }
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 3032400,  storage_rebate: 2911788, non_refundable_storage_fee: 29412
+
+task 11 'create-checkpoint'. lines 183-183:
+Checkpoint created: 3
+
+task 12 'view-checkpoint'. lines 185-185:
+CheckpointSummary { epoch: 0, seq: 3, content_digest: EomheWWiHFVb1p2NTJPWCDeLheSBLa8Y5VoDvKGmNS82,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, storage_cost: 31000400, storage_rebate: 6515784, non_refundable_storage_fee: 65816 }}
+
+task 13 'run-graphql'. lines 187-200:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "nodes": [
+          {
+            "display": null
+          },
+          {
+            "display": null
+          },
+          {
+            "display": [
+              {
+                "key": "vectors",
+                "value": null,
+                "error": "Vector of name vec is not supported as a Display value"
+              },
+              {
+                "key": "idd",
+                "value": null,
+                "error": "Field 'idd' not found"
+              },
+              {
+                "key": "namee",
+                "value": null,
+                "error": "Field 'namee' not found"
+              },
+              {
+                "key": "nums",
+                "value": "420",
+                "error": null
+              }
+            ]
+          },
+          {
+            "display": null
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14 'run'. lines 202-202:
+events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [160, 201, 126, 124, 108, 182, 215, 109, 149, 225, 42, 150, 75, 0, 224, 135, 0, 35, 86, 68, 46, 77, 14, 12, 68, 46, 85, 188, 1, 252, 162, 221, 3, 0, 15, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125, 5, 98, 111, 111, 108, 115, 7, 123, 98, 111, 111, 108, 115, 125, 5, 98, 117, 121, 101, 114, 7, 123, 98, 117, 121, 101, 114, 125, 4, 110, 97, 109, 101, 6, 123, 110, 97, 109, 101, 125, 7, 99, 114, 101, 97, 116, 111, 114, 9, 123, 99, 114, 101, 97, 116, 111, 114, 125, 5, 112, 114, 105, 99, 101, 7, 123, 112, 114, 105, 99, 101, 125, 11, 112, 114, 111, 106, 101, 99, 116, 95, 117, 114, 108, 58, 85, 110, 105, 113, 117, 101, 32, 66, 111, 97, 114, 32, 102, 114, 111, 109, 32, 116, 104, 101, 32, 66, 111, 97, 114, 115, 32, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 32, 119, 105, 116, 104, 32, 123, 110, 97, 109, 101, 125, 32, 97, 110, 100, 32, 123, 105, 100, 125, 8, 98, 97, 115, 101, 95, 117, 114, 108, 32, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 123, 105, 109, 103, 95, 117, 114, 108, 125, 11, 110, 111, 95, 116, 101, 109, 112, 108, 97, 116, 101, 23, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 3, 97, 103, 101, 21, 123, 109, 101, 116, 97, 100, 97, 116, 97, 46, 110, 101, 115, 116, 101, 100, 46, 97, 103, 101, 125, 8, 102, 117, 108, 108, 95, 117, 114, 108, 10, 123, 102, 117, 108, 108, 95, 117, 114, 108, 125, 13, 101, 115, 99, 97, 112, 101, 95, 115, 121, 110, 116, 97, 120, 8, 92, 123, 110, 97, 109, 101, 92, 125] }
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5236400,  storage_rebate: 3002076, non_refundable_storage_fee: 30324
+
+task 15 'create-checkpoint'. lines 204-204:
+Checkpoint created: 4
+
+task 16 'view-checkpoint'. lines 206-206:
+CheckpointSummary { epoch: 0, seq: 4, content_digest: DAoCKrW4f9Sdi89up81V6cL1R3ijYQJqvwNmDQGqaV3c,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, storage_cost: 36236800, storage_rebate: 9517860, non_refundable_storage_fee: 96140 }}
+
+task 17 'run-graphql'. lines 208-221:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "nodes": [
+          {
+            "display": null
+          },
+          {
+            "display": null
+          },
+          {
+            "display": [
+              {
+                "key": "vectors",
+                "value": null,
+                "error": "Vector of name vec is not supported as a Display value"
+              },
+              {
+                "key": "idd",
+                "value": null,
+                "error": "Field 'idd' not found"
+              },
+              {
+                "key": "namee",
+                "value": null,
+                "error": "Field 'namee' not found"
+              },
+              {
+                "key": "nums",
+                "value": "420",
+                "error": null
+              },
+              {
+                "key": "bools",
+                "value": "true",
+                "error": null
+              },
+              {
+                "key": "buyer",
+                "value": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e",
+                "error": null
+              },
+              {
+                "key": "name",
+                "value": "First Boar",
+                "error": null
+              },
+              {
+                "key": "creator",
+                "value": "Will",
+                "error": null
+              },
+              {
+                "key": "price",
+                "value": "",
+                "error": null
+              },
+              {
+                "key": "project_url",
+                "value": "Unique Boar from the Boars collection with First Boar and 0xc21157aecc76c14394e0d1eaa2d4cceb01c377b1905e84935894f76359282653",
+                "error": null
+              },
+              {
+                "key": "base_url",
+                "value": "https://get-a-boar.com/first.png",
+                "error": null
+              },
+              {
+                "key": "no_template",
+                "value": "https://get-a-boar.com/",
+                "error": null
+              },
+              {
+                "key": "age",
+                "value": "10",
+                "error": null
+              },
+              {
+                "key": "full_url",
+                "value": "https://get-a-boar.fullurl.com/",
+                "error": null
+              },
+              {
+                "key": "escape_syntax",
+                "value": "{name}",
+                "error": null
+              }
+            ]
+          },
+          {
+            "display": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -1,0 +1,221 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish --sender A
+module Test::boars {
+    use sui::object::{Self, UID};
+    use std::option::{Self, Option};
+    use sui::tx_context::{TxContext, sender};
+    use sui::transfer;
+    use sui::package;
+    use sui::url::{Self, Url};
+    use sui::display;
+    use std::string::{utf8, String};
+
+    /// For when a witness type passed is not an OTW.
+    const ENotOneTimeWitness: u64 = 0;
+
+    /// An OTW to use when creating a Publisher
+    struct BOARS has drop {}
+
+    struct Boar has key, store {
+        id: UID,
+        img_url: String,
+        name: String,
+        description: String,
+        creator: Option<String>,
+        price: Option<String>,
+        metadata: NestedMetadata,
+        full_url: Url,
+        nums: u64,
+        bools: bool,
+        buyer: address,
+        vec: vector<u64>,
+    }
+
+    struct Metadata has store {
+        age: u64,
+    }
+
+    struct NestedMetadata has store {
+        nested: Metadata
+    }
+
+    fun init(otw: BOARS, ctx: &mut TxContext) {
+        let pub = package::claim(otw, ctx);
+        let display = display::new<Boar>(&pub, ctx);
+
+        transfer::public_transfer(display, sender(ctx));
+        transfer::public_transfer(pub, sender(ctx));
+    }
+
+
+    public entry fun update_display_faulty(display_obj: &mut display::Display<Boar>) {
+      display::add_multiple(display_obj, vector[
+        utf8(b"vectors"),
+        utf8(b"idd"),
+        utf8(b"namee"),
+      ], vector[
+        utf8(b"{vec}"),
+        utf8(b"{idd}"),
+        utf8(b"{namee}"),
+      ]);
+      display::update_version(display_obj)
+    }
+
+    public entry fun single_add(display_obj: &mut display::Display<Boar>) {
+      display::add(display_obj, utf8(b"nums"), utf8(b"{nums}"));
+      display::update_version(display_obj)
+    }
+
+    public entry fun multi_add(display_obj: &mut display::Display<Boar>) {
+        display::add_multiple(display_obj, vector[
+            utf8(b"bools"),
+            utf8(b"buyer"),
+            utf8(b"name"),
+            utf8(b"creator"),
+            utf8(b"price"),
+            utf8(b"project_url"),
+            utf8(b"base_url"),
+            utf8(b"no_template"),
+            utf8(b"age"),
+            utf8(b"full_url"),
+            utf8(b"escape_syntax"),
+        ], vector[
+            // test bool
+            utf8(b"{bools}"),
+            // test address
+            utf8(b"{buyer}"),
+            // test string
+            utf8(b"{name}"),
+            // test optional string w/ Some value
+            utf8(b"{creator}"),
+            // test optional string w/ None value
+            utf8(b"{price}"),
+            // test multiple fields and UID
+            utf8(b"Unique Boar from the Boars collection with {name} and {id}"),
+            utf8(b"https://get-a-boar.com/{img_url}"),
+            // test no template value
+            utf8(b"https://get-a-boar.com/"),
+            // test nested struct
+            utf8(b"{metadata.nested.age}"),
+            // test Url type
+            utf8(b"{full_url}"),
+            // test escape syntax
+            utf8(b"\\{name\\}"),
+        ]);
+
+        display::update_version(display_obj);
+    }
+
+    public entry fun create_bear(ctx: &mut TxContext) {
+        let boar = Boar {
+            id: object::new(ctx),
+            img_url: utf8(b"first.png"),
+            name: utf8(b"First Boar"),
+            description: utf8(b"First Boar from the Boars collection!"),
+            creator: option::some(utf8(b"Will")),
+            price: option::none(),
+            metadata: NestedMetadata {
+                nested: Metadata {
+                    age: 10,
+                },
+            },
+            full_url: url::new_unsafe_from_bytes(b"https://get-a-boar.fullurl.com/"),
+            nums: 420,
+            bools: true,
+            buyer: sender(ctx),
+            vec: vector[1, 2, 3],
+        };
+        transfer::transfer(boar, sender(ctx))
+    }
+}
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objectConnection {
+      nodes {
+        asMoveObject {
+          contents {
+            json
+            type {
+              repr
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run Test::boars::create_bear --sender A
+
+//# run Test::boars::update_display_faulty --sender A --args object(1,1)
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objectConnection {
+      nodes {
+        display {
+          key
+          value
+          error
+        }
+      }
+    }
+  }
+}
+
+//# run Test::boars::single_add --sender A --args object(1,1)
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objectConnection {
+      nodes {
+        display {
+          key
+          value
+          error
+        }
+      }
+    }
+  }
+}
+
+//# run Test::boars::multi_add --sender A --args object(1,1)
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objectConnection {
+      nodes {
+        display {
+          key
+          value
+          error
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -137,24 +137,6 @@ module Test::boars {
 
 //# view-checkpoint
 
-//# run-graphql
-{
-  address(address: "@{A}") {
-    objectConnection {
-      nodes {
-        asMoveObject {
-          contents {
-            json
-            type {
-              repr
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 //# run Test::boars::create_bear --sender A
 
 //# run Test::boars::update_display_faulty --sender A --args object(1,1)
@@ -166,7 +148,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection {
+    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key
@@ -187,7 +169,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection {
+    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key
@@ -208,7 +190,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection {
+    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -445,6 +445,26 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ
 """
 scalar DateTime
 
+"""
+The set of named templates defined on-chain for the type of this object,
+to be handled off-chain. The server substitutes data from the object
+into these templates to generate a display string per template.
+"""
+type DisplayEntry {
+	"""
+	The identifier for a particular template string of the Display object.
+	"""
+	key: String!
+	"""
+	The template string for the key with placeholder values substituted.
+	"""
+	value: String
+	"""
+	An error string describing why the template could not be rendered.
+	"""
+	error: String
+}
+
 type DynamicField {
 	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
@@ -1366,6 +1386,12 @@ type Object implements ObjectOwner {
 	This number is recalculated based on the present storage gas price.
 	"""
 	storageRebate: BigInt
+	"""
+	The set of named templates defined on-chain for the type of this object,
+	to be handled off-chain. The server substitutes data from the object
+	into these templates to generate a display string per template.
+	"""
+	display: [DisplayEntry!]
 	"""
 	The Base64 encoded bcs serialization of the object's content.
 	"""

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -573,7 +573,8 @@ type Object implements IOwner & IObject {
 
 type DisplayEntry {
   key: String!
-  value: String!
+  value: String
+  error: String
 }
 
 type Epoch {

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -3,7 +3,7 @@
 
 use diesel::backend::Backend;
 use sui_indexer::{
-    schema_v2::{checkpoints, epochs, events, objects, transactions},
+    schema_v2::{checkpoints, display, epochs, events, objects, transactions},
     types_v2::OwnerType,
 };
 
@@ -42,6 +42,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     /// related to that checkpoint.
     fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
+    fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
     fn multi_get_txs(
         cursor: Option<i64>,
         descending_order: bool,

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -41,13 +41,14 @@ use crate::{
 };
 use async_graphql::connection::{Connection, Edge};
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+use move_core_types::language_storage::StructTag;
 use std::{collections::BTreeMap, str::FromStr};
 use sui_indexer::{
     apis::GovernanceReadApiV2,
     indexer_reader::IndexerReader,
     models_v2::{
-        checkpoints::StoredCheckpoint, epoch::StoredEpochInfo, events::StoredEvent,
-        objects::StoredObject, transactions::StoredTransaction,
+        checkpoints::StoredCheckpoint, display::StoredDisplay, epoch::StoredEpochInfo,
+        events::StoredEvent, objects::StoredObject, transactions::StoredTransaction,
     },
     schema_v2::transactions,
     types_v2::OwnerType,
@@ -218,6 +219,17 @@ impl PgManager {
         self.run_query_async_with_cost(query, |query| {
             move |conn| query.get_result::<StoredCheckpoint>(conn).optional()
         })
+        .await
+    }
+
+    async fn get_display_by_obj_type(
+        &self,
+        object_type: String,
+    ) -> Result<Option<StoredDisplay>, Error> {
+        self.run_query_async_with_cost(
+            move || Ok(QueryBuilder::get_display_by_obj_type(object_type.clone())),
+            |query| move |conn| query.get_result::<StoredDisplay>(conn).optional(),
+        )
         .await
     }
 
@@ -730,6 +742,14 @@ impl PgManager {
             .await?
             .map(Checkpoint::try_from)
             .transpose()
+    }
+
+    pub(crate) async fn fetch_display_object_by_type(
+        &self,
+        object_type: &StructTag,
+    ) -> Result<Option<StoredDisplay>, Error> {
+        let object_type = object_type.to_canonical_string(/* with_prefix */ true);
+        self.get_display_by_obj_type(object_type).await
     }
 
     pub(crate) async fn fetch_chain_identifier(&self) -> Result<String, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -23,7 +23,7 @@ use diesel::{
 use std::str::FromStr;
 use sui_indexer::{
     schema_v2::{
-        checkpoints, epochs, events, objects, transactions, tx_calls, tx_changed_objects,
+        checkpoints, display, epochs, events, objects, transactions, tx_calls, tx_changed_objects,
         tx_input_objects, tx_recipients, tx_senders,
     },
     types_v2::OwnerType,
@@ -90,6 +90,13 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
         checkpoints::dsl::checkpoints
             .order_by(checkpoints::dsl::sequence_number.asc())
+            .limit(1)
+            .into_boxed()
+    }
+
+    fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, Pg> {
+        display::dsl::display
+            .filter(display::dsl::object_type.eq(object_type))
             .limit(1)
             .into_boxed()
     }

--- a/crates/sui-graphql-rpc/src/types/display.rs
+++ b/crates/sui-graphql-rpc/src/types/display.rs
@@ -9,12 +9,24 @@ use sui_types::collection_types::VecMap;
 use crate::error::Error;
 use sui_json_rpc_types::SuiMoveValue;
 
-use super::{json::Json, move_value::try_to_json_value};
-
 #[derive(Debug, SimpleObject)]
 pub(crate) struct DisplayEntry {
     pub key: String,
     pub value: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum DisplayRenderError {
+    #[error("Display template value cannot be empty")]
+    TemplateValueEmpty,
+    #[error("Display template value of {0} exceeds maximum depth of {1}")]
+    ExceedsLookupDepth(usize, u64),
+    #[error("Vector of name {0} is not supported as a Display value")]
+    Vector(String),
+    #[error("Field '{0}' not found")]
+    FieldNotFound(String),
+    #[error("Unexpected MoveValue")]
+    UnexpectedMoveValue,
 }
 
 pub(crate) fn get_rendered_fields(
@@ -34,7 +46,12 @@ pub(crate) fn get_rendered_fields(
     Ok(rendered_fields)
 }
 
-// handles the PART = '{' CHAIN '}'
+/// Handles the PART of the grammar, defined as:
+/// PART   ::= '{' CHAIN '}'
+///          | '\{' | '\}'
+///          | [:utf8:]
+/// Defers resolution down to the IDENT to get_value_from_move_struct,
+/// and substitutes the result into the PART template.
 fn parse_template(template: &str, move_struct: &MoveStruct) -> Result<String, Error> {
     let mut output = template.to_string();
     let mut var_name = String::new();
@@ -53,8 +70,9 @@ fn parse_template(template: &str, move_struct: &MoveStruct) -> Result<String, Er
             }
             '}' if !escaped => {
                 in_braces = false;
-                let value = get_value_from_move_struct(move_struct, &var_name)?;
-                output = output.replace(&format!("{{{}}}", var_name), &format!("{}", value));
+                let value = get_value_from_move_struct(move_struct, &var_name)
+                    .map_err(|e| Error::Internal(e.to_string()))?;
+                output = output.replace(&format!("{{{}}}", var_name), &value.to_string());
             }
             _ if !escaped => {
                 if in_braces {
@@ -69,24 +87,21 @@ fn parse_template(template: &str, move_struct: &MoveStruct) -> Result<String, Er
     Ok(output.replace('\\', ""))
 }
 
+/// Handles the CHAIN and IDENT of the grammar, defined as:
+/// CHAIN  ::= IDENT | CHAIN '.' IDENT
+/// IDENT  ::= /* Move identifier */
 pub(crate) fn get_value_from_move_struct(
     move_struct: &MoveStruct,
     var_name: &str,
-) -> Result<Json, Error> {
-    // Supports CHAIN . IDENT today
+) -> Result<String, DisplayRenderError> {
     let parts: Vec<&str> = var_name.split('.').collect();
     if parts.is_empty() {
-        // todo: custom error
-        Err(Error::Internal(
-            "Display template value cannot be empty".to_string(),
-        ))?;
+        return Err(DisplayRenderError::TemplateValueEmpty);
     }
-    // todo: new limit on config
+    // todo: 10 is a carry-over from the sui-json-rpc implementation
+    // we should introduce this as a new limit on the config
     if parts.len() > 10 {
-        Err(Error::Internal(format!(
-            "Display template value nested depth cannot exist {}",
-            10
-        )))?;
+        return Err(DisplayRenderError::ExceedsLookupDepth(parts.len(), 10));
     }
 
     // update this as we iterate through the parts
@@ -105,31 +120,19 @@ pub(crate) fn get_value_from_move_struct(
                         None
                     }
                 })
-                .ok_or_else(|| Error::Internal(format!("Field '{}' not found", part))),
-            _ => Err(Error::Internal("Unexpected MoveValue".to_string())),
+                .ok_or_else(|| DisplayRenderError::FieldNotFound(part.to_string())),
+            _ => Err(DisplayRenderError::UnexpectedMoveValue),
         })?;
 
     // TODO: implement Display for MoveData and use that instead
-    match result {
-        MoveValue::Vector(_) => Err(Error::Internal(format!(
-            "Vector is not supported as a Display value {}",
-            var_name
-        )))?,
-        _ => Ok(try_to_json_value(result.clone())?.into()),
+    let sui_move_value: SuiMoveValue = result.clone().into();
+
+    match sui_move_value {
+        SuiMoveValue::Option(move_option) => match move_option.as_ref() {
+            Some(move_value) => Ok(move_value.to_string()),
+            None => Ok("".to_string()),
+        },
+        SuiMoveValue::Vector(_) => Err(DisplayRenderError::Vector(var_name.to_string())),
+        _ => Ok(sui_move_value.to_string()),
     }
-
-    // let sui_move_value: SuiMoveValue = result.clone().into();
-    // // MoveValue::json_impl(&self, layout: A::MoveTypeLayout)
-
-    // match sui_move_value {
-    //     SuiMoveValue::Option(move_option) => match move_option.as_ref() {
-    //         Some(move_value) => Ok(move_value.to_string()),
-    //         None => Ok("".to_string()),
-    //     },
-    //     SuiMoveValue::Vector(_) => Err(Error::Internal(format!(
-    //         "Vector is not supported as a Display value {}",
-    //         var_name
-    //     )))?,
-
-    //     _ => Ok(sui_move_value.to_string()),
 }

--- a/crates/sui-graphql-rpc/src/types/display.rs
+++ b/crates/sui-graphql-rpc/src/types/display.rs
@@ -3,8 +3,133 @@
 
 use async_graphql::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+use move_core_types::annotated_value::{MoveStruct, MoveValue};
+use sui_types::collection_types::VecMap;
+
+use crate::error::Error;
+use sui_json_rpc_types::SuiMoveValue;
+
+use super::{json::Json, move_value::try_to_json_value};
+
+#[derive(Debug, SimpleObject)]
 pub(crate) struct DisplayEntry {
     pub key: String,
     pub value: String,
+}
+
+pub(crate) fn get_rendered_fields(
+    fields: VecMap<String, String>,
+    move_struct: &MoveStruct,
+) -> Result<Vec<DisplayEntry>, Error> {
+    let mut rendered_fields: Vec<DisplayEntry> = vec![];
+
+    for entry in fields.contents.iter() {
+        let rendered_value = parse_template(&entry.value, move_struct)?;
+        rendered_fields.push(DisplayEntry {
+            key: entry.key.clone(),
+            value: rendered_value,
+        });
+    }
+
+    Ok(rendered_fields)
+}
+
+// handles the PART = '{' CHAIN '}'
+fn parse_template(template: &str, move_struct: &MoveStruct) -> Result<String, Error> {
+    let mut output = template.to_string();
+    let mut var_name = String::new();
+    let mut in_braces = false;
+    let mut escaped = false;
+
+    for ch in template.chars() {
+        match ch {
+            '\\' => {
+                escaped = true;
+                continue;
+            }
+            '{' if !escaped => {
+                in_braces = true;
+                var_name.clear();
+            }
+            '}' if !escaped => {
+                in_braces = false;
+                let value = get_value_from_move_struct(move_struct, &var_name)?;
+                output = output.replace(&format!("{{{}}}", var_name), &format!("{}", value));
+            }
+            _ if !escaped => {
+                if in_braces {
+                    var_name.push(ch);
+                }
+            }
+            _ => {}
+        }
+        escaped = false;
+    }
+
+    Ok(output.replace('\\', ""))
+}
+
+pub(crate) fn get_value_from_move_struct(
+    move_struct: &MoveStruct,
+    var_name: &str,
+) -> Result<Json, Error> {
+    // Supports CHAIN . IDENT today
+    let parts: Vec<&str> = var_name.split('.').collect();
+    if parts.is_empty() {
+        // todo: custom error
+        Err(Error::Internal(
+            "Display template value cannot be empty".to_string(),
+        ))?;
+    }
+    // todo: new limit on config
+    if parts.len() > 10 {
+        Err(Error::Internal(format!(
+            "Display template value nested depth cannot exist {}",
+            10
+        )))?;
+    }
+
+    // update this as we iterate through the parts
+    let start_value = &MoveValue::Struct(move_struct.clone());
+
+    let result = parts
+        .iter()
+        .try_fold(start_value, |current_value, part| match current_value {
+            MoveValue::Struct(s) => s
+                .fields
+                .iter()
+                .find_map(|(id, value)| {
+                    if id.to_string() == *part {
+                        Some(value)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| Error::Internal(format!("Field '{}' not found", part))),
+            _ => Err(Error::Internal("Unexpected MoveValue".to_string())),
+        })?;
+
+    // TODO: implement Display for MoveData and use that instead
+    match result {
+        MoveValue::Vector(_) => Err(Error::Internal(format!(
+            "Vector is not supported as a Display value {}",
+            var_name
+        )))?,
+        _ => Ok(try_to_json_value(result.clone())?.into()),
+    }
+
+    // let sui_move_value: SuiMoveValue = result.clone().into();
+    // // MoveValue::json_impl(&self, layout: A::MoveTypeLayout)
+
+    // match sui_move_value {
+    //     SuiMoveValue::Option(move_option) => match move_option.as_ref() {
+    //         Some(move_value) => Ok(move_value.to_string()),
+    //         None => Ok("".to_string()),
+    //     },
+    //     SuiMoveValue::Vector(_) => Err(Error::Internal(format!(
+    //         "Vector is not supported as a Display value {}",
+    //         var_name
+    //     )))?,
+
+    //     _ => Ok(sui_move_value.to_string()),
 }

--- a/crates/sui-graphql-rpc/src/types/display.rs
+++ b/crates/sui-graphql-rpc/src/types/display.rs
@@ -138,7 +138,7 @@ pub(crate) fn get_value_from_move_struct(
                 .fields
                 .iter()
                 .find_map(|(id, value)| {
-                    if id.to_string() == *part {
+                    if id.as_str() == *part {
                         Some(value)
                     } else {
                         None

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -208,7 +208,7 @@ impl TryFrom<(Identifier, A::MoveValue)> for MoveField {
     }
 }
 
-pub(crate) fn try_to_json_value(value: A::MoveValue) -> Result<Value, Error> {
+fn try_to_json_value(value: A::MoveValue) -> Result<Value, Error> {
     use A::MoveValue as V;
     Ok(match value {
         V::U8(n) => Value::Number(n.into()),

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -208,7 +208,7 @@ impl TryFrom<(Identifier, A::MoveValue)> for MoveField {
     }
 }
 
-fn try_to_json_value(value: A::MoveValue) -> Result<Value, Error> {
+pub(crate) fn try_to_json_value(value: A::MoveValue) -> Result<Value, Error> {
     use A::MoveValue as V;
     Ok(match value {
         V::U8(n) => Value::Number(n.into()),

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -96,6 +96,9 @@ impl Object {
         Some(BigInt::from(self.native.storage_rebate))
     }
 
+    /// The set of named templates defined on-chain for the type of this object,
+    /// to be handled off-chain. The server substitutes data from the object
+    /// into these templates to generate a display string per template.
     async fn display(&self, ctx: &Context<'_>) -> Result<Option<Vec<DisplayEntry>>> {
         let resolver: &Resolver<PackageCache> = ctx
             .data()

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -3,18 +3,16 @@
 
 use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base58, Encoding};
-use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout, MoveValue};
+use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
 use sui_indexer::models_v2::objects::StoredObject;
 use sui_json_rpc::name_service::NameServiceConfig;
-use sui_json_rpc_types::SuiMoveValue;
 use sui_package_resolver::Resolver;
-use sui_types::collection_types::VecMap;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::TypeTag;
 
 use super::big_int::BigInt;
-use super::display::DisplayEntry;
+use super::display::{get_rendered_fields, DisplayEntry};
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
@@ -415,113 +413,4 @@ pub(crate) async fn deserialize_move_struct(
     })?;
 
     Ok((struct_tag, move_struct))
-}
-
-pub(crate) fn get_rendered_fields(
-    fields: VecMap<String, String>,
-    move_struct: &MoveStruct,
-) -> Result<Vec<DisplayEntry>, Error> {
-    let mut rendered_fields = Vec::<DisplayEntry>::new();
-
-    for entry in fields.contents.iter() {
-        let rendered_value = parse_template(&entry.value, move_struct)?;
-        rendered_fields.push(DisplayEntry {
-            key: entry.key.clone(),
-            value: rendered_value,
-        });
-    }
-
-    Ok(rendered_fields)
-}
-
-// handles the PART = '{' CHAIN '}'
-fn parse_template(template: &str, move_struct: &MoveStruct) -> Result<String, Error> {
-    let mut output = template.to_string();
-    let mut var_name = String::new();
-    let mut in_braces = false;
-    let mut escaped = false;
-
-    for ch in template.chars() {
-        match ch {
-            '\\' => {
-                escaped = true;
-                continue;
-            }
-            '{' if !escaped => {
-                in_braces = true;
-                var_name.clear();
-            }
-            '}' if !escaped => {
-                in_braces = false;
-                let value = get_value_from_move_struct(move_struct, &var_name)?;
-                output = output.replace(&format!("{{{}}}", var_name), &value.to_string());
-            }
-            _ if !escaped => {
-                if in_braces {
-                    var_name.push(ch);
-                }
-            }
-            _ => {}
-        }
-        escaped = false;
-    }
-
-    Ok(output.replace('\\', ""))
-}
-
-pub fn get_value_from_move_struct(
-    move_struct: &MoveStruct,
-    var_name: &str,
-) -> Result<String, Error> {
-    // Supports CHAIN . IDENT today
-    let parts: Vec<&str> = var_name.split('.').collect();
-    if parts.is_empty() {
-        // todo: custom error
-        Err(Error::Internal(
-            "Display template value cannot be empty".to_string(),
-        ))?;
-    }
-    // todo: new limit on config
-    if parts.len() > 10 {
-        Err(Error::Internal(format!(
-            "Display template value nested depth cannot exist {}",
-            10
-        )))?;
-    }
-
-    // update this as we iterate through the parts
-    let start_value = &MoveValue::Struct(move_struct.clone());
-
-    let result = parts
-        .iter()
-        .try_fold(start_value, |current_value, part| match current_value {
-            MoveValue::Struct(s) => s
-                .fields
-                .iter()
-                .find_map(|(id, value)| {
-                    if id.to_string() == *part {
-                        Some(value)
-                    } else {
-                        None
-                    }
-                })
-                .ok_or_else(|| Error::Internal(format!("Field '{}' not found", part))),
-            _ => Err(Error::Internal("Unexpected MoveValue".to_string())),
-        })?;
-
-    // TODO: implement Display for MoveData and use that instead
-    let sui_move_value: SuiMoveValue = result.clone().into();
-
-    match sui_move_value {
-        SuiMoveValue::Option(move_option) => match move_option.as_ref() {
-            Some(move_value) => Ok(move_value.to_string()),
-            None => Ok("".to_string()),
-        },
-        SuiMoveValue::Vector(_) => Err(Error::Internal(format!(
-            "Vector is not supported as a Display value {}",
-            var_name
-        )))?,
-
-        _ => Ok(sui_move_value.to_string()),
-    }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -449,6 +449,26 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ
 """
 scalar DateTime
 
+"""
+The set of named templates defined on-chain for the type of this object,
+to be handled off-chain. The server substitutes data from the object
+into these templates to generate a display string per template.
+"""
+type DisplayEntry {
+	"""
+	The identifier for a particular template string of the Display object.
+	"""
+	key: String!
+	"""
+	The template string for the key with placeholder values substituted.
+	"""
+	value: String
+	"""
+	An error string describing why the template could not be rendered.
+	"""
+	error: String
+}
+
 type DynamicField {
 	"""
 	The string type, data, and serialized value of the DynamicField's 'name' field.
@@ -1370,6 +1390,12 @@ type Object implements ObjectOwner {
 	This number is recalculated based on the present storage gas price.
 	"""
 	storageRebate: BigInt
+	"""
+	The set of named templates defined on-chain for the type of this object,
+	to be handled off-chain. The server substitutes data from the object
+	into these templates to generate a display string per template.
+	"""
+	display: [DisplayEntry!]
 	"""
 	The Base64 encoded bcs serialization of the object's content.
 	"""


### PR DESCRIPTION
## Description 

Implements rendering Display<T> on the graphql::Object through the 'display' field. This will attempt to resolve each template string defined on Display<T>, and returns a corresponding DisplayEntry { key: String, value: Option<String>, error: Option<String> } where a successful render populates DisplayEntry { key, value, error: None }, and any errors encountered populates DisplayEntry { key, None, error }.

## Test Plan 

objects/display.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
