### PR TITLE
[GraphQL/Package Resolver] Limits on type parameter nesting

### DIFF
--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -52,6 +52,9 @@ pub enum Error {
     #[error("Expected {0} type parameters, but got {1}")]
     TypeArityMismatch(usize, usize),
 
+    #[error("Type parameter nesting exceeded limit of {0}")]
+    TypeParamNesting(usize, usize),
+
     #[error("Type Parameter {0} out of bounds ({1})")]
     TypeParamOOB(u16, usize),
 


### PR DESCRIPTION
## Description

Limit how deeply type parameters can be nested in a type tag that needs to be resolved.  This limit only applies to the "outermost" type parameter application, and not to type parameters that exist in signatures in Move bytecode (which already had to go through chain-enforced limits to be published).

## Test Plan

New unit tests:

```
sui-package-resolver$ cargo nextest run
```

## Stack

- #15393 
- #15407 
- #15408
- #15409 
- #15410
- #15442 
- #15443 
- #15444 