### PR TITLE
[graphql] switch to QueryableEpochInfo instead of StoredEpochInfo

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -43,23 +43,17 @@ Epoch advanced: 1
 task 10 'run-graphql'. lines 55-65:
 Response: {
   "data": {
-    "epoch": null
-  },
-  "errors": [
-    {
-      "message": "Internal error occurred while processing request: Can't convert system_state into SystemState. Error: unexpected end of input",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "epoch",
-        "validatorSet"
-      ]
+    "epoch": {
+      "validatorSet": {
+        "activeValidators": [
+          {
+            "apy": 1,
+            "name": "validator-0"
+          }
+        ]
+      }
     }
-  ]
+  }
 }
 
 task 11 'run'. lines 67-67:
@@ -146,21 +140,15 @@ Epoch advanced: 2
 task 28 'run-graphql'. lines 103-113:
 Response: {
   "data": {
-    "epoch": null
-  },
-  "errors": [
-    {
-      "message": "Internal error occurred while processing request: Can't convert system_state into SystemState. Error: unexpected end of input",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "epoch",
-        "validatorSet"
-      ]
+    "epoch": {
+      "validatorSet": {
+        "activeValidators": [
+          {
+            "apy": 2,
+            "name": "validator-0"
+          }
+        ]
+      }
     }
-  ]
+  }
 }

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.move
@@ -54,7 +54,7 @@ module P0::m {
 
 //# run-graphql
 {
-  epoch{
+  epoch(id: 1) {
     validatorSet {
       activeValidators {
         apy
@@ -102,7 +102,7 @@ module P0::m {
 
 //# run-graphql
 {
-  epoch{
+  epoch(id: 2) {
     validatorSet {
       activeValidators {
         apy

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::backend::Backend;
+use diesel::{
+    backend::Backend,
+    helper_types::{AsSelect, SqlTypeOf},
+};
 use sui_indexer::{
+    models_v2::epoch::QueryableEpochInfo,
     schema_v2::{checkpoints, display, epochs, events, objects, transactions},
     types_v2::OwnerType,
 };
@@ -34,8 +38,9 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, DB>;
     fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, DB>;
     fn get_obj_by_type(object_type: String) -> objects::BoxedQuery<'static, DB>;
-    fn get_epoch(epoch_id: i64) -> epochs::BoxedQuery<'static, DB>;
-    fn get_latest_epoch() -> epochs::BoxedQuery<'static, DB>;
+    fn get_epoch_info(epoch_id: i64)
+        -> epochs::BoxedQuery<'static, DB, QueryableEpochInfoType<DB>>;
+    fn get_latest_epoch_info() -> epochs::BoxedQuery<'static, DB, QueryableEpochInfoType<DB>>;
     fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, DB>;
     fn get_checkpoint_by_sequence_number(
         sequence_number: i64,
@@ -109,3 +114,5 @@ impl<T: QueryId> QueryId for Explained<T> {
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
 }
+
+pub type QueryableEpochInfoType<DB> = SqlTypeOf<AsSelect<QueryableEpochInfo, DB>>;

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -34,6 +34,8 @@ pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     objects::dsl::coin_type,
 >;
 
+pub type QueryableEpochInfoType<DB> = SqlTypeOf<AsSelect<QueryableEpochInfo, DB>>;
+
 pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, DB>;
     fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, DB>;
@@ -114,5 +116,3 @@ impl<T: QueryId> QueryId for Explained<T> {
 impl<T: diesel::query_builder::Query> diesel::query_builder::Query for Explained<T> {
     type SqlType = Text;
 }
-
-pub type QueryableEpochInfoType<DB> = SqlTypeOf<AsSelect<QueryableEpochInfo, DB>>;

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1205,6 +1205,16 @@ impl PgManager {
         Ok(Some(domain.to_string()))
     }
 
+    pub(crate) async fn fetch_sui_system_state(
+        &self,
+        epoch_id: u64,
+    ) -> Result<NativeSuiSystemStateSummary, Error> {
+        Ok(self
+            .inner
+            .spawn_blocking(move |this| this.get_epoch_sui_system_state(Some(epoch_id)))
+            .await?)
+    }
+
     pub(crate) async fn fetch_latest_sui_system_state(
         &self,
     ) -> Result<SuiSystemStateSummary, Error> {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -48,7 +48,7 @@ use sui_indexer::{
     apis::GovernanceReadApiV2,
     indexer_reader::IndexerReader,
     models_v2::{
-        checkpoints::StoredCheckpoint, display::StoredDisplay, epoch::StoredEpochInfo,
+        checkpoints::StoredCheckpoint, display::StoredDisplay, epoch::QueryableEpochInfo,
         events::StoredEvent, objects::StoredObject, transactions::StoredTransaction,
     },
     schema_v2::transactions,
@@ -193,7 +193,10 @@ impl PgManager {
         .await
     }
 
-    pub async fn get_epoch(&self, epoch_id: Option<i64>) -> Result<Option<StoredEpochInfo>, Error> {
+    pub async fn get_epoch(
+        &self,
+        epoch_id: Option<i64>,
+    ) -> Result<Option<QueryableEpochInfo>, Error> {
         let query_fn = move || {
             Ok(match epoch_id {
                 Some(epoch_id) => QueryBuilder::get_epoch(epoch_id),
@@ -202,7 +205,7 @@ impl PgManager {
         };
 
         self.run_query_async_with_cost(query_fn, |query| {
-            move |conn| query.get_result::<StoredEpochInfo>(conn).optional()
+            move |conn| query.get_result::<QueryableEpochInfo>(conn).optional()
         })
         .await
     }

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -199,8 +199,8 @@ impl PgManager {
     ) -> Result<Option<QueryableEpochInfo>, Error> {
         let query_fn = move || {
             Ok(match epoch_id {
-                Some(epoch_id) => QueryBuilder::get_epoch(epoch_id),
-                None => QueryBuilder::get_latest_epoch(),
+                Some(epoch_id) => QueryBuilder::get_epoch_info(epoch_id),
+                None => QueryBuilder::get_latest_epoch_info(),
             })
         };
 

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -60,12 +60,52 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     fn get_epoch(epoch_id: i64) -> epochs::BoxedQuery<'static, Pg> {
         epochs::dsl::epochs
             .filter(epochs::dsl::epoch.eq(epoch_id))
+            .select((
+                epochs::dsl::epoch,
+                epochs::dsl::first_checkpoint_id,
+                epochs::dsl::epoch_start_timestamp,
+                epochs::dsl::reference_gas_price,
+                epochs::dsl::protocol_version,
+                epochs::dsl::total_stake,
+                epochs::dsl::storage_fund_balance,
+                epochs::dsl::epoch_total_transactions,
+                epochs::dsl::last_checkpoint_id,
+                epochs::dsl::epoch_end_timestamp,
+                epochs::dsl::storage_fund_reinvestment,
+                epochs::dsl::storage_charge,
+                epochs::dsl::storage_rebate,
+                epochs::dsl::stake_subsidy_amount,
+                epochs::dsl::total_gas_fees,
+                epochs::dsl::total_stake_rewards_distributed,
+                epochs::dsl::leftover_storage_fund_inflow,
+                epochs::dsl::epoch_commitments,
+            ))
             .into_boxed()
     }
     fn get_latest_epoch() -> epochs::BoxedQuery<'static, Pg> {
         epochs::dsl::epochs
             .order_by(epochs::dsl::epoch.desc())
             .limit(1)
+            .select((
+                epochs::dsl::epoch,
+                epochs::dsl::first_checkpoint_id,
+                epochs::dsl::epoch_start_timestamp,
+                epochs::dsl::reference_gas_price,
+                epochs::dsl::protocol_version,
+                epochs::dsl::total_stake,
+                epochs::dsl::storage_fund_balance,
+                epochs::dsl::epoch_total_transactions,
+                epochs::dsl::last_checkpoint_id,
+                epochs::dsl::epoch_end_timestamp,
+                epochs::dsl::storage_fund_reinvestment,
+                epochs::dsl::storage_charge,
+                epochs::dsl::storage_rebate,
+                epochs::dsl::stake_subsidy_amount,
+                epochs::dsl::total_gas_fees,
+                epochs::dsl::total_stake_rewards_distributed,
+                epochs::dsl::leftover_storage_fund_inflow,
+                epochs::dsl::epoch_commitments,
+            ))
             .into_boxed()
     }
     fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, Pg> {

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder},
+    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder, QueryableEpochInfoType},
     db_data_provider::{DbValidationError, PageLimit, TypeFilterError},
 };
 use crate::{
@@ -22,6 +22,7 @@ use diesel::{
 };
 use std::str::FromStr;
 use sui_indexer::{
+    models_v2::epoch::QueryableEpochInfo,
     schema_v2::{
         checkpoints, display, epochs, events, objects, transactions, tx_calls, tx_changed_objects,
         tx_input_objects, tx_recipients, tx_senders,
@@ -31,6 +32,8 @@ use sui_indexer::{
 use sui_types::parse_sui_struct_tag;
 use tap::TapFallible;
 use tracing::{info, warn};
+
+use diesel::SelectableHelper;
 
 pub(crate) const EXPLAIN_COSTING_LOG_TARGET: &str = "gql-explain-costing";
 
@@ -57,55 +60,20 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
             .limit(1) // Fetches for a single object and as such has a limit of 1
             .into_boxed()
     }
-    fn get_epoch(epoch_id: i64) -> epochs::BoxedQuery<'static, Pg> {
+    fn get_epoch_info(
+        epoch_id: i64,
+    ) -> epochs::BoxedQuery<'static, Pg, QueryableEpochInfoType<Pg>> {
         epochs::dsl::epochs
             .filter(epochs::dsl::epoch.eq(epoch_id))
-            .select((
-                epochs::dsl::epoch,
-                epochs::dsl::first_checkpoint_id,
-                epochs::dsl::epoch_start_timestamp,
-                epochs::dsl::reference_gas_price,
-                epochs::dsl::protocol_version,
-                epochs::dsl::total_stake,
-                epochs::dsl::storage_fund_balance,
-                epochs::dsl::epoch_total_transactions,
-                epochs::dsl::last_checkpoint_id,
-                epochs::dsl::epoch_end_timestamp,
-                epochs::dsl::storage_fund_reinvestment,
-                epochs::dsl::storage_charge,
-                epochs::dsl::storage_rebate,
-                epochs::dsl::stake_subsidy_amount,
-                epochs::dsl::total_gas_fees,
-                epochs::dsl::total_stake_rewards_distributed,
-                epochs::dsl::leftover_storage_fund_inflow,
-                epochs::dsl::epoch_commitments,
-            ))
+            .select(QueryableEpochInfo::as_select())
             .into_boxed()
     }
-    fn get_latest_epoch() -> epochs::BoxedQuery<'static, Pg> {
+
+    fn get_latest_epoch_info() -> epochs::BoxedQuery<'static, Pg, QueryableEpochInfoType<Pg>> {
         epochs::dsl::epochs
             .order_by(epochs::dsl::epoch.desc())
             .limit(1)
-            .select((
-                epochs::dsl::epoch,
-                epochs::dsl::first_checkpoint_id,
-                epochs::dsl::epoch_start_timestamp,
-                epochs::dsl::reference_gas_price,
-                epochs::dsl::protocol_version,
-                epochs::dsl::total_stake,
-                epochs::dsl::storage_fund_balance,
-                epochs::dsl::epoch_total_transactions,
-                epochs::dsl::last_checkpoint_id,
-                epochs::dsl::epoch_end_timestamp,
-                epochs::dsl::storage_fund_reinvestment,
-                epochs::dsl::storage_charge,
-                epochs::dsl::storage_rebate,
-                epochs::dsl::stake_subsidy_amount,
-                epochs::dsl::total_gas_fees,
-                epochs::dsl::total_stake_rewards_distributed,
-                epochs::dsl::leftover_storage_fund_inflow,
-                epochs::dsl::epoch_commitments,
-            ))
+            .select(QueryableEpochInfo::as_select())
             .into_boxed()
     }
     fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, Pg> {

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -174,10 +174,9 @@ impl Epoch {
 
     #[graphql(skip)]
     async fn system_state(&self, ctx: &Context<'_>) -> Result<NativeSuiSystemStateSummary, Error> {
-        Ok(ctx
-            .data_unchecked::<PgManager>()
+        ctx.data_unchecked::<PgManager>()
             .fetch_sui_system_state(self.stored.epoch as u64)
-            .await?)
+            .await
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -33,8 +33,8 @@ impl Epoch {
     }
 
     /// Validator related properties, including the active validators
-    async fn validator_set(&self) -> Result<Option<ValidatorSet>> {
-        let system_state: NativeSuiSystemStateSummary = bcs::from_bytes(&self.stored.system_state)
+    async fn validator_set(&self, ctx: &Context<'_>) -> Result<Option<ValidatorSet>> {
+        let system_state: NativeSuiSystemStateSummary = bcs::from_bytes(&self.system_state(ctx))
             .map_err(|e| {
                 Error::Internal(format!(
                     "Can't convert system_state into SystemState. Error: {e}",
@@ -174,6 +174,14 @@ impl Epoch {
             .fetch_txs(first, after, last, before, Some(new_filter))
             .await
             .extend()
+    }
+
+    #[graphql(skip)]
+    async fn system_state(&self, ctx: &Context<'_>) -> Result<NativeSuiSystemStateSummary, Error> {
+        Ok(ctx
+            .data_unchecked::<PgManager>()
+            .fetch_system_state_summary(Some(self.stored.epoch_id))
+            .await?)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -12,12 +12,12 @@ use super::transaction_block::{TransactionBlock, TransactionBlockFilter};
 use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
 use async_graphql::*;
-use sui_indexer::models_v2::epoch::StoredEpochInfo;
+use sui_indexer::models_v2::epoch::QueryableEpochInfo;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary as NativeSuiSystemStateSummary;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Epoch {
-    pub stored: StoredEpochInfo,
+    pub stored: QueryableEpochInfo,
 }
 
 #[Object]
@@ -184,8 +184,8 @@ impl Epoch {
     }
 }
 
-impl From<StoredEpochInfo> for Epoch {
-    fn from(e: StoredEpochInfo) -> Self {
+impl From<QueryableEpochInfo> for Epoch {
+    fn from(e: QueryableEpochInfo) -> Self {
         Epoch { stored: e }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -34,12 +34,8 @@ impl Epoch {
 
     /// Validator related properties, including the active validators
     async fn validator_set(&self, ctx: &Context<'_>) -> Result<Option<ValidatorSet>> {
-        let system_state: NativeSuiSystemStateSummary =
-            bcs::from_bytes(&self.system_state_summary(ctx)).map_err(|e| {
-                Error::Internal(format!(
-                    "Can't convert system_state into SystemState. Error: {e}",
-                ))
-            })?;
+        let system_state = self.system_state(ctx).await?;
+
         let active_validators = convert_to_validators(system_state.active_validators, None);
         let validator_set = ValidatorSet {
             total_stake: Some(BigInt::from(self.stored.total_stake)),
@@ -174,6 +170,14 @@ impl Epoch {
             .fetch_txs(first, after, last, before, Some(new_filter))
             .await
             .extend()
+    }
+
+    #[graphql(skip)]
+    async fn system_state(&self, ctx: &Context<'_>) -> Result<NativeSuiSystemStateSummary, Error> {
+        Ok(ctx
+            .data_unchecked::<PgManager>()
+            .fetch_sui_system_state(self.stored.epoch as u64)
+            .await?)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -34,8 +34,8 @@ impl Epoch {
 
     /// Validator related properties, including the active validators
     async fn validator_set(&self, ctx: &Context<'_>) -> Result<Option<ValidatorSet>> {
-        let system_state: NativeSuiSystemStateSummary = bcs::from_bytes(&self.system_state(ctx))
-            .map_err(|e| {
+        let system_state: NativeSuiSystemStateSummary =
+            bcs::from_bytes(&self.system_state_summary(ctx)).map_err(|e| {
                 Error::Internal(format!(
                     "Can't convert system_state into SystemState. Error: {e}",
                 ))
@@ -174,14 +174,6 @@ impl Epoch {
             .fetch_txs(first, after, last, before, Some(new_filter))
             .await
             .extend()
-    }
-
-    #[graphql(skip)]
-    async fn system_state(&self, ctx: &Context<'_>) -> Result<NativeSuiSystemStateSummary, Error> {
-        Ok(ctx
-            .data_unchecked::<PgManager>()
-            .fetch_system_state_summary(Some(self.stored.epoch_id))
-            .await?)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -34,7 +34,7 @@ impl Epoch {
     async fn validator_set(&self, ctx: &Context<'_>) -> Result<Option<ValidatorSet>> {
         let system_state = ctx
             .data_unchecked::<PgManager>()
-            .fetch_sui_system_state(self.stored.epoch as u64)
+            .fetch_sui_system_state(Some(self.stored.epoch as u64))
             .await?;
 
         let active_validators = convert_to_validators(system_state.active_validators, None);

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -33,7 +33,7 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
 }
 
-#[derive(Queryable)]
+#[derive(Queryable, Clone, Debug)]
 pub struct QueryableEpochInfo {
     pub epoch: i64,
     pub first_checkpoint_id: i64,

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::{Insertable, Queryable};
+use diesel::{Insertable, Queryable, Selectable};
 
 use crate::errors::IndexerError;
 use crate::schema_v2::epochs;
@@ -33,7 +33,8 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
 }
 
-#[derive(Queryable, Clone, Debug)]
+#[derive(Queryable, Clone, Debug, Selectable)]
+#[diesel(table_name = epochs)]
 pub struct QueryableEpochInfo {
     pub epoch: i64,
     pub first_checkpoint_id: i64,

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -33,7 +33,7 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
 }
 
-#[derive(Queryable, Clone, Debug, Selectable)]
+#[derive(Queryable, Selectable)]
 #[diesel(table_name = epochs)]
 pub struct QueryableEpochInfo {
     pub epoch: i64,


### PR DESCRIPTION
## Description 

Once #15434 lands, we need to switch to QueryableEpochInfo instead of StoredEpochInfo.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
