### PR TITLE
[gql][fix] connections return correct values for last queries

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,9 @@
-processed 8 tasks
+processed 11 tasks
 
-task 1 'create-checkpoint'. lines 18-18:
+task 1 'create-checkpoint'. lines 21-21:
 Checkpoint created: 12
 
-task 2 'run-graphql'. lines 20-27:
+task 2 'run-graphql'. lines 23-30:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -25,7 +25,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 29-36:
+task 3 'run-graphql'. lines 32-39:
 Response: {
   "data": null,
   "errors": [
@@ -47,7 +47,7 @@ Response: {
   ]
 }
 
-task 4 'run-graphql'. lines 38-45:
+task 4 'run-graphql'. lines 41-48:
 Response: {
   "data": null,
   "errors": [
@@ -69,7 +69,7 @@ Response: {
   ]
 }
 
-task 5 'run-graphql'. lines 47-54:
+task 5 'run-graphql'. lines 50-57:
 Response: {
   "data": null,
   "errors": [
@@ -91,7 +91,7 @@ Response: {
   ]
 }
 
-task 6 'run-graphql'. lines 56-63:
+task 6 'run-graphql'. lines 59-66:
 Response: {
   "data": {
     "checkpointConnection": {
@@ -113,7 +113,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 65-72:
+task 7 'run-graphql'. lines 68-75:
 Response: {
   "data": null,
   "errors": [
@@ -133,4 +133,97 @@ Response: {
       }
     }
   ]
+}
+
+task 8 'run-graphql'. lines 77-84:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 0
+        },
+        {
+          "sequenceNumber": 1
+        },
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        },
+        {
+          "sequenceNumber": 4
+        },
+        {
+          "sequenceNumber": 5
+        },
+        {
+          "sequenceNumber": 6
+        },
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        },
+        {
+          "sequenceNumber": 10
+        },
+        {
+          "sequenceNumber": 11
+        },
+        {
+          "sequenceNumber": 12
+        }
+      ]
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 87-94:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 0
+        },
+        {
+          "sequenceNumber": 1
+        },
+        {
+          "sequenceNumber": 2
+        },
+        {
+          "sequenceNumber": 3
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 97-104:
+Response: {
+  "data": {
+    "checkpointConnection": {
+      "nodes": [
+        {
+          "sequenceNumber": 9
+        },
+        {
+          "sequenceNumber": 10
+        },
+        {
+          "sequenceNumber": 11
+        },
+        {
+          "sequenceNumber": 12
+        }
+      ]
+    }
+  }
 }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -12,6 +12,9 @@
 // last: 4, after: "6" -> error
 // last: 4, before: "6" -> checkpoints 2, 3, 4, 5
 // last: 4, before: "6", after: "3" -> error
+// no first or last -> checkpoints 0, 1, 2, 3
+// first: 4 -> checkpoints 0, 1, 2, 3
+// last: 4 -> checkpoints 9, 10, 11, 12
 
 //# init --addresses Test=0x0 --simulator
 
@@ -65,6 +68,35 @@
 //# run-graphql
 {
   checkpointConnection(last: 4, before: "6", after: "3") {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+//# run-graphql
+{
+  checkpointConnection {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  checkpointConnection(first: 4) {
+    nodes {
+      sequenceNumber
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  checkpointConnection(last: 4) {
     nodes {
       sequenceNumber
     }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -1,4 +1,4 @@
-processed 8 tasks
+processed 9 tasks
 
 init:
 A: object(0,0)
@@ -184,6 +184,56 @@ Response: {
               "new_value": "1"
             },
             "bcs": "AQAAAAAAAAA="
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 96-116:
+Response: {
+  "data": {
+    "eventConnection": {
+      "edges": [
+        {
+          "cursor": "3:0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+            },
+            "senders": [
+              {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            ],
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
+        },
+        {
+          "cursor": "3:1",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+            },
+            "senders": [
+              {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            ],
+            "json": {
+              "new_value": "2"
+            },
+            "bcs": "AgAAAAAAAAA="
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -27,9 +27,9 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(filter: {sender: $A}) {
+  eventConnection(filter: {sender: "@{A}"}) {
     edges {
       cursor
       node {
@@ -49,9 +49,9 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(first: 2 after: "2:0", filter: {sender: $A}) {
+  eventConnection(first: 2 after: "2:0", filter: {sender: "@{A}"}) {
     edges {
       cursor
       node {
@@ -71,9 +71,31 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(last: 2 before: "3:1", filter: {sender: $A}) {
+  eventConnection(last: 2 before: "3:1", filter: {sender: "@{A}"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        senders {
+          address
+        }
+        json
+        bcs
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  eventConnection(last: 2) {
     edges {
       cursor
       node {

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -1,4 +1,4 @@
-processed 13 tasks
+processed 14 tasks
 
 task 1 'publish'. lines 6-23:
 created: object(1,0)
@@ -125,6 +125,24 @@ Response: {
           },
           {
             "cursor": "0x7a71f9d1e630ab379913ad5fcf470b2061db2339a005c4ffb92af6b8a6452082"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 99-108:
+Response: {
+  "data": {
+    "address": {
+      "objectConnection": {
+        "edges": [
+          {
+            "cursor": "0x892552efa67a9d4f40ced8bfb35f0b0e2e1b3399c64729b11b8c00f77a539f5e"
+          },
+          {
+            "cursor": "0x8a9eeae01da257bcab470ef0ba0207ddb51bfd8f7a3b2dba01d439762d9f7b3c"
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -34,10 +34,10 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
   # select all objects owned by A
-  address(address: $A) {
+  address(address: "@{A}") {
     objectConnection {
       edges {
         cursor
@@ -46,10 +46,10 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   # select the first 2 objects owned by A
-  address(address: $A) {
+  address(address: "@{A}") {
     objectConnection(first: 2) {
       edges {
         cursor
@@ -58,13 +58,13 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A obj_5_0
+//# run-graphql
 {
-  address(address: $A) {
+  address(address: "@{A}") {
     # select the 2nd and 3rd objects
     # note that order does not correspond
     # to order in which objects were created
-    objectConnection(first: 2 after: $obj_5_0) {
+    objectConnection(first: 2 after: "@{obj_5_0}") {
       edges {
         cursor
       }
@@ -72,11 +72,11 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A obj_4_0
+//# run-graphql
 {
-  address(address: $A) {
+  address(address: "@{A}") {
     # select 4th and last object
-    objectConnection(first: 2 after: $obj_4_0) {
+    objectConnection(first: 2 after: "@{obj_4_0}") {
       edges {
         cursor
       }
@@ -84,11 +84,22 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables A obj_3_0
+//# run-graphql
 {
-  address(address: $A) {
+  address(address: "@{A}") {
     # select 3rd and 4th object
-    objectConnection(last: 2 before: $obj_3_0) {
+    objectConnection(last: 2 before: "@{obj_3_0}") {
+      edges {
+        cursor
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objectConnection(last: 2) {
       edges {
         cursor
       }

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -16,6 +16,8 @@ use diesel::{
     sql_types::Text,
 };
 
+use super::db_data_provider::PageLimit;
+
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     'a,
     (
@@ -45,7 +47,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_txs(
         cursor: Option<i64>,
         descending_order: bool,
-        limit: i64,
+        limit: PageLimit,
         filter: Option<TransactionBlockFilter>,
         after_tx_seq_num: Option<i64>,
         before_tx_seq_num: Option<i64>,
@@ -53,14 +55,14 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_coins(
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
-        limit: i64,
+        limit: PageLimit,
         address: Option<Vec<u8>>,
         coin_type: String,
     ) -> objects::BoxedQuery<'static, DB>;
     fn multi_get_objs(
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
-        limit: i64,
+        limit: PageLimit,
         filter: Option<ObjectFilter>,
         owner_type: Option<OwnerType>,
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
@@ -69,13 +71,13 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_checkpoints(
         before: Option<i64>,
         after: Option<i64>,
-        limit: i64,
+        limit: PageLimit,
         epoch: Option<i64>,
     ) -> checkpoints::BoxedQuery<'static, DB>;
     fn multi_get_events(
         before: Option<(i64, i64)>,
         after: Option<(i64, i64)>,
-        limit: i64,
+        limit: PageLimit,
         filter: Option<EventFilter>,
     ) -> Result<events::BoxedQuery<'static, DB>, Error>;
 }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -119,9 +119,25 @@ pub enum TypeFilterError {
     TooManyComponents(String, u64, &'static str),
 }
 
+// Db needs information on whether the first or last n are being selected
+#[derive(Clone, Copy)]
+pub(crate) enum PageLimit {
+    First(i64),
+    Last(i64),
+}
+
 pub(crate) struct PgManager {
     pub inner: IndexerReader,
     pub limits: Limits,
+}
+
+impl PageLimit {
+    pub(crate) fn value(&self) -> i64 {
+        match self {
+            PageLimit::First(limit) => *limit,
+            PageLimit::Last(limit) => *limit,
+        }
+    }
 }
 
 impl PgManager {
@@ -273,7 +289,7 @@ impl PgManager {
 
         result
             .map(|mut stored_objs| {
-                let has_next_page = stored_objs.len() as i64 > limit;
+                let has_next_page = stored_objs.len() as i64 > limit.value();
                 if has_next_page {
                     stored_objs.pop();
                 }
@@ -396,7 +412,7 @@ impl PgManager {
 
         result
             .map(|mut stored_txs| {
-                let has_next_page = stored_txs.len() as i64 > limit;
+                let has_next_page = stored_txs.len() as i64 > limit.value();
                 if has_next_page {
                     stored_txs.pop();
                 }
@@ -446,7 +462,7 @@ impl PgManager {
 
         result
             .map(|mut stored_checkpoints| {
-                let has_next_page = stored_checkpoints.len() as i64 > limit;
+                let has_next_page = stored_checkpoints.len() as i64 > limit.value();
                 if has_next_page {
                     stored_checkpoints.pop();
                 }
@@ -507,7 +523,7 @@ impl PgManager {
 
         result
             .map(|mut stored_events| {
-                let has_next_page = stored_events.len() as i64 > limit;
+                let has_next_page = stored_events.len() as i64 > limit.value();
                 if has_next_page {
                     stored_events.pop();
                 }
@@ -554,7 +570,7 @@ impl PgManager {
 
         result
             .map(|mut stored_objs| {
-                let has_next_page = stored_objs.len() as i64 > limit;
+                let has_next_page = stored_objs.len() as i64 > limit.value();
                 if has_next_page {
                     stored_objs.pop();
                 }
@@ -641,27 +657,24 @@ impl PgManager {
         &self,
         first: Option<u64>,
         last: Option<u64>,
-    ) -> Result<i64, Error> {
+    ) -> Result<PageLimit, Error> {
         if let Some(f) = first {
             if f > self.limits.max_page_size {
                 return Err(
                     DbValidationError::PageSizeExceeded(f, self.limits.max_page_size).into(),
                 );
             }
-        }
-
-        if let Some(l) = last {
+            return Ok(PageLimit::First(f as i64));
+        } else if let Some(l) = last {
             if l > self.limits.max_page_size {
                 return Err(
                     DbValidationError::PageSizeExceeded(l, self.limits.max_page_size).into(),
                 );
             }
+            return Ok(PageLimit::Last(l as i64));
+        } else {
+            Ok(PageLimit::First(self.limits.default_page_size as i64))
         }
-
-        // TODO (wlmyng): even though we do not allow passing in both first and last,
-        // per the cursor connection specs, if both are provided, from the response,
-        // we need to take the first F from the left and then take the last L from the right.
-        Ok(first.or(last).unwrap_or(self.limits.default_page_size) as i64)
     }
 
     pub(crate) async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -664,7 +664,7 @@ impl PgManager {
                     DbValidationError::PageSizeExceeded(f, self.limits.max_page_size).into(),
                 );
             }
-            return Ok(PageLimit::First(f as i64));
+            Ok(PageLimit::First(f as i64))
         } else if let Some(l) = last {
             if l > self.limits.max_page_size {
                 return Err(


### PR DESCRIPTION
## Description 

The bug is that when only last is provided, because the current implementation depends on using before or after to determine how to order the db, the code ends up returning the behavior as if we provided first. To address this, rather than pass first and last directly to pg_backend, I created a PageLimit enum with variants First, Last. db_data_provider is responsible for determining whether to set the variant as First or Last, and defaults to First(default_page_size) if a value is not provided. Then, pg_backend maps First -> asc and Last -> desc, optionally adding a filter for First -> after and Last -> before

## Test Plan 

Existing tests should work. Add new tests for connections with just (last: n) to snapshot expected results.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
