### PR TITLE
Add tests for handle_certificate

### DIFF
--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1070,12 +1070,12 @@ async fn test_handle_certificate_errors() {
         &*authority_state.secret,
     );
 
-    let mut committee = epoch_store.committee().deref().clone();
-    committee.epoch = next_epoch;
+    let mut committee_1 = epoch_store.committee().deref().clone();
+    committee_1.epoch = next_epoch;
     let ct = CertifiedTransaction::new(
         transfer_transaction.data().clone(),
         vec![signed_transaction.auth_sig().clone()],
-        &committee,
+        &committee_1,
     )
     .unwrap();
 
@@ -1087,4 +1087,85 @@ async fn test_handle_certificate_errors() {
             actual_epoch: 1
         }
     );
+
+    // Test handle certificate with invalid user input
+    let signed_transaction = VerifiedSignedTransaction::new(
+        epoch_store.epoch(),
+        VerifiedTransaction::new_unchecked(transfer_transaction.clone()),
+        authority_state.name,
+        &*authority_state.secret,
+    );
+
+    let mut empty_tx = transfer_transaction.clone();
+    let data = empty_tx.data_mut_for_testing();
+    data.inner_vec_mut_for_testing().clear();
+
+    let committee = epoch_store.committee().deref().clone();
+    let ct = CertifiedTransaction::new(
+        data.clone(),
+        vec![signed_transaction.auth_sig().clone()],
+        &committee,
+    )
+    .unwrap();
+
+    let err = client.handle_certificate_v2(ct.clone()).await.unwrap_err();
+
+    assert_matches!(
+        err,
+        SuiError::UserInputError {
+            error: UserInputError::Unsupported(message)
+        } if message == "SenderSignedData must contain exactly one transaction"
+    );
+
+    let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42);
+    let ct = CertifiedTransaction::new(
+        tx.data().clone(),
+        vec![signed_transaction.auth_sig().clone()],
+        &committee,
+    )
+    .unwrap();
+
+    let err = client.handle_certificate_v2(ct.clone()).await.unwrap_err();
+
+    assert_matches!(
+        err,
+        SuiError::UserInputError {
+            error: UserInputError::Unsupported(message)
+        } if message == "SenderSignedData must not contain system transaction"
+    );
+
+    let mut invalid_sig_count_tx = transfer_transaction.clone();
+    let data = invalid_sig_count_tx.data_mut_for_testing();
+    data.tx_signatures_mut_for_testing().clear();
+    let ct = CertifiedTransaction::new(
+        data.clone(),
+        vec![signed_transaction.auth_sig().clone()],
+        &committee,
+    )
+    .unwrap();
+    let err = client.handle_certificate_v2(ct.clone()).await.unwrap_err();
+
+    assert_matches!(
+        err,
+        SuiError::SignerSignatureNumberMismatch {
+            expected: 1,
+            actual: 0
+        }
+    );
+
+    let mut absent_sig_tx = transfer_transaction.clone();
+    let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
+    let data = absent_sig_tx.data_mut_for_testing();
+    *data.tx_signatures_mut_for_testing() =
+        vec![Signature::new_secure(data.intent_message(), &unknown_key).into()];
+    let ct = CertifiedTransaction::new(
+        data.clone(),
+        vec![signed_transaction.auth_sig().clone()],
+        &committee,
+    )
+    .unwrap();
+
+    let err = client.handle_certificate_v2(ct.clone()).await.unwrap_err();
+
+    assert_matches!(err, SuiError::SignerSignatureAbsent { .. });
 }


### PR DESCRIPTION
This PR is for item 67/68 in the fixit doc. There are multiple protections in place for incorrect epoch across safe client, stake aggregator & signature verifier, added some tests to ensure they are not moved. Added some tests as well for bad user input into handle certificate. This is already tested for handle transaction.