### PR TITLE
[GraphQL/MoveType] Expose type abilities

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.exp
@@ -1,0 +1,69 @@
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-30:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 32-35:
+created: object(2,0), object(2,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3435200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'create-checkpoint'. lines 37-37:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 39-55:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      }
+                    },
+                    "hasPublicTransfer": true
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x9b8e8a26ae95beeb9412eb5af37307e7f78b10d137b37177d742cd95c16f4a9a::m::Foo"
+                      }
+                    },
+                    "hasPublicTransfer": true
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x9b8e8a26ae95beeb9412eb5af37307e7f78b10d137b37177d742cd95c16f4a9a::m::Bar"
+                      }
+                    },
+                    "hasPublicTransfer": false
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.exp
@@ -29,6 +29,18 @@ Response: {
                   "asMoveObject": {
                     "contents": {
                       "type": {
+                        "repr": "0xae06ab7f9cf993590eaae24cec65e0aba29cf17db9bb8df81be901000ccc5bdf::m::Bar"
+                      }
+                    },
+                    "hasPublicTransfer": false
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
                         "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
                       }
                     },
@@ -41,22 +53,10 @@ Response: {
                   "asMoveObject": {
                     "contents": {
                       "type": {
-                        "repr": "0x9b8e8a26ae95beeb9412eb5af37307e7f78b10d137b37177d742cd95c16f4a9a::m::Foo"
+                        "repr": "0xae06ab7f9cf993590eaae24cec65e0aba29cf17db9bb8df81be901000ccc5bdf::m::Foo"
                       }
                     },
                     "hasPublicTransfer": true
-                  }
-                }
-              },
-              {
-                "outputState": {
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x9b8e8a26ae95beeb9412eb5af37307e7f78b10d137b37177d742cd95c16f4a9a::m::Bar"
-                      }
-                    },
-                    "hasPublicTransfer": false
                   }
                 }
               }

--- a/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 --accounts A --simulator
+
+//# publish
+module P0::m {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Foo has key, store {
+        id: UID,
+    }
+
+    struct Bar has key {
+        id: UID,
+    }
+
+    public fun foo(ctx: &mut TxContext): Foo {
+        Foo { id: object::new(ctx) }
+    }
+
+    public fun bar(ctx: &mut TxContext) {
+        transfer::transfer(
+            Bar { id: object::new(ctx) },
+            tx_context::sender(ctx),
+        )
+    }
+}
+
+//# programmable --inputs @A
+//> 0: P0::m::foo();
+//> 1: P0::m::bar();
+//> TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    transactionBlockConnection(last: 1) {
+        nodes {
+            effects {
+                objectChanges {
+                    outputState {
+                        asMoveObject {
+                            contents { type { repr } }
+                            hasPublicTransfer
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -1,6 +1,6 @@
-processed 7 tasks
+processed 8 tasks
 
-task 1 'run-graphql'. lines 6-14:
+task 1 'run-graphql'. lines 6-15:
 Response: {
   "data": {
     "type": {
@@ -88,7 +88,7 @@ Response: {
   }
 }
 
-task 2 'run-graphql'. lines 16-24:
+task 2 'run-graphql'. lines 17-26:
 Response: {
   "data": {
     "type": {
@@ -99,7 +99,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 26-34:
+task 3 'run-graphql'. lines 28-37:
 Response: {
   "data": {
     "type": {
@@ -114,7 +114,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 36-44:
+task 4 'run-graphql'. lines 39-48:
 Response: {
   "data": null,
   "errors": [
@@ -136,7 +136,7 @@ Response: {
   ]
 }
 
-task 5 'run-graphql'. lines 46-57:
+task 5 'run-graphql'. lines 50-60:
 Response: {
   "data": {
     "type": {
@@ -153,7 +153,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 59-74:
+task 6 'run-graphql'. lines 62-77:
 Response: {
   "data": null,
   "errors": [
@@ -174,4 +174,38 @@ Response: {
       }
     }
   ]
+}
+
+task 7 'run-graphql'. lines 79-102:
+Response: {
+  "data": {
+    "token": {
+      "abilities": [
+        "KEY"
+      ]
+    },
+    "coin": {
+      "abilities": [
+        "STORE",
+        "KEY"
+      ]
+    },
+    "balance": {
+      "abilities": [
+        "STORE"
+      ]
+    },
+    "coin_vector": {
+      "abilities": [
+        "STORE"
+      ]
+    },
+    "prim_vector": {
+      "abilities": [
+        "COPY",
+        "DROP",
+        "STORE"
+      ]
+    }
+  }
 }

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.move
@@ -5,6 +5,7 @@
 
 //# run-graphql
 # Happy path -- valid type, get everything
+
 {
     type(type: "0x2::priority_queue::PriorityQueue<0x2::coin::Coin<0x2::sui::SUI>>") {
         repr
@@ -15,6 +16,7 @@
 
 //# run-graphql
 # Happy path -- primitive type
+
 {
     type(type: "u64") {
         repr
@@ -25,6 +27,7 @@
 
 //# run-graphql
 # Happy path -- primitive type with generic parameter
+
 {
     type(type: "vector<u64>") {
         repr
@@ -35,6 +38,7 @@
 
 //# run-graphql
 # Unhappy path -- bad type tag (failed to parse)
+
 {
     type(type: "not_a_type") {
         repr
@@ -44,7 +48,6 @@
 }
 
 //# run-graphql
-
 # Semi-happy path -- the input looks like a type, but that type
 # doesn't exist. Depending on which fields you ask for, this request
 # may still succeed.
@@ -57,7 +60,6 @@
 }
 
 //# run-graphql
-
 # Unhappy side of semi-happy path -- asking for a layout for a type
 # that doesn't exist won't work.
 #
@@ -67,8 +69,34 @@
 # MoveType to signal an error in layout calculation and the GraphQL
 # field implementations to know that it is a user error or an internal
 # error.
+
 {
     type(type: "0x42::not::Here") {
         layout
+    }
+}
+
+//# run-graphql
+# Querying abilities for concrete types
+
+{
+    token: type(type: "0x2::token::Token<0x2::sui::SUI>") {
+        abilities
+    }
+
+    coin: type(type: "0x2::coin::Coin<0x2::sui::SUI>") {
+        abilities
+    }
+
+    balance: type(type: "0x2::balance::Balance<0x2::sui::SUI>") {
+        abilities
+    }
+
+    coin_vector: type(type: "vector<0x2::coin::Coin<0x2::sui::SUI>>") {
+        abilities
+    }
+
+    prim_vector: type(type: "vector<u64>") {
+        abilities
     }
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1109,7 +1109,8 @@ type MoveObject {
 	contents: MoveValue
 	"""
 	Determines whether a transaction can transfer this object, using the TransferObjects
-	command, which requires its type to have the `key` and `store` abilities.
+	transaction command or `sui::transfer::public_transfer`, both of which require the object to
+	have the `key` and `store` abilities.
 	"""
 	hasPublicTransfer: Boolean!
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1108,9 +1108,10 @@ type MoveObject {
 	"""
 	contents: MoveValue
 	"""
-	Determines whether a tx can transfer this object
+	Determines whether a transaction can transfer this object, using the TransferObjects
+	command, which requires its type to have the `key` and `store` abilities.
 	"""
-	hasPublicTransfer: Boolean
+	hasPublicTransfer: Boolean!
 	"""
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
@@ -1264,6 +1265,10 @@ type MoveType {
 	Structured representation of the "shape" of values that match this type.
 	"""
 	layout: MoveTypeLayout!
+	"""
+	The abilities this concrete type has.
+	"""
+	abilities: [MoveAbility!]!
 }
 
 """

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -1241,6 +1241,8 @@ type MoveType {
   signature: MoveTypeSignature!
   # Structured representation of the "shape" of values that match this type.
   layout: MoveTypeLayout!
+  # The abilities this concrete type has.
+  abilities: [MoveAbility!]!
 }
 
 # Represents types that could contain references or free type

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -38,7 +38,8 @@ impl MoveObject {
     }
 
     /// Determines whether a transaction can transfer this object, using the TransferObjects
-    /// command, which requires its type to have the `key` and `store` abilities.
+    /// transaction command or `sui::transfer::public_transfer`, both of which require the object to
+    /// have the `key` and `store` abilities.
     async fn has_public_transfer(&self, ctx: &Context<'_>) -> Result<bool> {
         let resolver: &Resolver<PackageCache> = ctx
             .data()

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -3,12 +3,15 @@
 
 use super::coin::CoinDowncastError;
 use super::coin_metadata::{CoinMetadata, CoinMetadataDowncastError};
+use super::move_type::MoveType;
 use super::move_value::MoveValue;
 use super::stake::StakedSuiDowncastError;
 use super::{coin::Coin, object::Object};
+use crate::context_data::package_cache::PackageCache;
 use crate::error::Error;
 use crate::types::stake::StakedSui;
 use async_graphql::*;
+use sui_package_resolver::Resolver;
 use sui_types::object::{Data, MoveObject as NativeMoveObject};
 use sui_types::TypeTag;
 
@@ -34,9 +37,17 @@ impl MoveObject {
         Some(MoveValue::new(type_, self.native.contents().into()))
     }
 
-    /// Determines whether a tx can transfer this object
-    async fn has_public_transfer(&self) -> Option<bool> {
-        Some(self.native.has_public_transfer())
+    /// Determines whether a transaction can transfer this object, using the TransferObjects
+    /// command, which requires its type to have the `key` and `store` abilities.
+    async fn has_public_transfer(&self, ctx: &Context<'_>) -> Result<bool> {
+        let resolver: &Resolver<PackageCache> = ctx
+            .data()
+            .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
+            .extend()?;
+
+        let type_ = MoveType::new(TypeTag::from(self.native.type_().clone()));
+        let set = type_.abilities_impl(resolver).await.extend()?;
+        Ok(set.has_key() && set.has_store())
     }
 
     /// Attempts to convert the Move object into an Object

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1113,7 +1113,7 @@ type MoveObject {
 	contents: MoveValue
 	"""
 	Determines whether a transaction can transfer this object, using the TransferObjects
-	command, which requires its type to have the `store` ability.
+	command, which requires its type to have the `key` and `store` abilities.
 	"""
 	hasPublicTransfer: Boolean!
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1112,9 +1112,10 @@ type MoveObject {
 	"""
 	contents: MoveValue
 	"""
-	Determines whether a tx can transfer this object
+	Determines whether a transaction can transfer this object, using the TransferObjects
+	command, which requires its type to have the `store` ability.
 	"""
-	hasPublicTransfer: Boolean
+	hasPublicTransfer: Boolean!
 	"""
 	Attempts to convert the Move object into an Object
 	This provides additional information such as version and digest on the top-level
@@ -1268,6 +1269,10 @@ type MoveType {
 	Structured representation of the "shape" of values that match this type.
 	"""
 	layout: MoveTypeLayout!
+	"""
+	The abilities this concrete type has.
+	"""
+	abilities: [MoveAbility!]!
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1113,7 +1113,8 @@ type MoveObject {
 	contents: MoveValue
 	"""
 	Determines whether a transaction can transfer this object, using the TransferObjects
-	command, which requires its type to have the `key` and `store` abilities.
+	transaction command or `sui::transfer::public_transfer`, both of which require the object to
+	have the `key` and `store` abilities.
 	"""
 	hasPublicTransfer: Boolean!
 	"""


### PR DESCRIPTION
## Description

Adds a GraphQL field to `MoveType` to expose its `abilities` and use the same source of information to compute `hasPublicTransfer`.

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- types.move public_transfer.move
```

## Stack

- #15393 