### PR TITLE
[GraphQL/Package Resolver] Limits for struct defs loaded

### DIFF
--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
     #[error("Struct not found: {0}::{1}::{2}")]
     StructNotFound(AccountAddress, String, String),
 
+    #[error("More than {0} struct definitions required to resolve type")]
+    TooManyTypeNodes(usize, usize),
+
     #[error("Expected at most {0} type parameters, got {1}")]
     TooManyTypeParams(usize, usize),
 


### PR DESCRIPTION
## Description

Hook up `max_type_nodes` to limit the number of struct defs that need to be loaded to resolve a single type request (a layout request or an abilities request).

## Test Plan

New unit test:

```
sui-package-resolve$ cargo nextest run
```

## Stack

- #15393 
- #15407 
- #15408
- #15409 
- #15410
- #15442 
- #15443 