### PR TITLE
[gql] events (eventConnection) on tx

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
@@ -1,0 +1,220 @@
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-22:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4818400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 24-24:
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 26-26:
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'create-checkpoint'. lines 28-28:
+Checkpoint created: 1
+
+task 5 'run-graphql'. lines 30-53:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "0"
+                  },
+                  "bcs": "AAAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        },
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "1"
+                  },
+                  "bcs": "AQAAAAAAAAA="
+                }
+              },
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "2"
+                  },
+                  "bcs": "AgAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 55-78:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "events": {
+            "edges": []
+          }
+        },
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "1"
+                  },
+                  "bcs": "AQAAAAAAAAA="
+                }
+              },
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "2"
+                  },
+                  "bcs": "AgAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 80-103:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "0"
+                  },
+                  "bcs": "AAAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        },
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "type": {
+                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+                  },
+                  "senders": [
+                    {
+                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                    }
+                  ],
+                  "json": {
+                    "new_value": "1"
+                  },
+                  "bcs": "AQAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
@@ -1,27 +1,32 @@
-processed 8 tasks
+processed 10 tasks
 
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 6-22:
+task 1 'publish'. lines 6-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4818400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5251600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run'. lines 24-24:
-events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0] }
+task 2 'run'. lines 30-30:
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3 'run'. lines 26-26:
-events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }
+task 3 'run'. lines 32-32:
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [10, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [11, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4 'create-checkpoint'. lines 28-28:
+task 4 'run'. lines 34-34:
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [100, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [101, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [102, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'create-checkpoint'. lines 36-36:
 Checkpoint created: 1
 
-task 5 'run-graphql'. lines 30-53:
+task 6 'run-graphql'. lines 38-55:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -34,18 +39,10 @@ Response: {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
-                    "new_value": "0"
+                    "new_value": "1"
                   },
-                  "bcs": "AAAAAAAAAAA="
+                  "bcs": "AQAAAAAAAAA="
                 }
               }
             ]
@@ -59,18 +56,10 @@ Response: {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
-                    "new_value": "1"
+                    "new_value": "10"
                   },
-                  "bcs": "AQAAAAAAAAA="
+                  "bcs": "CgAAAAAAAAA="
                 }
               },
               {
@@ -78,18 +67,49 @@ Response: {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
-                    "new_value": "2"
+                    "new_value": "11"
                   },
-                  "bcs": "AgAAAAAAAAA="
+                  "bcs": "CwAAAAAAAAA="
+                }
+              }
+            ]
+          }
+        },
+        {
+          "events": {
+            "edges": [
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "json": {
+                    "new_value": "100"
+                  },
+                  "bcs": "ZAAAAAAAAAA="
+                }
+              },
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "json": {
+                    "new_value": "101"
+                  },
+                  "bcs": "ZQAAAAAAAAA="
+                }
+              },
+              {
+                "node": {
+                  "sendingModule": {
+                    "name": "M1"
+                  },
+                  "json": {
+                    "new_value": "102"
+                  },
+                  "bcs": "ZgAAAAAAAAA="
                 }
               }
             ]
@@ -100,16 +120,75 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 55-78:
+task 7 'run-graphql'. lines 57-68:
+Response: {
+  "data": {
+    "eventConnection": {
+      "nodes": [
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "1"
+          },
+          "bcs": "AQAAAAAAAAA="
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "10"
+          },
+          "bcs": "CgAAAAAAAAA="
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "11"
+          },
+          "bcs": "CwAAAAAAAAA="
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "100"
+          },
+          "bcs": "ZAAAAAAAAAA="
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "101"
+          },
+          "bcs": "ZQAAAAAAAAA="
+        },
+        {
+          "sendingModule": {
+            "name": "M1"
+          },
+          "json": {
+            "new_value": "102"
+          },
+          "bcs": "ZgAAAAAAAAA="
+        }
+      ]
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 70-87:
 Response: {
   "data": {
     "transactionBlockConnection": {
       "nodes": [
-        {
-          "events": {
-            "edges": []
-          }
-        },
         {
           "events": {
             "edges": [
@@ -118,37 +197,10 @@ Response: {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
                     "new_value": "1"
                   },
                   "bcs": "AQAAAAAAAAA="
-                }
-              },
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
-                  "json": {
-                    "new_value": "2"
-                  },
-                  "bcs": "AgAAAAAAAAA="
                 }
               }
             ]
@@ -159,7 +211,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 80-103:
+task 9 'run-graphql'. lines 89-106:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -172,43 +224,21 @@ Response: {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
-                    "new_value": "0"
+                    "new_value": "101"
                   },
-                  "bcs": "AAAAAAAAAAA="
+                  "bcs": "ZQAAAAAAAAA="
                 }
-              }
-            ]
-          }
-        },
-        {
-          "events": {
-            "edges": [
+              },
               {
                 "node": {
                   "sendingModule": {
                     "name": "M1"
                   },
-                  "type": {
-                    "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
-                  },
-                  "senders": [
-                    {
-                      "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-                    }
-                  ],
                   "json": {
-                    "new_value": "1"
+                    "new_value": "102"
                   },
-                  "bcs": "AQAAAAAAAAA="
+                  "bcs": "ZgAAAAAAAAA="
                 }
               }
             ]

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.move
@@ -1,0 +1,103 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::event;
+
+    struct EventA has copy, drop {
+        new_value: u64
+    }
+
+    public entry fun emit_1(value: u64) {
+        event::emit(EventA { new_value: value })
+    }
+
+    public entry fun emit_2(value: u64) {
+        event::emit(EventA { new_value: value });
+        event::emit(EventA { new_value: value + 1})
+    }
+}
+
+//# run Test::M1::emit_1 --sender A --args 0
+
+//# run Test::M1::emit_2 --sender A --args 1
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+    nodes {
+      events {
+        edges {
+          node {
+            sendingModule {
+              name
+            }
+            type {
+              repr
+            }
+            senders {
+              address
+            }
+            json
+            bcs
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+    nodes {
+      events(first: 2 after: "2:0", filter: {sender: "@{A}"}) {
+        edges {
+          node {
+            sendingModule {
+              name
+            }
+            type {
+              repr
+            }
+            senders {
+              address
+            }
+            json
+            bcs
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+    nodes {
+      events(last: 2 before: "3:1", filter: {sender: "@{A}"}) {
+        edges {
+          node {
+            sendingModule {
+              name
+            }
+            type {
+              repr
+            }
+            senders {
+              address
+            }
+            json
+            bcs
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.move
@@ -19,11 +19,19 @@ module Test::M1 {
         event::emit(EventA { new_value: value });
         event::emit(EventA { new_value: value + 1})
     }
+
+        public entry fun emit_3(value: u64) {
+        event::emit(EventA { new_value: value });
+        event::emit(EventA { new_value: value + 1});
+        event::emit(EventA { new_value: value + 2});
+    }
 }
 
-//# run Test::M1::emit_1 --sender A --args 0
+//# run Test::M1::emit_1 --sender A --args 1
 
-//# run Test::M1::emit_2 --sender A --args 1
+//# run Test::M1::emit_2 --sender A --args 10
+
+//# run Test::M1::emit_3 --sender A --args 100
 
 //# create-checkpoint
 
@@ -37,12 +45,6 @@ module Test::M1 {
             sendingModule {
               name
             }
-            type {
-              repr
-            }
-            senders {
-              address
-            }
             json
             bcs
           }
@@ -54,19 +56,26 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+  eventConnection(filter: {sender: "@{A}"}) {
     nodes {
-      events(first: 2 after: "2:0", filter: {sender: "@{A}"}) {
+      sendingModule {
+        name
+      }
+      json
+      bcs
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactionBlockConnection(first: 1, filter: {sentAddress: "@{A}"}) {
+    nodes {
+      events(last: 1) {
         edges {
           node {
             sendingModule {
               name
-            }
-            type {
-              repr
-            }
-            senders {
-              address
             }
             json
             bcs
@@ -77,21 +86,15 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors 0
 {
-  transactionBlockConnection(filter: {sentAddress: "@{A}"}) {
+  transactionBlockConnection(last: 1, filter: {sentAddress: "@{A}"}) {
     nodes {
-      events(last: 2 before: "3:1", filter: {sender: "@{A}"}) {
+      events(first: 2, after: "@{cursor_0}") {
         edges {
           node {
             sendingModule {
               name
-            }
-            type {
-              repr
-            }
-            senders {
-              address
             }
             json
             bcs

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2402,7 +2402,7 @@ type TransactionBlock {
 	"""
 	Events emitted by this transaction block.
 	"""
-	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2400,6 +2400,10 @@ type TransactionBlock {
 	"""
 	effects: TransactionBlockEffects
 	"""
+	Events emitted by this transaction block.
+	"""
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,
 	there is no deadline for when a transaction must execute.

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,6 +3,8 @@
 
 use async_graphql::*;
 use sui_indexer::models_v2::events::StoredEvent;
+use sui_indexer::models_v2::transactions::StoredTransaction;
+use sui_types::event::Event as NativeEvent;
 use sui_types::{parse_sui_struct_tag, TypeTag};
 
 use crate::error::Error;
@@ -50,6 +52,56 @@ pub(crate) struct EventFilter {
     // pub any
     // pub all
     // pub not
+}
+
+impl Event {
+    pub(crate) fn try_from_stored_transaction(
+        stored_tx: &StoredTransaction,
+        idx: usize,
+    ) -> Result<Self, Error> {
+        let Some(serialized_event) = stored_tx
+            .events
+            .get(idx)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "Could not find event with event_sequence_number {} at transaction {}",
+                    idx, stored_tx.tx_sequence_number
+                ))
+            })?
+            .as_ref()
+        else {
+            return Err(Error::Internal(format!(
+                "Unexpected None value for event with event_sequence_number {} at transaction {}",
+                idx, stored_tx.tx_sequence_number
+            )));
+        };
+
+        let native_event: NativeEvent = bcs::from_bytes(serialized_event).map_err(|_| {
+            Error::Internal(format!(
+                "Failed to deserialize event with {} at transaction {}",
+                idx, stored_tx.tx_sequence_number
+            ))
+        })?;
+
+        let stored_event = StoredEvent {
+            tx_sequence_number: stored_tx.tx_sequence_number as i64,
+            event_sequence_number: idx as i64,
+            transaction_digest: stored_tx.transaction_digest.clone(),
+            checkpoint_sequence_number: stored_tx.checkpoint_sequence_number as i64,
+            senders: vec![Some(native_event.sender.to_vec())],
+            package: native_event.package_id.to_vec(),
+            module: native_event.transaction_module.to_string(),
+            event_type: native_event
+                .type_
+                .to_canonical_string(/* with_prefix */ true),
+            bcs: native_event.contents.clone(),
+            timestamp_ms: stored_tx.timestamp_ms,
+        };
+
+        Ok(Self {
+            stored: stored_event,
+        })
+    }
 }
 
 #[Object]

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -84,10 +84,10 @@ impl Event {
         })?;
 
         let stored_event = StoredEvent {
-            tx_sequence_number: stored_tx.tx_sequence_number as i64,
+            tx_sequence_number: stored_tx.tx_sequence_number,
             event_sequence_number: idx as i64,
             transaction_digest: stored_tx.transaction_digest.clone(),
-            checkpoint_sequence_number: stored_tx.checkpoint_sequence_number as i64,
+            checkpoint_sequence_number: stored_tx.checkpoint_sequence_number,
             senders: vec![Some(native_event.sender.to_vec())],
             package: native_event.package_id.to_vec(),
             module: native_event.transaction_module.to_string(),

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -19,7 +19,7 @@ pub(crate) struct Event {
     pub stored: StoredEvent,
 }
 
-#[derive(InputObject, Clone)]
+#[derive(InputObject, Clone, Default)]
 pub(crate) struct EventFilter {
     pub sender: Option<SuiAddress>,
     pub transaction_digest: Option<Digest>,

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use async_graphql::*;
+use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_indexer::models_v2::transactions::StoredTransaction;
 use sui_types::{
@@ -13,8 +13,14 @@ use sui_types::{
 use crate::error::Error;
 
 use super::{
-    address::Address, base64::Base64, digest::Digest, epoch::Epoch, gas::GasInput,
-    sui_address::SuiAddress, transaction_block_effects::TransactionBlockEffects,
+    address::Address,
+    base64::Base64,
+    digest::Digest,
+    epoch::Epoch,
+    event::{Event, EventFilter},
+    gas::GasInput,
+    sui_address::SuiAddress,
+    transaction_block_effects::TransactionBlockEffects,
     transaction_block_kind::TransactionBlockKind,
 };
 
@@ -107,6 +113,30 @@ impl TransactionBlock {
         Ok(Some(
             TransactionBlockEffects::try_from(self.stored.clone()).extend()?,
         ))
+    }
+
+    /// Events emitted by this transaction block.
+    async fn events(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+        filter: Option<EventFilter>,
+    ) -> Result<Option<Connection<String, Event>>> {
+        let mut event_filter = match filter {
+            Some(filter) => filter,
+            None => EventFilter::default(),
+        };
+
+        // Overwrite with the current transaction's digest.
+        event_filter.transaction_digest = Some(Base58::encode(&self.stored.transaction_digest));
+
+        ctx.data_unchecked::<PgManager>()
+            .fetch_events(first, after, last, before, Some(event_filter))
+            .await
+            .extend()
     }
 
     /// This field is set by senders of a transaction block. It is an epoch reference that sets a

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2406,7 +2406,7 @@ type TransactionBlock {
 	"""
 	Events emitted by this transaction block.
 	"""
-	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2404,6 +2404,10 @@ type TransactionBlock {
 	"""
 	effects: TransactionBlockEffects
 	"""
+	Events emitted by this transaction block.
+	"""
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,
 	there is no deadline for when a transaction must execute.


### PR DESCRIPTION
## Description 

StoredTransaction has a vector of serialized sui_types::Event. We can use this to resolve the events field on tx. StoredEvent and StoredTransaction share many data fields, and the remaining ones can be determined from the serialized sui_types::Event. Cursor framework handles pagination.


## Test Plan 

transactions/events.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
