### PR TITLE
[sui-node/metrics] recreate client

### DIFF
--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -55,7 +55,6 @@ impl MetricsPushClient {
             .identity(identity)
             .build()
             .unwrap();
-        println!("created new client");
         MetricsPushClient {
             certificate,
             client,

--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -136,6 +136,7 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
             interval.tick().await;
 
             if let Err(error) = push_metrics(&client, &url, &registry).await {
+                client = MetricsPushClient::new(config.network_key_pair().copy());
                 tracing::warn!("unable to push metrics: {error}");
             }
         }

--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -138,10 +138,10 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
             interval.tick().await;
 
             if let Err(error) = push_metrics(&client, &url, &registry).await {
+                tracing::warn!("unable to push metrics: {error}; new client will be created");
                 // aggressively recreate our client connection if we hit an error
                 // since our tick interval is only every min, this should not be racey
                 client = MetricsPushClient::new(config_copy.network_key_pair().copy());
-                tracing::warn!("unable to push metrics: {error}");
             }
         }
     });

--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -45,21 +45,6 @@ impl MetricsPushClient {
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }
-
-    /// recreate will return a new instance of self.  we only call this when we hit an error condition
-    /// on posting data. NB do not call this in a fast loop.  we have this to work around the move block
-    pub fn recreate(&self) -> Self {
-        let certificate = self.certificate.to_owned();
-        let identity = certificate.reqwest_identity();
-        let client = reqwest::Client::builder()
-            .identity(identity)
-            .build()
-            .unwrap();
-        MetricsPushClient {
-            certificate,
-            client,
-        }
-    }
 }
 
 /// Starts a task to periodically push metrics to a configured endpoint if a metrics push endpoint
@@ -84,7 +69,9 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
         _ => return,
     };
 
-    let mut client = MetricsPushClient::new(config.network_key_pair().copy());
+    // make a copy so we can make a new client later when we hit errors posting metrics
+    let config_copy = config.clone();
+    let mut client = MetricsPushClient::new(config_copy.network_key_pair().copy());
 
     async fn push_metrics(
         client: &MetricsPushClient,
@@ -153,7 +140,7 @@ pub fn start_metrics_push_task(config: &sui_config::NodeConfig, registry: Regist
             if let Err(error) = push_metrics(&client, &url, &registry).await {
                 // aggressively recreate our client connection if we hit an error
                 // since our tick interval is only every min, this should not be racey
-                client = client.recreate();
+                client = MetricsPushClient::new(config_copy.network_key_pair().copy());
                 tracing::warn!("unable to push metrics: {error}");
             }
         }


### PR DESCRIPTION
## Description 
In certain cases where we experience degraded metric submit rates or an inability to submit any, we can experience recovery issues when that degredataion subsides. It is an edge case but it seems to present every so often. The intent of this pr is to recreate a reqwest client anytime we hit an error submitting metrics. This will allow for automatic recovery of the node without restarting. Since our tick interval for submit is every 60 secs, it should be fine to recreate.

## Test Plan 
local instruments

```
2023-12-19T20:31:02.903599Z  WARN sui_node::metrics: unable to push metrics: error sending request for url (https://metrics-proxy.testnet.sui.io:8443/publish/metrics): error trying to connect: tcp connect error: Connection refused (os error 61); new client will be created
```
and it recovers:

```
2023-12-19T20:31:18.018332Z  INFO sui_proxy::peers: 4 peers managed to make it on the allow list
[crates/sui-proxy/src/handlers.rs:54] "great success" = "great success"
2023-12-19T20:31:21.528435Z  INFO tower_http::trace::on_response: finished processing request latency=0.009472292 s status=201
```
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
