### PR TITLE
Cleaned up sui move test args. Added sui-framework-test filter

### DIFF
--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -7,6 +7,8 @@ use std::{fs, io, path::PathBuf};
 use sui_move::unit_test::run_move_unit_tests;
 use sui_move_build::BuildConfig;
 
+const FILTER_ENV: &str = "FILTER";
+
 #[test]
 #[cfg_attr(msim, ignore)]
 fn run_sui_framework_tests() {
@@ -105,7 +107,8 @@ fn check_move_unit_tests(path: PathBuf) {
     config.config.warnings_are_errors = true;
     config.config.silence_warnings = false;
     let move_config = config.config.clone();
-    let testing_config = UnitTestingConfig::default_with_bound(Some(3_000_000));
+    let mut testing_config = UnitTestingConfig::default_with_bound(Some(3_000_000));
+    testing_config.filter = std::env::var(FILTER_ENV).ok().map(|s| s.to_string());
 
     // build tests first to enable Sui-specific test code verification
     config

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -5,8 +5,6 @@ use clap::Parser;
 #[cfg(feature = "unit_test")]
 use move_cli::base::test::UnitTestResult;
 use move_package::BuildConfig;
-#[cfg(feature = "unit_test")]
-use move_unit_test::UnitTestingConfig;
 use std::path::PathBuf;
 use sui_move_build::set_sui_flavor;
 
@@ -64,17 +62,7 @@ pub fn execute_move_command(
         Command::Prove(c) => c.execute(package_path, build_config),
         #[cfg(feature = "unit_test")]
         Command::Test(c) => {
-            let unit_test_config = UnitTestingConfig {
-                gas_limit: c.test.gas_limit,
-                filter: c.test.filter.clone(),
-                list: c.test.list,
-                num_threads: c.test.num_threads,
-                report_statistics: c.test.report_statistics.clone(),
-                check_stackless_vm: c.test.check_stackless_vm,
-                verbose: c.test.verbose_mode,
-                ..UnitTestingConfig::default_with_bound(None)
-            };
-            let result = c.execute(package_path, build_config, unit_test_config)?;
+            let result = c.execute(package_path, build_config)?;
 
             // Return a non-zero exit code if any test failed
             if let UnitTestResult::Failure = result {

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -38,23 +38,24 @@ pub struct Test {
 
 impl Test {
     pub fn execute(
-        &self,
+        self,
         path: Option<PathBuf>,
         build_config: BuildConfig,
-        unit_test_config: UnitTestingConfig,
     ) -> anyhow::Result<UnitTestResult> {
-        if !cfg!(debug_assertions) && self.test.compute_coverage {
+        let compute_coverage = self.test.compute_coverage;
+        if !cfg!(debug_assertions) && compute_coverage {
             return Err(anyhow::anyhow!(
                 "The --coverage flag is currently supported only in debug builds. Please build the Sui CLI from source in debug mode."
             ));
         }
         // find manifest file directory from a given path or (if missing) from current dir
         let rerooted_path = base::reroot_path(path)?;
+        let unit_test_config = self.test.unit_test_config();
         run_move_unit_tests(
             rerooted_path,
             build_config,
             Some(unit_test_config),
-            self.test.compute_coverage,
+            compute_coverage,
         )
     }
 }

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -80,30 +80,11 @@ impl Test {
         cost_table: Option<CostTable>,
     ) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
-        let Self {
-            gas_limit,
-            filter,
-            list,
-            num_threads,
-            report_statistics,
-            check_stackless_vm,
-            verbose_mode,
-            compute_coverage,
-        } = self;
-        let unit_test_config = UnitTestingConfig {
-            gas_limit,
-            filter,
-            list,
-            num_threads,
-            report_statistics,
-            check_stackless_vm,
-            verbose: verbose_mode,
-            ..UnitTestingConfig::default_with_bound(None)
-        };
+        let compute_coverage = self.compute_coverage;
         let result = run_move_unit_tests(
             &rerooted_path,
             config,
-            unit_test_config,
+            self.unit_test_config(),
             natives,
             cost_table,
             compute_coverage,
@@ -115,6 +96,29 @@ impl Test {
             std::process::exit(1)
         }
         Ok(())
+    }
+
+    pub fn unit_test_config(self) -> UnitTestingConfig {
+        let Self {
+            gas_limit,
+            filter,
+            list,
+            num_threads,
+            report_statistics,
+            check_stackless_vm,
+            verbose_mode,
+            compute_coverage: _,
+        } = self;
+        UnitTestingConfig {
+            gas_limit,
+            filter,
+            list,
+            num_threads,
+            report_statistics,
+            check_stackless_vm,
+            verbose: verbose_mode,
+            ..UnitTestingConfig::default_with_bound(None)
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

- Refactored the execution of sui-move-test execution to ensure flags aren't ignored 
- Added a `FILTER=<filter>` env for `sui-framework-test` that threads down to sui move test/unit test execution

## Test Plan 

- 👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
