### PR TITLE
[GraphQL/Package Resolver] Type Parameter width limit

### DIFF
--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
     #[error("Struct not found: {0}::{1}::{2}")]
     StructNotFound(AccountAddress, String, String),
 
+    #[error("Expected at most {0} type parameters, got {1}")]
+    TooManyTypeParams(usize, usize),
+
     #[error("Expected {0} type parameters, but got {1}")]
     TypeArityMismatch(usize, usize),
 


### PR DESCRIPTION
## Description

Implement enforcement for limit on number of type parameters in a single generic type instantiation.

## Test Plan

New unit test:

```
sui-package-resolver$ cargo nextest run
```

## Stack

- #15393 
- #15407 
- #15408
- #15409 
- #15410
- #15442 