### PR TITLE
[transfer-to-object] TTO support in test scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13017,6 +13017,7 @@ version = "1.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "better_any",
  "clap",
  "colored",
  "const-str",
@@ -14103,6 +14104,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "bcs",
+ "better_any",
  "bincode",
  "byteorder",
  "chrono",

--- a/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
@@ -362,33 +362,42 @@ module sui::test_scenario {
         sui::transfer::share_object_impl(t)
     }
 
-    public fun get_objects_owned_by<T: key>(object_id: ID): vector<ID> {
-        ids_for_address<T>(object::id_to_address(&object_id))
+    /// Return the IDs of the child objects that `parent` owns.
+    public fun child_object_ids_for_parent_object_id<T: key>(parent: ID): vector<ID> {
+        ids_for_address<T>(object::id_to_address(&parent))
     }
 
-    public fun get_receiving_ticket_for_object<T: key>(parent: &ID): sui::transfer::Receiving<T> {
+    /// Create a `Receiving<T>` receiving ticket for the most recent child
+    /// object of type `T` that is owned by the `parent` object ID. 
+    public fun receiving_ticket_for_most_recent_child_object<T: key>(
+        parent: &ID
+    ): sui::transfer::Receiving<T> {
         let id_opt = most_recent_id_for_address<T>(object::id_to_address(parent));
         assert!(option::is_some(&id_opt), EEmptyInventory);
         let id = option::destroy_some(id_opt);
-        assert!(!was_allocated_receiving_ticket(id), ECantReturnObject);
-        get_receiving_ticket_for_object_by_id<T>(id)
+        receiving_ticket_for_child_object_by_id<T>(id)
     }
 
-    public fun get_receiving_ticket_for_object_by_id<T: key>(object_id: ID): sui::transfer::Receiving<T> {
+    /// Create a `Receiving<T>` receiving ticket for the child object of type
+    /// `T` with the given `object_id`.
+    public fun receiving_ticket_for_child_object_by_id<T: key>(
+        object_id: ID
+    ): sui::transfer::Receiving<T> {
         let version = allocate_receiving_ticket_for_object<T>(object_id);
         sui::transfer::make_receiver(object_id, version)
     }
 
+    /// Deallocate a `Receiving<T>` receiving ticket. This must be done in
+    /// order to use the object further (unless the object was recieved) in a
+    /// test scenario.
     public fun return_receiving_ticket<T: key>(ticket: sui::transfer::Receiving<T>) {
         let id = sui::transfer::receiving_id(&ticket);
-        assert!(was_allocated_receiving_ticket(id), ECantReturnObject);
         deallocate_receiving_ticket_for_object(id);
     }
 
     /// Returns true if the object with `ID` id was an shared object in the global inventory
     native fun was_taken_shared(id: ID): bool;
 
-    native fun was_allocated_receiving_ticket(id: ID): bool;
     native fun allocate_receiving_ticket_for_object<T: key>(object_id: ID): u64;
     native fun deallocate_receiving_ticket_for_object(id: ID);
 

--- a/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
@@ -28,6 +28,18 @@ module sui::test_scenario {
     /// Object of that ID was not found in that inventory. It was possibly already taken
     const EObjectNotFound: u64 = 4;
 
+    #[allow(unused_const)]
+    /// Unable to allocate a receiving ticket for the object
+    const EUnableToAllocateReceivingTicket: u64 = 5;
+
+    #[allow(unused_const)]
+    /// A receiving ticket for the object was already allocated in the transaction
+    const EReceivingTicketAlreadyAllocated: u64 = 6;
+
+    #[allow(unused_const)]
+    /// Unable to deallocate the receiving ticket 
+    const EUnableToDeallocateReceivingTicket: u64 = 7;
+
     /// Utility for mocking a multi-transaction Sui execution in a single Move procedure.
     /// A `Scenario` maintains a view of the global object pool built up by the execution.
     /// These objects can be accessed via functions like `take_from_sender`, which gives the
@@ -350,8 +362,35 @@ module sui::test_scenario {
         sui::transfer::share_object_impl(t)
     }
 
+    public fun get_objects_owned_by<T: key>(object_id: ID): vector<ID> {
+        ids_for_address<T>(object::id_to_address(&object_id))
+    }
+
+    public fun get_receiving_ticket_for_object<T: key>(parent: &ID): sui::transfer::Receiving<T> {
+        let id_opt = most_recent_id_for_address<T>(object::id_to_address(parent));
+        assert!(option::is_some(&id_opt), EEmptyInventory);
+        let id = option::destroy_some(id_opt);
+        assert!(!was_allocated_receiving_ticket(id), ECantReturnObject);
+        get_receiving_ticket_for_object_by_id<T>(id)
+    }
+
+    public fun get_receiving_ticket_for_object_by_id<T: key>(object_id: ID): sui::transfer::Receiving<T> {
+        let version = allocate_receiving_ticket_for_object<T>(object_id);
+        sui::transfer::make_receiver(object_id, version)
+    }
+
+    public fun return_receiving_ticket<T: key>(ticket: sui::transfer::Receiving<T>) {
+        let id = sui::transfer::receiving_id(&ticket);
+        assert!(was_allocated_receiving_ticket(id), ECantReturnObject);
+        deallocate_receiving_ticket_for_object(id);
+    }
+
     /// Returns true if the object with `ID` id was an shared object in the global inventory
     native fun was_taken_shared(id: ID): bool;
+
+    native fun was_allocated_receiving_ticket(id: ID): bool;
+    native fun allocate_receiving_ticket_for_object<T: key>(object_id: ID): u64;
+    native fun deallocate_receiving_ticket_for_object(id: ID);
 
     // == internal ==
 

--- a/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
@@ -362,25 +362,25 @@ module sui::test_scenario {
         sui::transfer::share_object_impl(t)
     }
 
-    /// Return the IDs of the child objects that `parent` owns.
-    public fun child_object_ids_for_parent_object_id<T: key>(parent: ID): vector<ID> {
-        ids_for_address<T>(object::id_to_address(&parent))
+    /// Return the IDs of the receivalbe objects that `object` owns.
+    public fun receivable_object_ids_for_owner_object_id<T: key>(object: ID): vector<ID> {
+        ids_for_address<T>(object::id_to_address(&object))
     }
 
-    /// Create a `Receiving<T>` receiving ticket for the most recent child
-    /// object of type `T` that is owned by the `parent` object ID. 
-    public fun receiving_ticket_for_most_recent_child_object<T: key>(
-        parent: &ID
+    /// Create a `Receiving<T>` receiving ticket for the most recent 
+    /// object of type `T` that is owned by the `owner` object ID. 
+    public fun receiving_ticket_for_most_recent_object<T: key>(
+        owner: &ID
     ): sui::transfer::Receiving<T> {
-        let id_opt = most_recent_id_for_address<T>(object::id_to_address(parent));
+        let id_opt = most_recent_id_for_address<T>(object::id_to_address(owner));
         assert!(option::is_some(&id_opt), EEmptyInventory);
         let id = option::destroy_some(id_opt);
-        receiving_ticket_for_child_object_by_id<T>(id)
+        receiving_ticket_for_object_by_id<T>(id)
     }
 
-    /// Create a `Receiving<T>` receiving ticket for the child object of type
+    /// Create a `Receiving<T>` receiving ticket for the object of type
     /// `T` with the given `object_id`.
-    public fun receiving_ticket_for_child_object_by_id<T: key>(
+    public fun receiving_ticket_for_object_by_id<T: key>(
         object_id: ID
     ): sui::transfer::Receiving<T> {
         let version = allocate_receiving_ticket_for_object<T>(object_id);
@@ -398,8 +398,12 @@ module sui::test_scenario {
     /// Returns true if the object with `ID` id was an shared object in the global inventory
     native fun was_taken_shared(id: ID): bool;
 
+    /// Allocate the receiving ticket for the object of type `T` with the given
+    /// `object_id`. Returns the current version of object.
     native fun allocate_receiving_ticket_for_object<T: key>(object_id: ID): u64;
-    native fun deallocate_receiving_ticket_for_object(id: ID);
+
+    /// Deallocate the receiving ticket for the object with the given `object_id`.
+    native fun deallocate_receiving_ticket_for_object(object_id: ID);
 
     // == internal ==
 

--- a/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
@@ -363,24 +363,24 @@ module sui::test_scenario {
     }
 
     /// Return the IDs of the receivalbe objects that `object` owns.
-    public fun receivable_object_ids_for_owner_object_id<T: key>(object: ID): vector<ID> {
+    public fun receivable_object_ids_for_owner_id<T: key>(object: ID): vector<ID> {
         ids_for_address<T>(object::id_to_address(&object))
     }
 
     /// Create a `Receiving<T>` receiving ticket for the most recent 
     /// object of type `T` that is owned by the `owner` object ID. 
-    public fun receiving_ticket_for_most_recent_object<T: key>(
+    public fun most_recent_receiving_ticket<T: key>(
         owner: &ID
     ): sui::transfer::Receiving<T> {
         let id_opt = most_recent_id_for_address<T>(object::id_to_address(owner));
         assert!(option::is_some(&id_opt), EEmptyInventory);
         let id = option::destroy_some(id_opt);
-        receiving_ticket_for_object_by_id<T>(id)
+        receiving_ticket_by_id<T>(id)
     }
 
     /// Create a `Receiving<T>` receiving ticket for the object of type
     /// `T` with the given `object_id`.
-    public fun receiving_ticket_for_object_by_id<T: key>(
+    public fun receiving_ticket_by_id<T: key>(
         object_id: ID
     ): sui::transfer::Receiving<T> {
         let version = allocate_receiving_ticket_for_object<T>(object_id);

--- a/crates/sui-framework/packages/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/packages/sui-framework/sources/transfer.move
@@ -132,4 +132,17 @@ module sui::transfer {
     public(package) native fun transfer_impl<T: key>(obj: T, recipient: address);
 
     native fun receive_impl<T: key>(parent: address, to_receive: ID, version: u64): T;
+
+    #[test_only]
+    public(package) fun make_receiver<T: key>(id: ID, version: u64): Receiving<T> {
+        Receiving {
+            id,
+            version,
+        }
+    }
+
+    #[test_only]
+    public(package) fun receiving_id<T: key>(r: &Receiving<T>): ID {
+        r.id
+    }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -429,8 +429,8 @@ module sui::test_scenario_tests {
         {
 
             let mut parent = scenario.take_from_sender_by_id<Object>(id1);
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
-            let t3 = test_scenario::receiving_ticket_for_object_by_id<Object>(id3);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
+            let t3 = test_scenario::receiving_ticket_by_id<Object>(id3);
             let obj2 = transfer::receive(&mut parent.id, t2);
             let obj3 = transfer::receive(&mut parent.id, t3);
             assert!(parent.value == 10, EValueMismatch);
@@ -462,7 +462,7 @@ module sui::test_scenario_tests {
         {
 
             let mut parent = scenario.take_from_sender_by_id<Object>(id1);
-            let t2 = test_scenario::receiving_ticket_for_most_recent_object<Object>(&id1);
+            let t2 = test_scenario::most_recent_receiving_ticket<Object>(&id1);
             let obj2 = transfer::receive(&mut parent.id, t2);
             assert!(parent.value == 10, EValueMismatch);
             assert!(obj2.value == 20, EValueMismatch);
@@ -487,7 +487,7 @@ module sui::test_scenario_tests {
         };
         scenario.next_tx(sender);
         {
-            let _t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id1);
+            let _t2 = test_scenario::receiving_ticket_by_id<Object>(id1);
         };
         scenario.end();
     }
@@ -507,8 +507,8 @@ module sui::test_scenario_tests {
         };
         scenario.next_tx(sender);
         {
-            let _t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id1);
-            let _t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id1);
+            let _t2 = test_scenario::receiving_ticket_by_id<Object>(id1);
+            let _t2 = test_scenario::receiving_ticket_by_id<Object>(id1);
         };
         scenario.end();
     }
@@ -527,9 +527,9 @@ module sui::test_scenario_tests {
         };
         scenario.next_tx(sender);
         {
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id1);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id1);
             test_scenario::return_receiving_ticket(t2);
-            let _t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id1);
+            let _t2 = test_scenario::receiving_ticket_by_id<Object>(id1);
         };
         scenario.end();
     }
@@ -560,10 +560,10 @@ module sui::test_scenario_tests {
         {
 
             let mut parent = scenario.take_from_sender_by_id<Object>(id1);
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
             test_scenario::return_receiving_ticket(t2);
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
-            let t3 = test_scenario::receiving_ticket_for_object_by_id<Object>(id3);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
+            let t3 = test_scenario::receiving_ticket_by_id<Object>(id3);
             let obj2 = transfer::receive(&mut parent.id, t2);
             let obj3 = transfer::receive(&mut parent.id, t3);
             assert!(parent.value == 10, EValueMismatch);
@@ -603,10 +603,10 @@ module sui::test_scenario_tests {
         {
 
             let mut parent = scenario.take_from_sender_by_id<Object>(id1);
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
             test_scenario::return_receiving_ticket(t2);
-            let t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
-            let t3 = test_scenario::receiving_ticket_for_object_by_id<Object>(id3);
+            let t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
+            let t3 = test_scenario::receiving_ticket_by_id<Object>(id3);
             let mut obj2 = transfer::receive(&mut parent.id, t2);
             let obj3 = transfer::receive(&mut parent.id, t3);
             assert!(parent.value == 10, EValueMismatch);
@@ -647,8 +647,8 @@ module sui::test_scenario_tests {
         };
         scenario.next_tx(sender);
         {
-            let _t2 = test_scenario::receiving_ticket_for_object_by_id<Object>(id2);
-            let _t3 = test_scenario::receiving_ticket_for_object_by_id<Object>(id3);
+            let _t2 = test_scenario::receiving_ticket_by_id<Object>(id2);
+            let _t3 = test_scenario::receiving_ticket_by_id<Object>(id3);
         };
         scenario.end();
     }

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -35,6 +35,7 @@ sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", packa
 sui-move-build.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
+better_any = "0.1.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemalloc-ctl.workspace = true

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 use std::{
     collections::BTreeMap,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 use sui_move_build::decorate_warnings;
 use sui_move_natives::test_scenario::InMemoryTestStore;
@@ -85,8 +85,8 @@ impl ChildObjectResolver for DummyChildObjectStore {
     }
 }
 
-static TEST_STORE_INNER: Lazy<Mutex<InMemoryStorage>> =
-    Lazy::new(|| Mutex::new(InMemoryStorage::default()));
+static TEST_STORE_INNER: Lazy<RwLock<InMemoryStorage>> =
+    Lazy::new(|| RwLock::new(InMemoryStorage::default()));
 
 static TEST_STORE: Lazy<InMemoryTestStore> = Lazy::new(|| InMemoryTestStore(&TEST_STORE_INNER));
 

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -10,14 +10,20 @@ use move_package::BuildConfig;
 use move_unit_test::{extensions::set_extension_hook, UnitTestingConfig};
 use move_vm_runtime::native_extensions::NativeContextExtensions;
 use once_cell::sync::Lazy;
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 use sui_move_build::decorate_warnings;
+use sui_move_natives::test_scenario::InMemoryTestStore;
 use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     error::SuiResult,
     gas_model::tables::initial_cost_schedule_for_unit_tests,
+    in_memory_storage::InMemoryStorage,
     metrics::LimitsMetrics,
     object::Object,
     storage::ChildObjectResolver,
@@ -79,7 +85,10 @@ impl ChildObjectResolver for DummyChildObjectStore {
     }
 }
 
-static TEST_STORE: Lazy<DummyChildObjectStore> = Lazy::new(|| DummyChildObjectStore {});
+static TEST_STORE_INNER: Lazy<Mutex<InMemoryStorage>> =
+    Lazy::new(|| Mutex::new(InMemoryStorage::default()));
+
+static TEST_STORE: Lazy<InMemoryTestStore> = Lazy::new(|| InMemoryTestStore(&TEST_STORE_INNER));
 
 static SET_EXTENSION_HOOK: Lazy<()> =
     Lazy::new(|| set_extension_hook(Box::new(new_testing_object_and_natives_cost_runtime)));
@@ -137,4 +146,6 @@ fn new_testing_object_and_natives_cost_runtime(ext: &mut NativeContextExtensions
     ext.add(NativesCostTable::from_protocol_config(
         &ProtocolConfig::get_for_max_version_UNSAFE(),
     ));
+
+    ext.add(store);
 }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -69,6 +69,7 @@ typed-store-error.workspace = true
 derive_more.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+better_any.workspace = true
 
 [dev-dependencies]
 bincode.workspace = true

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -13,6 +13,7 @@ use crate::{
     object::{Object, Owner},
     storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
 };
+use better_any::{Tid, TidAble};
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
@@ -20,7 +21,7 @@ use std::collections::BTreeMap;
 
 // TODO: We should use AuthorityTemporaryStore instead.
 // Keeping this functionally identical to AuthorityTemporaryStore is a pain.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Tid)]
 pub struct InMemoryStorage {
     persistent: BTreeMap<ObjectID, Object>,
 }
@@ -187,6 +188,10 @@ impl InMemoryStorage {
     pub fn insert_object(&mut self, object: Object) {
         let id = object.id();
         self.persistent.insert(id, object);
+    }
+
+    pub fn remove_object(&mut self, object_id: ObjectID) -> Option<Object> {
+        self.persistent.remove(&object_id)
     }
 
     pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {

--- a/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
@@ -44,6 +44,12 @@ impl<'a> NativeContextExtensions<'a> {
             .unwrap()
     }
 
+    pub fn dump(&self) {
+        for x in self.map.keys() {
+            println!("key: {:?}", x);
+        }
+    }
+
     pub fn remove<T: TidAble<'a>>(&mut self) -> T {
         // can't use expect below because it requires `T: Debug`.
         match self

--- a/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/native_extensions.rs
@@ -44,12 +44,6 @@ impl<'a> NativeContextExtensions<'a> {
             .unwrap()
     }
 
-    pub fn dump(&self) {
-        for x in self.map.keys() {
-            println!("key: {:?}", x);
-        }
-    }
-
     pub fn remove<T: TidAble<'a>>(&mut self) -> T {
         // can't use expect below because it requires `T: Debug`.
         match self

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -67,7 +67,7 @@ mod dynamic_field;
 mod event;
 mod object;
 pub mod object_runtime;
-mod test_scenario;
+pub mod test_scenario;
 mod test_utils;
 mod transfer;
 mod tx_context;
@@ -809,6 +809,21 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
             "test_scenario",
             "ids_for_address",
             make_native!(test_scenario::ids_for_address),
+        ),
+        (
+            "test_scenario",
+            "allocate_receiving_ticket_for_object",
+            make_native!(test_scenario::allocate_receiving_ticket_for_object),
+        ),
+        (
+            "test_scenario",
+            "deallocate_receiving_ticket_for_object",
+            make_native!(test_scenario::deallocate_receiving_ticket_for_object),
+        ),
+        (
+            "test_scenario",
+            "was_allocated_receiving_ticket",
+            make_native!(test_scenario::was_allocated_receiving_ticket),
         ),
         (
             "transfer",

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -821,11 +821,6 @@ pub fn all_natives(silent: bool) -> NativeFunctionTable {
             make_native!(test_scenario::deallocate_receiving_ticket_for_object),
         ),
         (
-            "test_scenario",
-            "was_allocated_receiving_ticket",
-            make_native!(test_scenario::was_allocated_receiving_ticket),
-        ),
-        (
             "transfer",
             "transfer_impl",
             make_native!(transfer::transfer_internal),

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -61,6 +61,8 @@ pub(crate) struct TestInventories {
     pub(crate) taken_immutable_values: BTreeMap<Type, BTreeMap<ObjectID, Value>>,
     // object has been taken from the inventory
     pub(crate) taken: BTreeMap<ObjectID, Owner>,
+    // allocated receiving tickets
+    pub(crate) allocated_tickets: BTreeMap<ObjectID, (DynamicallyLoadedObjectMetadata, Value)>,
 }
 
 pub struct LoadedRuntimeObject {

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -115,7 +115,8 @@ pub fn end_transaction(
 
     let object_runtime_state = object_runtime_ref.take_state();
     // Determine writes and deletes
-    // We pass an empty map as we do not expose dynamic field objects in the system
+    // We pass the received objects since they should be viewed as "loaded" for the purposes of of
+    // calculating the effects of the transaction.
     let results = object_runtime_state.finish(received, BTreeMap::new());
     let RuntimeResults {
         writes,
@@ -550,26 +551,6 @@ pub fn was_taken_shared(
     Ok(NativeResult::ok(
         legacy_test_cost(),
         smallvec![Value::bool(was_taken)],
-    ))
-}
-
-// native fun was_allocated_receiving_ticket(id: ID): bool;
-pub fn was_allocated_receiving_ticket(
-    context: &mut NativeContext,
-    ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.is_empty());
-    let id = pop_id(&mut args)?;
-    assert!(args.is_empty());
-    let object_runtime: &ObjectRuntime = context.extensions().get();
-    let was_allocated = object_runtime
-        .test_inventories
-        .allocated_tickets
-        .contains_key(&id);
-    Ok(NativeResult::ok(
-        legacy_test_cost(),
-        smallvec![Value::bool(was_allocated)],
     ))
 }
 

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    get_nth_struct_field, legacy_test_cost,
+    get_nth_struct_field, get_tag_and_layouts, legacy_test_cost,
     object_runtime::{ObjectRuntime, RuntimeResults},
 };
+use better_any::{Tid, TidAble};
 use indexmap::{IndexMap, IndexSet};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -23,20 +24,63 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, BorrowMut},
     collections::{BTreeMap, BTreeSet, VecDeque},
+    sync::Mutex,
 };
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
+    digests::{ObjectDigest, TransactionDigest},
+    execution::DynamicallyLoadedObjectMetadata,
     id::UID,
-    object::Owner,
+    in_memory_storage::InMemoryStorage,
+    object::{MoveObject, Object, Owner},
+    storage::ChildObjectResolver,
 };
 
 const E_COULD_NOT_GENERATE_EFFECTS: u64 = 0;
 const E_INVALID_SHARED_OR_IMMUTABLE_USAGE: u64 = 1;
 const E_OBJECT_NOT_FOUND_CODE: u64 = 4;
+const E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET: u64 = 5;
+const E_RECEIVING_TICKET_ALREADY_ALLOCATED: u64 = 6;
+const E_UNABLE_TO_DEALLOCATE_RECEIVING_TICKET: u64 = 7;
 
 type Set<K> = IndexSet<K>;
+
+/// An in-memory test store is a thin wrapper around the in-memory storage in a mutex. The mutex
+/// allows this to be used by both the object runtime (for reading) and the test scenario (for
+/// writing) while hiding mutability.
+#[derive(Tid)]
+pub struct InMemoryTestStore(pub &'static Mutex<InMemoryStorage>);
+
+impl ChildObjectResolver for InMemoryTestStore {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        self.0
+            .lock()
+            .unwrap()
+            .read_child_object(parent, child, child_version_upper_bound)
+    }
+
+    fn get_object_received_at_version(
+        &self,
+        owner: &ObjectID,
+        receiving_object_id: &ObjectID,
+        receive_object_at_version: SequenceNumber,
+        epoch_id: sui_types::committee::EpochId,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        self.0.lock().unwrap().get_object_received_at_version(
+            owner,
+            receiving_object_id,
+            receive_object_at_version,
+            epoch_id,
+        )
+    }
+}
 
 // This function updates the inventories based on the transfers and deletes that occurred in the
 // transaction
@@ -62,10 +106,17 @@ pub fn end_transaction(
     // if true, we will "abort"
     let mut incorrect_shared_or_imm_handling = false;
 
+    let received = object_runtime_ref
+        .test_inventories
+        .allocated_tickets
+        .iter()
+        .map(|(k, (metadata, _))| (*k, metadata.clone()))
+        .collect();
+
     let object_runtime_state = object_runtime_ref.take_state();
     // Determine writes and deletes
     // We pass an empty map as we do not expose dynamic field objects in the system
-    let results = object_runtime_state.finish(BTreeMap::new(), BTreeMap::new());
+    let results = object_runtime_state.finish(received, BTreeMap::new());
     let RuntimeResults {
         writes,
         user_events,
@@ -500,6 +551,149 @@ pub fn was_taken_shared(
         legacy_test_cost(),
         smallvec![Value::bool(was_taken)],
     ))
+}
+
+// native fun was_allocated_receiving_ticket(id: ID): bool;
+pub fn was_allocated_receiving_ticket(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.is_empty());
+    let id = pop_id(&mut args)?;
+    assert!(args.is_empty());
+    let object_runtime: &ObjectRuntime = context.extensions().get();
+    let was_allocated = object_runtime
+        .test_inventories
+        .allocated_tickets
+        .contains_key(&id);
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::bool(was_allocated)],
+    ))
+}
+
+pub fn allocate_receiving_ticket_for_object(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let ty = get_specified_ty(ty_args);
+    let id = pop_id(&mut args)?;
+
+    let Some((tag, layout, _)) = get_tag_and_layouts(context, &ty)? else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
+        ));
+    };
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_version = SequenceNumber::new();
+    let inventories = &mut object_runtime.test_inventories;
+    if inventories.allocated_tickets.contains_key(&id) {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_RECEIVING_TICKET_ALREADY_ALLOCATED,
+        ));
+    }
+
+    let obj_value = inventories.objects.remove(&id).unwrap();
+    let Some(bytes) = obj_value.simple_serialize(&layout) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
+        ));
+    };
+    let move_object = unsafe {
+        MoveObject::new_from_execution_with_limit(
+            tag.into(),
+            false,
+            object_version,
+            bytes,
+            250 * 1024,
+        )
+    }
+    .unwrap();
+
+    let Some((owner, _)) = inventories
+        .address_inventories
+        .iter()
+        .find(|(_addr, objs)| objs.iter().any(|(_, ids)| ids.contains(&id)))
+    else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_OBJECT_NOT_FOUND_CODE,
+        ));
+    };
+
+    inventories.allocated_tickets.insert(
+        id,
+        (
+            DynamicallyLoadedObjectMetadata {
+                version: SequenceNumber::new(),
+                digest: ObjectDigest::MIN,
+                owner: Owner::AddressOwner(*owner),
+                storage_rebate: 0,
+                previous_transaction: TransactionDigest::default(),
+            },
+            obj_value,
+        ),
+    );
+
+    let object = Object::new_move(
+        move_object,
+        Owner::AddressOwner(*owner),
+        TransactionDigest::default(),
+    );
+
+    // NB: Must be a `&&` reference since the extension stores a static ref to the object storage.
+    let store: &&InMemoryTestStore = context.extensions().get();
+    store.0.lock().unwrap().borrow_mut().insert_object(object);
+
+    Ok(NativeResult::ok(
+        legacy_test_cost(),
+        smallvec![Value::u64(object_version.value())],
+    ))
+}
+
+pub fn deallocate_receiving_ticket_for_object(
+    context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let id = pop_id(&mut args)?;
+
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let inventories = &mut object_runtime.test_inventories;
+    // Deallocate the ticket -- we should never hit this scenario
+    let Some((_, value)) = inventories.allocated_tickets.remove(&id) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_UNABLE_TO_DEALLOCATE_RECEIVING_TICKET,
+        ));
+    };
+
+    // Insert the object value that we saved from earlier and put it back into the object set.
+    // This is fine since it can't have been touched.
+    inventories.objects.insert(id, value);
+
+    // Remove the object from storage. We should never hit this scenario either.
+    let store: &&InMemoryTestStore = context.extensions().get();
+    if store
+        .0
+        .lock()
+        .unwrap()
+        .borrow_mut()
+        .remove_object(id)
+        .is_none()
+    {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_UNABLE_TO_DEALLOCATE_RECEIVING_TICKET,
+        ));
+    };
+
+    Ok(NativeResult::ok(legacy_test_cost(), smallvec![]))
 }
 
 // impls


### PR DESCRIPTION
## Description 

This adds support for transfer-to-object/Receiving tickets in the test scenario.

In order to do this a "proper" object store needed to be added to the test scenario since we cannot count on caching to keep the object for us like we can with dynamic fields in test scenario tests.

This adds such a test by creating a shared `InMemoryStorage` (wrapped in a mutex since tests can be multi-threaded and we need internal mutability). Two handles are then created for this -- one for the storage read operations, and another is added to the context extension so that we can place "objects-to-be-received" into this store when we create the `Receiving` ticket.

This might generally be useful for other tests as well/refactoring the test scenario to be more realistic but I will leave any such investigations for another day.

## Test Plan 

Added tests for the new features to the test scenario tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
