### PR TITLE
Add more invariants for effects v2

### DIFF
--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -8,6 +8,7 @@ use crate::{
     error::{ExecutionError, ExecutionErrorKind, SuiError},
     event::Event,
     execution_status::CommandArgumentError,
+    is_system_package,
     object::{Data, Object, Owner},
     storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, StorageView},
     transfer::Receiving,
@@ -24,7 +25,7 @@ pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore 
 }
 
 /// A type containing all of the information needed to work with a deleted shared object in
-/// execution and when commiting the execution effects of the transaction. This holds:
+/// execution and when committing the execution effects of the transaction. This holds:
 /// 0. The object ID of the deleted shared object.
 /// 1. The version of the shared object.
 /// 2. Whether the object appeared as mutable (or owned) in the transaction, or as a read-only shared object.
@@ -146,6 +147,7 @@ impl ExecutionResultsV2 {
                     // only applies to system packages).  All other packages can only be created,
                     // and they are left alone.
                     if self.modified_objects.contains(id) {
+                        debug_assert!(is_system_package(*id));
                         pkg.increment_version();
                     }
                 }


### PR DESCRIPTION
## Description 

Add a few more assertions in effects v2, some comment updates and etc.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
