### PR TITLE
[bridge 15/n] handle sui tx digest

### DIFF
--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -3,7 +3,7 @@
 
 use mysten_metrics::start_prometheus_server;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use sui_bridge::server::run_server;
+use sui_bridge::server::{handler::BridgeRequestHandler, run_server};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -21,6 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     // TODO: allow configuration of port
     let socket_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9000);
-    run_server(&socket_address).await;
+
+    run_server(&socket_address, BridgeRequestHandler::new()).await;
     Ok(())
 }

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -26,9 +26,9 @@ pub const APPLICATION_JSON: &str = "application/json";
 pub const ETH_TO_SUI_TX_PATH: &str = "/sign/bridge_tx/eth/sui/:tx_hash/:event_index";
 pub const SUI_TO_ETH_TX_PATH: &str = "/sign/bridge_tx/sui/eth/:tx_digest/:event_index";
 
-pub async fn run_server(socket_address: &SocketAddr) {
+pub async fn run_server(socket_address: &SocketAddr, handler: BridgeRequestHandler) {
     axum::Server::bind(socket_address)
-        .serve(make_router(Arc::new(BridgeRequestHandler::new())).into_make_service())
+        .serve(make_router(Arc::new(handler)).into_make_service())
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Description 

implements simple logic for BridgeRequestHandler::handle_sui_tx_digest. Similar to https://github.com/MystenLabs/sui/pull/15405, optimization will be added together.

## Test Plan 

unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
implements simple logic for BridgeRequestHandler::handle_sui_tx_digest.